### PR TITLE
Make ILoggerFactory a scoped service

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
@@ -14,6 +15,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 {
@@ -636,10 +638,15 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                     $"({_code.Literal(property.Relational().ComputedColumnSql)})");
             }
 
+            var dummyLogger = new DiagnosticsLogger<DbLoggerCategory.Model>(
+                new LoggerFactory(),
+                new LoggingOptions(),
+                new DiagnosticListener(""));
+
             var valueGenerated = property.ValueGenerated;
             var isRowVersion = false;
             if (((Property)property).GetValueGeneratedConfigurationSource().HasValue
-                && new RelationalValueGeneratorConvention().GetValueGenerated((Property)property) != valueGenerated)
+                && new RelationalValueGeneratorConvention(dummyLogger).GetValueGenerated((Property)property) != valueGenerated)
             {
                 string methodName;
                 switch (valueGenerated)

--- a/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using JetBrains.Annotations;
@@ -18,6 +19,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
 using Microsoft.EntityFrameworkCore.Scaffolding.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
+using Microsoft.Extensions.Logging;
 using ScaffoldingAnnotationNames = Microsoft.EntityFrameworkCore.Scaffolding.Metadata.Internal.ScaffoldingAnnotationNames;
 
 namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
@@ -476,6 +478,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
             var keyBuilder = builder.HasKey(primaryKey.Columns.Select(GetPropertyName).ToArray());
 
+
             if (primaryKey.Columns.Count == 1
                 && primaryKey.Columns[0].ValueGenerated == null
                 && primaryKey.Columns[0].DefaultValueSql == null)
@@ -483,7 +486,12 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 var property = builder.Metadata.FindProperty(GetPropertyName(primaryKey.Columns[0]))?.AsProperty();
                 if (property != null)
                 {
-                    var conventionalValueGenerated = new RelationalValueGeneratorConvention().GetValueGenerated(property);
+                    var dummyLogger = new DiagnosticsLogger<DbLoggerCategory.Model>(
+                        new LoggerFactory(),
+                        new LoggingOptions(),
+                        new DiagnosticListener(""));
+
+                    var conventionalValueGenerated = new RelationalValueGeneratorConvention(dummyLogger).GetValueGenerated(property);
                     if (conventionalValueGenerated == ValueGenerated.OnAdd)
                     {
                         property.ValueGenerated = ValueGenerated.Never;

--- a/src/EFCore.InMemory/Metadata/Conventions/Internal/InMemoryConventionSetBuilder.cs
+++ b/src/EFCore.InMemory/Metadata/Conventions/Internal/InMemoryConventionSetBuilder.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 using Microsoft.Extensions.DependencyInjection;
@@ -23,6 +25,21 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Metadata.Conventions.Internal
     /// </summary>
     public class InMemoryConventionSetBuilder : IConventionSetBuilder
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public InMemoryConventionSetBuilder([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+        {
+            Logger = logger;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore.Proxies/Proxies/Internal/ProxiesConventionSetBuilder.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/ProxiesConventionSetBuilder.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
@@ -28,6 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
         private readonly IDbContextOptions _options;
         private readonly IConstructorBindingFactory _constructorBindingFactory;
         private readonly IProxyFactory _proxyFactory;
+        private readonly IDiagnosticsLogger<DbLoggerCategory.Model> _logger;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -36,11 +38,13 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
         public ProxiesConventionSetBuilder(
             [NotNull] IDbContextOptions options,
             [NotNull] IConstructorBindingFactory constructorBindingFactory,
-            [NotNull] IProxyFactory proxyFactory)
+            [NotNull] IProxyFactory proxyFactory,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
         {
             _options = options;
             _constructorBindingFactory = constructorBindingFactory;
             _proxyFactory = proxyFactory;
+            _logger = logger;
         }
 
         /// <summary>
@@ -53,6 +57,7 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
                 new ProxyBindingRewriter(
                     _proxyFactory,
                     _constructorBindingFactory,
+                    _logger,
                     _options.FindExtension<ProxiesOptionsExtension>()));
 
             return conventionSet;

--- a/src/EFCore.Proxies/Proxies/Internal/ProxyBindingRewriter.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/ProxyBindingRewriter.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
@@ -36,9 +37,10 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
         public ProxyBindingRewriter(
             [NotNull] IProxyFactory proxyFactory,
             [NotNull] IConstructorBindingFactory bindingFactory,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger,
             [CanBeNull] ProxiesOptionsExtension options)
         {
-            _directBindingConvention = new ConstructorBindingConvention(bindingFactory);
+            _directBindingConvention = new ConstructorBindingConvention(bindingFactory, logger);
             _proxyFactory = proxyFactory;
             _options = options;
         }

--- a/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
+++ b/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
@@ -63,8 +63,6 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 { typeof(IMigrationsAnnotationProvider), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(IMigrationCommandExecutor), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(IRelationalCommandBuilderFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
-                { typeof(IRawSqlCommandBuilder), new ServiceCharacteristics(ServiceLifetime.Singleton) },
-                { typeof(IMigrationsSqlGenerator), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(IRelationalTypeMappingSource), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(IRelationalValueBufferFactoryFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(IMaterializerFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
@@ -81,6 +79,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 { typeof(ICommandBatchPreparer), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IModificationCommandBatchFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IMigrationsModelDiffer), new ServiceCharacteristics(ServiceLifetime.Scoped) },
+                { typeof(IMigrationsSqlGenerator), new ServiceCharacteristics(ServiceLifetime.Scoped) },
+                { typeof(IRawSqlCommandBuilder), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IMigrator), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IMigrationsAssembly), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IBatchExecutor), new ServiceCharacteristics(ServiceLifetime.Scoped) },
@@ -177,7 +177,6 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 .AddDependencySingleton<UpdateSqlGeneratorDependencies>()
                 .AddDependencySingleton<QuerySqlGeneratorDependencies>()
                 .AddDependencySingleton<RelationalCompositeMethodCallTranslatorDependencies>()
-                .AddDependencySingleton<MigrationsSqlGeneratorDependencies>()
                 .AddDependencySingleton<MigrationsAnnotationProviderDependencies>()
                 .AddDependencySingleton<SqlTranslatingExpressionVisitorDependencies>()
                 .AddDependencySingleton<ParameterNameGeneratorDependencies>()
@@ -185,7 +184,9 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 .AddDependencySingleton<RelationalValueBufferFactoryDependencies>()
                 .AddDependencySingleton<RelationalProjectionExpressionVisitorDependencies>()
                 .AddDependencySingleton<RelationalTransactionFactoryDependencies>()
+                .AddDependencyScoped<MigrationsSqlGeneratorDependencies>()
                 .AddDependencyScoped<RelationalConventionSetBuilderDependencies>()
+                .AddDependencyScoped<ModificationCommandBatchFactoryDependencies>()
                 .AddDependencyScoped<CommandBatchPreparerDependencies>()
                 .AddDependencyScoped<RelationalDatabaseCreatorDependencies>()
                 .AddDependencyScoped<HistoryRepositoryDependencies>()

--- a/src/EFCore.Relational/Metadata/Conventions/Internal/DiscriminatorConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Internal/DiscriminatorConvention.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
@@ -14,6 +16,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     /// </summary>
     public class DiscriminatorConvention : IBaseTypeChangedConvention, IEntityTypeRemovedConvention
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public DiscriminatorConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+        {
+            Logger = logger;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore.Relational/Metadata/Conventions/Internal/RelationalColumnAttributeConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Internal/RelationalColumnAttributeConvention.cs
@@ -3,6 +3,8 @@
 
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
@@ -13,6 +15,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     /// </summary>
     public class RelationalColumnAttributeConvention : PropertyAttributeConvention<ColumnAttribute>
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public RelationalColumnAttributeConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+            : base(logger)
+        {
+        }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore.Relational/Metadata/Conventions/Internal/RelationalConventionSetBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Internal/RelationalConventionSetBuilder.cs
@@ -48,26 +48,28 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         /// </summary>
         public virtual ConventionSet AddConventions(ConventionSet conventionSet)
         {
-            ValueGeneratorConvention valueGeneratorConvention = new RelationalValueGeneratorConvention();
+            var logger = Dependencies.Logger;
+
+            ValueGeneratorConvention valueGeneratorConvention = new RelationalValueGeneratorConvention(logger);
 
             ReplaceConvention(conventionSet.BaseEntityTypeChangedConventions, valueGeneratorConvention);
             ReplaceConvention(conventionSet.PrimaryKeyChangedConventions, valueGeneratorConvention);
             ReplaceConvention(conventionSet.ForeignKeyAddedConventions, valueGeneratorConvention);
             ReplaceConvention(conventionSet.ForeignKeyRemovedConventions, valueGeneratorConvention);
 
-            var relationalColumnAttributeConvention = new RelationalColumnAttributeConvention();
+            var relationalColumnAttributeConvention = new RelationalColumnAttributeConvention(logger);
 
             conventionSet.PropertyAddedConventions.Add(relationalColumnAttributeConvention);
 
-            var sharedTableConvention = new SharedTableConvention();
+            var sharedTableConvention = new SharedTableConvention(logger);
 
-            var discriminatorConvention = new DiscriminatorConvention();
-            conventionSet.EntityTypeAddedConventions.Add(new RelationalTableAttributeConvention());
+            var discriminatorConvention = new DiscriminatorConvention(logger);
+            conventionSet.EntityTypeAddedConventions.Add(new RelationalTableAttributeConvention(logger));
             conventionSet.EntityTypeAddedConventions.Add(sharedTableConvention);
             conventionSet.EntityTypeRemovedConventions.Add(discriminatorConvention);
             conventionSet.BaseEntityTypeChangedConventions.Add(discriminatorConvention);
             conventionSet.BaseEntityTypeChangedConventions.Add(
-                new TableNameFromDbSetConvention(Dependencies.Context?.Context, Dependencies.SetFinder));
+                new TableNameFromDbSetConvention(Dependencies.Context?.Context, Dependencies.SetFinder, logger));
             conventionSet.EntityTypeAnnotationChangedConventions.Add(sharedTableConvention);
             conventionSet.PropertyFieldChangedConventions.Add(relationalColumnAttributeConvention);
             conventionSet.PropertyAnnotationChangedConventions.Add((RelationalValueGeneratorConvention)valueGeneratorConvention);
@@ -76,7 +78,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             conventionSet.ModelBuiltConventions.Add(sharedTableConvention);
 
-            conventionSet.ModelAnnotationChangedConventions.Add(new RelationalDbFunctionConvention());
+            conventionSet.ModelAnnotationChangedConventions.Add(new RelationalDbFunctionConvention(logger));
 
             return conventionSet;
         }

--- a/src/EFCore.Relational/Metadata/Conventions/Internal/RelationalDbFunctionConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Internal/RelationalDbFunctionConvention.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -18,6 +19,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     // Issue#11266 This type is being used by provider code. Do not break.
     public class RelationalDbFunctionConvention : IModelAnnotationChangedConvention
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public RelationalDbFunctionConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+        {
+            Logger = logger;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore.Relational/Metadata/Conventions/Internal/RelationalMaxIdentifierLengthConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Internal/RelationalMaxIdentifierLengthConvention.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
@@ -12,6 +14,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     // Issue#11266 This type is being used by provider code. Do not break.
     public class RelationalMaxIdentifierLengthConvention : IModelInitializedConvention
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public RelationalMaxIdentifierLengthConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+        {
+            Logger = logger;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore.Relational/Metadata/Conventions/Internal/RelationalTableAttributeConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Internal/RelationalTableAttributeConvention.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.ComponentModel.DataAnnotations.Schema;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
@@ -12,6 +14,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     /// </summary>
     public class RelationalTableAttributeConvention : EntityTypeAttributeConvention<TableAttribute>
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public RelationalTableAttributeConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+            : base(logger)
+        {
+        }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore.Relational/Metadata/Conventions/Internal/RelationalValueGeneratorConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Internal/RelationalValueGeneratorConvention.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
@@ -13,6 +15,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     // Issue#11266 This type is being used by provider code. Do not break.
     public class RelationalValueGeneratorConvention : ValueGeneratorConvention, IPropertyAnnotationChangedConvention
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public RelationalValueGeneratorConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+            : base(logger)
+        {
+        }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore.Relational/Metadata/Conventions/Internal/SharedTableConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Internal/SharedTableConvention.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
@@ -21,6 +23,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         IForeignKeyUniquenessChangedConvention,
         IModelBuiltConvention
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public SharedTableConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+        {
+            Logger = logger;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore.Relational/Metadata/Conventions/Internal/TableNameFromDbSetConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Internal/TableNameFromDbSetConvention.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
@@ -21,8 +22,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public TableNameFromDbSetConvention([CanBeNull] DbContext context, [CanBeNull] IDbSetFinder setFinder)
-            => _sets = setFinder?.CreateClrTypeDbSetMapping(context);
+        public TableNameFromDbSetConvention(
+            [CanBeNull] DbContext context,
+            [CanBeNull] IDbSetFinder setFinder,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+        {
+            _sets = setFinder?.CreateClrTypeDbSetMapping(context);
+            Logger = logger;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Relational/Metadata/Internal/DbFunction.cs
+++ b/src/EFCore.Relational/Metadata/Internal/DbFunction.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
@@ -191,7 +192,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        Expression IMethodCallTranslator.Translate(MethodCallExpression methodCallExpression)
+        Expression IMethodCallTranslator.Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             Check.NotNull(methodCallExpression, nameof(methodCallExpression));
 

--- a/src/EFCore.Relational/Migrations/HistoryRepository.cs
+++ b/src/EFCore.Relational/Migrations/HistoryRepository.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -61,7 +62,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             _model = new LazyRef<IModel>(
                 () =>
                 {
-                    var conventionSet = Dependencies.CoreConventionSetBuilder.CreateConventionSet();
+                    var conventionSet = Dependencies.CoreConventionSetBuilder.CreateConventionSet(
+                        new DiagnosticsLoggers(Dependencies.ModelLogger));
+
                     var modelBuilder = new ModelBuilder(Dependencies.ConventionSetBuilder.AddConventions(conventionSet));
 
                     modelBuilder.Entity<HistoryRow>(

--- a/src/EFCore.Relational/Migrations/HistoryRepositoryDependencies.cs
+++ b/src/EFCore.Relational/Migrations/HistoryRepositoryDependencies.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -71,6 +72,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         /// <param name="coreConventionSetBuilder"> The core convention set to use when creating the model. </param>
         /// <param name="conventionSetBuilders"> The convention sets to use when creating the model. </param>
         /// <param name="typeMappingSource"> The type mapper. </param>
+        /// <param name="modelLogger"> The logger for model building events. </param>
         public HistoryRepositoryDependencies(
             [NotNull] IRelationalDatabaseCreator databaseCreator,
             [NotNull] IRawSqlCommandBuilder rawSqlCommandBuilder,
@@ -81,7 +83,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             [NotNull] ISqlGenerationHelper sqlGenerationHelper,
             [NotNull] ICoreConventionSetBuilder coreConventionSetBuilder,
             [NotNull] IEnumerable<IConventionSetBuilder> conventionSetBuilders,
-            [NotNull] IRelationalTypeMappingSource typeMappingSource)
+            [NotNull] IRelationalTypeMappingSource typeMappingSource,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> modelLogger)
         {
             Check.NotNull(databaseCreator, nameof(databaseCreator));
             Check.NotNull(rawSqlCommandBuilder, nameof(rawSqlCommandBuilder));
@@ -93,6 +96,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             Check.NotNull(coreConventionSetBuilder, nameof(coreConventionSetBuilder));
             Check.NotNull(conventionSetBuilders, nameof(conventionSetBuilders));
             Check.NotNull(typeMappingSource, nameof(typeMappingSource));
+            Check.NotNull(modelLogger, nameof(modelLogger));
 
             DatabaseCreator = databaseCreator;
             RawSqlCommandBuilder = rawSqlCommandBuilder;
@@ -104,6 +108,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             CoreConventionSetBuilder = coreConventionSetBuilder;
             ConventionSetBuilder = new CompositeConventionSetBuilder((IReadOnlyList<IConventionSetBuilder>)conventionSetBuilders);
             TypeMappingSource = typeMappingSource;
+            ModelLogger = modelLogger;
         }
 
         /// <summary>
@@ -162,6 +167,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         public IRelationalTypeMappingSource TypeMappingSource { get; }
 
         /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public IDiagnosticsLogger<DbLoggerCategory.Model> ModelLogger { get; }
+
+        /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
         /// </summary>
         /// <param name="databaseCreator"> A replacement for the current dependency of this type. </param>
@@ -177,7 +188,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 SqlGenerationHelper,
                 CoreConventionSetBuilder,
                 ConventionSetBuilders,
-                TypeMappingSource);
+                TypeMappingSource,
+                ModelLogger);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -195,7 +207,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 SqlGenerationHelper,
                 CoreConventionSetBuilder,
                 ConventionSetBuilders,
-                TypeMappingSource);
+                TypeMappingSource,
+                ModelLogger);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -213,7 +226,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 SqlGenerationHelper,
                 CoreConventionSetBuilder,
                 ConventionSetBuilders,
-                TypeMappingSource);
+                TypeMappingSource,
+                ModelLogger);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -231,7 +245,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 SqlGenerationHelper,
                 CoreConventionSetBuilder,
                 ConventionSetBuilders,
-                TypeMappingSource);
+                TypeMappingSource,
+                ModelLogger);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -249,7 +264,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 SqlGenerationHelper,
                 CoreConventionSetBuilder,
                 ConventionSetBuilders,
-                TypeMappingSource);
+                TypeMappingSource,
+                ModelLogger);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -267,7 +283,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 SqlGenerationHelper,
                 CoreConventionSetBuilder,
                 ConventionSetBuilders,
-                TypeMappingSource);
+                TypeMappingSource,
+                ModelLogger);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -285,7 +302,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 sqlGenerationHelper,
                 CoreConventionSetBuilder,
                 ConventionSetBuilders,
-                TypeMappingSource);
+                TypeMappingSource,
+                ModelLogger);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -303,7 +321,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 SqlGenerationHelper,
                 coreConventionSetBuilder,
                 ConventionSetBuilders,
-                TypeMappingSource);
+                TypeMappingSource,
+                ModelLogger);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -323,7 +342,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 conventionSetBuilder is CompositeConventionSetBuilder compositeConventionSetBuilder
                     ? compositeConventionSetBuilder.Builders
                     : new[] { conventionSetBuilder },
-                TypeMappingSource);
+                TypeMappingSource,
+                ModelLogger);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -341,6 +361,26 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 SqlGenerationHelper,
                 CoreConventionSetBuilder,
                 ConventionSetBuilders,
-                typeMappingSource);
+                typeMappingSource,
+                ModelLogger);
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="modelLogger"> The type mapper. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public HistoryRepositoryDependencies With([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> modelLogger)
+            => new HistoryRepositoryDependencies(
+                DatabaseCreator,
+                RawSqlCommandBuilder,
+                Connection,
+                Options,
+                ModelDiffer,
+                MigrationsSqlGenerator,
+                SqlGenerationHelper,
+                CoreConventionSetBuilder,
+                ConventionSetBuilders,
+                TypeMappingSource,
+                modelLogger);
     }
 }

--- a/src/EFCore.Relational/Migrations/IMigrationsSqlGenerator.cs
+++ b/src/EFCore.Relational/Migrations/IMigrationsSqlGenerator.cs
@@ -15,9 +15,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations
     ///         then be executed or scripted from a list of <see cref="MigrationOperation" />s.
     ///     </para>
     ///     <para>
-    ///         The service lifetime is <see cref="ServiceLifetime.Singleton"/>. This means a single instance
-    ///         is used by many <see cref="DbContext"/> instances. The implementation must be thread-safe.
-    ///         This service cannot depend on services registered as <see cref="ServiceLifetime.Scoped"/>.
+    ///         The service lifetime is <see cref="ServiceLifetime.Scoped"/>. This means that each
+    ///         <see cref="DbContext"/> instance will use its own instance of this service.
+    ///         The implementation may depend on other services registered with any lifetime.
+    ///         The implementation does not need to be thread-safe.
     ///     </para>
     /// </summary>
     public interface IMigrationsSqlGenerator

--- a/src/EFCore.Relational/Migrations/Internal/Migrator.cs
+++ b/src/EFCore.Relational/Migrations/Internal/Migrator.cs
@@ -95,7 +95,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     _databaseCreator.Create();
                 }
 
-                var command = _rawSqlCommandBuilder.Build(_historyRepository.GetCreateScript());
+                var command = _rawSqlCommandBuilder.Build(
+                    _historyRepository.GetCreateScript());
 
                 command.ExecuteNonQuery(_connection);
             }
@@ -124,7 +125,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     await _databaseCreator.CreateAsync(cancellationToken);
                 }
 
-                var command = _rawSqlCommandBuilder.Build(_historyRepository.GetCreateScript());
+                var command = _rawSqlCommandBuilder.Build(
+                    _historyRepository.GetCreateScript());
 
                 await command.ExecuteNonQueryAsync(_connection, cancellationToken: cancellationToken);
             }

--- a/src/EFCore.Relational/Migrations/MigrationCommandListBuilder.cs
+++ b/src/EFCore.Relational/Migrations/MigrationCommandListBuilder.cs
@@ -15,25 +15,22 @@ namespace Microsoft.EntityFrameworkCore.Migrations
     /// </summary>
     public class MigrationCommandListBuilder
     {
-        private readonly IRelationalCommandBuilderFactory _commandBuilderFactory;
         private readonly List<MigrationCommand> _commands = new List<MigrationCommand>();
+        private readonly MigrationsSqlGeneratorDependencies _dependencies;
 
         private IRelationalCommandBuilder _commandBuilder;
 
         /// <summary>
         ///     Creates a new instance of the builder.
         /// </summary>
-        /// <param name="commandBuilderFactory">
-        ///     A factory used to create the underlying <see cref="IRelationalCommandBuilder" /> which
-        ///     is used to build commands.
-        /// </param>
-        /// s.
-        public MigrationCommandListBuilder([NotNull] IRelationalCommandBuilderFactory commandBuilderFactory)
+        /// <param name="dependencies"> Dependencies needed for SQL generations. </param>
+        public MigrationCommandListBuilder(
+            [NotNull] MigrationsSqlGeneratorDependencies dependencies)
         {
-            Check.NotNull(commandBuilderFactory, nameof(commandBuilderFactory));
+            Check.NotNull(dependencies, nameof(dependencies));
 
-            _commandBuilderFactory = commandBuilderFactory;
-            _commandBuilder = commandBuilderFactory.Create();
+            _dependencies = dependencies;
+            _commandBuilder = dependencies.CommandBuilderFactory.Create(dependencies.Logger);
         }
 
         /// <summary>
@@ -55,7 +52,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             if (_commandBuilder.GetLength() != 0)
             {
                 _commands.Add(new MigrationCommand(_commandBuilder.Build(), suppressTransaction));
-                _commandBuilder = _commandBuilderFactory.Create();
+                _commandBuilder = _dependencies.CommandBuilderFactory.Create(_dependencies.Logger);
             }
 
             return this;

--- a/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
+++ b/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
@@ -28,9 +28,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations
     ///         This class is typically inherited by database providers to customize the SQL generation.
     ///     </para>
     ///     <para>
-    ///         The service lifetime is <see cref="ServiceLifetime.Singleton"/>. This means a single instance
-    ///         is used by many <see cref="DbContext"/> instances. The implementation must be thread-safe.
-    ///         This service cannot depend on services registered as <see cref="ServiceLifetime.Scoped"/>.
+    ///         The service lifetime is <see cref="ServiceLifetime.Scoped"/>. This means that each
+    ///         <see cref="DbContext"/> instance will use its own instance of this service.
+    ///         The implementation may depend on other services registered with any lifetime.
+    ///         The implementation does not need to be thread-safe.
     ///     </para>
     /// </summary>
     public class MigrationsSqlGenerator : IMigrationsSqlGenerator
@@ -109,7 +110,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         {
             Check.NotNull(operations, nameof(operations));
 
-            var builder = new MigrationCommandListBuilder(Dependencies.CommandBuilderFactory);
+            var builder = new MigrationCommandListBuilder(Dependencies);
             foreach (var operation in operations)
             {
                 Generate(operation, model, builder);

--- a/src/EFCore.Relational/Query/ExpressionTranslators/ICompositeMethodCallTranslator.cs
+++ b/src/EFCore.Relational/Query/ExpressionTranslators/ICompositeMethodCallTranslator.cs
@@ -3,6 +3,7 @@
 
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -25,9 +26,13 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
         /// </summary>
         /// <param name="methodCallExpression"> The method call expression. </param>
         /// <param name="model"> The current model. </param>
+        /// <param name="logger"> The logger. </param>
         /// <returns>
         ///     A SQL expression representing the translated MethodCallExpression.
         /// </returns>
-        Expression Translate([NotNull] MethodCallExpression methodCallExpression, [NotNull] IModel model);
+        Expression Translate(
+            [NotNull] MethodCallExpression methodCallExpression,
+            [NotNull] IModel model,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> logger);
     }
 }

--- a/src/EFCore.Relational/Query/ExpressionTranslators/IMethodCallTranslator.cs
+++ b/src/EFCore.Relational/Query/ExpressionTranslators/IMethodCallTranslator.cs
@@ -3,6 +3,7 @@
 
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
 {
@@ -15,9 +16,12 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
         ///     Translates the given method call expression.
         /// </summary>
         /// <param name="methodCallExpression"> The method call expression. </param>
+        /// <param name="logger"> The logger to use. </param>
         /// <returns>
         ///     A SQL expression representing the translated MethodCallExpression.
         /// </returns>
-        Expression Translate([NotNull] MethodCallExpression methodCallExpression);
+        Expression Translate(
+            [NotNull] MethodCallExpression methodCallExpression,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> logger);
     }
 }

--- a/src/EFCore.Relational/Query/ExpressionTranslators/Internal/EnumHasFlagTranslator.cs
+++ b/src/EFCore.Relational/Query/ExpressionTranslators/Internal/EnumHasFlagTranslator.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -22,7 +23,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             Check.NotNull(methodCallExpression, nameof(methodCallExpression));
 

--- a/src/EFCore.Relational/Query/ExpressionTranslators/Internal/GetValueOrDefaultTranslator.cs
+++ b/src/EFCore.Relational/Query/ExpressionTranslators/Internal/GetValueOrDefaultTranslator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
@@ -17,7 +18,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             if (methodCallExpression.Method.Name == nameof(Nullable<int>.GetValueOrDefault)
                 && methodCallExpression.Type.IsNumeric())

--- a/src/EFCore.Relational/Query/ExpressionTranslators/Internal/IsNullOrEmptyTranslator.cs
+++ b/src/EFCore.Relational/Query/ExpressionTranslators/Internal/IsNullOrEmptyTranslator.cs
@@ -3,6 +3,7 @@
 
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -21,7 +22,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             Check.NotNull(methodCallExpression, nameof(methodCallExpression));
 

--- a/src/EFCore.Relational/Query/ExpressionTranslators/Internal/LikeTranslator.cs
+++ b/src/EFCore.Relational/Query/ExpressionTranslators/Internal/LikeTranslator.cs
@@ -3,6 +3,7 @@
 
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -28,7 +29,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             Check.NotNull(methodCallExpression, nameof(methodCallExpression));
 

--- a/src/EFCore.Relational/Query/ExpressionTranslators/MultipleOverloadStaticMethodCallTranslator.cs
+++ b/src/EFCore.Relational/Query/ExpressionTranslators/MultipleOverloadStaticMethodCallTranslator.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 
 namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
@@ -40,10 +41,13 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
         ///     Translates the given method call expression.
         /// </summary>
         /// <param name="methodCallExpression"> The method call expression. </param>
+        /// <param name="logger"> The logger. </param>
         /// <returns>
         ///     A SQL expression representing the translated MethodCallExpression.
         /// </returns>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             var methodInfos = _declaringType.GetTypeInfo().GetDeclaredMethods(_clrMethodName);
             return methodInfos.Contains(methodCallExpression.Method)

--- a/src/EFCore.Relational/Query/ExpressionTranslators/ParameterlessInstanceMethodCallTranslator.cs
+++ b/src/EFCore.Relational/Query/ExpressionTranslators/ParameterlessInstanceMethodCallTranslator.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 
 namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
@@ -37,10 +38,13 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
         ///     Translates the given method call expression.
         /// </summary>
         /// <param name="methodCallExpression"> The method call expression. </param>
+        /// <param name="logger"> The loger. </param>
         /// <returns>
         ///     A SQL expression representing the translated MethodCallExpression.
         /// </returns>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             if (_methodInfo.Equals(methodCallExpression.Method))
             {

--- a/src/EFCore.Relational/Query/ExpressionTranslators/RelationalCompositeMethodCallTranslator.cs
+++ b/src/EFCore.Relational/Query/ExpressionTranslators/RelationalCompositeMethodCallTranslator.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -45,7 +46,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
                 = new List<IMethodCallTranslator>
                 {
                     new EnumHasFlagTranslator(),
-                    new EqualsTranslator(dependencies.Logger),
+                    new EqualsTranslator(),
                     new GetValueOrDefaultTranslator(),
                     new IsNullOrEmptyTranslator(),
                     new LikeTranslator()
@@ -62,13 +63,17 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
         /// </summary>
         /// <param name="methodCallExpression"> The method call expression. </param>
         /// <param name="model"> The current model. </param>
+        /// <param name="logger"> The logger. </param>
         /// <returns>
         ///     A SQL expression representing the translated MethodCallExpression.
         /// </returns>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression, IModel model)
-            => ((IMethodCallTranslator)model.Relational().FindDbFunction(methodCallExpression.Method))?.Translate(methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IModel model,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+            => ((IMethodCallTranslator)model.Relational().FindDbFunction(methodCallExpression.Method))?.Translate(methodCallExpression, logger)
                ?? _plugins.Concat(_methodCallTranslators)
-                   .Select(translator => translator.Translate(methodCallExpression))
+                   .Select(translator => translator.Translate(methodCallExpression, logger))
                    .FirstOrDefault(translatedMethodCall => translatedMethodCall != null);
 
         /// <summary>

--- a/src/EFCore.Relational/Query/ExpressionTranslators/RelationalCompositeMethodCallTranslatorDependencies.cs
+++ b/src/EFCore.Relational/Query/ExpressionTranslators/RelationalCompositeMethodCallTranslatorDependencies.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -47,23 +46,14 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
         ///         the constructor at any point in this process.
         ///     </para>
         /// </summary>
-        /// <param name="logger"> A logger. </param>
         /// <param name="plugins"> The plugins. </param>
         public RelationalCompositeMethodCallTranslatorDependencies(
-            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> logger,
             [NotNull] IEnumerable<IMethodCallTranslatorPlugin> plugins)
         {
-            Check.NotNull(logger, nameof(logger));
             Check.NotNull(plugins, nameof(plugins));
 
-            Logger = logger;
             Plugins = plugins;
         }
-
-        /// <summary>
-        ///     The logger.
-        /// </summary>
-        public IDiagnosticsLogger<DbLoggerCategory.Query> Logger { get; }
 
         /// <summary>
         ///     Gets the plugins.
@@ -73,18 +63,10 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
         /// </summary>
-        /// <param name="logger"> A replacement for the current dependency of this type. </param>
-        /// <returns> A new parameter object with the given service replaced. </returns>
-        public RelationalCompositeMethodCallTranslatorDependencies With([NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> logger)
-            => new RelationalCompositeMethodCallTranslatorDependencies(logger, Plugins);
-
-        /// <summary>
-        ///     Clones this dependency parameter object with one service replaced.
-        /// </summary>
         /// <param name="plugins"> A replacement for the current dependency of this type. </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
         public RelationalCompositeMethodCallTranslatorDependencies With(
             [NotNull] IEnumerable<IMethodCallTranslatorPlugin> plugins)
-            => new RelationalCompositeMethodCallTranslatorDependencies(Logger, plugins);
+            => new RelationalCompositeMethodCallTranslatorDependencies(plugins);
     }
 }

--- a/src/EFCore.Relational/Query/ExpressionTranslators/SingleOverloadStaticMethodCallTranslator.cs
+++ b/src/EFCore.Relational/Query/ExpressionTranslators/SingleOverloadStaticMethodCallTranslator.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 
 namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
@@ -39,10 +40,13 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
         ///     Translates the given method call expression.
         /// </summary>
         /// <param name="methodCallExpression"> The method call expression. </param>
+        /// <param name="logger"> The logger. </param>
         /// <returns>
         ///     A SQL expression representing the translated MethodCallExpression.
         /// </returns>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
             => _methodInfo.Equals(methodCallExpression.Method)
                 ? new SqlFunctionExpression(_sqlFunctionName, methodCallExpression.Type, methodCallExpression.Arguments)
                 : null;

--- a/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -613,10 +613,12 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
             // if method is EFIndexer then we need to skip attempting to translate
             // the method call and fall through to binding the expression below
             // (this supports joining on an indexed property)
+            var compilationContext = _queryModelVisitor.QueryCompilationContext;
+
             var operand =
                 methodCallExpression.Method.IsEFIndexer()
                     ? null
-                    : _queryModelVisitor.QueryCompilationContext.Model.Relational().FindDbFunction(methodCallExpression.Method) != null
+                    : compilationContext.Model.Relational().FindDbFunction(methodCallExpression.Method) != null
                         ? methodCallExpression.Object
                         : Visit(methodCallExpression.Object);
 
@@ -642,7 +644,10 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                             ? Expression.Call(operand, methodCallExpression.Method, arguments)
                             : Expression.Call(methodCallExpression.Method, arguments);
 
-                    var translatedExpression = _methodCallTranslator.Translate(boundExpression, _queryModelVisitor.QueryCompilationContext.Model);
+                    var translatedExpression = _methodCallTranslator.Translate(
+                        boundExpression,
+                        compilationContext.Model,
+                        compilationContext.Loggers.GetLogger<DbLoggerCategory.Query>());
 
                     if (translatedExpression != null)
                     {

--- a/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query.Expressions.Internal;
@@ -65,6 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
 
             Dependencies = dependencies;
             _queryCompilationContext = queryCompilationContext;
+            Loggers = queryCompilationContext.Loggers;
         }
 
         /// <summary>
@@ -94,6 +96,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
                 _queryCompilationContext = null;
             }
         }
+
+        /// <summary>
+        ///     Loggers to use.
+        /// </summary>
+        protected virtual DiagnosticsLoggers Loggers { get; }
 
         /// <summary>
         ///     Dependencies used to create a <see cref="SelectExpression" />
@@ -1455,7 +1462,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         ///     The new default query SQL generator.
         /// </returns>
         public virtual IQuerySqlGenerator CreateDefaultQuerySqlGenerator()
-            => Dependencies.QuerySqlGeneratorFactory.CreateDefault(this);
+            => Dependencies.QuerySqlGeneratorFactory.CreateDefault(this, Loggers);
 
         /// <summary>
         ///     Creates the FromSql query SQL generator.
@@ -1469,10 +1476,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             [NotNull] string sql,
             [NotNull] Expression arguments)
             => Dependencies.QuerySqlGeneratorFactory
