### PR TITLE
Add back registration for logging and memory cache

### DIFF
--- a/src/EFCore/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/EFCore/EntityFrameworkServiceCollectionExtensions.cs
@@ -506,6 +506,10 @@ namespace Microsoft.Extensions.DependencyInjection
             ServiceLifetime optionsLifetime)
             where TContextImplementation : DbContext
         {
+            serviceCollection	
+                .AddMemoryCache()	
+                .AddLogging();
+
             serviceCollection.TryAdd(
                 new ServiceDescriptor(
                     typeof(DbContextOptions<TContextImplementation>),


### PR DESCRIPTION
We were making sure these were registered in `AddDbContext` because EF used to need them to be registered, but now it's only optional depending on what you're doing. However, it seems that even in ASP.NET code this causes problems because people are using `AddDbContext` as a means to add these things to the service provider. This indicates poorly written tests/samples, but I think we can assume such will exist in the wild too, so adding these back in to avoid the break.
