### PR TITLE
Change log-level for query-executed to Debug

### DIFF
--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -592,10 +592,10 @@ namespace Microsoft.EntityFrameworkCore.Internal
         public static readonly EventDefinition<string, string, System.Data.CommandType, int, string, string> LogRelationalLoggerExecutedCommand
             = new EventDefinition<string, string, System.Data.CommandType, int, string, string>(
                 RelationalEventId.CommandExecuted,
-                LogLevel.Information,
+                LogLevel.Debug,
                 "RelationalEventId.CommandExecuted",
                 LoggerMessage.Define<string, string, System.Data.CommandType, int, string, string>(
-                    LogLevel.Information,
+                    LogLevel.Debug,
                     RelationalEventId.CommandExecuted,
                     _resourceManager.GetString("LogRelationalLoggerExecutedCommand")));
 

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -327,7 +327,7 @@
   </data>
   <data name="LogRelationalLoggerExecutedCommand" xml:space="preserve">
     <value>Executed DbCommand ({elapsed}ms) [Parameters=[{parameters}], CommandType='{commandType}', CommandTimeout='{commandTimeout}']{newLine}{commandText}</value>
-    <comment>Information RelationalEventId.CommandExecuted string string System.Data.CommandType int string string</comment>
+    <comment>Debug RelationalEventId.CommandExecuted string string System.Data.CommandType int string string</comment>
   </data>
   <data name="LogRelationalLoggerCommandFailed" xml:space="preserve">
     <value>Failed executing DbCommand ({elapsed}ms) [Parameters=[{parameters}], CommandType='{commandType}', CommandTimeout='{commandTimeout}']{newLine}{commandText}</value>

--- a/test/EFCore.Relational.Tests/Storage/RelationalCommandTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalCommandTest.cs
@@ -943,7 +943,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Assert.Equal(2, logFactory.Log.Count);
 
             Assert.Equal(LogLevel.Debug, logFactory.Log[0].Level);
-            Assert.Equal(LogLevel.Information, logFactory.Log[1].Level);
+            Assert.Equal(LogLevel.Debug, logFactory.Log[1].Level);
 
             foreach (var (_, _, message, _, _) in logFactory.Log)
             {
@@ -999,7 +999,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Assert.Equal(CoreStrings.LogSensitiveDataLoggingEnabled.GenerateMessage(), logFactory.Log[0].Message);
 
             Assert.Equal(LogLevel.Debug, logFactory.Log[1].Level);
-            Assert.Equal(LogLevel.Information, logFactory.Log[2].Level);
+            Assert.Equal(LogLevel.Debug, logFactory.Log[2].Level);
 
             foreach (var (_, _, message, _, _) in logFactory.Log.Skip(1))
             {


### PR DESCRIPTION
Issue #14523

I looked at making it easy to change the level back, but the ASP.NET delegate compiler expects the LogLevel to come in pre-baked--i.e. its parameterized on the level, which means we would have to regenerate the delegate to do this.
