### PR TITLE
Introduce local DetectChanges

### DIFF
--- a/src/EFCore/ChangeTracking/ChangeTracker.cs
+++ b/src/EFCore/ChangeTracking/ChangeTracker.cs
@@ -188,10 +188,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         /// <returns> True if there are changes to save, otherwise false. </returns>
         public virtual bool HasChanges()
         {
-            if (AutoDetectChangesEnabled)
-            {
-                DetectChanges();
-            }
+            TryDetectChanges();
 
             return StateManager.ChangedCount > 0;
         }

--- a/src/EFCore/ChangeTracking/CollectionEntry.cs
+++ b/src/EFCore/ChangeTracking/CollectionEntry.cs
@@ -30,6 +30,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         public CollectionEntry([NotNull] InternalEntityEntry internalEntry, [NotNull] string name)
             : base(internalEntry, name, collection: true)
         {
+            LocalDetectChanges();
         }
 
         /// <summary>
@@ -39,6 +40,19 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         public CollectionEntry([NotNull] InternalEntityEntry internalEntry, [NotNull] INavigation navigation)
             : base(internalEntry, navigation)
         {
+            LocalDetectChanges();
+        }
+
+        private void LocalDetectChanges()
+        {
+            var collection = CurrentValue;
+            if (collection != null)
+            {
+                foreach (var entity in collection.OfType<object>().ToList())
+                {
+                    InternalEntry.StateManager.Context.Entry(entity);
+                }
+            }
         }
 
         /// <summary>

--- a/src/EFCore/ChangeTracking/EntityEntry.cs
+++ b/src/EFCore/ChangeTracking/EntityEntry.cs
@@ -85,6 +85,20 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         }
 
         /// <summary>
+        ///     Scans this entity instance to detect any changes made to the instance data. <see cref="DetectChanges()" />
+        ///     is usually called automatically by the context to get up-to-date information on an individual entity before
+        ///     returning change tracking information. You typically only need to call this method if you have
+        ///     disabled <see cref="ChangeTracker.AutoDetectChangesEnabled" />.
+        /// </summary>
+        public virtual void DetectChanges()
+        {
+            if (Context.Model[ChangeDetector.SkipDetectChangesAnnotation] == null)
+            {
+                Context.GetDependencies().ChangeDetector.DetectChanges(InternalEntry);
+            }
+        }
+
+        /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>

--- a/src/EFCore/ChangeTracking/ReferenceEntry.cs
+++ b/src/EFCore/ChangeTracking/ReferenceEntry.cs
@@ -26,6 +26,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         public ReferenceEntry([NotNull] InternalEntityEntry internalEntry, [NotNull] string name)
             : base(internalEntry, name, collection: false)
         {
+            LocalDetectChanges();
         }
 
         /// <summary>
@@ -35,6 +36,15 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         public ReferenceEntry([NotNull] InternalEntityEntry internalEntry, [NotNull] INavigation navigation)
             : base(internalEntry, navigation)
         {
+            LocalDetectChanges();
+        }
+
+        private void LocalDetectChanges()
+        {
+            if (!Metadata.IsDependentToPrincipal())
+            {
+                TargetEntry?.DetectChanges();
+            }
         }
 
         /// <summary>

--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -474,6 +474,14 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
+        private void TryDetectChanges(EntityEntry entry)
+        {
+            if (ChangeTracker.AutoDetectChangesEnabled)
+            {
+                 entry.DetectChanges();
+            }
+        }
+
         /// <summary>
         ///     Asynchronously saves all changes made in this context to the database.
         /// </summary>
@@ -684,9 +692,11 @@ namespace Microsoft.EntityFrameworkCore
             Check.NotNull(entity, nameof(entity));
             CheckDisposed();
 
-            TryDetectChanges();
+            var entry = EntryWithoutDetectChanges(entity);
 
-            return EntryWithoutDetectChanges(entity);
+            TryDetectChanges(entry);
+
+            return entry;
         }
 
         private EntityEntry<TEntity> EntryWithoutDetectChanges<TEntity>(TEntity entity)
@@ -711,9 +721,11 @@ namespace Microsoft.EntityFrameworkCore
             Check.NotNull(entity, nameof(entity));
             CheckDisposed();
 
-            TryDetectChanges();
+            var entry = EntryWithoutDetectChanges(entity);
 
-            return EntryWithoutDetectChanges(entity);
+            TryDetectChanges(entry);
+
+            return entry;
         }
 
         private EntityEntry EntryWithoutDetectChanges(object entity)

--- a/src/EFCore/Internal/LazyLoader.cs
+++ b/src/EFCore/Internal/LazyLoader.cs
@@ -87,28 +87,13 @@ namespace Microsoft.EntityFrameworkCore.Internal
 
         private bool ShouldLoad(object entity, string navigationName, [NotNullWhenTrue] out NavigationEntry? navigationEntry)
         {
-            EntityEntry GetEntryWithoutDetectChanges()
-            {
-                var autoDetectChangesEnabled = Context.ChangeTracker.AutoDetectChangesEnabled;
-                try
-                {
-                    Context.ChangeTracker.AutoDetectChangesEnabled = false;
-
-                    return Context.Entry(entity);
-                }
-                finally
-                {
-                    Context.ChangeTracker.AutoDetectChangesEnabled = autoDetectChangesEnabled;
-                }
-            }
-
             if (_disposed)
             {
                 Logger.LazyLoadOnDisposedContextWarning(Context, entity, navigationName);
             }
             else if (Context.ChangeTracker.LazyLoadingEnabled)
             {
-                var entityEntry = GetEntryWithoutDetectChanges();
+                var entityEntry = Context.Entry(entity); // Will use local-DetectChanges, if enabled.
                 var tempNavigationEntry = entityEntry.Navigation(navigationName);
 
                 if (entityEntry.State == EntityState.Detached)

--- a/test/EFCore.Tests/ChangeTracking/Internal/OwnedFixupTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/OwnedFixupTest.cs
@@ -691,7 +691,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     Assert.Equal(
                         CoreStrings.KeyReadOnly(
                             "ParentId",
-                            context.Entry(principal1).Reference(p => p.Child1).Metadata.GetTargetType().DisplayName()),
+                            "ParentPN.Child1#ChildPN"),
                         Assert.Throws<InvalidOperationException>(() => context.ChangeTracker.DetectChanges()).Message);
                 }
                 else
@@ -755,7 +755,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     Assert.Equal(
                         CoreStrings.KeyReadOnly(
                             "ParentId",
-                            context.Entry(principal1).Reference(p => p.Child1).Metadata.GetTargetType().DisplayName()),
+                            "Parent.Child1#Child"),
                         Assert.Throws<InvalidOperationException>(() => context.ChangeTracker.DetectChanges()).Message);
                 }
                 else


### PR DESCRIPTION
Issue #13552

It will DetectChanges in the current entry and any tracked principals. This ensures that any cascading operations are detected. Dependents are not checked eagerly, but if a Member/Reference/Collection method is called to get related dependent entities, then local DetectChanges is run on the related dependents. These two things eliminated any breaks in our functional tests.

Also, Lazy-loading now does a local DetectChanges, which means FK changes will be picked up and honored by the loader.
