### PR TITLE
Start throwing by default for excessive service provider use

### DIFF
--- a/src/EFCore.InMemory/Metadata/Conventions/Internal/InMemoryConventionSetBuilder.cs
+++ b/src/EFCore.InMemory/Metadata/Conventions/Internal/InMemoryConventionSetBuilder.cs
@@ -28,7 +28,9 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Metadata.Conventions.Internal
         {
             var serviceProvider = new ServiceCollection()
                 .AddEntityFrameworkInMemoryDatabase()
-                .AddDbContext<DbContext>(o => o.UseInMemoryDatabase(Guid.NewGuid().ToString()))
+                .AddDbContext<DbContext>((p, o) =>
+                    o.UseInMemoryDatabase(Guid.NewGuid().ToString())
+                        .UseInternalServiceProvider(p))
                 .BuildServiceProvider();
 
             using (var serviceScope = serviceProvider.GetRequiredService<IServiceScopeFactory>().CreateScope())

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerConventionSetBuilder.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerConventionSetBuilder.cs
@@ -89,7 +89,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         {
             var serviceProvider = new ServiceCollection()
                 .AddEntityFrameworkSqlServer()
-                .AddDbContext<DbContext>(o => o.UseSqlServer("Server=."))
+                .AddDbContext<DbContext>((p, o) =>
+                    o.UseSqlServer("Server=.")
+                        .UseInternalServiceProvider(p))
                 .BuildServiceProvider();
 
             using (var serviceScope = serviceProvider.GetRequiredService<IServiceScopeFactory>().CreateScope())

--- a/src/EFCore.Sqlite.Core/Metadata/Conventions/SqliteConventionSetBuilder.cs
+++ b/src/EFCore.Sqlite.Core/Metadata/Conventions/SqliteConventionSetBuilder.cs
@@ -30,7 +30,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         {
             var serviceProvider = new ServiceCollection()
                 .AddEntityFrameworkSqlite()
-                .AddDbContext<DbContext>(o => o.UseSqlite("Filename=_.db"))
+                .AddDbContext<DbContext>((p, o) =>
+                    o.UseSqlite("Filename=_.db")
+                        .UseInternalServiceProvider(p))
                 .BuildServiceProvider();
 
             using (var serviceScope = serviceProvider.GetRequiredService<IServiceScopeFactory>().CreateScope())

--- a/src/EFCore/DbContextOptionsBuilder.cs
+++ b/src/EFCore/DbContextOptionsBuilder.cs
@@ -199,9 +199,26 @@ namespace Microsoft.EntityFrameworkCore
         ///         so that EF will manage the service providers and can create new instances as required.
         ///     </para>
         /// </summary>
+        /// <param name="sensitiveDataLoggingEnabled"> If <c>true</c>, then sensitive data is logged. </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
         public virtual DbContextOptionsBuilder EnableSensitiveDataLogging(bool sensitiveDataLoggingEnabled = true)
             => WithOption(e => e.WithSensitiveDataLoggingEnabled(sensitiveDataLoggingEnabled));
+
+        /// <summary>
+        ///     <para>
+        ///         Enables or disables caching of internal service providers. Disabling caching can
+        ///         massively impact performance and should only be used in testing scenarios that
+        ///         build many service providers for test isolation.
+        ///     </para>
+        ///     <para>
+        ///         Note that if the application is setting the internal service provider through a call to
+        ///         <see cref="UseInternalServiceProvider" />, then setting this option wil have no effect.
+        ///     </para>
+        /// </summary>
+        /// <param name="cacheServiceProvider"> If <c>true</c>, then the internal service provider is cached. </param>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public virtual DbContextOptionsBuilder EnableServiceProviderCaching(bool cacheServiceProvider = true)
+            => WithOption(e => e.WithCacheServiceProvider(cacheServiceProvider));
 
         /// <summary>
         ///     <para>

--- a/src/EFCore/DbContextOptionsBuilder`.cs
+++ b/src/EFCore/DbContextOptionsBuilder`.cs
@@ -187,6 +187,22 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     <para>
+        ///         Enables or disables caching of internal service providers. Disabling caching can
+        ///         massively impact performance and should only be used in testing scenarios that
+        ///         build many service providers for test isolation.
+        ///     </para>
+        ///     <para>
+        ///         Note that if the application is setting the internal service provider through a call to
+        ///         <see cref="UseInternalServiceProvider" />, then setting this option wil have no effect.
+        ///     </para>
+        /// </summary>
+        /// <param name="cacheServiceProvider"> If <c>true</c>, then the internal service provider is cached. </param>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public new virtual DbContextOptionsBuilder<TContext> EnableServiceProviderCaching(bool cacheServiceProvider = true)
+            => (DbContextOptionsBuilder<TContext>)base.EnableServiceProviderCaching(cacheServiceProvider);
+
+        /// <summary>
+        ///     <para>
         ///         Sets the tracking behavior for LINQ queries run against the context. Disabling change tracking
         ///         is useful for read-only scenarios because it avoids the overhead of setting up change tracking for each
         ///         entity instance. You should not disable change tracking if you want to manipulate entity instances and

--- a/src/EFCore/Infrastructure/CoreOptionsExtension.cs
+++ b/src/EFCore/Infrastructure/CoreOptionsExtension.cs
@@ -41,9 +41,11 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         private int? _maxPoolSize;
         private long? _serviceProviderHash;
         private string _logFragment;
+        private bool _cacheServiceProvider = true;
 
         private WarningsConfiguration _warningsConfiguration
             = new WarningsConfiguration()
+                .TryWithExplicit(CoreEventId.ManyServiceProvidersCreatedWarning, WarningBehavior.Throw)
                 .TryWithExplicit(CoreEventId.LazyLoadOnDisposedContextWarning, WarningBehavior.Throw)
                 .TryWithExplicit(CoreEventId.DetachedLazyLoadingWarning, WarningBehavior.Throw);
 
@@ -70,6 +72,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             _warningsConfiguration = copyFrom.WarningsConfiguration;
             _queryTrackingBehavior = copyFrom.QueryTrackingBehavior;
             _maxPoolSize = copyFrom.MaxPoolSize;
+            _cacheServiceProvider = copyFrom.ServiceProviderCachingEnabled;
 
             if (copyFrom._replacedServices != null)
             {
@@ -255,6 +258,21 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         }
 
         /// <summary>
+        ///     Creates a new instance with all options the same as for this instance, but with the given option changed.
+        ///     It is unusual to call this method directly. Instead use <see cref="DbContextOptionsBuilder" />.
+        /// </summary>
+        /// <param name="cacheServiceProvider"> The option to change. </param>
+        /// <returns> A new instance with the option changed. </returns>
+        public virtual CoreOptionsExtension WithCacheServiceProvider(bool cacheServiceProvider)
+        {
+            var clone = Clone();
+
+            clone._cacheServiceProvider = cacheServiceProvider;
+
+            return clone;
+        }
+
+        /// <summary>
         ///     The option set from the <see cref="DbContextOptionsBuilder.EnableSensitiveDataLogging" /> method.
         /// </summary>
         public virtual bool IsSensitiveDataLoggingEnabled => _sensitiveDataLoggingEnabled;
@@ -298,6 +316,11 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     The option set from the <see cref="DbContextOptionsBuilder.UseQueryTrackingBehavior" /> method.
         /// </summary>
         public virtual QueryTrackingBehavior QueryTrackingBehavior => _queryTrackingBehavior;
+
+        /// <summary>
+        ///     The option set from the <see cref="DbContextOptionsBuilder.EnableServiceProviderCaching" /> method.
+        /// </summary>
+        public virtual bool ServiceProviderCachingEnabled => _cacheServiceProvider;
 
         /// <summary>
         ///     The options set from the <see cref="DbContextOptionsBuilder.ReplaceService{TService,TImplementation}" /> method.

--- a/test/EFCore.CrossStore.FunctionalTests/ConfigurationPatternsTest.cs
+++ b/test/EFCore.CrossStore.FunctionalTests/ConfigurationPatternsTest.cs
@@ -243,13 +243,8 @@ namespace Microsoft.EntityFrameworkCore
             {
                 using (SqlServerTestStore.GetNorthwindStore())
                 {
-                    var inMemoryServiceProvider = new ServiceCollection()
-                        .AddEntityFrameworkInMemoryDatabase()
-                        .BuildServiceProvider();
-
-                    var sqlServerServiceProvider = new ServiceCollection()
-                        .AddEntityFrameworkSqlServer()
-                        .BuildServiceProvider();
+                    var inMemoryServiceProvider = InMemoryFixture.DefaultServiceProvider;
+                    var sqlServerServiceProvider = SqlServerFixture.DefaultServiceProvider;
 
                     await NestedContextTest(
                         () => new BlogContext(inMemoryServiceProvider),

--- a/test/EFCore.CrossStore.FunctionalTests/DiscriminatorTest.cs
+++ b/test/EFCore.CrossStore.FunctionalTests/DiscriminatorTest.cs
@@ -106,7 +106,8 @@ namespace Microsoft.EntityFrameworkCore
             public DbSet<SubIntProduct2> SubIntProducts2 { get; set; }
 
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseInMemoryDatabase(nameof(Context4285));
+                => optionsBuilder
+                    .UseInMemoryDatabase(nameof(Context4285));
 
             protected override void OnModelCreating(ModelBuilder builder)
             {

--- a/test/EFCore.Design.Tests/Design/DbContextActivatorTest.cs
+++ b/test/EFCore.Design.Tests/Design/DbContextActivatorTest.cs
@@ -18,7 +18,9 @@ namespace Microsoft.EntityFrameworkCore.Design
         private class TestContext : DbContext
         {
             protected override void OnConfiguring(DbContextOptionsBuilder options)
-                => options.UseInMemoryDatabase(nameof(DbContextActivatorTest));
+                => options
+                    .EnableServiceProviderCaching(false)
+                    .UseInMemoryDatabase(nameof(DbContextActivatorTest));
         }
     }
 }

--- a/test/EFCore.Design.Tests/Design/Internal/DbContextOperationsTest.cs
+++ b/test/EFCore.Design.Tests/Design/Internal/DbContextOperationsTest.cs
@@ -31,7 +31,9 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
 #pragma warning restore RCS1213 // Remove unused member declaration.
                 => new TestWebHost(
                     new ServiceCollection()
-                        .AddDbContext<TestContext>(b => b.UseInMemoryDatabase(Guid.NewGuid().ToString()))
+                        .AddDbContext<TestContext>(b =>
+                            b.EnableServiceProviderCaching(false)
+                             .UseInMemoryDatabase(Guid.NewGuid().ToString()))
                         .BuildServiceProvider());
         }
 

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -3325,7 +3325,9 @@ namespace RootNamespace
             var serviceProvider = new ServiceCollection()
                 .AddEntityFrameworkSqlServer()
                 .AddEntityFrameworkSqlServerNetTopologySuite()
-                .AddDbContext<DbContext>(o => o.UseSqlServer("Server=.", b => b.UseNetTopologySuite()))
+                .AddDbContext<DbContext>((p, o) =>
+                    o.UseSqlServer("Server=.", b => b.UseNetTopologySuite())
+                        .UseInternalServiceProvider(p))
                 .BuildServiceProvider();
 
             using (var serviceScope = serviceProvider.GetRequiredService<IServiceScopeFactory>().CreateScope())

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/ModelCodeGeneratorTestBase.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/ModelCodeGeneratorTestBase.cs
@@ -22,7 +22,10 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         {
             var serviceProvider = new ServiceCollection()
                 .AddEntityFrameworkSqlServer()
-                .AddDbContext<DbContext>(o => o.UseSqlServer("Server=."))
+                .AddDbContext<DbContext>(
+                    (p, o) =>
+                        o.UseSqlServer("Server=.")
+                            .UseInternalServiceProvider(p))
                 .BuildServiceProvider();
 
             using (var serviceScope = serviceProvider.GetRequiredService<IServiceScopeFactory>().CreateScope())

--- a/test/EFCore.InMemory.FunctionalTests/ConfigPatternsInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/ConfigPatternsInMemoryTest.cs
@@ -44,7 +44,8 @@ namespace Microsoft.EntityFrameworkCore
             public DbSet<Blog> Blogs { get; set; }
 
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseInMemoryDatabase(nameof(ImplicitServicesAndConfigBlogContext));
+                => optionsBuilder
+                    .UseInMemoryDatabase(nameof(ImplicitServicesAndConfigBlogContext));
         }
 
         [Fact]
@@ -201,6 +202,9 @@ namespace Microsoft.EntityFrameworkCore
         private class NoServicesAndNoConfigBlogContext : DbContext
         {
             public DbSet<Blog> Blogs { get; set; }
+
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder.EnableServiceProviderCaching(false);
         }
 
         [Fact]
@@ -360,7 +364,9 @@ namespace Microsoft.EntityFrameworkCore
         public void Can_register_configuration_with_DI_container_and_have_it_injected()
         {
             var optionsBuilder = new DbContextOptionsBuilder();
-            optionsBuilder.UseInMemoryDatabase(nameof(InjectConfigurationBlogContext));
+            optionsBuilder
+                .EnableServiceProviderCaching(false)
+                .UseInMemoryDatabase(nameof(InjectConfigurationBlogContext));
 
             var services = new ServiceCollection();
             services.AddTransient<InjectConfigurationBlogContext>()

--- a/test/EFCore.InMemory.FunctionalTests/DatabaseInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/DatabaseInMemoryTest.cs
@@ -142,7 +142,9 @@ namespace Microsoft.EntityFrameworkCore
             public DbSet<Artist> Artists { get; set; }
 
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseInMemoryDatabase(nameof(SimpleContext));
+                => optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase(nameof(SimpleContext));
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)
                 => modelBuilder.Entity<Artist>().HasKey(a => a.ArtistId);

--- a/test/EFCore.InMemory.FunctionalTests/GlobalDatabaseTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/GlobalDatabaseTest.cs
@@ -68,6 +68,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             using (var context = new BooFooContext(
                 new DbContextOptionsBuilder()
+                    .EnableServiceProviderCaching(false)
                     .UseInMemoryDatabase(nameof(BooFooContext), _databaseRoot)
                     .Options))
             {
@@ -77,6 +78,7 @@ namespace Microsoft.EntityFrameworkCore
 
             using (var context = new BooFooContext(
                 new DbContextOptionsBuilder()
+                    .EnableServiceProviderCaching(false)
                     .UseInMemoryDatabase(nameof(BooFooContext), _databaseRoot)
                     .EnableSensitiveDataLogging()
                     .Options))
@@ -90,6 +92,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             using (var context = new BooFooContext(
                 new DbContextOptionsBuilder()
+                    .EnableServiceProviderCaching(false)
                     .UseInMemoryDatabase(nameof(BooFooContext), _databaseRoot)
                     .Options))
             {
@@ -98,8 +101,9 @@ namespace Microsoft.EntityFrameworkCore
             }
 
             var serviceProvider = new ServiceCollection()
-                .AddDbContext<BooFooContext>(
-                    b => b.UseInMemoryDatabase(nameof(BooFooContext), _databaseRoot))
+                .AddDbContext<BooFooContext>(b =>
+                    b.UseInMemoryDatabase(nameof(BooFooContext), _databaseRoot)
+                        .EnableServiceProviderCaching(false))
                 .BuildServiceProvider();
 
             using (var scope = serviceProvider.CreateScope())

--- a/test/EFCore.InMemory.FunctionalTests/InMemoryFixture.cs
+++ b/test/EFCore.InMemory.FunctionalTests/InMemoryFixture.cs
@@ -4,17 +4,32 @@
 using System;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.EntityFrameworkCore
 {
     public class InMemoryFixture
     {
+        public static IServiceProvider DefaultServiceProvider { get; }
+            = BuildServiceProvider();
+
+        public static IServiceProvider DefaultSensitiveServiceProvider { get; }
+            = BuildServiceProvider();
+
         public readonly IServiceProvider ServiceProvider;
 
         public InMemoryFixture()
         {
-            ServiceProvider = InMemoryTestStoreFactory.Instance.AddProviderServices(new ServiceCollection())
-                .BuildServiceProvider();
+            ServiceProvider = BuildServiceProvider();
         }
+
+        public static ServiceProvider BuildServiceProvider(ILoggerFactory loggerFactory)
+            => BuildServiceProvider(new ServiceCollection().AddSingleton(loggerFactory));
+
+        public static ServiceProvider BuildServiceProvider(IServiceCollection providerServices = null)
+            => InMemoryTestStoreFactory.Instance.AddProviderServices(
+                    providerServices
+                    ?? new ServiceCollection())
+                .BuildServiceProvider();
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/LoggingInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/LoggingInMemoryTest.cs
@@ -1,12 +1,16 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.Extensions.DependencyInjection;
+
 namespace Microsoft.EntityFrameworkCore
 {
     public class LoggingInMemoryTest : LoggingTestBase
     {
-        protected override DbContextOptionsBuilder CreateOptionsBuilder()
-            => new DbContextOptionsBuilder().UseInMemoryDatabase("LoggingInMemoryTest");
+        protected override DbContextOptionsBuilder CreateOptionsBuilder(IServiceCollection services)
+            => new DbContextOptionsBuilder()
+                .UseInMemoryDatabase("LoggingInMemoryTest")
+                .UseInternalServiceProvider(services.AddEntityFrameworkInMemoryDatabase().BuildServiceProvider());
 
         protected override string ProviderName => "Microsoft.EntityFrameworkCore.InMemory";
 

--- a/test/EFCore.InMemory.FunctionalTests/NamedDatabaseTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/NamedDatabaseTest.cs
@@ -254,7 +254,9 @@ namespace Microsoft.EntityFrameworkCore
 
                 if (_databaseName == null)
                 {
-                    optionsBuilder.UseInMemoryDatabase(Guid.NewGuid().ToString());
+                    optionsBuilder
+                        .EnableServiceProviderCaching(false)
+                        .UseInMemoryDatabase(Guid.NewGuid().ToString());
                 }
                 else
                 {

--- a/test/EFCore.InMemory.FunctionalTests/Query/QueryBugsInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/QueryBugsInMemoryTest.cs
@@ -117,7 +117,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             {
-                optionsBuilder.UseInMemoryDatabase("9849");
+                optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase("9849");
             }
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -224,7 +226,9 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             {
-                optionsBuilder.UseInMemoryDatabase("3595");
+                optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase("3595");
             }
         }
 
@@ -500,7 +504,9 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             {
-                optionsBuilder.UseInMemoryDatabase("3101");
+                optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase("3101");
             }
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -681,7 +687,9 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             {
-                optionsBuilder.UseInMemoryDatabase("5456");
+                optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase("5456");
             }
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -741,7 +749,9 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             {
-                optionsBuilder.UseInMemoryDatabase("8282");
+                optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase("8282");
             }
         }
 

--- a/test/EFCore.InMemory.Tests/InMemoryDatabaseCreatorTest.cs
+++ b/test/EFCore.InMemory.Tests/InMemoryDatabaseCreatorTest.cs
@@ -141,7 +141,9 @@ namespace Microsoft.EntityFrameworkCore
             public DbSet<Fraggle> Fraggles { get; set; }
 
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseInMemoryDatabase(nameof(FraggleContext));
+                => optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase(nameof(FraggleContext));
         }
 
         private class Fraggle

--- a/test/EFCore.InMemory.Tests/InMemoryDatabaseFacadeTest.cs
+++ b/test/EFCore.InMemory.Tests/InMemoryDatabaseFacadeTest.cs
@@ -19,7 +19,9 @@ namespace Microsoft.EntityFrameworkCore
         private class ProviderContext : DbContext
         {
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseInMemoryDatabase("Maltesers");
+                => optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase("Maltesers");
         }
     }
 }

--- a/test/EFCore.Proxies.Tests/LazyLoadingProxyTests.cs
+++ b/test/EFCore.Proxies.Tests/LazyLoadingProxyTests.cs
@@ -133,11 +133,6 @@ namespace Microsoft.EntityFrameworkCore
                 .AddEntityFrameworkInMemoryDatabase()
                 .BuildServiceProvider();
 
-            var withProxies = new ServiceCollection()
-                .AddEntityFrameworkInMemoryDatabase()
-                .AddEntityFrameworkProxies()
-                .BuildServiceProvider();
-
             using (var context = new NeweyContext(withoutProxies, nameof(Proxy_services_must_be_available), false))
             {
                 context.Add(new March82GGtp());
@@ -149,7 +144,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.Same(typeof(March82GGtp), context.Set<March82GGtp>().Single().GetType());
             }
 
-            using (var context = new NeweyContext(withProxies, nameof(Proxy_services_must_be_available)))
+            using (var context = new NeweyContext(nameof(Proxy_services_must_be_available)))
             {
                 Assert.Same(typeof(March82GGtp), context.Set<March82GGtp>().Single().GetType().BaseType);
             }
@@ -277,7 +272,10 @@ namespace Microsoft.EntityFrameworkCore
             var serviceProvider = new ServiceCollection()
                 .AddEntityFrameworkInMemoryDatabase()
                 .AddEntityFrameworkProxies()
-                .AddDbContext<JammieDodgerContext>(b => b.UseInMemoryDatabase("Jammie").UseLazyLoadingProxies())
+                .AddDbContext<JammieDodgerContext>((p, b) =>
+                    b.UseInMemoryDatabase("Jammie")
+                        .UseInternalServiceProvider(p)
+                        .UseLazyLoadingProxies())
                 .BuildServiceProvider();
 
             using (var scope = serviceProvider.CreateScope())
@@ -365,6 +363,12 @@ namespace Microsoft.EntityFrameworkCore
 
             public NeweyContext(string dbName = null, bool useProxies = true)
             {
+                _internalServiceProvider
+                    = new ServiceCollection()
+                        .AddEntityFrameworkInMemoryDatabase()
+                        .AddEntityFrameworkProxies()
+                        .BuildServiceProvider();
+
                 _dbName = dbName;
                 _useProxies = useProxies;
             }
@@ -420,6 +424,10 @@ namespace Microsoft.EntityFrameworkCore
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
                 => optionsBuilder
                     .UseLazyLoadingProxies()
+                    .UseInternalServiceProvider(new ServiceCollection()
+                        .AddEntityFrameworkInMemoryDatabase()
+                        .AddEntityFrameworkProxies()
+                        .BuildServiceProvider())
                     .UseInMemoryDatabase(Guid.NewGuid().ToString());
         }
 
@@ -492,6 +500,10 @@ namespace Microsoft.EntityFrameworkCore
         {
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
                 => optionsBuilder
+                    .UseInternalServiceProvider(new ServiceCollection()
+                        .AddEntityFrameworkInMemoryDatabase()
+                        .AddEntityFrameworkProxies()
+                        .BuildServiceProvider())
                     .UseInMemoryDatabase(Guid.NewGuid().ToString());
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -503,6 +515,10 @@ namespace Microsoft.EntityFrameworkCore
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
                 => optionsBuilder
                     .UseLazyLoadingProxies(false)
+                    .UseInternalServiceProvider(new ServiceCollection()
+                        .AddEntityFrameworkInMemoryDatabase()
+                        .AddEntityFrameworkProxies()
+                        .BuildServiceProvider())
                     .UseInMemoryDatabase(Guid.NewGuid().ToString());
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/test/EFCore.Relational.Specification.Tests/LoggingRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/LoggingRelationalTestBase.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 // ReSharper disable InconsistentNaming
@@ -17,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             Assert.Equal(
                 ExpectedMessage("MaxBatchSize=10 " + DefaultOptions),
-                ActualMessage(CreateOptionsBuilder(b => b.MaxBatchSize(10))));
+                ActualMessage(s => CreateOptionsBuilder(s, b => b.MaxBatchSize(10))));
         }
 
         [Fact]
@@ -25,7 +26,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             Assert.Equal(
                 ExpectedMessage("CommandTimeout=10 " + DefaultOptions),
-                ActualMessage(CreateOptionsBuilder(b => b.CommandTimeout(10))));
+                ActualMessage(s => CreateOptionsBuilder(s, b => b.CommandTimeout(10))));
         }
 
         [Fact]
@@ -33,7 +34,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             Assert.Equal(
                 ExpectedMessage("UseRelationalNulls " + DefaultOptions),
-                ActualMessage(CreateOptionsBuilder(b => b.UseRelationalNulls())));
+                ActualMessage(s => CreateOptionsBuilder(s, b => b.UseRelationalNulls())));
         }
 
         [Fact]