-                .CreateFromSql(
-                    this,
-                    Check.NotEmpty(sql, nameof(sql)),
-                    Check.NotNull(arguments, nameof(arguments)));
+                .CreateFromSql(this, sql, arguments, Loggers);
 
         /// <summary>
         ///     Convert this object into a string representation.

--- a/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -930,7 +930,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             if (throwOnNullResult
                 && handlerContext.QueryModelVisitor.ParentQueryModelVisitor != null)
             {
-                handlerContext.QueryModelVisitor.QueryCompilationContext.Logger
+                handlerContext.QueryModelVisitor.QueryCompilationContext.Loggers.GetLogger<DbLoggerCategory.Query>()
                     .QueryPossibleExceptionWithAggregateOperator();
             }
 

--- a/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -86,7 +86,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             ParentQueryModelVisitor = parentQueryModelVisitor;
 
             _storeMaterializerExpression
-                = CoreStrings.LogQueryExecutionPlanned.GetLogBehavior(QueryCompilationContext.Logger) != WarningBehavior.Ignore;
+                = CoreStrings.LogQueryExecutionPlanned.GetLogBehavior(
+                      QueryCompilationContext.Loggers.GetLogger<DbLoggerCategory.Query>()) != WarningBehavior.Ignore;
         }
 
         /// <summary>
@@ -137,7 +138,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                                     TypedRelationalValueBufferFactoryFactory.DataReaderParameter,
                                     FastQueryMaterializerCreatingVisitor.DbContextParameter),
                                 Expression.Constant(QueryCompilationContext.ContextType),
-                                Expression.Constant(QueryCompilationContext.Logger));
+                                Expression.Constant(QueryCompilationContext.Loggers.GetLogger<DbLoggerCategory.Query>()));
                     }
                 }
             }
@@ -1484,7 +1485,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             Check.NotNull(queryModelElement, nameof(queryModelElement));
 
-            QueryCompilationContext.Logger.QueryClientEvaluationWarning(queryModel, queryModelElement);
+            QueryCompilationContext.Loggers.GetLogger<DbLoggerCategory.Query>()
+                .QueryClientEvaluationWarning(queryModel, queryModelElement);
         }
 
         private class TypeIsExpressionTranslatingVisitor : ExpressionVisitorBase

--- a/src/EFCore.Relational/Query/Sql/IQuerySqlGeneratorFactory.cs
+++ b/src/EFCore.Relational/Query/Sql/IQuerySqlGeneratorFactory.cs
@@ -3,6 +3,7 @@
 
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -24,10 +25,13 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         ///     Creates the default SQL generator.
         /// </summary>
         /// <param name="selectExpression"> The select expression. </param>
+        /// <param name="loggers"> Some loggers. </param>
         /// <returns>
         ///     The default SQL generator.
         /// </returns>
-        IQuerySqlGenerator CreateDefault([NotNull] SelectExpression selectExpression);
+        IQuerySqlGenerator CreateDefault(
+            [NotNull] SelectExpression selectExpression,
+            DiagnosticsLoggers loggers);
 
         /// <summary>
         ///     Creates a FromSql SQL generator.
@@ -35,12 +39,14 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         /// <param name="selectExpression"> The select expression. </param>
         /// <param name="sql"> The SQL. </param>
         /// <param name="arguments"> The arguments. </param>
+        /// <param name="loggers"> Some loggers. </param>
         /// <returns>
         ///     The FromSql SQL generator.
         /// </returns>
         IQuerySqlGenerator CreateFromSql(
             [NotNull] SelectExpression selectExpression,
             [NotNull] string sql,
-            [NotNull] Expression arguments);
+            [NotNull] Expression arguments,
+            DiagnosticsLoggers loggers);
     }
 }

--- a/src/EFCore.Relational/Query/Sql/Internal/FromSqlNonComposedQuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Sql/Internal/FromSqlNonComposedQuerySqlGenerator.cs
@@ -6,6 +6,7 @@ using System.Data.Common;
 using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -30,8 +31,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql.Internal
             [NotNull] QuerySqlGeneratorDependencies dependencies,
             [NotNull] SelectExpression selectExpression,
             [NotNull] string sql,
-            [NotNull] Expression arguments)
-            : base(dependencies, selectExpression)
+            [NotNull] Expression arguments,
+            DiagnosticsLoggers loggers)
+            : base(dependencies, selectExpression, loggers)
         {
             Check.NotEmpty(sql, nameof(sql));
             Check.NotNull(arguments, nameof(arguments));

--- a/src/EFCore.Relational/Query/Sql/QuerySqlGeneratorDependencies.cs
+++ b/src/EFCore.Relational/Query/Sql/QuerySqlGeneratorDependencies.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -51,25 +50,21 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         /// <param name="sqlGenerationHelper"> The SQL generation helper. </param>
         /// <param name="parameterNameGeneratorFactory"> The parameter name generator factory. </param>
         /// <param name="typeMappingSource"> The type mapper. </param>
-        /// <param name="logger"> The logger. </param>
         public QuerySqlGeneratorDependencies(
             [NotNull] IRelationalCommandBuilderFactory commandBuilderFactory,
             [NotNull] ISqlGenerationHelper sqlGenerationHelper,
             [NotNull] IParameterNameGeneratorFactory parameterNameGeneratorFactory,
-            [NotNull] IRelationalTypeMappingSource typeMappingSource,
-            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+            [NotNull] IRelationalTypeMappingSource typeMappingSource)
         {
             Check.NotNull(commandBuilderFactory, nameof(commandBuilderFactory));
             Check.NotNull(sqlGenerationHelper, nameof(sqlGenerationHelper));
             Check.NotNull(parameterNameGeneratorFactory, nameof(parameterNameGeneratorFactory));
             Check.NotNull(typeMappingSource, nameof(typeMappingSource));
-            Check.NotNull(logger, nameof(logger));
 
             CommandBuilderFactory = commandBuilderFactory;
             SqlGenerationHelper = sqlGenerationHelper;
             ParameterNameGeneratorFactory = parameterNameGeneratorFactory;
             TypeMappingSource = typeMappingSource;
-            Logger = logger;
         }
 
         /// <summary>
@@ -93,11 +88,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         public IRelationalTypeMappingSource TypeMappingSource { get; }
 
         /// <summary>
-        ///     The logger.
-        /// </summary>
-        public IDiagnosticsLogger<DbLoggerCategory.Query> Logger { get; }
-
-        /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
         /// </summary>
         /// <param name="commandBuilderFactory"> A replacement for the current dependency of this type. </param>
@@ -107,8 +97,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                 commandBuilderFactory,
                 SqlGenerationHelper,
                 ParameterNameGeneratorFactory,
-                TypeMappingSource,
-                Logger);
+                TypeMappingSource);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -120,8 +109,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                 CommandBuilderFactory,
                 sqlGenerationHelper,
                 ParameterNameGeneratorFactory,
-                TypeMappingSource,
-                Logger);
+                TypeMappingSource);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -133,8 +121,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                 CommandBuilderFactory,
                 SqlGenerationHelper,
                 parameterNameGeneratorFactory,
-                TypeMappingSource,
-                Logger);
+                TypeMappingSource);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -146,20 +133,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                 CommandBuilderFactory,
                 SqlGenerationHelper,
                 ParameterNameGeneratorFactory,
-                typeMappingSource,
-                Logger);
-
-        /// <summary>
-        ///     Clones this dependency parameter object with one service replaced.
-        /// </summary>
-        /// <param name="logger"> A replacement for the current dependency of this type. </param>
-        /// <returns> A new parameter object with the given service replaced. </returns>
-        public QuerySqlGeneratorDependencies With([NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> logger)
-            => new QuerySqlGeneratorDependencies(
-                CommandBuilderFactory,
-                SqlGenerationHelper,
-                ParameterNameGeneratorFactory,
-                TypeMappingSource,
-                logger);
+                typeMappingSource);
     }
 }

--- a/src/EFCore.Relational/Query/Sql/QuerySqlGeneratorFactoryBase.cs
+++ b/src/EFCore.Relational/Query/Sql/QuerySqlGeneratorFactoryBase.cs
@@ -3,6 +3,7 @@
 
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.Sql.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -42,10 +43,13 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         ///     Creates a default query SQL generator.
         /// </summary>
         /// <param name="selectExpression"> The select expression. </param>
+        /// <param name="loggers"> Some loggers. </param>
         /// <returns>
         ///     The new default query SQL generator.
         /// </returns>
-        public abstract IQuerySqlGenerator CreateDefault(SelectExpression selectExpression);
+        public abstract IQuerySqlGenerator CreateDefault(
+            SelectExpression selectExpression,
+            DiagnosticsLoggers loggers);
 
         /// <summary>
         ///     Creates a query SQL generator for a FromSql query.
@@ -53,17 +57,16 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         /// <param name="selectExpression"> The select expression. </param>
         /// <param name="sql"> The SQL. </param>
         /// <param name="arguments"> The arguments. </param>
+        /// <param name="loggers"> Some loggers. </param>
         /// <returns>
         ///     The query SQL generator.
         /// </returns>
         public virtual IQuerySqlGenerator CreateFromSql(
             SelectExpression selectExpression,
             string sql,
-            Expression arguments)
+            Expression arguments,
+            DiagnosticsLoggers loggers)
             => new FromSqlNonComposedQuerySqlGenerator(
-                Dependencies,
-                Check.NotNull(selectExpression, nameof(selectExpression)),
-                Check.NotEmpty(sql, nameof(sql)),
-                Check.NotNull(arguments, nameof(arguments)));
+                Dependencies, selectExpression, sql, arguments, loggers);
     }
 }

--- a/src/EFCore.Relational/Storage/IRawSqlCommandBuilder.cs
+++ b/src/EFCore.Relational/Storage/IRawSqlCommandBuilder.cs
@@ -16,9 +16,10 @@ namespace Microsoft.EntityFrameworkCore.Storage
     ///         not used in application code.
     ///     </para>
     ///     <para>
-    ///         The service lifetime is <see cref="ServiceLifetime.Singleton"/>. This means a single instance
-    ///         is used by many <see cref="DbContext"/> instances. The implementation must be thread-safe.
-    ///         This service cannot depend on services registered as <see cref="ServiceLifetime.Scoped"/>.
+    ///         The service lifetime is <see cref="ServiceLifetime.Scoped"/>. This means that each
+    ///         <see cref="DbContext"/> instance will use its own instance of this service.
+    ///         The implementation may depend on other services registered with any lifetime.
+    ///         The implementation does not need to be thread-safe.
     ///     </para>
     /// </summary>
     public interface IRawSqlCommandBuilder

--- a/src/EFCore.Relational/Storage/IRelationalCommandBuilderFactory.cs
+++ b/src/EFCore.Relational/Storage/IRelationalCommandBuilderFactory.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.Storage
@@ -25,6 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Creates a new <see cref="IRelationalCommandBuilder" />.
         /// </summary>
         /// <returns> The newly created builder. </returns>
-        IRelationalCommandBuilder Create();
+        IRelationalCommandBuilder Create(
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger);
     }
 }

