### PR TITLE
Add activate scripts

### DIFF
--- a/activate.ps1
+++ b/activate.ps1
@@ -1,0 +1,57 @@
+#
+# This file must be used by invoking ". .\activate.ps1" from the command line.
+# You cannot run it directly.
+# To exit from the environment this creates, execute the 'deactivate' function.
+#
+
+function deactivate ([switch]$init) {
+
+    # reset old environment variables
+    if (Test-Path variable:_OLD_PATH) {
+        $env:PATH = $_OLD_PATH
+        Remove-Item variable:_OLD_PATH
+    }
+
+    if (test-path function:_old_prompt) {
+        Set-Item Function:prompt -Value $function:_old_prompt -ea ignore
+        remove-item function:_old_prompt
+    }
+
+    Remove-Item env:DOTNET_ROOT -ea ignore
+    Remove-Item env:DOTNET_MULTILEVEL_LOOKUP -ea ignore
+    if (-not $init) {
+        # Remove the deactivate function
+        Remove-Item function:deactivate
+    }
+}
+
+# Cleanup the environment
+deactivate -init
+
+$_OLD_PATH = $env:PATH
+# Tell dotnet where to find itself
+$env:DOTNET_ROOT = "$PSScriptRoot\.dotnet"
+# Tell dotnet not to look beyond the DOTNET_ROOT folder for more dotnet things
+$env:DOTNET_MULTILEVEL_LOOKUP = 0
+# Put dotnet first on PATH
+$env:PATH = "${env:DOTNET_ROOT};${env:PATH}"
+
+# Set the shell prompt
+if (-not $env:DISABLE_CUSTOM_PROMPT) {
+    $function:_old_prompt = $function:prompt
+    function dotnet_prompt {
+        # Add a prefix to the current prompt, but don't discard it.
+        write-host "($( split-path $PSScriptRoot -leaf )) " -nonewline
+        & $function:_old_prompt
+    }
+
+    Set-Item Function:prompt -Value $function:dotnet_prompt -ea ignore
+}
+
+Write-Host -f Magenta "Enabled the .NET Core environment. Execute 'deactivate' to exit."
+if (-not (Test-Path "${env:DOTNET_ROOT}\dotnet.exe")) {
+    Write-Host -f Yellow ".NET Core has not been installed yet. Run $PSScriptRoot\restore.cmd to install it."
+}
+else {
+    Write-Host "dotnet = ${env:DOTNET_ROOT}\dotnet.exe"
+}

--- a/activate.sh
+++ b/activate.sh
@@ -1,0 +1,69 @@
+#
+# This file must be used by invoking "source activate.sh" from the command line.
+# You cannot run it directly.
+# To exit from the environment this creates, execute the 'deactivate' function.
+
+_MAGENTA="\033[0;95m"
+_YELLOW="\033[0;33m"
+_RESET="\033[0m"
+
+deactivate () {
+
+    # reset old environment variables
+    if [ ! -z "${_OLD_PATH:-}" ] ; then
+        export PATH="$_OLD_PATH"
+        unset _OLD_PATH
+    fi
+
+    if [ ! -z "${_OLD_PS1:-}" ] ; then
+        export PS1="$_OLD_PS1"
+        unset _OLD_PS1
+    fi
+
+    # This should detect bash and zsh, which have a hash command that must
+    # be called to get it to forget past commands.  Without forgetting
+    # past commands the $PATH changes we made may not be respected
+    if [ -n "${BASH:-}" ] || [ -n "${ZSH_VERSION:-}" ] ; then
+        hash -r 2>/dev/null
+    fi
+
+    unset DOTNET_ROOT
+    unset DOTNET_MULTILEVEL_LOOKUP
+    if [ ! "${1:-}" = "init" ] ; then
+        # Remove the deactivate function
+        unset -f deactivate
+    fi
+}
+
+# Cleanup the environment
+deactivate init
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+_OLD_PATH="$PATH"
+# Tell dotnet where to find itself
+export DOTNET_ROOT="$DIR/.dotnet"
+# Tell dotnet not to look beyond the DOTNET_ROOT folder for more dotnet things
+export DOTNET_MULTILEVEL_LOOKUP=0
+# Put dotnet first on PATH
+export PATH="$DOTNET_ROOT:$PATH"
+
+# Set the shell prompt
+if [ -z "${DISABLE_CUSTOM_PROMPT:-}" ] ; then
+    _OLD_PS1="$PS1"
+    export PS1="(`basename \"$DIR\"`) $PS1"
+fi
+
+# This should detect bash and zsh, which have a hash command that must
+# be called to get it to forget past commands.  Without forgetting
+# past commands the $PATH changes we made may not be respected
+if [ -n "${BASH:-}" ] || [ -n "${ZSH_VERSION:-}" ] ; then
+    hash -r 2>/dev/null
+fi
+
+echo "${_MAGENTA}Enabled the .NET Core environment. Execute 'deactivate' to exit.${_RESET}"
+
+if [ ! -f "$DOTNET_ROOT/dotnet" ]; then
+    echo "${_YELLOW}.NET Core has not been installed yet. Run $DIR/restore.sh to install it.${_RESET}"
+else
+    echo "dotnet = $DOTNET_ROOT/dotnet"
+fi


### PR DESCRIPTION
These put the local `dotnet` on the path so you can use it normally

PowerShell: . .\activate.ps1
macOS/Linux: source activate.sh