### PR TITLE
Added nameof syntax in scaffolding data annotations attributes

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
@@ -331,9 +331,16 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 {
                     var foreignKeyAttribute = new AttributeWriter(nameof(ForeignKeyAttribute));
 
-                    foreignKeyAttribute.AddParameter(
-                        _code.Literal(
-                            string.Join(",", navigation.ForeignKey.Properties.Select(p => p.Name))));
+                    if (navigation.ForeignKey.Properties.Count > 1)
+                    {
+                        foreignKeyAttribute.AddParameter(
+                              _code.Literal(
+                                  string.Join(",", navigation.ForeignKey.Properties.Select(p => p.Name))));
+                    }
+                    else
+                    {
+                        foreignKeyAttribute.AddParameter($"nameof({navigation.ForeignKey.Properties.First().Name})");
+                    }
 
                     _sb.AppendLine(foreignKeyAttribute.ToString());
                 }
@@ -350,7 +357,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 {
                     var inversePropertyAttribute = new AttributeWriter(nameof(InversePropertyAttribute));
 
-                    inversePropertyAttribute.AddParameter(_code.Literal(inverseNavigation.Name));
+                    inversePropertyAttribute.AddParameter($"nameof({inverseNavigation.DeclaringEntityType.Name}.{inverseNavigation.Name})");
 
                     _sb.AppendLine(inversePropertyAttribute.ToString());
                 }

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityTypeGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityTypeGeneratorTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                         {
                             x.Property<int>("Id");
 
-                            x.HasOne("Person", "Author").WithMany();
+                            x.HasOne("Person", "Author").WithMany("Posts");
                             x.HasMany("Contribution", "Contributions").WithOne();
                         }),
                 new ModelCodeGenerationOptions
@@ -53,7 +53,8 @@ namespace TestNamespace
         public int Id { get; set; }
         public int? AuthorId { get; set; }
 
-        [ForeignKey(""AuthorId"")]
+        [ForeignKey(nameof(AuthorId))]
+        [InverseProperty(nameof(Person.Posts))]
         public virtual Person Author { get; set; }
         public virtual ICollection<Contribution> Contributions { get; set; }
     }


### PR DESCRIPTION
Summary of the changes
- Switched up ForeignKeyAttribute and InversePropertyAttribute to use nameof() syntax
- Added InversePropertyAttribute into code generation unit test

Fixes #11744