--- a/src/EFCore.Relational/Storage/Internal/RelationalCommandBuilderFactory.cs
+++ b/src/EFCore.Relational/Storage/Internal/RelationalCommandBuilderFactory.cs
@@ -21,7 +21,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
     /// </summary>
     public class RelationalCommandBuilderFactory : IRelationalCommandBuilderFactory
     {
-        private readonly IDiagnosticsLogger<DbLoggerCategory.Database.Command> _logger;
         private readonly IRelationalTypeMappingSource _typeMappingSource;
 
         /// <summary>
@@ -29,13 +28,10 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public RelationalCommandBuilderFactory(
-            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
             [NotNull] IRelationalTypeMappingSource typeMappingSource)
         {
-            Check.NotNull(logger, nameof(logger));
             Check.NotNull(typeMappingSource, nameof(typeMappingSource));
 
-            _logger = logger;
             _typeMappingSource = typeMappingSource;
         }
 
@@ -43,7 +39,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual IRelationalCommandBuilder Create() => CreateCore(_logger, _typeMappingSource);
+        public virtual IRelationalCommandBuilder Create(
+            IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger)
+            => CreateCore(logger, _typeMappingSource);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Relational/Update/AffectedCountModificationCommandBatch.cs
+++ b/src/EFCore.Relational/Update/AffectedCountModificationCommandBatch.cs
@@ -27,18 +27,9 @@ namespace Microsoft.EntityFrameworkCore.Update
         /// <summary>
         ///     Creates a new <see cref="AffectedCountModificationCommandBatch" /> instance.
         /// </summary>
-        /// <param name="commandBuilderFactory"> The builder to build commands. </param>
-        /// <param name="sqlGenerationHelper"> A helper for SQL generation. </param>
-        /// <param name="updateSqlGenerator"> A SQL generator for insert, update, and delete commands. </param>
-        /// <param name="valueBufferFactoryFactory">
-        ///     A factory for creating factories for creating <see cref="ValueBuffer" />s to be used when reading from the data reader.
-        /// </param>
-        protected AffectedCountModificationCommandBatch(
-            [NotNull] IRelationalCommandBuilderFactory commandBuilderFactory,
-            [NotNull] ISqlGenerationHelper sqlGenerationHelper,
-            [NotNull] IUpdateSqlGenerator updateSqlGenerator,
-            [NotNull] IRelationalValueBufferFactoryFactory valueBufferFactoryFactory)
-            : base(commandBuilderFactory, sqlGenerationHelper, updateSqlGenerator, valueBufferFactoryFactory)
+        /// <param name="dependencies"> Service dependencies. </param>
+        protected AffectedCountModificationCommandBatch([NotNull] ModificationCommandBatchFactoryDependencies dependencies)
+            : base(dependencies)
         {
         }
 

--- a/src/EFCore.Relational/Update/ModificationCommandBatchFactoryDependencies.cs
+++ b/src/EFCore.Relational/Update/ModificationCommandBatchFactoryDependencies.cs
@@ -1,0 +1,165 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Utilities;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.EntityFrameworkCore.Update
+{
+    /// <summary>
+    ///     <para>
+    ///         Service dependencies parameter class for <see cref="IModificationCommandBatchFactory" />
+    ///     </para>
+    ///     <para>
+    ///         This type is typically used by database providers (and other extensions). It is generally
+    ///         not used in application code.
+    ///     </para>
+    ///     <para>
+    ///         Do not construct instances of this class directly from either provider or application code as the
+    ///         constructor signature may change as new dependencies are added. Instead, use this type in
+    ///         your constructor so that an instance will be created and injected automatically by the
+    ///         dependency injection container. To create an instance with some dependent services replaced,
+    ///         first resolve the object from the dependency injection container, then replace selected
+    ///         services using the 'With...' methods. Do not call the constructor at any point in this process.
+    ///     </para>
+    ///     <para>
+    ///         The service lifetime is <see cref="ServiceLifetime.Scoped"/>. This means that each
+    ///         <see cref="DbContext"/> instance will use its own instance of this service.
+    ///         The implementation may depend on other services registered with any lifetime.
+    ///         The implementation does not need to be thread-safe.
+    ///     </para>
+    /// </summary>
+    public sealed class ModificationCommandBatchFactoryDependencies
+    {
+        /// <summary>
+        ///     <para>
+        ///         Creates the service dependencies parameter object for a <see cref="IModificationCommandBatchFactory" />.
+        ///     </para>
+        ///     <para>
+        ///         Do not call this constructor directly from either provider or application code as it may change
+        ///         as new dependencies are added. Instead, use this type in your constructor so that an instance
+        ///         will be created and injected automatically by the dependency injection container. To create
+        ///         an instance with some dependent services replaced, first resolve the object from the dependency
+        ///         injection container, then replace selected services using the 'With...' methods. Do not call
+        ///         the constructor at any point in this process.
+        ///     </para>
+        /// </summary>
+        /// <param name="valueBufferFactoryFactory"> The value buffer factory. </param>
+        /// <param name="commandBuilderFactory"> The command builder factory. </param>
+        /// <param name="sqlGenerationHelper"> The sql generator. </param>
+        /// <param name="updateSqlGenerator"> The update generator. </param>
+        /// <param name="logger"> A logger. </param>
+        public ModificationCommandBatchFactoryDependencies(
+            [NotNull] IRelationalCommandBuilderFactory commandBuilderFactory,
+            [NotNull] ISqlGenerationHelper sqlGenerationHelper,
+            [NotNull] IUpdateSqlGenerator updateSqlGenerator,
+            [NotNull] IRelationalValueBufferFactoryFactory valueBufferFactoryFactory,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger)
+        {
+            Check.NotNull(commandBuilderFactory, nameof(commandBuilderFactory));
+            Check.NotNull(sqlGenerationHelper, nameof(sqlGenerationHelper));
+            Check.NotNull(updateSqlGenerator, nameof(updateSqlGenerator));
+            Check.NotNull(valueBufferFactoryFactory, nameof(valueBufferFactoryFactory));
+            Check.NotNull(logger, nameof(logger));
+
+            CommandBuilderFactory = commandBuilderFactory;
+            SqlGenerationHelper = sqlGenerationHelper;
+            UpdateSqlGenerator = updateSqlGenerator;
+            ValueBufferFactoryFactory = valueBufferFactoryFactory;
+            Logger = logger;
+        }
+
+        /// <summary>
+        ///     A logger.
+        /// </summary>
+        public IDiagnosticsLogger<DbLoggerCategory.Database.Command> Logger { get; }
+
+        /// <summary>
+        ///     The command builder factory.
+        /// </summary>
+        public IRelationalCommandBuilderFactory CommandBuilderFactory { get; }
+
+        /// <summary>
+        ///     The SQL generator helper.
+        /// </summary>
+        public ISqlGenerationHelper SqlGenerationHelper { get; }
+
+        /// <summary>
+        ///     The update SQL generator.
+        /// </summary>
+        public IUpdateSqlGenerator UpdateSqlGenerator { get; }
+
+        /// <summary>
+        ///     The value buffer factory.
+        /// </summary>
+        public IRelationalValueBufferFactoryFactory ValueBufferFactoryFactory { get; }
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="logger"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public ModificationCommandBatchFactoryDependencies With([NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger)
+            => new ModificationCommandBatchFactoryDependencies(
+                CommandBuilderFactory,
+                SqlGenerationHelper,
+                UpdateSqlGenerator,
+                ValueBufferFactoryFactory,
+                logger);
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="valueBufferFactoryFactory"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public ModificationCommandBatchFactoryDependencies With([NotNull] IRelationalValueBufferFactoryFactory valueBufferFactoryFactory)
+            => new ModificationCommandBatchFactoryDependencies(
+                CommandBuilderFactory,
+                SqlGenerationHelper,
+                UpdateSqlGenerator,
+                valueBufferFactoryFactory,
+                Logger);
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="commandBuilderFactory"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public ModificationCommandBatchFactoryDependencies With([NotNull] IRelationalCommandBuilderFactory commandBuilderFactory)
+            => new ModificationCommandBatchFactoryDependencies(
+                commandBuilderFactory,
+                SqlGenerationHelper,
+                UpdateSqlGenerator,
+                ValueBufferFactoryFactory,
+                Logger);
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="sqlGenerationHelper"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public ModificationCommandBatchFactoryDependencies With([NotNull] ISqlGenerationHelper sqlGenerationHelper)
+            => new ModificationCommandBatchFactoryDependencies(
+                CommandBuilderFactory,
+                sqlGenerationHelper,
+                UpdateSqlGenerator,
+                ValueBufferFactoryFactory,
+                Logger);
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="updateSqlGenerator"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public ModificationCommandBatchFactoryDependencies With([NotNull] IUpdateSqlGenerator updateSqlGenerator)
+            => new ModificationCommandBatchFactoryDependencies(
+                CommandBuilderFactory,
+                SqlGenerationHelper,
+                updateSqlGenerator,
+                ValueBufferFactoryFactory,
+                Logger);
+    }
+}

--- a/src/EFCore.Relational/Update/SingularModificationCommandBatch.cs
+++ b/src/EFCore.Relational/Update/SingularModificationCommandBatch.cs
@@ -20,22 +20,9 @@ namespace Microsoft.EntityFrameworkCore.Update
         /// <summary>
         ///     Creates a new <see cref="SingularModificationCommandBatch" /> instance.
         /// </summary>
-        /// <param name="commandBuilderFactory"> The builder to build commands. </param>
-        /// <param name="sqlGenerationHelper"> A helper for SQL generation. </param>
-        /// <param name="updateSqlGenerator"> A SQL generator for insert, update, and delete commands. </param>
-        /// <param name="valueBufferFactoryFactory">
-        ///     A factory for creating factories for creating <see cref="ValueBuffer" />s to be used when reading from the data reader.
-        /// </param>
-        public SingularModificationCommandBatch(
-            [NotNull] IRelationalCommandBuilderFactory commandBuilderFactory,
-            [NotNull] ISqlGenerationHelper sqlGenerationHelper,
-            [NotNull] IUpdateSqlGenerator updateSqlGenerator,
-            [NotNull] IRelationalValueBufferFactoryFactory valueBufferFactoryFactory)
-            : base(
-                commandBuilderFactory,
-                sqlGenerationHelper,
-                updateSqlGenerator,
-                valueBufferFactoryFactory)
+        /// <param name="dependencies"> Service dependencies. </param>
+        public SingularModificationCommandBatch([NotNull] ModificationCommandBatchFactoryDependencies dependencies)
+            : base(dependencies)
         {
         }
 

--- a/src/EFCore.SqlServer.NTS/Query/ExpressionTranslators/Internal/SqlServerGeometryCollectionMethodTranslator.cs
+++ b/src/EFCore.SqlServer.NTS/Query/ExpressionTranslators/Internal/SqlServerGeometryCollectionMethodTranslator.cs
@@ -4,6 +4,7 @@
 using System.Linq.Expressions;
 using System.Reflection;
 using GeoAPI.Geometries;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
@@ -32,7 +33,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             if (!typeof(IGeometryCollection).IsAssignableFrom(methodCallExpression.Method.DeclaringType))
             {

--- a/src/EFCore.SqlServer.NTS/Query/ExpressionTranslators/Internal/SqlServerGeometryMethodTranslator.cs
+++ b/src/EFCore.SqlServer.NTS/Query/ExpressionTranslators/Internal/SqlServerGeometryMethodTranslator.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
 using GeoAPI.Geometries;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
@@ -64,7 +65,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             if (!typeof(IGeometry).IsAssignableFrom(methodCallExpression.Method.DeclaringType))
             {

--- a/src/EFCore.SqlServer.NTS/Query/ExpressionTranslators/Internal/SqlServerLineStringMethodTranslator.cs
+++ b/src/EFCore.SqlServer.NTS/Query/ExpressionTranslators/Internal/SqlServerLineStringMethodTranslator.cs
@@ -4,6 +4,7 @@
 using System.Linq.Expressions;
 using System.Reflection;
 using GeoAPI.Geometries;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
@@ -32,7 +33,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             if (!typeof(ILineString).IsAssignableFrom(methodCallExpression.Method.DeclaringType))
             {

--- a/src/EFCore.SqlServer.NTS/Query/ExpressionTranslators/Internal/SqlServerPolygonMethodTranslator.cs
+++ b/src/EFCore.SqlServer.NTS/Query/ExpressionTranslators/Internal/SqlServerPolygonMethodTranslator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq.Expressions;
 using System.Reflection;
 using GeoAPI.Geometries;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
@@ -33,7 +34,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             if (!typeof(IPolygon).IsAssignableFrom(methodCallExpression.Method.DeclaringType))
             {

--- a/src/EFCore.SqlServer/Metadata/Conventions/Internal/SqlServerDbFunctionConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/Internal/SqlServerDbFunctionConvention.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -13,6 +15,15 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Metadata.Conventions.Internal
     /// </summary>
     public class SqlServerDbFunctionConvention : RelationalDbFunctionConvention
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public SqlServerDbFunctionConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+            : base(logger)
+        {
+        }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore.SqlServer/Metadata/Conventions/Internal/SqlServerIndexConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/Internal/SqlServerIndexConvention.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
@@ -31,10 +32,19 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Metadata.Conventions.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public SqlServerIndexConvention([NotNull] ISqlGenerationHelper sqlGenerationHelper)
+        public SqlServerIndexConvention(
+            [NotNull] ISqlGenerationHelper sqlGenerationHelper,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
         {
             _sqlGenerationHelper = sqlGenerationHelper;
+            Logger = logger;
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.SqlServer/Metadata/Conventions/Internal/SqlServerMemoryOptimizedTablesConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/Internal/SqlServerMemoryOptimizedTablesConvention.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -15,6 +17,21 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Metadata.Conventions.Internal
     /// </summary>
     public class SqlServerMemoryOptimizedTablesConvention : IEntityTypeAnnotationChangedConvention, IKeyAddedConvention, IIndexAddedConvention
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public SqlServerMemoryOptimizedTablesConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+        {
+            Logger = logger;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore.SqlServer/Metadata/Conventions/Internal/SqlServerValueGenerationStrategyConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/Internal/SqlServerValueGenerationStrategyConvention.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -14,6 +16,21 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Metadata.Conventions.Internal
     /// </summary>
     public class SqlServerValueGenerationStrategyConvention : IModelInitializedConvention, IModelBuiltConvention
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public SqlServerValueGenerationStrategyConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+        {
+            Logger = logger;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
+
         InternalModelBuilder IModelInitializedConvention.Apply(InternalModelBuilder modelBuilder)
         {
             modelBuilder.SqlServer(ConfigurationSource.Convention).ValueGenerationStrategy(SqlServerValueGenerationStrategy.IdentityColumn);

--- a/src/EFCore.SqlServer/Metadata/Conventions/Internal/SqlServerValueGeneratorConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/Internal/SqlServerValueGeneratorConvention.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
@@ -15,6 +17,15 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Metadata.Conventions.Internal
     /// </summary>
     public class SqlServerValueGeneratorConvention : RelationalValueGeneratorConvention
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public SqlServerValueGeneratorConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+            : base(logger)
+        {
+        }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerConventionSetBuilder.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerConventionSetBuilder.cs
@@ -49,14 +49,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             base.AddConventions(conventionSet);
 
-            var valueGenerationStrategyConvention = new SqlServerValueGenerationStrategyConvention();
+            var logger = Dependencies.Logger;
+
+            var valueGenerationStrategyConvention = new SqlServerValueGenerationStrategyConvention(logger);
             conventionSet.ModelInitializedConventions.Add(valueGenerationStrategyConvention);
             conventionSet.ModelInitializedConventions.Add(new RelationalMaxIdentifierLengthConvention(128));
 
-            ValueGeneratorConvention valueGeneratorConvention = new SqlServerValueGeneratorConvention();
+            ValueGeneratorConvention valueGeneratorConvention = new SqlServerValueGeneratorConvention(logger);
             ReplaceConvention(conventionSet.BaseEntityTypeChangedConventions, valueGeneratorConvention);
 
-            var sqlServerInMemoryTablesConvention = new SqlServerMemoryOptimizedTablesConvention();
+            var sqlServerInMemoryTablesConvention = new SqlServerMemoryOptimizedTablesConvention(logger);
             conventionSet.EntityTypeAnnotationChangedConventions.Add(sqlServerInMemoryTablesConvention);
 
             ReplaceConvention(conventionSet.PrimaryKeyChangedConventions, valueGeneratorConvention);
@@ -67,7 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             ReplaceConvention(conventionSet.ForeignKeyRemovedConventions, valueGeneratorConvention);
 
-            var sqlServerIndexConvention = new SqlServerIndexConvention(_sqlGenerationHelper);
+            var sqlServerIndexConvention = new SqlServerIndexConvention(_sqlGenerationHelper,logger);
 
             conventionSet.BaseEntityTypeChangedConventions.Add(sqlServerIndexConvention);
 
@@ -85,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             conventionSet.PropertyAnnotationChangedConventions.Add(sqlServerIndexConvention);
             conventionSet.PropertyAnnotationChangedConventions.Add((SqlServerValueGeneratorConvention)valueGeneratorConvention);
 
-            ReplaceConvention(conventionSet.ModelAnnotationChangedConventions, (RelationalDbFunctionConvention)new SqlServerDbFunctionConvention());
+            ReplaceConvention(conventionSet.ModelAnnotationChangedConventions, (RelationalDbFunctionConvention)new SqlServerDbFunctionConvention(logger));
 
             return conventionSet;
         }

--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -27,9 +27,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations
     ///         SQL Server-specific implementation of <see cref="MigrationsSqlGenerator" />.
     ///     </para>
     ///     <para>
-    ///         The service lifetime is <see cref="ServiceLifetime.Singleton"/>. This means a single instance
-    ///         is used by many <see cref="DbContext"/> instances. The implementation must be thread-safe.
-    ///         This service cannot depend on services registered as <see cref="ServiceLifetime.Scoped"/>.
+    ///         The service lifetime is <see cref="ServiceLifetime.Scoped"/>. This means that each
+    ///         <see cref="DbContext"/> instance will use its own instance of this service.
+    ///         The implementation may depend on other services registered with any lifetime.
+    ///         The implementation does not need to be thread-safe.
     ///     </para>
     /// </summary>
     public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerContainsOptimizedTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerContainsOptimizedTranslator.cs
@@ -3,6 +3,7 @@
 
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
@@ -21,7 +22,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             if (Equals(methodCallExpression.Method, _methodInfo))
             {

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerConvertTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerConvertTranslator.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
@@ -54,7 +55,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
             => _supportedMethods.Contains(methodCallExpression.Method)
                 ? new SqlFunctionExpression(
                     "CONVERT",

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerDateAddTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerDateAddTranslator.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
@@ -39,10 +40,13 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
         ///     Translates the given method call expression.
         /// </summary>
         /// <param name="methodCallExpression">The method call expression.</param>
+        /// <param name="logger"> The logger. </param>
         /// <returns>
         ///     A SQL expression representing the translated MethodCallExpression.
         /// </returns>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             if (_methodInfoDatePartMapping.TryGetValue(methodCallExpression.Method, out var datePart))
             {

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerDateDiffTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerDateDiffTranslator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -242,7 +243,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             Check.NotNull(methodCallExpression, nameof(methodCallExpression));
 

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerEndsWithOptimizedTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerEndsWithOptimizedTranslator.cs
@@ -3,6 +3,7 @@
 
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
@@ -21,7 +22,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             if (Equals(methodCallExpression.Method, _methodInfo))
             {

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerFullTextSearchMethodCallTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerFullTextSearchMethodCallTranslator.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
@@ -45,7 +46,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             Check.NotNull(methodCallExpression, nameof(methodCallExpression));
 

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerMathTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerMathTranslator.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -61,7 +62,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             Check.NotNull(methodCallExpression, nameof(methodCallExpression));
 

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerObjectToStringTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerObjectToStringTranslator.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
@@ -44,7 +45,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             return methodCallExpression.Method.Name == nameof(ToString)
                    && methodCallExpression.Arguments.Count == 0

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStartsWithOptimizedTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStartsWithOptimizedTranslator.cs
@@ -3,6 +3,7 @@
 
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
@@ -24,7 +25,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             if (Equals(methodCallExpression.Method, _methodInfo))
             {

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringConcatMethodCallTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringConcatMethodCallTranslator.cs
@@ -3,6 +3,7 @@
 
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.Internal
@@ -22,7 +23,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
             => _stringConcatMethodInfo.Equals(methodCallExpression.Method)
                 ? Expression.Add(methodCallExpression.Arguments[0], methodCallExpression.Arguments[1], _stringConcatMethodInfo)
                 : null;

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringIndexOfTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringIndexOfTranslator.cs
@@ -3,6 +3,7 @@
 
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
@@ -21,7 +22,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             if (Equals(methodCallExpression.Method, _methodInfo))
             {

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringIsNullOrWhiteSpaceTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringIsNullOrWhiteSpaceTranslator.cs
@@ -3,6 +3,7 @@
 
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
@@ -21,7 +22,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             if (methodCallExpression.Method.Equals(_methodInfo))
             {

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringReplaceTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringReplaceTranslator.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
@@ -22,7 +23,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
             => _methodInfo.Equals(methodCallExpression.Method)
                 ? new SqlFunctionExpression(
                     "REPLACE",

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringSubstringTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringSubstringTranslator.cs
@@ -3,6 +3,7 @@
 
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
@@ -21,7 +22,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
             => _methodInfo.Equals(methodCallExpression.Method)
                 ? new SqlFunctionExpression(
                     "SUBSTRING",

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringTrimEndTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringTrimEndTranslator.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
@@ -27,7 +28,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             if (_methodInfoWithoutArgs?.Equals(methodCallExpression.Method) == true
                 || _methodInfoWithCharArrayArg.Equals(methodCallExpression.Method)

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringTrimStartTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringTrimStartTranslator.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
@@ -27,7 +28,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             if (_methodInfoWithoutArgs?.Equals(methodCallExpression.Method) == true
                 || _methodInfoWithCharArrayArg.Equals(methodCallExpression.Method)

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringTrimTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringTrimTranslator.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
@@ -27,7 +28,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             if (_methodInfoWithoutArgs.Equals(methodCallExpression.Method)
                 || _methodInfoWithCharArrayArg.Equals(methodCallExpression.Method)

--- a/src/EFCore.SqlServer/Query/Sql/Internal/SqlServerQuerySqlGenerator.cs
+++ b/src/EFCore.SqlServer/Query/Sql/Internal/SqlServerQuerySqlGenerator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors;
 using Microsoft.EntityFrameworkCore.Query.Sql;
@@ -28,8 +29,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Sql.Internal
         public SqlServerQuerySqlGenerator(
             [NotNull] QuerySqlGeneratorDependencies dependencies,
             [NotNull] SelectExpression selectExpression,
-            bool rowNumberPagingEnabled)
-            : base(dependencies, selectExpression)
+            bool rowNumberPagingEnabled,
+            DiagnosticsLoggers loggers)
+            : base(dependencies, selectExpression, loggers)
         {
             if (rowNumberPagingEnabled)
             {

--- a/src/EFCore.SqlServer/Query/Sql/Internal/SqlServerQuerySqlGeneratorFactory.cs
+++ b/src/EFCore.SqlServer/Query/Sql/Internal/SqlServerQuerySqlGeneratorFactory.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.Sql;
 using Microsoft.EntityFrameworkCore.SqlServer.Infrastructure.Internal;
@@ -41,10 +42,10 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Sql.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public override IQuerySqlGenerator CreateDefault(SelectExpression selectExpression)
+        public override IQuerySqlGenerator CreateDefault(
+            SelectExpression selectExpression,
+            DiagnosticsLoggers loggers)
             => new SqlServerQuerySqlGenerator(
-                Dependencies,
-                Check.NotNull(selectExpression, nameof(selectExpression)),
-                _sqlServerOptions.RowNumberPagingEnabled);
+                Dependencies, selectExpression, _sqlServerOptions.RowNumberPagingEnabled, loggers);
     }
 }

--- a/src/EFCore.SqlServer/Update/Internal/SqlServerModificationCommandBatch.cs
+++ b/src/EFCore.SqlServer/Update/Internal/SqlServerModificationCommandBatch.cs
@@ -32,17 +32,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Update.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public SqlServerModificationCommandBatch(
-            [NotNull] IRelationalCommandBuilderFactory commandBuilderFactory,
-            [NotNull] ISqlGenerationHelper sqlGenerationHelper,
-            // ReSharper disable once SuggestBaseTypeForParameter
-            [NotNull] ISqlServerUpdateSqlGenerator updateSqlGenerator,
-            [NotNull] IRelationalValueBufferFactoryFactory valueBufferFactoryFactory,
+            [NotNull] ModificationCommandBatchFactoryDependencies dependencies,
             int? maxBatchSize)
-            : base(
-                commandBuilderFactory,
-                sqlGenerationHelper,
-                updateSqlGenerator,
-                valueBufferFactoryFactory)
+            : base(dependencies)
         {
             if (maxBatchSize.HasValue
                 && maxBatchSize.Value <= 0)

--- a/src/EFCore.SqlServer/Update/Internal/SqlServerModificationCommandBatchFactory.cs
+++ b/src/EFCore.SqlServer/Update/Internal/SqlServerModificationCommandBatchFactory.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.SqlServer.Infrastructure.Internal;
-using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Update;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -26,10 +25,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Update.Internal
     /// </summary>
     public class SqlServerModificationCommandBatchFactory : IModificationCommandBatchFactory
     {
-        private readonly IRelationalCommandBuilderFactory _commandBuilderFactory;
-        private readonly ISqlGenerationHelper _sqlGenerationHelper;
-        private readonly ISqlServerUpdateSqlGenerator _updateSqlGenerator;
-        private readonly IRelationalValueBufferFactoryFactory _valueBufferFactoryFactory;
+        private readonly ModificationCommandBatchFactoryDependencies _dependencies;
         private readonly IDbContextOptions _options;
 
         /// <summary>
@@ -37,22 +33,13 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Update.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public SqlServerModificationCommandBatchFactory(
-            [NotNull] IRelationalCommandBuilderFactory commandBuilderFactory,
-            [NotNull] ISqlGenerationHelper sqlGenerationHelper,
-            [NotNull] ISqlServerUpdateSqlGenerator updateSqlGenerator,
-            [NotNull] IRelationalValueBufferFactoryFactory valueBufferFactoryFactory,
+            [NotNull] ModificationCommandBatchFactoryDependencies dependencies,
             [NotNull] IDbContextOptions options)
         {
-            Check.NotNull(commandBuilderFactory, nameof(commandBuilderFactory));
-            Check.NotNull(sqlGenerationHelper, nameof(sqlGenerationHelper));
-            Check.NotNull(updateSqlGenerator, nameof(updateSqlGenerator));
-            Check.NotNull(valueBufferFactoryFactory, nameof(valueBufferFactoryFactory));
+            Check.NotNull(dependencies, nameof(dependencies));
             Check.NotNull(options, nameof(options));
 
-            _commandBuilderFactory = commandBuilderFactory;
-            _sqlGenerationHelper = sqlGenerationHelper;
-            _updateSqlGenerator = updateSqlGenerator;
-            _valueBufferFactoryFactory = valueBufferFactoryFactory;
+            _dependencies = dependencies;
             _options = options;
         }
 
@@ -64,12 +51,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Update.Internal
         {
             var optionsExtension = _options.Extensions.OfType<SqlServerOptionsExtension>().FirstOrDefault();
 
-            return new SqlServerModificationCommandBatch(
-                _commandBuilderFactory,
-                _sqlGenerationHelper,
-                _updateSqlGenerator,
-                _valueBufferFactoryFactory,
-                optionsExtension?.MaxBatchSize);
+            return new SqlServerModificationCommandBatch(_dependencies, optionsExtension?.MaxBatchSize);
         }
     }
 }

--- a/src/EFCore.SqlServer/ValueGeneration/Internal/ISqlServerSequenceValueGeneratorFactory.cs
+++ b/src/EFCore.SqlServer/ValueGeneration/Internal/ISqlServerSequenceValueGeneratorFactory.cs
@@ -4,6 +4,7 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.ValueGeneration.Internal
@@ -21,6 +22,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.ValueGeneration.Internal
         ValueGenerator Create(
             [NotNull] IProperty property,
             [NotNull] SqlServerSequenceValueGeneratorState generatorState,
-            [NotNull] ISqlServerConnection connection);
+            [NotNull] ISqlServerConnection connection,
+            [NotNull] IRawSqlCommandBuilder rawSqlCommandBuilder);
     }
 }

--- a/src/EFCore.SqlServer/ValueGeneration/Internal/SqlServerSequenceValueGeneratorFactory.cs
+++ b/src/EFCore.SqlServer/ValueGeneration/Internal/SqlServerSequenceValueGeneratorFactory.cs
@@ -20,7 +20,6 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.ValueGeneration.Internal
     /// </summary>
     public class SqlServerSequenceValueGeneratorFactory : ISqlServerSequenceValueGeneratorFactory
     {
-        private readonly IRawSqlCommandBuilder _rawSqlCommandBuilder;
         private readonly ISqlServerUpdateSqlGenerator _sqlGenerator;
 
         /// <summary>
@@ -28,13 +27,10 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.ValueGeneration.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public SqlServerSequenceValueGeneratorFactory(
-            [NotNull] IRawSqlCommandBuilder rawSqlCommandBuilder,
             [NotNull] ISqlServerUpdateSqlGenerator sqlGenerator)
         {
-            Check.NotNull(rawSqlCommandBuilder, nameof(rawSqlCommandBuilder));
             Check.NotNull(sqlGenerator, nameof(sqlGenerator));
 
-            _rawSqlCommandBuilder = rawSqlCommandBuilder;
             _sqlGenerator = sqlGenerator;
         }
 
@@ -42,62 +38,67 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.ValueGeneration.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual ValueGenerator Create(IProperty property, SqlServerSequenceValueGeneratorState generatorState, ISqlServerConnection connection)
+        public virtual ValueGenerator Create(
+            IProperty property,
+            SqlServerSequenceValueGeneratorState generatorState,
+            ISqlServerConnection connection,
+            IRawSqlCommandBuilder rawSqlCommandBuilder)
         {
             Check.NotNull(property, nameof(property));
             Check.NotNull(generatorState, nameof(generatorState));
             Check.NotNull(connection, nameof(connection));
+            Check.NotNull(rawSqlCommandBuilder, nameof(rawSqlCommandBuilder));
 
             var type = property.ClrType.UnwrapNullableType().UnwrapEnumType();
 
             if (type == typeof(long))
             {
-                return new SqlServerSequenceHiLoValueGenerator<long>(_rawSqlCommandBuilder, _sqlGenerator, generatorState, connection);
+                return new SqlServerSequenceHiLoValueGenerator<long>(rawSqlCommandBuilder, _sqlGenerator, generatorState, connection);
             }
 
             if (type == typeof(int))
             {
-                return new SqlServerSequenceHiLoValueGenerator<int>(_rawSqlCommandBuilder, _sqlGenerator, generatorState, connection);
+                return new SqlServerSequenceHiLoValueGenerator<int>(rawSqlCommandBuilder, _sqlGenerator, generatorState, connection);
             }
 
             if (type == typeof(decimal))
             {
-                return new SqlServerSequenceHiLoValueGenerator<decimal>(_rawSqlCommandBuilder, _sqlGenerator, generatorState, connection);
+                return new SqlServerSequenceHiLoValueGenerator<decimal>(rawSqlCommandBuilder, _sqlGenerator, generatorState, connection);
             }
 
             if (type == typeof(short))
             {
-                return new SqlServerSequenceHiLoValueGenerator<short>(_rawSqlCommandBuilder, _sqlGenerator, generatorState, connection);
+                return new SqlServerSequenceHiLoValueGenerator<short>(rawSqlCommandBuilder, _sqlGenerator, generatorState, connection);
             }
 
             if (type == typeof(byte))
             {
-                return new SqlServerSequenceHiLoValueGenerator<byte>(_rawSqlCommandBuilder, _sqlGenerator, generatorState, connection);
+                return new SqlServerSequenceHiLoValueGenerator<byte>(rawSqlCommandBuilder, _sqlGenerator, generatorState, connection);
             }
 
             if (type == typeof(char))
             {
-                return new SqlServerSequenceHiLoValueGenerator<char>(_rawSqlCommandBuilder, _sqlGenerator, generatorState, connection);
+                return new SqlServerSequenceHiLoValueGenerator<char>(rawSqlCommandBuilder, _sqlGenerator, generatorState, connection);
             }
 
             if (type == typeof(ulong))
             {
-                return new SqlServerSequenceHiLoValueGenerator<ulong>(_rawSqlCommandBuilder, _sqlGenerator, generatorState, connection);
+                return new SqlServerSequenceHiLoValueGenerator<ulong>(rawSqlCommandBuilder, _sqlGenerator, generatorState, connection);
             }
 
             if (type == typeof(uint))
             {
-                return new SqlServerSequenceHiLoValueGenerator<uint>(_rawSqlCommandBuilder, _sqlGenerator, generatorState, connection);
+                return new SqlServerSequenceHiLoValueGenerator<uint>(rawSqlCommandBuilder, _sqlGenerator, generatorState, connection);
             }
 
             if (type == typeof(ushort))
             {
-                return new SqlServerSequenceHiLoValueGenerator<ushort>(_rawSqlCommandBuilder, _sqlGenerator, generatorState, connection);
+                return new SqlServerSequenceHiLoValueGenerator<ushort>(rawSqlCommandBuilder, _sqlGenerator, generatorState, connection);
             }
 
             if (type == typeof(sbyte))
             {
-                return new SqlServerSequenceHiLoValueGenerator<sbyte>(_rawSqlCommandBuilder, _sqlGenerator, generatorState, connection);
+                return new SqlServerSequenceHiLoValueGenerator<sbyte>(rawSqlCommandBuilder, _sqlGenerator, generatorState, connection);
             }
 
             throw new ArgumentException(

--- a/src/EFCore.Sqlite.Core/Internal/SqliteModelValidator.cs
+++ b/src/EFCore.Sqlite.Core/Internal/SqliteModelValidator.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.Extensions.DependencyInjection;
@@ -37,23 +38,25 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public override void Validate(IModel model)
+        public override void Validate(IModel model, DiagnosticsLoggers loggers)
         {
-            base.Validate(model);
+            base.Validate(model, loggers);
 
-            ValidateNoSchemas(model);
-            ValidateNoSequences(model);
+            ValidateNoSchemas(model, loggers);
+            ValidateNoSequences(model, loggers);
         }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected virtual void ValidateNoSchemas([NotNull] IModel model)
+        protected virtual void ValidateNoSchemas([NotNull] IModel model, DiagnosticsLoggers loggers)
         {
+            var logger = loggers.GetLogger<DbLoggerCategory.Model.Validation>();
+
             foreach (var entityType in model.GetEntityTypes().Where(e => e.Relational().Schema != null))
             {
-                Dependencies.Logger.SchemaConfiguredWarning(entityType, entityType.Relational().Schema);
+                logger.SchemaConfiguredWarning(entityType, entityType.Relational().Schema);
             }
         }
 
@@ -61,11 +64,13 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected virtual void ValidateNoSequences([NotNull] IModel model)
+        protected virtual void ValidateNoSequences([NotNull] IModel model, DiagnosticsLoggers loggers)
         {
+            var logger = loggers.GetLogger<DbLoggerCategory.Model.Validation>();
+
             foreach (var sequence in model.Relational().Sequences)
             {
-                Dependencies.Logger.SequenceConfiguredWarning(sequence);
+                logger.SequenceConfiguredWarning(sequence);
             }
         }
     }

--- a/src/EFCore.Sqlite.Core/Migrations/SqliteMigrationsSqlGenerator.cs
+++ b/src/EFCore.Sqlite.Core/Migrations/SqliteMigrationsSqlGenerator.cs
@@ -25,9 +25,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations
     ///         SQLite-specific implementation of <see cref="MigrationsSqlGenerator" />.
     ///     </para>
     ///     <para>
-    ///         The service lifetime is <see cref="ServiceLifetime.Singleton"/>. This means a single instance
-    ///         is used by many <see cref="DbContext"/> instances. The implementation must be thread-safe.
-    ///         This service cannot depend on services registered as <see cref="ServiceLifetime.Scoped"/>.
+    ///         The service lifetime is <see cref="ServiceLifetime.Scoped"/>. This means that each
+    ///         <see cref="DbContext"/> instance will use its own instance of this service.
+    ///         The implementation may depend on other services registered with any lifetime.
+    ///         The implementation does not need to be thread-safe.
     ///     </para>
     /// </summary>
     public class SqliteMigrationsSqlGenerator : MigrationsSqlGenerator

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteContainsOptimizedTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteContainsOptimizedTranslator.cs
@@ -3,6 +3,7 @@
 
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
@@ -21,7 +22,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Inter
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             if (Equals(methodCallExpression.Method, _methodInfo))
             {

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteDateTimeAddTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteDateTimeAddTranslator.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
@@ -40,10 +41,13 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Inter
         ///     Translates the given method call expression.
         /// </summary>
         /// <param name="methodCallExpression">The method call expression.</param>
+        /// <param name="logger"> The logger. </param>
         /// <returns>
         ///     A SQL expression representing the translated MethodCallExpression.
         /// </returns>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             var method = methodCallExpression.Method;
 

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteEndsWithOptimizedTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteEndsWithOptimizedTranslator.cs
@@ -3,6 +3,7 @@
 
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
@@ -21,7 +22,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Inter
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             if (Equals(methodCallExpression.Method, _methodInfo))
             {

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteMathTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteMathTranslator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
@@ -50,7 +51,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Inter
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
             => _supportedMethods.TryGetValue(methodCallExpression.Method, out var sqlFunctionName)
                 ? new SqlFunctionExpression(sqlFunctionName, methodCallExpression.Type, methodCallExpression.Arguments)
                 : null;

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStartsWithOptimizedTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStartsWithOptimizedTranslator.cs
@@ -3,6 +3,7 @@
 
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
@@ -24,7 +25,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Inter
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             if (Equals(methodCallExpression.Method, _methodInfo))
             {

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringIndexOfTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringIndexOfTranslator.cs
@@ -3,6 +3,7 @@
 
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
@@ -21,7 +22,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Inter
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
             => Equals(methodCallExpression.Method, _methodInfo)
                 ? Expression.Subtract(
                     new SqlFunctionExpression(

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringIsNullOrWhiteSpaceTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringIsNullOrWhiteSpaceTranslator.cs
@@ -3,6 +3,7 @@
 
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
@@ -21,7 +22,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Inter
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             if (_methodInfo.Equals(methodCallExpression.Method))
             {

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringReplaceTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringReplaceTranslator.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
@@ -22,7 +23,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Inter
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
             => _methodInfo.Equals(methodCallExpression.Method)
                 ? new SqlFunctionExpression(
                     "replace",

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringSubstringTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringSubstringTranslator.cs
@@ -3,6 +3,7 @@
 
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
@@ -21,7 +22,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Inter
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
             => _methodInfo.Equals(methodCallExpression.Method)
                 ? new SqlFunctionExpression(
                     "substr",

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringTrimEndTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringTrimEndTranslator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
@@ -32,7 +33,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Inter
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             var methodInfo = methodCallExpression.Method;
 

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringTrimStartTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringTrimStartTranslator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
@@ -32,7 +33,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Inter
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             var methodInfo = methodCallExpression.Method;
 

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringTrimTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringTrimTranslator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
@@ -32,7 +33,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Inter
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             var methodInfo = methodCallExpression.Method;
 

--- a/src/EFCore.Sqlite.Core/Query/Sql/Internal/SqliteQuerySqlGenerator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Sql/Internal/SqliteQuerySqlGenerator.cs
@@ -3,6 +3,7 @@
 
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.Sql;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -22,8 +23,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Sql.Internal
         /// </summary>
         public SqliteQuerySqlGenerator(
             [NotNull] QuerySqlGeneratorDependencies dependencies,
-            [NotNull] SelectExpression selectExpression)
-            : base(dependencies, selectExpression)
+            [NotNull] SelectExpression selectExpression,
+            DiagnosticsLoggers loggers)
+            : base(dependencies, selectExpression, loggers)
         {
         }
 

--- a/src/EFCore.Sqlite.Core/Query/Sql/Internal/SqliteQuerySqlGeneratorFactory.cs
+++ b/src/EFCore.Sqlite.Core/Query/Sql/Internal/SqliteQuerySqlGeneratorFactory.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.Sql;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -35,9 +36,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Sql.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public override IQuerySqlGenerator CreateDefault(SelectExpression selectExpression)
-            => new SqliteQuerySqlGenerator(
-                Dependencies,
-                Check.NotNull(selectExpression, nameof(selectExpression)));
+        public override IQuerySqlGenerator CreateDefault(
+            SelectExpression selectExpression,
+            DiagnosticsLoggers loggers)
+            => new SqliteQuerySqlGenerator(Dependencies, selectExpression, loggers);
     }
 }

--- a/src/EFCore.Sqlite.Core/Update/Internal/SqliteModificationCommandBatchFactory.cs
+++ b/src/EFCore.Sqlite.Core/Update/Internal/SqliteModificationCommandBatchFactory.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Update;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -23,30 +22,18 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Update.Internal
     /// </summary>
     public class SqliteModificationCommandBatchFactory : IModificationCommandBatchFactory
     {
-        private readonly IRelationalCommandBuilderFactory _commandBuilderFactory;
-        private readonly ISqlGenerationHelper _sqlGenerationHelper;
-        private readonly IUpdateSqlGenerator _updateSqlGenerator;
-        private readonly IRelationalValueBufferFactoryFactory _valueBufferFactoryFactory;
+        private readonly ModificationCommandBatchFactoryDependencies _dependencies;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public SqliteModificationCommandBatchFactory(
-            [NotNull] IRelationalCommandBuilderFactory commandBuilderFactory,
-            [NotNull] ISqlGenerationHelper sqlGenerationHelper,
-            [NotNull] IUpdateSqlGenerator updateSqlGenerator,
-            [NotNull] IRelationalValueBufferFactoryFactory valueBufferFactoryFactory)
+            [NotNull] ModificationCommandBatchFactoryDependencies dependencies)
         {
-            Check.NotNull(commandBuilderFactory, nameof(commandBuilderFactory));
-            Check.NotNull(sqlGenerationHelper, nameof(sqlGenerationHelper));
-            Check.NotNull(updateSqlGenerator, nameof(updateSqlGenerator));
-            Check.NotNull(valueBufferFactoryFactory, nameof(valueBufferFactoryFactory));
+            Check.NotNull(dependencies, nameof(dependencies));
 
-            _commandBuilderFactory = commandBuilderFactory;
-            _sqlGenerationHelper = sqlGenerationHelper;
-            _updateSqlGenerator = updateSqlGenerator;
-            _valueBufferFactoryFactory = valueBufferFactoryFactory;
+            _dependencies = dependencies;
         }
 
         /// <summary>
@@ -54,10 +41,6 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Update.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual ModificationCommandBatch Create()
-            => new SingularModificationCommandBatch(
-                _commandBuilderFactory,
-                _sqlGenerationHelper,
-                _updateSqlGenerator,
-                _valueBufferFactoryFactory);
+            => new SingularModificationCommandBatch(_dependencies);
     }
 }

--- a/src/EFCore.Sqlite.NTS/Query/ExpressionTranslators/Internal/SqliteGeometryCollectionMethodTranslator.cs
+++ b/src/EFCore.Sqlite.NTS/Query/ExpressionTranslators/Internal/SqliteGeometryCollectionMethodTranslator.cs
@@ -4,6 +4,7 @@
 using System.Linq.Expressions;
 using System.Reflection;
 using GeoAPI.Geometries;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
@@ -21,7 +22,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Inter
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             var method = methodCallExpression.Method.OnInterface(typeof(IGeometryCollection));
             if (Equals(method, _item))

--- a/src/EFCore.Sqlite.NTS/Query/ExpressionTranslators/Internal/SqliteGeometryMethodTranslator.cs
+++ b/src/EFCore.Sqlite.NTS/Query/ExpressionTranslators/Internal/SqliteGeometryMethodTranslator.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using GeoAPI.Geometries;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 using NetTopologySuite.Geometries;
@@ -55,7 +56,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Inter
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             var method = methodCallExpression.Method.OnInterface(typeof(IGeometry));
             if (_methodToFunctionName.TryGetValue(method, out var functionName))

--- a/src/EFCore.Sqlite.NTS/Query/ExpressionTranslators/Internal/SqliteLineStringMethodTranslator.cs
+++ b/src/EFCore.Sqlite.NTS/Query/ExpressionTranslators/Internal/SqliteLineStringMethodTranslator.cs
@@ -4,6 +4,7 @@
 using System.Linq.Expressions;
 using System.Reflection;
 using GeoAPI.Geometries;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
@@ -21,7 +22,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Inter
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             var method = methodCallExpression.Method.OnInterface(typeof(ILineString));
             if (Equals(method, _getPointN))

--- a/src/EFCore.Sqlite.NTS/Query/ExpressionTranslators/Internal/SqlitePolygonMethodTranslator.cs
+++ b/src/EFCore.Sqlite.NTS/Query/ExpressionTranslators/Internal/SqlitePolygonMethodTranslator.cs
@@ -4,6 +4,7 @@
 using System.Linq.Expressions;
 using System.Reflection;
 using GeoAPI.Geometries;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
@@ -21,7 +22,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Inter
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        public virtual Expression Translate(
+            MethodCallExpression methodCallExpression,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             var method = methodCallExpression.Method.OnInterface(typeof(IPolygon));
             if (Equals(method, _getInteriorRingN))

--- a/src/EFCore/DbContextOptionsBuilder.cs
+++ b/src/EFCore/DbContextOptionsBuilder.cs
@@ -82,18 +82,12 @@ namespace Microsoft.EntityFrameworkCore
         /// <summary>
         ///     <para>
         ///         Sets the <see cref="ILoggerFactory" /> that will be used to create <see cref="ILogger" /> instances
-        ///         for logging done by this context. It is never necessary to call this method since EF can obtain
-        ///         or create a logger factory automatically.
+        ///         for logging done by this context.
         ///     </para>
         ///     <para>
         ///         There is no need to call this method when using one of the 'AddDbContext' methods.
         ///         'AddDbContext' will ensure that the <see cref="ILoggerFactory" /> used by EF is obtained from the
         ///         application service provider.
-        ///     </para>
-        ///     <para>
-        ///         Note that changing the logger factory can cause EF to build a new internal service provider, which
-        ///         may cause issues with performance. Generally it is expected that no more than one or two different
-        ///         instances will be used for a given application.
         ///     </para>
         ///     <para>
         ///         This method cannot be used if the application is setting the internal service provider
@@ -130,13 +124,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     <para>
-        ///         Sets the <see cref="IMemoryCache" /> to be used for query caching by this context. It is never
-        ///         necessary to call this method since EF can obtain or create a memory cache automatically.
-        ///     </para>
-        ///     <para>
-        ///         There is no need to call this method when using one of the 'AddDbContext' methods.
-        ///         'AddDbContext' will ensure that the <see cref="IMemoryCache" /> used by EF is obtained from the
-        ///         application service provider.
+        ///         Sets the <see cref="IMemoryCache" /> to be used for query caching by this context.
         ///     </para>
         ///     <para>
         ///         Note that changing the memory cache can cause EF to build a new internal service provider, which

--- a/src/EFCore/DbContextOptionsBuilder`.cs
+++ b/src/EFCore/DbContextOptionsBuilder`.cs
@@ -64,18 +64,12 @@ namespace Microsoft.EntityFrameworkCore
         /// <summary>
         ///     <para>
         ///         Sets the <see cref="ILoggerFactory" /> that will be used to create <see cref="ILogger" /> instances
-        ///         for logging done by this context. It is never necessary to call this method since EF can obtain
-        ///         or create a logger factory automatically.
+        ///         for logging done by this context.
         ///     </para>
         ///     <para>
         ///         There is no need to call this method when using one of the 'AddDbContext' methods.
         ///         'AddDbContext' will ensure that the <see cref="ILoggerFactory" /> used by EF is obtained from the
         ///         application service provider.
-        ///     </para>
-        ///     <para>
-        ///         Note that changing the logger factory can cause EF to build a new internal service provider, which
-        ///         may cause issues with performance. Generally it is expected that no more than one or two different
-        ///         instances will be used for a given application.
         ///     </para>
         ///     <para>
         ///         This method cannot be used if the application is setting the internal service provider
@@ -112,13 +106,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     <para>
-        ///         Sets the <see cref="IMemoryCache" /> to be used for query caching by this context. It is never
-        ///         necessary to call this method since EF can obtain or create a memory cache automatically.
-        ///     </para>
-        ///     <para>
-        ///         There is no need to call this method when using one of the 'AddDbContext' methods.
-        ///         'AddDbContext' will ensure that the <see cref="IMemoryCache" /> used by EF is obtained from the
-        ///         application service provider.
+        ///         Sets the <see cref="IMemoryCache" /> to be used for query caching by this context.
         ///     </para>
         ///     <para>
         ///         Note that changing the memory cache can cause EF to build a new internal service provider, which

--- a/src/EFCore/Diagnostics/DiagnosticsLoggers.cs
+++ b/src/EFCore/Diagnostics/DiagnosticsLoggers.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     A collection of <see cref="IDiagnosticsLogger{TLoggerCategory}" /> for
+    ///     different logger categories. The producer is responsible for adding
+    ///     the loggers needed by the consumer.
+    /// </summary>
+    public readonly struct DiagnosticsLoggers
+    {
+        private readonly IDiagnosticsLogger[] _loggers;
+
+        /// <summary>
+        ///     Creates a new collection of loggers.
+        /// </summary>
+        /// <param name="loggers"> The loggers </param>
+        public DiagnosticsLoggers([NotNull] params IDiagnosticsLogger[] loggers)
+        {
+            Check.NotNull(loggers, nameof(loggers));
+
+            _loggers = loggers;
+        }
+
+        /// <summary>
+        ///     Gets the logger for the given category, or null if it is not available.
+        /// </summary>
+        /// <typeparam name="T"> The logging category. </typeparam>
+        /// <returns> The logger. </returns>
+        public IDiagnosticsLogger<T> GetLogger<T>() where T : LoggerCategory<T>, new()
+            => _loggers.OfType<IDiagnosticsLogger<T>>().FirstOrDefault();
+    }
+}

--- a/src/EFCore/Diagnostics/IDiagnosticsLogger.cs
+++ b/src/EFCore/Diagnostics/IDiagnosticsLogger.cs
@@ -14,18 +14,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     ///         for ASP.NET and <see cref="DiagnosticSource" /> for everything else.
     ///     </para>
     ///     <para>
-    ///         Also intercepts messages such that warnings
-    ///         can be either logged or thrown, and such that a decision as to whether to log
-    ///         sensitive data or not can be made.
-    ///     </para>
-    ///     <para>
     ///         The service lifetime is <see cref="ServiceLifetime.Singleton"/>. This means a single instance
     ///         is used by many <see cref="DbContext"/> instances. The implementation must be thread-safe.
     ///         This service cannot depend on services registered as <see cref="ServiceLifetime.Scoped"/>.
     ///     </para>
     /// </summary>
-    public interface IDiagnosticsLogger<TLoggerCategory>
-        where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
+    public interface IDiagnosticsLogger
     {
         /// <summary>
         ///     Checks if the given <paramref name="logLevel" /> is enabled or the given event, and,

--- a/src/EFCore/Diagnostics/IDiagnosticsLogger`.cs
+++ b/src/EFCore/Diagnostics/IDiagnosticsLogger`.cs
@@ -1,0 +1,31 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     <para>
+    ///         Combines <see cref="ILogger" /> and <see cref="DiagnosticSource" />
+    ///         for use by all EF Core logging so that events can be sent to both <see cref="ILogger" />
+    ///         for ASP.NET and <see cref="DiagnosticSource" /> for everything else.
+    ///     </para>
+    ///     <para>
+    ///         Also intercepts messages such that warnings
+    ///         can be either logged or thrown, and such that a decision as to whether to log
+    ///         sensitive data or not can be made.
+    ///     </para>
+    ///     <para>
+    ///         The service lifetime is <see cref="ServiceLifetime.Singleton"/>. This means a single instance
+    ///         is used by many <see cref="DbContext"/> instances. The implementation must be thread-safe.
+    ///         This service cannot depend on services registered as <see cref="ServiceLifetime.Scoped"/>.
+    ///     </para>
+    /// </summary>
+    public interface IDiagnosticsLogger<TLoggerCategory> : IDiagnosticsLogger
+        where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
+    {
+    }
+}

--- a/src/EFCore/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/EFCore/EntityFrameworkServiceCollectionExtensions.cs
@@ -506,10 +506,6 @@ namespace Microsoft.Extensions.DependencyInjection
             ServiceLifetime optionsLifetime)
             where TContextImplementation : DbContext
         {
-            serviceCollection
-                .AddMemoryCache()
-                .AddLogging();
-
             serviceCollection.TryAdd(
                 new ServiceDescriptor(
                     typeof(DbContextOptions<TContextImplementation>),

--- a/src/EFCore/Infrastructure/CoreOptionsExtension.cs
+++ b/src/EFCore/Infrastructure/CoreOptionsExtension.cs
@@ -348,7 +348,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             var loggerFactory = GetLoggerFactory();
             if (loggerFactory != null)
             {
-                services.AddSingleton(loggerFactory);
+                services.AddScoped<ILoggerFactory>(_ => new ExternalLoggerFactory(loggerFactory));
             }
 
             var memoryCache = GetMemoryCache();
@@ -361,7 +361,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         }
 
         private IMemoryCache GetMemoryCache()
-            => MemoryCache ?? ApplicationServiceProvider?.GetService<IMemoryCache>();
+            => MemoryCache;
 
         private ILoggerFactory GetLoggerFactory()
             => LoggerFactory ?? ApplicationServiceProvider?.GetService<ILoggerFactory>();
@@ -375,8 +375,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         {
             if (_serviceProviderHash == null)
             {
-                var hashCode = GetLoggerFactory()?.GetHashCode() ?? 0L;
-                hashCode = (hashCode * 397) ^ (GetMemoryCache()?.GetHashCode() ?? 0L);
+                var hashCode = GetMemoryCache()?.GetHashCode() ?? 0L;
                 hashCode = (hashCode * 3) ^ _sensitiveDataLoggingEnabled.GetHashCode();
                 hashCode = (hashCode * 3) ^ _detailedErrorsEnabled.GetHashCode();
                 hashCode = (hashCode * 1073742113) ^ _warningsConfiguration.GetServiceProviderHashCode();
@@ -403,7 +402,6 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         {
             Check.NotNull(debugInfo, nameof(debugInfo));
 
-            debugInfo["Core:" + nameof(DbContextOptionsBuilder.UseLoggerFactory)] = (GetLoggerFactory()?.GetHashCode() ?? 0L).ToString(CultureInfo.InvariantCulture);
             debugInfo["Core:" + nameof(DbContextOptionsBuilder.UseMemoryCache)] = (GetMemoryCache()?.GetHashCode() ?? 0L).ToString(CultureInfo.InvariantCulture);
             debugInfo["Core:" + nameof(DbContextOptionsBuilder.EnableSensitiveDataLogging)] = _sensitiveDataLoggingEnabled.GetHashCode().ToString(CultureInfo.InvariantCulture);
             debugInfo["Core:" + nameof(DbContextOptionsBuilder.EnableDetailedErrors)] = _detailedErrorsEnabled.GetHashCode().ToString(CultureInfo.InvariantCulture);

--- a/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
+++ b/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
@@ -22,6 +22,7 @@ using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ReLinq = Remotion.Linq.Parsing.ExpressionVisitors.TreeEvaluation;
@@ -72,7 +73,6 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 { typeof(ITypeMappingSource), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(IModelCustomizer), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(IModelCacheKeyFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
-                { typeof(ILoggerFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(IModelSource), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(IInternalEntityEntryFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(IInternalEntityEntrySubscriber), new ServiceCharacteristics(ServiceLifetime.Singleton) },
@@ -92,13 +92,15 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 { typeof(IEagerLoadingExpressionVisitorFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(IQuerySourceTracingExpressionVisitorFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(IProjectionExpressionVisitorFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
-                { typeof(IDiagnosticsLogger<>), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(IValueConverterSelector), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(IConstructorBindingFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(IRegisteredServices), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(IPropertyParameterBindingFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(IParameterBindingFactories), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(IMemberClassifier), new ServiceCharacteristics(ServiceLifetime.Singleton) },
+                { typeof(IMemoryCache), new ServiceCharacteristics(ServiceLifetime.Singleton) },
+                { typeof(IDiagnosticsLogger<>), new ServiceCharacteristics(ServiceLifetime.Scoped) },
+                { typeof(ILoggerFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IEntityGraphAttacher), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IKeyPropagator), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(INavigationFixer), new ServiceCharacteristics(ServiceLifetime.Scoped) },
@@ -285,6 +287,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             TryAdd<IParameterBindingFactory, LazyLoaderParameterBindingFactory>();
             TryAdd<IParameterBindingFactory, ContextParameterBindingFactory>();
             TryAdd<IParameterBindingFactory, EntityTypeParameterBindingFactory>();
+            TryAdd<IMemoryCache>(p => new MemoryCache(new MemoryCacheOptions()));
 
             ServiceCollectionMap
                 .TryAddSingleton<DiagnosticSource>(new DiagnosticListener(DbLoggerCategory.Name));
@@ -307,8 +310,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 .AddDependencyScoped<ValueGeneratorSelectorDependencies>()
                 .AddDependencyScoped<EntityQueryModelVisitorDependencies>()
                 .AddDependencyScoped<DatabaseDependencies>()
-                .AddDependencyScoped<QueryCompilationContextDependencies>()
-                .ServiceCollection.AddMemoryCache();
+                .AddDependencyScoped<QueryCompilationContextDependencies>();
 
             ServiceCollectionMap.TryAddSingleton<IRegisteredServices>(
                 new RegisteredServices(ServiceCollectionMap.ServiceCollection.Select(s => s.ServiceType)));

--- a/src/EFCore/Infrastructure/IModelSource.cs
+++ b/src/EFCore/Infrastructure/IModelSource.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 using Microsoft.Extensions.DependencyInjection;
@@ -31,10 +32,12 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <param name="context"> The context the model is being produced for. </param>
         /// <param name="conventionSetBuilder"> The convention set to use when creating the model. </param>
         /// <param name="validator"> The validator to verify the model can be successfully used with the context. </param>
+        /// <param name="loggers"> The loggers to use. </param>
         /// <returns> The model to be used. </returns>
         IModel GetModel(
             [NotNull] DbContext context,
             [NotNull] IConventionSetBuilder conventionSetBuilder,
-            [NotNull] IModelValidator validator);
+            [NotNull] IModelValidator validator,
+            DiagnosticsLoggers loggers);
     }
 }

--- a/src/EFCore/Infrastructure/IModelValidator.cs
+++ b/src/EFCore/Infrastructure/IModelValidator.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -22,6 +23,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <summary>
         ///     Validates a model, throwing an exception if any errors are found.
         /// </summary>
-        void Validate([NotNull] IModel model);
+        /// <param name="model"> The model to validate. </param>
+        /// <param name="loggers"> Loggers to use. </param>
+        void Validate([NotNull] IModel model, DiagnosticsLoggers loggers);
     }
 }

--- a/src/EFCore/Infrastructure/ModelValidator.cs
+++ b/src/EFCore/Infrastructure/ModelValidator.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -48,30 +49,31 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     Validates a model, throwing an exception if any errors are found.
         /// </summary>
         /// <param name="model"> The model to validate. </param>
-        public virtual void Validate(IModel model)
+        /// <param name="loggers"> Loggers to use. </param>
+        public virtual void Validate(IModel model, DiagnosticsLoggers loggers)
         {
-            ValidateNoShadowEntities(model);
-            ValidateDefiningNavigations(model);
-            ValidateOwnership(model);
-            ValidateNonNullPrimaryKeys(model);
-            ValidateNoShadowKeys(model);
-            ValidateNoMutableKeys(model);
-            ValidateNoCycles(model);
-            ValidateClrInheritance(model);
-            ValidateChangeTrackingStrategy(model);
-            ValidateForeignKeys(model);
-            ValidateFieldMapping(model);
-            ValidateQueryTypes(model);
-            ValidateQueryFilters(model);
-            ValidateData(model);
-            LogShadowProperties(model);
+            ValidateNoShadowEntities(model, loggers);
+            ValidateDefiningNavigations(model, loggers);
+            ValidateOwnership(model, loggers);
+            ValidateNonNullPrimaryKeys(model, loggers);
+            ValidateNoShadowKeys(model, loggers);
+            ValidateNoMutableKeys(model, loggers);
+            ValidateNoCycles(model, loggers);
+            ValidateClrInheritance(model, loggers);
+            ValidateChangeTrackingStrategy(model, loggers);
+            ValidateForeignKeys(model, loggers);
+            ValidateFieldMapping(model, loggers);
+            ValidateQueryTypes(model, loggers);
+            ValidateQueryFilters(model, loggers);
+            ValidateData(model, loggers);
+            LogShadowProperties(model, loggers);
         }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected virtual void ValidateNoShadowEntities([NotNull] IModel model)
+        protected virtual void ValidateNoShadowEntities([NotNull] IModel model, DiagnosticsLoggers loggers)
         {
             Check.NotNull(model, nameof(model));
 
@@ -87,7 +89,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected virtual void ValidateNoShadowKeys([NotNull] IModel model)
+        protected virtual void ValidateNoShadowKeys([NotNull] IModel model, DiagnosticsLoggers loggers)
         {
             Check.NotNull(model, nameof(model));
 
@@ -126,7 +128,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected virtual void ValidateNoMutableKeys([NotNull] IModel model)
+        protected virtual void ValidateNoMutableKeys([NotNull] IModel model, DiagnosticsLoggers loggers)
         {
             Check.NotNull(model, nameof(model));
 
@@ -147,7 +149,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected virtual void ValidateNoCycles([NotNull] IModel model)
+        protected virtual void ValidateNoCycles([NotNull] IModel model, DiagnosticsLoggers loggers)
         {
             var unvalidatedEntityTypes = new HashSet<IEntityType>(model.GetEntityTypes());
             foreach (var entityType in model.GetEntityTypes())
@@ -189,7 +191,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected virtual void ValidateNonNullPrimaryKeys([NotNull] IModel model)
+        protected virtual void ValidateNonNullPrimaryKeys([NotNull] IModel model, DiagnosticsLoggers loggers)
         {
             Check.NotNull(model, nameof(model));
 
@@ -208,14 +210,14 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected virtual void ValidateClrInheritance([NotNull] IModel model)
+        protected virtual void ValidateClrInheritance([NotNull] IModel model, DiagnosticsLoggers loggers)
         {
             Check.NotNull(model, nameof(model));
 
             var validEntityTypes = new HashSet<IEntityType>();
             foreach (var entityType in model.GetEntityTypes())
             {
-                ValidateClrInheritance(model, entityType, validEntityTypes);
+                ValidateClrInheritance(model, entityType, validEntityTypes, loggers);
             }
         }
 
@@ -224,7 +226,10 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected virtual void ValidateClrInheritance(
-            [NotNull] IModel model, [NotNull] IEntityType entityType, [NotNull] HashSet<IEntityType> validEntityTypes)
+            [NotNull] IModel model,
+            [NotNull] IEntityType entityType,
+            [NotNull] HashSet<IEntityType> validEntityTypes,
+            DiagnosticsLoggers loggers)
         {
             Check.NotNull(model, nameof(model));
             Check.NotNull(entityType, nameof(entityType));
@@ -272,7 +277,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected virtual void ValidateChangeTrackingStrategy([NotNull] IModel model)
+        protected virtual void ValidateChangeTrackingStrategy([NotNull] IModel model, DiagnosticsLoggers loggers)
         {
             Check.NotNull(model, nameof(model));
 
@@ -290,7 +295,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected virtual void ValidateOwnership([NotNull] IModel model)
+        protected virtual void ValidateOwnership([NotNull] IModel model, DiagnosticsLoggers loggers)
         {
             Check.NotNull(model, nameof(model));
 
@@ -356,8 +361,10 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected virtual void ValidateForeignKeys([NotNull] IModel model)
+        protected virtual void ValidateForeignKeys([NotNull] IModel model, DiagnosticsLoggers loggers)
         {
+            var modelLogger = loggers.GetLogger<DbLoggerCategory.Model>();
+
             foreach (var entityType in model.GetEntityTypes())
             {
                 foreach (var declaredForeignKey in entityType.GetDeclaredForeignKeys())
@@ -365,7 +372,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                     if (declaredForeignKey.PrincipalEntityType == declaredForeignKey.DeclaringEntityType
                         && PropertyListComparer.Instance.Equals(declaredForeignKey.PrincipalKey.Properties, declaredForeignKey.Properties))
                     {
-                        Dependencies.ModelLogger.RedundantForeignKeyWarning(declaredForeignKey);
+                        modelLogger.RedundantForeignKeyWarning(declaredForeignKey);
                     }
 
                     if (entityType.BaseType == null)
@@ -402,7 +409,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected virtual void ValidateDefiningNavigations([NotNull] IModel model)
+        protected virtual void ValidateDefiningNavigations([NotNull] IModel model, DiagnosticsLoggers loggers)
         {
             Check.NotNull(model, nameof(model));
 
@@ -450,7 +457,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected virtual void ValidateFieldMapping([NotNull] IModel model)
+        protected virtual void ValidateFieldMapping([NotNull] IModel model, DiagnosticsLoggers loggers)
         {
             Check.NotNull(model, nameof(model));
 
@@ -509,7 +516,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected virtual void ValidateQueryTypes([NotNull] IModel model)
+        protected virtual void ValidateQueryTypes([NotNull] IModel model, DiagnosticsLoggers loggers)
         {
             Check.NotNull(model, nameof(model));
 
@@ -538,7 +545,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected virtual void ValidateQueryFilters([NotNull] IModel model)
+        protected virtual void ValidateQueryFilters([NotNull] IModel model, DiagnosticsLoggers loggers)
         {
             Check.NotNull(model, nameof(model));
 
@@ -559,12 +566,12 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected virtual void ValidateData([NotNull] IModel model)
+        protected virtual void ValidateData([NotNull] IModel model, DiagnosticsLoggers loggers)
         {
             Check.NotNull(model, nameof(model));
 
             var identityMaps = new Dictionary<IKey, IIdentityMap>();
-            var sensitiveDataLogged = Dependencies.Logger.ShouldLogSensitiveData();
+            var sensitiveDataLogged = loggers.GetLogger<DbLoggerCategory.Model.Validation>().ShouldLogSensitiveData();
 
             foreach (var entityType in model.GetEntityTypes().Where(et => !et.IsQueryType))
             {
@@ -678,9 +685,11 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected virtual void LogShadowProperties([NotNull] IModel model)
+        protected virtual void LogShadowProperties([NotNull] IModel model, DiagnosticsLoggers loggers)
         {
             Check.NotNull(model, nameof(model));
+
+            var modelLogger = loggers.GetLogger<DbLoggerCategory.Model>();
 
             foreach (var entityType in model.GetEntityTypes().Where(t => t.ClrType != null))
             {
@@ -688,7 +697,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 {
                     if (property.IsShadowProperty)
                     {
-                        Dependencies.ModelLogger.ShadowPropertyCreated(property);
+                        modelLogger.ShadowPropertyCreated(property);
                     }
                 }
             }

--- a/src/EFCore/Infrastructure/ModelValidatorDependencies.cs
+++ b/src/EFCore/Infrastructure/ModelValidatorDependencies.cs
@@ -1,9 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.Infrastructure
@@ -50,43 +47,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///         the constructor at any point in this process.
         ///     </para>
         /// </summary>
-        /// <param name="logger"> The validation logger. </param>
-        /// <param name="modelLogger"> The model logger. </param>
-        public ModelValidatorDependencies(
-            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Model.Validation> logger,
-            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> modelLogger)
+        public ModelValidatorDependencies()
         {
-            Check.NotNull(logger, nameof(logger));
-            Check.NotNull(modelLogger, nameof(modelLogger));
-
-            Logger = logger;
-            ModelLogger = modelLogger;
         }
-
-        /// <summary>
-        ///     The validation logger.
-        /// </summary>
-        public IDiagnosticsLogger<DbLoggerCategory.Model.Validation> Logger { get; }
-
-        /// <summary>
-        ///     The model logger.
-        /// </summary>
-        public IDiagnosticsLogger<DbLoggerCategory.Model> ModelLogger { get; }
-
-        /// <summary>
-        ///     Clones this dependency parameter object with one service replaced.
-        /// </summary>
-        /// <param name="logger"> A replacement for the current dependency of this type. </param>
-        /// <returns> A new parameter object with the given service replaced. </returns>
-        public ModelValidatorDependencies With([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model.Validation> logger)
-            => new ModelValidatorDependencies(logger, ModelLogger);
-
-        /// <summary>
-        ///     Clones this dependency parameter object with one service replaced.
-        /// </summary>
-        /// <param name="modelLogger"> A replacement for the current dependency of this type. </param>
-        /// <returns> A new parameter object with the given service replaced. </returns>
-        public ModelValidatorDependencies With([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> modelLogger)
-            => new ModelValidatorDependencies(Logger, modelLogger);
     }
 }

--- a/src/EFCore/Internal/DbContextServices.cs
+++ b/src/EFCore/Internal/DbContextServices.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
@@ -78,8 +79,12 @@ namespace Microsoft.EntityFrameworkCore.Internal
 
                 return _scopedProvider.GetService<IModelSource>().GetModel(
                     _currentContext.Context,
-                    new CompositeConventionSetBuilder(_scopedProvider.GetService<IEnumerable<IConventionSetBuilder>>().ToList()),
-                    _scopedProvider.GetService<IModelValidator>());
+                    new CompositeConventionSetBuilder(_scopedProvider.GetService<IEnumerable<IConventionSetBuilder>>()
+                        .ToList()),
+                    _scopedProvider.GetService<IModelValidator>(),
+                    new DiagnosticsLoggers(
+                        _scopedProvider.GetService<IDiagnosticsLogger<DbLoggerCategory.Model>>(),
+                        _scopedProvider.GetService<IDiagnosticsLogger<DbLoggerCategory.Model.Validation>>()));
             }
             finally
             {

--- a/src/EFCore/Internal/ExternalLoggerFactory.cs
+++ b/src/EFCore/Internal/ExternalLoggerFactory.cs
@@ -1,0 +1,50 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class ExternalLoggerFactory : ILoggerFactory
+    {
+        private readonly ILoggerFactory _underlyingFactory;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public ExternalLoggerFactory([NotNull] ILoggerFactory underlyingFactory)
+        {
+            _underlyingFactory = underlyingFactory;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual void Dispose()
+        {
+            // Intentionally do nothing here so we don't dispose an external resource that
+            // we did not create.
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual ILogger CreateLogger(string categoryName)
+            => _underlyingFactory.CreateLogger(categoryName);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual void AddProvider(ILoggerProvider provider)
+            => _underlyingFactory.AddProvider(provider);
+    }
+}

--- a/src/EFCore/Internal/ServiceProviderCache.cs
+++ b/src/EFCore/Internal/ServiceProviderCache.cs
@@ -98,22 +98,26 @@ namespace Microsoft.EntityFrameworkCore.Internal
                         .EnsureInitialized(serviceProvider, options);
                 }
 
-                var logger = serviceProvider.GetRequiredService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>();
-
-                if (_configurations.Count == 0)
+                using (var scope = serviceProvider.CreateScope())
                 {
-                    logger.ServiceProviderCreated(serviceProvider);
-                }
-                else
-                {
-                    logger.ServiceProviderDebugInfo(
-                        debugInfo,
-                        _configurations.Values.Select(v => v.DebugInfo).ToList());
+                    var logger =
+                        scope.ServiceProvider.GetRequiredService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>();
 
-                    if (_configurations.Count >= 20)
+                    if (_configurations.Count == 0)
                     {
-                        logger.ManyServiceProvidersCreatedWarning(
-                            _configurations.Values.Select(e => e.ServiceProvider).ToList());
+                        logger.ServiceProviderCreated(serviceProvider);
+                    }
+                    else
+                    {
+                        logger.ServiceProviderDebugInfo(
+                            debugInfo,
+                            _configurations.Values.Select(v => v.DebugInfo).ToList());
+
+                        if (_configurations.Count >= 20)
+                        {
+                            logger.ManyServiceProvidersCreatedWarning(
+                                _configurations.Values.Select(e => e.ServiceProvider).ToList());
+                        }
                     }
                 }
 

--- a/src/EFCore/Metadata/Conventions/Internal/BackingFieldConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/BackingFieldConvention.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
@@ -16,6 +17,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     /// </summary>
     public class BackingFieldConvention : IPropertyAddedConvention, INavigationAddedConvention
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public BackingFieldConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+        {
+            Logger = logger;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore/Metadata/Conventions/Internal/BaseTypeDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/BaseTypeDiscoveryConvention.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
@@ -11,6 +13,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     /// </summary>
     public class BaseTypeDiscoveryConvention : InheritanceDiscoveryConventionBase, IEntityTypeAddedConvention
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public BaseTypeDiscoveryConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+            : base(logger)
+        {
+        }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore/Metadata/Conventions/Internal/CacheCleanupConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/CacheCleanupConvention.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
@@ -11,6 +13,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     /// </summary>
     public class CacheCleanupConvention : IModelBuiltConvention
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public CacheCleanupConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+        {
+            Logger = logger;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore/Metadata/Conventions/Internal/CascadeDeleteConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/CascadeDeleteConvention.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
@@ -12,6 +13,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     /// </summary>
     public class CascadeDeleteConvention : IForeignKeyAddedConvention, IForeignKeyRequirednessChangedConvention
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public CascadeDeleteConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+        {
+            Logger = logger;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore/Metadata/Conventions/Internal/ChangeTrackingStrategyConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ChangeTrackingStrategyConvention.cs
@@ -1,7 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
@@ -12,6 +14,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     /// </summary>
     public class ChangeTrackingStrategyConvention : IModelBuiltConvention
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public ChangeTrackingStrategyConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+        {
+            Logger = logger;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore/Metadata/Conventions/Internal/ConcurrencyCheckAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ConcurrencyCheckAttributeConvention.cs
@@ -3,6 +3,8 @@
 
 using System.ComponentModel.DataAnnotations;
 using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -14,6 +16,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     /// </summary>
     public class ConcurrencyCheckAttributeConvention : PropertyAttributeConvention<ConcurrencyCheckAttribute>
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public ConcurrencyCheckAttributeConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+            : base(logger)
+        {
+        }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore/Metadata/Conventions/Internal/ConstructorBindingConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ConstructorBindingConvention.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
@@ -23,8 +24,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public ConstructorBindingConvention([NotNull] IConstructorBindingFactory bindingFactory)
-            => _bindingFactory = bindingFactory;
+        public ConstructorBindingConvention(
+            [NotNull] IConstructorBindingFactory bindingFactory,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+        {
+            _bindingFactory = bindingFactory;
+            Logger = logger;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -41,43 +42,44 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual ConventionSet CreateConventionSet()
+        public virtual ConventionSet CreateConventionSet(DiagnosticsLoggers loggers)
         {
             var conventionSet = new ConventionSet();
+            var logger = loggers.GetLogger<DbLoggerCategory.Model>();
 
             var propertyDiscoveryConvention
                 = new PropertyDiscoveryConvention(
-                    Dependencies.TypeMappingSource);
+                    Dependencies.TypeMappingSource, logger);
 
             var keyDiscoveryConvention
-                = new KeyDiscoveryConvention(Dependencies.Logger);
+                = new KeyDiscoveryConvention(logger);
 
             var inversePropertyAttributeConvention
-                = new InversePropertyAttributeConvention(Dependencies.MemberClassifier, Dependencies.Logger);
+                = new InversePropertyAttributeConvention(Dependencies.MemberClassifier, logger);
 
             var relationshipDiscoveryConvention
-                = new RelationshipDiscoveryConvention(Dependencies.MemberClassifier, Dependencies.Logger);
+                = new RelationshipDiscoveryConvention(Dependencies.MemberClassifier, logger);
 
             var servicePropertyDiscoveryConvention
-                = new ServicePropertyDiscoveryConvention(Dependencies.TypeMappingSource, Dependencies.ParameterBindingFactories);
+                = new ServicePropertyDiscoveryConvention(Dependencies.TypeMappingSource, Dependencies.ParameterBindingFactories, logger);
 
-            conventionSet.EntityTypeAddedConventions.Add(new NotMappedEntityTypeAttributeConvention());
-            conventionSet.EntityTypeAddedConventions.Add(new OwnedEntityTypeAttributeConvention());
-            conventionSet.EntityTypeAddedConventions.Add(new NotMappedMemberAttributeConvention());
-            conventionSet.EntityTypeAddedConventions.Add(new BaseTypeDiscoveryConvention());
+            conventionSet.EntityTypeAddedConventions.Add(new NotMappedEntityTypeAttributeConvention(logger));
+            conventionSet.EntityTypeAddedConventions.Add(new OwnedEntityTypeAttributeConvention(logger));
+            conventionSet.EntityTypeAddedConventions.Add(new NotMappedMemberAttributeConvention(logger));
+            conventionSet.EntityTypeAddedConventions.Add(new BaseTypeDiscoveryConvention(logger));
             conventionSet.EntityTypeAddedConventions.Add(propertyDiscoveryConvention);
             conventionSet.EntityTypeAddedConventions.Add(servicePropertyDiscoveryConvention);
             conventionSet.EntityTypeAddedConventions.Add(keyDiscoveryConvention);
             conventionSet.EntityTypeAddedConventions.Add(inversePropertyAttributeConvention);
             conventionSet.EntityTypeAddedConventions.Add(relationshipDiscoveryConvention);
-            conventionSet.EntityTypeAddedConventions.Add(new DerivedTypeDiscoveryConvention());
+            conventionSet.EntityTypeAddedConventions.Add(new DerivedTypeDiscoveryConvention(logger));
 
             conventionSet.EntityTypeIgnoredConventions.Add(inversePropertyAttributeConvention);
 
-            conventionSet.EntityTypeRemovedConventions.Add(new OwnedTypesConvention());
+            conventionSet.EntityTypeRemovedConventions.Add(new OwnedTypesConvention(logger));
 
-            var foreignKeyIndexConvention = new ForeignKeyIndexConvention(Dependencies.Logger);
-            var valueGeneratorConvention = new ValueGeneratorConvention();
+            var foreignKeyIndexConvention = new ForeignKeyIndexConvention(logger);
+            var valueGeneratorConvention = new ValueGeneratorConvention(logger);
 
             conventionSet.BaseEntityTypeChangedConventions.Add(propertyDiscoveryConvention);
             conventionSet.BaseEntityTypeChangedConventions.Add(servicePropertyDiscoveryConvention);
@@ -87,21 +89,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             conventionSet.BaseEntityTypeChangedConventions.Add(foreignKeyIndexConvention);
             conventionSet.BaseEntityTypeChangedConventions.Add(valueGeneratorConvention);
 
-            var foreignKeyPropertyDiscoveryConvention = new ForeignKeyPropertyDiscoveryConvention(Dependencies.Logger);
+            var foreignKeyPropertyDiscoveryConvention = new ForeignKeyPropertyDiscoveryConvention(logger);
 
             conventionSet.EntityTypeMemberIgnoredConventions.Add(inversePropertyAttributeConvention);
             conventionSet.EntityTypeMemberIgnoredConventions.Add(relationshipDiscoveryConvention);
             conventionSet.EntityTypeMemberIgnoredConventions.Add(foreignKeyPropertyDiscoveryConvention);
             conventionSet.EntityTypeMemberIgnoredConventions.Add(servicePropertyDiscoveryConvention);
 
-            var keyAttributeConvention = new KeyAttributeConvention();
-            var backingFieldConvention = new BackingFieldConvention();
-            var concurrencyCheckAttributeConvention = new ConcurrencyCheckAttributeConvention();
-            var databaseGeneratedAttributeConvention = new DatabaseGeneratedAttributeConvention();
-            var requiredPropertyAttributeConvention = new RequiredPropertyAttributeConvention();
-            var maxLengthAttributeConvention = new MaxLengthAttributeConvention();
-            var stringLengthAttributeConvention = new StringLengthAttributeConvention();
-            var timestampAttributeConvention = new TimestampAttributeConvention();
+            var keyAttributeConvention = new KeyAttributeConvention(logger);
+            var backingFieldConvention = new BackingFieldConvention(logger);
+            var concurrencyCheckAttributeConvention = new ConcurrencyCheckAttributeConvention(logger);
+            var databaseGeneratedAttributeConvention = new DatabaseGeneratedAttributeConvention(logger);
+            var requiredPropertyAttributeConvention = new RequiredPropertyAttributeConvention(logger);
+            var maxLengthAttributeConvention = new MaxLengthAttributeConvention(logger);
+            var stringLengthAttributeConvention = new StringLengthAttributeConvention(logger);
+            var timestampAttributeConvention = new TimestampAttributeConvention(logger);
 
             conventionSet.PropertyAddedConventions.Add(backingFieldConvention);
             conventionSet.PropertyAddedConventions.Add(concurrencyCheckAttributeConvention);
@@ -124,8 +126,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             conventionSet.KeyRemovedConventions.Add(foreignKeyIndexConvention);
             conventionSet.KeyRemovedConventions.Add(keyDiscoveryConvention);
 
-            var cascadeDeleteConvention = new CascadeDeleteConvention();
-            var foreignKeyAttributeConvention = new ForeignKeyAttributeConvention(Dependencies.MemberClassifier, Dependencies.Logger);
+            var cascadeDeleteConvention = new CascadeDeleteConvention(logger);
+            var foreignKeyAttributeConvention = new ForeignKeyAttributeConvention(Dependencies.MemberClassifier, logger);
 
             conventionSet.ForeignKeyAddedConventions.Add(foreignKeyAttributeConvention);
             conventionSet.ForeignKeyAddedConventions.Add(foreignKeyPropertyDiscoveryConvention);
@@ -145,31 +147,32 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             conventionSet.ForeignKeyRequirednessChangedConventions.Add(cascadeDeleteConvention);
             conventionSet.ForeignKeyRequirednessChangedConventions.Add(foreignKeyPropertyDiscoveryConvention);
 
-            conventionSet.ForeignKeyOwnershipChangedConventions.Add(new NavigationEagerLoadingConvention());
+            conventionSet.ForeignKeyOwnershipChangedConventions.Add(new NavigationEagerLoadingConvention(logger));
             conventionSet.ForeignKeyOwnershipChangedConventions.Add(keyDiscoveryConvention);
             conventionSet.ForeignKeyOwnershipChangedConventions.Add(relationshipDiscoveryConvention);
 
-            conventionSet.ModelBuiltConventions.Add(new ModelCleanupConvention());
+            conventionSet.ModelBuiltConventions.Add(new ModelCleanupConvention(logger));
             conventionSet.ModelBuiltConventions.Add(keyAttributeConvention);
             conventionSet.ModelBuiltConventions.Add(foreignKeyAttributeConvention);
-            conventionSet.ModelBuiltConventions.Add(new ChangeTrackingStrategyConvention());
-            conventionSet.ModelBuiltConventions.Add(new ConstructorBindingConvention(Dependencies.ConstructorBindingFactory));
-            conventionSet.ModelBuiltConventions.Add(new TypeMappingConvention(Dependencies.TypeMappingSource));
-            conventionSet.ModelBuiltConventions.Add(new IgnoredMembersValidationConvention());
+            conventionSet.ModelBuiltConventions.Add(new ChangeTrackingStrategyConvention(logger));
+            conventionSet.ModelBuiltConventions.Add(new ConstructorBindingConvention(Dependencies.ConstructorBindingFactory, logger));
+            conventionSet.ModelBuiltConventions.Add(new TypeMappingConvention(Dependencies.TypeMappingSource, logger));
+            conventionSet.ModelBuiltConventions.Add(new IgnoredMembersValidationConvention(logger));
             conventionSet.ModelBuiltConventions.Add(foreignKeyIndexConvention);
 
             conventionSet.ModelBuiltConventions.Add(
                 new PropertyMappingValidationConvention(
                     Dependencies.TypeMappingSource,
-                    Dependencies.MemberClassifier));
+                    Dependencies.MemberClassifier,
+                    logger));
 
-            conventionSet.ModelBuiltConventions.Add(new RelationshipValidationConvention());
+            conventionSet.ModelBuiltConventions.Add(new RelationshipValidationConvention(logger));
             conventionSet.ModelBuiltConventions.Add(foreignKeyPropertyDiscoveryConvention);
             conventionSet.ModelBuiltConventions.Add(servicePropertyDiscoveryConvention);
-            conventionSet.ModelBuiltConventions.Add(new CacheCleanupConvention());
+            conventionSet.ModelBuiltConventions.Add(new CacheCleanupConvention(logger));
 
             conventionSet.NavigationAddedConventions.Add(backingFieldConvention);
-            conventionSet.NavigationAddedConventions.Add(new RequiredNavigationAttributeConvention(Dependencies.Logger));
+            conventionSet.NavigationAddedConventions.Add(new RequiredNavigationAttributeConvention(logger));
             conventionSet.NavigationAddedConventions.Add(inversePropertyAttributeConvention);
             conventionSet.NavigationAddedConventions.Add(foreignKeyPropertyDiscoveryConvention);
             conventionSet.NavigationAddedConventions.Add(relationshipDiscoveryConvention);

--- a/src/EFCore/Metadata/Conventions/Internal/CoreConventionSetBuilderDependencies.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/CoreConventionSetBuilderDependencies.cs
@@ -66,8 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             [NotNull] ITypeMappingSource typeMappingSource,
             [CanBeNull] IConstructorBindingFactory constructorBindingFactory,
             [CanBeNull] IParameterBindingFactories parameterBindingFactories,
-            [CanBeNull] IMemberClassifier memberClassifier,
-            [CanBeNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+            [CanBeNull] IMemberClassifier memberClassifier)
         {
             Check.NotNull(typeMappingSource, nameof(typeMappingSource));
 
@@ -99,9 +98,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             }
 
             ConstructorBindingFactory = constructorBindingFactory;
-
-            Logger = logger
-                     ?? new DiagnosticsLogger<DbLoggerCategory.Model>(new LoggerFactory(), new LoggingOptions(), new DiagnosticListener(""));
         }
 
         /// <summary>
@@ -129,19 +125,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         public IConstructorBindingFactory ConstructorBindingFactory { get; }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
-
-        /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
         /// </summary>
         /// <param name="typeMappingSource"> A replacement for the current dependency of this type. </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
         public CoreConventionSetBuilderDependencies With([NotNull] ITypeMappingSource typeMappingSource)
             => new CoreConventionSetBuilderDependencies(
-                typeMappingSource, ConstructorBindingFactory, ParameterBindingFactories, MemberClassifier, Logger);
+                typeMappingSource, ConstructorBindingFactory, ParameterBindingFactories, MemberClassifier);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -150,7 +140,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         /// <returns> A new parameter object with the given service replaced. </returns>
         public CoreConventionSetBuilderDependencies With([NotNull] IConstructorBindingFactory constructorBindingFactory)
             => new CoreConventionSetBuilderDependencies(
-                TypeMappingSource, constructorBindingFactory, ParameterBindingFactories, MemberClassifier, Logger);
+                TypeMappingSource, constructorBindingFactory, ParameterBindingFactories, MemberClassifier);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -159,7 +149,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         /// <returns> A new parameter object with the given service replaced. </returns>
         public CoreConventionSetBuilderDependencies With([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
             => new CoreConventionSetBuilderDependencies(
-                TypeMappingSource, ConstructorBindingFactory, ParameterBindingFactories, MemberClassifier, logger);
+                TypeMappingSource, ConstructorBindingFactory, ParameterBindingFactories, MemberClassifier);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -168,7 +158,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         /// <returns> A new parameter object with the given service replaced. </returns>
         public CoreConventionSetBuilderDependencies With([NotNull] IParameterBindingFactories parameterBindingFactories)
             => new CoreConventionSetBuilderDependencies(
-                TypeMappingSource, ConstructorBindingFactory, parameterBindingFactories, MemberClassifier, Logger);
+                TypeMappingSource, ConstructorBindingFactory, parameterBindingFactories, MemberClassifier);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -177,6 +167,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         /// <returns> A new parameter object with the given service replaced. </returns>
         public CoreConventionSetBuilderDependencies With([NotNull] IMemberClassifier memberClassifier)
             => new CoreConventionSetBuilderDependencies(
-                TypeMappingSource, ConstructorBindingFactory, ParameterBindingFactories, memberClassifier, Logger);
+                TypeMappingSource, ConstructorBindingFactory, ParameterBindingFactories, memberClassifier);
     }
 }

--- a/src/EFCore/Metadata/Conventions/Internal/DatabaseGeneratedAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/DatabaseGeneratedAttributeConvention.cs
@@ -3,6 +3,8 @@
 
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -15,6 +17,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     // Issue#11266 This type is being used by provider code. Do not break.
     public class DatabaseGeneratedAttributeConvention : PropertyAttributeConvention<DatabaseGeneratedAttribute>
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public DatabaseGeneratedAttributeConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+            : base(logger)
+        {
+        }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore/Metadata/Conventions/Internal/DerivedTypeDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/DerivedTypeDiscoveryConvention.cs
@@ -3,6 +3,8 @@
 
 using System.Linq;
 using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
@@ -13,6 +15,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     /// </summary>
     public class DerivedTypeDiscoveryConvention : InheritanceDiscoveryConventionBase, IEntityTypeAddedConvention
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public DerivedTypeDiscoveryConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+            : base(logger)
+        {
+        }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore/Metadata/Conventions/Internal/EntityTypeAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/EntityTypeAttributeConvention.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -16,6 +17,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     public abstract class EntityTypeAttributeConvention<TAttribute> : IEntityTypeAddedConvention
         where TAttribute : Attribute
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected EntityTypeAttributeConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+        {
+            Logger = logger;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore/Metadata/Conventions/Internal/ForeignKeyAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ForeignKeyAttributeConvention.cs
@@ -21,7 +21,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     public class ForeignKeyAttributeConvention : IForeignKeyAddedConvention, IModelBuiltConvention
     {
         private readonly IMemberClassifier _memberClassifier;
-        private readonly IDiagnosticsLogger<DbLoggerCategory.Model> _logger;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -34,8 +33,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Check.NotNull(memberClassifier, nameof(memberClassifier));
 
             _memberClassifier = memberClassifier;
-            _logger = logger;
+            Logger = logger;
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -56,7 +61,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             if (fkPropertyOnDependent != null
                 && fkPropertyOnPrincipal != null)
             {
-                _logger.ForeignKeyAttributesOnBothPropertiesWarning(
+                Logger.ForeignKeyAttributesOnBothPropertiesWarning(
                     foreignKey.PrincipalToDependent,
                     foreignKey.DependentToPrincipal,
                     fkPropertyOnPrincipal,
@@ -80,7 +85,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             if (fkPropertiesOnDependentToPrincipal != null
                 && fkPropertiesOnPrincipalToDependent != null)
             {
-                _logger.ForeignKeyAttributesOnBothNavigationsWarning(
+                Logger.ForeignKeyAttributesOnBothNavigationsWarning(
                     relationshipBuilder.Metadata.DependentToPrincipal, relationshipBuilder.Metadata.PrincipalToDependent);
 
                 relationshipBuilder = SplitNavigationsToSeparateRelationships(relationshipBuilder);
@@ -149,7 +154,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     if (fkPropertiesOnNavigation.Count != 1
                         || !Equals(fkPropertiesOnNavigation.First(), fkProperty.GetSimpleMemberName()))
                     {
-                        _logger.ConflictingForeignKeyAttributesOnNavigationAndPropertyWarning(
+                        Logger.ConflictingForeignKeyAttributesOnNavigationAndPropertyWarning(
                             fkPropertiesOnDependentToPrincipal != null
                                 ? relationshipBuilder.Metadata.DependentToPrincipal
                                 : relationshipBuilder.Metadata.PrincipalToDependent,

--- a/src/EFCore/Metadata/Conventions/Internal/ForeignKeyIndexConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ForeignKeyIndexConvention.cs
@@ -26,16 +26,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         IIndexUniquenessChangedConvention,
         IModelBuiltConvention
     {
-        private readonly IDiagnosticsLogger<DbLoggerCategory.Model> _logger;
-
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public ForeignKeyIndexConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
         {
-            _logger = logger;
+            Logger = logger;
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -296,8 +300,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         public virtual InternalModelBuilder Apply(InternalModelBuilder modelBuilder)
         {
             var definition = CoreStrings.LogRedundantIndexRemoved;
-            if (definition.GetLogBehavior(_logger) == WarningBehavior.Ignore
-                && !_logger.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (definition.GetLogBehavior(Logger) == WarningBehavior.Ignore
+                && !Logger.DiagnosticSource.IsEnabled(definition.EventId.Name))
             {
                 return modelBuilder;
             }
@@ -312,7 +316,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                         {
                             if (declaredForeignKey.Properties.Count != key.Properties.Count)
                             {
-                                _logger.RedundantIndexRemoved(declaredForeignKey.Properties, key.Properties);
+                                Logger.RedundantIndexRemoved(declaredForeignKey.Properties, key.Properties);
                             }
                         }
                     }
@@ -323,7 +327,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                         {
                             if (declaredForeignKey.Properties.Count != existingIndex.Properties.Count)
                             {
-                                _logger.RedundantIndexRemoved(declaredForeignKey.Properties, existingIndex.Properties);
+                                Logger.RedundantIndexRemoved(declaredForeignKey.Properties, existingIndex.Properties);
                             }
                         }
                     }

--- a/src/EFCore/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConvention.cs
@@ -30,16 +30,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         IPrimaryKeyChangedConvention,
         IModelBuiltConvention
     {
-        private readonly IDiagnosticsLogger<DbLoggerCategory.Model> _logger;
-
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public ForeignKeyPropertyDiscoveryConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
         {
-            _logger = logger;
+            Logger = logger;
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -408,7 +412,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     p => !p.IsShadowProperty
                          || p.GetConfigurationSource().Overrides(ConfigurationSource.DataAnnotation)))
                 {
-                    _logger.IncompatibleMatchingForeignKeyProperties(foreignKeyProperties, propertiesToReference);
+                    Logger.IncompatibleMatchingForeignKeyProperties(foreignKeyProperties, propertiesToReference);
                 }
 
                 // Stop searching if match found, but is incompatible
@@ -654,7 +658,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                         if (conflictingShadowFk != null)
                         {
                             conflictingFkFound = true;
-                            _logger.ConflictingShadowForeignKeysWarning(conflictingShadowFk);
+                            Logger.ConflictingShadowForeignKeysWarning(conflictingShadowFk);
                         }
                     }
                 }

--- a/src/EFCore/Metadata/Conventions/Internal/ICoreConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ICoreConventionSetBuilder.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
@@ -22,6 +24,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        ConventionSet CreateConventionSet();
+        ConventionSet CreateConventionSet(DiagnosticsLoggers loggers);
     }
 }

--- a/src/EFCore/Metadata/Conventions/Internal/IgnoredMembersValidationConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/IgnoredMembersValidationConvention.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Diagnostics;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
@@ -14,6 +16,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     /// </summary>
     public class IgnoredMembersValidationConvention : IModelBuiltConvention
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public IgnoredMembersValidationConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+        {
+            Logger = logger;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore/Metadata/Conventions/Internal/InheritanceDiscoveryConventionBase.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/InheritanceDiscoveryConventionBase.cs
@@ -3,6 +3,7 @@
 
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -14,6 +15,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     /// </summary>
     public abstract class InheritanceDiscoveryConventionBase
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected InheritanceDiscoveryConventionBase([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+        {
+            Logger = logger;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore/Metadata/Conventions/Internal/InversePropertyAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/InversePropertyAttributeConvention.cs
@@ -22,8 +22,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     public class InversePropertyAttributeConvention :
         NavigationAttributeEntityTypeConvention<InversePropertyAttribute>, IModelBuiltConvention
     {
-        private readonly IDiagnosticsLogger<DbLoggerCategory.Model> _logger;
-
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
@@ -31,9 +29,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         public InversePropertyAttributeConvention(
             [NotNull] IMemberClassifier memberClassifier,
             [NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
-            : base(memberClassifier)
+            : base(memberClassifier, logger)
         {
-            _logger = logger;
         }
 
         /// <summary>
@@ -180,7 +177,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 && ownership.PrincipalEntityType == targetEntityTypeBuilder.Metadata
                 && ownership.PrincipalToDependent?.GetIdentifyingMemberInfo() != inverseNavigationPropertyInfo)
             {
-                _logger.NonOwnershipInverseNavigationWarning(
+                Logger.NonOwnershipInverseNavigationWarning(
                     entityType, navigationMemberInfo,
                     targetEntityTypeBuilder.Metadata, inverseNavigationPropertyInfo,
                     ownership.PrincipalToDependent.GetIdentifyingMemberInfo());
@@ -191,7 +188,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 && entityType.DefiningEntityType == targetEntityTypeBuilder.Metadata
                 && entityType.DefiningNavigationName != inverseNavigationPropertyInfo.GetSimpleMemberName())
             {
-                _logger.NonDefiningInverseNavigationWarning(
+                Logger.NonDefiningInverseNavigationWarning(
                     entityType, navigationMemberInfo,
                     targetEntityTypeBuilder.Metadata, inverseNavigationPropertyInfo,
                     entityType.DefiningEntityType.GetRuntimeProperties()[entityType.DefiningNavigationName]);
@@ -338,7 +335,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                             inverseNavigation.Value);
                         if (ambiguousInverse != null)
                         {
-                            _logger.MultipleInversePropertiesSameTargetWarning(
+                            Logger.MultipleInversePropertiesSameTargetWarning(
                                 new[] { Tuple.Create(referencingNavigationWithAttribute.Item1, referencingNavigationWithAttribute.Item2.ClrType), Tuple.Create(ambiguousInverse.Value.Item1, ambiguousInverse.Value.Item2.ClrType) },
                                 inverseNavigation.Key,
                                 entityType.ClrType);

--- a/src/EFCore/Metadata/Conventions/Internal/KeyAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/KeyAttributeConvention.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -18,6 +20,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     /// </summary>
     public class KeyAttributeConvention : PropertyAttributeConvention<KeyAttribute>, IModelBuiltConvention
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public KeyAttributeConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+            : base(logger)
+        {
+        }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore/Metadata/Conventions/Internal/KeyDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/KeyDiscoveryConvention.cs
@@ -29,16 +29,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         IForeignKeyOwnershipChangedConvention
     {
         private const string KeySuffix = "Id";
-        private readonly IDiagnosticsLogger<DbLoggerCategory.Model> _logger;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public KeyDiscoveryConvention([CanBeNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+        public KeyDiscoveryConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
         {
-            _logger = logger;
+            Logger = logger;
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -78,7 +83,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 keyProperties = (List<Property>)DiscoverKeyProperties(entityType, candidateProperties);
                 if (keyProperties.Count > 1)
                 {
-                    _logger?.MultiplePrimaryKeyCandidates(keyProperties[0], keyProperties[1]);
+                    Logger?.MultiplePrimaryKeyCandidates(keyProperties[0], keyProperties[1]);
                     return entityTypeBuilder;
                 }
             }

--- a/src/EFCore/Metadata/Conventions/Internal/MaxLengthAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/MaxLengthAttributeConvention.cs
@@ -3,6 +3,8 @@
 
 using System.ComponentModel.DataAnnotations;
 using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -14,6 +16,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     /// </summary>
     public class MaxLengthAttributeConvention : PropertyAttributeConvention<MaxLengthAttribute>
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public MaxLengthAttributeConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+            : base(logger)
+        {
+        }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore/Metadata/Conventions/Internal/ModelCleanupConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ModelCleanupConvention.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
@@ -12,6 +14,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     /// </summary>
     public class ModelCleanupConvention : IModelBuiltConvention
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public ModelCleanupConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+        {
+            Logger = logger;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore/Metadata/Conventions/Internal/NavigationAttributeEntityTypeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/NavigationAttributeEntityTypeConvention.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -30,12 +31,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected NavigationAttributeEntityTypeConvention(
-            [NotNull] IMemberClassifier memberClassifier)
+            [NotNull] IMemberClassifier memberClassifier,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
         {
             Check.NotNull(memberClassifier, nameof(memberClassifier));
 
             _memberClassifier = memberClassifier;
+            Logger = logger;
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Metadata/Conventions/Internal/NavigationAttributeNavigationConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/NavigationAttributeNavigationConvention.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -19,6 +20,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     public abstract class NavigationAttributeNavigationConvention<TAttribute> : INavigationAddedConvention
         where TAttribute : Attribute
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected NavigationAttributeNavigationConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+        {
+            Logger = logger;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore/Metadata/Conventions/Internal/NavigationEagerLoadingConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/NavigationEagerLoadingConvention.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
@@ -11,6 +13,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     /// </summary>
     public class NavigationEagerLoadingConvention : IForeignKeyOwnershipChangedConvention
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public NavigationEagerLoadingConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+        {
+            Logger = logger;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore/Metadata/Conventions/Internal/NotMappedEntityTypeAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/NotMappedEntityTypeAttributeConvention.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.ComponentModel.DataAnnotations.Schema;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -13,6 +15,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     /// </summary>
     public class NotMappedEntityTypeAttributeConvention : EntityTypeAttributeConvention<NotMappedAttribute>
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public NotMappedEntityTypeAttributeConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+            : base(logger)
+        {
+        }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore/Metadata/Conventions/Internal/NotMappedMemberAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/NotMappedMemberAttributeConvention.cs
@@ -5,6 +5,8 @@ using System;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -16,6 +18,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     /// </summary>
     public class NotMappedMemberAttributeConvention : IEntityTypeAddedConvention
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public NotMappedMemberAttributeConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+        {
+            Logger = logger;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore/Metadata/Conventions/Internal/OwnedEntityTypeAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/OwnedEntityTypeAttributeConvention.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
@@ -11,6 +13,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     /// </summary>
     public class OwnedEntityTypeAttributeConvention : EntityTypeAttributeConvention<OwnedAttribute>
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public OwnedEntityTypeAttributeConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+            : base(logger)
+        {
+        }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore/Metadata/Conventions/Internal/OwnedTypesConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/OwnedTypesConvention.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
@@ -12,6 +14,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     /// </summary>
     public class OwnedTypesConvention : IEntityTypeRemovedConvention
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public OwnedTypesConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+        {
+            Logger = logger;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore/Metadata/Conventions/Internal/PropertyAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/PropertyAttributeConvention.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -16,6 +17,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     public abstract class PropertyAttributeConvention<TAttribute> : IPropertyAddedConvention, IPropertyFieldChangedConvention
         where TAttribute : Attribute
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected PropertyAttributeConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+        {
+            Logger = logger;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore/Metadata/Conventions/Internal/PropertyDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/PropertyDiscoveryConvention.cs
@@ -3,6 +3,7 @@
 
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -22,12 +23,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public PropertyDiscoveryConvention(
-            [NotNull] ITypeMappingSource typeMappingSource)
+            [NotNull] ITypeMappingSource typeMappingSource,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
         {
-            Check.NotNull(typeMappingSource, nameof(typeMappingSource));
-
             _typeMappingSource = typeMappingSource;
+            Logger = logger;
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Metadata/Conventions/Internal/PropertyMappingValidationConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/PropertyMappingValidationConvention.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -28,14 +29,22 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         /// </summary>
         public PropertyMappingValidationConvention(
             [NotNull] ITypeMappingSource typeMappingSource,
-            [NotNull] IMemberClassifier memberClassifier)
+            [NotNull] IMemberClassifier memberClassifier,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
         {
             Check.NotNull(typeMappingSource, nameof(typeMappingSource));
             Check.NotNull(memberClassifier, nameof(memberClassifier));
 
             _typeMappingSource = typeMappingSource;
             _memberClassifier = memberClassifier;
+            Logger = logger;
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Metadata/Conventions/Internal/RelationshipDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/RelationshipDiscoveryConvention.cs
@@ -28,7 +28,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         IForeignKeyOwnershipChangedConvention
     {
         private readonly IMemberClassifier _memberClassifier;
-        private readonly IDiagnosticsLogger<DbLoggerCategory.Model> _logger;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -42,8 +41,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Check.NotNull(logger, nameof(logger));
 
             _memberClassifier = memberClassifier;
-            _logger = logger;
+            Logger = logger;
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -681,7 +686,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 {
                     if (!isAmbiguousOnBase)
                     {
-                        _logger.MultipleNavigationProperties(
+                        Logger.MultipleNavigationProperties(
                             relationshipCandidate.NavigationProperties.Count == 0
                                 ? new[] { new Tuple<MemberInfo, Type>(null, targetEntityType.ClrType) }
                                 : relationshipCandidate.NavigationProperties.Select(n => new Tuple<MemberInfo, Type>(n, entityType.ClrType)),

--- a/src/EFCore/Metadata/Conventions/Internal/RelationshipValidationConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/RelationshipValidationConvention.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -14,6 +16,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     /// </summary>
     public class RelationshipValidationConvention : IModelBuiltConvention
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public RelationshipValidationConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+        {
+            Logger = logger;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore/Metadata/Conventions/Internal/RequiredNavigationAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/RequiredNavigationAttributeConvention.cs
@@ -17,15 +17,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     /// </summary>
     public class RequiredNavigationAttributeConvention : NavigationAttributeNavigationConvention<RequiredAttribute>
     {
-        private readonly IDiagnosticsLogger<DbLoggerCategory.Model> _logger;
-
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public RequiredNavigationAttributeConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+            : base(logger)
         {
-            _logger = logger;
         }
 
         /// <summary>
@@ -47,7 +45,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     var attributes = GetAttributes<RequiredAttribute>(inverse.DeclaringEntityType, inverse.Name);
                     if (attributes.Any())
                     {
-                        _logger.RequiredAttributeOnBothNavigations(navigation, inverse);
+                        Logger.RequiredAttributeOnBothNavigations(navigation, inverse);
                         return relationshipBuilder;
                     }
                 }
@@ -68,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     return relationshipBuilder;
                 }
 
-                _logger.RequiredAttributeOnDependent(newRelationshipBuilder.Metadata.DependentToPrincipal);
+                Logger.RequiredAttributeOnDependent(newRelationshipBuilder.Metadata.DependentToPrincipal);
                 relationshipBuilder = newRelationshipBuilder;
             }
 

--- a/src/EFCore/Metadata/Conventions/Internal/RequiredPropertyAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/RequiredPropertyAttributeConvention.cs
@@ -3,6 +3,8 @@
 
 using System.ComponentModel.DataAnnotations;
 using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -14,6 +16,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     /// </summary>
     public class RequiredPropertyAttributeConvention : PropertyAttributeConvention<RequiredAttribute>
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public RequiredPropertyAttributeConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+            : base(logger)
+        {
+        }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore/Metadata/Conventions/Internal/ServicePropertyDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ServicePropertyDiscoveryConvention.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -34,14 +35,22 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         /// </summary>
         public ServicePropertyDiscoveryConvention(
             [NotNull] ITypeMappingSource typeMappingSource,
-            [NotNull] IParameterBindingFactories parameterBindingFactories)
+            [NotNull] IParameterBindingFactories parameterBindingFactories,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
         {
             Check.NotNull(typeMappingSource, nameof(typeMappingSource));
             Check.NotNull(parameterBindingFactories, nameof(parameterBindingFactories));
 
             _typeMappingSource = typeMappingSource;
             _parameterBindingFactories = parameterBindingFactories;
+            Logger = logger;
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Metadata/Conventions/Internal/StringLengthAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/StringLengthAttributeConvention.cs
@@ -3,6 +3,8 @@
 
 using System.ComponentModel.DataAnnotations;
 using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -14,6 +16,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     /// </summary>
     public class StringLengthAttributeConvention : PropertyAttributeConvention<StringLengthAttribute>
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public StringLengthAttributeConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+            : base(logger)
+        {
+        }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore/Metadata/Conventions/Internal/TimestampAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/TimestampAttributeConvention.cs
@@ -3,6 +3,8 @@
 
 using System.ComponentModel.DataAnnotations;
 using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -14,6 +16,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     /// </summary>
     public class TimestampAttributeConvention : PropertyAttributeConvention<TimestampAttribute>
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public TimestampAttributeConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+            : base(logger)
+        {
+        }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore/Metadata/Conventions/Internal/TypeMappingConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/TypeMappingConvention.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 
@@ -20,10 +21,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public TypeMappingConvention([NotNull] ITypeMappingSource typeMappingSource)
+        public TypeMappingConvention(
+            [NotNull] ITypeMappingSource typeMappingSource,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
         {
             _typeMappingSource = typeMappingSource;
+            Logger = logger;
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Metadata/Conventions/Internal/ValidatingConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ValidatingConvention.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
@@ -14,14 +15,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     public class ValidatingConvention : IModelBuiltConvention
     {
         private readonly IModelValidator _validator;
+        private readonly DiagnosticsLoggers _loggers;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public ValidatingConvention([NotNull] IModelValidator validator)
+        public ValidatingConvention([NotNull] IModelValidator validator, DiagnosticsLoggers loggers)
         {
             _validator = validator;
+            _loggers = loggers;
         }
 
         /// <summary>
@@ -30,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         /// </summary>
         public virtual InternalModelBuilder Apply(InternalModelBuilder modelBuilder)
         {
-            _validator.Validate(modelBuilder.Metadata);
+            _validator.Validate(modelBuilder.Metadata, _loggers);
 
             return modelBuilder;
         }

--- a/src/EFCore/Metadata/Conventions/Internal/ValueGeneratorConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ValueGeneratorConvention.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
@@ -19,6 +20,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         IForeignKeyRemovedConvention,
         IBaseTypeChangedConvention
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public ValueGeneratorConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+        {
+            Logger = logger;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore/Query/EntityQueryModelVisitor.cs
+++ b/src/EFCore/Query/EntityQueryModelVisitor.cs
@@ -160,10 +160,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             Check.NotNull(queryModel, nameof(queryModel));
 
-            using (QueryCompilationContext.Logger.Logger.BeginScope(this))
+            var logger = QueryCompilationContext.Loggers.GetLogger<DbLoggerCategory.Query>();
+
+            using (logger.Logger.BeginScope(this))
             {
                 QueryCompilationContext.IsAsyncQuery = false;
-                QueryCompilationContext.Logger.QueryModelCompiling(queryModel);
+                logger.QueryModelCompiling(queryModel);
 
                 _blockTaskExpressions = false;
 
@@ -195,10 +197,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             Check.NotNull(queryModel, nameof(queryModel));
 
-            using (QueryCompilationContext.Logger.Logger.BeginScope(this))
+            var logger = QueryCompilationContext.Loggers.GetLogger<DbLoggerCategory.Query>();
+
+            using (logger.Logger.BeginScope(this))
             {
                 QueryCompilationContext.IsAsyncQuery = true;
-                QueryCompilationContext.Logger.QueryModelCompiling(queryModel);
+                logger.QueryModelCompiling(queryModel);
 
                 _blockTaskExpressions = false;
 
@@ -229,7 +233,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         .MakeGenericMethod(_expression.Type.GetSequenceType()),
                     _expression,
                     Expression.Constant(QueryCompilationContext.ContextType),
-                    Expression.Constant(QueryCompilationContext.Logger),
+                    Expression.Constant(QueryCompilationContext.Loggers.GetLogger<DbLoggerCategory.Query>()),
                     QueryContextParameter);
 
         /// <summary>
@@ -290,6 +294,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             Check.NotNull(queryModel, nameof(queryModel));
 
+            var logger = QueryCompilationContext.Loggers.GetLogger<DbLoggerCategory.Query>();
+
             queryModel.TransformExpressions(
                 new DuplicateQueryModelIdentifyingExpressionVisitor(_queryCompilationContext).Visit);
 
@@ -301,7 +307,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             var eagerLoadingExpressionVisitor = _eagerLoadingExpressionVisitorFactory
                 .Create(_queryCompilationContext, _querySourceTracingExpressionVisitorFactory);
             eagerLoadingExpressionVisitor.VisitQueryModel(queryModel);
-            new NondeterministicResultCheckingVisitor(QueryCompilationContext.Logger, this).VisitQueryModel(queryModel);
+            new NondeterministicResultCheckingVisitor(logger, this).VisitQueryModel(queryModel);
 
             OnBeforeNavigationRewrite(queryModel);
 
@@ -347,7 +353,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             // Log results
 
-            QueryCompilationContext.Logger.QueryModelOptimized(queryModel);
+            logger.QueryModelOptimized(queryModel);
         }
 
         /// <summary>
@@ -738,7 +744,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
             finally
             {
-                QueryCompilationContext.Logger.QueryExecutionPlanned(_expressionPrinter, queryExecutorExpression);
+                QueryCompilationContext.Loggers.GetLogger<DbLoggerCategory.Query>()
+                    .QueryExecutionPlanned(_expressionPrinter, queryExecutorExpression);
             }
         }
 

--- a/src/EFCore/Query/ExpressionVisitors/Internal/EntityEqualityRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/EntityEqualityRewritingExpressionVisitor.cs
@@ -158,7 +158,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 // collection navigation is only null if its parent entity is null (null propagation thru navigation)
                 // it is probable that user wanted to see if the collection is (not) empty
                 // log warning suggesting to use Any() instead.
-                _queryCompilationContext.Logger
+                _queryCompilationContext.Loggers.GetLogger<DbLoggerCategory.Query>()
                     .PossibleUnintendedCollectionNavigationNullComparisonWarning(properties);
 
                 return Visit(
@@ -248,7 +248,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 if (leftNavigation.Equals(rightNavigation))
                 {
                     // Log a warning that comparing 2 collections causes reference comparison
-                    _queryCompilationContext.Logger.PossibleUnintendedReferenceComparisonWarning(left, right);
+                    _queryCompilationContext.Loggers.GetLogger<DbLoggerCategory.Query>()
+                        .PossibleUnintendedReferenceComparisonWarning(left, right);
 
                     return Visit(
                         Expression.MakeBinary(

--- a/src/EFCore/Query/ExpressionVisitors/Internal/ModelExpressionApplyingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/ModelExpressionApplyingExpressionVisitor.cs
@@ -59,7 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 ((QueryModelGenerator)queryModelGenerator).EvaluatableExpressionFilter,
                 _parameters,
                 _queryCompilationContext.ContextType,
-                _queryCompilationContext.Logger,
+                _queryCompilationContext.Loggers.GetLogger<DbLoggerCategory.Query>(),
                 parameterize: false,
                 generateContextAccessors: true);
         }

--- a/src/EFCore/Query/ExpressionVisitors/Internal/ParameterExtractingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/ParameterExtractingExpressionVisitor.cs
@@ -14,6 +14,10 @@ using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 {
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
     public class ParameterExtractingExpressionVisitor : ExpressionVisitor
     {
         private const string QueryFilterPrefix = "ef_filter";
@@ -31,6 +35,10 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         private IDictionary<Expression, bool> _evaluatableExpressions;
         private IQueryProvider _currentQueryProvider;
 
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public ParameterExtractingExpressionVisitor(
             IEvaluatableExpressionFilter evaluatableExpressionFilter,
             IParameterValues parameterValues,
@@ -52,6 +60,10 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             }
         }
 
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public virtual Expression ExtractParameters(Expression expression)
         {
             var oldEvaluatableExpressions = _evaluatableExpressions;
@@ -68,6 +80,10 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             }
         }
 
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public override Expression Visit(Expression expression)
         {
             if (expression == null)
@@ -84,6 +100,10 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             return base.Visit(expression);
         }
 
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         protected virtual bool PreserveConvertNode(Expression expression)
         {
             if (expression is UnaryExpression unaryExpression
@@ -108,6 +128,10 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             return false;
         }
 
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         protected override Expression VisitBinary(BinaryExpression binaryExpression)
         {
             if (!binaryExpression.IsLogicalOperation())
@@ -151,6 +175,10 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                && ((constantValue && nodeType == ExpressionType.OrElse)
                    || (!constantValue && nodeType == ExpressionType.AndAlso));
 
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         protected override Expression VisitConstant(ConstantExpression constantExpression)
         {
             if (constantExpression.Value is IDetachableContext detachableContext)

--- a/src/EFCore/Query/Internal/IncludeCompiler.cs
+++ b/src/EFCore/Query/Internal/IncludeCompiler.cs
@@ -122,9 +122,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         /// </summary>
         public virtual void LogIgnoredIncludes()
         {
+            var logger = _queryCompilationContext.Loggers.GetLogger<DbLoggerCategory.Query>();
+
             foreach (var includeResultOperator in _includeResultOperators.Where(iro => !iro.IsImplicitLoad))
             {
-                _queryCompilationContext.Logger.IncludeIgnoredWarning(includeResultOperator);
+                logger.IncludeIgnoredWarning(includeResultOperator);
             }
         }
 
@@ -182,7 +184,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     continue;
                 }
 
-                _queryCompilationContext.Logger.NavigationIncluded(includeResultOperator);
+                _queryCompilationContext.Loggers.GetLogger<DbLoggerCategory.Query>()
+                    .NavigationIncluded(includeResultOperator);
+
                 _includeResultOperators.Remove(includeResultOperator);
             }
 

--- a/src/EFCore/Query/Internal/QueryCompilationContextDependencies.cs
+++ b/src/EFCore/Query/Internal/QueryCompilationContextDependencies.cs
@@ -33,18 +33,21 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         public QueryCompilationContextDependencies(
             [NotNull] IModel model,
             [NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> logger,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> commandLogger,
             [NotNull] IEntityQueryModelVisitorFactory entityQueryModelVisitorFactory,
             [NotNull] IRequiresMaterializationExpressionVisitorFactory requiresMaterializationExpressionVisitorFactory,
             [NotNull] ICurrentDbContext currentContext)
         {
             Check.NotNull(model, nameof(model));
             Check.NotNull(logger, nameof(logger));
+            Check.NotNull(commandLogger, nameof(commandLogger));
             Check.NotNull(entityQueryModelVisitorFactory, nameof(entityQueryModelVisitorFactory));
             Check.NotNull(requiresMaterializationExpressionVisitorFactory, nameof(requiresMaterializationExpressionVisitorFactory));
             Check.NotNull(currentContext, nameof(currentContext));
 
             Model = model;
             Logger = logger;
+            CommandLogger = commandLogger;
             EntityQueryModelVisitorFactory = entityQueryModelVisitorFactory;
             RequiresMaterializationExpressionVisitorFactory = requiresMaterializationExpressionVisitorFactory;
             CurrentContext = currentContext;
@@ -61,6 +64,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public IDiagnosticsLogger<DbLoggerCategory.Query> Logger { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public IDiagnosticsLogger<DbLoggerCategory.Database.Command> CommandLogger { get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -88,6 +97,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             => new QueryCompilationContextDependencies(
                 model,
                 Logger,
+                CommandLogger,
                 EntityQueryModelVisitorFactory,
                 RequiresMaterializationExpressionVisitorFactory,
                 CurrentContext);
@@ -100,6 +110,20 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             => new QueryCompilationContextDependencies(
                 Model,
                 logger,
+                CommandLogger,
+                EntityQueryModelVisitorFactory,
+                RequiresMaterializationExpressionVisitorFactory,
+                CurrentContext);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public QueryCompilationContextDependencies With([NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> commandLogger)
+            => new QueryCompilationContextDependencies(
+                Model,
+                Logger,
+                commandLogger,
                 EntityQueryModelVisitorFactory,
                 RequiresMaterializationExpressionVisitorFactory,
                 CurrentContext);
@@ -112,6 +136,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             => new QueryCompilationContextDependencies(
                 Model,
                 Logger,
+                CommandLogger,
                 entityQueryModelVisitorFactory,
                 RequiresMaterializationExpressionVisitorFactory,
                 CurrentContext);
@@ -125,6 +150,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             => new QueryCompilationContextDependencies(
                 Model,
                 Logger,
+                CommandLogger,
                 EntityQueryModelVisitorFactory,
                 requiresMaterializationExpressionVisitorFactory,
                 CurrentContext);
@@ -137,6 +163,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             => new QueryCompilationContextDependencies(
                 Model,
                 Logger,
+                CommandLogger,
                 EntityQueryModelVisitorFactory,
                 RequiresMaterializationExpressionVisitorFactory,
                 currentContext);

--- a/src/EFCore/Query/QueryCompilationContext.cs
+++ b/src/EFCore/Query/QueryCompilationContext.cs
@@ -55,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Check.NotNull(linqOperatorProvider, nameof(linqOperatorProvider));
 
             Model = dependencies.Model;
-            Logger = dependencies.Logger;
+            Loggers = new DiagnosticsLoggers(dependencies.Logger, dependencies.CommandLogger);
 
             _entityQueryModelVisitorFactory = dependencies.EntityQueryModelVisitorFactory;
             _requiresMaterializationExpressionVisitorFactory = dependencies.RequiresMaterializationExpressionVisitorFactory;
@@ -133,12 +133,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual IModel Model { get; }
 
         /// <summary>
-        ///     Gets the logger.
+        ///     Gets the loggers.
         /// </summary>
         /// <value>
-        ///     The logger.
+        ///     The loggers.
         /// </value>
-        public virtual IDiagnosticsLogger<DbLoggerCategory.Query> Logger { get; }
+        public virtual DiagnosticsLoggers Loggers { get; }
 
         /// <summary>
         ///     Gets the LINQ operator provider.

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/ModelCodeGeneratorTestBase.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/ModelCodeGeneratorTestBase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
@@ -35,7 +36,9 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                     return new CompositeConventionSetBuilder(
                             context.GetService<IEnumerable<IConventionSetBuilder>>().ToList())
                         .AddConventions(
-                            context.GetService<ICoreConventionSetBuilder>().CreateConventionSet());
+                            context.GetService<ICoreConventionSetBuilder>().CreateConventionSet(
+                                new DiagnosticsLoggers(
+                                    context.GetService<IDiagnosticsLogger<DbLoggerCategory.Model>>())));
                 }
             }
         }

--- a/test/EFCore.InMemory.FunctionalTests/GlobalDatabaseTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/GlobalDatabaseTest.cs
@@ -40,7 +40,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [Fact]
-        public void Different_stores_are_used_when_AddDbContext_force_different_internal_service_provider()
+        public void AddDbContext_does_not_force_different_internal_service_provider()
         {
             using (var context = new BooFooContext(
                 new DbContextOptionsBuilder()
@@ -59,7 +59,7 @@ namespace Microsoft.EntityFrameworkCore
             using (var scope = serviceProvider.CreateScope())
             {
                 var context = scope.ServiceProvider.GetService<BooFooContext>();
-                Assert.Empty(context.Foos.ToList());
+                Assert.NotEmpty(context.Foos.ToList());
             }
         }
 

--- a/test/EFCore.Relational.Specification.Tests/TestUtilities/RelationalDatabaseCleaner.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestUtilities/RelationalDatabaseCleaner.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
@@ -39,6 +40,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             var connection = facade.GetService<IRelationalConnection>();
             var sqlBuilder = facade.GetService<IRawSqlCommandBuilder>();
             var loggerFactory = facade.GetService<ILoggerFactory>();
+            var commandLogger = facade.GetService<IDiagnosticsLogger<DbLoggerCategory.Database.Command>>();
 
             if (!creator.Exists())
             {

--- a/test/EFCore.Relational.Tests/Metadata/Conventions/Internal/DiscriminatorConventionTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/Conventions/Internal/DiscriminatorConventionTest.cs
@@ -17,8 +17,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         public void Sets_discriminator_for_two_level_hierarchy()
         {
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<Entity>();
+            var logger = new TestLogger<DbLoggerCategory.Model>();
 
-            Assert.True(new DiscriminatorConvention().Apply(entityTypeBuilder, oldBaseType: null));
+            Assert.True(new DiscriminatorConvention(logger).Apply(entityTypeBuilder, oldBaseType: null));
 
             Assert.Null(entityTypeBuilder.Metadata.Relational().DiscriminatorProperty);
             Assert.Null(entityTypeBuilder.Metadata.Relational().DiscriminatorValue);
@@ -26,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var baseTypeBuilder = entityTypeBuilder.ModelBuilder.Entity(typeof(EntityBase), ConfigurationSource.Explicit);
             Assert.Same(entityTypeBuilder, entityTypeBuilder.HasBaseType(baseTypeBuilder.Metadata, ConfigurationSource.DataAnnotation));
 
-            Assert.True(new DiscriminatorConvention().Apply(entityTypeBuilder, oldBaseType: null));
+            Assert.True(new DiscriminatorConvention(logger).Apply(entityTypeBuilder, oldBaseType: null));
 
             var discriminator = entityTypeBuilder.Metadata.Relational().DiscriminatorProperty;
 
@@ -36,7 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Equal(typeof(Entity).Name, entityTypeBuilder.Metadata.Relational().DiscriminatorValue);
 
             Assert.NotNull(entityTypeBuilder.HasBaseType((Type)null, ConfigurationSource.DataAnnotation));
-            Assert.True(new DiscriminatorConvention().Apply(entityTypeBuilder, oldBaseType: baseTypeBuilder.Metadata));
+            Assert.True(new DiscriminatorConvention(logger).Apply(entityTypeBuilder, oldBaseType: baseTypeBuilder.Metadata));
             Assert.Null(baseTypeBuilder.Metadata.Relational().DiscriminatorProperty);
             Assert.Null(entityTypeBuilder.Metadata.Relational().DiscriminatorProperty);
         }
@@ -44,9 +45,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         [Fact]
         public void Sets_discriminator_for_three_level_hierarchy()
         {
+            var logger = new TestLogger<DbLoggerCategory.Model>();
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<Entity>();
 
-            Assert.True(new DiscriminatorConvention().Apply(entityTypeBuilder, oldBaseType: null));
+            Assert.True(new DiscriminatorConvention(logger).Apply(entityTypeBuilder, oldBaseType: null));
 
             Assert.Null(entityTypeBuilder.Metadata.Relational().DiscriminatorProperty);
             Assert.Null(entityTypeBuilder.Metadata.Relational().DiscriminatorValue);
@@ -54,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var baseTypeBuilder = entityTypeBuilder.ModelBuilder.Entity(typeof(EntityBase), ConfigurationSource.Explicit);
             Assert.Same(entityTypeBuilder, entityTypeBuilder.HasBaseType(baseTypeBuilder.Metadata, ConfigurationSource.DataAnnotation));
 
-            Assert.True(new DiscriminatorConvention().Apply(entityTypeBuilder, oldBaseType: null));
+            Assert.True(new DiscriminatorConvention(logger).Apply(entityTypeBuilder, oldBaseType: null));
 
             var derivedTypeBuilder = entityTypeBuilder.ModelBuilder.Entity(typeof(DerivedEntity), ConfigurationSource.Explicit);
             Assert.Same(derivedTypeBuilder, derivedTypeBuilder.HasBaseType(entityTypeBuilder.Metadata, ConfigurationSource.DataAnnotation));
@@ -62,7 +64,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 derivedTypeBuilder.Metadata,
                 entityTypeBuilder.ModelBuilder.Entity(typeof(DerivedEntity).FullName, ConfigurationSource.Convention).Metadata);
 
-            Assert.True(new DiscriminatorConvention().Apply(derivedTypeBuilder, oldBaseType: null));
+            Assert.True(new DiscriminatorConvention(logger).Apply(derivedTypeBuilder, oldBaseType: null));
 
             var discriminator = entityTypeBuilder.Metadata.Relational().DiscriminatorProperty;
             Assert.NotNull(discriminator);
@@ -73,7 +75,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Equal(typeof(DerivedEntity).Name, derivedTypeBuilder.Metadata.Relational().DiscriminatorValue);
 
             entityTypeBuilder.HasBaseType((Type)null, ConfigurationSource.DataAnnotation);
-            Assert.True(new DiscriminatorConvention().Apply(entityTypeBuilder, oldBaseType: baseTypeBuilder.Metadata));
+            Assert.True(new DiscriminatorConvention(logger).Apply(entityTypeBuilder, oldBaseType: baseTypeBuilder.Metadata));
 
             Assert.Null(baseTypeBuilder.Metadata.Relational().DiscriminatorProperty);
             discriminator = entityTypeBuilder.Metadata.Relational().DiscriminatorProperty;
@@ -87,12 +89,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         public void Uses_explicit_discriminator_if_compatible()
         {
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<Entity>();
+            var logger = new TestLogger<DbLoggerCategory.Model>();
 
             var baseTypeBuilder = entityTypeBuilder.ModelBuilder.Entity(typeof(EntityBase), ConfigurationSource.DataAnnotation);
             entityTypeBuilder.HasBaseType(baseTypeBuilder.Metadata, ConfigurationSource.DataAnnotation);
             baseTypeBuilder.Relational(ConfigurationSource.Explicit).HasDiscriminator("T", typeof(string));
 
-            Assert.True(new DiscriminatorConvention().Apply(entityTypeBuilder, oldBaseType: null));
+            Assert.True(new DiscriminatorConvention(logger).Apply(entityTypeBuilder, oldBaseType: null));
 
             var discriminator = entityTypeBuilder.Metadata.Relational().DiscriminatorProperty;
             Assert.NotNull(discriminator);
@@ -107,12 +110,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         public void Does_nothing_if_explicit_discriminator_is_not_compatible()
         {
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<Entity>();
+            var logger = new TestLogger<DbLoggerCategory.Model>();
 
             var baseTypeBuilder = entityTypeBuilder.ModelBuilder.Entity(typeof(EntityBase), ConfigurationSource.DataAnnotation);
             entityTypeBuilder.HasBaseType(baseTypeBuilder.Metadata, ConfigurationSource.DataAnnotation);
             baseTypeBuilder.Relational(ConfigurationSource.Explicit).HasDiscriminator("T", typeof(int));
 
-            Assert.True(new DiscriminatorConvention().Apply(entityTypeBuilder, oldBaseType: null));
+            Assert.True(new DiscriminatorConvention(logger).Apply(entityTypeBuilder, oldBaseType: null));
 
             var discriminator = entityTypeBuilder.Metadata.Relational().DiscriminatorProperty;
             Assert.NotNull(discriminator);
@@ -127,13 +131,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         public void Does_nothing_if_explicit_discriminator_set_on_derived_type()
         {
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<Entity>();
+            var logger = new TestLogger<DbLoggerCategory.Model>();
 
             entityTypeBuilder.Relational(ConfigurationSource.Explicit).HasDiscriminator("T", typeof(string));
 
             var baseTypeBuilder = entityTypeBuilder.ModelBuilder.Entity(typeof(EntityBase), ConfigurationSource.Convention);
             entityTypeBuilder.HasBaseType(baseTypeBuilder.Metadata, ConfigurationSource.Convention);
 
-            Assert.True(new DiscriminatorConvention().Apply(entityTypeBuilder, oldBaseType: null));
+            Assert.True(new DiscriminatorConvention(logger).Apply(entityTypeBuilder, oldBaseType: null));
 
             Assert.Null(entityTypeBuilder.Metadata.Relational().DiscriminatorProperty);
             Assert.Null(baseTypeBuilder.Metadata.Relational().DiscriminatorProperty);
@@ -141,7 +146,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Null(entityTypeBuilder.Metadata.Relational().DiscriminatorValue);
 
             entityTypeBuilder.HasBaseType((Type)null, ConfigurationSource.DataAnnotation);
-            Assert.True(new DiscriminatorConvention().Apply(entityTypeBuilder, oldBaseType: baseTypeBuilder.Metadata));
+            Assert.True(new DiscriminatorConvention(logger).Apply(entityTypeBuilder, oldBaseType: baseTypeBuilder.Metadata));
 
             Assert.Null(baseTypeBuilder.Metadata.Relational().DiscriminatorProperty);
             Assert.NotNull(entityTypeBuilder.Metadata.Relational().DiscriminatorProperty);

--- a/test/EFCore.Relational.Tests/Metadata/Conventions/Internal/RelationalPropertyMappingValidationConventionTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/Conventions/Internal/RelationalPropertyMappingValidationConventionTest.cs
@@ -51,7 +51,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             return new PropertyMappingValidationConvention(
                 typeMappingSource,
                 TestServiceFactory.Instance.Create<IMemberClassifier>(
-                    (typeof(ITypeMappingSource), typeMappingSource)));
+                    (typeof(ITypeMappingSource), typeMappingSource)),
+                new TestLogger<DbLoggerCategory.Model>());
         }
     }
 }

--- a/test/EFCore.Relational.Tests/Metadata/DbFunctionMetadataTests.cs
+++ b/test/EFCore.Relational.Tests/Metadata/DbFunctionMetadataTests.cs
@@ -8,6 +8,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
+using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
 // ReSharper disable UnusedMember.Local
@@ -488,7 +489,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         {
             var conventionset = new ConventionSet();
 
-            conventionset.ModelAnnotationChangedConventions.Add(new RelationalDbFunctionConvention());
+            conventionset.ModelAnnotationChangedConventions.Add(
+                new RelationalDbFunctionConvention(new TestLogger<DbLoggerCategory.Model>()));
 
             return new ModelBuilder(conventionset);
         }

--- a/test/EFCore.Relational.Tests/Metadata/RelationalEntityTypeAttributeConventionTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/RelationalEntityTypeAttributeConventionTest.cs
@@ -33,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             entityBuilder.HasAnnotation(RelationalAnnotationNames.TableName, "ConventionalName", ConfigurationSource.Convention);
             entityBuilder.HasAnnotation(RelationalAnnotationNames.Schema, "ConventionalSchema", ConfigurationSource.Convention);
 
-            new RelationalTableAttributeConvention().Apply(entityBuilder);
+            new RelationalTableAttributeConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(entityBuilder);
 
             Assert.Equal("MyTable", entityBuilder.Metadata.Relational().TableName);
             Assert.Equal("MySchema", entityBuilder.Metadata.Relational().Schema);
@@ -47,7 +47,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             entityBuilder.HasAnnotation(RelationalAnnotationNames.TableName, "ExplicitName", ConfigurationSource.Explicit);
             entityBuilder.HasAnnotation(RelationalAnnotationNames.Schema, "ExplicitName", ConfigurationSource.Explicit);
 
-            new RelationalTableAttributeConvention().Apply(entityBuilder);
+            new RelationalTableAttributeConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(entityBuilder);
 
             Assert.Equal("ExplicitName", entityBuilder.Metadata.Relational().TableName);
             Assert.Equal("ExplicitName", entityBuilder.Metadata.Relational().Schema);
@@ -60,7 +60,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                 new PropertyDiscoveryConvention(
                     new TestRelationalTypeMappingSource(
                         TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
-                        TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>())));
+                        TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>()),
+                    new TestLogger<DbLoggerCategory.Model>()));
 
             var modelBuilder = new InternalModelBuilder(new Model(conventionSet));
 

--- a/test/EFCore.Relational.Tests/Metadata/RelationalPropertyAttributeConventionTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/RelationalPropertyAttributeConventionTest.cs
@@ -46,7 +46,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             propertyBuilder.HasAnnotation(RelationalAnnotationNames.ColumnName, "ConventionalName", ConfigurationSource.Convention);
             propertyBuilder.HasAnnotation(RelationalAnnotationNames.ColumnType, "BYTE", ConfigurationSource.Convention);
 
-            new RelationalColumnAttributeConvention().Apply(propertyBuilder);
+            new RelationalColumnAttributeConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(propertyBuilder);
 
             Assert.Equal("Post Name", propertyBuilder.Metadata.Relational().ColumnName);
             Assert.Equal("DECIMAL", propertyBuilder.Metadata.Relational().ColumnType);
@@ -62,7 +62,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             propertyBuilder.HasAnnotation(RelationalAnnotationNames.ColumnName, "ExplicitName", ConfigurationSource.Explicit);
             propertyBuilder.HasAnnotation(RelationalAnnotationNames.ColumnType, "BYTE", ConfigurationSource.Explicit);
 
-            new RelationalColumnAttributeConvention().Apply(propertyBuilder);
+            new RelationalColumnAttributeConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(propertyBuilder);
 
             Assert.Equal("ExplicitName", propertyBuilder.Metadata.Relational().ColumnName);
             Assert.Equal("BYTE", propertyBuilder.Metadata.Relational().ColumnType);
@@ -75,7 +75,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                 new PropertyDiscoveryConvention(
                     new TestRelationalTypeMappingSource(
                         TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
-                        TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>())));
+                        TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>()),
+                    new TestLogger<DbLoggerCategory.Model>()));
 
             var modelBuilder = new InternalModelBuilder(new Model(conventionSet));
 

--- a/test/EFCore.Relational.Tests/ModificationCommandBatchFactoryDependenciesTest.cs
+++ b/test/EFCore.Relational.Tests/ModificationCommandBatchFactoryDependenciesTest.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.EntityFrameworkCore.Update;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public class ModificationCommandBatchFactoryDependenciesTest
+    {
+        [Fact]
+        public void Can_use_With_methods_to_clone_and_replace_service()
+        {
+            RelationalTestHelpers.Instance.TestDependenciesClone<ModificationCommandBatchFactoryDependencies>();
+        }
+    }
+}

--- a/test/EFCore.Relational.Tests/Storage/RawSqlCommandBuilderTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RawSqlCommandBuilderTest.cs
@@ -14,13 +14,12 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public virtual void Builds_RelationalCommand_without_optional_parameters()
         {
             var builder = new RawSqlCommandBuilder(
-                new RelationalCommandBuilderFactory(
-                    new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
-                    new TestRelationalTypeMappingSource(
-                        TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
-                        TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>())),
+                new RelationalCommandBuilderFactory(new TestRelationalTypeMappingSource(
+                    TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
+                    TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>())),
                 new RelationalSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies()),
-                new ParameterNameGeneratorFactory(new ParameterNameGeneratorDependencies()));
+                new ParameterNameGeneratorFactory(new ParameterNameGeneratorDependencies()),
+                new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>());
 
             var command = builder.Build("SQL COMMAND TEXT");
 
@@ -32,13 +31,12 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public virtual void Builds_RelationalCommand_with_empty_parameter_list()
         {
             var builder = new RawSqlCommandBuilder(
-                new RelationalCommandBuilderFactory(
-                    new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
-                    new TestRelationalTypeMappingSource(
-                        TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
-                        TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>())),
+                new RelationalCommandBuilderFactory(new TestRelationalTypeMappingSource(
+                    TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
+                    TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>())),
                 new RelationalSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies()),
-                new ParameterNameGeneratorFactory(new ParameterNameGeneratorDependencies()));
+                new ParameterNameGeneratorFactory(new ParameterNameGeneratorDependencies()),
+                new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>());
 
             var rawSqlCommand = builder.Build("SQL COMMAND TEXT", Array.Empty<object>());
 
@@ -51,13 +49,12 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public virtual void Builds_RelationalCommand_with_parameters()
         {
             var builder = new RawSqlCommandBuilder(
-                new RelationalCommandBuilderFactory(
-                    new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
-                    new TestRelationalTypeMappingSource(
-                        TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
-                        TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>())),
+                new RelationalCommandBuilderFactory(new TestRelationalTypeMappingSource(
+                    TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
+                    TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>())),
                 new RelationalSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies()),
-                new ParameterNameGeneratorFactory(new ParameterNameGeneratorDependencies()));
+                new ParameterNameGeneratorFactory(new ParameterNameGeneratorDependencies()),
+                new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>());
 
             var rawSqlCommand = builder.Build("SQL COMMAND TEXT {0} {1} {2}", new object[] { 1, 2L, "three" });
 

--- a/test/EFCore.Relational.Tests/Storage/RelationalDatabaseFacadeExtensionsTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalDatabaseFacadeExtensionsTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -339,10 +340,14 @@ namespace Microsoft.EntityFrameworkCore.Storage
         private class TestRawSqlCommandBuilder : IRawSqlCommandBuilder
         {
             private readonly IRelationalCommandBuilderFactory _commandBuilderFactory;
+            private readonly IDiagnosticsLogger<DbLoggerCategory.Database.Command> _logger;
 
-            public TestRawSqlCommandBuilder(IRelationalCommandBuilderFactory relationalCommandBuilderFactory)
+            public TestRawSqlCommandBuilder(
+                IRelationalCommandBuilderFactory relationalCommandBuilderFactory,
+                IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger)
             {
                 _commandBuilderFactory = relationalCommandBuilderFactory;
+                _logger = logger;
             }
 
             public string Sql { get; private set; }
@@ -355,7 +360,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 Sql = sql;
                 Parameters = parameters;
 
-                return new RawSqlCommand(_commandBuilderFactory.Create().Build(), new Dictionary<string, object>());
+                return new RawSqlCommand(_commandBuilderFactory.Create(_logger).Build(), new Dictionary<string, object>());
             }
         }
     }

--- a/test/EFCore.Relational.Tests/TestUtilities/RelationalTestHelpers.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/RelationalTestHelpers.cs
@@ -29,11 +29,9 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 extension.WithConnection(new FakeDbConnection("Database=Fake")));
         }
 
-        public override IModelValidator CreateModelValidator(
-            DiagnosticsLogger<DbLoggerCategory.Model> modelLogger,
-            DiagnosticsLogger<DbLoggerCategory.Model.Validation> validationLogger)
+        public override IModelValidator CreateModelValidator()
             => new RelationalModelValidator(
-                new ModelValidatorDependencies(validationLogger, modelLogger),
+                new ModelValidatorDependencies(),
                 new RelationalModelValidatorDependencies(
                     new TestRelationalTypeMappingSource(
                         TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),

--- a/test/EFCore.Relational.Tests/TestUtilities/TestModificationCommandBatchFactory.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/TestModificationCommandBatchFactory.cs
@@ -1,28 +1,18 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Update;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities
 {
     public class TestModificationCommandBatchFactory : IModificationCommandBatchFactory
     {
-        private readonly IRelationalCommandBuilderFactory _commandBuilderFactory;
-        private readonly ISqlGenerationHelper _sqlGenerationHelper;
-        private readonly IUpdateSqlGenerator _updateSqlGenerator;
-        private readonly IRelationalValueBufferFactoryFactory _valueBufferFactoryFactory;
+        private readonly ModificationCommandBatchFactoryDependencies _dependencies;
 
         public TestModificationCommandBatchFactory(
-            IRelationalCommandBuilderFactory commandBuilderFactory,
-            ISqlGenerationHelper sqlGenerationHelper,
-            IUpdateSqlGenerator updateSqlGenerator,
-            IRelationalValueBufferFactoryFactory valueBufferFactoryFactory)
+            ModificationCommandBatchFactoryDependencies dependencies)
         {
-            _commandBuilderFactory = commandBuilderFactory;
-            _sqlGenerationHelper = sqlGenerationHelper;
-            _updateSqlGenerator = updateSqlGenerator;
-            _valueBufferFactoryFactory = valueBufferFactoryFactory;
+            _dependencies = dependencies;
         }
 
         public int CreateCount { get; private set; }
@@ -31,11 +21,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         {
             CreateCount++;
 
-            return new SingularModificationCommandBatch(
-                _commandBuilderFactory,
-                _sqlGenerationHelper,
-                _updateSqlGenerator,
-                _valueBufferFactoryFactory);
+            return new SingularModificationCommandBatch(_dependencies);
         }
     }
 }

--- a/test/EFCore.Relational.Tests/TestUtilities/TestQuerySqlGenerator.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/TestQuerySqlGenerator.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.Sql;
 
@@ -10,8 +11,9 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
     {
         public TestQuerySqlGenerator(
             QuerySqlGeneratorDependencies dependencies,
-            SelectExpression selectExpression)
-            : base(dependencies, selectExpression)
+            SelectExpression selectExpression,
+            DiagnosticsLoggers loggers)
+            : base(dependencies, selectExpression, loggers)
         {
         }
     }

--- a/test/EFCore.Relational.Tests/TestUtilities/TestQuerySqlGeneratorFactory.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/TestQuerySqlGeneratorFactory.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.Sql;
 
@@ -13,7 +14,9 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         {
         }
 
-        public override IQuerySqlGenerator CreateDefault(SelectExpression selectExpression)
-            => new TestQuerySqlGenerator(Dependencies, selectExpression);
+        public override IQuerySqlGenerator CreateDefault(
+            SelectExpression selectExpression,
+            DiagnosticsLoggers loggers)
+            => new TestQuerySqlGenerator(Dependencies, selectExpression, loggers);
     }
 }

--- a/test/EFCore.Relational.Tests/TestUtilities/TestRelationalConventionSetBuilder.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/TestRelationalConventionSetBuilder.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -25,6 +26,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                         null))
                 .AddConventions(
                     TestServiceFactory.Instance.Create<CoreConventionSetBuilder>()
-                        .CreateConventionSet());
+                        .CreateConventionSet(
+                            new DiagnosticsLoggers(
+                                new FakeDiagnosticsLogger<DbLoggerCategory.Model>())));
     }
 }

--- a/test/EFCore.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
+++ b/test/EFCore.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
@@ -567,21 +567,23 @@ namespace Microsoft.EntityFrameworkCore.Update
             public ModificationCommandBatchFake(
                 IUpdateSqlGenerator sqlGenerator = null)
                 : base(
-                    new RelationalCommandBuilderFactory(
-                        new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
-                        new TestRelationalTypeMappingSource(
-                            TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
-                            TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>())),
-                    new RelationalSqlGenerationHelper(
-                        new RelationalSqlGenerationHelperDependencies()),
-                    sqlGenerator ?? new FakeSqlGenerator(
-                        RelationalTestHelpers.Instance.CreateContextServices().GetRequiredService<UpdateSqlGeneratorDependencies>()),
-                    new TypedRelationalValueBufferFactoryFactory(
-                        new RelationalValueBufferFactoryDependencies(
+                    new ModificationCommandBatchFactoryDependencies(
+                        new RelationalCommandBuilderFactory(
                             new TestRelationalTypeMappingSource(
                                 TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
-                                TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>()),
-                            new CoreSingletonOptions())))
+                                TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>())),
+                        new RelationalSqlGenerationHelper(
+                            new RelationalSqlGenerationHelperDependencies()),
+                        sqlGenerator ?? new FakeSqlGenerator(
+                            RelationalTestHelpers.Instance.CreateContextServices()
+                                .GetRequiredService<UpdateSqlGeneratorDependencies>()),
+                        new TypedRelationalValueBufferFactoryFactory(
+                            new RelationalValueBufferFactoryDependencies(
+                                new TestRelationalTypeMappingSource(
+                                    TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
+                                    TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>()),
+                                new CoreSingletonOptions())),
+                        new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>()))
             {
                 ShouldAddCommand = true;
                 ShouldValidateSql = true;

--- a/test/EFCore.Specification.Tests/DataAnnotationTestBase.cs
+++ b/test/EFCore.Specification.Tests/DataAnnotationTestBase.cs
@@ -46,15 +46,19 @@ namespace Microsoft.EntityFrameworkCore
         {
             var context = CreateContext();
             var conventionSetBuilder = CreateConventionSetBuilder(context);
+            var loggers = new DiagnosticsLoggers(
+                context.GetService<IDiagnosticsLogger<DbLoggerCategory.Model>>(),
+                context.GetService<IDiagnosticsLogger<DbLoggerCategory.Model.Validation>>());
+
             var conventionSet = new CoreConventionSetBuilder(context.GetService<CoreConventionSetBuilderDependencies>())
-                .CreateConventionSet();
+                .CreateConventionSet(loggers);
 
             conventionSet = conventionSetBuilder == null
                 ? conventionSet
                 : conventionSetBuilder.AddConventions(conventionSet);
 
             conventionSet.ModelBuiltConventions.Add(
-                new ValidatingConvention(context.GetService<IModelValidator>()));
+                new ValidatingConvention(context.GetService<IModelValidator>(), loggers));
 
             return new ModelBuilder(conventionSet);
         }

--- a/test/EFCore.Specification.Tests/TestUtilities/TestModelSource.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/TestModelSource.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
@@ -19,10 +20,14 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             _onModelCreating = onModelCreating;
         }
 
-        protected override IModel CreateModel(DbContext context, IConventionSetBuilder conventionSetBuilder, IModelValidator validator)
+        protected override IModel CreateModel(
+            DbContext context,
+            IConventionSetBuilder conventionSetBuilder,
+            IModelValidator validator,
+            DiagnosticsLoggers loggers)
         {
-            var conventionSet = CreateConventionSet(conventionSetBuilder);
-            conventionSet.ModelBuiltConventions.Add(new ValidatingConvention(validator));
+            var conventionSet = CreateConventionSet(conventionSetBuilder, loggers);
+            conventionSet.ModelBuiltConventions.Add(new ValidatingConvention(validator, loggers));
 
             var modelBuilder = new ModelBuilder(conventionSet);
 

--- a/test/EFCore.Specification.Tests/TestUtilities/TestServiceFactory.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/TestServiceFactory.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.Extensions.DependencyInjection;
@@ -28,7 +29,10 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             = new List<(Type, object)>
             {
                 (typeof(IRegisteredServices), new RegisteredServices(Enumerable.Empty<Type>())),
-                (typeof(ServiceParameterBindingFactory), new ServiceParameterBindingFactory(typeof(IStateManager)))
+                (typeof(ServiceParameterBindingFactory), new ServiceParameterBindingFactory(typeof(IStateManager))),
+                (typeof(IDiagnosticsLogger<DbLoggerCategory.Model>), new TestLogger<DbLoggerCategory.Model>()),
+                (typeof(IDiagnosticsLogger<DbLoggerCategory.Model.Validation>), new TestLogger<DbLoggerCategory.Model.Validation>()),
+                (typeof(IDiagnosticsLogger<DbLoggerCategory.Query>), new TestLogger<DbLoggerCategory.Query>())
             };
 
         public TService Create<TService>(params (Type Type, object Implementation)[] specialCases)

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerDbFunctionMetadataTests.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerDbFunctionMetadataTests.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Metadata.Conventions.Internal;
+using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore
@@ -66,7 +67,8 @@ namespace Microsoft.EntityFrameworkCore
         {
             var conventionset = new ConventionSet();
 
-            conventionset.ModelAnnotationChangedConventions.Add(new SqlServerDbFunctionConvention());
+            conventionset.ModelAnnotationChangedConventions.Add(
+                new SqlServerDbFunctionConvention(new TestLogger<DbLoggerCategory.Model>()));
 
             return new ModelBuilder(conventionset);
         }

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerTestHelpers.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerTestHelpers.cs
@@ -24,11 +24,9 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         protected override void UseProviderOptions(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder.UseSqlServer(new SqlConnection("Database=DummyDatabase"));
 
-        public override IModelValidator CreateModelValidator(
-            DiagnosticsLogger<DbLoggerCategory.Model> modelLogger,
-            DiagnosticsLogger<DbLoggerCategory.Model.Validation> validationLogger)
+        public override IModelValidator CreateModelValidator()
             => new SqlServerModelValidator(
-                new ModelValidatorDependencies(validationLogger, modelLogger),
+                new ModelValidatorDependencies(),
                 new RelationalModelValidatorDependencies(
                     new SqlServerTypeMappingSource(
                         TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestRelationalCommandBuilderFactory.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestRelationalCommandBuilderFactory.cs
@@ -14,19 +14,17 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 {
     public class TestRelationalCommandBuilderFactory : IRelationalCommandBuilderFactory
     {
-        private readonly IDiagnosticsLogger<DbLoggerCategory.Database.Command> _logger;
         private readonly IRelationalTypeMappingSource _typeMappingSource;
 
         public TestRelationalCommandBuilderFactory(
-            IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
             IRelationalTypeMappingSource typeMappingSource)
         {
-            _logger = logger;
             _typeMappingSource = typeMappingSource;
         }
 
-        public virtual IRelationalCommandBuilder Create()
-            => new TestRelationalCommandBuilder(_logger, _typeMappingSource);
+        public virtual IRelationalCommandBuilder Create(
+            IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger)
+            => new TestRelationalCommandBuilder(logger, _typeMappingSource);
 
         private class TestRelationalCommandBuilder : IRelationalCommandBuilder
         {

--- a/test/EFCore.SqlServer.Tests/SqlServerDatabaseCreatorTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerDatabaseCreatorTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
@@ -199,7 +200,8 @@ namespace Microsoft.EntityFrameworkCore
 
         private class FakeRelationalCommandBuilderFactory : IRelationalCommandBuilderFactory
         {
-            public IRelationalCommandBuilder Create() => new FakeRelationalCommandBuilder();
+            public IRelationalCommandBuilder Create(IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger)
+                => new FakeRelationalCommandBuilder();
         }
 
         private class FakeRelationalCommandBuilder : IRelationalCommandBuilder

--- a/test/EFCore.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Update.Internal;
@@ -205,9 +206,12 @@ namespace Microsoft.EntityFrameworkCore
                 _current = -blockSize + 1;
             }
 
-            public IRelationalCommand Build(string sql) => new FakeRelationalCommand(this);
+            public IRelationalCommand Build(string sql)
+                => new FakeRelationalCommand(this);
 
-            public RawSqlCommand Build(string sql, IEnumerable<object> parameters)
+            public RawSqlCommand Build(
+                string sql,
+                IEnumerable<object> parameters)
                 => new RawSqlCommand(
                     new FakeRelationalCommand(this),
                     new Dictionary<string, object>());

--- a/test/EFCore.SqlServer.Tests/Update/SqlServerModificationCommandBatchFactoryTest.cs
+++ b/test/EFCore.SqlServer.Tests/Update/SqlServerModificationCommandBatchFactoryTest.cs
@@ -25,19 +25,20 @@ namespace Microsoft.EntityFrameworkCore.Update
                 TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>());
 
             var factory = new SqlServerModificationCommandBatchFactory(
-                new RelationalCommandBuilderFactory(
-                    new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
-                    typeMapper),
-                new SqlServerSqlGenerationHelper(
-                    new RelationalSqlGenerationHelperDependencies()),
-                new SqlServerUpdateSqlGenerator(
-                    new UpdateSqlGeneratorDependencies(
-                        new SqlServerSqlGenerationHelper(
-                            new RelationalSqlGenerationHelperDependencies()),
-                        typeMapper)),
-                new TypedRelationalValueBufferFactoryFactory(
-                    new RelationalValueBufferFactoryDependencies(
-                        typeMapper, new CoreSingletonOptions())),
+                new ModificationCommandBatchFactoryDependencies(
+                    new RelationalCommandBuilderFactory(
+                        typeMapper),
+                    new SqlServerSqlGenerationHelper(
+                        new RelationalSqlGenerationHelperDependencies()),
+                    new SqlServerUpdateSqlGenerator(
+                        new UpdateSqlGeneratorDependencies(
+                            new SqlServerSqlGenerationHelper(
+                                new RelationalSqlGenerationHelperDependencies()),
+                            typeMapper)),
+                    new TypedRelationalValueBufferFactoryFactory(
+                        new RelationalValueBufferFactoryDependencies(
+                            typeMapper, new CoreSingletonOptions())),
+                    new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>()),
                 optionsBuilder.Options);
 
             var batch = factory.Create();
@@ -57,19 +58,20 @@ namespace Microsoft.EntityFrameworkCore.Update
                 TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>());
 
             var factory = new SqlServerModificationCommandBatchFactory(
-                new RelationalCommandBuilderFactory(
-                    new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
-                    typeMapper),
-                new SqlServerSqlGenerationHelper(
-                    new RelationalSqlGenerationHelperDependencies()),
-                new SqlServerUpdateSqlGenerator(
-                    new UpdateSqlGeneratorDependencies(
-                        new SqlServerSqlGenerationHelper(
-                            new RelationalSqlGenerationHelperDependencies()),
-                        typeMapper)),
-                new TypedRelationalValueBufferFactoryFactory(
-                    new RelationalValueBufferFactoryDependencies(
-                        typeMapper, new CoreSingletonOptions())),
+                new ModificationCommandBatchFactoryDependencies(
+                    new RelationalCommandBuilderFactory(
+                        typeMapper),
+                    new SqlServerSqlGenerationHelper(
+                        new RelationalSqlGenerationHelperDependencies()),
+                    new SqlServerUpdateSqlGenerator(
+                        new UpdateSqlGeneratorDependencies(
+                            new SqlServerSqlGenerationHelper(
+                                new RelationalSqlGenerationHelperDependencies()),
+                            typeMapper)),
+                    new TypedRelationalValueBufferFactoryFactory(
+                        new RelationalValueBufferFactoryDependencies(
+                            typeMapper, new CoreSingletonOptions())),
+                    new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>()),
                 optionsBuilder.Options);
 
             var batch = factory.Create();

--- a/test/EFCore.SqlServer.Tests/Update/SqlServerModificationCommandBatchTest.cs
+++ b/test/EFCore.SqlServer.Tests/Update/SqlServerModificationCommandBatchTest.cs
@@ -22,19 +22,20 @@ namespace Microsoft.EntityFrameworkCore.Update
                 TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>());
 
             var batch = new SqlServerModificationCommandBatch(
-                new RelationalCommandBuilderFactory(
-                    new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
-                    typeMapper),
-                new SqlServerSqlGenerationHelper(
-                    new RelationalSqlGenerationHelperDependencies()),
-                new SqlServerUpdateSqlGenerator(
-                    new UpdateSqlGeneratorDependencies(
-                        new SqlServerSqlGenerationHelper(
-                            new RelationalSqlGenerationHelperDependencies()),
-                        typeMapper)),
-                new TypedRelationalValueBufferFactoryFactory(
-                    new RelationalValueBufferFactoryDependencies(
-                        typeMapper, new CoreSingletonOptions())),
+                new ModificationCommandBatchFactoryDependencies(
+                    new RelationalCommandBuilderFactory(
+                        typeMapper),
+                    new SqlServerSqlGenerationHelper(
+                        new RelationalSqlGenerationHelperDependencies()),
+                    new SqlServerUpdateSqlGenerator(
+                        new UpdateSqlGeneratorDependencies(
+                            new SqlServerSqlGenerationHelper(
+                                new RelationalSqlGenerationHelperDependencies()),
+                            typeMapper)),
+                    new TypedRelationalValueBufferFactoryFactory(
+                        new RelationalValueBufferFactoryDependencies(
+                            typeMapper, new CoreSingletonOptions())),
+                    new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>()),
                 1);
 
             Assert.True(

--- a/test/EFCore.Sqlite.FunctionalTests/Query/BadDataSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/BadDataSqliteTest.cs
@@ -149,9 +149,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         private class BadDataCommandBuilderFactory : RelationalCommandBuilderFactory
         {
             public BadDataCommandBuilderFactory(
-                IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
                 IRelationalTypeMappingSource typeMappingSource)
-                : base(logger, typeMappingSource)
+                : base(typeMappingSource)
             {
             }
 

--- a/test/EFCore.Sqlite.FunctionalTests/TestUtilities/SqliteTestHelpers.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/TestUtilities/SqliteTestHelpers.cs
@@ -24,11 +24,9 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         protected override void UseProviderOptions(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder.UseSqlite(new SqliteConnection("Data Source=:memory:"));
 
-        public override IModelValidator CreateModelValidator(
-            DiagnosticsLogger<DbLoggerCategory.Model> modelLogger,
-            DiagnosticsLogger<DbLoggerCategory.Model.Validation> validationLogger)
+        public override IModelValidator CreateModelValidator()
             => new SqliteModelValidator(
-                new ModelValidatorDependencies(validationLogger, modelLogger),
+                new ModelValidatorDependencies(),
                 new RelationalModelValidatorDependencies(
                     new SqliteTypeMappingSource(
                         TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),

--- a/test/EFCore.Tests/DbContextServicesTest.cs
+++ b/test/EFCore.Tests/DbContextServicesTest.cs
@@ -512,7 +512,11 @@ namespace Microsoft.EntityFrameworkCore
 
         private class FakeModelSource : IModelSource
         {
-            public IModel GetModel(DbContext context, IConventionSetBuilder conventionSetBuilder, IModelValidator validator)
+            public IModel GetModel(
+                DbContext context,
+                IConventionSetBuilder conventionSetBuilder,
+                IModelValidator validator,
+                DiagnosticsLoggers loggers)
                 => new Model();
         }
 
@@ -555,7 +559,7 @@ namespace Microsoft.EntityFrameworkCore
             using (var context = new ConstructorTestContextWithOC1B(loggerFactory, memoryCache))
             {
                 Assert.NotNull(singleton = context.GetService<IInMemoryStoreCache>());
-                Assert.Same(loggerFactory, context.GetService<ILoggerFactory>());
+                Assert.NotSame(loggerFactory, context.GetService<ILoggerFactory>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
 
                 Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
@@ -566,7 +570,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 // Singleton internal services not the same because service provider caching is off
                 Assert.NotSame(singleton, context.GetService<IInMemoryStoreCache>());
-                Assert.Same(loggerFactory, context.GetService<ILoggerFactory>());
+                Assert.NotSame(loggerFactory, context.GetService<ILoggerFactory>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
             }
         }
@@ -622,7 +626,7 @@ namespace Microsoft.EntityFrameworkCore
             using (var context = new ConstructorTestContextWithOC3A(options))
             {
                 Assert.NotNull(singleton = context.GetService<IInMemoryStoreCache>());
-                Assert.Same(loggerFactory, context.GetService<ILoggerFactory>());
+                Assert.NotSame(loggerFactory, context.GetService<ILoggerFactory>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.NotSame(options, context.GetService<IDbContextOptions>());
 
@@ -633,7 +637,7 @@ namespace Microsoft.EntityFrameworkCore
             using (var context = new ConstructorTestContextWithOC3A(options))
             {
                 Assert.NotSame(singleton, context.GetService<IInMemoryStoreCache>());
-                Assert.Same(loggerFactory, context.GetService<ILoggerFactory>());
+                Assert.NotSame(loggerFactory, context.GetService<ILoggerFactory>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.NotSame(options, context.GetService<IDbContextOptions>());
             }
@@ -646,26 +650,23 @@ namespace Microsoft.EntityFrameworkCore
                 .AddEntityFrameworkInMemoryDatabase()
                 .BuildServiceProvider();
 
-            var singleton = new object[3];
+            var singleton = new object[2];
 
             using (var context = new ConstructorTestContextWithOC2A(internalServiceProvider))
             {
                 Assert.NotNull(singleton[0] = context.GetService<IInMemoryStoreCache>());
-                Assert.NotNull(singleton[1] = context.GetService<ILoggerFactory>());
-                Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
+                Assert.NotNull(singleton[1] = context.GetService<IMemoryCache>());
 
                 Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
 
                 Assert.Same(singleton[0], internalServiceProvider.GetService<IInMemoryStoreCache>());
-                Assert.Same(singleton[1], internalServiceProvider.GetService<ILoggerFactory>());
-                Assert.Same(singleton[2], internalServiceProvider.GetService<IMemoryCache>());
+                Assert.Same(singleton[1], internalServiceProvider.GetService<IMemoryCache>());
             }
 
             using (var context = new ConstructorTestContextWithOC2A(internalServiceProvider))
             {
                 Assert.Same(singleton[0], context.GetService<IInMemoryStoreCache>());
-                Assert.Same(singleton[1], context.GetService<ILoggerFactory>());
-                Assert.Same(singleton[2], context.GetService<IMemoryCache>());
+                Assert.Same(singleton[1], context.GetService<IMemoryCache>());
             }
         }
 
@@ -692,16 +693,13 @@ namespace Microsoft.EntityFrameworkCore
 
                 Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
 
-                // Singleton services not the same because service provider caching is off
                 Assert.Same(singleton[0], internalServiceProvider.GetService<IInMemoryStoreCache>());
-                Assert.Same(singleton[1], internalServiceProvider.GetService<ILoggerFactory>());
                 Assert.Same(singleton[2], internalServiceProvider.GetService<IMemoryCache>());
             }
 
             using (var context = new ConstructorTestContextWithOC3A(options))
             {
                 Assert.Same(singleton[0], context.GetService<IInMemoryStoreCache>());
-                Assert.Same(singleton[1], context.GetService<ILoggerFactory>());
                 Assert.Same(singleton[2], context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
             }
@@ -759,7 +757,7 @@ namespace Microsoft.EntityFrameworkCore
             using (var context = new ConstructorTestContext1A(options))
             {
                 Assert.NotNull(singleton = context.GetService<IInMemoryStoreCache>());
-                Assert.Same(loggerFactory, context.GetService<ILoggerFactory>());
+                Assert.NotSame(loggerFactory, context.GetService<ILoggerFactory>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
 
@@ -770,7 +768,7 @@ namespace Microsoft.EntityFrameworkCore
             using (var context = new ConstructorTestContext1A(options))
             {
                 Assert.NotSame(singleton, context.GetService<IInMemoryStoreCache>());
-                Assert.Same(loggerFactory, context.GetService<ILoggerFactory>());
+                Assert.NotSame(loggerFactory, context.GetService<ILoggerFactory>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
             }
@@ -788,27 +786,24 @@ namespace Microsoft.EntityFrameworkCore
                 .UseInternalServiceProvider(internalServiceProvider)
                 .Options;
 
-            var singleton = new object[3];
+            var singleton = new object[2];
 
             using (var context = new ConstructorTestContext1A(options))
             {
                 Assert.NotNull(singleton[0] = context.GetService<IInMemoryStoreCache>());
-                Assert.NotNull(singleton[1] = context.GetService<ILoggerFactory>());
-                Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
+                Assert.NotNull(singleton[1] = context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
 
                 Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
 
                 Assert.Same(singleton[0], internalServiceProvider.GetService<IInMemoryStoreCache>());
-                Assert.Same(singleton[1], internalServiceProvider.GetService<ILoggerFactory>());
-                Assert.Same(singleton[2], internalServiceProvider.GetService<IMemoryCache>());
+                Assert.Same(singleton[1], internalServiceProvider.GetService<IMemoryCache>());
             }
 
             using (var context = new ConstructorTestContext1A(options))
             {
                 Assert.Same(singleton[0], context.GetService<IInMemoryStoreCache>());
-                Assert.Same(singleton[1], context.GetService<ILoggerFactory>());
-                Assert.Same(singleton[2], context.GetService<IMemoryCache>());
+                Assert.Same(singleton[1], context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
             }
         }
@@ -821,13 +816,12 @@ namespace Microsoft.EntityFrameworkCore
                 .UseInMemoryDatabase(Guid.NewGuid().ToString())
                 .Options;
 
-            var singleton = new object[3];
+            var singleton = new object[2];
 
             using (var context = new DbContext(options))
             {
                 Assert.NotNull(singleton[0] = context.GetService<IInMemoryStoreCache>());
-                Assert.NotNull(singleton[1] = context.GetService<ILoggerFactory>());
-                Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
+                Assert.NotNull(singleton[1] = context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
 
                 Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
@@ -836,8 +830,7 @@ namespace Microsoft.EntityFrameworkCore
             using (var context = new DbContext(options))
             {
                 Assert.Same(singleton[0], context.GetService<IInMemoryStoreCache>());
-                Assert.Same(singleton[1], context.GetService<ILoggerFactory>());
-                Assert.Same(singleton[2], context.GetService<IMemoryCache>());
+                Assert.Same(singleton[1], context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
             }
         }
@@ -896,27 +889,24 @@ namespace Microsoft.EntityFrameworkCore
                 .UseInternalServiceProvider(internalServiceProvider)
                 .Options;
 
-            var singleton = new object[3];
+            var singleton = new object[2];
 
             using (var context = new DbContext(options))
             {
                 Assert.NotNull(singleton[0] = context.GetService<IInMemoryStoreCache>());
-                Assert.NotNull(singleton[1] = context.GetService<ILoggerFactory>());
-                Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
+                Assert.NotNull(singleton[1] = context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
 
                 Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
 
                 Assert.Same(singleton[0], internalServiceProvider.GetService<IInMemoryStoreCache>());
-                Assert.Same(singleton[1], internalServiceProvider.GetService<ILoggerFactory>());
-                Assert.Same(singleton[2], internalServiceProvider.GetService<IMemoryCache>());
+                Assert.Same(singleton[1], internalServiceProvider.GetService<IMemoryCache>());
             }
 
             using (var context = new DbContext(options))
             {
                 Assert.Same(singleton[0], context.GetService<IInMemoryStoreCache>());
-                Assert.Same(singleton[1], context.GetService<ILoggerFactory>());
-                Assert.Same(singleton[2], context.GetService<IMemoryCache>());
+                Assert.Same(singleton[1], context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
             }
         }
@@ -983,9 +973,10 @@ namespace Microsoft.EntityFrameworkCore
         {
             var appServiceProvider = new ServiceCollection()
                 .AddDbContext<ConstructorTestContextWithOC1B>()
+                .AddLogging()
+                .AddMemoryCache()
                 .BuildServiceProvider();
 
-            var loggerFactory = appServiceProvider.GetService<ILoggerFactory>();
             var memoryCache = appServiceProvider.GetService<IMemoryCache>();
 
             IInMemoryStoreCache singleton;
@@ -997,7 +988,6 @@ namespace Microsoft.EntityFrameworkCore
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC1B>();
 
                 Assert.NotNull(singleton = context.GetService<IInMemoryStoreCache>());
-                Assert.Same(loggerFactory, context.GetService<ILoggerFactory>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
 
                 Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
@@ -1011,7 +1001,6 @@ namespace Microsoft.EntityFrameworkCore
 
                 // Singleton internal services not the same because service provider caching is off
                 Assert.NotSame(singleton, context.GetService<IInMemoryStoreCache>());
-                Assert.Same(loggerFactory, context.GetService<ILoggerFactory>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
             }
         }
@@ -1034,7 +1023,7 @@ namespace Microsoft.EntityFrameworkCore
                 .AddScoped<SomeScopedAppService>()
                 .BuildServiceProvider();
 
-            var singleton = new object[4];
+            var singleton = new object[3];
             SomeAppService appSingleton;
             SomeScopedAppService appScoped;
 
@@ -1045,9 +1034,8 @@ namespace Microsoft.EntityFrameworkCore
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
 
                 Assert.NotNull(singleton[0] = context.GetService<IInMemoryStoreCache>());
-                Assert.NotNull(singleton[1] = context.GetService<ILoggerFactory>());
-                Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
-                Assert.NotNull(singleton[3] = context.GetService<IDbContextOptions>());
+                Assert.NotNull(singleton[1] = context.GetService<IMemoryCache>());
+                Assert.NotNull(singleton[2] = context.GetService<IDbContextOptions>());
 
                 Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
 
@@ -1067,9 +1055,8 @@ namespace Microsoft.EntityFrameworkCore
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
 
                 Assert.NotSame(singleton[0], context.GetService<IInMemoryStoreCache>());
-                Assert.Same(singleton[1], context.GetService<ILoggerFactory>());
-                Assert.Same(singleton[2], context.GetService<IMemoryCache>());
-                Assert.NotSame(singleton[3], context.GetService<IDbContextOptions>());
+                Assert.NotSame(singleton[1], context.GetService<IMemoryCache>());
+                Assert.NotSame(singleton[2], context.GetService<IDbContextOptions>());
 
                 var scoped = context.GetService<SomeScopedAppService>();
                 Assert.NotSame(appScoped, scoped);
@@ -1087,8 +1074,8 @@ namespace Microsoft.EntityFrameworkCore
                 .AddDbContext<ConstructorTestContextWithOC3A>(b => b.UseInMemoryDatabase(Guid.NewGuid().ToString()))
                 .BuildServiceProvider();
 
-            var loggerFactory = appServiceProvider.GetService<ILoggerFactory>();
-            var memoryCache = appServiceProvider.GetService<IMemoryCache>();
+            ILoggerFactory loggerFactory;
+            IMemoryCache memoryCache;
 
             IInMemoryStoreCache singleton;
             IDbContextOptions options;
@@ -1100,8 +1087,8 @@ namespace Microsoft.EntityFrameworkCore
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
 
                 Assert.NotNull(singleton = context.GetService<IInMemoryStoreCache>());
-                Assert.Same(loggerFactory, context.GetService<ILoggerFactory>());
-                Assert.Same(memoryCache, context.GetService<IMemoryCache>());
+                Assert.NotNull(loggerFactory = context.GetService<ILoggerFactory>());
+                Assert.NotNull(memoryCache = context.GetService<IMemoryCache>());
                 Assert.NotNull(options = context.GetService<IDbContextOptions>());
 
                 Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
@@ -1115,8 +1102,8 @@ namespace Microsoft.EntityFrameworkCore
 
                 // Singleton services not the same because service provider caching is off
                 Assert.NotSame(singleton, context.GetService<IInMemoryStoreCache>());
-                Assert.Same(loggerFactory, context.GetService<ILoggerFactory>());
-                Assert.Same(memoryCache, context.GetService<IMemoryCache>());
+                Assert.NotSame(loggerFactory, context.GetService<ILoggerFactory>());
+                Assert.NotSame(memoryCache, context.GetService<IMemoryCache>());
                 Assert.NotSame(options, context.GetService<IDbContextOptions>());
             }
         }
@@ -1138,7 +1125,6 @@ namespace Microsoft.EntityFrameworkCore
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC2A>();
 
                 Assert.NotNull(singleton[0] = context.GetService<IInMemoryStoreCache>());
-                Assert.NotNull(singleton[1] = context.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
 
                 Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
@@ -1151,7 +1137,6 @@ namespace Microsoft.EntityFrameworkCore
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC2A>();
 
                 Assert.Same(singleton[0], context.GetService<IInMemoryStoreCache>());
-                Assert.Same(singleton[1], context.GetService<ILoggerFactory>());
                 Assert.Same(singleton[2], context.GetService<IMemoryCache>());
             }
         }
@@ -1169,7 +1154,7 @@ namespace Microsoft.EntityFrameworkCore
                         .UseInternalServiceProvider(internalServiceProvider))
                 .BuildServiceProvider();
 
-            var singleton = new object[4];
+            var singleton = new object[3];
 
             using (var serviceScope = appServiceProvider
                 .GetRequiredService<IServiceScopeFactory>()
@@ -1178,9 +1163,8 @@ namespace Microsoft.EntityFrameworkCore
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
 
                 Assert.NotNull(singleton[0] = context.GetService<IInMemoryStoreCache>());
-                Assert.NotNull(singleton[1] = context.GetService<ILoggerFactory>());
-                Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
-                Assert.NotNull(singleton[3] = context.GetService<IDbContextOptions>());
+                Assert.NotNull(singleton[1] = context.GetService<IMemoryCache>());
+                Assert.NotNull(singleton[2] = context.GetService<IDbContextOptions>());
 
                 Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
             }
@@ -1192,9 +1176,8 @@ namespace Microsoft.EntityFrameworkCore
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
 
                 Assert.Same(singleton[0], context.GetService<IInMemoryStoreCache>());
-                Assert.Same(singleton[1], context.GetService<ILoggerFactory>());
-                Assert.Same(singleton[2], context.GetService<IMemoryCache>());
-                Assert.NotSame(singleton[3], context.GetService<IDbContextOptions>());
+                Assert.Same(singleton[1], context.GetService<IMemoryCache>());
+                Assert.NotSame(singleton[2], context.GetService<IDbContextOptions>());
             }
         }
 
@@ -1229,9 +1212,8 @@ namespace Microsoft.EntityFrameworkCore
                     : serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
 
                 Assert.NotNull(singleton[0] = context.GetService<IInMemoryStoreCache>());
-                Assert.NotNull(singleton[1] = context.GetService<ILoggerFactory>());
-                Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
-                Assert.NotNull(singleton[3] = context.GetService<IDbContextOptions>());
+                Assert.NotNull(singleton[1] = context.GetService<IMemoryCache>());
+                Assert.NotNull(singleton[2] = context.GetService<IDbContextOptions>());
 
                 Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
             }
@@ -1245,9 +1227,8 @@ namespace Microsoft.EntityFrameworkCore
                     : serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
 
                 Assert.Same(singleton[0], context.GetService<IInMemoryStoreCache>());
-                Assert.Same(singleton[1], context.GetService<ILoggerFactory>());
-                Assert.Same(singleton[2], context.GetService<IMemoryCache>());
-                Assert.NotSame(singleton[3], context.GetService<IDbContextOptions>());
+                Assert.Same(singleton[1], context.GetService<IMemoryCache>());
+                Assert.NotSame(singleton[2], context.GetService<IDbContextOptions>());
             }
         }
 
@@ -1264,7 +1245,6 @@ namespace Microsoft.EntityFrameworkCore
                     singletonOptions ? ServiceLifetime.Singleton : ServiceLifetime.Scoped)
                 .BuildServiceProvider();
 
-            var loggerFactory = appServiceProvider.GetService<ILoggerFactory>();
             var memoryCache = appServiceProvider.GetService<IMemoryCache>();
 
             IInMemoryStoreCache singleton;
@@ -1277,7 +1257,6 @@ namespace Microsoft.EntityFrameworkCore
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
 
                 Assert.NotNull(singleton = context.GetService<IInMemoryStoreCache>());
-                Assert.Same(loggerFactory, context.GetService<ILoggerFactory>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.NotNull(options = context.GetService<IDbContextOptions>());
 
@@ -1291,7 +1270,6 @@ namespace Microsoft.EntityFrameworkCore
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
 
                 Assert.Same(singleton, context.GetService<IInMemoryStoreCache>());
-                Assert.Same(loggerFactory, context.GetService<ILoggerFactory>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 if (singletonOptions)
                 {
@@ -1313,7 +1291,7 @@ namespace Microsoft.EntityFrameworkCore
                        .UseInMemoryDatabase(Guid.NewGuid().ToString()))
                 .BuildServiceProvider();
 
-            var singleton = new object[4];
+            var singleton = new object[3];
 
             using (var serviceScope = appServiceProvider
                 .GetRequiredService<IServiceScopeFactory>()
@@ -1322,9 +1300,8 @@ namespace Microsoft.EntityFrameworkCore
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
 
                 Assert.NotNull(singleton[0] = context.GetService<IInMemoryStoreCache>());
-                Assert.NotNull(singleton[1] = context.GetService<ILoggerFactory>());
-                Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
-                Assert.NotNull(singleton[3] = context.GetService<IDbContextOptions>());
+                Assert.NotNull(singleton[1] = context.GetService<IMemoryCache>());
+                Assert.NotNull(singleton[2] = context.GetService<IDbContextOptions>());
 
                 Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
             }
@@ -1336,9 +1313,8 @@ namespace Microsoft.EntityFrameworkCore
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
 
                 Assert.NotSame(singleton[0], context.GetService<IInMemoryStoreCache>());
-                Assert.Same(singleton[1], context.GetService<ILoggerFactory>());
-                Assert.Same(singleton[2], context.GetService<IMemoryCache>());
-                Assert.NotSame(singleton[3], context.GetService<IDbContextOptions>());
+                Assert.NotSame(singleton[1], context.GetService<IMemoryCache>());
+                Assert.NotSame(singleton[2], context.GetService<IDbContextOptions>());
             }
         }
 
@@ -1351,9 +1327,8 @@ namespace Microsoft.EntityFrameworkCore
                         .UseInMemoryDatabase(Guid.NewGuid().ToString()))
                 .BuildServiceProvider();
 
-            var loggerFactory = appServiceProvider.GetService<ILoggerFactory>();
-            var memoryCache = appServiceProvider.GetService<IMemoryCache>();
-
+            ILoggerFactory loggerFactory;
+            IMemoryCache memoryCache;
             IInMemoryStoreCache singleton;
             IDbContextOptions options;
 
@@ -1364,8 +1339,8 @@ namespace Microsoft.EntityFrameworkCore
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
 
                 Assert.NotNull(singleton = context.GetService<IInMemoryStoreCache>());
-                Assert.Same(loggerFactory, context.GetService<ILoggerFactory>());
-                Assert.Same(memoryCache, context.GetService<IMemoryCache>());
+                Assert.NotNull(loggerFactory = context.GetService<ILoggerFactory>());
+                Assert.NotNull(memoryCache = context.GetService<IMemoryCache>());
                 Assert.NotNull(options = context.GetService<IDbContextOptions>());
 
                 Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
@@ -1378,8 +1353,8 @@ namespace Microsoft.EntityFrameworkCore
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
 
                 Assert.NotSame(singleton, context.GetService<IInMemoryStoreCache>());
-                Assert.Same(loggerFactory, context.GetService<ILoggerFactory>());
-                Assert.Same(memoryCache, context.GetService<IMemoryCache>());
+                Assert.NotSame(loggerFactory, context.GetService<ILoggerFactory>());
+                Assert.NotSame(memoryCache, context.GetService<IMemoryCache>());
                 Assert.NotSame(options, context.GetService<IDbContextOptions>());
             }
         }
@@ -1397,7 +1372,7 @@ namespace Microsoft.EntityFrameworkCore
                         .UseInternalServiceProvider(internalServiceProvider))
                 .BuildServiceProvider();
 
-            var singleton = new object[4];
+            var singleton = new object[3];
 
             using (var serviceScope = appServiceProvider
                 .GetRequiredService<IServiceScopeFactory>()
@@ -1406,9 +1381,8 @@ namespace Microsoft.EntityFrameworkCore
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
 
                 Assert.NotNull(singleton[0] = context.GetService<IInMemoryStoreCache>());
-                Assert.NotNull(singleton[1] = context.GetService<ILoggerFactory>());
-                Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
-                Assert.NotNull(singleton[3] = context.GetService<IDbContextOptions>());
+                Assert.NotNull(singleton[1] = context.GetService<IMemoryCache>());
+                Assert.NotNull(singleton[2] = context.GetService<IDbContextOptions>());
 
                 Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
             }
@@ -1420,9 +1394,8 @@ namespace Microsoft.EntityFrameworkCore
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
 
                 Assert.Same(singleton[0], context.GetService<IInMemoryStoreCache>());
-                Assert.Same(singleton[1], context.GetService<ILoggerFactory>());
-                Assert.Same(singleton[2], context.GetService<IMemoryCache>());
-                Assert.NotSame(singleton[3], context.GetService<IDbContextOptions>());
+                Assert.Same(singleton[1], context.GetService<IMemoryCache>());
+                Assert.NotSame(singleton[2], context.GetService<IDbContextOptions>());
             }
         }
 
@@ -1435,7 +1408,7 @@ namespace Microsoft.EntityFrameworkCore
                     (p, b) => b.UseInMemoryDatabase(Guid.NewGuid().ToString()).UseInternalServiceProvider(p))
                 .BuildServiceProvider();
 
-            var singleton = new object[4];
+            var singleton = new object[3];
 
             using (var serviceScope = appServiceProvider
                 .GetRequiredService<IServiceScopeFactory>()
@@ -1444,9 +1417,8 @@ namespace Microsoft.EntityFrameworkCore
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
 
                 Assert.NotNull(singleton[0] = context.GetService<IInMemoryStoreCache>());
-                Assert.NotNull(singleton[1] = context.GetService<ILoggerFactory>());
-                Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
-                Assert.NotNull(singleton[3] = context.GetService<IDbContextOptions>());
+                Assert.NotNull(singleton[1] = context.GetService<IMemoryCache>());
+                Assert.NotNull(singleton[2] = context.GetService<IDbContextOptions>());
 
                 Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
             }
@@ -1458,9 +1430,8 @@ namespace Microsoft.EntityFrameworkCore
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
 
                 Assert.Same(singleton[0], context.GetService<IInMemoryStoreCache>());
-                Assert.Same(singleton[1], context.GetService<ILoggerFactory>());
-                Assert.Same(singleton[2], context.GetService<IMemoryCache>());
-                Assert.NotSame(singleton[3], context.GetService<IDbContextOptions>());
+                Assert.Same(singleton[1], context.GetService<IMemoryCache>());
+                Assert.NotSame(singleton[2], context.GetService<IDbContextOptions>());
             }
         }
 
@@ -1473,7 +1444,6 @@ namespace Microsoft.EntityFrameworkCore
                     (p, b) => b.UseInMemoryDatabase(Guid.NewGuid().ToString()).UseInternalServiceProvider(p))
                 .BuildServiceProvider();
 
-            var loggerFactory = appServiceProvider.GetService<ILoggerFactory>();
             var memoryCache = appServiceProvider.GetService<IMemoryCache>();
 
             IInMemoryStoreCache singleton;
@@ -1486,7 +1456,6 @@ namespace Microsoft.EntityFrameworkCore
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
 
                 Assert.NotNull(singleton = context.GetService<IInMemoryStoreCache>());
-                Assert.Same(loggerFactory, context.GetService<ILoggerFactory>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.NotNull(options = context.GetService<IDbContextOptions>());
 
@@ -1500,7 +1469,6 @@ namespace Microsoft.EntityFrameworkCore
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
 
                 Assert.Same(singleton, context.GetService<IInMemoryStoreCache>());
-                Assert.Same(loggerFactory, context.GetService<ILoggerFactory>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.NotSame(options, context.GetService<IDbContextOptions>());
             }
@@ -1524,9 +1492,8 @@ namespace Microsoft.EntityFrameworkCore
                 var context = serviceScope.ServiceProvider.GetService<DbContext>();
 
                 Assert.NotNull(singleton[0] = context.GetService<IInMemoryStoreCache>());
-                Assert.NotNull(singleton[1] = context.GetService<ILoggerFactory>());
-                Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
-                Assert.NotNull(singleton[3] = context.GetService<IDbContextOptions>());
+                Assert.NotNull(singleton[1] = context.GetService<IMemoryCache>());
+                Assert.NotNull(singleton[2] = context.GetService<IDbContextOptions>());
 
                 Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
             }
@@ -1538,9 +1505,8 @@ namespace Microsoft.EntityFrameworkCore
                 var context = serviceScope.ServiceProvider.GetService<DbContext>();
 
                 Assert.NotSame(singleton[0], context.GetService<IInMemoryStoreCache>());
-                Assert.Same(singleton[1], context.GetService<ILoggerFactory>());
-                Assert.Same(singleton[2], context.GetService<IMemoryCache>());
-                Assert.NotSame(singleton[3], context.GetService<IDbContextOptions>());
+                Assert.NotSame(singleton[1], context.GetService<IMemoryCache>());
+                Assert.NotSame(singleton[2], context.GetService<IDbContextOptions>());
             }
         }
 
@@ -1553,9 +1519,10 @@ namespace Microsoft.EntityFrameworkCore
                         .UseInMemoryDatabase(Guid.NewGuid().ToString())
                         .UseMemoryCache(p.GetService<IMemoryCache>())
                         .UseLoggerFactory(p.GetService<ILoggerFactory>()))
+                .AddMemoryCache()
+                .AddLogging()
                 .BuildServiceProvider();
 
-            var loggerFactory = appServiceProvider.GetService<ILoggerFactory>();
             var memoryCache = appServiceProvider.GetService<IMemoryCache>();
 
             IDbContextOptions options;
@@ -1568,7 +1535,6 @@ namespace Microsoft.EntityFrameworkCore
                 var context = serviceScope.ServiceProvider.GetService<DbContext>();
 
                 Assert.NotNull(singleton = context.GetService<IInMemoryStoreCache>());
-                Assert.Same(loggerFactory, context.GetService<ILoggerFactory>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.NotNull(options = context.GetService<IDbContextOptions>());
 
@@ -1582,7 +1548,6 @@ namespace Microsoft.EntityFrameworkCore
                 var context = serviceScope.ServiceProvider.GetService<DbContext>();
 
                 Assert.NotSame(singleton, context.GetService<IInMemoryStoreCache>());
-                Assert.Same(loggerFactory, context.GetService<ILoggerFactory>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.NotSame(options, context.GetService<IDbContextOptions>());
             }
@@ -1596,7 +1561,7 @@ namespace Microsoft.EntityFrameworkCore
                 .AddDbContext<DbContext>((p, b) => b.UseInMemoryDatabase(Guid.NewGuid().ToString()).UseInternalServiceProvider(p))
                 .BuildServiceProvider();
 
-            var singleton = new object[4];
+            var singleton = new object[3];
 
             using (var serviceScope = appServiceProvider
                 .GetRequiredService<IServiceScopeFactory>()
@@ -1605,9 +1570,8 @@ namespace Microsoft.EntityFrameworkCore
                 var context = serviceScope.ServiceProvider.GetService<DbContext>();
 
                 Assert.NotNull(singleton[0] = context.GetService<IInMemoryStoreCache>());
-                Assert.NotNull(singleton[1] = context.GetService<ILoggerFactory>());
-                Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
-                Assert.NotNull(singleton[3] = context.GetService<IDbContextOptions>());
+                Assert.NotNull(singleton[1] = context.GetService<IMemoryCache>());
+                Assert.NotNull(singleton[2] = context.GetService<IDbContextOptions>());
 
                 Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
             }
@@ -1619,9 +1583,8 @@ namespace Microsoft.EntityFrameworkCore
                 var context = serviceScope.ServiceProvider.GetService<DbContext>();
 
                 Assert.Same(singleton[0], context.GetService<IInMemoryStoreCache>());
-                Assert.Same(singleton[1], context.GetService<ILoggerFactory>());
-                Assert.Same(singleton[2], context.GetService<IMemoryCache>());
-                Assert.NotSame(singleton[3], context.GetService<IDbContextOptions>());
+                Assert.Same(singleton[1], context.GetService<IMemoryCache>());
+                Assert.NotSame(singleton[2], context.GetService<IDbContextOptions>());
             }
         }
 
@@ -1875,7 +1838,7 @@ namespace Microsoft.EntityFrameworkCore
                         .AddTransient<ConstructorTestContextWithOC3A>()
                         .BuildServiceProvider());
 
-            var singleton = new object[3];
+            var singleton = new object[2];
 
             using (var serviceScope = appServiceProvider
                 .GetRequiredService<IServiceScopeFactory>()
@@ -1887,8 +1850,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotSame(context1, context2);
 
                 Assert.NotNull(singleton[0] = context1.GetService<IInMemoryStoreCache>());
-                Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
-                Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
+                Assert.NotNull(singleton[1] = context1.GetService<IMemoryCache>());
 
                 Assert.NotNull(context1.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
 
@@ -1907,8 +1869,7 @@ namespace Microsoft.EntityFrameworkCore
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
 
                 Assert.Same(singleton[0], context.GetService<IInMemoryStoreCache>());
-                Assert.Same(singleton[1], context.GetService<ILoggerFactory>());
-                Assert.Same(singleton[2], context.GetService<IMemoryCache>());
+                Assert.Same(singleton[1], context.GetService<IMemoryCache>());
 
                 context.Dispose();
                 Assert.Throws<ObjectDisposedException>(() => context.Model);
@@ -2055,7 +2016,7 @@ namespace Microsoft.EntityFrameworkCore
                     .AddTransient<DbContext>()
                     .BuildServiceProvider();
 
-            var singleton = new object[3];
+            var singleton = new object[2];
 
             using (var serviceScope = appServiceProvider
                 .GetRequiredService<IServiceScopeFactory>()
@@ -2067,8 +2028,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotSame(context1, context2);
 
                 Assert.NotNull(singleton[0] = context1.GetService<IInMemoryStoreCache>());
-                Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
-                Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
+                Assert.NotNull(singleton[1] = context1.GetService<IMemoryCache>());
 
                 Assert.NotNull(context1.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
 
@@ -2087,8 +2047,7 @@ namespace Microsoft.EntityFrameworkCore
                 var context = serviceScope.ServiceProvider.GetService<DbContext>();
 
                 Assert.NotSame(singleton[0], context.GetService<IInMemoryStoreCache>());
-                Assert.Same(singleton[1], context.GetService<ILoggerFactory>());
-                Assert.Same(singleton[2], context.GetService<IMemoryCache>());
+                Assert.NotSame(singleton[1], context.GetService<IMemoryCache>());
 
                 context.Dispose();
                 Assert.Throws<ObjectDisposedException>(() => context.Model);
@@ -2129,7 +2088,7 @@ namespace Microsoft.EntityFrameworkCore
 
             var appServiceProvider = serviceCollection.BuildServiceProvider();
 
-            var singleton = new object[3];
+            var singleton = new object[2];
 
             using (var serviceScope = appServiceProvider
                 .GetRequiredService<IServiceScopeFactory>()
@@ -2141,8 +2100,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotSame(context1, context2);
 
                 Assert.NotNull(singleton[0] = context1.GetService<IInMemoryStoreCache>());
-                Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
-                Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
+                Assert.NotNull(singleton[1] = context1.GetService<IMemoryCache>());
 
                 Assert.NotNull(context1.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
 
@@ -2161,8 +2119,7 @@ namespace Microsoft.EntityFrameworkCore
                 var context = serviceScope.ServiceProvider.GetService<DbContext>();
 
                 Assert.Same(singleton[0], context.GetService<IInMemoryStoreCache>());
-                Assert.Same(singleton[1], context.GetService<ILoggerFactory>());
-                Assert.Same(singleton[2], context.GetService<IMemoryCache>());
+                Assert.Same(singleton[1], context.GetService<IMemoryCache>());
 
                 context.Dispose();
                 Assert.Throws<ObjectDisposedException>(() => context.Model);
@@ -2218,12 +2175,12 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
 
                 // ReSharper disable once PossibleNullReferenceException
-                Assert.Equal(2, loggerFactory.CreatedLoggers.Count(n => n == DbLoggerCategory.Infrastructure.Name));
+                Assert.Equal(3, loggerFactory.CreatedLoggers.Count(n => n == DbLoggerCategory.Infrastructure.Name));
             }
 
             Assert.NotNull(appServiceProvider.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
             // ReSharper disable once PossibleNullReferenceException
-            Assert.Equal(2, loggerFactory.CreatedLoggers.Count(n => n == DbLoggerCategory.Infrastructure.Name));
+            Assert.Equal(3, loggerFactory.CreatedLoggers.Count(n => n == DbLoggerCategory.Infrastructure.Name));
         }
 
         [Fact]

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTestBase.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTestBase.cs
@@ -217,8 +217,10 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
             conventionSet.ModelBuiltConventions.Add(
                 new ValidatingConvention(
-                    TestHelpers.CreateModelValidator(
-                        CreateModelLogger(sensitiveDataLoggingEnabled), CreateValidationLogger(sensitiveDataLoggingEnabled))));
+                    TestHelpers.CreateModelValidator(),
+                    new Diagnostics.DiagnosticsLoggers(
+                        CreateModelLogger(sensitiveDataLoggingEnabled),
+                        CreateValidationLogger(sensitiveDataLoggingEnabled))));
 
             return new ModelBuilder(conventionSet);
         }

--- a/test/EFCore.Tests/Metadata/Conventions/ConventionSetBuilderTests.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/ConventionSetBuilderTests.cs
@@ -3,6 +3,7 @@
 
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -24,8 +25,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             return model;
         }
 
-        protected virtual ConventionSet GetConventionSet() =>
-            InMemoryTestHelpers.Instance.CreateContextServices().GetRequiredService<ICoreConventionSetBuilder>().CreateConventionSet();
+        protected virtual ConventionSet GetConventionSet()
+        {
+            var contextServices = InMemoryTestHelpers.Instance.CreateContextServices();
+
+            return contextServices.GetRequiredService<ICoreConventionSetBuilder>()
+                .CreateConventionSet(
+                    new DiagnosticsLoggers(
+                        contextServices.GetService<IDiagnosticsLogger<DbLoggerCategory.Model>>()));
+        }
 
         [Table("ProductTable")]
         protected class Product

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/BackingFieldConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/BackingFieldConventionTest.cs
@@ -3,6 +3,7 @@
 
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
 // ReSharper disable ArrangeAccessorOwnerBody
@@ -68,7 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         {
             var entityType = new Model().AddEntityType(typeof(TheDarkSideOfTheMoon));
             var property = entityType.AddProperty("SpeakToMe", typeof(int));
-            new BackingFieldConvention().Apply(property.Builder);
+            new BackingFieldConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(property.Builder);
 
             Assert.Null(property.GetFieldName());
         }
@@ -118,7 +119,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         {
             var entityType = new Model().AddEntityType(typeof(TheDarkerSideOfTheMoon));
             var property = entityType.AddProperty("SpeakToMe", typeof(int));
-            new BackingFieldConvention().Apply(property.Builder);
+            new BackingFieldConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(property.Builder);
 
             Assert.Null(property.GetFieldName());
         }
@@ -128,7 +129,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var entityType = new Model().AddEntityType(typeof(TEntity));
             var property = entityType.AddProperty(propertyName, typeof(int));
 
-            new BackingFieldConvention().Apply(property.Builder);
+            new BackingFieldConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(property.Builder);
 
             Assert.Equal(fieldName, property.GetFieldName());
         }
@@ -139,7 +140,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var entityType = new Model().AddEntityType(typeof(TheDarkSide));
             var property = entityType.AddProperty(OfTheMoon.TheGreatGigInTheSkyProperty);
 
-            new BackingFieldConvention().Apply(property.Builder);
+            new BackingFieldConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(property.Builder);
 
             Assert.Equal("_theGreatGigInTheSky", property.GetFieldName());
         }
@@ -150,7 +151,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var entityType = new Model().AddEntityType(typeof(TheDarkSide));
             var property = entityType.AddProperty(TheDarkSide.OnBaseProperty);
 
-            new BackingFieldConvention().Apply(property.Builder);
+            new BackingFieldConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(property.Builder);
 
             Assert.Equal("_onBase", property.GetFieldName());
         }
@@ -162,7 +163,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var property = entityType.AddProperty("OnTheRun", typeof(int));
             property.SetField("m_onTheRun");
 
-            new BackingFieldConvention().Apply(property.Builder);
+            new BackingFieldConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(property.Builder);
 
             Assert.Equal("m_onTheRun", property.GetFieldName());
         }
@@ -174,7 +175,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var property = entityType.AddProperty("OnTheRun", typeof(int));
             property.SetField("m_onTheRun", ConfigurationSource.DataAnnotation);
 
-            new BackingFieldConvention().Apply(property.Builder);
+            new BackingFieldConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(property.Builder);
 
             Assert.Equal("m_onTheRun", property.GetFieldName());
         }

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/BaseTypeDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/BaseTypeDiscoveryConventionTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
@@ -16,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var entityBuilderC = entityBuilderA.ModelBuilder.Entity(typeof(C), ConfigurationSource.Explicit);
             Assert.Null(entityBuilderC.Metadata.BaseType);
 
-            new BaseTypeDiscoveryConvention().Apply(entityBuilderC);
+            new BaseTypeDiscoveryConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(entityBuilderC);
 
             Assert.Same(entityBuilderB.Metadata, entityBuilderC.Metadata.BaseType);
         }
@@ -28,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var entityBuilderC = entityBuilderA.ModelBuilder.Entity(typeof(C), ConfigurationSource.Explicit);
             Assert.Null(entityBuilderC.Metadata.BaseType);
 
-            new BaseTypeDiscoveryConvention().Apply(entityBuilderC);
+            new BaseTypeDiscoveryConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(entityBuilderC);
 
             Assert.Same(entityBuilderA.Metadata, entityBuilderC.Metadata.BaseType);
         }
@@ -41,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var entityBuilderC = entityBuilderA.ModelBuilder.Entity(typeof(C), ConfigurationSource.Explicit);
             entityBuilderC.HasBaseType(entityBuilderA.Metadata, ConfigurationSource.Convention);
 
-            new BaseTypeDiscoveryConvention().Apply(entityBuilderC);
+            new BaseTypeDiscoveryConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(entityBuilderC);
 
             Assert.Same(entityBuilderB.Metadata, entityBuilderC.Metadata.BaseType);
         }

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/DerivedTypeDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/DerivedTypeDiscoveryConventionTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
@@ -17,12 +18,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Null(entityBuilderB.Metadata.BaseType);
             Assert.Null(entityBuilderC.Metadata.BaseType);
 
-            new DerivedTypeDiscoveryConvention().Apply(entityBuilderA);
+            new DerivedTypeDiscoveryConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(entityBuilderA);
 
             Assert.Same(entityBuilderA.Metadata, entityBuilderB.Metadata.BaseType);
             Assert.Same(entityBuilderA.Metadata, entityBuilderC.Metadata.BaseType);
 
-            new DerivedTypeDiscoveryConvention().Apply(entityBuilderB);
+            new DerivedTypeDiscoveryConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(entityBuilderB);
 
             Assert.Same(entityBuilderA.Metadata, entityBuilderB.Metadata.BaseType);
             Assert.Same(entityBuilderB.Metadata, entityBuilderC.Metadata.BaseType);
@@ -36,7 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var entityBuilderC = entityBuilderA.ModelBuilder.Entity(typeof(C), ConfigurationSource.Explicit);
             entityBuilderC.HasBaseType(entityBuilderB.Metadata, ConfigurationSource.DataAnnotation);
 
-            new DerivedTypeDiscoveryConvention().Apply(entityBuilderA);
+            new DerivedTypeDiscoveryConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(entityBuilderA);
 
             Assert.Same(entityBuilderA.Metadata, entityBuilderB.Metadata.BaseType);
             Assert.Same(entityBuilderB.Metadata, entityBuilderC.Metadata.BaseType);
@@ -51,7 +52,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var entityBuilderC = entityBuilderA.ModelBuilder.Entity(typeof(C), ConfigurationSource.Explicit);
             entityBuilderC.HasBaseType(entityBuilderA.Metadata, ConfigurationSource.Convention);
 
-            new DerivedTypeDiscoveryConvention().Apply(entityBuilderB);
+            new DerivedTypeDiscoveryConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(entityBuilderB);
 
             Assert.Same(entityBuilderB.Metadata, entityBuilderC.Metadata.BaseType);
         }

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/EntityTypeAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/EntityTypeAttributeConventionTest.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             var entityBuilder = modelBuilder.Entity(typeof(A), ConfigurationSource.Convention);
 
-            new NotMappedEntityTypeAttributeConvention().Apply(entityBuilder);
+            new NotMappedEntityTypeAttributeConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(entityBuilder);
 
             Assert.Equal(0, modelBuilder.Metadata.GetEntityTypes().Count());
         }
@@ -34,7 +34,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             var entityBuilder = modelBuilder.Entity(typeof(A), ConfigurationSource.Explicit);
 
-            new NotMappedEntityTypeAttributeConvention().Apply(entityBuilder);
+            new NotMappedEntityTypeAttributeConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(entityBuilder);
 
             Assert.Equal(1, modelBuilder.Metadata.GetEntityTypes().Count());
         }

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/KeyDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/KeyDiscoveryConventionTest.cs
@@ -154,7 +154,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var entityBuilder = modelBuilder.Entity(typeof(T), ConfigurationSource.Convention);
 
             new PropertyDiscoveryConvention(
-                    TestServiceFactory.Instance.Create<InMemoryTypeMappingSource>())
+                    TestServiceFactory.Instance.Create<InMemoryTypeMappingSource>(),
+                    new TestLogger<DbLoggerCategory.Model>())
                 .Apply(entityBuilder);
 
             return entityBuilder;

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/ModelCleanupConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/ModelCleanupConventionTest.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
@@ -21,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             dependentEntityBuilder.Relationship(
                 principalEntityBuilder, nameof(OneToOneDependent.OneToOnePrincipal), null, ConfigurationSource.Convention);
 
-            new ModelCleanupConvention().Apply(modelBuilder);
+            new ModelCleanupConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(modelBuilder);
 
             Assert.Equal(nameof(OneToOnePrincipal), modelBuilder.Metadata.GetEntityTypes().Single().DisplayName());
         }
@@ -35,7 +36,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             dependentEntityBuilder.Relationship(
                 principalEntityBuilder, null, nameof(OneToOnePrincipal.OneToOneDependent), ConfigurationSource.Convention);
 
-            new ModelCleanupConvention().Apply(modelBuilder);
+            new ModelCleanupConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(modelBuilder);
 
             Assert.Equal(2, modelBuilder.Metadata.GetEntityTypes().Count());
         }
@@ -57,7 +58,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             baseEntityBuilder.Relationship(baseEntityBuilder, ConfigurationSource.Convention);
             baseEntityBuilder.Relationship(baseEntityBuilder, ConfigurationSource.Convention);
 
-            new ModelCleanupConvention().Apply(modelBuilder);
+            new ModelCleanupConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(modelBuilder);
 
             Assert.True(modelBuilder.Metadata.GetEntityTypes().All(e => !e.GetDeclaredForeignKeys().Any()));
         }

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/PropertyAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/PropertyAttributeConventionTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             propertyBuilder.IsConcurrencyToken(false, ConfigurationSource.Convention);
 
-            new ConcurrencyCheckAttributeConvention().Apply(propertyBuilder);
+            new ConcurrencyCheckAttributeConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(propertyBuilder);
 
             Assert.True(propertyBuilder.Metadata.IsConcurrencyToken);
         }
@@ -46,7 +46,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             propertyBuilder.IsConcurrencyToken(false, ConfigurationSource.Explicit);
 
-            new ConcurrencyCheckAttributeConvention().Apply(propertyBuilder);
+            new ConcurrencyCheckAttributeConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(propertyBuilder);
 
             Assert.False(propertyBuilder.Metadata.IsConcurrencyToken);
         }
@@ -82,7 +82,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             propertyBuilder.ValueGenerated(ValueGenerated.OnAdd, ConfigurationSource.Convention);
 
-            new DatabaseGeneratedAttributeConvention().Apply(propertyBuilder);
+            new DatabaseGeneratedAttributeConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(propertyBuilder);
 
             Assert.Equal(ValueGenerated.OnAddOrUpdate, propertyBuilder.Metadata.ValueGenerated);
         }
@@ -96,7 +96,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             propertyBuilder.ValueGenerated(ValueGenerated.Never, ConfigurationSource.Explicit);
 
-            new DatabaseGeneratedAttributeConvention().Apply(propertyBuilder);
+            new DatabaseGeneratedAttributeConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(propertyBuilder);
 
             Assert.Equal(ValueGenerated.Never, propertyBuilder.Metadata.ValueGenerated);
         }
@@ -136,7 +136,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     "Id"
                 }, ConfigurationSource.Convention);
 
-            new KeyAttributeConvention().Apply(propertyBuilder);
+            new KeyAttributeConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(propertyBuilder);
 
             Assert.Equal("MyPrimaryKey", entityTypeBuilder.Metadata.FindPrimaryKey().Properties[0].Name);
         }
@@ -154,7 +154,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     "Id"
                 }, ConfigurationSource.Explicit);
 
-            new KeyAttributeConvention().Apply(propertyBuilder);
+            new KeyAttributeConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(propertyBuilder);
 
             Assert.Equal("Id", entityTypeBuilder.Metadata.FindPrimaryKey().Properties[0].Name);
         }
@@ -168,7 +168,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             Assert.Null(entityTypeBuilder.Metadata.FindDeclaredPrimaryKey());
 
-            new KeyAttributeConvention().Apply(propertyBuilder);
+            new KeyAttributeConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(propertyBuilder);
 
             Assert.Equal(1, entityTypeBuilder.Metadata.FindDeclaredPrimaryKey().Properties.Count);
             Assert.Equal("MyPrimaryKey", entityTypeBuilder.Metadata.FindDeclaredPrimaryKey().Properties[0].Name);
@@ -178,7 +178,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         public void KeyAttribute_throws_when_setting_composite_primary_key()
         {
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<B>();
-            var keyAttributeConvention = new KeyAttributeConvention();
+            var keyAttributeConvention = new KeyAttributeConvention(new TestLogger<DbLoggerCategory.Model>());
 
             Assert.Null(entityTypeBuilder.Metadata.FindDeclaredPrimaryKey());
 
@@ -222,7 +222,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             Assert.Equal(
                 CoreStrings.KeyAttributeOnDerivedEntity(derivedEntityTypeBuilder.Metadata.DisplayName(), propertyBuilder.Metadata.Name),
-                Assert.Throws<InvalidOperationException>(() => new KeyAttributeConvention().Apply(derivedEntityTypeBuilder.ModelBuilder))
+                Assert.Throws<InvalidOperationException>(
+                        () => new KeyAttributeConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(derivedEntityTypeBuilder.ModelBuilder))
                     .Message);
         }
 
@@ -240,7 +241,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     "Name"
                 }, ConfigurationSource.Explicit);
 
-            new KeyAttributeConvention().Apply(derivedEntityTypeBuilder.ModelBuilder);
+            new KeyAttributeConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(derivedEntityTypeBuilder.ModelBuilder);
 
             Assert.Equal(2, baseEntityTypeBuilder.Metadata.FindPrimaryKey().Properties.Count);
         }
@@ -268,7 +269,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             propertyBuilder.HasMaxLength(100, ConfigurationSource.Convention);
 
-            new MaxLengthAttributeConvention().Apply(propertyBuilder);
+            new MaxLengthAttributeConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(propertyBuilder);
 
             Assert.Equal(10, propertyBuilder.Metadata.GetMaxLength());
         }
@@ -282,7 +283,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             propertyBuilder.HasMaxLength(100, ConfigurationSource.Explicit);
 
-            new MaxLengthAttributeConvention().Apply(propertyBuilder);
+            new MaxLengthAttributeConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(propertyBuilder);
 
             Assert.Equal(100, propertyBuilder.Metadata.GetMaxLength());
         }
@@ -315,7 +316,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
             entityTypeBuilder.Property("IgnoredProperty", typeof(string), ConfigurationSource.Convention);
 
-            entityTypeBuilder = new NotMappedMemberAttributeConvention().Apply(entityTypeBuilder);
+            entityTypeBuilder = new NotMappedMemberAttributeConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(entityTypeBuilder);
 
             Assert.False(entityTypeBuilder.Metadata.GetProperties().Any(p => p.Name == "IgnoredProperty"));
         }
@@ -326,7 +327,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
             entityTypeBuilder.Property("IgnoredProperty", typeof(string), ConfigurationSource.Explicit);
 
-            entityTypeBuilder = new NotMappedMemberAttributeConvention().Apply(entityTypeBuilder);
+            entityTypeBuilder = new NotMappedMemberAttributeConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(entityTypeBuilder);
 
             Assert.True(entityTypeBuilder.Metadata.GetProperties().Any(p => p.Name == "IgnoredProperty"));
         }
@@ -357,7 +358,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<F>();
             entityTypeBuilder.Property("IgnoredProperty", typeof(string), ConfigurationSource.Convention);
 
-            entityTypeBuilder = new NotMappedMemberAttributeConvention().Apply(entityTypeBuilder);
+            entityTypeBuilder = new NotMappedMemberAttributeConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(entityTypeBuilder);
 
             Assert.False(entityTypeBuilder.Metadata.GetProperties().Any(p => p.Name == "IgnoredProperty"));
         }
@@ -375,7 +376,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             propertyBuilder.IsRequired(false, ConfigurationSource.Convention);
 
-            new RequiredPropertyAttributeConvention().Apply(propertyBuilder);
+            new RequiredPropertyAttributeConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(propertyBuilder);
 
             Assert.False(propertyBuilder.Metadata.IsNullable);
         }
@@ -389,7 +390,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             propertyBuilder.IsRequired(false, ConfigurationSource.Explicit);
 
-            new RequiredPropertyAttributeConvention().Apply(propertyBuilder);
+            new RequiredPropertyAttributeConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(propertyBuilder);
 
             Assert.True(propertyBuilder.Metadata.IsNullable);
         }
@@ -425,7 +426,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             propertyBuilder.HasMaxLength(100, ConfigurationSource.Convention);
 
-            new StringLengthAttributeConvention().Apply(propertyBuilder);
+            new StringLengthAttributeConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(propertyBuilder);
 
             Assert.Equal(20, propertyBuilder.Metadata.GetMaxLength());
         }
@@ -439,7 +440,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             propertyBuilder.HasMaxLength(100, ConfigurationSource.Explicit);
 
-            new StringLengthAttributeConvention().Apply(propertyBuilder);
+            new StringLengthAttributeConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(propertyBuilder);
 
             Assert.Equal(100, propertyBuilder.Metadata.GetMaxLength());
         }
@@ -476,7 +477,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             propertyBuilder.ValueGenerated(ValueGenerated.Never, ConfigurationSource.Convention);
             propertyBuilder.IsConcurrencyToken(false, ConfigurationSource.Convention);
 
-            new TimestampAttributeConvention().Apply(propertyBuilder);
+            new TimestampAttributeConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(propertyBuilder);
 
             Assert.Equal(ValueGenerated.OnAddOrUpdate, propertyBuilder.Metadata.ValueGenerated);
             Assert.True(propertyBuilder.Metadata.IsConcurrencyToken);
@@ -492,7 +493,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             propertyBuilder.ValueGenerated(ValueGenerated.Never, ConfigurationSource.Explicit);
             propertyBuilder.IsConcurrencyToken(false, ConfigurationSource.Explicit);
 
-            new TimestampAttributeConvention().Apply(propertyBuilder);
+            new TimestampAttributeConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(propertyBuilder);
 
             Assert.Equal(ValueGenerated.Never, propertyBuilder.Metadata.ValueGenerated);
             Assert.False(propertyBuilder.Metadata.IsConcurrencyToken);
@@ -534,7 +535,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var conventionSet = new ConventionSet();
             conventionSet.EntityTypeAddedConventions.Add(
                 new PropertyDiscoveryConvention(
-                    CreateTypeMapper()));
+                    CreateTypeMapper(),
+                    new TestLogger<DbLoggerCategory.Model>()));
 
             var modelBuilder = new InternalModelBuilder(new Model(conventionSet));
 

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/PropertyDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/PropertyDiscoveryConventionTest.cs
@@ -151,7 +151,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             Assert.Same(
                 entityBuilder, new PropertyDiscoveryConvention(
-                    TestServiceFactory.Instance.Create<InMemoryTypeMappingSource>()).Apply(entityBuilder));
+                    TestServiceFactory.Instance.Create<InMemoryTypeMappingSource>(),
+                    new TestLogger<DbLoggerCategory.Model>()).Apply(entityBuilder));
 
             Assert.Empty(entityBuilder.Metadata.GetProperties());
         }
@@ -211,7 +212,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             Assert.Same(
                 entityBuilder, new PropertyDiscoveryConvention(
-                        TestServiceFactory.Instance.Create<InMemoryTypeMappingSource>())
+                        TestServiceFactory.Instance.Create<InMemoryTypeMappingSource>(),
+                        new TestLogger<DbLoggerCategory.Model>())
                     .Apply(entityBuilder));
 
             Assert.Equal(
@@ -233,7 +235,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             Assert.Same(
                 entityBuilder, new PropertyDiscoveryConvention(
-                        TestServiceFactory.Instance.Create<InMemoryTypeMappingSource>())
+                        TestServiceFactory.Instance.Create<InMemoryTypeMappingSource>(),
+                        new TestLogger<DbLoggerCategory.Model>())
                     .Apply(entityBuilder));
 
             Assert.Empty(entityBuilder.Metadata.GetProperties());

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/PropertyMappingValidationConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/PropertyMappingValidationConventionTest.cs
@@ -188,7 +188,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             return new PropertyMappingValidationConvention(
                 typeMappingSource,
                 TestServiceFactory.Instance.Create<IMemberClassifier>(
-                    (typeof(ITypeMappingSource), typeMappingSource)));
+                    (typeof(ITypeMappingSource), typeMappingSource)),
+                new TestLogger<DbLoggerCategory.Model>());
         }
 
         protected class NonPrimitiveNonNavigationAsPropertyEntity

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/RelationshipDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/RelationshipDiscoveryConventionTest.cs
@@ -244,7 +244,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var entityBuilder = CreateInternalEntityBuilder<ManyToManyFirst>();
 
             Assert.Same(entityBuilder, CreateRelationshipDiscoveryConvention().Apply(entityBuilder));
-            new ModelCleanupConvention().Apply(entityBuilder.ModelBuilder);
+            new ModelCleanupConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(entityBuilder.ModelBuilder);
 
             Assert.Empty(entityBuilder.Metadata.GetForeignKeys());
             Assert.Empty(entityBuilder.Metadata.GetNavigations());
@@ -531,7 +531,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit);
 
             Assert.Same(entityBuilder, CreateRelationshipDiscoveryConvention().Apply(entityBuilder));
-            new ModelCleanupConvention().Apply(modelBuilder);
+            new ModelCleanupConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(modelBuilder);
 
             VerifyRelationship(
                 entityBuilder.Metadata.FindNavigation(nameof(NavigationsToBaseAndDerived.Base)),

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/ValueGeneratorConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/ValueGeneratorConventionTest.cs
@@ -52,7 +52,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             var keyBuilder = entityBuilder.PrimaryKey(properties, ConfigurationSource.Convention);
 
-            Assert.True(new ValueGeneratorConvention().Apply(entityBuilder, (Key)null));
+            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(entityBuilder, (Key)null));
 
             var keyProperties = keyBuilder.Metadata.Properties;
 
@@ -85,7 +85,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             var keyBuilder = referencedEntityBuilder.PrimaryKey(properties, ConfigurationSource.Convention);
 
-            Assert.True(new ValueGeneratorConvention().Apply(referencedEntityBuilder, (Key)null));
+            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(referencedEntityBuilder, (Key)null));
 
             var keyProperties = keyBuilder.Metadata.Properties;
 
@@ -118,7 +118,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             var keyBuilder = referencedEntityBuilder.PrimaryKey(properties, ConfigurationSource.Convention);
 
-            Assert.True(new ValueGeneratorConvention().Apply(referencedEntityBuilder, (Key)null));
+            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(referencedEntityBuilder, (Key)null));
 
             var keyProperties = keyBuilder.Metadata.Properties;
 
@@ -150,7 +150,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             var keyBuilder = referencedEntityBuilder.PrimaryKey(new[] { properties[1] }, ConfigurationSource.Convention);
 
-            Assert.True(new ValueGeneratorConvention().Apply(referencedEntityBuilder, (Key)null));
+            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(referencedEntityBuilder, (Key)null));
 
             var keyProperties = keyBuilder.Metadata.Properties;
 
@@ -174,7 +174,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             var keyBuilder = entityBuilder.PrimaryKey(properties, ConfigurationSource.Convention);
 
-            Assert.True(new ValueGeneratorConvention().Apply(entityBuilder, (Key)null));
+            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(entityBuilder, (Key)null));
 
             var keyProperties = keyBuilder.Metadata.Properties;
 
@@ -198,7 +198,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             var keyBuilder = referencedEntityBuilder.PrimaryKey(properties, ConfigurationSource.Convention);
 
-            Assert.True(new ValueGeneratorConvention().Apply(referencedEntityBuilder, (Key)null));
+            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(referencedEntityBuilder, (Key)null));
 
             var keyProperties = keyBuilder.Metadata.Properties;
 
@@ -209,7 +209,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention),
                 ConfigurationSource.Convention);
 
-            Assert.Same(foreignKeyBuilder, new ValueGeneratorConvention().Apply(foreignKeyBuilder));
+            Assert.Same(foreignKeyBuilder, new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(foreignKeyBuilder));
 
             Assert.False(keyProperties[0].RequiresValueGenerator());
             Assert.Equal(ValueGenerated.Never, keyProperties[0].ValueGenerated);
@@ -232,7 +232,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             var keyBuilder = referencedEntityBuilder.PrimaryKey(properties, ConfigurationSource.Convention);
 
-            Assert.True(new ValueGeneratorConvention().Apply(referencedEntityBuilder, (Key)null));
+            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(referencedEntityBuilder, (Key)null));
 
             var keyProperties = keyBuilder.Metadata.Properties;
 
@@ -243,14 +243,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention),
                 ConfigurationSource.Convention);
 