@@ -41,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             Assert.Equal(
                 ExpectedMessage("MigrationsAssembly=A.B.C " + DefaultOptions),
-                ActualMessage(CreateOptionsBuilder(b => b.MigrationsAssembly("A.B.C"))));
+                ActualMessage(s => CreateOptionsBuilder(s, b => b.MigrationsAssembly("A.B.C"))));
         }
 
         [Fact]
@@ -49,7 +50,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             Assert.Equal(
                 ExpectedMessage("MigrationsHistoryTable=MyHistory " + DefaultOptions),
-                ActualMessage(CreateOptionsBuilder(b => b.MigrationsHistoryTable("MyHistory"))));
+                ActualMessage(s => CreateOptionsBuilder(s, b => b.MigrationsHistoryTable("MyHistory"))));
         }
 
         [Fact]
@@ -57,12 +58,14 @@ namespace Microsoft.EntityFrameworkCore
         {
             Assert.Equal(
                 ExpectedMessage("MigrationsHistoryTable=mySchema.MyHistory " + DefaultOptions),
-                ActualMessage(CreateOptionsBuilder(b => b.MigrationsHistoryTable("MyHistory", "mySchema"))));
+                ActualMessage(s => CreateOptionsBuilder(s, b => b.MigrationsHistoryTable("MyHistory", "mySchema"))));
         }
 
         protected abstract DbContextOptionsBuilder CreateOptionsBuilder(
+            IServiceCollection services,
             Action<RelationalDbContextOptionsBuilder<TBuilder, TExtension>> relationalAction);
 
