### PR TITLE
Nullable annotation for EFCore/Storage and others

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
     <PackageTags>Entity Framework Core;entity-framework-core;EF;Data;O/RM;EntityFramework;EntityFrameworkCore;EFCore</PackageTags>
     <Product>Microsoft Entity Framework Core</Product>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <DebugType>portable</DebugType>
     <PackageLicenseUrl>https://raw.githubusercontent.com/aspnet/AspNetCore/2.0.0/LICENSE.txt</PackageLicenseUrl>
     <PackageIconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</PackageIconUrl>

--- a/src/EFCore.Abstractions/DbFunctionAttribute.cs
+++ b/src/EFCore.Abstractions/DbFunctionAttribute.cs
@@ -17,8 +17,8 @@ namespace Microsoft.EntityFrameworkCore
     public class DbFunctionAttribute : Attribute
 #pragma warning restore CA1813 // Avoid unsealed attributes
     {
-        private string _functionName;
-        private string _schema;
+        private string? _functionName;
+        private string? _schema;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="DbFunctionAttribute" /> class.
@@ -32,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="functionName">The name of the function in the database.</param>
         /// <param name="schema">The schema of the function in the database.</param>
-        public DbFunctionAttribute([NotNull] string functionName, [CanBeNull] string schema = null)
+        public DbFunctionAttribute([NotNull] string functionName, [CanBeNull] string? schema = null)
         {
             Check.NotEmpty(functionName, nameof(functionName));
 
@@ -43,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <summary>
         ///     The name of the function in the database.
         /// </summary>
-        public virtual string FunctionName
+        public virtual string? FunctionName
         {
             get => _functionName;
             [param: NotNull]
@@ -58,7 +58,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <summary>
         ///     The schema of the function in the database.
         /// </summary>
-        public virtual string Schema
+        public virtual string? Schema
         {
             get => _schema;
             [param: CanBeNull] set => _schema = value;

--- a/src/EFCore.Abstractions/EFCore.Abstractions.csproj
+++ b/src/EFCore.Abstractions/EFCore.Abstractions.csproj
@@ -8,6 +8,9 @@
     <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>..\..\EFCore.ruleset</CodeAnalysisRuleSet>
+    <LangVersion>8.0</LangVersion>
+    <NullableContextOptions>enable</NullableContextOptions>
+    <NullableReferenceTypes>true</NullableReferenceTypes>  <!-- Older SDK -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EFCore.Abstractions/Infrastructure/ILazyLoader.cs
+++ b/src/EFCore.Abstractions/Infrastructure/ILazyLoader.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <param name="entity"> The entity on which the navigation property is located. </param>
         /// <param name="navigationName"> The navigation property name. </param>
         // ReSharper disable once AssignNullToNotNullAttribute
-        void Load([NotNull] object entity, [NotNull] [CallerMemberName] string navigationName = null);
+        void Load([NotNull] object entity, [NotNull] [CallerMemberName] string navigationName = "");
 
         /// <summary>
         ///     Loads a navigation property if it has not already been loaded.
@@ -35,6 +35,6 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             [NotNull] object entity,
             CancellationToken cancellationToken = default,
             // ReSharper disable once AssignNullToNotNullAttribute
-            [NotNull] [CallerMemberName] string navigationName = null);
+            [NotNull] [CallerMemberName] string navigationName = "");
     }
 }

--- a/src/EFCore.Abstractions/Infrastructure/LazyLoaderExtensions.cs
+++ b/src/EFCore.Abstractions/Infrastructure/LazyLoaderExtensions.cs
@@ -23,12 +23,12 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <returns>
         ///     The loaded navigation property value, or the navigation property value unchanged if the loader is <c>null</c>.
         /// </returns>
