### PR TITLE
Make DetectChanges honor store-generated key values when tracking new entities

### DIFF
--- a/src/EFCore/ChangeTracking/ChangeTracker.cs
+++ b/src/EFCore/ChangeTracking/ChangeTracker.cs
@@ -251,14 +251,16 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
             [NotNull] object rootEntity,
             [NotNull] Action<EntityEntryGraphNode> callback)
             => TrackGraph(
-                rootEntity, callback, (n, c) =>
+                rootEntity,
+                callback,
+                n =>
                 {
                     if (n.Entry.State != EntityState.Detached)
                     {
                         return false;
                     }
 
-                    c(n);
+                    n.NodeState(n);
 
                     return n.Entry.State != EntityState.Detached;
                 });
@@ -281,7 +283,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         ///     <para>
         ///         Typically traversal of the graph should stop whenever an already tracked entity is encountered or when
         ///         an entity is reached that should not be tracked. For this typical behavior, use the
-        ///         <see cref="TrackGraph(object,Action{EntityEntryGraphNode})" /> overload. This overload, on the other hand,
+        ///         <see cref="TrackGraph"/> overload. This overload, on the other hand,
         ///         allows the callback to decide when traversal will end, but the onus is then on the caller to ensure that
         ///         traversal will not enter an infinite loop.
         ///     </para>
@@ -297,7 +299,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         public virtual void TrackGraph<TState>(
             [NotNull] object rootEntity,
             [CanBeNull] TState state,
-            [NotNull] Func<EntityEntryGraphNode, TState, bool> callback)
+            [NotNull] Func<EntityEntryGraphNode<TState>, bool> callback)
         {
             Check.NotNull(rootEntity, nameof(rootEntity));
             Check.NotNull(callback, nameof(callback));
@@ -305,8 +307,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
             var rootEntry = StateManager.GetOrCreateEntry(rootEntity);
 
             GraphIterator.TraverseGraph(
-                new EntityEntryGraphNode(rootEntry, null, null),
-                state,
+                new EntityEntryGraphNode<TState>(rootEntry, state, null, null),
                 callback);
         }
 

--- a/src/EFCore/ChangeTracking/EntityEntry.cs
+++ b/src/EFCore/ChangeTracking/EntityEntry.cs
@@ -257,7 +257,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         ///         true since any value is considered a valid key value.
         ///     </para>
         /// </summary>
-        public virtual bool IsKeySet => InternalEntry.IsKeySet;
+        public virtual bool IsKeySet => InternalEntry.IsKeySet.IsSet;
 
         /// <summary>
         ///     Gets the current property values for this entity.

--- a/src/EFCore/ChangeTracking/EntityEntryGraphNode`.cs
+++ b/src/EFCore/ChangeTracking/EntityEntryGraphNode`.cs
@@ -14,11 +14,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///     Provides access to change tracking information and operations for a node in a
     ///     graph of entities that is being traversed.
     /// </summary>
