### PR TITLE
[WIP] First look at using nullable references in the codebase

### DIFF
--- a/src/EFCore.Abstractions/DbFunctionAttribute.cs
+++ b/src/EFCore.Abstractions/DbFunctionAttribute.cs
@@ -17,8 +17,8 @@ namespace Microsoft.EntityFrameworkCore
     public class DbFunctionAttribute : Attribute
 #pragma warning restore CA1813 // Avoid unsealed attributes
     {
-        private string _functionName;
-        private string _schema;
+        private string? _functionName;
+        private string? _schema;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="DbFunctionAttribute" /> class.
@@ -32,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="functionName">The name of the function in the database.</param>
         /// <param name="schema">The schema of the function in the database.</param>
-        public DbFunctionAttribute([NotNull] string functionName, [CanBeNull] string schema = null)
+        public DbFunctionAttribute([NotNull] string functionName, [CanBeNull] string? schema = null)
         {
             Check.NotEmpty(functionName, nameof(functionName));
 
@@ -43,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <summary>
         ///     The name of the function in the database.
         /// </summary>
-        public virtual string FunctionName
+        public virtual string? FunctionName
         {
             get => _functionName;
             [param: NotNull]
@@ -58,7 +58,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <summary>
         ///     The schema of the function in the database.
         /// </summary>
-        public virtual string Schema
+        public virtual string? Schema
         {
             get => _schema;
             [param: CanBeNull] set => _schema = value;

--- a/src/EFCore.Abstractions/EFCore.Abstractions.csproj
+++ b/src/EFCore.Abstractions/EFCore.Abstractions.csproj
@@ -8,6 +8,8 @@
     <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>..\..\EFCore.ruleset</CodeAnalysisRuleSet>
+    <LangVersion>8.0</LangVersion>
+    <NullableReferenceTypes>true</NullableReferenceTypes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EFCore.Abstractions/Infrastructure/ILazyLoader.cs
+++ b/src/EFCore.Abstractions/Infrastructure/ILazyLoader.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <param name="entity"> The entity on which the navigation property is located. </param>
         /// <param name="navigationName"> The navigation property name. </param>
         // ReSharper disable once AssignNullToNotNullAttribute
-        void Load([NotNull] object entity, [NotNull] [CallerMemberName] string navigationName = null);
+        void Load([NotNull] object entity, [NotNull] [CallerMemberName] string? navigationName = null);
 
         /// <summary>
         ///     Loads a navigation property if it has not already been loaded.
@@ -35,6 +35,6 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             [NotNull] object entity,
             CancellationToken cancellationToken = default,
             // ReSharper disable once AssignNullToNotNullAttribute
-            [NotNull] [CallerMemberName] string navigationName = null);
+            [NotNull] [CallerMemberName] string? navigationName = null);
     }
 }

--- a/src/EFCore.Abstractions/Infrastructure/LazyLoaderExtensions.cs
+++ b/src/EFCore.Abstractions/Infrastructure/LazyLoaderExtensions.cs
@@ -23,12 +23,12 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <returns>
         ///     The loaded navigation property value, or the navigation property value unchanged if the loader is <c>null</c>.
         /// </returns>
-        public static TRelated Load<TRelated>(
-            [CanBeNull] this ILazyLoader loader,
+        public static TRelated? Load<TRelated>(
+            [CanBeNull] this ILazyLoader? loader,
             [NotNull] object entity,
-            [CanBeNull] ref TRelated navigationField,
+            [CanBeNull] ref TRelated? navigationField,
             // ReSharper disable once AssignNullToNotNullAttribute
-            [NotNull] [CallerMemberName] string navigationName = null)
+            [NotNull] [CallerMemberName] string navigationName = "")
             where TRelated : class
         {
             // ReSharper disable once AssignNullToNotNullAttribute

--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -472,7 +472,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
         private CurrentValueType GetValueType(
             IProperty property,
-            Func<object, object, bool> equals = null)
+            Func<object, object, bool>? equals = null)
         {
             var tempIndex = property.GetStoreGeneratedIndex();
             if (tempIndex == -1)

--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -53,17 +53,17 @@ namespace Microsoft.EntityFrameworkCore
         IDbQueryCache,
         IDbContextPoolable
     {
-        private IDictionary<Type, object> _sets;
-        private IDictionary<Type, object> _queries;
+        private IDictionary<Type, object>? _sets;
+        private IDictionary<Type, object>? _queries;
         private readonly DbContextOptions _options;
 
-        private IDbContextServices _contextServices;
-        private IDbContextDependencies _dbContextDependencies;
-        private DatabaseFacade _database;
-        private ChangeTracker _changeTracker;
+        private IDbContextServices? _contextServices;
+        private IDbContextDependencies? _dbContextDependencies;
+        private DatabaseFacade? _database;
+        private ChangeTracker? _changeTracker;
 
-        private IServiceScope _serviceScope;
-        private IDbContextPool _dbContextPool;
+        private IServiceScope? _serviceScope;
+        private IDbContextPool? _dbContextPool;
         private bool _initializing;
         private bool _disposed;
 
@@ -592,7 +592,7 @@ namespace Microsoft.EntityFrameworkCore
             }
             else
             {
-                ((IResettableService)_changeTracker)?.ResetState();
+                ((IResettableService?)_changeTracker)?.ResetState();
             }
 
             if (_database != null)

--- a/src/EFCore/Diagnostics/EventDefinition.cs
+++ b/src/EFCore/Diagnostics/EventDefinition.cs
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     /// </summary>
     public class EventDefinition : EventDefinitionBase
     {
-        private readonly Action<ILogger, Exception> _logAction;
+        private readonly Action<ILogger, Exception?> _logAction;
 
         /// <summary>
         ///     Creates an event definition instance.
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public EventDefinition(
             EventId eventId,
             LogLevel level,
-            [NotNull] Action<ILogger, Exception> logAction)
+            [NotNull] Action<ILogger, Exception?> logAction)
             : this(eventId, level, null, logAction)
         {
         }
@@ -41,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             EventId eventId,
             LogLevel level,
             [CanBeNull] string eventIdCode,
-            [NotNull] Action<ILogger, Exception> logAction)
+            [NotNull] Action<ILogger, Exception?> logAction)
             : base(eventId, level, eventIdCode)
         {
             Check.NotNull(logAction, nameof(logAction));
@@ -55,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <param name="exception"> Optional exception associated with this event. </param>
         /// <returns> The message string. </returns>
-        public virtual string GenerateMessage([CanBeNull] Exception exception = null)
+        public virtual string GenerateMessage([CanBeNull] Exception? exception = null)
         {
             var extractor = new MessageExtractingLogger();
             _logAction(extractor, exception);
@@ -72,7 +72,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public virtual void Log<TLoggerCategory>(
             [NotNull] IDiagnosticsLogger<TLoggerCategory> logger,
             WarningBehavior warningBehavior,
-            [CanBeNull] Exception exception = null)
+            [CanBeNull] Exception? exception = null)
             where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
         {
             switch (warningBehavior)

--- a/src/EFCore/Diagnostics/EventDefinition`.cs
+++ b/src/EFCore/Diagnostics/EventDefinition`.cs
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     /// </summary>
     public class EventDefinition<TParam> : EventDefinitionBase
     {
-        private readonly Action<ILogger, TParam, Exception> _logAction;
+        private readonly Action<ILogger, TParam, Exception?> _logAction;
 
         /// <summary>
         ///     Creates an event definition instance.
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public EventDefinition(
             EventId eventId,
             LogLevel level,
-            [NotNull] Action<ILogger, TParam, Exception> logAction)
+            [NotNull] Action<ILogger, TParam, Exception?> logAction)
             : this(eventId, level, null, logAction)
         {
         }
@@ -41,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             EventId eventId,
             LogLevel level,
             [CanBeNull] string eventIdCode,
-            [NotNull] Action<ILogger, TParam, Exception> logAction)
+            [NotNull] Action<ILogger, TParam, Exception?> logAction)
             : base(eventId, level, eventIdCode)
         {
             Check.NotNull(logAction, nameof(logAction));
@@ -58,7 +58,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <returns> The message string. </returns>
         public virtual string GenerateMessage(
             [CanBeNull] TParam arg,
-            [CanBeNull] Exception exception = null)
+            [CanBeNull] Exception? exception = null)
         {
             var extractor = new MessageExtractingLogger();
             _logAction(extractor, arg, exception);
@@ -77,7 +77,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             [NotNull] IDiagnosticsLogger<TLoggerCategory> logger,
             WarningBehavior warningBehavior,
             [CanBeNull] TParam arg,
-            [CanBeNull] Exception exception = null)
+            [CanBeNull] Exception? exception = null)
             where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
         {
             switch (warningBehavior)

--- a/src/EFCore/Diagnostics/EventDefinition``.cs
+++ b/src/EFCore/Diagnostics/EventDefinition``.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public EventDefinition(
             EventId eventId,
             LogLevel level,
-            [NotNull] Action<ILogger, TParam1, TParam2, Exception> logAction)
+            [NotNull] Action<ILogger, TParam1, TParam2, Exception?> logAction)
             : this(eventId, level, null, logAction)
         {
         }
@@ -41,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             EventId eventId,
             LogLevel level,
             [CanBeNull] string eventIdCode,