-        public static TRelated Load<TRelated>(
-            [CanBeNull] this ILazyLoader loader,
+        public static TRelated? Load<TRelated>(
+            [CanBeNull] this ILazyLoader? loader,
             [NotNull] object entity,
-            [CanBeNull] ref TRelated navigationField,
+            [CanBeNull] ref TRelated? navigationField,
             // ReSharper disable once AssignNullToNotNullAttribute
-            [NotNull] [CallerMemberName] string navigationName = null)
+            [NotNull] [CallerMemberName] string navigationName = "")
             where TRelated : class
         {
             // ReSharper disable once AssignNullToNotNullAttribute

--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -20,6 +20,8 @@ using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore
 {
     /// <summary>
@@ -53,17 +55,17 @@ namespace Microsoft.EntityFrameworkCore
         IDbQueryCache,
         IDbContextPoolable
     {
-        private IDictionary<Type, object> _sets;
-        private IDictionary<Type, object> _queries;
+        private IDictionary<Type, object>? _sets;
+        private IDictionary<Type, object>? _queries;
         private readonly DbContextOptions _options;
 
-        private IDbContextServices _contextServices;
-        private IDbContextDependencies _dbContextDependencies;
-        private DatabaseFacade _database;
-        private ChangeTracker _changeTracker;
+        private IDbContextServices? _contextServices;
+        private IDbContextDependencies? _dbContextDependencies;
+        private DatabaseFacade? _database;
+        private ChangeTracker? _changeTracker;
 
-        private IServiceScope _serviceScope;
-        private IDbContextPool _dbContextPool;
+        private IServiceScope? _serviceScope;
+        private IDbContextPool? _dbContextPool;
         private bool _initializing;
         private bool _disposed;
 
@@ -592,7 +594,7 @@ namespace Microsoft.EntityFrameworkCore
             }
             else
             {
-                ((IResettableService)_changeTracker)?.ResetState();
+                ((IResettableService?)_changeTracker)?.ResetState();
             }
 
             if (_database != null)
@@ -1389,7 +1391,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The type of entity to find. </param>
         /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
         /// <returns>The entity found, or null.</returns>
-        public virtual object Find([NotNull] Type entityType, [CanBeNull] params object[] keyValues)
+        public virtual object? Find([NotNull] Type entityType, [CanBeNull] params object[]? keyValues)
         {
             CheckDisposed();
 
@@ -1406,7 +1408,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The type of entity to find. </param>
         /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
         /// <returns>The entity found, or null.</returns>
-        public virtual Task<object> FindAsync([NotNull] Type entityType, [CanBeNull] params object[] keyValues)
+        public virtual Task<object?> FindAsync([NotNull] Type entityType, [CanBeNull] params object[]? keyValues)
         {
             CheckDisposed();
 
@@ -1424,7 +1426,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns>The entity found, or null.</returns>
-        public virtual Task<object> FindAsync([NotNull] Type entityType, [CanBeNull] object[] keyValues, CancellationToken cancellationToken)
+        public virtual Task<object?> FindAsync([NotNull] Type entityType, [CanBeNull] object[]? keyValues, CancellationToken cancellationToken)
         {
             CheckDisposed();
 
@@ -1441,7 +1443,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <typeparam name="TEntity"> The type of entity to find. </typeparam>
         /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
         /// <returns>The entity found, or null.</returns>
-        public virtual TEntity Find<TEntity>([CanBeNull] params object[] keyValues)
+        public virtual TEntity? Find<TEntity>([CanBeNull] params object[]? keyValues)
             where TEntity : class
         {
             CheckDisposed();
@@ -1459,7 +1461,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <typeparam name="TEntity"> The type of entity to find. </typeparam>
         /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
         /// <returns>The entity found, or null.</returns>
-        public virtual Task<TEntity> FindAsync<TEntity>([CanBeNull] params object[] keyValues)
+        public virtual Task<TEntity?> FindAsync<TEntity>([CanBeNull] params object[]? keyValues)
             where TEntity : class
         {
             CheckDisposed();
@@ -1478,7 +1480,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns>The entity found, or null.</returns>
-        public virtual Task<TEntity> FindAsync<TEntity>([CanBeNull] object[] keyValues, CancellationToken cancellationToken)
+        public virtual Task<TEntity?> FindAsync<TEntity>([CanBeNull] object[]? keyValues, CancellationToken cancellationToken)
             where TEntity : class
         {
             CheckDisposed();

--- a/src/EFCore/DbSet`.cs
+++ b/src/EFCore/DbSet`.cs
@@ -15,6 +15,8 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore
 {
     /// <summary>
@@ -72,7 +74,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
         /// <returns>The entity found, or null.</returns>
-        public virtual TEntity Find([CanBeNull] params object[] keyValues) => throw new NotImplementedException();
+        public virtual TEntity? Find([CanBeNull] params object[]? keyValues) => throw new NotImplementedException();
 
         /// <summary>
         ///     Finds an entity with the given primary key values. If an entity with the given primary key values
@@ -83,7 +85,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
         /// <returns>The entity found, or null.</returns>
-        public virtual Task<TEntity> FindAsync([CanBeNull] params object[] keyValues) => throw new NotImplementedException();
+        public virtual Task<TEntity?> FindAsync([CanBeNull] params object[]? keyValues) => throw new NotImplementedException();
 
         /// <summary>
         ///     Finds an entity with the given primary key values. If an entity with the given primary key values
@@ -95,7 +97,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns>The entity found, or null.</returns>
-        public virtual Task<TEntity> FindAsync([CanBeNull] object[] keyValues, CancellationToken cancellationToken)
+        public virtual Task<TEntity?> FindAsync([CanBeNull] object[]? keyValues, CancellationToken cancellationToken)
             => throw new NotImplementedException();
 
         /// <summary>

--- a/src/EFCore/Diagnostics/EventDefinition.cs
+++ b/src/EFCore/Diagnostics/EventDefinition.cs
@@ -6,6 +6,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.Logging;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Diagnostics
 {
     /// <summary>
@@ -14,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     /// </summary>
     public class EventDefinition : EventDefinitionBase
     {
-        private readonly Action<ILogger, Exception> _logAction;
+        private readonly Action<ILogger, Exception?> _logAction;
 
         /// <summary>
         ///     Creates an event definition instance.
@@ -25,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public EventDefinition(
             EventId eventId,
             LogLevel level,
-            [NotNull] Action<ILogger, Exception> logAction)
+            [NotNull] Action<ILogger, Exception?> logAction)
             : this(eventId, level, null, logAction)
         {
         }
@@ -40,8 +42,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public EventDefinition(
             EventId eventId,
             LogLevel level,
-            [CanBeNull] string eventIdCode,
-            [NotNull] Action<ILogger, Exception> logAction)
+            [CanBeNull] string? eventIdCode,
+            [NotNull] Action<ILogger, Exception?> logAction)
             : base(eventId, level, eventIdCode)
         {
             Check.NotNull(logAction, nameof(logAction));
@@ -55,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <param name="exception"> Optional exception associated with this event. </param>
         /// <returns> The message string. </returns>
-        public virtual string GenerateMessage([CanBeNull] Exception exception = null)
+        public virtual string GenerateMessage([CanBeNull] Exception? exception = null)
         {
             var extractor = new MessageExtractingLogger();
             _logAction(extractor, exception);
@@ -72,7 +74,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public virtual void Log<TLoggerCategory>(
             [NotNull] IDiagnosticsLogger<TLoggerCategory> logger,
             WarningBehavior warningBehavior,
-            [CanBeNull] Exception exception = null)
+            [CanBeNull] Exception? exception = null)
             where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
         {
             switch (warningBehavior)

--- a/src/EFCore/Diagnostics/EventDefinitionBase.cs
+++ b/src/EFCore/Diagnostics/EventDefinitionBase.cs
@@ -7,6 +7,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.Extensions.Logging;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Diagnostics
 {
     /// <summary>
@@ -30,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="eventId"> The <see cref="EventId" />. </param>
         /// <param name="level"> The <see cref="LogLevel" /> at which the event will be logged. </param>
         /// <param name="eventIdCode"> A string representing the code that should be passed to ConfigureWanings. </param>
-        protected EventDefinitionBase(EventId eventId, LogLevel level, [CanBeNull] string eventIdCode)
+        protected EventDefinitionBase(EventId eventId, LogLevel level, [CanBeNull] string? eventIdCode)
         {
             EventId = eventId;
             Level = level;
@@ -50,7 +52,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <summary>
         ///     A string representing the code that should be passed to ConfigureWanings to suppress this event as an error.
         /// </summary>
-        public virtual string EventIdCode { get; }
+        public virtual string? EventIdCode { get; }
 
         /// <summary>
         ///     Returns a warning-as-error exception wrapping the given message for this event.
@@ -79,11 +81,16 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         protected sealed class MessageExtractingLogger : ILogger
         {
+            private string? _message;
+
             /// <summary>
             ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
             ///     directly from your code. This API may change or be removed in future releases.
             /// </summary>
-            public string Message { get; [param: CanBeNull] private set; }
+            public string Message {
+                get => _message ?? throw new InvalidOperationException();
+                private set => _message = value;
+            }
 
             /// <summary>
             ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Diagnostics/EventDefinition`.cs
+++ b/src/EFCore/Diagnostics/EventDefinition`.cs
@@ -6,6 +6,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.Logging;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Diagnostics
 {
     /// <summary>
@@ -14,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     /// </summary>
     public class EventDefinition<TParam> : EventDefinitionBase
     {
-        private readonly Action<ILogger, TParam, Exception> _logAction;
+        private readonly Action<ILogger, TParam, Exception?> _logAction;
 
         /// <summary>
         ///     Creates an event definition instance.
@@ -25,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public EventDefinition(
             EventId eventId,
             LogLevel level,
-            [NotNull] Action<ILogger, TParam, Exception> logAction)
+            [NotNull] Action<ILogger, TParam, Exception?> logAction)
             : this(eventId, level, null, logAction)
         {
         }
@@ -40,8 +42,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public EventDefinition(
             EventId eventId,
             LogLevel level,
-            [CanBeNull] string eventIdCode,
-            [NotNull] Action<ILogger, TParam, Exception> logAction)
+            [CanBeNull] string? eventIdCode,
+            [NotNull] Action<ILogger, TParam, Exception?> logAction)
             : base(eventId, level, eventIdCode)
         {
             Check.NotNull(logAction, nameof(logAction));
@@ -58,7 +60,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <returns> The message string. </returns>
         public virtual string GenerateMessage(
             [CanBeNull] TParam arg,
-            [CanBeNull] Exception exception = null)
+            [CanBeNull] Exception? exception = null)
         {
             var extractor = new MessageExtractingLogger();
             _logAction(extractor, arg, exception);
@@ -77,7 +79,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             [NotNull] IDiagnosticsLogger<TLoggerCategory> logger,
             WarningBehavior warningBehavior,
             [CanBeNull] TParam arg,
-            [CanBeNull] Exception exception = null)
+            [CanBeNull] Exception? exception = null)
             where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
         {
             switch (warningBehavior)

--- a/src/EFCore/Diagnostics/EventDefinition``.cs
+++ b/src/EFCore/Diagnostics/EventDefinition``.cs
@@ -6,6 +6,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.Logging;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Diagnostics
 {
     /// <summary>
@@ -14,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     /// </summary>
     public class EventDefinition<TParam1, TParam2> : EventDefinitionBase
     {
-        private readonly Action<ILogger, TParam1, TParam2, Exception> _logAction;
+        private readonly Action<ILogger, TParam1, TParam2, Exception?> _logAction;
 
         /// <summary>
         ///     Creates an event definition instance.
@@ -25,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public EventDefinition(
             EventId eventId,
             LogLevel level,
-            [NotNull] Action<ILogger, TParam1, TParam2, Exception> logAction)
+            [NotNull] Action<ILogger, TParam1, TParam2, Exception?> logAction)
             : this(eventId, level, null, logAction)
         {
         }
@@ -40,8 +42,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public EventDefinition(
             EventId eventId,
             LogLevel level,
-            [CanBeNull] string eventIdCode,
-            [NotNull] Action<ILogger, TParam1, TParam2, Exception> logAction)
+            [CanBeNull] string? eventIdCode,
+            [NotNull] Action<ILogger, TParam1, TParam2, Exception?> logAction)
             : base(eventId, level, eventIdCode)
         {
             Check.NotNull(logAction, nameof(logAction));
@@ -60,7 +62,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public virtual string GenerateMessage(
             [CanBeNull] TParam1 arg1,
             [CanBeNull] TParam2 arg2,
-            [CanBeNull] Exception exception = null)
+            [CanBeNull] Exception? exception = null)
         {
             var extractor = new MessageExtractingLogger();
             _logAction(extractor, arg1, arg2, exception);
@@ -81,7 +83,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             WarningBehavior warningBehavior,
             [CanBeNull] TParam1 arg1,
             [CanBeNull] TParam2 arg2,
-            [CanBeNull] Exception exception = null)
+            [CanBeNull] Exception? exception = null)
             where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
         {
             switch (warningBehavior)

--- a/src/EFCore/Diagnostics/EventDefinition```.cs
+++ b/src/EFCore/Diagnostics/EventDefinition```.cs
@@ -6,6 +6,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.Logging;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Diagnostics
 {
     /// <summary>
@@ -14,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     /// </summary>
     public class EventDefinition<TParam1, TParam2, TParam3> : EventDefinitionBase
     {
-        private readonly Action<ILogger, TParam1, TParam2, TParam3, Exception> _logAction;
+        private readonly Action<ILogger, TParam1, TParam2, TParam3, Exception?> _logAction;
 
         /// <summary>
         ///     Creates an event definition instance.
@@ -25,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public EventDefinition(
             EventId eventId,
             LogLevel level,
-            [NotNull] Action<ILogger, TParam1, TParam2, TParam3, Exception> logAction)
+            [NotNull] Action<ILogger, TParam1, TParam2, TParam3, Exception?> logAction)
             : this(eventId, level, null, logAction)
         {
         }
@@ -40,8 +42,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public EventDefinition(
             EventId eventId,
             LogLevel level,
-            [CanBeNull] string eventIdCode,
-            [NotNull] Action<ILogger, TParam1, TParam2, TParam3, Exception> logAction)
+            [CanBeNull] string? eventIdCode,
+            [NotNull] Action<ILogger, TParam1, TParam2, TParam3, Exception?> logAction)
             : base(eventId, level, eventIdCode)
         {
             Check.NotNull(logAction, nameof(logAction));
@@ -62,7 +64,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             [CanBeNull] TParam1 arg1,
             [CanBeNull] TParam2 arg2,
             [CanBeNull] TParam3 arg3,
-            [CanBeNull] Exception exception = null)
+            [CanBeNull] Exception? exception = null)
         {
             var extractor = new MessageExtractingLogger();
             _logAction(extractor, arg1, arg2, arg3, exception);
@@ -85,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             [CanBeNull] TParam1 arg1,
             [CanBeNull] TParam2 arg2,
             [CanBeNull] TParam3 arg3,
-            [CanBeNull] Exception exception = null)
+            [CanBeNull] Exception? exception = null)
             where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
         {
             switch (warningBehavior)

--- a/src/EFCore/Diagnostics/EventDefinition````.cs
+++ b/src/EFCore/Diagnostics/EventDefinition````.cs
@@ -6,6 +6,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.Logging;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Diagnostics
 {
     /// <summary>
@@ -14,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     /// </summary>
     public class EventDefinition<TParam1, TParam2, TParam3, TParam4> : EventDefinitionBase
     {
-        private readonly Action<ILogger, TParam1, TParam2, TParam3, TParam4, Exception> _logAction;
+        private readonly Action<ILogger, TParam1, TParam2, TParam3, TParam4, Exception?> _logAction;
 
         /// <summary>
         ///     Creates an event definition instance.
@@ -25,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public EventDefinition(
             EventId eventId,
             LogLevel level,
-            [NotNull] Action<ILogger, TParam1, TParam2, TParam3, TParam4, Exception> logAction)
+            [NotNull] Action<ILogger, TParam1, TParam2, TParam3, TParam4, Exception?> logAction)
             : this(eventId, level, null, logAction)
         {
         }
@@ -40,8 +42,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public EventDefinition(
             EventId eventId,
             LogLevel level,
-            [CanBeNull] string eventIdCode,
-            [NotNull] Action<ILogger, TParam1, TParam2, TParam3, TParam4, Exception> logAction)
+            [CanBeNull] string? eventIdCode,
+            [NotNull] Action<ILogger, TParam1, TParam2, TParam3, TParam4, Exception?> logAction)
             : base(eventId, level, eventIdCode)
         {
             Check.NotNull(logAction, nameof(logAction));
@@ -64,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             [CanBeNull] TParam2 arg2,
             [CanBeNull] TParam3 arg3,
             [CanBeNull] TParam4 arg4,
-            [CanBeNull] Exception exception = null)
+            [CanBeNull] Exception? exception = null)
         {
             var extractor = new MessageExtractingLogger();
             _logAction(extractor, arg1, arg2, arg3, arg4, exception);
@@ -89,7 +91,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             [CanBeNull] TParam2 arg2,
             [CanBeNull] TParam3 arg3,
             [CanBeNull] TParam4 arg4,
-            [CanBeNull] Exception exception = null)
+            [CanBeNull] Exception? exception = null)
             where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
         {
             switch (warningBehavior)

--- a/src/EFCore/Diagnostics/EventDefinition`````.cs
+++ b/src/EFCore/Diagnostics/EventDefinition`````.cs
@@ -6,6 +6,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.Logging;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Diagnostics
 {
     /// <summary>
@@ -14,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     /// </summary>
     public class EventDefinition<TParam1, TParam2, TParam3, TParam4, TParam5> : EventDefinitionBase
     {
-        private readonly Action<ILogger, TParam1, TParam2, TParam3, TParam4, TParam5, Exception> _logAction;
+        private readonly Action<ILogger, TParam1, TParam2, TParam3, TParam4, TParam5, Exception?> _logAction;
 
         /// <summary>
         ///     Creates an event definition instance.
@@ -25,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public EventDefinition(
             EventId eventId,
             LogLevel level,
-            [NotNull] Action<ILogger, TParam1, TParam2, TParam3, TParam4, TParam5, Exception> logAction)
+            [NotNull] Action<ILogger, TParam1, TParam2, TParam3, TParam4, TParam5, Exception?> logAction)
             : this(eventId, level, null, logAction)
         {
         }
@@ -40,8 +42,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public EventDefinition(
             EventId eventId,
             LogLevel level,
-            [CanBeNull] string eventIdCode,
-            [NotNull] Action<ILogger, TParam1, TParam2, TParam3, TParam4, TParam5, Exception> logAction)
+            [CanBeNull] string? eventIdCode,
+            [NotNull] Action<ILogger, TParam1, TParam2, TParam3, TParam4, TParam5, Exception?> logAction)
             : base(eventId, level, eventIdCode)
         {
             Check.NotNull(logAction, nameof(logAction));
@@ -66,7 +68,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             [CanBeNull] TParam3 arg3,
             [CanBeNull] TParam4 arg4,
             [CanBeNull] TParam5 arg5,
-            [CanBeNull] Exception exception = null)
+            [CanBeNull] Exception? exception = null)
         {
             var extractor = new MessageExtractingLogger();
             _logAction(extractor, arg1, arg2, arg3, arg4, arg5, exception);
@@ -93,7 +95,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             [CanBeNull] TParam3 arg3,
             [CanBeNull] TParam4 arg4,
             [CanBeNull] TParam5 arg5,
-            [CanBeNull] Exception exception = null)
+            [CanBeNull] Exception? exception = null)
             where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
         {
             switch (warningBehavior)

--- a/src/EFCore/Diagnostics/EventDefinition``````.cs
+++ b/src/EFCore/Diagnostics/EventDefinition``````.cs
@@ -6,6 +6,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.Logging;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Diagnostics
 {
     /// <summary>
@@ -14,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     /// </summary>
     public class EventDefinition<TParam1, TParam2, TParam3, TParam4, TParam5, TParam6> : EventDefinitionBase
     {
-        private readonly Action<ILogger, TParam1, TParam2, TParam3, TParam4, TParam5, TParam6, Exception> _logAction;
+        private readonly Action<ILogger, TParam1, TParam2, TParam3, TParam4, TParam5, TParam6, Exception?> _logAction;
 
         /// <summary>
         ///     Creates an event definition instance.
@@ -25,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public EventDefinition(
             EventId eventId,
             LogLevel level,
-            [NotNull] Action<ILogger, TParam1, TParam2, TParam3, TParam4, TParam5, TParam6, Exception> logAction)
+            [NotNull] Action<ILogger, TParam1, TParam2, TParam3, TParam4, TParam5, TParam6, Exception?> logAction)
             : this(eventId, level, null, logAction)
         {
         }
@@ -40,8 +42,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public EventDefinition(
             EventId eventId,
             LogLevel level,
-            [CanBeNull] string eventIdCode,
-            [NotNull] Action<ILogger, TParam1, TParam2, TParam3, TParam4, TParam5, TParam6, Exception> logAction)
+            [CanBeNull] string? eventIdCode,
+            [NotNull] Action<ILogger, TParam1, TParam2, TParam3, TParam4, TParam5, TParam6, Exception?> logAction)
             : base(eventId, level, eventIdCode)
         {
             Check.NotNull(logAction, nameof(logAction));
@@ -68,7 +70,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             [CanBeNull] TParam4 arg4,
             [CanBeNull] TParam5 arg5,
             [CanBeNull] TParam6 arg6,
-            [CanBeNull] Exception exception = null)
+            [CanBeNull] Exception? exception = null)
         {
             var extractor = new MessageExtractingLogger();
             _logAction(extractor, arg1, arg2, arg3, arg4, arg5, arg6, exception);
@@ -97,7 +99,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             [CanBeNull] TParam4 arg4,
             [CanBeNull] TParam5 arg5,
             [CanBeNull] TParam6 arg6,
-            [CanBeNull] Exception exception = null)
+            [CanBeNull] Exception? exception = null)
             where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
         {
             switch (warningBehavior)

--- a/src/EFCore/Diagnostics/FallbackEventDefinition.cs
+++ b/src/EFCore/Diagnostics/FallbackEventDefinition.cs
@@ -6,6 +6,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.Logging;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Diagnostics
 {
     /// <summary>
@@ -38,7 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public FallbackEventDefinition(
             EventId eventId,
             LogLevel level,
-            [CanBeNull] string eventIdCode,
+            [CanBeNull] string? eventIdCode,
             [NotNull] string messageFormat)
             : base(eventId, level, eventIdCode)
         {

--- a/src/EFCore/EFCore.csproj
+++ b/src/EFCore/EFCore.csproj
@@ -13,6 +13,7 @@ Microsoft.EntityFrameworkCore.DbSet
     <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>..\..\EFCore.ruleset</CodeAnalysisRuleSet>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EFCore/EntityFrameworkQueryableExtensions.cs
+++ b/src/EFCore/EntityFrameworkQueryableExtensions.cs
@@ -17,6 +17,8 @@ using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
@@ -3136,7 +3138,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         private static MethodInfo GetMethod<TResult>(
-            string name, int parameterCount = 0, Func<MethodInfo, bool> predicate = null)
+            string name, int parameterCount = 0, Func<MethodInfo, bool>? predicate = null)
             => GetMethod(
                 name,
                 parameterCount,
@@ -3144,7 +3146,7 @@ namespace Microsoft.EntityFrameworkCore
                       && (predicate == null || predicate(mi)));
 
         private static MethodInfo GetMethod(
-            string name, int parameterCount = 0, Func<MethodInfo, bool> predicate = null)
+            string name, int parameterCount = 0, Func<MethodInfo, bool>? predicate = null)
             => typeof(Queryable).GetTypeInfo().GetDeclaredMethods(name)
                 .Single(
                     mi => mi.GetParameters().Length == parameterCount + 1

--- a/src/EFCore/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/EFCore/EntityFrameworkServiceCollectionExtensions.cs
@@ -12,6 +12,8 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
+#nullable enable
+
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -30,7 +32,7 @@ namespace Microsoft.Extensions.DependencyInjection
         ///           public void ConfigureServices(IServiceCollection services)
         ///           {
         ///               var connectionString = "connection string to database";
-        /// 
+        ///
         ///               services.AddDbContext&lt;MyContext&gt;(options => options.UseSqlServer(connectionString));
         ///           }
         ///       </code>
@@ -60,7 +62,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </returns>
         public static IServiceCollection AddDbContext<TContext>(
             [NotNull] this IServiceCollection serviceCollection,
-            [CanBeNull] Action<DbContextOptionsBuilder> optionsAction = null,
+            [CanBeNull] Action<DbContextOptionsBuilder>? optionsAction = null,
             ServiceLifetime contextLifetime = ServiceLifetime.Scoped,
             ServiceLifetime optionsLifetime = ServiceLifetime.Scoped)
             where TContext : DbContext
@@ -76,7 +78,7 @@ namespace Microsoft.Extensions.DependencyInjection
         ///           public void ConfigureServices(IServiceCollection services)
         ///           {
         ///               var connectionString = "connection string to database";
-        /// 
+        ///
         ///               services.AddDbContext&lt;MyContext&gt;(options => options.UseSqlServer(connectionString));
         ///           }
         ///       </code>
@@ -107,15 +109,15 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </returns>
         public static IServiceCollection AddDbContext<TContextService, TContextImplementation>(
             [NotNull] this IServiceCollection serviceCollection,
-            [CanBeNull] Action<DbContextOptionsBuilder> optionsAction = null,
+            [CanBeNull] Action<DbContextOptionsBuilder>? optionsAction = null,
             ServiceLifetime contextLifetime = ServiceLifetime.Scoped,
             ServiceLifetime optionsLifetime = ServiceLifetime.Scoped)
             where TContextImplementation : DbContext, TContextService
             => AddDbContext<TContextService, TContextImplementation>(
                 serviceCollection,
                 optionsAction == null
-                    ? (Action<IServiceProvider, DbContextOptionsBuilder>)null
-                    : (p, b) => optionsAction.Invoke(b), contextLifetime, optionsLifetime);
+                    ? (Action<IServiceProvider, DbContextOptionsBuilder>?)null
+                    : (p, b) => optionsAction?.Invoke(b), contextLifetime, optionsLifetime);
 
         /// <summary>
         ///     Registers the given context as a service in the <see cref="IServiceCollection" /> and enables DbContext pooling.
@@ -305,7 +307,7 @@ namespace Microsoft.Extensions.DependencyInjection
         ///           public void ConfigureServices(IServiceCollection services)
         ///           {
         ///               var connectionString = "connection string to database";
-        /// 
+        ///
         ///               services.AddDbContext&lt;MyContext&gt;(ServiceLifetime.Scoped);
         ///           }
         ///       </code>
@@ -334,7 +336,7 @@ namespace Microsoft.Extensions.DependencyInjection
         ///           public void ConfigureServices(IServiceCollection services)
         ///           {
         ///               var connectionString = "connection string to database";
-        /// 
+        ///
         ///               services.AddDbContext&lt;MyContext&gt;(ServiceLifetime.Scoped);
         ///           }
         ///       </code>
@@ -355,7 +357,7 @@ namespace Microsoft.Extensions.DependencyInjection
             where TContextService : class
             => AddDbContext<TContextService, TContextImplementation>(
                 serviceCollection,
-                (Action<IServiceProvider, DbContextOptionsBuilder>)null,
+                (Action<IServiceProvider, DbContextOptionsBuilder>?)null,
                 contextLifetime,
                 optionsLifetime);
 
@@ -379,7 +381,7 @@ namespace Microsoft.Extensions.DependencyInjection
         ///           public void ConfigureServices(IServiceCollection services)
         ///           {
         ///               var connectionString = "connection string to database";
-        /// 
+        ///
         ///               services
         ///                   .AddEntityFrameworkSqlServer()
         ///                   .AddDbContext&lt;MyContext&gt;((serviceProvider, options) =>
@@ -439,7 +441,7 @@ namespace Microsoft.Extensions.DependencyInjection
         ///           public void ConfigureServices(IServiceCollection services)
         ///           {
         ///               var connectionString = "connection string to database";
-        /// 
+        ///
         ///               services
         ///                   .AddEntityFrameworkSqlServer()
         ///                   .AddDbContext&lt;MyContext&gt;((serviceProvider, options) =>
@@ -474,7 +476,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </returns>
         public static IServiceCollection AddDbContext<TContextService, TContextImplementation>(
             [NotNull] this IServiceCollection serviceCollection,
-            [CanBeNull] Action<IServiceProvider, DbContextOptionsBuilder> optionsAction,
+            [CanBeNull] Action<IServiceProvider, DbContextOptionsBuilder>? optionsAction,
             ServiceLifetime contextLifetime = ServiceLifetime.Scoped,
             ServiceLifetime optionsLifetime = ServiceLifetime.Scoped)
             where TContextImplementation : DbContext, TContextService
@@ -500,7 +502,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         private static void AddCoreServices<TContextImplementation>(
             IServiceCollection serviceCollection,
-            Action<IServiceProvider, DbContextOptionsBuilder> optionsAction,
+            Action<IServiceProvider, DbContextOptionsBuilder>? optionsAction,
             ServiceLifetime optionsLifetime)
             where TContextImplementation : DbContext
         {
@@ -523,7 +525,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         private static DbContextOptions<TContext> DbContextOptionsFactory<TContext>(
             [NotNull] IServiceProvider applicationServiceProvider,
-            [CanBeNull] Action<IServiceProvider, DbContextOptionsBuilder> optionsAction)
+            [CanBeNull] Action<IServiceProvider, DbContextOptionsBuilder>? optionsAction)
             where TContext : DbContext
         {
             var builder = new DbContextOptionsBuilder<TContext>(

--- a/src/EFCore/Internal/IEntityFinder.cs
+++ b/src/EFCore/Internal/IEntityFinder.cs
@@ -8,6 +8,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Internal
 {
     /// <summary>
@@ -20,13 +22,13 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        object Find([CanBeNull] object[] keyValues);
+        object? Find([CanBeNull] object[]? keyValues);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        Task<object> FindAsync([CanBeNull] object[] keyValues, CancellationToken cancellationToken = default);
+        Task<object?> FindAsync([CanBeNull] object[]? keyValues, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -53,13 +55,13 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        object[] GetDatabaseValues([NotNull] InternalEntityEntry entry);
+        object[]? GetDatabaseValues([NotNull] InternalEntityEntry entry);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        Task<object[]> GetDatabaseValuesAsync(
+        Task<object[]?> GetDatabaseValuesAsync(
             [NotNull] InternalEntityEntry entry, CancellationToken cancellationToken = default);
     }
 }

--- a/src/EFCore/Internal/IEntityFinder`.cs
+++ b/src/EFCore/Internal/IEntityFinder`.cs
@@ -8,6 +8,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Internal
 {
     /// <summary>
@@ -21,13 +23,13 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        new TEntity Find([CanBeNull] object[] keyValues);
+        new TEntity? Find([CanBeNull] object[]? keyValues);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        new Task<TEntity> FindAsync([CanBeNull] object[] keyValues, CancellationToken cancellationToken = default);
+        new Task<TEntity?> FindAsync([CanBeNull] object[]? keyValues, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Internal/InternalDbQuery.cs
+++ b/src/EFCore/Internal/InternalDbQuery.cs
@@ -12,6 +12,8 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Internal
 {
     /// <summary>
@@ -23,8 +25,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
         where TQuery : class
     {
         private readonly DbContext _context;
-        private IEntityType _entityType;
-        private EntityQueryable<TQuery> _entityQueryable;
+        private IEntityType? _entityType;
+        private EntityQueryable<TQuery>? _entityQueryable;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Internal/InternalDbSet.cs
+++ b/src/EFCore/Internal/InternalDbSet.cs
@@ -15,6 +15,8 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Internal
 {
     /// <summary>
@@ -26,9 +28,9 @@ namespace Microsoft.EntityFrameworkCore.Internal
         where TEntity : class
     {
         private readonly DbContext _context;
-        private IEntityType _entityType;
-        private EntityQueryable<TEntity> _entityQueryable;
-        private LocalView<TEntity> _localView;
+        private IEntityType? _entityType;
+        private EntityQueryable<TEntity>? _entityQueryable;
+        private LocalView<TEntity>? _localView;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -115,21 +117,21 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public override TEntity Find(params object[] keyValues)
+        public override TEntity? Find(params object[]? keyValues)
             => Finder.Find(keyValues);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public override Task<TEntity> FindAsync(params object[] keyValues)
+        public override Task<TEntity?> FindAsync(params object[]? keyValues)
             => Finder.FindAsync(keyValues);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public override Task<TEntity> FindAsync(object[] keyValues, CancellationToken cancellationToken)
+        public override Task<TEntity?> FindAsync(object[]? keyValues, CancellationToken cancellationToken)
             => Finder.FindAsync(keyValues, cancellationToken);
 
         /// <summary>

--- a/src/EFCore/Internal/NonCapturingLazyInitializer.cs
+++ b/src/EFCore/Internal/NonCapturingLazyInitializer.cs
@@ -5,6 +5,8 @@ using System;
 using System.Threading;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Internal
 {
     /// <summary>
@@ -19,19 +21,20 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static TValue EnsureInitialized<TParam, TValue>(
-            [CanBeNull] ref TValue target,
+            [CanBeNull] ref TValue? target,
             [CanBeNull] TParam param,
             [NotNull] Func<TParam, TValue> valueFactory)
             where TValue : class
         {
-            if (Volatile.Read(ref target) != null)
+            var tmp = Volatile.Read(ref target);
+            if (tmp != null)
             {
-                return target;
+                return tmp;
             }
 
             Interlocked.CompareExchange(ref target, valueFactory(param), null);
 
-            return target;
+            return target!;
         }
 
         /// <summary>
@@ -39,20 +42,21 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static TValue EnsureInitialized<TParam1, TParam2, TValue>(
-            [CanBeNull] ref TValue target,
+            [CanBeNull] ref TValue? target,
             [CanBeNull] TParam1 param1,
             [CanBeNull] TParam2 param2,
             [NotNull] Func<TParam1, TParam2, TValue> valueFactory)
             where TValue : class
         {
-            if (Volatile.Read(ref target) != null)
+            var tmp = Volatile.Read(ref target);
+            if (tmp != null)
             {
-                return target;
+                return tmp;
             }
 
             Interlocked.CompareExchange(ref target, valueFactory(param1, param2), null);
 
-            return target;
+            return target!;
         }
 
         /// <summary>
@@ -60,18 +64,19 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static TValue EnsureInitialized<TValue>(
-            [CanBeNull] ref TValue target,
+            [CanBeNull] ref TValue? target,
             [NotNull] TValue value)
             where TValue : class
         {
-            if (Volatile.Read(ref target) != null)
+            var tmp = Volatile.Read(ref target);
+            if (tmp != null)
             {
-                return target;
+                return tmp;
             }
 
             Interlocked.CompareExchange(ref target, value, null);
 
-            return target;
+            return target!;
         }
 
         /// <summary>
@@ -79,19 +84,19 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static TValue EnsureInitialized<TParam, TValue>(
-            [CanBeNull] ref TValue target,
+            [CanBeNull] ref TValue? target,
             [CanBeNull] TParam param,
             [NotNull] Action<TParam> valueFactory)
             where TValue : class
         {
             if (Volatile.Read(ref target) != null)
             {
-                return target;
+                return target!;
             }
 
             valueFactory(param);
 
-            return Volatile.Read(ref target);
+            return Volatile.Read(ref target)!;
         }
     }
 }

--- a/src/EFCore/Internal/TypeExtensions.cs
+++ b/src/EFCore/Internal/TypeExtensions.cs
@@ -8,6 +8,8 @@ using System.Reflection;
 using System.Text;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Internal
 {
     /// <summary>
@@ -40,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public static bool IsDefaultValue([NotNull] this Type type, [CanBeNull] object value)
+        public static bool IsDefaultValue([NotNull] this Type type, [CanBeNull] object? value)
             => (value?.Equals(type.GetDefaultValue()) != false);
 
         /// <summary>

--- a/src/EFCore/ModelBuilder.cs
+++ b/src/EFCore/ModelBuilder.cs
@@ -14,6 +14,8 @@ using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore
 {
     /// <summary>
@@ -343,7 +345,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns>
         ///     The same <see cref="ModelBuilder" /> instance so that additional configuration calls can be chained.
         /// </returns>
-        public virtual ModelBuilder ApplyConfigurationsFromAssembly(Assembly assembly, Func<Type, bool> predicate = null)
+        public virtual ModelBuilder ApplyConfigurationsFromAssembly(Assembly assembly, Func<Type, bool>? predicate = null)
         {
             var applyEntityConfigurationMethod = typeof(ModelBuilder)
                 .GetMethods()
@@ -392,7 +394,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     separate owned type instances.
         /// </summary>
         /// <typeparam name="T"> The entity type to be configured. </typeparam>
-        public virtual OwnedEntityTypeBuilder<T> Owned<T>()
+        public virtual OwnedEntityTypeBuilder<T>? Owned<T>()
             where T : class
         {
             Builder.Owned(typeof(T), ConfigurationSource.Explicit);
@@ -405,7 +407,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     separate owned type instances.
         /// </summary>
         /// <param name="type"> The entity type to be configured. </param>
-        public virtual OwnedEntityTypeBuilder Owned([NotNull] Type type)
+        public virtual OwnedEntityTypeBuilder? Owned([NotNull] Type type)
         {
             Check.NotNull(type, nameof(type));
 

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -7,6 +7,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Logging;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Internal
 {
     /// <summary>
@@ -1840,7 +1842,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         /// <summary>
         ///     Cannot create a relationship between '{newPrincipalEntityType}.{newPrincipalNavigation}' and '{newDependentEntityType}.{newDependentNavigation}', because there already is a relationship between '{existingPrincipalEntityType}.{existingPrincipalNavigation}' and '{existingDependentEntityType}.{existingDependentNavigation}'. Navigation properties can only participate in a single relationship.
         /// </summary>
-        public static string ConflictingRelationshipNavigation([CanBeNull] object newPrincipalEntityType, [CanBeNull] object newPrincipalNavigation, [CanBeNull] object newDependentEntityType, [CanBeNull] object newDependentNavigation, [CanBeNull] object existingPrincipalEntityType, [CanBeNull] object existingPrincipalNavigation, [CanBeNull] object existingDependentEntityType, [CanBeNull] object existingDependentNavigation)
+        public static string ConflictingRelationshipNavigation([CanBeNull] object? newPrincipalEntityType, [CanBeNull] object? newPrincipalNavigation, [CanBeNull] object? newDependentEntityType, [CanBeNull] object? newDependentNavigation, [CanBeNull] object? existingPrincipalEntityType, [CanBeNull] object? existingPrincipalNavigation, [CanBeNull] object? existingDependentEntityType, [CanBeNull] object? existingDependentNavigation)
             => string.Format(
                 GetString("ConflictingRelationshipNavigation", nameof(newPrincipalEntityType), nameof(newPrincipalNavigation), nameof(newDependentEntityType), nameof(newDependentNavigation), nameof(existingPrincipalEntityType), nameof(existingPrincipalNavigation), nameof(existingDependentEntityType), nameof(existingDependentNavigation)),
                 newPrincipalEntityType, newPrincipalNavigation, newDependentEntityType, newDependentNavigation, existingPrincipalEntityType, existingPrincipalNavigation, existingDependentEntityType, existingDependentNavigation);

--- a/src/EFCore/Storage/CoreTypeMapping.cs
+++ b/src/EFCore/Storage/CoreTypeMapping.cs
@@ -11,6 +11,8 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>
@@ -39,10 +41,10 @@ namespace Microsoft.EntityFrameworkCore.Storage
             /// <param name="valueGeneratorFactory"> An optional factory for creating a specific <see cref="ValueGenerator" />. </param>
             public CoreTypeMappingParameters(
                 [NotNull] Type clrType,
-                [CanBeNull] ValueConverter converter = null,
-                [CanBeNull] ValueComparer comparer = null,
-                [CanBeNull] ValueComparer keyComparer = null,
-                [CanBeNull] Func<IProperty, IEntityType, ValueGenerator> valueGeneratorFactory = null)
+                [CanBeNull] ValueConverter? converter = null,
+                [CanBeNull] ValueComparer? comparer = null,
+                [CanBeNull] ValueComparer? keyComparer = null,
+                [CanBeNull] Func<IProperty, IEntityType, ValueGenerator>? valueGeneratorFactory = null)
                 : this(clrType, converter, comparer, keyComparer, null, valueGeneratorFactory)
             {
             }
@@ -58,11 +60,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
             /// <param name="valueGeneratorFactory"> An optional factory for creating a specific <see cref="ValueGenerator" />. </param>
             public CoreTypeMappingParameters(
                 [NotNull] Type clrType,
-                [CanBeNull] ValueConverter converter,
-                [CanBeNull] ValueComparer comparer,
-                [CanBeNull] ValueComparer keyComparer,
-                [CanBeNull] ValueComparer structuralComparer,
-                [CanBeNull] Func<IProperty, IEntityType, ValueGenerator> valueGeneratorFactory)
+                [CanBeNull] ValueConverter? converter,
+                [CanBeNull] ValueComparer? comparer,
+                [CanBeNull] ValueComparer? keyComparer,
+                [CanBeNull] ValueComparer? structuralComparer,
+                [CanBeNull] Func<IProperty, IEntityType, ValueGenerator>? valueGeneratorFactory)
             {
                 Check.NotNull(clrType, nameof(clrType));
 
@@ -82,28 +84,28 @@ namespace Microsoft.EntityFrameworkCore.Storage
             /// <summary>
             ///     The mapping converter.
             /// </summary>
-            public ValueConverter Converter { get; }
+            public ValueConverter? Converter { get; }
 
             /// <summary>
             ///     The mapping comparer.
             /// </summary>
-            public ValueComparer Comparer { get; }
+            public ValueComparer? Comparer { get; }
 
             /// <summary>
             ///     The mapping key comparer.
             /// </summary>
-            public ValueComparer KeyComparer { get; }
+            public ValueComparer? KeyComparer { get; }
 
             /// <summary>
             ///     The mapping structural comparer.
             /// </summary>
-            public ValueComparer StructuralComparer { get; }
+            public ValueComparer? StructuralComparer { get; }
 
             /// <summary>
             ///     An optional factory for creating a specific <see cref="ValueGenerator" /> to use with
             ///     this mapping.
             /// </summary>
-            public Func<IProperty, IEntityType, ValueGenerator> ValueGeneratorFactory { get; }
+            public Func<IProperty, IEntityType, ValueGenerator>? ValueGeneratorFactory { get; }
 
             /// <summary>
             ///     Creates a new <see cref="CoreTypeMappingParameters" /> parameter object with the given
@@ -121,9 +123,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
                     ValueGeneratorFactory);
         }
 
-        private ValueComparer _comparer;
-        private ValueComparer _keyComparer;
-        private readonly ValueComparer _structuralComparer;
+        private ValueComparer? _comparer;
+        private ValueComparer? _keyComparer;
+        private readonly ValueComparer? _structuralComparer;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="CoreTypeMapping" /> class.
@@ -171,13 +173,13 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Converts types to and from the store whenever this mapping is used.
         ///     May be null if no conversion is needed.
         /// </summary>
-        public virtual ValueConverter Converter => Parameters.Converter;
+        public virtual ValueConverter? Converter => Parameters.Converter;
 
         /// <summary>
         ///     An optional factory for creating a specific <see cref="ValueGenerator" /> to use with
         ///     this mapping.
         /// </summary>
-        public virtual Func<IProperty, IEntityType, ValueGenerator> ValueGeneratorFactory { get; }
+        public virtual Func<IProperty, IEntityType, ValueGenerator>? ValueGeneratorFactory { get; }
 
         /// <summary>
         ///     A <see cref="ValueComparer" /> adds custom value snapshotting and comparison for

--- a/src/EFCore/Storage/Database.cs
+++ b/src/EFCore/Storage/Database.cs
@@ -11,6 +11,8 @@ using Microsoft.EntityFrameworkCore.Update;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Remotion.Linq;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/DatabaseDependencies.cs
+++ b/src/EFCore/Storage/DatabaseDependencies.cs
@@ -5,6 +5,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/DatabaseProvider.cs
+++ b/src/EFCore/Storage/DatabaseProvider.cs
@@ -7,6 +7,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/DatabaseProviderDependencies.cs
+++ b/src/EFCore/Storage/DatabaseProviderDependencies.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/ExecutionResult.cs
+++ b/src/EFCore/Storage/ExecutionResult.cs
@@ -3,6 +3,8 @@
 
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/ExecutionStrategy.cs
+++ b/src/EFCore/Storage/ExecutionStrategy.cs
@@ -11,6 +11,8 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>
@@ -161,7 +163,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
         private TResult ExecuteImplementation<TState, TResult>(
             Func<DbContext, TState, TResult> operation,
-            Func<DbContext, TState, ExecutionResult<TResult>> verifySucceeded,
+            Func<DbContext, TState, ExecutionResult<TResult>>? verifySucceeded,
             TState state)
         {
             while (true)
@@ -253,7 +255,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
         private async Task<TResult> ExecuteImplementationAsync<TState, TResult>(
             Func<DbContext, TState, CancellationToken, Task<TResult>> operation,
-            Func<DbContext, TState, CancellationToken, Task<ExecutionResult<TResult>>> verifySucceeded,
+            Func<DbContext, TState, CancellationToken, Task<ExecutionResult<TResult>>>? verifySucceeded,
             TState state,
             CancellationToken cancellationToken)
         {

--- a/src/EFCore/Storage/ExecutionStrategyDependencies.cs
+++ b/src/EFCore/Storage/ExecutionStrategyDependencies.cs
@@ -7,6 +7,8 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/IDatabase.cs
+++ b/src/EFCore/Storage/IDatabase.cs
@@ -10,6 +10,8 @@ using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Update;
 using Remotion.Linq;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/IDatabaseCreator.cs
+++ b/src/EFCore/Storage/IDatabaseCreator.cs
@@ -4,6 +4,8 @@
 using System.Threading;
 using System.Threading.Tasks;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/IDatabaseProvider.cs
+++ b/src/EFCore/Storage/IDatabaseProvider.cs
@@ -4,6 +4,8 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/IDbContextTransaction.cs
+++ b/src/EFCore/Storage/IDbContextTransaction.cs
@@ -4,6 +4,8 @@
 using System;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/IDbContextTransactionManager.cs
+++ b/src/EFCore/Storage/IDbContextTransactionManager.cs
@@ -5,6 +5,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/IExecutionStrategy.cs
+++ b/src/EFCore/Storage/IExecutionStrategy.cs
@@ -6,6 +6,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/IExecutionStrategyFactory.cs
+++ b/src/EFCore/Storage/IExecutionStrategyFactory.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/ITransactionEnlistmentManager.cs
+++ b/src/EFCore/Storage/ITransactionEnlistmentManager.cs
@@ -4,6 +4,8 @@
 using System.Transactions;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/ITypeMappingSource.cs
+++ b/src/EFCore/Storage/ITypeMappingSource.cs
@@ -6,6 +6,8 @@ using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>
@@ -29,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="property"> The property. </param>
         /// <returns> The type mapping, or <c>null</c> if none was found. </returns>
-        CoreTypeMapping FindMapping([NotNull] IProperty property);
+        CoreTypeMapping? FindMapping([NotNull] IProperty property);
 
         /// <summary>
         ///     <para>
@@ -43,7 +45,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="member"> The field or property. </param>
         /// <returns> The type mapping, or <c>null</c> if none was found. </returns>
-        CoreTypeMapping FindMapping([NotNull] MemberInfo member);
+        CoreTypeMapping? FindMapping([NotNull] MemberInfo member);
 
         /// <summary>
         ///     <para>
@@ -57,6 +59,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="type"> The CLR type. </param>
         /// <returns> The type mapping, or <c>null</c> if none was found. </returns>
-        CoreTypeMapping FindMapping([NotNull] Type type);
+        CoreTypeMapping? FindMapping([NotNull] Type type);
     }
 }

--- a/src/EFCore/Storage/ITypeMappingSourcePlugin.cs
+++ b/src/EFCore/Storage/ITypeMappingSourcePlugin.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/Internal/ExecutionStrategyFactory.cs
+++ b/src/EFCore/Storage/Internal/ExecutionStrategyFactory.cs
@@ -4,6 +4,8 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.Internal
 {
     /// <summary>

--- a/src/EFCore/Storage/Internal/NoopExecutionStrategy.cs
+++ b/src/EFCore/Storage/Internal/NoopExecutionStrategy.cs
@@ -6,6 +6,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.Internal
 {
     /// <summary>

--- a/src/EFCore/Storage/MaterializationContext.cs
+++ b/src/EFCore/Storage/MaterializationContext.cs
@@ -6,6 +6,8 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/RetryLimitExceededException.cs
+++ b/src/EFCore/Storage/RetryLimitExceededException.cs
@@ -4,6 +4,8 @@
 using System;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/TypeMappingInfo.cs
+++ b/src/EFCore/Storage/TypeMappingInfo.cs
@@ -10,6 +10,8 @@ using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>
@@ -34,7 +36,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         {
             Check.NotNull(principals, nameof(principals));
 
-            ValueConverter customConverter = null;
+            ValueConverter? customConverter = null;
             int? size = null;
             bool? isUnicode = null;
             for (var i = 0; i < principals.Count; i++)

--- a/src/EFCore/Storage/TypeMappingSource.cs
+++ b/src/EFCore/Storage/TypeMappingSource.cs
@@ -10,6 +10,8 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
+#nullable enable
+
 #pragma warning disable 1574, CS0419 // Ambiguous reference in cref attribute
 namespace Microsoft.EntityFrameworkCore.Storage
 {
@@ -25,8 +27,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
     /// </summary>
     public abstract class TypeMappingSource : TypeMappingSourceBase
     {
-        private readonly ConcurrentDictionary<(TypeMappingInfo, Type, ValueConverter), CoreTypeMapping> _explicitMappings
-            = new ConcurrentDictionary<(TypeMappingInfo, Type, ValueConverter), CoreTypeMapping>();
+        private readonly ConcurrentDictionary<(TypeMappingInfo, Type?, ValueConverter?), CoreTypeMapping?> _explicitMappings
+            = new ConcurrentDictionary<(TypeMappingInfo, Type?, ValueConverter?), CoreTypeMapping?>();
 
         /// <summary>
         ///     Initializes a new instance of the this class.
@@ -37,12 +39,12 @@ namespace Microsoft.EntityFrameworkCore.Storage
         {
         }
 
-        private CoreTypeMapping FindMappingWithConversion(
+        private CoreTypeMapping? FindMappingWithConversion(
             in TypeMappingInfo mappingInfo,
-            [CanBeNull] IReadOnlyList<IProperty> principals)
+            [CanBeNull] IReadOnlyList<IProperty>? principals)
         {
-            Type providerClrType = null;
-            ValueConverter customConverter = null;
+            Type? providerClrType = null;
+            ValueConverter? customConverter = null;
             if (principals != null)
             {
                 for (var i = 0; i < principals.Count; i++)
@@ -141,7 +143,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="property"> The property. </param>
         /// <returns> The type mapping, or <c>null</c> if none was found. </returns>
-        public override CoreTypeMapping FindMapping(IProperty property)
+        public override CoreTypeMapping? FindMapping(IProperty property)
         {
             var mapping = property.FindMapping();
             if (mapping != null)
@@ -168,7 +170,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="type"> The CLR type. </param>
         /// <returns> The type mapping, or <c>null</c> if none was found. </returns>
-        public override CoreTypeMapping FindMapping(Type type)
+        public override CoreTypeMapping? FindMapping(Type type)
             => FindMappingWithConversion(new TypeMappingInfo(type), null);
 
         /// <summary>
@@ -186,7 +188,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="member"> The field or property. </param>
         /// <returns> The type mapping, or <c>null</c> if none was found. </returns>
-        public override CoreTypeMapping FindMapping(MemberInfo member)
+        public override CoreTypeMapping? FindMapping(MemberInfo member)
             => FindMappingWithConversion(new TypeMappingInfo(member), null);
     }
 }

--- a/src/EFCore/Storage/TypeMappingSourceBase.cs
+++ b/src/EFCore/Storage/TypeMappingSourceBase.cs
@@ -7,6 +7,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 #pragma warning disable 1574, CS0419 // Ambiguous reference in cref attribute
 namespace Microsoft.EntityFrameworkCore.Storage
 {
@@ -50,7 +52,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="mappingInfo"> The mapping info to use to create the mapping. </param>
         /// <returns> The type mapping, or <c>null</c> if none could be found. </returns>
-        protected virtual CoreTypeMapping FindMapping(in TypeMappingInfo mappingInfo)
+        protected virtual CoreTypeMapping? FindMapping(in TypeMappingInfo mappingInfo)
         {
             foreach (var plugin in Dependencies.Plugins)
             {
@@ -70,8 +72,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="mapping"> The mapping, if any. </param>
         /// <param name="property"> The property, if any. </param>
         protected virtual void ValidateMapping(
-            [CanBeNull] CoreTypeMapping mapping,
-            [CanBeNull] IProperty property)
+            [CanBeNull] CoreTypeMapping? mapping,
+            [CanBeNull] IProperty? property)
         {
         }
 
@@ -85,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="property"> The property. </param>
         /// <returns> The type mapping, or <c>null</c> if none was found. </returns>
-        public abstract CoreTypeMapping FindMapping(IProperty property);
+        public abstract CoreTypeMapping? FindMapping(IProperty property);
 
         /// <summary>
         ///     <para>
@@ -102,7 +104,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="type"> The CLR type. </param>
         /// <returns> The type mapping, or <c>null</c> if none was found. </returns>
-        public abstract CoreTypeMapping FindMapping(Type type);
+        public abstract CoreTypeMapping? FindMapping(Type type);
 
         /// <summary>
         ///     <para>
@@ -119,6 +121,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="member"> The field or property. </param>
         /// <returns> The type mapping, or <c>null</c> if none was found. </returns>
-        public abstract CoreTypeMapping FindMapping(MemberInfo member);
+        public abstract CoreTypeMapping? FindMapping(MemberInfo member);
     }
 }

--- a/src/EFCore/Storage/TypeMappingSourceDependencies.cs
+++ b/src/EFCore/Storage/TypeMappingSourceDependencies.cs
@@ -6,6 +6,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/ValueBuffer.cs
+++ b/src/EFCore/Storage/ValueBuffer.cs
@@ -7,6 +7,8 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/ValueConversion/BoolToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/BoolToStringConverter.cs
@@ -6,6 +6,8 @@ using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -26,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         public BoolToStringConverter(
             [NotNull] string falseValue,
             [NotNull] string trueValue,
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 Check.NotEmpty(falseValue, nameof(falseValue)),
                 Check.NotEmpty(trueValue, nameof(trueValue)),

--- a/src/EFCore/Storage/ValueConversion/BoolToTwoValuesConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/BoolToTwoValuesConverter.cs
@@ -5,6 +5,8 @@ using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -31,8 +33,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         public BoolToTwoValuesConverter(
             [CanBeNull] TProvider falseValue,
             [CanBeNull] TProvider trueValue,
-            [CanBeNull] Expression<Func<TProvider, bool>> fromProvider = null,
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] Expression<Func<TProvider, bool>>? fromProvider = null,
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(ToProvider(falseValue, trueValue), fromProvider ?? ToBool(trueValue), mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/BoolToZeroOneConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/BoolToZeroOneConverter.cs
@@ -4,6 +4,8 @@
 using System;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -18,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public BoolToZeroOneConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public BoolToZeroOneConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(Zero(), One(), null, mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/BytesToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/BytesToStringConverter.cs
@@ -4,6 +4,8 @@
 using System;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -19,10 +21,12 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     facets for the converted data.
         /// </param>
         public BytesToStringConverter(
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
+#nullable disable // https://github.com/dotnet/roslyn/issues/30953
                 v => v == null ? null : Convert.ToBase64String(v),
                 v => v == null ? null : Convert.FromBase64String(v),
+#nullable enable
                 mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/CastingConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/CastingConverter.cs
@@ -5,6 +5,8 @@ using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -16,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         // ReSharper disable once StaticMemberInGenericType
         private static readonly ConverterMappingHints _defaultHints = CreateDefaultHints();
 
-        private static ConverterMappingHints CreateDefaultHints()
+        private static ConverterMappingHints? CreateDefaultHints()
         {
             if (typeof(TProvider).UnwrapNullableType() == typeof(decimal))
             {
@@ -41,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// <summary>
         ///     Creates a new instance of this converter.
         /// </summary>
-        public CastingConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public CastingConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 Convert<TModel, TProvider>(),
                 Convert<TProvider, TModel>(),

--- a/src/EFCore/Storage/ValueConversion/CharToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/CharToStringConverter.cs
@@ -4,6 +4,8 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -21,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public CharToStringConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public CharToStringConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 ToString(),
                 ToChar(),

--- a/src/EFCore/Storage/ValueConversion/ConverterMappingHints.cs
+++ b/src/EFCore/Storage/ValueConversion/ConverterMappingHints.cs
@@ -6,6 +6,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -27,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
             int? precision = null,
             int? scale = null,
             bool? unicode = null,
-            [CanBeNull] Func<IProperty, IEntityType, ValueGenerator> valueGeneratorFactory = null)
+            [CanBeNull] Func<IProperty, IEntityType, ValueGenerator>? valueGeneratorFactory = null)
         {
             Size = size;
             Precision = precision;
@@ -42,7 +44,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// </summary>
         /// <param name="hints"> The hints to add. </param>
         /// <returns> The combined hints. </returns>
-        public virtual ConverterMappingHints With([CanBeNull] ConverterMappingHints hints)
+        public virtual ConverterMappingHints With([CanBeNull] ConverterMappingHints? hints)
             => hints == null
                 ? this
                 : new ConverterMappingHints(
@@ -76,6 +78,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     An optional factory for creating a specific <see cref="ValueGenerator" /> to use for model
         ///     values when this converter is being used.
         /// </summary>
-        public virtual Func<IProperty, IEntityType, ValueGenerator> ValueGeneratorFactory { get; }
+        public virtual Func<IProperty, IEntityType, ValueGenerator>? ValueGeneratorFactory { get; }
     }
 }

--- a/src/EFCore/Storage/ValueConversion/DateTimeOffsetToBinaryConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/DateTimeOffsetToBinaryConverter.cs
@@ -4,6 +4,8 @@
 using System;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -19,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public DateTimeOffsetToBinaryConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public DateTimeOffsetToBinaryConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 v => ((v.Ticks / 1000) << 11) | ((long)v.Offset.TotalMinutes & 0x7FF),
                 v => new DateTimeOffset(

--- a/src/EFCore/Storage/ValueConversion/DateTimeOffsetToBytesConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/DateTimeOffsetToBytesConverter.cs
@@ -5,6 +5,8 @@ using System;
 using System.Linq;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -28,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public DateTimeOffsetToBytesConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public DateTimeOffsetToBytesConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 v => ToBytes(v),
                 v => v == null ? default : FromBytes(v),
@@ -44,8 +46,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 
         private static byte[] ToBytes(DateTimeOffset value)
         {
-            var timeBytes = (byte[])_longToBytes.ConvertToProvider(value.DateTime.ToBinary());
-            var offsetBytes = (byte[])_shortToBytes.ConvertToProvider(value.Offset.TotalMinutes);
+            var timeBytes = (byte[])_longToBytes.ConvertToProvider(value.DateTime.ToBinary())!;
+            var offsetBytes = (byte[])_shortToBytes.ConvertToProvider(value.Offset.TotalMinutes)!;
             return timeBytes.Concat(offsetBytes).ToArray();
         }
 

--- a/src/EFCore/Storage/ValueConversion/DateTimeOffsetToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/DateTimeOffsetToStringConverter.cs
@@ -5,6 +5,8 @@ using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -19,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public DateTimeOffsetToStringConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public DateTimeOffsetToStringConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 ToString(),
                 ToDateTimeOffset(),

--- a/src/EFCore/Storage/ValueConversion/DateTimeToBinaryConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/DateTimeToBinaryConverter.cs
@@ -4,6 +4,8 @@
 using System;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -19,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public DateTimeToBinaryConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public DateTimeToBinaryConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 v => v.ToBinary(),
                 v => DateTime.FromBinary(v),

--- a/src/EFCore/Storage/ValueConversion/DateTimeToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/DateTimeToStringConverter.cs
@@ -5,6 +5,8 @@ using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -19,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public DateTimeToStringConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public DateTimeToStringConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 ToString(),
                 ToDateTime(),

--- a/src/EFCore/Storage/ValueConversion/DateTimeToTicksConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/DateTimeToTicksConverter.cs
@@ -4,6 +4,8 @@
 using System;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -18,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public DateTimeToTicksConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public DateTimeToTicksConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 v => v.Ticks,
                 v => new DateTime(v),

--- a/src/EFCore/Storage/ValueConversion/DefaultValueConverterRegistryDependencies.cs
+++ b/src/EFCore/Storage/ValueConversion/DefaultValueConverterRegistryDependencies.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>

--- a/src/EFCore/Storage/ValueConversion/EnumToNumberConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/EnumToNumberConverter.cs
@@ -6,6 +6,8 @@ using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -18,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         // ReSharper disable once StaticMemberInGenericType
         private static readonly ConverterMappingHints _defaultHints = CreateDefaultHints();
 
-        private static ConverterMappingHints CreateDefaultHints()
+        private static ConverterMappingHints? CreateDefaultHints()
         {
             var underlyingModelType = typeof(TEnum).UnwrapEnumType();
 
@@ -35,10 +37,12 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public EnumToNumberConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public EnumToNumberConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
+#nullable disable // https://github.com/dotnet/roslyn/issues/30953
                 ToNumber(),
                 ToEnum(),
+#nullable enable
                 _defaultHints == null
                     ? mappingHints
                     : _defaultHints.With(mappingHints))

--- a/src/EFCore/Storage/ValueConversion/EnumToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/EnumToStringConverter.cs
@@ -4,6 +4,8 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -19,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public EnumToStringConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public EnumToStringConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 ToString(),
                 ToEnum(),

--- a/src/EFCore/Storage/ValueConversion/GuidToBytesConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/GuidToBytesConverter.cs
@@ -5,6 +5,8 @@ using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -31,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public GuidToBytesConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public GuidToBytesConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 v => v.ToByteArray(),
                 v => v == null ? Guid.Empty : new Guid(v),

--- a/src/EFCore/Storage/ValueConversion/GuidToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/GuidToStringConverter.cs
@@ -5,6 +5,8 @@ using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -20,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public GuidToStringConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public GuidToStringConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 ToString(),
                 ToGuid(),

--- a/src/EFCore/Storage/ValueConversion/IValueConverterSelector.cs
+++ b/src/EFCore/Storage/ValueConversion/IValueConverterSelector.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -24,6 +26,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// <returns> The converters available. </returns>
         IEnumerable<ValueConverterInfo> Select(
             [NotNull] Type modelClrType,
-            [CanBeNull] Type providerClrType = null);
+            [CanBeNull] Type? providerClrType = null);
     }
 }

--- a/src/EFCore/Storage/ValueConversion/Internal/CompositeValueConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/CompositeValueConverter.cs
@@ -7,6 +7,8 @@ using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Remotion.Linq.Parsing.ExpressionVisitors;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
 {
     /// <summary>
@@ -22,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
         public CompositeValueConverter(
             [NotNull] ValueConverter converter1,
             [NotNull] ValueConverter converter2,
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 Compose(
                     (Expression<Func<TModel, TMiddle>>)converter1.ConvertToProviderExpression,

--- a/src/EFCore/Storage/ValueConversion/Internal/StringCharConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/StringCharConverter.cs
@@ -6,6 +6,8 @@ using System.Globalization;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
 {
     /// <summary>
@@ -21,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
         public StringCharConverter(
             [NotNull] Expression<Func<TModel, TProvider>> convertToProviderExpression,
             [NotNull] Expression<Func<TProvider, TModel>> convertFromProviderExpression,
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/Internal/StringDateTimeConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/StringDateTimeConverter.cs
@@ -6,6 +6,8 @@ using System.Globalization;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
 {
     /// <summary>
@@ -29,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
         public StringDateTimeConverter(
             [NotNull] Expression<Func<TModel, TProvider>> convertToProviderExpression,
             [NotNull] Expression<Func<TProvider, TModel>> convertFromProviderExpression,
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/Internal/StringDateTimeOffsetConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/StringDateTimeOffsetConverter.cs
@@ -6,6 +6,8 @@ using System.Globalization;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
 {
     /// <summary>
@@ -29,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
         public StringDateTimeOffsetConverter(
             [NotNull] Expression<Func<TModel, TProvider>> convertToProviderExpression,
             [NotNull] Expression<Func<TProvider, TModel>> convertFromProviderExpression,
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/Internal/StringEnumConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/StringEnumConverter.cs
@@ -6,6 +6,8 @@ using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
 {
     /// <summary>
@@ -22,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
         public StringEnumConverter(
             [NotNull] Expression<Func<TModel, TProvider>> convertToProviderExpression,
             [NotNull] Expression<Func<TProvider, TModel>> convertFromProviderExpression,
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/Internal/StringGuidConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/StringGuidConverter.cs
@@ -6,6 +6,8 @@ using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
 {
     /// <summary>
@@ -31,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
         public StringGuidConverter(
             [NotNull] Expression<Func<TModel, TProvider>> convertToProviderExpression,
             [NotNull] Expression<Func<TProvider, TModel>> convertFromProviderExpression,
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/Internal/StringNumberConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/StringNumberConverter.cs
@@ -6,6 +6,8 @@ using System.Globalization;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
 {
     /// <summary>
@@ -29,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
         public StringNumberConverter(
             [NotNull] Expression<Func<TModel, TProvider>> convertToProviderExpression,
             [NotNull] Expression<Func<TProvider, TModel>> convertFromProviderExpression,
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
         {
         }
@@ -78,7 +80,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected static new Expression<Func<TNumber, string>> ToString()
+        protected static new Expression<Func<TNumber, string?>> ToString()
         {
             var type = typeof(TNumber).UnwrapNullableType();
 

--- a/src/EFCore/Storage/ValueConversion/Internal/StringTimeSpanConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/StringTimeSpanConverter.cs
@@ -6,6 +6,8 @@ using System.Globalization;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
 {
     /// <summary>
@@ -29,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
         public StringTimeSpanConverter(
             [NotNull] Expression<Func<TModel, TProvider>> convertToProviderExpression,
             [NotNull] Expression<Func<TProvider, TModel>> convertFromProviderExpression,
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/NumberToBytesConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/NumberToBytesConverter.cs
@@ -6,6 +6,8 @@ using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -32,7 +34,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public NumberToBytesConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public NumberToBytesConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(ToBytes(), ToNumber(), _defaultHints.With(mappingHints))
         {
         }

--- a/src/EFCore/Storage/ValueConversion/NumberToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/NumberToStringConverter.cs
@@ -4,6 +4,8 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -19,10 +21,12 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     facets for the converted data.
         /// </param>
         public NumberToStringConverter(
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
+#nullable disable
                 ToString(),
                 ToNumber(),
+#nullable enable
                 _defaultHints.With(mappingHints))
         {
         }

--- a/src/EFCore/Storage/ValueConversion/StringToBoolConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToBoolConverter.cs
@@ -4,6 +4,8 @@
 using System;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -19,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     facets for the converted data.
         /// </param>
         public StringToBoolConverter(
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 v => Convert.ToBoolean(v),
                 v => Convert.ToString(v),

--- a/src/EFCore/Storage/ValueConversion/StringToBytesConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToBytesConverter.cs
@@ -4,6 +4,8 @@
 using System.Text;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -21,10 +23,12 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// </param>
         public StringToBytesConverter(
             [NotNull] Encoding encoding,
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
+#nullable disable
                 v => v == null ? null : encoding.GetBytes(v),
                 v => v == null ? null : encoding.GetString(v),
+#nullable enable
                 mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/StringToCharConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToCharConverter.cs
@@ -4,6 +4,8 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -21,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public StringToCharConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public StringToCharConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 ToChar(),
                 ToString(),

--- a/src/EFCore/Storage/ValueConversion/StringToDateTimeConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToDateTimeConverter.cs
@@ -5,6 +5,8 @@ using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -19,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public StringToDateTimeConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public StringToDateTimeConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 ToDateTime(),
                 ToString(),

--- a/src/EFCore/Storage/ValueConversion/StringToDateTimeOffsetConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToDateTimeOffsetConverter.cs
@@ -5,6 +5,8 @@ using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -20,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     facets for the converted data.
         /// </param>
         public StringToDateTimeOffsetConverter(
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 ToDateTimeOffset(),
                 ToString(),

--- a/src/EFCore/Storage/ValueConversion/StringToEnumConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToEnumConverter.cs
@@ -4,6 +4,8 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -19,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public StringToEnumConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public StringToEnumConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 ToEnum(),
                 ToString(),

--- a/src/EFCore/Storage/ValueConversion/StringToGuidConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToGuidConverter.cs
@@ -5,6 +5,8 @@ using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -20,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public StringToGuidConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public StringToGuidConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 ToGuid(),
                 ToString(),

--- a/src/EFCore/Storage/ValueConversion/StringToNumberConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToNumberConverter.cs
@@ -4,6 +4,8 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -19,10 +21,12 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     facets for the converted data.
         /// </param>
         public StringToNumberConverter(
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
+#nullable disable // https://github.com/dotnet/roslyn/issues/30953
                 ToNumber(),
                 ToString(),
+#nullable enable
                 _defaultHints.With(mappingHints))
         {
         }

--- a/src/EFCore/Storage/ValueConversion/StringToTimeSpanConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToTimeSpanConverter.cs
@@ -5,6 +5,8 @@ using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -19,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public StringToTimeSpanConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public StringToTimeSpanConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 ToTimeSpan(),
                 ToString(),

--- a/src/EFCore/Storage/ValueConversion/TimeSpanToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/TimeSpanToStringConverter.cs
@@ -5,6 +5,8 @@ using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -19,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public TimeSpanToStringConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public TimeSpanToStringConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(
                 ToString(),
                 ToTimeSpan(),

--- a/src/EFCore/Storage/ValueConversion/TimeSpanToTicksConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/TimeSpanToTicksConverter.cs
@@ -4,6 +4,8 @@
 using System;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -18,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public TimeSpanToTicksConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+        public TimeSpanToTicksConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(v => v.Ticks, v => new TimeSpan(v), mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/ValueConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/ValueConverter.cs
@@ -9,6 +9,8 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -37,8 +39,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         protected ValueConverter(
             [NotNull] LambdaExpression convertToProviderExpression,
             [NotNull] LambdaExpression convertFromProviderExpression,
-            [CanBeNull] ConverterMappingHints mappingHints = null)
-
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
         {
             Check.NotNull(convertToProviderExpression, nameof(convertToProviderExpression));
             Check.NotNull(convertFromProviderExpression, nameof(convertFromProviderExpression));
@@ -52,13 +53,13 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Gets the function to convert objects when writing data to the store,
         ///     setup to handle nulls, boxing, and non-exact matches of simple types.
         /// </summary>
-        public abstract Func<object, object> ConvertToProvider { get; }
+        public abstract Func<object?, object?> ConvertToProvider { get; }
 
         /// <summary>
         ///     Gets the function to convert objects when reading data from the store,
         ///     setup to handle nulls, boxing, and non-exact matches of simple types.
         /// </summary>
-        public abstract Func<object, object> ConvertFromProvider { get; }
+        public abstract Func<object?, object?> ConvertFromProvider { get; }
 
         /// <summary>
         ///     Gets the expression to convert objects when writing data to the store,
@@ -88,7 +89,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </summary>
-        public virtual ConverterMappingHints MappingHints { get; }
+        public virtual ConverterMappingHints? MappingHints { get; }
 
         /// <summary>
         ///     Checks that the type used with a value converter is supported by that converter and throws if not.
@@ -125,7 +126,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// <param name="secondConverter"> The second converter. </param>
         /// <returns> The composed converter. </returns>
         public virtual ValueConverter ComposeWith(
-            [CanBeNull] ValueConverter secondConverter)
+            [CanBeNull] ValueConverter? secondConverter)
         {
             if (secondConverter == null)
             {

--- a/src/EFCore/Storage/ValueConversion/ValueConverterInfo.cs
+++ b/src/EFCore/Storage/ValueConversion/ValueConverterInfo.cs
@@ -5,6 +5,8 @@ using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -29,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
             [NotNull] Type modelClrType,
             [NotNull] Type providerClrType,
             [NotNull] Func<ValueConverterInfo, ValueConverter> factory,
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
         {
             _factory = factory;
             Check.NotNull(modelClrType, nameof(modelClrType));
@@ -55,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </summary>
-        public ConverterMappingHints MappingHints { get; }
+        public ConverterMappingHints? MappingHints { get; }
 
         /// <summary>
         ///     Creates an instance of the <see cref="ValueConverter" />.

--- a/src/EFCore/Storage/ValueConversion/ValueConverterSelector.cs
+++ b/src/EFCore/Storage/ValueConversion/ValueConverterSelector.cs
@@ -9,6 +9,8 @@ using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -57,7 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// <returns> The converters available. </returns>
         public virtual IEnumerable<ValueConverterInfo> Select(
             Type modelClrType,
-            Type providerClrType = null)
+            Type? providerClrType = null)
         {
             Check.NotNull(modelClrType, nameof(modelClrType));
 
@@ -272,7 +274,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         }
 
         private IEnumerable<ValueConverterInfo> ForChar(
-            Type underlyingModelType, Type underlyingProviderType)
+            Type underlyingModelType, Type? underlyingProviderType)
         {
             if (underlyingProviderType == null
                 || underlyingProviderType == typeof(string))
@@ -293,7 +295,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         }
 
         private IEnumerable<ValueConverterInfo> CharToBytes(
-            Type underlyingModelType, Type underlyingProviderType)
+            Type underlyingModelType, Type? underlyingProviderType)
         {
             if (underlyingProviderType == null
                 || underlyingProviderType == typeof(byte[]))
@@ -305,7 +307,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         }
 
         private IEnumerable<ValueConverterInfo> EnumToStringOrBytes(
-            Type underlyingModelType, Type underlyingProviderType)
+            Type underlyingModelType, Type? underlyingProviderType)
         {
             if (underlyingProviderType == null
                 || underlyingProviderType == typeof(string))
@@ -345,7 +347,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         }
 
         private IEnumerable<ValueConverterInfo> NumberToStringOrBytes(
-            Type underlyingModelType, Type underlyingProviderType)
+            Type underlyingModelType, Type? underlyingProviderType)
         {
             if (underlyingProviderType == null
                 || underlyingProviderType == typeof(string))
@@ -372,9 +374,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 
         private IEnumerable<ValueConverterInfo> FindNumericConvertions(
             Type modelType,
-            Type providerType,
+            Type? providerType,
             Type converterType,
-            Func<Type, Type, IEnumerable<ValueConverterInfo>> afterPreferred)
+            Func<Type, Type?, IEnumerable<ValueConverterInfo>>? afterPreferred)
         {
             var usedTypes = new List<Type>
             {
@@ -474,7 +476,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         private IEnumerable<ValueConverterInfo> FindPreferredConversions(
             Type[] candidateTypes,
             Type modelType,
-            Type providerType,
+            Type? providerType,
             Type converterType)
         {
             var underlyingModelType = modelType.UnwrapEnumType();

--- a/src/EFCore/Storage/ValueConversion/ValueConverter`.cs
+++ b/src/EFCore/Storage/ValueConversion/ValueConverter`.cs
@@ -6,6 +6,8 @@ using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -14,8 +16,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
     /// </summary>
     public class ValueConverter<TModel, TProvider> : ValueConverter
     {
-        private Func<object, object> _convertToProvider;
-        private Func<object, object> _convertFromProvider;
+        private Func<object?, object?>? _convertToProvider;
+        private Func<object?, object?>? _convertFromProvider;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="ValueConverter{TModel,TProvider}" /> class.
@@ -29,19 +31,19 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         public ValueConverter(
             [NotNull] Expression<Func<TModel, TProvider>> convertToProviderExpression,
             [NotNull] Expression<Func<TProvider, TModel>> convertFromProviderExpression,
-            [CanBeNull] ConverterMappingHints mappingHints = null)
+            [CanBeNull] ConverterMappingHints? mappingHints = null)
             : base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
         {
             _convertToProvider = SanitizeConverter(convertToProviderExpression);
             _convertFromProvider = SanitizeConverter(convertFromProviderExpression);
         }
 
-        private static Func<object, object> SanitizeConverter<TIn, TOut>(Expression<Func<TIn, TOut>> convertExpression)
+        private static Func<object?, object?> SanitizeConverter<TIn, TOut>(Expression<Func<TIn, TOut>> convertExpression)
         {
             var compiled = convertExpression.Compile();
 
             return v => v == null
-                ? (object)null
+                ? (object?)null
                 : compiled(Sanitize<TIn>(v));
         }
 
@@ -58,7 +60,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Gets the function to convert objects when writing data to the store,
         ///     setup to handle nulls, boxing, and non-exact matches of simple types.
         /// </summary>
-        public override Func<object, object> ConvertToProvider
+        public override Func<object?, object?> ConvertToProvider
             => NonCapturingLazyInitializer.EnsureInitialized(
                 ref _convertToProvider, this, c => SanitizeConverter(c.ConvertToProviderExpression));
 
@@ -66,7 +68,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Gets the function to convert objects when reading data from the store,
         ///     setup to handle nulls, boxing, and non-exact matches of simple types.
         /// </summary>
-        public override Func<object, object> ConvertFromProvider
+        public override Func<object?, object?> ConvertFromProvider
             => NonCapturingLazyInitializer.EnsureInitialized(
                 ref _convertFromProvider, this, c => SanitizeConverter(c.ConvertFromProviderExpression));
 

--- a/src/Shared/Check.cs
+++ b/src/Shared/Check.cs
@@ -8,6 +8,10 @@ using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
 
+// Disable nullability checks until all projects using this file are converted to perform nullability checks
+// themselves
+#nullable disable
+
 namespace Microsoft.EntityFrameworkCore.Utilities
 {
     [DebuggerStepThrough]

--- a/src/Shared/NullableAnnotations.cs
+++ b/src/Shared/NullableAnnotations.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Parameter,
+                   AllowMultiple = false)]
+    public class NotNullWhenTrueAttribute : Attribute
+    {
+        public NotNullWhenTrueAttribute() { }
+    }
+}

--- a/src/Shared/SharedTypeExtensions.cs
+++ b/src/Shared/SharedTypeExtensions.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
+#nullable enable
+
 // ReSharper disable once CheckNamespace
 namespace System
 {
@@ -147,11 +149,11 @@ namespace System
             return sequenceType;
         }
 
-        public static Type TryGetSequenceType(this Type type)
+        public static Type? TryGetSequenceType(this Type type)
             => type.TryGetElementType(typeof(IEnumerable<>))
                ?? type.TryGetElementType(typeof(IAsyncEnumerable<>));
 
-        public static Type TryGetElementType(this Type type, Type interfaceOrBaseType)
+        public static Type? TryGetElementType(this Type type, Type interfaceOrBaseType)
         {
             if (type.GetTypeInfo().IsGenericTypeDefinition)
             {
@@ -160,7 +162,7 @@ namespace System
 
             var types = GetGenericTypeImplementations(type, interfaceOrBaseType);
 
-            Type singleImplementation = null;
+            Type? singleImplementation = null;
             foreach (var impelementation in types)
             {
                 if (singleImplementation == null)
@@ -297,7 +299,7 @@ namespace System
 #pragma warning restore IDE0034 // Simplify 'default' expression
         };
 
-        public static object GetDefaultValue(this Type type)
+        public static object? GetDefaultValue(this Type type)
         {
             if (!type.GetTypeInfo().IsValueType)
             {


### PR DESCRIPTION
This is a first PR annotating the EF Core codebase for C# 8.0 nullability. Since this is a huge task, I'm splitting it down into subsections and enabling nullability checks on a file-by-file basis (with `#nullable enable`). When an entire project is annotated, I'll remove all of these and enable checks at the csproj level.

This takes care of:
* EFCore.Abstractions
* EFCore/Storage
* EFCore/Internal
* EFCore/

Part of #14150

Updates the entire solution to use C# 8.0