-    public class EntityEntryGraphNode : IInfrastructure<InternalEntityEntry>
+    public class EntityEntryGraphNode<TState> : EntityEntryGraphNode
     {
-        private readonly InternalEntityEntry _entry;
-        private readonly InternalEntityEntry _sourceEntry;
-
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
@@ -26,41 +23,18 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         [DebuggerStepThrough]
         public EntityEntryGraphNode(
             [NotNull] InternalEntityEntry entry,
+            [CanBeNull] TState state,
             [CanBeNull] InternalEntityEntry sourceEntry,
             [CanBeNull] INavigation inboundNavigation)
+            : base(entry, sourceEntry, inboundNavigation)
         {
-            Check.NotNull(entry, nameof(entry));
-
-            _entry = entry;
-            _sourceEntry = sourceEntry;
-            InboundNavigation = inboundNavigation;
+            NodeState = state;
         }
 
         /// <summary>
-        ///     Gets the entry tracking information about this entity.
+        ///     Gets or sets state that will be available to all nodes that are visited after this node.
         /// </summary>
-        public virtual EntityEntry SourceEntry => _sourceEntry == null ? null : new EntityEntry(_sourceEntry);
-
-        /// <summary>
-        ///     Gets the navigation property that is being traversed to reach this node in the graph.
-        /// </summary>
-        public virtual INavigation InboundNavigation { get; }
-
-        /// <summary>
-        ///     Gets the entry tracking information about this entity.
-        /// </summary>
-        public virtual EntityEntry Entry => new EntityEntry(_entry);
-
-        /// <summary>
-        ///     <para>
-        ///         Gets the internal entry that is tracking information about this entity.
-        ///     </para>
-        ///     <para>
-        ///         This property is intended for use by extension methods. It is not intended to be used in
-        ///         application code.
-        ///     </para>
-        /// </summary>
-        InternalEntityEntry IInfrastructure<InternalEntityEntry>.Instance => _entry;
+        public virtual TState NodeState { get; }
 
         /// <summary>
         ///     Creates a new node for the entity that is being traversed next in the graph.
@@ -71,17 +45,18 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         /// </param>
         /// <param name="reachedVia"> The navigation property that is being traversed to reach the new node. </param>
         /// <returns> The newly created node. </returns>
-        public virtual EntityEntryGraphNode CreateNode(
-            [NotNull] EntityEntryGraphNode currentNode,
-            [NotNull] InternalEntityEntry internalEntityEntry,
-            [NotNull] INavigation reachedVia)
+        public override EntityEntryGraphNode CreateNode(
+            EntityEntryGraphNode currentNode,
+            InternalEntityEntry internalEntityEntry,
+            INavigation reachedVia)
         {
             Check.NotNull(currentNode, nameof(currentNode));
             Check.NotNull(internalEntityEntry, nameof(internalEntityEntry));
             Check.NotNull(reachedVia, nameof(reachedVia));
 
-            return new EntityEntryGraphNode(
+            return new EntityEntryGraphNode<TState>(
                 internalEntityEntry,
+                ((EntityEntryGraphNode<TState>)currentNode).NodeState,
                 currentNode.Entry.GetInfrastructure(),
                 reachedVia);
         }

--- a/src/EFCore/ChangeTracking/IEntityEntryGraphIterator.cs
+++ b/src/EFCore/ChangeTracking/IEntityEntryGraphIterator.cs
@@ -17,27 +17,23 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         ///     Traverses a graph of entities allowing an action to be taken at each node.
         /// </summary>
         /// <param name="node"> The node that is being visited. </param>
-        /// <param name="state"> An arbitrary state object. </param>
         /// <param name="handleNode"> A delegate to call to handle the node. </param>
         /// <typeparam name="TState"> The type of the state object. </typeparam>
         void TraverseGraph<TState>(
-            [NotNull] EntityEntryGraphNode node,
-            [CanBeNull] TState state,
-            [NotNull] Func<EntityEntryGraphNode, TState, bool> handleNode);
+            [NotNull] EntityEntryGraphNode<TState> node,
+            [NotNull] Func<EntityEntryGraphNode<TState>, bool> handleNode);
 
         /// <summary>
         ///     Traverses a graph of entities allowing an action to be taken at each node.
         /// </summary>
         /// <param name="node"> The node that is being visited. </param>
-        /// <param name="state"> An arbitrary state object. </param>
         /// <param name="handleNode"> A delegate to call to handle the node. </param>
         /// <param name="cancellationToken">  A <see cref="CancellationToken" /> to observe while waiting for the task to complete. </param>
         /// <typeparam name="TState"> The type of the state object. </typeparam>
         /// <returns> A task that represents the asynchronous operation. </returns>
         Task TraverseGraphAsync<TState>(
-            [NotNull] EntityEntryGraphNode node,
-            [CanBeNull] TState state,
-            [NotNull] Func<EntityEntryGraphNode, TState, CancellationToken, Task<bool>> handleNode,
+            [NotNull] EntityEntryGraphNode<TState> node,
+            [NotNull] Func<EntityEntryGraphNode<TState>, CancellationToken, Task<bool>> handleNode,
             CancellationToken cancellationToken = default);
     }
 }