-        protected override DbContextOptionsBuilder CreateOptionsBuilder() => CreateOptionsBuilder(null);
+        protected override DbContextOptionsBuilder CreateOptionsBuilder(IServiceCollection services)
+            => CreateOptionsBuilder(services, null);
     }
 }

--- a/test/EFCore.Relational.Specification.Tests/MigrationsFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/MigrationsFixtureBase.cs
@@ -4,6 +4,7 @@
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore
 {
@@ -14,7 +15,14 @@ namespace Microsoft.EntityFrameworkCore
         protected override string StoreName { get; } = "MigrationsTest";
 
         public EmptyMigrationsContext CreateEmptyContext()
-            => new EmptyMigrationsContext(TestStore.AddProviderOptions(new DbContextOptionsBuilder()).Options);
+            => new EmptyMigrationsContext(
+                TestStore.AddProviderOptions(
+                        new DbContextOptionsBuilder())
+                    .UseInternalServiceProvider(
+                        TestStoreFactory.AddProviderServices(
+                                new ServiceCollection())
+                            .BuildServiceProvider())
+                    .Options);
 
         public new virtual MigrationsContext CreateContext() => base.CreateContext();
 

--- a/test/EFCore.Relational.Tests/RelationalConnectionTest.cs
+++ b/test/EFCore.Relational.Tests/RelationalConnectionTest.cs
@@ -103,11 +103,11 @@ namespace Microsoft.EntityFrameworkCore
         [Fact]
         public void Throws_with_add_when_no_EF_services_because_parameterless_constructor_use_Database()
         {
-            var appServiceProivder = new ServiceCollection()
+            var appServiceProvider = new ServiceCollection()
                 .AddDbContext<ConstructorTestContextNoConfiguration>()
                 .BuildServiceProvider();
 
-            using (var serviceScope = appServiceProivder
+            using (var serviceScope = appServiceProvider
                 .GetRequiredService<IServiceScopeFactory>()
                 .CreateScope())
             {
@@ -129,6 +129,9 @@ namespace Microsoft.EntityFrameworkCore
 
         private class ConstructorTestContextNoConfiguration : DbContext
         {
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder.UseInternalServiceProvider(
+                    new ServiceCollection().AddEntityFrameworkInMemoryDatabase().BuildServiceProvider());
         }
 
         [Fact]

--- a/test/EFCore.Relational.Tests/Update/BatchExecutorTest.cs
+++ b/test/EFCore.Relational.Tests/Update/BatchExecutorTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;
@@ -9,6 +10,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Update
@@ -93,8 +95,13 @@ namespace Microsoft.EntityFrameworkCore.Update
 
         private class TestContext : DbContext
         {
+            private static readonly IServiceProvider _serviceProvider
+                = FakeRelationalOptionsExtension.AddEntityFrameworkRelationalDatabase(
+                        new ServiceCollection())
+                    .BuildServiceProvider();
+
             public TestContext()
-                : base(RelationalTestHelpers.Instance.CreateOptions())
+                : base(RelationalTestHelpers.Instance.CreateOptions(_serviceProvider))
             {
             }
 

--- a/test/EFCore.Relational.Tests/Update/ModificationCommandComparerTest.cs
+++ b/test/EFCore.Relational.Tests/Update/ModificationCommandComparerTest.cs
@@ -21,8 +21,9 @@ namespace Microsoft.EntityFrameworkCore.Update
             var entityType = model.AddEntityType(typeof(object));
 
             var optionsBuilder = new DbContextOptionsBuilder()
-                .UseModel(model);
-            optionsBuilder.UseInMemoryDatabase(Guid.NewGuid().ToString());
+                .UseModel(model)
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider);
 
             var stateManager = new DbContext(optionsBuilder.Options).GetService<IStateManager>();
 
@@ -154,7 +155,10 @@ namespace Microsoft.EntityFrameworkCore.Update
             var model = new Model();
             var entityType = model.AddEntityType(typeof(object));
 
-            var optionsBuilder = new DbContextOptionsBuilder().UseModel(model).UseInMemoryDatabase(Guid.NewGuid().ToString());
+            var optionsBuilder = new DbContextOptionsBuilder()
+                .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                .UseModel(model)
+                .UseInMemoryDatabase(Guid.NewGuid().ToString());
 
             var stateManager = new DbContext(optionsBuilder.Options).GetService<IStateManager>();
 

--- a/test/EFCore.Specification.Tests/ServiceProviderFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/ServiceProviderFixtureBase.cs
@@ -29,6 +29,7 @@ namespace Microsoft.EntityFrameworkCore
             => AddOptions(testStore.AddProviderOptions(new DbContextOptionsBuilder()))
                 .EnableDetailedErrors()
                 .UseInternalServiceProvider(ServiceProvider)
+                .EnableServiceProviderCaching(false)
                 .Options;
 
         protected override IServiceCollection AddServices(IServiceCollection serviceCollection)

--- a/test/EFCore.Specification.Tests/TestUtilities/TestStore.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/TestStore.cs
@@ -63,7 +63,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         public abstract void Clean(DbContext context);
 
         protected virtual DbContext CreateDefaultContext()
-            => new DbContext(AddProviderOptions(new DbContextOptionsBuilder()).Options);
+            => new DbContext(AddProviderOptions(new DbContextOptionsBuilder().EnableServiceProviderCaching(false)).Options);
 
         protected virtual TestStoreIndex GetTestStoreIndex(IServiceProvider serviceProvider) => _globalTestStoreIndex;
 

--- a/test/EFCore.SqlServer.FunctionalTests/ConnectionSpecificationTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ConnectionSpecificationTest.cs
@@ -50,7 +50,9 @@ namespace Microsoft.EntityFrameworkCore
         private class StringInOnConfiguringContext : NorthwindContextBase
         {
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseSqlServer(SqlServerNorthwindTestStoreFactory.NorthwindConnectionString, b => b.ApplyConfiguration());
+                => optionsBuilder
+                    .EnableServiceProviderCaching(false)
+                    .UseSqlServer(SqlServerNorthwindTestStoreFactory.NorthwindConnectionString, b => b.ApplyConfiguration());
         }
 
         [Fact]
@@ -93,7 +95,9 @@ namespace Microsoft.EntityFrameworkCore
             }
 
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseSqlServer(_connection, b => b.ApplyConfiguration());
+                => optionsBuilder
+                    .EnableServiceProviderCaching(false)
+                    .UseSqlServer(_connection, b => b.ApplyConfiguration());
 
             public override void Dispose()
             {
@@ -141,6 +145,8 @@ namespace Microsoft.EntityFrameworkCore
 
         private class NoUseSqlServerContext : NorthwindContextBase
         {
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder.EnableServiceProviderCaching(false);
         }
 
         [Fact]
@@ -191,7 +197,9 @@ namespace Microsoft.EntityFrameworkCore
             {
                 Assert.Same(_options, optionsBuilder.Options);
 
-                optionsBuilder.UseSqlServer(_connection, b => b.ApplyConfiguration());
+                optionsBuilder
+                    .EnableServiceProviderCaching(false)
+                    .UseSqlServer(_connection, b => b.ApplyConfiguration());
 
                 Assert.NotSame(_options, optionsBuilder.Options);
             }
@@ -246,7 +254,9 @@ namespace Microsoft.EntityFrameworkCore
             {
                 Assert.Same(_options, optionsBuilder.Options);
 
-                optionsBuilder.UseSqlServer(SqlServerNorthwindTestStoreFactory.NorthwindConnectionString, b => b.ApplyConfiguration());
+                optionsBuilder
+                    .EnableServiceProviderCaching(false)
+                    .UseSqlServer(SqlServerNorthwindTestStoreFactory.NorthwindConnectionString, b => b.ApplyConfiguration());
 
                 Assert.NotSame(_options, optionsBuilder.Options);
             }
@@ -269,7 +279,7 @@ namespace Microsoft.EntityFrameworkCore
                 = new ServiceCollection()
                     .AddSingleton<IConfiguration>(configBuilder.Build())
                     .AddDbContext<UseConfigurationContext>(
-                        b => b.UseSqlServer(connectionString))
+                        b => b.UseSqlServer(connectionString).EnableServiceProviderCaching(false))
                     .BuildServiceProvider();
 
             using (SqlServerTestStore.GetNorthwindStore())

--- a/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
@@ -29,10 +29,14 @@ namespace Microsoft.EntityFrameworkCore
             where TContext : DbContext, TContextService
             => new ServiceCollection()
                 .AddDbContextPool<TContextService, TContext>(
-                    ob => ob.UseSqlServer(SqlServerNorthwindTestStoreFactory.NorthwindConnectionString),
+                    ob =>
+                        ob.UseSqlServer(SqlServerNorthwindTestStoreFactory.NorthwindConnectionString)
+                            .EnableServiceProviderCaching(false),
                     poolSize)
                 .AddDbContextPool<ISecondContext, SecondContext>(
-                    ob => ob.UseSqlServer(SqlServerNorthwindTestStoreFactory.NorthwindConnectionString),
+                    ob =>
+                        ob.UseSqlServer(SqlServerNorthwindTestStoreFactory.NorthwindConnectionString)
+                            .EnableServiceProviderCaching(false),
                     poolSize)
                 .BuildServiceProvider();
 
@@ -40,10 +44,14 @@ namespace Microsoft.EntityFrameworkCore
             where TContext : DbContext
             => new ServiceCollection()
                 .AddDbContextPool<TContext>(
-                    ob => ob.UseSqlServer(SqlServerNorthwindTestStoreFactory.NorthwindConnectionString),
+                    ob =>
+                        ob.UseSqlServer(SqlServerNorthwindTestStoreFactory.NorthwindConnectionString)
+                            .EnableServiceProviderCaching(false),
                     poolSize)
                 .AddDbContextPool<SecondContext>(
-                    ob => ob.UseSqlServer(SqlServerNorthwindTestStoreFactory.NorthwindConnectionString),
+                    ob =>
+                        ob.UseSqlServer(SqlServerNorthwindTestStoreFactory.NorthwindConnectionString)
+                            .EnableServiceProviderCaching(false),
                     poolSize)
                 .BuildServiceProvider();
 

--- a/test/EFCore.SqlServer.FunctionalTests/LoggingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/LoggingSqlServerTest.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.SqlServer.Infrastructure.Internal;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 // ReSharper disable InconsistentNaming
@@ -16,12 +17,15 @@ namespace Microsoft.EntityFrameworkCore
         {
             Assert.Equal(
                 ExpectedMessage("RowNumberPaging " + DefaultOptions),
-                ActualMessage(CreateOptionsBuilder(b => ((SqlServerDbContextOptionsBuilder)b).UseRowNumberForPaging())));
+                ActualMessage(s => CreateOptionsBuilder(s, b => ((SqlServerDbContextOptionsBuilder)b).UseRowNumberForPaging())));
         }
 
         protected override DbContextOptionsBuilder CreateOptionsBuilder(
+            IServiceCollection services,
             Action<RelationalDbContextOptionsBuilder<SqlServerDbContextOptionsBuilder, SqlServerOptionsExtension>> relationalAction)
-            => new DbContextOptionsBuilder().UseSqlServer("Data Source=LoggingSqlServerTest.db", relationalAction);
+            => new DbContextOptionsBuilder()
+                .UseInternalServiceProvider(services.AddEntityFrameworkSqlServer().BuildServiceProvider())
+                .UseSqlServer("Data Source=LoggingSqlServerTest.db", relationalAction);
 
         protected override string ProviderName => "Microsoft.EntityFrameworkCore.SqlServer";
     }

--- a/test/EFCore.SqlServer.FunctionalTests/MigrationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/MigrationsSqlServerTest.cs
@@ -443,7 +443,9 @@ CreatedTable
         [ConditionalFact]
         public async Task Empty_Migration_Creates_Database()
         {
-            using (var context = new BloggingContext(Fixture.TestStore.AddProviderOptions(new DbContextOptionsBuilder()).Options))
+            using (var context = new BloggingContext(
+                Fixture.TestStore.AddProviderOptions(
+                    new DbContextOptionsBuilder().EnableServiceProviderCaching(false)).Options))
             {
                 var creator = (SqlServerDatabaseCreator)context.GetService<IRelationalDatabaseCreator>();
                 creator.RetryTimeout = TimeSpan.FromMinutes(10);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/CompiledQueryCacheKeyGeneratorTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/CompiledQueryCacheKeyGeneratorTest.cs
@@ -43,6 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             var builder = testStore.AddProviderOptions(new DbContextOptionsBuilder())
                 .EnableSensitiveDataLogging()
+                .EnableServiceProviderCaching(false)
                 .ConfigureWarnings(
                     b => b.Default(WarningBehavior.Throw)
                         .Log(CoreEventId.SensitiveDataLoggingEnabledWarning)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -3517,6 +3517,7 @@ WHERE ([t].[__RowNumber__] > @__p_0) AND ([t].[__RowNumber__] <= (@__p_0 + @__p_
             {
                 optionsBuilder
                     .UseLoggerFactory(_loggerFactory)
+                    .EnableServiceProviderCaching(false)
                     .UseSqlServer(
                         SqlServerTestStore.CreateConnectionString("RowNumberPaging_Owned"),
                         b => b.UseRowNumberForPaging());

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerConfigPatternsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerConfigPatternsTest.cs
@@ -36,8 +36,11 @@ namespace Microsoft.EntityFrameworkCore
                 public DbSet<Customer> Customers { get; set; }
 
                 protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                    => optionsBuilder.UseSqlServer(
-                        SqlServerNorthwindTestStoreFactory.NorthwindConnectionString, b => b.ApplyConfiguration());
+                    => optionsBuilder
+                        .EnableServiceProviderCaching(false)
+                        .UseSqlServer(
+                            SqlServerNorthwindTestStoreFactory.NorthwindConnectionString,
+                            b => b.ApplyConfiguration());
 
                 protected override void OnModelCreating(ModelBuilder modelBuilder)
                     => ConfigureModel(modelBuilder);
@@ -53,6 +56,7 @@ namespace Microsoft.EntityFrameworkCore
                 {
                     using (var context = new NorthwindContext(
                         new DbContextOptionsBuilder()
+                            .EnableServiceProviderCaching(false)
                             .UseSqlServer(SqlServerNorthwindTestStoreFactory.NorthwindConnectionString, b => b.ApplyConfiguration())
                             .Options))
                     {
@@ -209,6 +213,9 @@ namespace Microsoft.EntityFrameworkCore
 
                 protected override void OnModelCreating(ModelBuilder modelBuilder)
                     => ConfigureModel(modelBuilder);
+
+                protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                    => optionsBuilder.EnableServiceProviderCaching(false);
             }
         }
 
@@ -317,6 +324,7 @@ namespace Microsoft.EntityFrameworkCore
                     .AddTransient<NorthwindContext>()
                     .AddSingleton(
                         new DbContextOptionsBuilder()
+                            .EnableServiceProviderCaching(false)
                             .UseSqlServer(SqlServerNorthwindTestStoreFactory.NorthwindConnectionString, b => b.ApplyConfiguration())
                             .Options).BuildServiceProvider();
 
@@ -365,6 +373,7 @@ namespace Microsoft.EntityFrameworkCore
                 {
                     using (var context = new NorthwindContext(
                         new DbContextOptionsBuilder()
+                            .EnableServiceProviderCaching(false)
                             .UseSqlServer(SqlServerNorthwindTestStoreFactory.NorthwindConnectionString, b => b.ApplyConfiguration())
                             .Options))
                     {
@@ -413,7 +422,9 @@ namespace Microsoft.EntityFrameworkCore
                 public DbSet<Customer> Customers { get; set; }
 
                 protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                    => optionsBuilder.UseSqlServer(_connectionString, b => b.ApplyConfiguration());
+                    => optionsBuilder
+                        .EnableServiceProviderCaching(false)
+                        .UseSqlServer(_connectionString, b => b.ApplyConfiguration());
 
                 protected override void OnModelCreating(ModelBuilder modelBuilder)
                     => ConfigureModel(modelBuilder);

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerFixture.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -10,6 +11,9 @@ namespace Microsoft.EntityFrameworkCore
 {
     public class SqlServerFixture : ServiceProviderFixtureBase
     {
+        public static IServiceProvider DefaultServiceProvider { get; }
+            = new ServiceCollection().AddEntityFrameworkSqlServer().BuildServiceProvider();
+
         public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ServiceProvider.GetRequiredService<ILoggerFactory>();
         protected override ITestStoreFactory TestStoreFactory => SqlServerTestStoreFactory.Instance;
 

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerValueGenerationScenariosTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerValueGenerationScenariosTest.cs
@@ -1290,7 +1290,11 @@ END");
             public DbSet<ConcurrentBlog> ConcurrentBlogs { get; set; }
 
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseSqlServer(SqlServerTestStore.CreateConnectionString(_databaseName), b => b.ApplyConfiguration());
+                => optionsBuilder
+                    .EnableServiceProviderCaching(false)
+                    .UseSqlServer(
+                        SqlServerTestStore.CreateConnectionString(_databaseName),
+                        b => b.ApplyConfiguration());
         }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerTestStore.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerTestStore.cs
@@ -110,7 +110,11 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                     if (_fileName == null)
                     {
-                        using (var context = new DbContext(AddProviderOptions(new DbContextOptionsBuilder()).Options))
+                        using (var context = new DbContext(
+                            AddProviderOptions(
+                                    new DbContextOptionsBuilder()
+                                        .EnableServiceProviderCaching(false))
+                                .Options))
                         {
                             Clean(context);
                             return true;

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestSqlServerRetryingExecutionStrategy.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestSqlServerRetryingExecutionStrategy.cs
@@ -21,7 +21,10 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
         public TestSqlServerRetryingExecutionStrategy()
             : base(
-                new DbContext(new DbContextOptionsBuilder().UseSqlServer(TestEnvironment.DefaultConnection).Options),
+                new DbContext(
+                    new DbContextOptionsBuilder()
+                        .EnableServiceProviderCaching(false)
+                        .UseSqlServer(TestEnvironment.DefaultConnection).Options),
                 DefaultMaxRetryCount, DefaultMaxDelay, _additionalErrorNumbers)
         {
         }

--- a/test/EFCore.SqlServer.Tests/CommandConfigurationTests.cs
+++ b/test/EFCore.SqlServer.Tests/CommandConfigurationTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 #pragma warning disable RCS1102 // Make class static.
@@ -67,7 +68,9 @@ namespace Microsoft.EntityFrameworkCore
                     => Database.SetCommandTimeout(commandTimeout);
 
                 protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                    => optionsBuilder.UseSqlServer(new FakeDbConnection("A=B"));
+                    => optionsBuilder
+                        .UseInternalServiceProvider(SqlServerFixture.DefaultServiceProvider)
+                        .UseSqlServer(new FakeDbConnection("A=B"));
             }
         }
     }

--- a/test/EFCore.SqlServer.Tests/DbSetAsTableNameSqlServerTest.cs
+++ b/test/EFCore.SqlServer.Tests/DbSetAsTableNameSqlServerTest.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.Extensions.DependencyInjection;
+
 namespace Microsoft.EntityFrameworkCore
 {
     public class DbSetAsTableNameSqlServerTest : DbSetAsTableNameTest
@@ -15,13 +17,17 @@ namespace Microsoft.EntityFrameworkCore
         protected class SqlServerSetsContext : SetsContext
         {
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseSqlServer("Database = Dummy");
+                => optionsBuilder
+                    .UseInternalServiceProvider(SqlServerFixture.DefaultServiceProvider)
+                    .UseSqlServer("Database = Dummy");
         }
 
         protected class SqlServerNamedTablesContextContext : NamedTablesContext
         {
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseSqlServer("Database = Dummy");
+                => optionsBuilder
+                    .UseInternalServiceProvider(SqlServerFixture.DefaultServiceProvider)
+                    .UseSqlServer("Database = Dummy");
         }
     }
 }

--- a/test/EFCore.SqlServer.Tests/ModelBuilding/ModelBuilderSqlServerTest.Other.cs
+++ b/test/EFCore.SqlServer.Tests/ModelBuilding/ModelBuilderSqlServerTest.Other.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.ModelBuilding
 {
@@ -10,6 +11,11 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
     {
         protected override DbContextOptions Configure()
             => new DbContextOptionsBuilder()
+                .UseInternalServiceProvider(
+                    new ServiceCollection()
+                        .AddEntityFrameworkSqlServer()
+                        .AddSingleton<IModelCacheKeyFactory, TestModelCacheKeyFactory>()
+                        .BuildServiceProvider())
                 .UseSqlServer("Database = None")
                 .Options;
 

--- a/test/EFCore.SqlServer.Tests/SqlServerDatabaseFacadeTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerDatabaseFacadeTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore
@@ -57,7 +58,9 @@ namespace Microsoft.EntityFrameworkCore
         public void IsSqlServer_when_using_constructor()
         {
             using (var context = new ProviderContext(
-                new DbContextOptionsBuilder().UseSqlServer("Database=Maltesers").Options))
+                new DbContextOptionsBuilder()
+                    .UseInternalServiceProvider(SqlServerFixture.DefaultServiceProvider)
+                    .UseSqlServer("Database=Maltesers").Options))
             {
                 Assert.True(context.Database.IsSqlServer());
             }
@@ -67,7 +70,9 @@ namespace Microsoft.EntityFrameworkCore
         public void IsSqlServer_in_OnModelCreating_when_using_constructor()
         {
             using (var context = new ProviderOnModelContext(
-                new DbContextOptionsBuilder().UseSqlServer("Database=Maltesers").Options))
+                new DbContextOptionsBuilder()
+                    .UseInternalServiceProvider(SqlServerFixture.DefaultServiceProvider)
+                    .UseSqlServer("Database=Maltesers").Options))
             {
                 var _ = context.Model; // Trigger context initialization
                 Assert.True(context.IsSqlServerSet);
@@ -78,7 +83,9 @@ namespace Microsoft.EntityFrameworkCore
         public void IsSqlServer_in_constructor_when_using_constructor()
         {
             using (var context = new ProviderConstructorContext(
-                new DbContextOptionsBuilder().UseSqlServer("Database=Maltesers").Options))
+                new DbContextOptionsBuilder()
+                    .UseInternalServiceProvider(SqlServerFixture.DefaultServiceProvider)
+                    .UseSqlServer("Database=Maltesers").Options))
             {
                 var _ = context.Model; // Trigger context initialization
                 Assert.True(context.IsSqlServerSet);
@@ -89,7 +96,9 @@ namespace Microsoft.EntityFrameworkCore
         public void Cannot_use_IsSqlServer_in_OnConfguring_with_constructor()
         {
             using (var context = new ProviderUseInOnConfiguringContext(
-                new DbContextOptionsBuilder().UseSqlServer("Database=Maltesers").Options))
+                new DbContextOptionsBuilder()
+                    .UseInternalServiceProvider(SqlServerFixture.DefaultServiceProvider)
+                    .UseSqlServer("Database=Maltesers").Options))
             {
                 Assert.Equal(
                     CoreStrings.RecursiveOnConfiguring,
@@ -105,7 +114,9 @@ namespace Microsoft.EntityFrameworkCore
         public void Not_IsSqlServer_when_using_different_provider()
         {
             using (var context = new ProviderContext(
-                new DbContextOptionsBuilder().UseInMemoryDatabase("Maltesers").Options))
+                new DbContextOptionsBuilder()
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase("Maltesers").Options))
             {
                 Assert.False(context.Database.IsSqlServer());
             }
@@ -128,7 +139,9 @@ namespace Microsoft.EntityFrameworkCore
         private class SqlServerOnConfiguringContext : ProviderContext
         {
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseSqlServer("Database=Maltesers");
+                => optionsBuilder
+                    .UseInternalServiceProvider(SqlServerFixture.DefaultServiceProvider)
+                    .UseSqlServer("Database=Maltesers");
         }
 
         private class SqlServerOnModelContext : SqlServerOnConfiguringContext

--- a/test/EFCore.SqlServer.Tests/Storage/SqlServerTypeMappingTest.cs
+++ b/test/EFCore.SqlServer.Tests/Storage/SqlServerTypeMappingTest.cs
@@ -12,6 +12,7 @@ using System.Reflection;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 // ReSharper disable InconsistentNaming
@@ -79,7 +80,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
             public DbSet<WithRowVersion> _ { get; set; }
 
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseSqlServer("Data Source=Branston");
+                => optionsBuilder
+                    .UseInternalServiceProvider(SqlServerFixture.DefaultServiceProvider)
+                    .UseSqlServer("Data Source=Branston");
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)
             {
@@ -363,6 +366,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
         }
 
         protected override DbContextOptions ContextOptions { get; }
-            = new DbContextOptionsBuilder().UseSqlServer("Server=Dummy").Options;
+            = new DbContextOptionsBuilder()
+                .UseInternalServiceProvider(SqlServerFixture.DefaultServiceProvider)
+                .UseSqlServer("Server=Dummy").Options;
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/LoggingSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/LoggingSqliteTest.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Sqlite.Infrastructure.Internal;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 // ReSharper disable InconsistentNaming
@@ -16,12 +17,15 @@ namespace Microsoft.EntityFrameworkCore
         {
             Assert.Equal(
                 ExpectedMessage("SuppressForeignKeyEnforcement " + DefaultOptions),
-                ActualMessage(CreateOptionsBuilder(b => ((SqliteDbContextOptionsBuilder)b).SuppressForeignKeyEnforcement())));
+                ActualMessage(s => CreateOptionsBuilder(s, b => ((SqliteDbContextOptionsBuilder)b).SuppressForeignKeyEnforcement())));
         }
 
         protected override DbContextOptionsBuilder CreateOptionsBuilder(
+            IServiceCollection services,
             Action<RelationalDbContextOptionsBuilder<SqliteDbContextOptionsBuilder, SqliteOptionsExtension>> relationalAction)
-            => new DbContextOptionsBuilder().UseSqlite("Data Source=LoggingSqliteTest.db", relationalAction);
+            => new DbContextOptionsBuilder()
+                .UseInternalServiceProvider(services.AddEntityFrameworkSqlite().BuildServiceProvider())
+                .UseSqlite("Data Source=LoggingSqliteTest.db", relationalAction);
 
         protected override string ProviderName => "Microsoft.EntityFrameworkCore.Sqlite";
     }

--- a/test/EFCore.Sqlite.FunctionalTests/TestUtilities/SqliteTestStore.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/TestUtilities/SqliteTestStore.cs
@@ -5,6 +5,7 @@ using System;
 using System.Data.Common;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities
 {
@@ -16,16 +17,16 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             => new SqliteTestStore(name, sharedCache: sharedCache);
 
         public static SqliteTestStore GetOrCreateInitialized(string name)
-            => new SqliteTestStore(name).InitializeSqlite(null, (Func<DbContext>)null, null);
+            => new SqliteTestStore(name).InitializeSqlite(
+                new ServiceCollection().AddEntityFrameworkSqlite().BuildServiceProvider(),
+                (Func<DbContext>)null,
+                null);
 
         public static SqliteTestStore GetExisting(string name)
             => new SqliteTestStore(name, seed: false);
 
         public static SqliteTestStore Create(string name, bool sharedCache = true)
             => new SqliteTestStore(name, sharedCache: sharedCache, shared: false);
-
-        public static SqliteTestStore CreateInitialized(string name)
-            => new SqliteTestStore(name, shared: false).InitializeSqlite(null, (Func<DbContext>)null, null);
 
         private readonly bool _seed;
 

--- a/test/EFCore.Sqlite.Tests/DbSetAsTableNameSqliteTest.cs
+++ b/test/EFCore.Sqlite.Tests/DbSetAsTableNameSqliteTest.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.Extensions.DependencyInjection;
+
 namespace Microsoft.EntityFrameworkCore
 {
     public class DbSetAsTableNameSqliteTest : DbSetAsTableNameTest
@@ -15,13 +17,23 @@ namespace Microsoft.EntityFrameworkCore
         protected class SqliteSetsContext : SetsContext
         {
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseSqlite("Database = Dummy");
+                => optionsBuilder
+                    .UseInternalServiceProvider(
+                        new ServiceCollection()
+                            .AddEntityFrameworkSqlite()
+                            .BuildServiceProvider())
+                    .UseSqlite("Database = Dummy");
         }
 
         protected class SqliteNamedTablesContextContext : NamedTablesContext
         {
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseSqlite("Database = Dummy");
+                => optionsBuilder
+                    .UseInternalServiceProvider(
+                        new ServiceCollection()
+                            .AddEntityFrameworkSqlite()
+                            .BuildServiceProvider())
+                    .UseSqlite("Database = Dummy");
         }
     }
 }

--- a/test/EFCore.Sqlite.Tests/SqliteDatabaseFacadeTest.cs
+++ b/test/EFCore.Sqlite.Tests/SqliteDatabaseFacadeTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore
@@ -11,7 +12,12 @@ namespace Microsoft.EntityFrameworkCore
         public void IsSqlite_when_using_SQLite()
         {
             using (var context = new ProviderContext(
-                new DbContextOptionsBuilder().UseSqlite("Database=Maltesers").Options))
+                new DbContextOptionsBuilder()
+                    .UseInternalServiceProvider(
+                        new ServiceCollection()
+                            .AddEntityFrameworkSqlite()
+                            .BuildServiceProvider())
+                    .UseSqlite("Database=Maltesers").Options))
             {
                 Assert.True(context.Database.IsSqlite());
             }
@@ -21,7 +27,9 @@ namespace Microsoft.EntityFrameworkCore
         public void Not_IsSqlite_when_using_different_provider()
         {
             using (var context = new ProviderContext(
-                new DbContextOptionsBuilder().UseInMemoryDatabase("Maltesers").Options))
+                new DbContextOptionsBuilder()
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase("Maltesers").Options))
             {
                 Assert.False(context.Database.IsSqlite());
             }

--- a/test/EFCore.Sqlite.Tests/Storage/SqliteTypeMappingTest.cs
+++ b/test/EFCore.Sqlite.Tests/Storage/SqliteTypeMappingTest.cs
@@ -7,6 +7,7 @@ using System.Data.Common;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Storage
@@ -106,6 +107,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
         }
 
         protected override DbContextOptions ContextOptions { get; }
-            = new DbContextOptionsBuilder().UseSqlite("Filename=dummmy.db").Options;
+            = new DbContextOptionsBuilder()
+                .UseInternalServiceProvider(new ServiceCollection().AddEntityFrameworkSqlite().BuildServiceProvider())
+                .UseSqlite("Filename=dummmy.db").Options;
     }
 }

--- a/test/EFCore.Tests/ChangeTracking/AggregatesTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/AggregatesTest.cs
@@ -650,7 +650,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         private class AggregateContext : DbContext
         {
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseInMemoryDatabase(nameof(AggregateContext));
+                => optionsBuilder
+                    .UseInMemoryDatabase(nameof(AggregateContext))
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider);
 
             public DbSet<Blog> Blogs { get; set; }
             public DbSet<Post> Posts { get; set; }

--- a/test/EFCore.Tests/ChangeTracking/ChangeTrackerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/ChangeTrackerTest.cs
@@ -1040,12 +1040,19 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         private static readonly ListLoggerFactory _loggerFactory
             = new ListLoggerFactory();
 
+        private static readonly IServiceProvider _serviceProvider
+            = InMemoryFixture.BuildServiceProvider(_loggerFactory);
+
+        private static readonly IServiceProvider _sensitiveProvider
+            = InMemoryFixture.BuildServiceProvider(_loggerFactory);
+
         private static readonly IServiceProvider _poolProvider
             = new ServiceCollection()
                 .AddEntityFrameworkInMemoryDatabase()
                 .AddDbContextPool<LikeAZooContextPooled>(
-                    p => p.UseInMemoryDatabase(nameof(LikeAZooContextPooled))
-                        .UseLoggerFactory(_loggerFactory))
+                    p =>
+                        p.UseInMemoryDatabase(nameof(LikeAZooContextPooled))
+                            .UseInternalServiceProvider(InMemoryFixture.BuildServiceProvider(_loggerFactory)))
                 .BuildServiceProvider();
 
         private class LikeAZooContextPooled : LikeAZooContext
