### PR TITLE
Refactored store type parsing in type mapping

### DIFF
--- a/src/EFCore.Relational/Storage/RelationalTypeMappingInfo.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMappingInfo.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations.Schema;
-using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -21,10 +19,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
     public readonly struct RelationalTypeMappingInfo : IEquatable<RelationalTypeMappingInfo>
     {
         private readonly TypeMappingInfo _coreTypeMappingInfo;
-        private readonly int? _parsedSize;
-        private readonly int? _parsedPrecision;
-        private readonly int? _parsedScale;
-        private readonly bool _isMax;
 
         /// <summary>
         ///     Creates a new instance of <see cref="RelationalTypeMappingInfo" />.
@@ -39,63 +33,54 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Creates a new instance of <see cref="RelationalTypeMappingInfo" />.
         /// </summary>
         /// <param name="principals"> The principal property chain for the property for which mapping is needed. </param>
-        public RelationalTypeMappingInfo([NotNull] IReadOnlyList<IProperty> principals)
+        /// <param name="storeTypeName"> The provider-specific relational type name for which mapping is needed. </param>
+        /// <param name="storeTypeNameBase"> The provider-specific relational type name, with any facets removed. </param>
+        /// <param name="fallbackUnicode"> Specifies a fallback Specifies Unicode or ANSI mapping for the mapping, in case one isn't found at the core level, or <c>null</c> for default. </param>
+        /// <param name="fixedLength"> Specifies a fixed length mapping, or <c>null</c> for default. </param>
+        /// <param name="fallbackSize"> Specifies a fallback size for the mapping, in case one isn't found at the core level, or <c>null</c> for default. </param>
+        /// <param name="fallbackPrecision"> Specifies a fallback precision for the mapping, in case one isn't found at the core level, or <c>null</c> for default. </param>
+        /// <param name="fallbackScale"> Specifies a fallback scale for the mapping, in case one isn't found at the core level, or <c>null</c> for default. </param>
+        public RelationalTypeMappingInfo(
+            [NotNull] IReadOnlyList<IProperty> principals,
+            [CanBeNull] string storeTypeName = null,
+            [CanBeNull] string storeTypeNameBase = null,
+            bool? fallbackUnicode = null,
+            bool? fixedLength = null,
+            int? fallbackSize = null,
+            int? fallbackPrecision = null,
+            int? fallbackScale = null)
         {
-            _coreTypeMappingInfo = new TypeMappingInfo(principals);
-
-            string storeTypeName = null;
-            bool? fixedLength = null;
-            for (var i = 0; i < principals.Count; i++)
-            {
-                var principal = principals[i];
-                if (storeTypeName == null)
-                {
-                    var columnType = (string)principal[RelationalAnnotationNames.ColumnType];
-                    if (columnType != null)
-                    {
-                        storeTypeName = columnType;
-                    }
-                }
-
-                if (fixedLength == null)
-                {
-                    fixedLength = principal.Relational().IsFixedLength;
-                }
-            }
+            _coreTypeMappingInfo = new TypeMappingInfo(principals, fallbackUnicode, fallbackSize, fallbackPrecision, fallbackScale);
 
             IsFixedLength = fixedLength;
             StoreTypeName = storeTypeName;
-            StoreTypeNameBase = ParseStoreTypeName(storeTypeName, out _parsedSize, out _parsedPrecision, out _parsedScale, out _isMax);
-        }
-
-        /// <summary>
-        ///     Creates a new instance of <see cref="RelationalTypeMappingInfo" />.
-        /// </summary>
-        /// <param name="type"> The CLR type in the model for which mapping is needed. </param>
-        public RelationalTypeMappingInfo([NotNull] Type type)
-        {
-            _coreTypeMappingInfo = new TypeMappingInfo(type);
-            StoreTypeName = null;
-            StoreTypeNameBase = null;
-            IsFixedLength = null;
-            _parsedSize = null;
-            _parsedPrecision = null;
-            _parsedScale = null;
-            _isMax = false;
+            StoreTypeNameBase = storeTypeNameBase;
         }
 
         /// <summary>
         ///     Creates a new instance of <see cref="RelationalTypeMappingInfo" />.
         /// </summary>
         /// <param name="storeTypeName"> The provider-specific relational type name for which mapping is needed. </param>
-        public RelationalTypeMappingInfo([NotNull] string storeTypeName)
+        /// <param name="storeTypeNameBase"> The provider-specific relational type name, with any facets removed. </param>
+        /// <param name="unicode"> Specifies Unicode or ANSI mapping, or <c>null</c> for default. </param>
+        /// <param name="size"> Specifies a size for the mapping, or <c>null</c> for default. </param>
+        /// <param name="precision"> Specifies a precision for the mapping, or <c>null</c> for default. </param>
+        /// <param name="scale"> Specifies a scale for the mapping, or <c>null</c> for default. </param>
+        public RelationalTypeMappingInfo(
+            [NotNull] string storeTypeName,
+            [NotNull] string storeTypeNameBase,
+            bool? unicode,
+            int? size,
+            int? precision,
+            int? scale)
         {
             // Note: Empty string is allowed for store type name because SQLite
             Check.NotNull(storeTypeName, nameof(storeTypeName));
+            Check.NotNull(storeTypeNameBase, nameof(storeTypeNameBase));
 
-            _coreTypeMappingInfo = new TypeMappingInfo();
+            _coreTypeMappingInfo = new TypeMappingInfo(null, false, unicode, size, null, precision, scale);
             StoreTypeName = storeTypeName;
-            StoreTypeNameBase = ParseStoreTypeName(storeTypeName, out _parsedSize, out _parsedPrecision, out _parsedScale, out _isMax);
+            StoreTypeNameBase = storeTypeNameBase;
             IsFixedLength = null;
         }
 
@@ -103,29 +88,27 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Creates a new instance of <see cref="RelationalTypeMappingInfo" />.
         /// </summary>
         /// <param name="member"> The property or field for which mapping is needed. </param>
-        public RelationalTypeMappingInfo([NotNull] MemberInfo member)
+        /// <param name="storeTypeName"> The provider-specific relational type name for which mapping is needed. </param>
+        /// <param name="storeTypeNameBase"> The provider-specific relational type name, with any facets removed. </param>
+        /// <param name="unicode"> Specifies Unicode or ANSI mapping, or <c>null</c> for default. </param>
+        /// <param name="size"> Specifies a size for the mapping, or <c>null</c> for default. </param>
+        /// <param name="precision"> Specifies a precision for the mapping, or <c>null</c> for default. </param>
+        /// <param name="scale"> Specifies a scale for the mapping, or <c>null</c> for default. </param>
+        public RelationalTypeMappingInfo(
+            [NotNull] MemberInfo member,
+            [CanBeNull] string storeTypeName = null,
+            [CanBeNull] string storeTypeNameBase = null,
+            bool? unicode = null,
+            int? size = null,
+            int? precision = null,
+            int? scale = null)
         {
             Check.NotNull(member, nameof(member));
 
-            _coreTypeMappingInfo = new TypeMappingInfo(member);
+            _coreTypeMappingInfo = new TypeMappingInfo(member, unicode, size, precision, scale);
 
-            if (Attribute.IsDefined(member, typeof(ColumnAttribute), inherit: true))
-            {
-                var attribute = member.GetCustomAttributes<ColumnAttribute>(inherit: true).First();
-                StoreTypeName = attribute.TypeName;
-                StoreTypeNameBase = ParseStoreTypeName(
-                    attribute.TypeName, out _parsedSize, out _parsedPrecision, out _parsedScale, out _isMax);
-            }
-            else
-            {
-                StoreTypeName = null;
-                StoreTypeNameBase = null;
-                _parsedSize = null;
-                _parsedPrecision = null;
-                _parsedScale = null;
-                _isMax = false;
-            }
-
+            StoreTypeName = storeTypeName;
+            StoreTypeNameBase = storeTypeNameBase;
             IsFixedLength = null;
         }
 
@@ -149,7 +132,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             var mappingHints = converter.MappingHints;
 
             StoreTypeName = source.StoreTypeName;
-            StoreTypeNameBase = ParseStoreTypeName(source.StoreTypeName, out _parsedSize, out _parsedPrecision, out _parsedScale, out _isMax);
+            StoreTypeNameBase = source.StoreTypeNameBase;
             IsFixedLength = source.IsFixedLength ?? (mappingHints as RelationalConverterMappingHints)?.IsFixedLength;
         }
 
