### PR TITLE
Stop making string and binary keys be generated by default

### DIFF
--- a/src/EFCore/Metadata/Conventions/Internal/ValueGeneratorConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ValueGeneratorConvention.cs
@@ -135,8 +135,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             return (propertyType.IsInteger()
                     && propertyType != typeof(byte))
                    || propertyType == typeof(Guid)
-                   || propertyType == typeof(string)
-                   || propertyType == typeof(byte[])
                 ? true
                 : false;
         }

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -947,8 +947,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringKey"", b =>
                 {
-                    b.Property<string>(""Id"")
-                        .ValueGeneratedOnAdd();
+                    b.Property<string>(""Id"");
 
                     b.HasKey(""Id"");
 
@@ -2176,8 +2175,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     GetHeading() + @"
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringKey"", b =>
                 {
-                    b.Property<string>(""Id"")
-                        .ValueGeneratedOnAdd();
+                    b.Property<string>(""Id"");
 
                     b.HasKey(""Id"");
 
@@ -2226,8 +2224,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     GetHeading() + @"
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringKey"", b =>
                 {
-                    b.Property<string>(""Id"")
-                        .ValueGeneratedOnAdd();
+                    b.Property<string>(""Id"");
 
                     b.HasKey(""Id"");
 

--- a/test/EFCore.InMemory.FunctionalTests/Query/WarningsTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/WarningsTest.cs
@@ -302,6 +302,14 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             public DbSet<WarningAsErrorEntity> WarningAsErrorEntities { get; set; }
 
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder
+                    .Entity<WarningAsErrorEntity>()
+                    .Property(e => e.Id)
+                    .ValueGeneratedOnAdd();
+            }
+
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
                 => optionsBuilder
                     .UseInternalServiceProvider(_serviceProvider)

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -1586,8 +1586,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 {
                     x.ToTable("Crab");
 
-                    x.Property<string>("CrabId")
-                        .ValueGeneratedOnAdd();
+                    x.Property<string>("CrabId");
 
                     x.HasKey("CrabId");
                 });

--- a/test/EFCore.Specification.Tests/Query/InheritanceFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/InheritanceFixtureBase.cs
@@ -15,23 +15,11 @@ namespace Microsoft.EntityFrameworkCore.Query
             modelBuilder.Entity<Kiwi>();
             modelBuilder.Entity<Eagle>();
             modelBuilder.Entity<Bird>();
-
-            modelBuilder.Entity<Animal>(b =>
-            {
-                b.HasKey(e => e.Species);
-                b.Property(e => e.Species).ValueGeneratedNever();
-            });
-
+            modelBuilder.Entity<Animal>().HasKey(e => e.Species);
             modelBuilder.Entity<Rose>();
             modelBuilder.Entity<Daisy>();
             modelBuilder.Entity<Flower>();
-
-            modelBuilder.Entity<Plant>(b =>
-            {
-                b.HasKey(e => e.Species);
-                b.Property(e => e.Species).ValueGeneratedNever();
-            });
-
+            modelBuilder.Entity<Plant>().HasKey(e => e.Species);
             modelBuilder.Entity<Country>();
             modelBuilder.Entity<Drink>();
             modelBuilder.Entity<Tea>();

--- a/test/EFCore.SqlServer.FunctionalTests/BatchingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BatchingTest.cs
@@ -223,6 +223,7 @@ namespace Microsoft.EntityFrameworkCore
                 modelBuilder.Entity<Owner>(
                     b =>
                     {
+                        b.Property(e => e.Id).ValueGeneratedOnAdd();
                         b.Property(e => e.Version).IsConcurrencyToken().ValueGeneratedOnAddOrUpdate();
                         b.Property(e => e.Name).HasColumnType("nvarchar(450)");
                     });

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -387,6 +387,7 @@ namespace Microsoft.EntityFrameworkCore
 
         private class SNum
         {
+            [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
             public string Id { get; set; }
             public string TheWalrus { get; set; }
         }
@@ -408,6 +409,7 @@ namespace Microsoft.EntityFrameworkCore
 
         private class BNum
         {
+            [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
             public byte[] Id { get; set; }
             public string TheWalrus { get; set; }
         }

--- a/test/EFCore.Tests/DbContextTest.cs
+++ b/test/EFCore.Tests/DbContextTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -1025,6 +1026,7 @@ namespace Microsoft.EntityFrameworkCore
         private class TestAssembly
         {
             [Key]
+            [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
             public string Name { get; set; }
 
             public ICollection<TestClass> Classes { get; } = new List<TestClass>();

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/ValueGeneratorConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/ValueGeneratorConventionTest.cs
@@ -320,7 +320,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         }
 
         [Fact]
-        public void Identity_set_when_primary_key_property_is_string()
+        public void Identity_not_set_when_primary_key_property_is_string()
         {
             var modelBuilder = CreateInternalModelBuilder();
             var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
@@ -333,12 +333,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             var property = keyBuilder.Metadata.Properties.First();
 
-            Assert.Equal(ValueGenerated.OnAdd, property.ValueGenerated);
-            Assert.True(property.RequiresValueGenerator());
+            Assert.Equal(ValueGenerated.Never, property.ValueGenerated);
+            Assert.False(property.RequiresValueGenerator());
         }
 
         [Fact]
-        public void Identity_set_when_primary_key_property_is_byte_array()
+        public void Identity_not_set_when_primary_key_property_is_byte_array()
         {
             var modelBuilder = CreateInternalModelBuilder();
             var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
@@ -348,8 +348,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             var property = keyBuilder.Metadata.Properties.First();
 
-            Assert.Equal(ValueGenerated.OnAdd, property.ValueGenerated);
-            Assert.True(property.RequiresValueGenerator());
+            Assert.Equal(ValueGenerated.Never, property.ValueGenerated);
+            Assert.False(property.RequiresValueGenerator());
         }
 
         [Fact]

--- a/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
@@ -216,8 +216,8 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
                 var nameProperty = entity.FindPrimaryKey().Properties.Single();
                 Assert.Equal(Customer.NameProperty.Name, nameProperty.Name);
-                Assert.True(nameProperty.RequiresValueGenerator());
-                Assert.Equal(ValueGenerated.OnAdd, nameProperty.ValueGenerated);
+                Assert.False(nameProperty.RequiresValueGenerator());
+                Assert.Equal(ValueGenerated.Never, nameProperty.ValueGenerated);
 
                 var idProperty = (IProperty)entity.FindProperty(Customer.IdProperty);
                 Assert.Equal(ValueGenerated.Never, idProperty.ValueGenerated);


### PR DESCRIPTION
Issue #14617

Previously, they were generated on the client by default, with GUIDs used as the generated value. Now they are not generated by default (which is how they are usually used) but can be configured to the old behavior in the normal way.