-            Assert.Same(relationshipBuilder, new ValueGeneratorConvention().Apply(relationshipBuilder));
+            Assert.Same(relationshipBuilder, new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(relationshipBuilder));
 
             Assert.False(keyProperties[0].RequiresValueGenerator());
             Assert.Equal(ValueGenerated.Never, keyProperties[0].ValueGenerated);
 
             referencedEntityBuilder.RemoveForeignKey(relationshipBuilder.Metadata, ConfigurationSource.Convention);
 
-            new ValueGeneratorConvention().Apply(referencedEntityBuilder, relationshipBuilder.Metadata);
+            new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(referencedEntityBuilder, relationshipBuilder.Metadata);
 
             Assert.True(keyProperties[0].RequiresValueGenerator());
             Assert.Equal(ValueGenerated.OnAdd, keyProperties[0].ValueGenerated);
@@ -272,7 +272,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     "Id"
                 }, ConfigurationSource.Convention);
 
-            Assert.True(new ValueGeneratorConvention().Apply(entityBuilder, (Key)null));
+            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(entityBuilder, (Key)null));
 
             var property = keyBuilder.Metadata.Properties.First();
 
@@ -291,7 +291,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     "Number"
                 }, ConfigurationSource.Convention);
 
-            Assert.True(new ValueGeneratorConvention().Apply(entityBuilder, (Key)null));
+            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(entityBuilder, (Key)null));
 
             var property = keyBuilder.Metadata.Properties.First();
 