@@ -158,6 +141,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="type"> The CLR type in the model for which mapping is needed. </param>
         /// <param name="storeTypeName"> The database type name. </param>
+        /// <param name="storeTypeNameBase"> The provider-specific relational type name, with any facets removed. </param>
         /// <param name="keyOrIndex"> If <c>true</c>, then a special mapping for a key or index may be returned. </param>
         /// <param name="unicode"> Specifies Unicode or ANSI mapping, or <c>null</c> for default. </param>
         /// <param name="size"> Specifies a size for the mapping, or <c>null</c> for default. </param>
@@ -167,76 +151,21 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="scale"> Specifies a scale for the mapping, or <c>null</c> for default. </param>
         public RelationalTypeMappingInfo(
             [NotNull] Type type,
-            [CanBeNull] string storeTypeName,
-            bool keyOrIndex,
-            bool? unicode,
-            int? size,
-            bool? rowVersion,
-            bool? fixedLength,
-            int? precision,
-            int? scale)
+            [CanBeNull] string storeTypeName = null,
+            [CanBeNull] string storeTypeNameBase = null,
+            bool keyOrIndex = false,
+            bool? unicode = null,
+            int? size = null,
+            bool? rowVersion = null,
+            bool? fixedLength = null,
+            int? precision = null,
+            int? scale = null)
         {
             _coreTypeMappingInfo = new TypeMappingInfo(type, keyOrIndex, unicode, size, rowVersion, precision, scale);
 
             IsFixedLength = fixedLength;
             StoreTypeName = storeTypeName;
-            StoreTypeNameBase = ParseStoreTypeName(storeTypeName, out _parsedSize, out _parsedPrecision, out _parsedScale, out _isMax);
-        }
-
-        private static string ParseStoreTypeName(
-            string storeTypeName,
-            out int? size,
-            out int? precision,
-            out int? scale,
-            out bool isMax)
-        {
-            size = null;
-            precision = null;
-            scale = null;
-            isMax = false;
-
-            if (storeTypeName != null)
-            {
-                var openParen = storeTypeName.IndexOf("(", StringComparison.Ordinal);
-                if (openParen > 0)
-                {
-                    var closeParen = storeTypeName.IndexOf(")", openParen + 1, StringComparison.Ordinal);
-                    if (closeParen > openParen)
-                    {
-                        var comma = storeTypeName.IndexOf(",", openParen + 1, StringComparison.Ordinal);
-                        if (comma > openParen
-                            && comma < closeParen)
-                        {
-                            if (int.TryParse(storeTypeName.Substring(openParen + 1, comma - openParen - 1), out var parsedPrecision))
-                            {
-                                precision = parsedPrecision;
-                            }
-
-                            if (int.TryParse(storeTypeName.Substring(comma + 1, closeParen - comma - 1), out var parsedScale))
-                            {
-                                scale = parsedScale;
-                            }
-                        }
-                        else
-                        {
-                            var sizeString = storeTypeName.Substring(openParen + 1, closeParen - openParen - 1).Trim();
-                            if (sizeString.Equals("max", StringComparison.OrdinalIgnoreCase))
-                            {
-                                isMax = true;
-                            }
-                            else if (int.TryParse(sizeString, out var parsedSize))
-                            {
-                                size = parsedSize;
-                                precision = parsedSize;
-                            }
-                        }
-
-                        return storeTypeName.Substring(0, openParen);
-                    }
-                }
-            }
-
-            return storeTypeName;
+            StoreTypeNameBase = storeTypeNameBase;
         }
 
         /// <summary>
