### PR TITLE
CI: Continue on errors while installing SpatiaLite on Ubuntu

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -86,5 +86,6 @@ jobs:
           steps:
             - bash: sudo apt-get install -y libsqlite3-mod-spatialite
               displayName: Install SpatiaLite
+              continueOnError: true
             - script: eng/common/cibuild.sh --configuration $(_BuildConfig) --prepareMachine
               name: Build


### PR DESCRIPTION
We already do this on macOS. When it fails, it will show up as a warning in the CI and the tests will be skipped.