@@ -1075,7 +1082,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
                 => optionsBuilder
-                    .UseLoggerFactory(_loggerFactory)
+                    .UseInternalServiceProvider(_serviceProvider)
                     .UseInMemoryDatabase(nameof(LikeAZooContext));
         }
 
@@ -1084,7 +1091,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
                 => optionsBuilder
                     .EnableSensitiveDataLogging()
-                    .UseLoggerFactory(_loggerFactory)
+                    .UseInternalServiceProvider(_sensitiveProvider)
                     .UseInMemoryDatabase(nameof(LikeAZooContextSensitive));
         }
 
@@ -3073,7 +3080,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                     });
 
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseInMemoryDatabase(nameof(TheShadows));
+                => optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase(nameof(TheShadows));
         }
 
         private class Dark

--- a/test/EFCore.Tests/ChangeTracking/CollectionEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/CollectionEntryTest.cs
@@ -576,7 +576,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         private class FreezerContext : DbContext
         {
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseInMemoryDatabase(nameof(FreezerContext));
+                => optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase(nameof(FreezerContext));
 
             public DbSet<Chunky> Icecream { get; set; }
 

--- a/test/EFCore.Tests/ChangeTracking/EntityEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/EntityEntryTest.cs
@@ -148,7 +148,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         private class KeySetContext : DbContext
         {
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseInMemoryDatabase(nameof(KeySetContext));
+                => optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase(nameof(KeySetContext));
 
             public DbSet<StoreGenerated> StoreGenerated { get; set; }
             public DbSet<NotStoreGenerated> NotStoreGenerated { get; set; }
@@ -1014,7 +1016,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         private class FreezerContext : DbContext
         {
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseInMemoryDatabase(nameof(FreezerContext));
+                => optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase(nameof(FreezerContext));
 
             public DbSet<Chunky> Icecream { get; set; }
 

--- a/test/EFCore.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
@@ -359,7 +359,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             protected virtual bool UseTypeMapping => false;
 
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseInMemoryDatabase(Guid.NewGuid().ToString());
+                => optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase(Guid.NewGuid().ToString());
 
             protected internal override void OnModelCreating(ModelBuilder modelBuilder)
             {

--- a/test/EFCore.Tests/ChangeTracking/Internal/FixupCompositeTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/FixupCompositeTest.cs
@@ -4750,7 +4750,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             }
 
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseInMemoryDatabase(nameof(FixupContext));
+                => optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase(nameof(FixupContext));
         }
 
         private void AssertFixup(DbContext context, Action asserts)

--- a/test/EFCore.Tests/ChangeTracking/Internal/FixupTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/FixupTest.cs
@@ -2972,7 +2972,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             }
 
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseInMemoryDatabase(nameof(FixupContext));
+                => optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase(nameof(FixupContext));
         }
 
         private void AssertFixup(DbContext context, Action asserts)