-            [NotNull] Action<ILogger, TParam1, TParam2, Exception> logAction)
+            [NotNull] Action<ILogger, TParam1, TParam2, Exception?> logAction)
             : base(eventId, level, eventIdCode)
         {
             Check.NotNull(logAction, nameof(logAction));
@@ -60,7 +60,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public virtual string GenerateMessage(
             [CanBeNull] TParam1 arg1,
             [CanBeNull] TParam2 arg2,
-            [CanBeNull] Exception exception = null)
+            [CanBeNull] Exception? exception = null)
         {
             var extractor = new MessageExtractingLogger();
             _logAction(extractor, arg1, arg2, exception);
@@ -81,7 +81,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             WarningBehavior warningBehavior,
             [CanBeNull] TParam1 arg1,
             [CanBeNull] TParam2 arg2,
-            [CanBeNull] Exception exception = null)
+            [CanBeNull] Exception? exception = null)
             where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
         {
             switch (warningBehavior)

--- a/src/EFCore/Diagnostics/EventDefinition```.cs
+++ b/src/EFCore/Diagnostics/EventDefinition```.cs
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     /// </summary>
     public class EventDefinition<TParam1, TParam2, TParam3> : EventDefinitionBase
     {
-        private readonly Action<ILogger, TParam1, TParam2, TParam3, Exception> _logAction;
+        private readonly Action<ILogger, TParam1, TParam2, TParam3, Exception?> _logAction;
 
         /// <summary>
         ///     Creates an event definition instance.
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public EventDefinition(
             EventId eventId,
             LogLevel level,
-            [NotNull] Action<ILogger, TParam1, TParam2, TParam3, Exception> logAction)
+            [NotNull] Action<ILogger, TParam1, TParam2, TParam3, Exception?> logAction)
             : this(eventId, level, null, logAction)
         {
         }
@@ -41,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             EventId eventId,
             LogLevel level,
             [CanBeNull] string eventIdCode,
-            [NotNull] Action<ILogger, TParam1, TParam2, TParam3, Exception> logAction)
+            [NotNull] Action<ILogger, TParam1, TParam2, TParam3, Exception?> logAction)
             : base(eventId, level, eventIdCode)
         {
             Check.NotNull(logAction, nameof(logAction));
@@ -62,7 +62,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             [CanBeNull] TParam1 arg1,
             [CanBeNull] TParam2 arg2,
             [CanBeNull] TParam3 arg3,
-            [CanBeNull] Exception exception = null)
+            [CanBeNull] Exception? exception = null)
         {
             var extractor = new MessageExtractingLogger();
             _logAction(extractor, arg1, arg2, arg3, exception);
@@ -85,7 +85,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             [CanBeNull] TParam1 arg1,
             [CanBeNull] TParam2 arg2,
             [CanBeNull] TParam3 arg3,
-            [CanBeNull] Exception exception = null)
+            [CanBeNull] Exception? exception = null)
             where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
         {
             switch (warningBehavior)

--- a/src/EFCore/Diagnostics/EventDefinition````.cs
+++ b/src/EFCore/Diagnostics/EventDefinition````.cs
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     /// </summary>
     public class EventDefinition<TParam1, TParam2, TParam3, TParam4> : EventDefinitionBase
     {
-        private readonly Action<ILogger, TParam1, TParam2, TParam3, TParam4, Exception> _logAction;
+        private readonly Action<ILogger, TParam1, TParam2, TParam3, TParam4, Exception?> _logAction;
 
         /// <summary>
         ///     Creates an event definition instance.
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public EventDefinition(
             EventId eventId,
             LogLevel level,
-            [NotNull] Action<ILogger, TParam1, TParam2, TParam3, TParam4, Exception> logAction)
+            [NotNull] Action<ILogger, TParam1, TParam2, TParam3, TParam4, Exception?> logAction)
             : this(eventId, level, null, logAction)
         {
         }
@@ -41,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             EventId eventId,
             LogLevel level,
             [CanBeNull] string eventIdCode,
-            [NotNull] Action<ILogger, TParam1, TParam2, TParam3, TParam4, Exception> logAction)
+            [NotNull] Action<ILogger, TParam1, TParam2, TParam3, TParam4, Exception?> logAction)
             : base(eventId, level, eventIdCode)
         {
             Check.NotNull(logAction, nameof(logAction));
@@ -64,7 +64,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             [CanBeNull] TParam2 arg2,
             [CanBeNull] TParam3 arg3,
             [CanBeNull] TParam4 arg4,
-            [CanBeNull] Exception exception = null)
+            [CanBeNull] Exception? exception = null)
         {
             var extractor = new MessageExtractingLogger();
             _logAction(extractor, arg1, arg2, arg3, arg4, exception);
@@ -89,7 +89,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             [CanBeNull] TParam2 arg2,
             [CanBeNull] TParam3 arg3,
             [CanBeNull] TParam4 arg4,
-            [CanBeNull] Exception exception = null)
+            [CanBeNull] Exception? exception = null)
             where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
         {
             switch (warningBehavior)

--- a/src/EFCore/Diagnostics/EventDefinition`````.cs
+++ b/src/EFCore/Diagnostics/EventDefinition`````.cs
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     /// </summary>
     public class EventDefinition<TParam1, TParam2, TParam3, TParam4, TParam5> : EventDefinitionBase
     {
-        private readonly Action<ILogger, TParam1, TParam2, TParam3, TParam4, TParam5, Exception> _logAction;
+        private readonly Action<ILogger, TParam1, TParam2, TParam3, TParam4, TParam5, Exception?> _logAction;
 
         /// <summary>
         ///     Creates an event definition instance.
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public EventDefinition(
             EventId eventId,
             LogLevel level,
-            [NotNull] Action<ILogger, TParam1, TParam2, TParam3, TParam4, TParam5, Exception> logAction)
+            [NotNull] Action<ILogger, TParam1, TParam2, TParam3, TParam4, TParam5, Exception?> logAction)
             : this(eventId, level, null, logAction)
         {
         }
@@ -41,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             EventId eventId,
             LogLevel level,
             [CanBeNull] string eventIdCode,
-            [NotNull] Action<ILogger, TParam1, TParam2, TParam3, TParam4, TParam5, Exception> logAction)
+            [NotNull] Action<ILogger, TParam1, TParam2, TParam3, TParam4, TParam5, Exception?> logAction)
             : base(eventId, level, eventIdCode)
         {
             Check.NotNull(logAction, nameof(logAction));
@@ -66,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             [CanBeNull] TParam3 arg3,
             [CanBeNull] TParam4 arg4,
             [CanBeNull] TParam5 arg5,
-            [CanBeNull] Exception exception = null)
+            [CanBeNull] Exception? exception = null)
         {
             var extractor = new MessageExtractingLogger();
             _logAction(extractor, arg1, arg2, arg3, arg4, arg5, exception);
@@ -93,7 +93,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             [CanBeNull] TParam3 arg3,
             [CanBeNull] TParam4 arg4,
             [CanBeNull] TParam5 arg5,
-            [CanBeNull] Exception exception = null)
+            [CanBeNull] Exception? exception = null)
             where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
         {
             switch (warningBehavior)

--- a/src/EFCore/Diagnostics/EventDefinition``````.cs
+++ b/src/EFCore/Diagnostics/EventDefinition``````.cs
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     /// </summary>
     public class EventDefinition<TParam1, TParam2, TParam3, TParam4, TParam5, TParam6> : EventDefinitionBase
     {
-        private readonly Action<ILogger, TParam1, TParam2, TParam3, TParam4, TParam5, TParam6, Exception> _logAction;
+        private readonly Action<ILogger, TParam1, TParam2, TParam3, TParam4, TParam5, TParam6, Exception?> _logAction;
 
         /// <summary>
         ///     Creates an event definition instance.
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public EventDefinition(
             EventId eventId,
             LogLevel level,
-            [NotNull] Action<ILogger, TParam1, TParam2, TParam3, TParam4, TParam5, TParam6, Exception> logAction)
+            [NotNull] Action<ILogger, TParam1, TParam2, TParam3, TParam4, TParam5, TParam6, Exception?> logAction)
             : this(eventId, level, null, logAction)
         {
         }
@@ -41,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             EventId eventId,
             LogLevel level,
             [CanBeNull] string eventIdCode,
-            [NotNull] Action<ILogger, TParam1, TParam2, TParam3, TParam4, TParam5, TParam6, Exception> logAction)
+            [NotNull] Action<ILogger, TParam1, TParam2, TParam3, TParam4, TParam5, TParam6, Exception?> logAction)
             : base(eventId, level, eventIdCode)
         {
             Check.NotNull(logAction, nameof(logAction));
@@ -68,7 +68,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             [CanBeNull] TParam4 arg4,
             [CanBeNull] TParam5 arg5,
             [CanBeNull] TParam6 arg6,
-            [CanBeNull] Exception exception = null)
+            [CanBeNull] Exception? exception = null)
         {
             var extractor = new MessageExtractingLogger();
             _logAction(extractor, arg1, arg2, arg3, arg4, arg5, arg6, exception);
@@ -97,7 +97,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             [CanBeNull] TParam4 arg4,
             [CanBeNull] TParam5 arg5,
             [CanBeNull] TParam6 arg6,
-            [CanBeNull] Exception exception = null)
+            [CanBeNull] Exception? exception = null)
             where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
         {
             switch (warningBehavior)

--- a/src/EFCore/EFCore.csproj
+++ b/src/EFCore/EFCore.csproj
@@ -13,6 +13,8 @@ Microsoft.EntityFrameworkCore.DbSet
     <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>..\..\EFCore.ruleset</CodeAnalysisRuleSet>
+    <LangVersion>8.0</LangVersion>
+    <NullableReferenceTypes>true</NullableReferenceTypes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EFCore/EntityFrameworkQueryableExtensions.cs
+++ b/src/EFCore/EntityFrameworkQueryableExtensions.cs
@@ -3136,7 +3136,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         private static MethodInfo GetMethod<TResult>(
-            string name, int parameterCount = 0, Func<MethodInfo, bool> predicate = null)
+            string name, int parameterCount = 0, Func<MethodInfo, bool>? predicate = null)
             => GetMethod(
                 name,
                 parameterCount,
@@ -3144,7 +3144,7 @@ namespace Microsoft.EntityFrameworkCore
                       && (predicate == null || predicate(mi)));
 
         private static MethodInfo GetMethod(
-            string name, int parameterCount = 0, Func<MethodInfo, bool> predicate = null)
+            string name, int parameterCount = 0, Func<MethodInfo, bool>? predicate = null)
             => typeof(Queryable).GetTypeInfo().GetDeclaredMethods(name)
                 .Single(
                     mi => mi.GetParameters().Length == parameterCount + 1

--- a/src/EFCore/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/EFCore/EntityFrameworkServiceCollectionExtensions.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Extensions.DependencyInjection
         ///           public void ConfigureServices(IServiceCollection services)
         ///           {
         ///               var connectionString = "connection string to database";
-        /// 
+        ///
         ///               services.AddDbContext&lt;MyContext&gt;(options => options.UseSqlServer(connectionString));
         ///           }
         ///       </code>
@@ -60,7 +60,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </returns>
         public static IServiceCollection AddDbContext<TContext>(
             [NotNull] this IServiceCollection serviceCollection,
-            [CanBeNull] Action<DbContextOptionsBuilder> optionsAction = null,
+            [CanBeNull] Action<DbContextOptionsBuilder>? optionsAction = null,
             ServiceLifetime contextLifetime = ServiceLifetime.Scoped,
             ServiceLifetime optionsLifetime = ServiceLifetime.Scoped)
             where TContext : DbContext
@@ -76,7 +76,7 @@ namespace Microsoft.Extensions.DependencyInjection
         ///           public void ConfigureServices(IServiceCollection services)
         ///           {
         ///               var connectionString = "connection string to database";
-        /// 
+        ///
         ///               services.AddDbContext&lt;MyContext&gt;(options => options.UseSqlServer(connectionString));
         ///           }
         ///       </code>
@@ -107,7 +107,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </returns>
         public static IServiceCollection AddDbContext<TContextService, TContextImplementation>(
             [NotNull] this IServiceCollection serviceCollection,
-            [CanBeNull] Action<DbContextOptionsBuilder> optionsAction = null,
+            [CanBeNull] Action<DbContextOptionsBuilder>? optionsAction = null,
             ServiceLifetime contextLifetime = ServiceLifetime.Scoped,
             ServiceLifetime optionsLifetime = ServiceLifetime.Scoped)
             where TContextImplementation : DbContext, TContextService
@@ -305,7 +305,7 @@ namespace Microsoft.Extensions.DependencyInjection
         ///           public void ConfigureServices(IServiceCollection services)
         ///           {
         ///               var connectionString = "connection string to database";
-        /// 
+        ///
         ///               services.AddDbContext&lt;MyContext&gt;(ServiceLifetime.Scoped);
         ///           }
         ///       </code>
@@ -334,7 +334,7 @@ namespace Microsoft.Extensions.DependencyInjection
         ///           public void ConfigureServices(IServiceCollection services)
         ///           {
         ///               var connectionString = "connection string to database";
-        /// 
+        ///
         ///               services.AddDbContext&lt;MyContext&gt;(ServiceLifetime.Scoped);
         ///           }
         ///       </code>
@@ -379,7 +379,7 @@ namespace Microsoft.Extensions.DependencyInjection
         ///           public void ConfigureServices(IServiceCollection services)
         ///           {
         ///               var connectionString = "connection string to database";
-        /// 
+        ///
         ///               services
         ///                   .AddEntityFrameworkSqlServer()
         ///                   .AddDbContext&lt;MyContext&gt;((serviceProvider, options) =>
@@ -439,7 +439,7 @@ namespace Microsoft.Extensions.DependencyInjection
         ///           public void ConfigureServices(IServiceCollection services)
         ///           {
         ///               var connectionString = "connection string to database";
-        /// 
+        ///
         ///               services
         ///                   .AddEntityFrameworkSqlServer()
         ///                   .AddDbContext&lt;MyContext&gt;((serviceProvider, options) =>

--- a/src/EFCore/Internal/LazyLoader.cs
+++ b/src/EFCore/Internal/LazyLoader.cs
@@ -54,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         // ReSharper disable once AssignNullToNotNullAttribute
-        public virtual void Load(object entity, [CallerMemberName] string navigationName = null)
+        public virtual void Load(object entity, [CallerMemberName] string? navigationName = null)
         {
             Check.NotNull(entity, nameof(entity));
             Check.NotEmpty(navigationName, nameof(navigationName));
@@ -73,7 +73,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
             object entity,
             CancellationToken cancellationToken = default,
             // ReSharper disable once AssignNullToNotNullAttribute
-            [CallerMemberName] string navigationName = null)
+            [CallerMemberName] string? navigationName = null)
         {
             Check.NotNull(entity, nameof(entity));
             Check.NotEmpty(navigationName, nameof(navigationName));

--- a/src/EFCore/Internal/NonCapturingLazyInitializer.cs
+++ b/src/EFCore/Internal/NonCapturingLazyInitializer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static TValue EnsureInitialized<TParam, TValue>(
-            [CanBeNull] ref TValue target,
+            [CanBeNull] ref TValue? target,
             [CanBeNull] TParam param,
             [NotNull] Func<TParam, TValue> valueFactory)
             where TValue : class

--- a/src/EFCore/Metadata/Builders/CollectionNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/CollectionNavigationBuilder.cs
@@ -31,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         public CollectionNavigationBuilder(
             [NotNull] EntityType declaringEntityType,
             [NotNull] EntityType relatedEntityType,
-            [CanBeNull] string navigationName,
+            [CanBeNull] string? navigationName,
             [NotNull] InternalRelationshipBuilder builder)
         {
             Check.NotNull(builder, nameof(builder));
@@ -49,7 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         public CollectionNavigationBuilder(
             [NotNull] EntityType declaringEntityType,
             [NotNull] EntityType relatedEntityType,
-            [CanBeNull] PropertyInfo navigationProperty,
+            [CanBeNull] PropertyInfo? navigationProperty,
             [NotNull] InternalRelationshipBuilder builder)
         {
             Check.NotNull(builder, nameof(builder));
@@ -113,7 +113,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     If null or not specified, then there is no navigation property on the other end of the relationship.
         /// </param>
         /// <returns> An object to further configure the relationship. </returns>
-        public virtual ReferenceCollectionBuilder WithOne([CanBeNull] string navigationName = null)
+        public virtual ReferenceCollectionBuilder WithOne([CanBeNull] string? navigationName = null)
             => new ReferenceCollectionBuilder(
                 DeclaringEntityType,
                 RelatedEntityType,
@@ -123,14 +123,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected virtual InternalRelationshipBuilder WithOneBuilder([CanBeNull] string navigationName)
+        protected virtual InternalRelationshipBuilder WithOneBuilder([CanBeNull] string? navigationName)
             => WithOneBuilder(PropertyIdentity.Create(navigationName));
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected virtual InternalRelationshipBuilder WithOneBuilder([CanBeNull] PropertyInfo navigationProperty)
+        protected virtual InternalRelationshipBuilder WithOneBuilder([CanBeNull] PropertyInfo? navigationProperty)
             => WithOneBuilder(PropertyIdentity.Create(navigationProperty));
 
         private InternalRelationshipBuilder WithOneBuilder(PropertyIdentity reference)

--- a/src/EFCore/Metadata/Builders/CollectionNavigationBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/CollectionNavigationBuilder`.cs
@@ -34,7 +34,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         public CollectionNavigationBuilder(
             [NotNull] EntityType declaringEntityType,
             [NotNull] EntityType relatedEntityType,
-            [CanBeNull] string navigationName,
+            [CanBeNull] string? navigationName,
             [NotNull] InternalRelationshipBuilder builder)
             : base(declaringEntityType, relatedEntityType, navigationName, builder)
         {
@@ -47,7 +47,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         public CollectionNavigationBuilder(
             [NotNull] EntityType declaringEntityType,
             [NotNull] EntityType relatedEntityType,
-            [CanBeNull] PropertyInfo navigationProperty,
+            [CanBeNull] PropertyInfo? navigationProperty,
             [NotNull] InternalRelationshipBuilder builder)
             : base(declaringEntityType, relatedEntityType, navigationProperty, builder)
         {
@@ -61,7 +61,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     If null, there is no navigation property on the other end of the relationship.
         /// </param>
         /// <returns> An object to further configure the relationship. </returns>
-        public new virtual ReferenceCollectionBuilder<TEntity, TRelatedEntity> WithOne([CanBeNull] string navigationName = null)
+        public new virtual ReferenceCollectionBuilder<TEntity, TRelatedEntity> WithOne([CanBeNull] string? navigationName = null)
             => new ReferenceCollectionBuilder<TEntity, TRelatedEntity>(
                 DeclaringEntityType,
                 RelatedEntityType,
@@ -84,7 +84,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// </param>
         /// <returns> An object to further configure the relationship. </returns>
         public virtual ReferenceCollectionBuilder<TEntity, TRelatedEntity> WithOne(
-            [CanBeNull] Expression<Func<TRelatedEntity, TEntity>> navigationExpression)
+            [CanBeNull] Expression<Func<TRelatedEntity, TEntity>>? navigationExpression)
             => new ReferenceCollectionBuilder<TEntity, TRelatedEntity>(
                 DeclaringEntityType,
                 RelatedEntityType,

--- a/src/EFCore/Metadata/Builders/CollectionOwnershipBuilder.cs
+++ b/src/EFCore/Metadata/Builders/CollectionOwnershipBuilder.cs
@@ -547,7 +547,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> An object that can be used to configure the relationship. </returns>
         public virtual ReferenceNavigationBuilder HasOne(
             [NotNull] string relatedTypeName,
-            [CanBeNull] string navigationName = null)
+            [CanBeNull] string? navigationName = null)
         {
             Check.NotEmpty(relatedTypeName, nameof(relatedTypeName));
             Check.NullButNotEmpty(navigationName, nameof(navigationName));
@@ -590,7 +590,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> An object that can be used to configure the relationship. </returns>
         public virtual ReferenceNavigationBuilder HasOne(
             [NotNull] Type relatedType,
-            [CanBeNull] string navigationName = null)
+            [CanBeNull] string? navigationName = null)
         {
             Check.NotNull(relatedType, nameof(relatedType));
             Check.NullButNotEmpty(navigationName, nameof(navigationName));

--- a/src/EFCore/Metadata/Builders/CollectionOwnershipBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/CollectionOwnershipBuilder`.cs
@@ -633,7 +633,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// </param>
         /// <returns> An object that can be used to configure the relationship. </returns>
         public virtual ReferenceNavigationBuilder<TDependentEntity, TNewRelatedEntity> HasOne<TNewRelatedEntity>(
-            [CanBeNull] Expression<Func<TDependentEntity, TNewRelatedEntity>> navigationExpression = null)
+            [CanBeNull] Expression<Func<TDependentEntity, TNewRelatedEntity>>? navigationExpression = null)
             where TNewRelatedEntity : class
         {
             var navigation = navigationExpression?.GetPropertyAccess();

--- a/src/EFCore/Metadata/Builders/EntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Builders/EntityTypeBuilder.cs
@@ -488,7 +488,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> An object that can be used to configure the relationship. </returns>
         public virtual ReferenceNavigationBuilder HasOne(
             [NotNull] string relatedTypeName,
-            [CanBeNull] string navigationName = null)
+            [CanBeNull] string? navigationName = null)
         {
             Check.NotEmpty(relatedTypeName, nameof(relatedTypeName));
             Check.NullButNotEmpty(navigationName, nameof(navigationName));
@@ -531,7 +531,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> An object that can be used to configure the relationship. </returns>
         public virtual ReferenceNavigationBuilder HasOne(
             [NotNull] Type relatedType,
-            [CanBeNull] string navigationName = null)
+            [CanBeNull] string? navigationName = null)
         {
             Check.NotNull(relatedType, nameof(relatedType));
             Check.NullButNotEmpty(navigationName, nameof(navigationName));
@@ -573,7 +573,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> An object that can be used to configure the relationship. </returns>
         public virtual CollectionNavigationBuilder HasMany(
             [NotNull] string relatedTypeName,
-            [CanBeNull] string navigationName = null)
+            [CanBeNull] string? navigationName = null)
         {
             Check.NotEmpty(relatedTypeName, nameof(relatedTypeName));
             Check.NullButNotEmpty(navigationName, nameof(navigationName));
@@ -624,7 +624,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> An object that can be used to configure the relationship. </returns>
         public virtual CollectionNavigationBuilder HasMany(
             [NotNull] Type relatedType,
-            [CanBeNull] string navigationName = null)
+            [CanBeNull] string? navigationName = null)
         {
             Check.NotNull(relatedType, nameof(relatedType));
             Check.NullButNotEmpty(navigationName, nameof(navigationName));

--- a/src/EFCore/Metadata/Builders/EntityTypeBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/EntityTypeBuilder`.cs
@@ -501,7 +501,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// </param>
         /// <returns> An object that can be used to configure the relationship. </returns>
         public virtual ReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne<TRelatedEntity>(
-            [CanBeNull] Expression<Func<TEntity, TRelatedEntity>> navigationExpression = null)
+            [CanBeNull] Expression<Func<TEntity, TRelatedEntity>>? navigationExpression = null)
             where TRelatedEntity : class
         {
             var navigation = navigationExpression?.GetPropertyAccess();
@@ -593,7 +593,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// </param>
         /// <returns> An object that can be used to configure the relationship. </returns>
         public virtual CollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany<TRelatedEntity>(
-            [CanBeNull] Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression = null)
+            [CanBeNull] Expression<Func<TEntity, IEnumerable<TRelatedEntity>>>? navigationExpression = null)
             where TRelatedEntity : class
         {
             var navigation = navigationExpression?.GetPropertyAccess();

--- a/src/EFCore/Metadata/Builders/QueryTypeBuilder.cs
+++ b/src/EFCore/Metadata/Builders/QueryTypeBuilder.cs
@@ -204,7 +204,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> An object that can be used to configure the relationship. </returns>
         public virtual ReferenceNavigationBuilder HasOne(
             [NotNull] string relatedTypeName,
-            [CanBeNull] string navigationName = null)
+            [CanBeNull] string? navigationName = null)
         {
             Check.NotEmpty(relatedTypeName, nameof(relatedTypeName));
             Check.NullButNotEmpty(navigationName, nameof(navigationName));
@@ -242,7 +242,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> An object that can be used to configure the relationship. </returns>
         public virtual ReferenceNavigationBuilder HasOne(
             [NotNull] Type relatedType,
-            [CanBeNull] string navigationName = null)
+            [CanBeNull] string? navigationName = null)
         {
             Check.NotNull(relatedType, nameof(relatedType));
             Check.NullButNotEmpty(navigationName, nameof(navigationName));

--- a/src/EFCore/Metadata/Builders/QueryTypeBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/QueryTypeBuilder`.cs
@@ -158,7 +158,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// </param>
         /// <returns> An object that can be used to configure the relationship. </returns>
         public virtual ReferenceNavigationBuilder<TQuery, TRelatedEntity> HasOne<TRelatedEntity>(
-            [CanBeNull] Expression<Func<TQuery, TRelatedEntity>> navigationExpression = null)
+            [CanBeNull] Expression<Func<TQuery, TRelatedEntity>>? navigationExpression = null)
             where TRelatedEntity : class
         {
             var relatedEntityType = Builder.Metadata.FindInDefinitionPath(typeof(TRelatedEntity)) ??

--- a/src/EFCore/Metadata/Builders/ReferenceNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/ReferenceNavigationBuilder.cs
@@ -111,7 +111,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     If null or not specified, there is no navigation property on the other end of the relationship.
         /// </param>
         /// <returns> An object to further configure the relationship. </returns>
-        public virtual ReferenceCollectionBuilder WithMany([CanBeNull] string collection = null)
+        public virtual ReferenceCollectionBuilder WithMany([CanBeNull] string? collection = null)
             => new ReferenceCollectionBuilder(
                 RelatedEntityType,
                 DeclaringEntityType,
@@ -177,7 +177,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     If null or not specified, there is no navigation property on the other end of the relationship.
         /// </param>
         /// <returns> An object to further configure the relationship. </returns>
-        public virtual ReferenceReferenceBuilder WithOne([CanBeNull] string reference = null)
+        public virtual ReferenceReferenceBuilder WithOne([CanBeNull] string? reference = null)
             => new ReferenceReferenceBuilder(
                 DeclaringEntityType,
                 RelatedEntityType,
@@ -187,14 +187,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected virtual InternalRelationshipBuilder WithOneBuilder([CanBeNull] string navigationName)
+        protected virtual InternalRelationshipBuilder WithOneBuilder([CanBeNull] string? navigationName)
             => WithOneBuilder(PropertyIdentity.Create(navigationName));
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected virtual InternalRelationshipBuilder WithOneBuilder([CanBeNull] PropertyInfo navigationProperty)
+        protected virtual InternalRelationshipBuilder WithOneBuilder([CanBeNull] PropertyInfo? navigationProperty)
             => WithOneBuilder(PropertyIdentity.Create(navigationProperty));
 
         private InternalRelationshipBuilder WithOneBuilder(PropertyIdentity reference)

--- a/src/EFCore/Metadata/Builders/ReferenceNavigationBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/ReferenceNavigationBuilder`.cs
@@ -69,7 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     If null or not specified, there is no navigation property on the other end of the relationship.
         /// </param>
         /// <returns> An object to further configure the relationship. </returns>
-        public new virtual ReferenceCollectionBuilder<TRelatedEntity, TEntity> WithMany([CanBeNull] string navigationName = null)
+        public new virtual ReferenceCollectionBuilder<TRelatedEntity, TEntity> WithMany([CanBeNull] string? navigationName = null)
             => new ReferenceCollectionBuilder<TRelatedEntity, TEntity>(
                 RelatedEntityType,
                 DeclaringEntityType,
@@ -113,7 +113,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     If null or not specified, there is no navigation property on the other end of the relationship.
         /// </param>
         /// <returns> An object to further configure the relationship. </returns>
-        public new virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne([CanBeNull] string navigationName = null)
+        public new virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne([CanBeNull] string? navigationName = null)
             => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
                 DeclaringEntityType,
                 RelatedEntityType,

--- a/src/EFCore/Metadata/Builders/ReferenceOwnershipBuilder.cs
+++ b/src/EFCore/Metadata/Builders/ReferenceOwnershipBuilder.cs
@@ -549,7 +549,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> An object that can be used to configure the relationship. </returns>
         public virtual ReferenceNavigationBuilder HasOne(
             [NotNull] string relatedTypeName,
-            [CanBeNull] string navigationName = null)
+            [CanBeNull] string? navigationName = null)
         {
             Check.NotEmpty(relatedTypeName, nameof(relatedTypeName));
             Check.NullButNotEmpty(navigationName, nameof(navigationName));
@@ -592,7 +592,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> An object that can be used to configure the relationship. </returns>
         public virtual ReferenceNavigationBuilder HasOne(
             [NotNull] Type relatedType,
-            [CanBeNull] string navigationName = null)
+            [CanBeNull] string? navigationName = null)
         {
             Check.NotNull(relatedType, nameof(relatedType));
             Check.NullButNotEmpty(navigationName, nameof(navigationName));
@@ -634,7 +634,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> An object that can be used to configure the relationship. </returns>
         public virtual CollectionNavigationBuilder HasMany(
             [NotNull] string relatedTypeName,
-            [CanBeNull] string navigationName = null)
+            [CanBeNull] string? navigationName = null)
         {
             Check.NotEmpty(relatedTypeName, nameof(relatedTypeName));
             Check.NullButNotEmpty(navigationName, nameof(navigationName));
@@ -685,7 +685,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> An object that can be used to configure the relationship. </returns>
         public virtual CollectionNavigationBuilder HasMany(
             [NotNull] Type relatedType,
-            [CanBeNull] string navigationName = null)
+            [CanBeNull] string? navigationName = null)
         {
             Check.NotNull(relatedType, nameof(relatedType));
             Check.NullButNotEmpty(navigationName, nameof(navigationName));

--- a/src/EFCore/Metadata/Builders/ReferenceOwnershipBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/ReferenceOwnershipBuilder`.cs
@@ -635,7 +635,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// </param>
         /// <returns> An object that can be used to configure the relationship. </returns>
         public virtual ReferenceNavigationBuilder<TRelatedEntity, TNewRelatedEntity> HasOne<TNewRelatedEntity>(
-            [CanBeNull] Expression<Func<TRelatedEntity, TNewRelatedEntity>> navigationExpression = null)
+            [CanBeNull] Expression<Func<TRelatedEntity, TNewRelatedEntity>>? navigationExpression = null)
             where TNewRelatedEntity : class
         {
             var navigation = navigationExpression?.GetPropertyAccess();
@@ -676,7 +676,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// </param>
         /// <returns> An object that can be used to configure the relationship. </returns>
         public virtual CollectionNavigationBuilder<TRelatedEntity, TNewRelatedEntity> HasMany<TNewRelatedEntity>(
-            [CanBeNull] Expression<Func<TRelatedEntity, IEnumerable<TNewRelatedEntity>>> navigationExpression = null)
+            [CanBeNull] Expression<Func<TRelatedEntity, IEnumerable<TNewRelatedEntity>>>? navigationExpression = null)
             where TNewRelatedEntity : class
         {
             var navigation = navigationExpression?.GetPropertyAccess();

--- a/src/EFCore/Metadata/Conventions/Internal/ConventionNode.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ConventionNode.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             private bool _readonly;
 #endif
 
-            public ConventionScope(ConventionScope parent, List<ConventionNode> children = null)
+            public ConventionScope(ConventionScope parent, List<ConventionNode>? children = null)
             {
                 Parent = parent;
                 _children = children;

--- a/src/EFCore/Metadata/Internal/ContextParameterBinding.cs
+++ b/src/EFCore/Metadata/Internal/ContextParameterBinding.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public ContextParameterBinding(
             [NotNull] Type contextType,
-            [CanBeNull] IPropertyBase consumedProperty = null)
+            [CanBeNull] IPropertyBase? consumedProperty = null)
             : base(contextType, contextType, consumedProperty)
         {
         }

--- a/src/EFCore/Metadata/Internal/DefaultServiceParameterBinding.cs
+++ b/src/EFCore/Metadata/Internal/DefaultServiceParameterBinding.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public DefaultServiceParameterBinding(
             [NotNull] Type parameterType,
             [NotNull] Type serviceType,
-            [CanBeNull] IPropertyBase consumedProperty = null)
+            [CanBeNull] IPropertyBase? consumedProperty = null)
             : base(parameterType, serviceType, consumedProperty)
         {
         }

--- a/src/EFCore/Metadata/Internal/EntityMaterializerSource.cs
+++ b/src/EFCore/Metadata/Internal/EntityMaterializerSource.cs
@@ -57,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual Expression CreateMaterializeExpression(
             IEntityType entityType,
             Expression materializationExpression,
-            int[] indexMap = null)
+            int[]? indexMap = null)
         {
             if (!entityType.HasClrType())
             {

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -1584,7 +1584,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual Property AddProperty(
             [NotNull] string name,
-            [CanBeNull] Type propertyType = null,
+            [CanBeNull] Type? propertyType = null,
             // ReSharper disable once MethodOverloadWithOptionalParameter
             ConfigurationSource configurationSource = ConfigurationSource.Explicit,
             ConfigurationSource? typeConfigurationSource = ConfigurationSource.Explicit)

--- a/src/EFCore/Metadata/Internal/EntityTypeParameterBinding.cs
+++ b/src/EFCore/Metadata/Internal/EntityTypeParameterBinding.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public EntityTypeParameterBinding([CanBeNull] IPropertyBase consumedProperty = null)
+        public EntityTypeParameterBinding([CanBeNull] IPropertyBase? consumedProperty = null)
             : base(typeof(IEntityType), typeof(IEntityType), consumedProperty)
         {
         }

--- a/src/EFCore/Metadata/Internal/IEntityMaterializerSource.cs
+++ b/src/EFCore/Metadata/Internal/IEntityMaterializerSource.cs
@@ -31,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         Expression CreateMaterializeExpression(
             [NotNull] IEntityType entityType,
             [NotNull] Expression materializationExpression,
-            [CanBeNull] int[] indexMap = null);
+            [CanBeNull] int[]? indexMap = null);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -2608,7 +2608,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual IReadOnlyList<Property> GetOrCreateProperties(
             [CanBeNull] IReadOnlyList<string> propertyNames,
             ConfigurationSource? configurationSource,
-            [CanBeNull] IReadOnlyList<Property> referencedProperties = null,
+            [CanBeNull] IReadOnlyList<Property>? referencedProperties = null,
             bool required = false,
             bool useDefaultType = false)
         {

--- a/src/EFCore/Metadata/Internal/InternalModelBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalModelBuilder.cs
@@ -528,7 +528,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual IReadOnlyList<InternalEntityTypeBuilder> FindLeastDerivedEntityTypes([NotNull] Type type, [CanBeNull] Func<InternalEntityTypeBuilder, bool> condition = null)
+        public virtual IReadOnlyList<InternalEntityTypeBuilder> FindLeastDerivedEntityTypes([NotNull] Type type, [CanBeNull] Func<InternalEntityTypeBuilder, bool>? condition = null)
         {
             var cache = new Dictionary<TypeInfo, int>
             {

--- a/src/EFCore/Metadata/Internal/InternalRelationshipBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalRelationshipBuilder.cs
@@ -1501,7 +1501,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         private bool CanSetForeignKey(
             IReadOnlyList<Property> properties,
             ConfigurationSource? configurationSource,
-            EntityType dependentEntityType = null,
+            EntityType? dependentEntityType = null,
             bool overrideSameSource = true)
             => CanSetForeignKey(
                 properties,
@@ -1513,7 +1513,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         private bool CanSetForeignKey(
             IReadOnlyList<Property> properties,
-            EntityType dependentEntityType,
+            EntityType? dependentEntityType,
             ConfigurationSource? configurationSource,
             out bool resetIsRequired,
             out bool resetPrincipalKey,
@@ -1536,7 +1536,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         private bool CanSetForeignKey(
             IReadOnlyList<Property> properties,
-            EntityType dependentEntityType,
+            EntityType? dependentEntityType,
             IReadOnlyList<Property> principalKeyProperties,
             EntityType principalEntityType,
             ConfigurationSource? configurationSource,
@@ -1719,13 +1719,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         private InternalRelationshipBuilder ReplaceForeignKey(
             ConfigurationSource? configurationSource,
-            InternalEntityTypeBuilder principalEntityTypeBuilder = null,
-            InternalEntityTypeBuilder dependentEntityTypeBuilder = null,
+            InternalEntityTypeBuilder? principalEntityTypeBuilder = null,
+            InternalEntityTypeBuilder? dependentEntityTypeBuilder = null,
             PropertyIdentity? navigationToPrincipal = null,
             PropertyIdentity? navigationToDependent = null,
-            IReadOnlyList<Property> dependentProperties = null,
-            IReadOnlyList<Property> oldNameDependentProperties = null,
-            IReadOnlyList<Property> principalProperties = null,
+            IReadOnlyList<Property>? dependentProperties = null,
+            IReadOnlyList<Property>? oldNameDependentProperties = null,
+            IReadOnlyList<Property>? principalProperties = null,
             bool? isUnique = null,
             bool? isRequired = null,
             bool? isOwnership = null,

--- a/src/EFCore/Metadata/Internal/PropertyIdentity.cs
+++ b/src/EFCore/Metadata/Internal/PropertyIdentity.cs
@@ -59,7 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         [DebuggerStepThrough]
-        public static PropertyIdentity Create([CanBeNull] string name)
+        public static PropertyIdentity Create([CanBeNull] string? name)
             => name == null ? None : new PropertyIdentity(name);
 
         /// <summary>
@@ -67,14 +67,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         [DebuggerStepThrough]
-        public static PropertyIdentity Create([CanBeNull] MemberInfo property)
+        public static PropertyIdentity Create([CanBeNull] MemberInfo? property)
             => property == null ? None : new PropertyIdentity(property);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public static PropertyIdentity Create([CanBeNull] Navigation navigation)
+        public static PropertyIdentity Create([CanBeNull] Navigation? navigation)
             => navigation?.GetIdentifyingMemberInfo() == null
                 ? Create(navigation?.Name)
                 : Create(navigation.GetIdentifyingMemberInfo());

--- a/src/EFCore/Metadata/Internal/RelationshipSnapshot.cs
+++ b/src/EFCore/Metadata/Internal/RelationshipSnapshot.cs
@@ -40,7 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual InternalRelationshipBuilder Attach([CanBeNull] InternalEntityTypeBuilder entityTypeBuilder = null)
+        public virtual InternalRelationshipBuilder Attach([CanBeNull] InternalEntityTypeBuilder? entityTypeBuilder = null)
         {
             entityTypeBuilder = entityTypeBuilder ?? Relationship.Metadata.DeclaringEntityType.Builder;
             var newRelationship = Relationship.Attach(entityTypeBuilder);

--- a/src/EFCore/Metadata/Internal/ServiceMethodParameterBinding.cs
+++ b/src/EFCore/Metadata/Internal/ServiceMethodParameterBinding.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             [NotNull] Type parameterType,
             [NotNull] Type serviceType,
             [NotNull] MethodInfo method,
-            [CanBeNull] IPropertyBase consumedProperty = null)
+            [CanBeNull] IPropertyBase? consumedProperty = null)
             : base(parameterType, serviceType, consumedProperty)
         {
             Method = method;

--- a/src/EFCore/Metadata/Internal/ServiceParameterBinding.cs
+++ b/src/EFCore/Metadata/Internal/ServiceParameterBinding.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         protected ServiceParameterBinding(
             [NotNull] Type parameterType,
             [NotNull] Type serviceType,
-            [CanBeNull] IPropertyBase consumedProperty = null)
+            [CanBeNull] IPropertyBase? consumedProperty = null)
             : base(parameterType, consumedProperty != null ? new[] { consumedProperty } : Array.Empty<IPropertyBase>())
         {
             ServiceType = serviceType;

--- a/src/EFCore/ModelBuilder.cs
+++ b/src/EFCore/ModelBuilder.cs
@@ -343,7 +343,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns>
         ///     The same <see cref="ModelBuilder" /> instance so that additional configuration calls can be chained.
         /// </returns>
-        public virtual ModelBuilder ApplyConfigurationsFromAssembly(Assembly assembly, Func<Type, bool> predicate = null)
+        public virtual ModelBuilder ApplyConfigurationsFromAssembly(Assembly assembly, Func<Type, bool>? predicate = null)
         {
             var applyEntityConfigurationMethod = typeof(ModelBuilder)
                 .GetMethods()

--- a/src/EFCore/Query/EntityLoadInfo.cs
+++ b/src/EFCore/Query/EntityLoadInfo.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Query
     public readonly struct EntityLoadInfo
     {
         private readonly Func<MaterializationContext, object> _materializer;
-        private readonly Dictionary<Type, int[]> _typeIndexMap;
+        private readonly Dictionary<Type, int[]>? _typeIndexMap;
         private readonly MaterializationContext _materializationContext;
 
         /// <summary>
@@ -34,7 +34,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         public EntityLoadInfo(
             in MaterializationContext materializationContext,
             [NotNull] Func<MaterializationContext, object> materializer,
-            [CanBeNull] Dictionary<Type, int[]> typeIndexMap = null)
+            [CanBeNull] Dictionary<Type, int[]>? typeIndexMap = null)
         {
             // hot path
             Debug.Assert(materializer != null);

--- a/src/EFCore/Query/EntityQueryModelVisitor.cs
+++ b/src/EFCore/Query/EntityQueryModelVisitor.cs
@@ -542,7 +542,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// </summary>
         /// <param name="queryModel"> The query. </param>
         /// <param name="type"> The type of results returned by the query. </param>
-        protected virtual void SingleResultToSequence([NotNull] QueryModel queryModel, [CanBeNull] Type type = null)
+        protected virtual void SingleResultToSequence([NotNull] QueryModel queryModel, [CanBeNull] Type? type = null)
         {
             Check.NotNull(queryModel, nameof(queryModel));
 
@@ -1432,7 +1432,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// </returns>
         public virtual Expression ReplaceClauseReferences(
             [NotNull] Expression expression,
-            [CanBeNull] IQuerySource querySource = null,
+            [CanBeNull] IQuerySource? querySource = null,
             bool inProjection = false)
         {
             Check.NotNull(expression, nameof(expression));
@@ -1530,7 +1530,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             [NotNull] Type memberType,
             [NotNull] Expression expression,
             int index,
-            [CanBeNull] IProperty property = null)
+            [CanBeNull] IProperty? property = null)
         {
             Check.NotNull(memberType, nameof(memberType));
             Check.NotNull(expression, nameof(expression));

--- a/src/EFCore/Storage/CoreTypeMapping.cs
+++ b/src/EFCore/Storage/CoreTypeMapping.cs
@@ -39,10 +39,10 @@ namespace Microsoft.EntityFrameworkCore.Storage
             /// <param name="valueGeneratorFactory"> An optional factory for creating a specific <see cref="ValueGenerator" />. </param>
             public CoreTypeMappingParameters(
                 [NotNull] Type clrType,
-                [CanBeNull] ValueConverter converter = null,
-                [CanBeNull] ValueComparer comparer = null,
-                [CanBeNull] ValueComparer keyComparer = null,
-                [CanBeNull] Func<IProperty, IEntityType, ValueGenerator> valueGeneratorFactory = null)
+                [CanBeNull] ValueConverter? converter = null,
+                [CanBeNull] ValueComparer? comparer = null,
+                [CanBeNull] ValueComparer? keyComparer = null,
+                [CanBeNull] Func<IProperty, IEntityType, ValueGenerator>? valueGeneratorFactory = null)
                 : this(clrType, converter, comparer, keyComparer, null, valueGeneratorFactory)
             {
             }
@@ -58,11 +58,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
             /// <param name="valueGeneratorFactory"> An optional factory for creating a specific <see cref="ValueGenerator" />. </param>
             public CoreTypeMappingParameters(
                 [NotNull] Type clrType,
-                [CanBeNull] ValueConverter converter,
-                [CanBeNull] ValueComparer comparer,
-                [CanBeNull] ValueComparer keyComparer,
-                [CanBeNull] ValueComparer structuralComparer,
-                [CanBeNull] Func<IProperty, IEntityType, ValueGenerator> valueGeneratorFactory)
+                [CanBeNull] ValueConverter? converter,
+                [CanBeNull] ValueComparer? comparer,
+                [CanBeNull] ValueComparer? keyComparer,
+                [CanBeNull] ValueComparer? structuralComparer,
+                [CanBeNull] Func<IProperty, IEntityType, ValueGenerator>? valueGeneratorFactory)
             {
                 Check.NotNull(clrType, nameof(clrType));
 
@@ -82,28 +82,28 @@ namespace Microsoft.EntityFrameworkCore.Storage
             /// <summary>
             ///     The mapping converter.
             /// </summary>
-            public ValueConverter Converter { get; }
+            public ValueConverter? Converter { get; }
 
             /// <summary>
             ///     The mapping comparer.
             /// </summary>
-            public ValueComparer Comparer { get; }
+            public ValueComparer? Comparer { get; }
 
             /// <summary>
             ///     The mapping key comparer.
             /// </summary>
-            public ValueComparer KeyComparer { get; }
+            public ValueComparer? KeyComparer { get; }
 
             /// <summary>
             ///     The mapping structural comparer.
             /// </summary>
-            public ValueComparer StructuralComparer { get; }
+            public ValueComparer? StructuralComparer { get; }
 
             /// <summary>
             ///     An optional factory for creating a specific <see cref="ValueGenerator" /> to use with
             ///     this mapping.
             /// </summary>
-            public Func<IProperty, IEntityType, ValueGenerator> ValueGeneratorFactory { get; }
+            public Func<IProperty, IEntityType, ValueGenerator>? ValueGeneratorFactory { get; }
 
             /// <summary>
             ///     Creates a new <see cref="CoreTypeMappingParameters" /> parameter object with the given
@@ -121,9 +121,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
                     ValueGeneratorFactory);
         }
 
-        private ValueComparer _comparer;
-        private ValueComparer _keyComparer;
-        private readonly ValueComparer _structuralComparer;
+        private ValueComparer? _comparer;
+        private ValueComparer? _keyComparer;
+        private readonly ValueComparer? _structuralComparer;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="CoreTypeMapping" /> class.
@@ -171,13 +171,13 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Converts types to and from the store whenever this mapping is used.
         ///     May be null if no conversion is needed.
         /// </summary>
-        public virtual ValueConverter Converter => Parameters.Converter;
+        public virtual ValueConverter? Converter => Parameters.Converter;
 
         /// <summary>
         ///     An optional factory for creating a specific <see cref="ValueGenerator" /> to use with
         ///     this mapping.
         /// </summary>
-        public virtual Func<IProperty, IEntityType, ValueGenerator> ValueGeneratorFactory { get; }
+        public virtual Func<IProperty, IEntityType, ValueGenerator>? ValueGeneratorFactory { get; }
 
         /// <summary>
         ///     A <see cref="ValueComparer" /> adds custom value snapshotting and comparison for

--- a/src/EFCore/Storage/ExecutionStrategy.cs
+++ b/src/EFCore/Storage/ExecutionStrategy.cs
@@ -161,7 +161,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
         private TResult ExecuteImplementation<TState, TResult>(
             Func<DbContext, TState, TResult> operation,
-            Func<DbContext, TState, ExecutionResult<TResult>> verifySucceeded,
+            Func<DbContext, TState, ExecutionResult<TResult>>? verifySucceeded,
             TState state)
         {
             while (true)
@@ -253,7 +253,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
         private async Task<TResult> ExecuteImplementationAsync<TState, TResult>(
             Func<DbContext, TState, CancellationToken, Task<TResult>> operation,
-            Func<DbContext, TState, CancellationToken, Task<ExecutionResult<TResult>>> verifySucceeded,
+            Func<DbContext, TState, CancellationToken, Task<ExecutionResult<TResult>>>? verifySucceeded,
             TState state,
             CancellationToken cancellationToken)
         {

--- a/src/EFCore/Storage/ITypeMappingSource.cs
+++ b/src/EFCore/Storage/ITypeMappingSource.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="property"> The property. </param>
         /// <returns> The type mapping, or <c>null</c> if none was found. </returns>
-        CoreTypeMapping FindMapping([NotNull] IProperty property);
+        CoreTypeMapping? FindMapping([NotNull] IProperty property);
 
         /// <summary>
         ///     <para>
@@ -43,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="member"> The field or property. </param>
         /// <returns> The type mapping, or <c>null</c> if none was found. </returns>
-        CoreTypeMapping FindMapping([NotNull] MemberInfo member);
+        CoreTypeMapping? FindMapping([NotNull] MemberInfo member);
 
         /// <summary>
         ///     <para>
@@ -57,6 +57,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="type"> The CLR type. </param>
         /// <returns> The type mapping, or <c>null</c> if none was found. </returns>
-        CoreTypeMapping FindMapping([NotNull] Type type);
+        CoreTypeMapping? FindMapping([NotNull] Type type);
     }
 }

--- a/src/EFCore/Storage/TypeMappingInfo.cs
+++ b/src/EFCore/Storage/TypeMappingInfo.cs
@@ -34,7 +34,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         {
             Check.NotNull(principals, nameof(principals));
 
-            ValueConverter customConverter = null;
+            ValueConverter? customConverter = null;
             int? size = null;
             bool? isUnicode = null;
             for (var i = 0; i < principals.Count; i++)

--- a/src/EFCore/Storage/TypeMappingSourceBase.cs
+++ b/src/EFCore/Storage/TypeMappingSourceBase.cs
@@ -50,7 +50,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="mappingInfo"> The mapping info to use to create the mapping. </param>
         /// <returns> The type mapping, or <c>null</c> if none could be found. </returns>
-        protected virtual CoreTypeMapping FindMapping(in TypeMappingInfo mappingInfo)
+        protected virtual CoreTypeMapping? FindMapping(in TypeMappingInfo mappingInfo)
         {
             foreach (var plugin in Dependencies.Plugins)
             {
@@ -70,8 +70,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="mapping"> The mapping, if any. </param>
         /// <param name="property"> The property, if any. </param>
         protected virtual void ValidateMapping(
-            [CanBeNull] CoreTypeMapping mapping,
-            [CanBeNull] IProperty property)
+            [CanBeNull] CoreTypeMapping? mapping,
+            [CanBeNull] IProperty? property)
         {
         }
 
@@ -85,7 +85,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="property"> The property. </param>
         /// <returns> The type mapping, or <c>null</c> if none was found. </returns>
-        public abstract CoreTypeMapping FindMapping(IProperty property);
+        public abstract CoreTypeMapping? FindMapping(IProperty property);
 
         /// <summary>
         ///     <para>
@@ -102,7 +102,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="type"> The CLR type. </param>
         /// <returns> The type mapping, or <c>null</c> if none was found. </returns>
-        public abstract CoreTypeMapping FindMapping(Type type);
+        public abstract CoreTypeMapping? FindMapping(Type type);
 
         /// <summary>
         ///     <para>
@@ -119,6 +119,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="member"> The field or property. </param>
         /// <returns> The type mapping, or <c>null</c> if none was found. </returns>
-        public abstract CoreTypeMapping FindMapping(MemberInfo member);
+        public abstract CoreTypeMapping? FindMapping(MemberInfo member);
     }
 }

--- a/src/EFCore/Storage/ValueConversion/BoolToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/BoolToStringConverter.cs
@@ -26,7 +26,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         public BoolToStringConverter(
             [NotNull] string falseValue,
             [NotNull] string trueValue,
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 Check.NotEmpty(falseValue, nameof(falseValue)),
                 Check.NotEmpty(trueValue, nameof(trueValue)),

--- a/src/EFCore/Storage/ValueConversion/BoolToTwoValuesConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/BoolToTwoValuesConverter.cs
@@ -31,8 +31,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         public BoolToTwoValuesConverter(
             [CanBeNull] TProvider falseValue,
             [CanBeNull] TProvider trueValue,
-            [CanBeNull] Expression<Func<TProvider, bool>> fromProvider = null,
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] Expression<Func<TProvider, bool>>? fromProvider = null,
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(ToProvider(falseValue, trueValue), fromProvider ?? ToBool(trueValue), mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/BoolToZeroOneConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/BoolToZeroOneConverter.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public BoolToZeroOneConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public BoolToZeroOneConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(Zero(), One(), null, mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/BytesToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/BytesToStringConverter.cs
@@ -19,10 +19,12 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     facets for the converted data.
         /// </param>
         public BytesToStringConverter(
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
+#nullable disable
                 v => v == null ? null : Convert.ToBase64String(v),
                 v => v == null ? null : Convert.FromBase64String(v),
+#nullable enable
                 mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/CastingConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/CastingConverter.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         // ReSharper disable once StaticMemberInGenericType
         private static readonly ConverterMappingHints _defaultHints = CreateDefaultHints();
 
-        private static ConverterMappingHints CreateDefaultHints()
+        private static ConverterMappingHints? CreateDefaultHints()
         {
             if (typeof(TProvider).UnwrapNullableType() == typeof(decimal))
             {
@@ -41,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// <summary>
         ///     Creates a new instance of this converter.
         /// </summary>
-        public CastingConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public CastingConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 Convert<TModel, TProvider>(),
                 Convert<TProvider, TModel>(),

--- a/src/EFCore/Storage/ValueConversion/CharToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/CharToStringConverter.cs
@@ -21,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public CharToStringConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public CharToStringConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 ToString(),
                 ToChar(),

--- a/src/EFCore/Storage/ValueConversion/ConverterMappingHints.cs
+++ b/src/EFCore/Storage/ValueConversion/ConverterMappingHints.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
             int? precision = null,
             int? scale = null,
             bool? unicode = null,
-            [CanBeNull] Func<IProperty, IEntityType, ValueGenerator> valueGeneratorFactory = null)
+            [CanBeNull] Func<IProperty, IEntityType, ValueGenerator>? valueGeneratorFactory = null)
         {
             Size = size;
             Precision = precision;
@@ -42,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// </summary>
         /// <param name="hints"> The hints to add. </param>
         /// <returns> The combined hints. </returns>
-        public virtual ConverterMappingHints With([CanBeNull] ConverterMappingHints hints)
+        public virtual ConverterMappingHints With([CanBeNull] ConverterMappingHints? hints)
             => hints == null
                 ? this
                 : new ConverterMappingHints(
@@ -76,6 +76,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     An optional factory for creating a specific <see cref="ValueGenerator" /> to use for model
         ///     values when this converter is being used.
         /// </summary>
-        public virtual Func<IProperty, IEntityType, ValueGenerator> ValueGeneratorFactory { get; }
+        public virtual Func<IProperty, IEntityType, ValueGenerator>? ValueGeneratorFactory { get; }
     }
 }

--- a/src/EFCore/Storage/ValueConversion/DateTimeOffsetToBinaryConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/DateTimeOffsetToBinaryConverter.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public DateTimeOffsetToBinaryConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public DateTimeOffsetToBinaryConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 v => ((v.Ticks / 1000) << 11) | ((long)v.Offset.TotalMinutes & 0x7FF),
                 v => new DateTimeOffset(

--- a/src/EFCore/Storage/ValueConversion/DateTimeOffsetToBytesConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/DateTimeOffsetToBytesConverter.cs
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public DateTimeOffsetToBytesConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public DateTimeOffsetToBytesConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 v => ToBytes(v),
                 v => v == null ? default : FromBytes(v),
@@ -44,8 +44,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 
         private static byte[] ToBytes(DateTimeOffset value)
         {
-            var timeBytes = (byte[])_longToBytes.ConvertToProvider(value.DateTime.ToBinary());
-            var offsetBytes = (byte[])_shortToBytes.ConvertToProvider(value.Offset.TotalMinutes);
+            var timeBytes = (byte[])_longToBytes.ConvertToProvider(value.DateTime.ToBinary())!;
+            var offsetBytes = (byte[])_shortToBytes.ConvertToProvider(value.Offset.TotalMinutes)!;
             return timeBytes.Concat(offsetBytes).ToArray();
         }
 

--- a/src/EFCore/Storage/ValueConversion/DateTimeOffsetToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/DateTimeOffsetToStringConverter.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public DateTimeOffsetToStringConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public DateTimeOffsetToStringConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 ToString(),
                 ToDateTimeOffset(),

--- a/src/EFCore/Storage/ValueConversion/DateTimeToBinaryConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/DateTimeToBinaryConverter.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public DateTimeToBinaryConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public DateTimeToBinaryConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 v => v.ToBinary(),
                 v => DateTime.FromBinary(v),

--- a/src/EFCore/Storage/ValueConversion/DateTimeToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/DateTimeToStringConverter.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public DateTimeToStringConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public DateTimeToStringConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 ToString(),
                 ToDateTime(),

--- a/src/EFCore/Storage/ValueConversion/DateTimeToTicksConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/DateTimeToTicksConverter.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public DateTimeToTicksConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public DateTimeToTicksConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 v => v.Ticks,
                 v => new DateTime(v),

--- a/src/EFCore/Storage/ValueConversion/EnumToNumberConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/EnumToNumberConverter.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         // ReSharper disable once StaticMemberInGenericType
         private static readonly ConverterMappingHints _defaultHints = CreateDefaultHints();
 
-        private static ConverterMappingHints CreateDefaultHints()
+        private static ConverterMappingHints? CreateDefaultHints()
         {
             var underlyingModelType = typeof(TEnum).UnwrapEnumType();
 
@@ -35,10 +35,12 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public EnumToNumberConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public EnumToNumberConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
+#nullable disable
                 ToNumber(),
                 ToEnum(),
+#nullable enable
                 _defaultHints == null
                     ? mappingHints
                     : _defaultHints.With(mappingHints))

--- a/src/EFCore/Storage/ValueConversion/EnumToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/EnumToStringConverter.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public EnumToStringConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public EnumToStringConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 ToString(),
                 ToEnum(),

--- a/src/EFCore/Storage/ValueConversion/GuidToBytesConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/GuidToBytesConverter.cs
@@ -31,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public GuidToBytesConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public GuidToBytesConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 v => v.ToByteArray(),
                 v => v == null ? Guid.Empty : new Guid(v),

--- a/src/EFCore/Storage/ValueConversion/GuidToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/GuidToStringConverter.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public GuidToStringConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public GuidToStringConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 ToString(),
                 ToGuid(),

--- a/src/EFCore/Storage/ValueConversion/IValueConverterSelector.cs
+++ b/src/EFCore/Storage/ValueConversion/IValueConverterSelector.cs
@@ -24,6 +24,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// <returns> The converters available. </returns>
         IEnumerable<ValueConverterInfo> Select(
             [NotNull] Type modelClrType,
-            [CanBeNull] Type providerClrType = null);
+            [CanBeNull] Type? providerClrType = null);
     }
 }

--- a/src/EFCore/Storage/ValueConversion/Internal/CompositeValueConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/CompositeValueConverter.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
         public CompositeValueConverter(
             [NotNull] ValueConverter converter1,
             [NotNull] ValueConverter converter2,
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 Compose(
                     (Expression<Func<TModel, TMiddle>>)converter1.ConvertToProviderExpression,

--- a/src/EFCore/Storage/ValueConversion/Internal/StringCharConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/StringCharConverter.cs
@@ -21,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
         public StringCharConverter(
             [NotNull] Expression<Func<TModel, TProvider>> convertToProviderExpression,
             [NotNull] Expression<Func<TProvider, TModel>> convertFromProviderExpression,
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/Internal/StringDateTimeConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/StringDateTimeConverter.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
         public StringDateTimeConverter(
             [NotNull] Expression<Func<TModel, TProvider>> convertToProviderExpression,
             [NotNull] Expression<Func<TProvider, TModel>> convertFromProviderExpression,
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/Internal/StringDateTimeOffsetConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/StringDateTimeOffsetConverter.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
         public StringDateTimeOffsetConverter(
             [NotNull] Expression<Func<TModel, TProvider>> convertToProviderExpression,
             [NotNull] Expression<Func<TProvider, TModel>> convertFromProviderExpression,
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/Internal/StringEnumConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/StringEnumConverter.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
         public StringEnumConverter(
             [NotNull] Expression<Func<TModel, TProvider>> convertToProviderExpression,
             [NotNull] Expression<Func<TProvider, TModel>> convertFromProviderExpression,
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/Internal/StringGuidConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/StringGuidConverter.cs
@@ -31,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
         public StringGuidConverter(
             [NotNull] Expression<Func<TModel, TProvider>> convertToProviderExpression,
             [NotNull] Expression<Func<TProvider, TModel>> convertFromProviderExpression,
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/Internal/StringNumberConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/StringNumberConverter.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
         public StringNumberConverter(
             [NotNull] Expression<Func<TModel, TProvider>> convertToProviderExpression,
             [NotNull] Expression<Func<TProvider, TModel>> convertFromProviderExpression,
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
         {
         }
@@ -78,7 +78,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected static new Expression<Func<TNumber, string>> ToString()
+        protected static new Expression<Func<TNumber, string?>> ToString()
         {
             var type = typeof(TNumber).UnwrapNullableType();
 

--- a/src/EFCore/Storage/ValueConversion/Internal/StringTimeSpanConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/StringTimeSpanConverter.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
         public StringTimeSpanConverter(
             [NotNull] Expression<Func<TModel, TProvider>> convertToProviderExpression,
             [NotNull] Expression<Func<TProvider, TModel>> convertFromProviderExpression,
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/NumberToBytesConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/NumberToBytesConverter.cs
@@ -32,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public NumberToBytesConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public NumberToBytesConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(ToBytes(), ToNumber(), _defaultHints.With(mappingHints))
         {
         }

--- a/src/EFCore/Storage/ValueConversion/NumberToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/NumberToStringConverter.cs
@@ -19,10 +19,12 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     facets for the converted data.
         /// </param>
         public NumberToStringConverter(
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
+#nullable disable
                 ToString(),
                 ToNumber(),
+#nullable enable
                 _defaultHints.With(mappingHints))
         {
         }

--- a/src/EFCore/Storage/ValueConversion/StringToBoolConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToBoolConverter.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     facets for the converted data.
         /// </param>
         public StringToBoolConverter(
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 v => Convert.ToBoolean(v),
                 v => Convert.ToString(v),

--- a/src/EFCore/Storage/ValueConversion/StringToBytesConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToBytesConverter.cs
@@ -21,10 +21,12 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// </param>
         public StringToBytesConverter(
             [NotNull] Encoding encoding,
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
+#nullable disable
                 v => v == null ? null : encoding.GetBytes(v),
                 v => v == null ? null : encoding.GetString(v),
+#nullable enable
                 mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/StringToCharConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToCharConverter.cs
@@ -21,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public StringToCharConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public StringToCharConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 ToChar(),
                 ToString(),

--- a/src/EFCore/Storage/ValueConversion/StringToDateTimeConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToDateTimeConverter.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public StringToDateTimeConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public StringToDateTimeConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 ToDateTime(),
                 ToString(),

--- a/src/EFCore/Storage/ValueConversion/StringToDateTimeOffsetConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToDateTimeOffsetConverter.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     facets for the converted data.
         /// </param>
         public StringToDateTimeOffsetConverter(
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 ToDateTimeOffset(),
                 ToString(),

--- a/src/EFCore/Storage/ValueConversion/StringToEnumConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToEnumConverter.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public StringToEnumConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public StringToEnumConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 ToEnum(),
                 ToString(),

--- a/src/EFCore/Storage/ValueConversion/StringToGuidConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToGuidConverter.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public StringToGuidConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public StringToGuidConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 ToGuid(),
                 ToString(),

--- a/src/EFCore/Storage/ValueConversion/StringToNumberConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToNumberConverter.cs
@@ -19,10 +19,12 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     facets for the converted data.
         /// </param>
         public StringToNumberConverter(
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
+#nullable disable
                 ToNumber(),
                 ToString(),
+#nullable enable
                 _defaultHints.With(mappingHints))
         {
         }

--- a/src/EFCore/Storage/ValueConversion/StringToTimeSpanConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToTimeSpanConverter.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public StringToTimeSpanConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public StringToTimeSpanConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 ToTimeSpan(),
                 ToString(),

--- a/src/EFCore/Storage/ValueConversion/TimeSpanToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/TimeSpanToStringConverter.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public TimeSpanToStringConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public TimeSpanToStringConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 ToString(),
                 ToTimeSpan(),

--- a/src/EFCore/Storage/ValueConversion/TimeSpanToTicksConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/TimeSpanToTicksConverter.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public TimeSpanToTicksConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public TimeSpanToTicksConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(v => v.Ticks, v => new TimeSpan(v), mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/ValueConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/ValueConverter.cs
@@ -37,8 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         protected ValueConverter(
             [NotNull] LambdaExpression convertToProviderExpression,
             [NotNull] LambdaExpression convertFromProviderExpression,
-            [CanBeNull] ConverterMappingHints mappingHints = null)
-
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
         {
             Check.NotNull(convertToProviderExpression, nameof(convertToProviderExpression));
             Check.NotNull(convertFromProviderExpression, nameof(convertFromProviderExpression));
@@ -52,13 +51,13 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Gets the function to convert objects when writing data to the store,
         ///     setup to handle nulls, boxing, and non-exact matches of simple types.
         /// </summary>
-        public abstract Func<object, object> ConvertToProvider { get; }
+        public abstract Func<object?, object?> ConvertToProvider { get; }
 
         /// <summary>
         ///     Gets the function to convert objects when reading data from the store,
         ///     setup to handle nulls, boxing, and non-exact matches of simple types.
         /// </summary>
-        public abstract Func<object, object> ConvertFromProvider { get; }
+        public abstract Func<object?, object?> ConvertFromProvider { get; }
 
         /// <summary>
         ///     Gets the expression to convert objects when writing data to the store,
@@ -88,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </summary>
-        public virtual ConverterMappingHints MappingHints { get; }
+        public virtual ConverterMappingHints? MappingHints { get; }
 
         /// <summary>
         ///     Checks that the type used with a value converter is supported by that converter and throws if not.
@@ -125,7 +124,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// <param name="secondConverter"> The second converter. </param>
         /// <returns> The composed converter. </returns>
         public virtual ValueConverter ComposeWith(
-            [CanBeNull] ValueConverter secondConverter)
+            [CanBeNull] ValueConverter? secondConverter)
         {
             if (secondConverter == null)
             {

--- a/src/EFCore/Storage/ValueConversion/ValueConverterInfo.cs
+++ b/src/EFCore/Storage/ValueConversion/ValueConverterInfo.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
             [NotNull] Type modelClrType,
             [NotNull] Type providerClrType,
             [NotNull] Func<ValueConverterInfo, ValueConverter> factory,
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
         {
             _factory = factory;
             Check.NotNull(modelClrType, nameof(modelClrType));
@@ -55,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </summary>
-        public ConverterMappingHints MappingHints { get; }
+        public ConverterMappingHints? MappingHints { get; }
 
         /// <summary>
         ///     Creates an instance of the <see cref="ValueConverter" />.

--- a/src/EFCore/Storage/ValueConversion/ValueConverterSelector.cs
+++ b/src/EFCore/Storage/ValueConversion/ValueConverterSelector.cs
@@ -57,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// <returns> The converters available. </returns>
         public virtual IEnumerable<ValueConverterInfo> Select(
             Type modelClrType,
-            Type providerClrType = null)
+            Type? providerClrType = null)
         {
             Check.NotNull(modelClrType, nameof(modelClrType));
 
@@ -272,7 +272,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         }
 
         private IEnumerable<ValueConverterInfo> ForChar(
-            Type underlyingModelType, Type underlyingProviderType)
+            Type underlyingModelType, Type? underlyingProviderType)
         {
             if (underlyingProviderType == null
                 || underlyingProviderType == typeof(string))
@@ -293,7 +293,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         }
 
         private IEnumerable<ValueConverterInfo> CharToBytes(
-            Type underlyingModelType, Type underlyingProviderType)
+            Type underlyingModelType, Type? underlyingProviderType)
         {
             if (underlyingProviderType == null
                 || underlyingProviderType == typeof(byte[]))
@@ -305,7 +305,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         }
 
         private IEnumerable<ValueConverterInfo> EnumToStringOrBytes(
-            Type underlyingModelType, Type underlyingProviderType)
+            Type underlyingModelType, Type? underlyingProviderType)
         {
             if (underlyingProviderType == null
                 || underlyingProviderType == typeof(string))
@@ -345,7 +345,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         }
 
         private IEnumerable<ValueConverterInfo> NumberToStringOrBytes(
-            Type underlyingModelType, Type underlyingProviderType)
+            Type underlyingModelType, Type? underlyingProviderType)
         {
             if (underlyingProviderType == null
                 || underlyingProviderType == typeof(string))
@@ -372,9 +372,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 
         private IEnumerable<ValueConverterInfo> FindNumericConvertions(
             Type modelType,
-            Type providerType,
+            Type? providerType,
             Type converterType,
-            Func<Type, Type, IEnumerable<ValueConverterInfo>> afterPreferred)
+            Func<Type, Type?, IEnumerable<ValueConverterInfo>>? afterPreferred)
         {
             var usedTypes = new List<Type>
             {
@@ -474,7 +474,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         private IEnumerable<ValueConverterInfo> FindPreferredConversions(
             Type[] candidateTypes,
             Type modelType,
-            Type providerType,
+            Type? providerType,
             Type converterType)
         {
             var underlyingModelType = modelType.UnwrapEnumType();

--- a/src/EFCore/Storage/ValueConversion/ValueConverter`.cs
+++ b/src/EFCore/Storage/ValueConversion/ValueConverter`.cs
@@ -14,8 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
     /// </summary>
     public class ValueConverter<TModel, TProvider> : ValueConverter
     {
-        private Func<object, object> _convertToProvider;
-        private Func<object, object> _convertFromProvider;
+        private Func<object?, object?>? _convertToProvider;
+        private Func<object?, object?>? _convertFromProvider;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="ValueConverter{TModel,TProvider}" /> class.
@@ -29,19 +29,19 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         public ValueConverter(
             [NotNull] Expression<Func<TModel, TProvider>> convertToProviderExpression,
             [NotNull] Expression<Func<TProvider, TModel>> convertFromProviderExpression,
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
         {
             _convertToProvider = SanitizeConverter(convertToProviderExpression);
             _convertFromProvider = SanitizeConverter(convertFromProviderExpression);
         }
 
-        private static Func<object, object> SanitizeConverter<TIn, TOut>(Expression<Func<TIn, TOut>> convertExpression)
+        private static Func<object?, object?> SanitizeConverter<TIn, TOut>(Expression<Func<TIn, TOut>> convertExpression)
         {
             var compiled = convertExpression.Compile();
 
             return v => v == null
-                ? (object)null
+                ? (object?)null
                 : compiled(Sanitize<TIn>(v));
         }
 
@@ -58,7 +58,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Gets the function to convert objects when writing data to the store,
         ///     setup to handle nulls, boxing, and non-exact matches of simple types.
         /// </summary>
-        public override Func<object, object> ConvertToProvider
+        public override Func<object?, object?> ConvertToProvider
             => NonCapturingLazyInitializer.EnsureInitialized(
                 ref _convertToProvider, this, c => SanitizeConverter(c.ConvertToProviderExpression));
 
@@ -66,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Gets the function to convert objects when reading data from the store,
         ///     setup to handle nulls, boxing, and non-exact matches of simple types.
         /// </summary>
-        public override Func<object, object> ConvertFromProvider
+        public override Func<object?, object?> ConvertFromProvider
             => NonCapturingLazyInitializer.EnsureInitialized(
                 ref _convertFromProvider, this, c => SanitizeConverter(c.ConvertFromProviderExpression));
 

--- a/src/Shared/Check.cs
+++ b/src/Shared/Check.cs
@@ -8,6 +8,10 @@ using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
 
+// Disable nullability checks until all projects using this file are converted to perform nullability checks
+// themselves
+#nullable disable
+
 namespace Microsoft.EntityFrameworkCore.Utilities
 {
     [DebuggerStepThrough]


### PR DESCRIPTION
This is a very partial first attempt at annotating the codebase for C# 8 reference nullability. Only EFCore/Storage has been "fully" annotated up to now, since there's a lot of work involved and I don't want to go too far before we decide we want to go for it.

The main blocker for now is that the only IDE which supports C# 8 is VS2019 Preview 1, so I think the entire time needs to commit to this before we can do the change. At a later point other editors (VS for Mac, VS Code, Rider) should also add experimental support, and that may be a more appropriate time to take the plunge.

Overall the change isn't hard and IMHO adds lots of safety. I've encountered one problematic point, though: it's no longer possible to write a generic function which may accept or return null, while at the same time being usable over both reference and value types. In other words, the following is now impossible write:

```c#
T Foo<T> => default;
```

Changing the function to return `T?` fails, because the compiler requires us to constrain it to either reference types or value types (and in any case, `T?` for value types means `Nullable<T>`, which is very different from `default(T)`).

This is problematic, for example, in ValueConverter, [which accepts an arbitrary `Func<TModel, TProvider>`](https://github.com/roji/EntityFrameworkCore/blob/commence-nullification/src/EFCore/Storage/ValueConversion/ValueConverter%60.cs#L30) (over reference or value types), but [some converters need to be able to accept and return null](https://github.com/roji/EntityFrameworkCore/blob/commence-nullification/src/EFCore/Storage/ValueConversion/StringToBytesConverter.cs#L27). I've worked around this for now by disabling nullability checks for those specific regions of code, but to do this properly a refactor may be needed (extracting the nullability handling out of the functions). It may be worth raising this with the language team to get their view.