--- a/src/EFCore/ChangeTracking/Internal/EntityEntryGraphIterator.cs
+++ b/src/EFCore/ChangeTracking/Internal/EntityEntryGraphIterator.cs
@@ -22,11 +22,10 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void TraverseGraph<TState>(
-            EntityEntryGraphNode node,
-            TState state,
-            Func<EntityEntryGraphNode, TState, bool> handleNode)
+            EntityEntryGraphNode<TState> node,
+            Func<EntityEntryGraphNode<TState>, bool> handleNode)
         {
-            if (!handleNode(node, state))
+            if (!handleNode(node))
             {
                 return;
             }
@@ -50,8 +49,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                                 ? stateManager.GetOrCreateEntry(relatedEntity, targetEntityType)
                                 : stateManager.GetOrCreateEntry(relatedEntity);
                             TraverseGraph(
-                                node.CreateNode(node, targetEntry, navigation),
-                                state,
+                                (EntityEntryGraphNode<TState>)node.CreateNode(node, targetEntry, navigation),
                                 handleNode);
                         }
                     }
@@ -61,8 +59,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                             ? stateManager.GetOrCreateEntry(navigationValue, targetEntityType)
                             : stateManager.GetOrCreateEntry(navigationValue);
                         TraverseGraph(
-                            node.CreateNode(node, targetEntry, navigation),
-                            state,
+                            (EntityEntryGraphNode<TState>)node.CreateNode(node, targetEntry, navigation),
                             handleNode);
                     }
                 }
@@ -74,12 +71,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual async Task TraverseGraphAsync<TState>(
-            EntityEntryGraphNode node,
-            TState state,
-            Func<EntityEntryGraphNode, TState, CancellationToken, Task<bool>> handleNode,
+            EntityEntryGraphNode<TState> node,
+            Func<EntityEntryGraphNode<TState>, CancellationToken, Task<bool>> handleNode,
             CancellationToken cancellationToken = default)
         {
-            if (!await handleNode(node, state, cancellationToken))
+            if (!await handleNode(node, cancellationToken))
             {
                 return;
             }
@@ -103,8 +99,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                                 ? stateManager.GetOrCreateEntry(relatedEntity, targetType)
                                 : stateManager.GetOrCreateEntry(relatedEntity);
                             await TraverseGraphAsync(
-                                node.CreateNode(node, targetEntry, navigation),
-                                state,
+                                (EntityEntryGraphNode<TState>)node.CreateNode(node, targetEntry, navigation),
                                 handleNode,
                                 cancellationToken);
                         }
@@ -115,8 +110,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                             ? stateManager.GetOrCreateEntry(navigationValue, targetType)
                             : stateManager.GetOrCreateEntry(navigationValue);
                         await TraverseGraphAsync(
-                            node.CreateNode(node, targetEntry, navigation),
-                            state,
+                            (EntityEntryGraphNode<TState>)node.CreateNode(node, targetEntry, navigation),
                             handleNode,
                             cancellationToken);
                     }

--- a/src/EFCore/ChangeTracking/Internal/IEntityGraphAttacher.cs
+++ b/src/EFCore/ChangeTracking/Internal/IEntityGraphAttacher.cs
@@ -17,7 +17,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        void AttachGraph([NotNull] InternalEntityEntry rootEntry, EntityState entityState, bool forceStateWhenUnknownKey);
+        void AttachGraph(
+            [NotNull] InternalEntityEntry rootEntry,
+            EntityState targetState,
+            EntityState storeGeneratedWithKeySetTargetState,
+            bool forceStateWhenUnknownKey);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -25,7 +29,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         /// </summary>
         Task AttachGraphAsync(
             [NotNull] InternalEntityEntry rootEntry,
-            EntityState entityState,
+            EntityState targetState,
+            EntityState storeGeneratedWithKeySetTargetState,
             bool forceStateWhenUnknownKey,
             CancellationToken cancellationToken = default);
     }

