### PR TITLE
[2.2] Stop assuming dependent entity types have a key

### DIFF
--- a/src/EFCore.Specification.Tests/LoadTestBase.cs
+++ b/src/EFCore.Specification.Tests/LoadTestBase.cs
@@ -6383,6 +6383,52 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
+        protected class OptionalChildView
+        {
+            private readonly Action<object, string> _loader;
+            private RootClass _root;
+
+            public OptionalChildView()
+            {
+            }
+
+            public OptionalChildView(Action<object, string> lazyLoader)
+            {
+                _loader = lazyLoader;
+            }
+
+            public int? RootId { get; set; }
+
+            public RootClass Root
+            {
+                get => _loader.Load(this, ref _root);
+                set => _root = value;
+            }
+        }
+
+        protected class RequiredChildView
+        {
+            private readonly Action<object, string> _loader;
+            private RootClass _root;
+
+            public RequiredChildView()
+            {
+            }
+
+            public RequiredChildView(Action<object, string> lazyLoader)
+            {
+                _loader = lazyLoader;
+            }
+
+            public int RootId { get; set; }
+
+            public RootClass Root
+            {
+                get => _loader.Load(this, ref _root);
+                set => _root = value;
+            }
+        }
+
         protected DbContext CreateContext(bool lazyLoadingEnabled = false, bool noTracking = false)
         {
             var context = Fixture.CreateContext();
@@ -6507,6 +6553,9 @@ namespace Microsoft.EntityFrameworkCore
                 modelBuilder.Entity<Product>();
                 modelBuilder.Entity<Deposit>();
                 modelBuilder.Entity<SimpleProduct>();
+
+                modelBuilder.Query<OptionalChildView>();
+                modelBuilder.Query<RequiredChildView>();
             }
 
             protected override void Seed(PoolableDbContext context)

--- a/src/EFCore/ChangeTracking/Internal/StateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/StateManager.cs
@@ -423,7 +423,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
         private IIdentityMap FindIdentityMap(IKey key)
         {
-            if (_identityMap0 == null)
+            if (_identityMap0 == null
+                || key == null)
             {
                 return null;
             }


### PR DESCRIPTION
Fixes #14226

Specifically, when using a store-generated key, propagation of a key value will cause dependents to be searched for, which can't be found since the dependents don't have keys.