@@ -3044,7 +3046,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             public DbSet<TestClass> Classes { get; set; }
 
             protected internal override void OnConfiguring(DbContextOptionsBuilder options)
-                => options.UseInMemoryDatabase(nameof(FixupContext));
+                => options
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase(nameof(FixupContext));
 
             protected internal override void OnModelCreating(ModelBuilder modelBuilder)
             {

--- a/test/EFCore.Tests/ChangeTracking/Internal/NavigationFixerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/NavigationFixerTest.cs
@@ -52,7 +52,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             public DbSet<Post> Posts { get; set; }
 
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseInMemoryDatabase(typeof(FixupContext).FullName);
+                => optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase(typeof(FixupContext).FullName);
         }
 
         private class Blog

--- a/test/EFCore.Tests/ChangeTracking/Internal/OwnedFixupTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/OwnedFixupTest.cs
@@ -1205,7 +1205,10 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             {
-                optionsBuilder.UseInMemoryDatabase(nameof(FixupContext));
+                optionsBuilder
+                    .UseInMemoryDatabase(nameof(FixupContext))
+                    .UseInternalServiceProvider(InMemoryFixture.BuildServiceProvider());
+
                 if (!_ignoreDuplicates)
                 {
                     optionsBuilder.ConfigureWarnings(

--- a/test/EFCore.Tests/ChangeTracking/Internal/QueryFixupTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/QueryFixupTest.cs
@@ -1464,7 +1464,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             }
 
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseInMemoryDatabase(nameof(QueryFixupContext));
+                => optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase(nameof(QueryFixupContext));
         }
 
         private void AssertFixup(DbContext context, Action asserts)

--- a/test/EFCore.Tests/ChangeTracking/Internal/ShadowFixupTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/ShadowFixupTest.cs
@@ -342,7 +342,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             }
 
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseInMemoryDatabase(nameof(FixupContext));
+                => optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase(nameof(FixupContext));
         }
 
         private void AssertFixup(DbContext context, Action asserts)