--- a/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
@@ -185,10 +185,16 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             {
                 stateManager.RecordReferencedUntrackedEntity(newValue, navigation, entry);
                 entry.SetRelationshipSnapshotValue(navigation, newValue);
+
                 newTargetEntry = targetEntityType.HasDefiningNavigation()
                     ? stateManager.GetOrCreateEntry(newValue, targetEntityType)
                     : stateManager.GetOrCreateEntry(newValue);
-                _attacher.AttachGraph(newTargetEntry, EntityState.Added, forceStateWhenUnknownKey: false);
+
+                _attacher.AttachGraph(
+                    newTargetEntry,
+                    EntityState.Added,
+                    EntityState.Modified,
+                    forceStateWhenUnknownKey: false);
             }
         }
 
@@ -278,7 +284,12 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 else
                 {
                     stateManager.RecordReferencedUntrackedEntity(newValue, navigation, entry);
-                    _attacher.AttachGraph(newTargetEntry, EntityState.Added, forceStateWhenUnknownKey: false);
+
+                    _attacher.AttachGraph(
+                        newTargetEntry,
+                        EntityState.Added,
+                        EntityState.Modified,
+                        forceStateWhenUnknownKey: false);
                 }
 
                 entry.AddToCollectionSnapshot(navigation, newValue);
