### PR TITLE
CI: Don't pipe to SQLCMD

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,7 @@ jobs:
             - powershell: |
                 SqlLocalDB stop MSSQLLocalDB -i
                 SqlLocalDB start MSSQLLocalDB
-                @'
+                & "$env:ProgramFiles\Microsoft SQL Server\110\Tools\Binn\SQLCMD.EXE" -S '(localdb)\MSSQLLocalDB' -Q @'
                   DECLARE @name nvarchar(255);
                   DECLARE db CURSOR FOR SELECT Name FROM sysdatabases WHERE Name NOT IN ('master', 'tempdb', 'model', 'msdb');
                   OPEN db;
@@ -57,8 +57,9 @@ jobs:
                   END;
                   CLOSE db;
                   DEALLOCATE db;
-                '@ | & "$env:ProgramFiles\Microsoft SQL Server\110\Tools\Binn\SQLCMD.EXE" -S '(localdb)\MSSQLLocalDB' -d master
+                '@
               displayName: Cleanup databases
+              failOnStderr: true
             - script: eng\common\cibuild.cmd -configuration $(_BuildConfig) -prepareMachine $(_InternalBuildArgs)
               name: Build
             # Detect OSS Components in use in the product. Only needs to run on one OS in the matrix.


### PR DESCRIPTION
Seeing if this fixes errors like this:
```
Msg 102, Level 15, State 1, Server a0000PG\LOCALDB#A2A01434, Line 1
Incorrect syntax near '�'.
```