--- a/test/EFCore.Tests/ChangeTracking/Internal/ShadowFkFixupTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/ShadowFkFixupTest.cs
@@ -2128,7 +2128,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             }
 
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseInMemoryDatabase(nameof(FixupContext));
+                => optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase(nameof(FixupContext));
         }
 
         private void AssertFixup(DbContext context, Action asserts)

--- a/test/EFCore.Tests/ChangeTracking/Internal/StateManagerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/StateManagerTest.cs
@@ -322,17 +322,18 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         private class SensitiveIdentityConflictContext : IdentityConflictContext
         {
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            {
-                optionsBuilder.EnableSensitiveDataLogging();
-
-                base.OnConfiguring(optionsBuilder);
-            }
+                => optionsBuilder
+                    .UseInMemoryDatabase(nameof(IdentityConflictContext))
+                    .EnableSensitiveDataLogging()
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultSensitiveServiceProvider);
         }
 
         private class IdentityConflictContext : DbContext
         {
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseInMemoryDatabase(nameof(IdentityConflictContext));
+                => optionsBuilder
+                    .UseInMemoryDatabase(nameof(IdentityConflictContext))
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider);
 
             protected internal override void OnModelCreating(ModelBuilder modelBuilder)
             {

--- a/test/EFCore.Tests/ChangeTracking/MemberEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/MemberEntryTest.cs
@@ -257,7 +257,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         private class FreezerContext : DbContext
         {
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseInMemoryDatabase(nameof(FreezerContext));
+                => optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase(nameof(FreezerContext));
 
             public DbSet<Chunky> Icecream { get; set; }
         }

--- a/test/EFCore.Tests/ChangeTracking/NavigationEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/NavigationEntryTest.cs
@@ -214,7 +214,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         private class FreezerContext : DbContext
         {
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseInMemoryDatabase(nameof(FreezerContext));
+                => optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase(nameof(FreezerContext));
 
             public DbSet<Chunky> Icecream { get; set; }
         }

--- a/test/EFCore.Tests/ChangeTracking/PropertyEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/PropertyEntryTest.cs
@@ -133,7 +133,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         {
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             {
-                optionsBuilder.UseInMemoryDatabase(GetType().FullName);
+                optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase(GetType().FullName);
             }
 
             protected internal override void OnModelCreating(ModelBuilder modelBuilder)
@@ -1117,7 +1119,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             {
-                optionsBuilder.UseInMemoryDatabase(GetType().FullName);
+                optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase(GetType().FullName);
             }
 
             protected internal override void OnModelCreating(ModelBuilder modelBuilder)

--- a/test/EFCore.Tests/ChangeTracking/ReferenceEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/ReferenceEntryTest.cs
@@ -571,7 +571,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         private class FreezerContext : DbContext
         {
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseInMemoryDatabase(nameof(FreezerContext));
+                => optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase(nameof(FreezerContext));
 
             public DbSet<Chunky> Icecream { get; set; }
 

--- a/test/EFCore.Tests/ContextConfigurationTest.cs
+++ b/test/EFCore.Tests/ContextConfigurationTest.cs
@@ -106,6 +106,7 @@ namespace Microsoft.EntityFrameworkCore
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
                 => optionsBuilder
                     .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                    .EnableServiceProviderCaching(false)
                     .UseInternalServiceProvider(_serviceProvider);
         }
     }

--- a/test/EFCore.Tests/DbContextTest.cs
+++ b/test/EFCore.Tests/DbContextTest.cs
@@ -217,7 +217,9 @@ namespace Microsoft.EntityFrameworkCore
             public DbSet<Question> Questions { get; set; }
 
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseInMemoryDatabase(databaseName: "issue7119");
+                => optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase(databaseName: "issue7119");
 
             protected internal override void OnModelCreating(ModelBuilder modelBuilder)
             {
@@ -909,7 +911,9 @@ namespace Microsoft.EntityFrameworkCore
         {
             var fakeServiceProvider = new FakeServiceProvider();
             var context = new DbContext(
-                new DbContextOptionsBuilder().UseInternalServiceProvider(fakeServiceProvider).UseInMemoryDatabase(Guid.NewGuid().ToString())
+                new DbContextOptionsBuilder()
+                    .UseInternalServiceProvider(fakeServiceProvider)
+                    .UseInMemoryDatabase(Guid.NewGuid().ToString())
                     .Options);
 
             var scopeService =
@@ -1047,7 +1051,9 @@ namespace Microsoft.EntityFrameworkCore
             public DbSet<Test> Tests { get; set; }
 
             protected internal override void OnConfiguring(DbContextOptionsBuilder options)
-                => options.UseInMemoryDatabase(nameof(NullShadowKeyContext));
+                => options
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase(nameof(NullShadowKeyContext));
 
             protected internal override void OnModelCreating(ModelBuilder modelBuilder)
             {

--- a/test/EFCore.Tests/DbSetTest.cs
+++ b/test/EFCore.Tests/DbSetTest.cs
@@ -157,7 +157,9 @@ namespace Microsoft.EntityFrameworkCore
             public DbSet<IgnoredEntity> Ignored { get; set; }
 
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseInMemoryDatabase(Guid.NewGuid().ToString());
+                => optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase(Guid.NewGuid().ToString());
 
             protected internal override void OnModelCreating(ModelBuilder modelBuilder)
                 => modelBuilder.Ignore<IgnoredEntity>();

--- a/test/EFCore.Tests/Infrastructure/CoreEventIdTest.cs
+++ b/test/EFCore.Tests/Infrastructure/CoreEventIdTest.cs
@@ -38,7 +38,9 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             var queryModel = new QueryModel(
                 new MainFromClause("A", typeof(object), Expression.Constant("A")), new SelectClause(Expression.Constant("A")));
             var includeResultOperator = new IncludeResultOperator(new[] { "Foo" }, Expression.Constant("A"));
-            var options = new DbContextOptionsBuilder().UseInMemoryDatabase("D").Options;
+            var options = new DbContextOptionsBuilder()
+                .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                .UseInMemoryDatabase("D").Options;
 
             var fakeFactories = new Dictionary<Type, Func<object>>
             {

--- a/test/EFCore.Tests/Infrastructure/InternalSeviceCollectionMapTest.cs
+++ b/test/EFCore.Tests/Infrastructure/InternalSeviceCollectionMapTest.cs
@@ -250,7 +250,10 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         [Fact]
         public virtual void Same_INavigationFixer_is_returned_for_all_registrations()
         {
-            using (var context = new DbContext(new DbContextOptionsBuilder().UseInMemoryDatabase(Guid.NewGuid().ToString()).Options))
+            using (var context = new DbContext(
+                new DbContextOptionsBuilder()
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase(Guid.NewGuid().ToString()).Options))
             {
                 var navFixer = context.GetService<INavigationFixer>();
 

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/ConstructorBindingConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/ConstructorBindingConventionTest.cs
@@ -711,7 +711,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         private class NoFieldContext : DbContext
         {
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseInMemoryDatabase(Guid.NewGuid().ToString());
+                => optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase(Guid.NewGuid().ToString());
 
             public DbSet<NoField> NoFields { get; }
             public DbSet<NoFieldRelated> NoFieldRelateds { get; }

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/PropertyAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/PropertyAttributeConventionTest.cs
@@ -632,7 +632,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         private class MyContext : DbContext
         {
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseInMemoryDatabase(nameof(MyContext));
+                => optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase(nameof(MyContext));
 
             protected internal override void OnModelCreating(ModelBuilder modelBuilder)
                 => modelBuilder.Entity<B>().HasKey(

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/PropertyDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/PropertyDiscoveryConventionTest.cs
@@ -48,7 +48,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public DbSet<DerivedWithoutPrivates> Entities { get; set; }
 
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseInMemoryDatabase(nameof(WithPrivatesContext));
+                => optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase(nameof(WithPrivatesContext));
         }
 
         [Fact]

--- a/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
@@ -2062,7 +2062,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         private class Levels : DbContext
         {
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseInMemoryDatabase(Guid.NewGuid().ToString());
+                => optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase(Guid.NewGuid().ToString());
 
             protected internal override void OnModelCreating(ModelBuilder modelBuilder)
             {

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilder.Other.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilder.Other.cs
@@ -9,6 +9,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.ModelBuilding
@@ -263,10 +264,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             private readonly Action<ModelBuilder> _builder;
 
             public CustomModelBuildingContext(DbContextOptions options, Action<ModelBuilder> builder)
-                : base(
-                    new DbContextOptionsBuilder(options)
-                        .ReplaceService<IModelCacheKeyFactory, TestModelCacheKeyFactory>()
-                        .Options)
+                : base(options)
             {
                 _builder = builder;
             }
@@ -279,7 +277,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
         {
         }
 
-        private class TestModelCacheKeyFactory : IModelCacheKeyFactory
+        protected class TestModelCacheKeyFactory : IModelCacheKeyFactory
         {
             public object Create(DbContext context) => new object();
         }
@@ -307,6 +305,10 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
         protected virtual DbContextOptions Configure()
             => new DbContextOptionsBuilder()
+                .UseInternalServiceProvider(
+                    InMemoryFixture.BuildServiceProvider(
+                        new ServiceCollection()
+                            .AddSingleton<IModelCacheKeyFactory, TestModelCacheKeyFactory>()))
                 .UseInMemoryDatabase(nameof(CustomModelBuildingContext))
                 .Options;
     }

--- a/test/EFCore.Tests/ModelBuilding/OneToManyTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OneToManyTestBase.cs
@@ -2690,6 +2690,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
                 var contextOptions = new DbContextOptionsBuilder()
                     .UseModel(modelBuilder.Model)
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
                     .UseInMemoryDatabase("Can_use_self_referencing_overlapping_FK_PK")
                     .Options;
 

--- a/test/EFCore.Tests/ModelBuilding/OneToOneTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OneToOneTestBase.cs
@@ -4351,6 +4351,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
                 var contextOptions = new DbContextOptionsBuilder()
                     .UseModel(modelBuilder.Model)
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
                     .UseInMemoryDatabase("Can_use_self_referencing_overlapping_FK_PK_one_to_one")
                     .Options;
 

--- a/test/EFCore.Tests/ModelSourceTest.cs
+++ b/test/EFCore.Tests/ModelSourceTest.cs
@@ -66,7 +66,9 @@ namespace Microsoft.EntityFrameworkCore
             }
 
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseInMemoryDatabase(nameof(SlowContext));
+                => optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase(nameof(SlowContext));
         }
 
         [Fact]

--- a/test/EFCore.Tests/QueryProviderTest.cs
+++ b/test/EFCore.Tests/QueryProviderTest.cs
@@ -45,7 +45,9 @@ namespace Microsoft.EntityFrameworkCore
             public DbSet<TestEntity> TestEntities { get; set; }
 
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseInMemoryDatabase(Guid.NewGuid().ToString());
+                => optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase(Guid.NewGuid().ToString());
         }
 
         #endregion

--- a/test/EFCore.Tests/TestUtilities/FakeStateManager.cs
+++ b/test/EFCore.Tests/TestUtilities/FakeStateManager.cs
@@ -108,7 +108,11 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         public InternalEntityEntry GetPrincipalUsingRelationshipSnapshot(InternalEntityEntry entityEntry, IForeignKey foreignKey) =>
             throw new NotImplementedException();
 
-        public DbContext Context => new DbContext(new DbContextOptionsBuilder().UseInMemoryDatabase("D").Options);
+        public DbContext Context => new DbContext(new DbContextOptionsBuilder()
+            .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+            .UseInMemoryDatabase("D")
+            .Options);
+
         public event EventHandler<EntityTrackedEventArgs> Tracked;
         public void OnTracked(InternalEntityEntry internalEntityEntry, bool fromQuery) => Tracked?.Invoke(null, null);
         public event EventHandler<EntityStateChangedEventArgs> StateChanged;


### PR DESCRIPTION
Issue #10236

Most of the changes here are two our tests where we use the internal service provider both as a convenience and to test specific behavior around the caching. The tests have been either:
* Updated to use an external service provider explicitly
* Updated to make use of a new option `ServiceProviderCachingEnabled`, which is on by default, but can be switched off to still use the internal service provider, but not to cache it.
* Left untouched where the behavior being tested depends on service provider caching.

This means our tests will not hit the error. We have a lot of testing of the general warning-as-error mechanism. Tested the new default throw here manually.