@@ -623,8 +634,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             // truth and not attempt to ascertain relationships from navigation properties
             if (!fromQuery)
             {
-                var setModified = entry.EntityState != EntityState.Unchanged
-                                  && entry.EntityState != EntityState.Modified;
+                var setModified = entry.EntityState != EntityState.Unchanged;
 
                 foreach (var foreignKey in entityType.GetReferencingForeignKeys())
                 {
@@ -716,8 +726,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             if (navigationValue != null)
             {
-                var setModified = referencedEntry.EntityState != EntityState.Unchanged
-                                  && referencedEntry.EntityState != EntityState.Modified;
+                var setModified = referencedEntry.EntityState != EntityState.Unchanged;
 
                 if (!navigation.IsDependentToPrincipal())
                 {

--- a/src/EFCore/ChangeTracking/NavigationEntry.cs
+++ b/src/EFCore/ChangeTracking/NavigationEntry.cs
@@ -256,7 +256,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                 if (anyNonPk
                     && !property.IsPrimaryKey())
                 {
-                    internalEntityEntry.SetPropertyModified(property, isModified: modified);
+                    internalEntityEntry.SetPropertyModified(property, isModified: modified, acceptChanges: true);
                 }
             }
         }

--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -723,7 +723,11 @@ namespace Microsoft.EntityFrameworkCore
         {
             if (entry.EntityState == EntityState.Detached)
             {
-                DbContextDependencies.EntityGraphAttacher.AttachGraph(entry, entityState, forceStateWhenUnknownKey: true);
+                DbContextDependencies.EntityGraphAttacher.AttachGraph(
+                    entry,
+                    entityState,
+                    entityState,
+                    forceStateWhenUnknownKey: true);
             }
             else
             {
@@ -743,6 +747,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 await DbContextDependencies.EntityGraphAttacher.AttachGraphAsync(
                     entry,
+                    entityState,
                     entityState,
                     forceStateWhenUnknownKey: true,
                     cancellationToken: cancellationToken);

--- a/test/EFCore.InMemory.FunctionalTests/StoreGeneratedFixupInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/StoreGeneratedFixupInMemoryTest.cs
@@ -17,6 +17,11 @@ namespace Microsoft.EntityFrameworkCore
         {
         }
 
+        public override void Temporary_value_equals_database_generated_value()
+        {
+            // In-memory doesn't use real store-generated values.
+        }
+
         [Fact]
         public void InMemory_database_does_not_use_temp_values()
         {
@@ -58,118 +63,118 @@ namespace Microsoft.EntityFrameworkCore
                 modelBuilder.Entity<Parent>(
                     b =>
                     {
-                        b.Property(e => e.Id1).ValueGeneratedOnAdd();
-                        b.Property(e => e.Id2).ValueGeneratedOnAdd();
+                        b.Property(e => e.Id1).ValueGeneratedNever();
+                        b.Property(e => e.Id2).ValueGeneratedNever();
                     });
 
                 modelBuilder.Entity<Child>(
                     b =>
                     {
-                        b.Property(e => e.Id1).ValueGeneratedOnAdd();
-                        b.Property(e => e.Id2).ValueGeneratedOnAdd();
+                        b.Property(e => e.Id1).ValueGeneratedNever();
+                        b.Property(e => e.Id2).ValueGeneratedNever();
                     });
 
                 modelBuilder.Entity<ParentPN>(
                     b =>
                     {
-                        b.Property(e => e.Id1).ValueGeneratedOnAdd();
-                        b.Property(e => e.Id2).ValueGeneratedOnAdd();
+                        b.Property(e => e.Id1).ValueGeneratedNever();
+                        b.Property(e => e.Id2).ValueGeneratedNever();
                     });
 
                 modelBuilder.Entity<ChildPN>(
                     b =>
                     {
-                        b.Property(e => e.Id1).ValueGeneratedOnAdd();
-                        b.Property(e => e.Id2).ValueGeneratedOnAdd();
+                        b.Property(e => e.Id1).ValueGeneratedNever();
+                        b.Property(e => e.Id2).ValueGeneratedNever();
                     });
 
                 modelBuilder.Entity<ParentDN>(
                     b =>
                     {
-                        b.Property(e => e.Id1).ValueGeneratedOnAdd();
-                        b.Property(e => e.Id2).ValueGeneratedOnAdd();
+                        b.Property(e => e.Id1).ValueGeneratedNever();
+                        b.Property(e => e.Id2).ValueGeneratedNever();
                     });
 
                 modelBuilder.Entity<ChildDN>(
                     b =>
                     {
-                        b.Property(e => e.Id1).ValueGeneratedOnAdd();
-                        b.Property(e => e.Id2).ValueGeneratedOnAdd();
+                        b.Property(e => e.Id1).ValueGeneratedNever();
+                        b.Property(e => e.Id2).ValueGeneratedNever();
                     });
 
                 modelBuilder.Entity<ParentNN>(
                     b =>
                     {
-                        b.Property(e => e.Id1).ValueGeneratedOnAdd();
-                        b.Property(e => e.Id2).ValueGeneratedOnAdd();
+                        b.Property(e => e.Id1).ValueGeneratedNever();
+                        b.Property(e => e.Id2).ValueGeneratedNever();
                     });
 
                 modelBuilder.Entity<ChildNN>(
                     b =>
                     {
-                        b.Property(e => e.Id1).ValueGeneratedOnAdd();
-                        b.Property(e => e.Id2).ValueGeneratedOnAdd();
+                        b.Property(e => e.Id1).ValueGeneratedNever();
+                        b.Property(e => e.Id2).ValueGeneratedNever();
                     });
 
                 modelBuilder.Entity<CategoryDN>(
                     b =>
                     {
-                        b.Property(e => e.Id1).ValueGeneratedOnAdd();
-                        b.Property(e => e.Id2).ValueGeneratedOnAdd();
+                        b.Property(e => e.Id1).ValueGeneratedNever();
+                        b.Property(e => e.Id2).ValueGeneratedNever();
                     });
 
                 modelBuilder.Entity<ProductDN>(
                     b =>
                     {
-                        b.Property(e => e.Id1).ValueGeneratedOnAdd();
-                        b.Property(e => e.Id2).ValueGeneratedOnAdd();
+                        b.Property(e => e.Id1).ValueGeneratedNever();
+                        b.Property(e => e.Id2).ValueGeneratedNever();
                     });
 
                 modelBuilder.Entity<CategoryPN>(
                     b =>
                     {
-                        b.Property(e => e.Id1).ValueGeneratedOnAdd();
-                        b.Property(e => e.Id2).ValueGeneratedOnAdd();
+                        b.Property(e => e.Id1).ValueGeneratedNever();
+                        b.Property(e => e.Id2).ValueGeneratedNever();
                     });
 
                 modelBuilder.Entity<ProductPN>(
                     b =>
                     {
-                        b.Property(e => e.Id1).ValueGeneratedOnAdd();
-                        b.Property(e => e.Id2).ValueGeneratedOnAdd();
+                        b.Property(e => e.Id1).ValueGeneratedNever();
+                        b.Property(e => e.Id2).ValueGeneratedNever();
                     });
 
                 modelBuilder.Entity<CategoryNN>(
                     b =>
                     {
-                        b.Property(e => e.Id1).ValueGeneratedOnAdd();
-                        b.Property(e => e.Id2).ValueGeneratedOnAdd();
+                        b.Property(e => e.Id1).ValueGeneratedNever();
+                        b.Property(e => e.Id2).ValueGeneratedNever();
                     });
 
                 modelBuilder.Entity<ProductNN>(
                     b =>
                     {
-                        b.Property(e => e.Id1).ValueGeneratedOnAdd();
-                        b.Property(e => e.Id2).ValueGeneratedOnAdd();
+                        b.Property(e => e.Id1).ValueGeneratedNever();
+                        b.Property(e => e.Id2).ValueGeneratedNever();
                     });
 
                 modelBuilder.Entity<Category>(
                     b =>
                     {
-                        b.Property(e => e.Id1).ValueGeneratedOnAdd();
-                        b.Property(e => e.Id2).ValueGeneratedOnAdd();
+                        b.Property(e => e.Id1).ValueGeneratedNever();
+                        b.Property(e => e.Id2).ValueGeneratedNever();
                     });
 
                 modelBuilder.Entity<Product>(
                     b =>
                     {
-                        b.Property(e => e.Id1).ValueGeneratedOnAdd();
-                        b.Property(e => e.Id2).ValueGeneratedOnAdd();
+                        b.Property(e => e.Id1).ValueGeneratedNever();
+                        b.Property(e => e.Id2).ValueGeneratedNever();
                     });
 
-                modelBuilder.Entity<Item>(b => b.Property(e => e.Id).ValueGeneratedOnAdd());
+                modelBuilder.Entity<Item>(b => b.Property(e => e.Id).ValueGeneratedNever());
 
-                modelBuilder.Entity<Game>(b => b.Property(e => e.Id).ValueGeneratedOnAdd());
+                modelBuilder.Entity<Game>(b => b.Property(e => e.Id).ValueGeneratedNever());
             }
         }
     }

--- a/test/EFCore.Specification.Tests/Query/InheritanceFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/InheritanceFixtureBase.cs
@@ -15,11 +15,23 @@ namespace Microsoft.EntityFrameworkCore.Query
             modelBuilder.Entity<Kiwi>();
             modelBuilder.Entity<Eagle>();
             modelBuilder.Entity<Bird>();
-            modelBuilder.Entity<Animal>().HasKey(e => e.Species);
+
+            modelBuilder.Entity<Animal>(b =>
+            {
+                b.HasKey(e => e.Species);
+                b.Property(e => e.Species).ValueGeneratedNever();
+            });
+
             modelBuilder.Entity<Rose>();
             modelBuilder.Entity<Daisy>();
             modelBuilder.Entity<Flower>();
-            modelBuilder.Entity<Plant>().HasKey(e => e.Species);
+
+            modelBuilder.Entity<Plant>(b =>
+            {
+                b.HasKey(e => e.Species);
+                b.Property(e => e.Species).ValueGeneratedNever();
+            });
+
             modelBuilder.Entity<Country>();
             modelBuilder.Entity<Drink>();
             modelBuilder.Entity<Tea>();

--- a/test/EFCore.Specification.Tests/StoreGeneratedFixupTestBase.cs
+++ b/test/EFCore.Specification.Tests/StoreGeneratedFixupTestBase.cs
@@ -3937,7 +3937,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [Fact]
-        public void Temporary_value_equals_database_generated_value()
+        public virtual void Temporary_value_equals_database_generated_value()
         {
             using (var context = CreateContext())
             {

--- a/test/EFCore.Tests/ChangeTracking/ChangeTrackerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/ChangeTrackerTest.cs
@@ -2873,14 +2873,14 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                 var traversal = new List<string>();
 
                 context.ChangeTracker.TrackGraph(
-                    category, visited, (e, v) =>
+                    category, visited, e =>
                     {
-                        if (v.Contains(e.Entry.Entity))
+                        if (e.NodeState.Contains(e.Entry.Entity))
                         {
                             return false;
                         }
 
-                        v.Add(e.Entry.Entity);
+                        e.NodeState.Add(e.Entry.Entity);
 
                         traversal.Add(NodeString(e));
 
@@ -2948,14 +2948,14 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                 var traversal = new List<string>();
 
                 context.ChangeTracker.TrackGraph(
-                    category, visited, (e, v) =>
+                    category, visited, e =>
                     {
-                        if (v.Contains(e.Entry.Entity))
+                        if (e.NodeState.Contains(e.Entry.Entity))
                         {
                             return false;
                         }
 
-                        v.Add(e.Entry.Entity);
+                        e.NodeState.Add(e.Entry.Entity);
 
                         traversal.Add(NodeString(e));
 

--- a/test/EFCore.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
@@ -2382,11 +2382,15 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             public Tuple<InternalEntityEntry, EntityState> Attached { get; set; }
 
-            public override void AttachGraph(InternalEntityEntry rootEntry, EntityState entityState, bool forceStateWhenUnknownKey)
+            public override void AttachGraph(
+                InternalEntityEntry rootEntry,
+                EntityState targetState,
+                EntityState storeGeneratedWithKeySetTargetState,
+                bool forceStateWhenUnknownKey)
             {
-                Attached = Tuple.Create(rootEntry, entityState);
+                Attached = Tuple.Create(rootEntry, targetState);
 
-                base.AttachGraph(rootEntry, entityState, forceStateWhenUnknownKey);
+                base.AttachGraph(rootEntry, targetState, storeGeneratedWithKeySetTargetState, forceStateWhenUnknownKey);
             }
         }
 

--- a/test/EFCore.Tests/ChangeTracking/Internal/FixupTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/FixupTest.cs
@@ -1024,7 +1024,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                         Assert.Equal(setToPrincipal || setFk ? principal.Id : 0, dependent.CategoryId);
                         Assert.Same(setToPrincipal ? principal : null, dependent.Category);
                         Assert.Equal(setToPrincipal || setToDependent ? new[] { dependent } : null, principal.Products);
-                        Assert.Equal(setToPrincipal ? EntityState.Added : EntityState.Detached, context.Entry(principal).State);
+                        Assert.Equal(setToPrincipal ? EntityState.Modified : EntityState.Detached, context.Entry(principal).State);
                         Assert.Equal(
                             entityState == EntityState.Unchanged && (setToPrincipal || setFk) ? EntityState.Modified : entityState,
                             context.Entry(dependent).State);
@@ -1130,7 +1130,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                         Assert.Same(setToDependent || setToPrincipal ? principal : null, dependent.Category);
                         Assert.Equal(setToDependent ? new[] { dependent } : null, principal.Products);
                         Assert.Equal(entityState, context.Entry(principal).State);
-                        Assert.Equal(setToDependent ? EntityState.Added : EntityState.Detached, context.Entry(dependent).State);
+                        Assert.Equal(setToDependent ? EntityState.Modified : EntityState.Detached, context.Entry(dependent).State);
                     });
             }
         }
@@ -1264,7 +1264,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                         Assert.Equal(principal.Id, dependent.CategoryId);
                         Assert.Equal(setToDependent ? new[] { dependent } : Array.Empty<ProductPN>(), principal.Products);
                         Assert.Equal(entityState, context.Entry(principal).State);
-                        Assert.Equal(setToDependent ? EntityState.Added : EntityState.Detached, context.Entry(dependent).State);
+                        Assert.Equal(setToDependent ? EntityState.Modified : EntityState.Detached, context.Entry(dependent).State);
                     });
             }
         }