@@ -311,7 +311,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     "Number"
                 }, ConfigurationSource.Convention);
 
-            Assert.True(new ValueGeneratorConvention().Apply(entityBuilder, (Key)null));
+            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(entityBuilder, (Key)null));
 
             var keyProperties = keyBuilder.Metadata.Properties;
 
@@ -392,7 +392,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Same(idProperty, entityBuilder.Metadata.FindProperty("Id"));
             Assert.Same(numberProperty, entityBuilder.Metadata.FindProperty("Number"));
 
-            Assert.True(new ValueGeneratorConvention().Apply(entityBuilder, (Key)null));
+            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(entityBuilder, (Key)null));
 
             Assert.Same(idProperty, entityBuilder.Metadata.FindProperty("Id"));
             Assert.Same(numberProperty, entityBuilder.Metadata.FindProperty("Number"));
@@ -416,7 +416,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     "Id"
                 }, ConfigurationSource.Convention);
 
-            Assert.True(new ValueGeneratorConvention().Apply(entityBuilder, (Key)null));
+            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(entityBuilder, (Key)null));
 
             var property = keyBuilder.Metadata.Properties.First();
 
@@ -437,7 +437,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             };
             var keyBuilder = referencedEntityBuilder.PrimaryKey(properties, ConfigurationSource.Convention);
 