@@ -245,29 +174,24 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public string StoreTypeName { get; }
 
         /// <summary>
-        ///     The provider-specific relational type name, with any size/precision/scale removed.
+        ///     The provider-specific relational type name, with any facets removed.
         /// </summary>
         public string StoreTypeNameBase { get; }
 
         /// <summary>
-        ///     <c>True</c> if the store type name ends in "(max)".
-        /// </summary>
-        public bool StoreTypeNameSizeIsMax => _isMax;
-
-        /// <summary>
         ///     Indicates the store-size to use for the mapping, or null if none.
         /// </summary>
-        public int? Size => _coreTypeMappingInfo.Size ?? _parsedSize;
+        public int? Size => _coreTypeMappingInfo.Size;
 
         /// <summary>
         ///     The suggested precision of the mapped data type.
         /// </summary>
-        public int? Precision => _coreTypeMappingInfo.Precision ?? _parsedPrecision;
+        public int? Precision => _coreTypeMappingInfo.Precision;
 
         /// <summary>
         ///     The suggested scale of the mapped data type.
         /// </summary>
-        public int? Scale => _coreTypeMappingInfo.Scale ?? _parsedScale;
+        public int? Scale => _coreTypeMappingInfo.Scale;
 
         /// <summary>
         ///     Whether or not the mapped data type is fixed length.


### PR DESCRIPTION
* Moved parsing of the store type from RelationalTypeMappingInfo to RelationalTypeMappingSource, where it can be overridden.
* Moved considerable additional initialization logic from RTMI to RTS. RTMI no longer holds parsed facet fallbacks (e.g. `_parsedSize`) - the type mapping info is simply initialized with the right value.
* Collapsed together some constructors in RelationalTypeMappingInfo and TypeMappingInfo.
* Added option to parse Unicode from the store type for MySQL.
* Removed IsMax setting which wasn't used anywhere.

Part of #11896

Some additional comments:
* Do we really not need IsMax anymore, it wasn't being used anywhere? If we need it, I can add it back in a way that's SQL Server-specific rather than at the relational level.
* One thing that still doesn't seem possible, is for provider-specific facets to be managed via the fluent API or attributes. For example, in theory it could be nice for providers to have fluent APIs for managing, say, the SRID of a property. This is because {Relational,}TypeMappingInfo only contains the specific set of standard facets (size/precision/scale/unicode), and isn't annotatable or anything. It also doesn't refer to the IProperty or MemberInfo, which would allow the provider's type mapping source to perform additional lookups. Any objection to adding that?
* After all this I may look a little bit at store type name generation in RelationalTypeMapping, to make sure the current design doesn't limit us in any way.