### PR TITLE
Add support for ExpressionType.Index to ExpressionEqualityComparer (fixes #14509)

### DIFF
--- a/src/EFCore/Query/Internal/ExpressionEqualityComparer.cs
+++ b/src/EFCore/Query/Internal/ExpressionEqualityComparer.cs
@@ -284,6 +284,16 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                         break;
                     }
+                    case ExpressionType.Index:
+                    {
+                        var indexExpression = (IndexExpression)obj;
+
+                        hashCode += (hashCode * 397) ^ (indexExpression.Indexer?.GetHashCode() ?? 0);
+                        hashCode += (hashCode * 397) ^ GetHashCode(indexExpression.Object);
+                        hashCode += (hashCode * 397) ^ GetHashCode(indexExpression.Arguments);
+
+                        break;
+                    }
                     default:
                         throw new NotImplementedException();
                 }
@@ -426,6 +436,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         return CompareExtension(a, b);
                     case ExpressionType.Default:
                         return CompareDefault((DefaultExpression)a, (DefaultExpression)b);
+                    case ExpressionType.Index:
+                        return CompareIndex((IndexExpression)a, (IndexExpression)b);
                     default:
                         throw new NotImplementedException();
                 }
@@ -747,6 +759,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             private bool CompareElementInit(ElementInit a, ElementInit b)
                 => Equals(a.AddMethod, b.AddMethod)
+                   && CompareExpressionList(a.Arguments, b.Arguments);
+
+            private bool CompareIndex(IndexExpression a, IndexExpression b)
+                => Equals(a.Indexer, b.Indexer)
+                   && Compare(a.Object, b.Object)
                    && CompareExpressionList(a.Arguments, b.Arguments);
 
             private class ScopedDictionary<TKey, TValue>


### PR DESCRIPTION
I couldn't get the build to work locally so I'm not sure that the test is correct but... here goes!