-            Assert.True(new ValueGeneratorConvention().Apply(referencedEntityBuilder, (Key)null));
+            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(referencedEntityBuilder, (Key)null));
 
             var property = keyBuilder.Metadata.Properties.First();
 
@@ -448,7 +448,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention),
                 ConfigurationSource.Convention);
 
-            Assert.Same(relationshipBuilder, new ValueGeneratorConvention().Apply(relationshipBuilder));
+            Assert.Same(relationshipBuilder, new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(relationshipBuilder));
 
             Assert.Equal(ValueGenerated.Never, ((IProperty)property).ValueGenerated);
         }
@@ -467,7 +467,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             };
             var keyBuilder = referencedEntityBuilder.PrimaryKey(properties, ConfigurationSource.Convention);
 
-            Assert.True(new ValueGeneratorConvention().Apply(referencedEntityBuilder, (Key)null));
+            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(referencedEntityBuilder, (Key)null));
 
             var property = keyBuilder.Metadata.Properties.First();
 
@@ -478,13 +478,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention),
                 ConfigurationSource.Convention);
 
-            Assert.Same(relationshipBuilder, new ValueGeneratorConvention().Apply(relationshipBuilder));
+            Assert.Same(relationshipBuilder, new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(relationshipBuilder));
 
             Assert.Equal(ValueGenerated.Never, ((IProperty)property).ValueGenerated);
 
             referencedEntityBuilder.RemoveForeignKey(relationshipBuilder.Metadata, ConfigurationSource.Convention);
 