@@ -1329,7 +1329,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     {
                         Assert.Equal(principal.Id, dependent.CategoryId);
                         Assert.Same(setToPrincipal ? principal : null, dependent.Category);
-                        Assert.Equal(setToPrincipal ? EntityState.Added : EntityState.Detached, context.Entry(principal).State);
+                        Assert.Equal(setToPrincipal ? EntityState.Modified : EntityState.Detached, context.Entry(principal).State);
                         Assert.Equal(
                             entityState == EntityState.Added ? EntityState.Added : EntityState.Modified,
                             context.Entry(dependent).State);
@@ -1569,7 +1569,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                         Assert.Equal(setToPrincipal || setFk ? principal.Id : 0, dependent.ParentId);
                         Assert.Same(setToPrincipal ? principal : null, dependent.Parent);
                         Assert.Same(setToPrincipal || setToDependent ? dependent : null, principal.Child);
-                        Assert.Equal(setToPrincipal ? EntityState.Added : EntityState.Detached, context.Entry(principal).State);
+                        Assert.Equal(setToPrincipal ? EntityState.Modified : EntityState.Detached, context.Entry(principal).State);
                         Assert.Equal(
                             entityState == EntityState.Unchanged && (setFk || setToPrincipal)
                                 ? EntityState.Modified
@@ -1684,7 +1684,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                         Assert.Same(setToDependent || setToPrincipal ? principal : null, dependent.Parent);
                         Assert.Same(setToDependent ? dependent : null, principal.Child);
                         Assert.Equal(entityState, context.Entry(principal).State);
-                        Assert.Equal(setToDependent ? EntityState.Added : EntityState.Detached, context.Entry(dependent).State);
+                        Assert.Equal(setToDependent ? EntityState.Modified : EntityState.Detached, context.Entry(dependent).State);
                     });
             }
         }
@@ -1818,7 +1818,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                         Assert.Equal(principal.Id, dependent.ParentId);
                         Assert.Same(setToDependent ? dependent : null, principal.Child);
                         Assert.Equal(entityState, context.Entry(principal).State);
-                        Assert.Equal(setToDependent ? EntityState.Added : EntityState.Detached, context.Entry(dependent).State);
+                        Assert.Equal(setToDependent ? EntityState.Modified : EntityState.Detached, context.Entry(dependent).State);
                     });
             }
         }
@@ -1883,7 +1883,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     {
                         Assert.Equal(principal.Id, dependent.ParentId);
                         Assert.Same(setToPrincipal ? principal : null, dependent.Parent);
-                        Assert.Equal(setToPrincipal ? EntityState.Added : EntityState.Detached, context.Entry(principal).State);
+                        Assert.Equal(setToPrincipal ? EntityState.Modified : EntityState.Detached, context.Entry(principal).State);
                         Assert.Equal(
                             entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
                     });


### PR DESCRIPTION
Issue #14616

Detected entities with generated key values that have already been set are marked as Modified instead of Added.

Also, some re-working of the EntityGraphAttacher to make the node generic on TState.