-            Assert.True(new ValueGeneratorConvention().Apply(referencedEntityBuilder, (Key)null));
+            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(referencedEntityBuilder, (Key)null));
 
             Assert.Equal(ValueGenerated.OnAdd, property.ValueGenerated);
         }
@@ -494,13 +494,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         private static InternalModelBuilder CreateInternalModelBuilder()
         {
             var conventions = new ConventionSet();
+            var logger = new TestLogger<DbLoggerCategory.Model>();
 
             conventions.EntityTypeAddedConventions.Add(
                 new PropertyDiscoveryConvention(
-                    TestServiceFactory.Instance.Create<InMemoryTypeMappingSource>()));
-            conventions.EntityTypeAddedConventions.Add(new KeyDiscoveryConvention(new TestLogger<DbLoggerCategory.Model>()));
+                    TestServiceFactory.Instance.Create<InMemoryTypeMappingSource>(),
+                    logger));
 
-            var keyConvention = new ValueGeneratorConvention();
+            conventions.EntityTypeAddedConventions.Add(new KeyDiscoveryConvention(logger));
+
+            var keyConvention = new ValueGeneratorConvention(logger);
 
             conventions.ForeignKeyAddedConventions.Add(keyConvention);
             conventions.ForeignKeyRemovedConventions.Add(keyConvention);

--- a/test/EFCore.Tests/Metadata/Internal/ClrCollectionAccessorFactoryTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/ClrCollectionAccessorFactoryTest.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
+using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
 // ReSharper disable UnassignedGetOnlyAutoProperty
@@ -253,7 +254,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     nameof(MyEntity.AsICollectionWithCustomComparer),
                     BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance));
 
-            new BackingFieldConvention().Apply(foreignKey.Builder, navigation);
+            new BackingFieldConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(foreignKey.Builder, navigation);
 
             var accessor = new ClrCollectionAccessorFactory().Create(navigation);
 
@@ -411,7 +412,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var navigation = foreignKey.HasPrincipalToDependent(
                 typeof(MyEntity).GetProperty(navigationName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance));
 
-            new BackingFieldConvention().Apply(foreignKey.Builder, navigation);
+            new BackingFieldConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(foreignKey.Builder, navigation);
 
             return navigation;
         }

--- a/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
@@ -1689,7 +1690,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 ConfigureOrdersHierarchy(modelBuilder);
             }
 
-            var validationConvention = new IgnoredMembersValidationConvention();
+            var logger = new TestLogger<DbLoggerCategory.Model>();
+            var validationConvention = new IgnoredMembersValidationConvention(logger);
             if (exceptionExpected)
             {
                 Assert.Equal(
@@ -1704,7 +1706,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             var modelValidator = InMemoryTestHelpers.Instance.CreateContextServices().GetRequiredService<IModelValidator>();
 
-            modelValidator.Validate(modelBuilder.Metadata);
+            modelValidator.Validate(
+                modelBuilder.Metadata,
+                new DiagnosticsLoggers(
+                    logger,
+                    new TestLogger<DbLoggerCategory.Model.Validation>()));
 
             Assert.Equal(
                 expectedIgnored,

--- a/test/EFCore.Tests/Metadata/Internal/InternalModelBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalModelBuilderTest.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
+using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
 // ReSharper disable UnusedMember.Local
@@ -270,7 +271,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             Assert.True(modelBuilder.Ignore(typeof(Customer), ConfigurationSource.Explicit));
 
-            modelBuilder = new ModelCleanupConvention().Apply(modelBuilder);
+            modelBuilder = new ModelCleanupConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(modelBuilder);
             Assert.Empty(modelBuilder.Metadata.GetEntityTypes());
         }
 
@@ -291,7 +292,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             Assert.True(modelBuilder.Ignore(typeof(Customer), ConfigurationSource.DataAnnotation));
 
-            modelBuilder = new ModelCleanupConvention().Apply(modelBuilder);
+            modelBuilder = new ModelCleanupConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(modelBuilder);
             Assert.Equal(new[] { typeof(Order), typeof(Product) }, modelBuilder.Metadata.GetEntityTypes().Select(et => et.ClrType));
             Assert.Equal(typeof(Product), orderEntityTypeBuilder.Metadata.GetForeignKeys().Single().PrincipalEntityType.ClrType);
         }
@@ -313,7 +314,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             Assert.True(modelBuilder.Ignore(typeof(Customer), ConfigurationSource.DataAnnotation));
 
-            modelBuilder = new ModelCleanupConvention().Apply(modelBuilder);
+            modelBuilder = new ModelCleanupConvention(new TestLogger<DbLoggerCategory.Model>()).Apply(modelBuilder);
             Assert.Equal(new[] { typeof(Order), typeof(Product) }, modelBuilder.Metadata.GetEntityTypes().Select(et => et.ClrType));
             Assert.Equal(typeof(Product), orderEntityTypeBuilder.Metadata.GetForeignKeys().Single().PrincipalEntityType.ClrType);
         }

--- a/test/EFCore.Tests/Metadata/Internal/PropertyBaseTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/PropertyBaseTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -768,7 +769,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             try
             {
                 InMemoryTestHelpers.Instance.CreateContextServices().GetRequiredService<IModelValidator>()
-                    .Validate(propertyBase.DeclaringType.Model);
+                    .Validate(propertyBase.DeclaringType.Model,
+                        new DiagnosticsLoggers(
+                            new TestLogger<DbLoggerCategory.Model>(),
+                            new TestLogger<DbLoggerCategory.Model.Validation>()));
 
                 Assert.Null(failMessage);
             }

--- a/test/EFCore.Tests/ModelSourceTest.cs
+++ b/test/EFCore.Tests/ModelSourceTest.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -75,9 +76,12 @@ namespace Microsoft.EntityFrameworkCore
         public void Adds_all_entities_based_on_all_distinct_entity_types_found()
         {
             var setFinder = new FakeSetFinder();
+            var loggers = new DiagnosticsLoggers(
+                new TestLogger<DbLoggerCategory.Model>(),
+                new TestLogger<DbLoggerCategory.Model.Validation>());
 
             var model = CreateDefaultModelSource(setFinder)
-                .GetModel(InMemoryTestHelpers.Instance.CreateContext(), _nullConventionSetBuilder, _coreModelValidator);
+                .GetModel(InMemoryTestHelpers.Instance.CreateContext(), _nullConventionSetBuilder, _coreModelValidator, loggers);
 
             Assert.Equal(
                 new[] { typeof(SetA).DisplayName(), typeof(SetB).DisplayName() },
@@ -117,21 +121,27 @@ namespace Microsoft.EntityFrameworkCore
         public void Caches_model_by_context_type()
         {
             var modelSource = CreateDefaultModelSource(new DbSetFinder());
+            var loggers = new DiagnosticsLoggers(
+                new TestLogger<DbLoggerCategory.Model>(),
+                new TestLogger<DbLoggerCategory.Model.Validation>());
 
-            var model1 = modelSource.GetModel(new Context1(), _nullConventionSetBuilder, _coreModelValidator);
-            var model2 = modelSource.GetModel(new Context2(), _nullConventionSetBuilder, _coreModelValidator);
+            var model1 = modelSource.GetModel(new Context1(), _nullConventionSetBuilder, _coreModelValidator, loggers);
+            var model2 = modelSource.GetModel(new Context2(), _nullConventionSetBuilder, _coreModelValidator, loggers);
 
             Assert.NotSame(model1, model2);
-            Assert.Same(model1, modelSource.GetModel(new Context1(), _nullConventionSetBuilder, _coreModelValidator));
-            Assert.Same(model2, modelSource.GetModel(new Context2(), _nullConventionSetBuilder, _coreModelValidator));
+            Assert.Same(model1, modelSource.GetModel(new Context1(), _nullConventionSetBuilder, _coreModelValidator, loggers));
+            Assert.Same(model2, modelSource.GetModel(new Context2(), _nullConventionSetBuilder, _coreModelValidator, loggers));
         }
 
         [Fact]
         public void Stores_model_version_information_as_annotation_on_model()
         {
             var modelSource = CreateDefaultModelSource(new DbSetFinder());
+            var loggers = new DiagnosticsLoggers(
+                new TestLogger<DbLoggerCategory.Model>(),
+                new TestLogger<DbLoggerCategory.Model.Validation>());
 
-            var model = modelSource.GetModel(new Context1(), _nullConventionSetBuilder, _coreModelValidator);
+            var model = modelSource.GetModel(new Context1(), _nullConventionSetBuilder, _coreModelValidator, loggers);
             var packageVersion = typeof(Context1).Assembly.GetCustomAttributes<AssemblyMetadataAttribute>()
                 .Single(m => m.Key == "PackageVersion").Value;
 

--- a/test/EFCore.Tests/ServiceProviderCacheTest.cs
+++ b/test/EFCore.Tests/ServiceProviderCacheTest.cs
@@ -125,7 +125,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [Fact]
-        public void Reports_debug_info_for_different_ILoggerFactory_instances()
+        public void Different_ILoggerFactory_instances_does_not_trigger_new_internal_provider()
         {
             var config1 = CreateOptions<CoreOptionsExtension>(new ListLoggerFactory());
 
@@ -138,14 +138,7 @@ namespace Microsoft.EntityFrameworkCore
             var first = cache.GetOrAdd(config1, true);
             var second = cache.GetOrAdd(config2, true);
 
-            Assert.NotSame(first, second);
-
-            Assert.Equal(1, loggerFactory.Log.Count);
-
-            Assert.Equal(
-                CoreStrings.LogServiceProviderDebugInfo.GenerateMessage(
-                    CoreStrings.ServiceProviderConfigChanged("Core:UseLoggerFactory")),
-                loggerFactory.Log[0].Message);
+            Assert.Same(first, second);
         }
 
         [Fact]


### PR DESCRIPTION
Issue #14698

Main changes:
* ILoggerFactory is still captured in AddDbContext, but as a wrapped scoped factory
  * Same thing can be done with UseLoggerFactory
  * No longer pathological to pass a different instance each time
* IMemoryCache is no longer captured from AddDbContext
  * Can still be passed to UseMemoryCache
* IRawSqlCommandBuilder and IMigrationsSqlGenerator have been made scoped
* Validation and query compilation, method call translators, and a few more now accept the logger to use
