### PR TITLE
Fix another race condition in GetRuntimeProperties()

### DIFF
--- a/src/EFCore/Metadata/Internal/TypeBase.cs
+++ b/src/EFCore/Metadata/Internal/TypeBase.cs
@@ -122,7 +122,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
                 // _runtimeProperties should not be mutated after it has been assigned
                 Thread.MemoryBarrier();
-                _runtimeProperties = runtimeProperties;
+                if (_runtimeProperties == null)
+                {
+                    _runtimeProperties = runtimeProperties;
+                    return runtimeProperties;
+                }
             }
 
             return _runtimeProperties;

--- a/src/EFCore/Metadata/Internal/TypeBaseExtensions.cs
+++ b/src/EFCore/Metadata/Internal/TypeBaseExtensions.cs
@@ -49,10 +49,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             var runtimeProperties = type is TypeBase typeBase
                 ? typeBase.GetRuntimeProperties().Values // better perf if we've already computed them once
-                : type.ClrType.GetRuntimeProperties();
+                : type.ClrType?.GetRuntimeProperties();
 
             // find the indexer with single argument of type string which returns an object
-            return runtimeProperties.FirstOrDefault(p => p.IsEFIndexerProperty());
+            return runtimeProperties?.FirstOrDefault(p => p.IsEFIndexerProperty());
         }
     }
 }

--- a/src/EFCore/Storage/ValueConversion/CastingConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/CastingConverter.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
     public class CastingConverter<TModel, TProvider> : ValueConverter<TModel, TProvider>
     {
         // ReSharper disable once StaticMemberInGenericType
-        private static readonly ConverterMappingHints _defaultHints = CreateDefaultHints();
+        private static readonly ConverterMappingHints? _defaultHints = CreateDefaultHints();
 
         private static ConverterMappingHints? CreateDefaultHints()
         {
@@ -47,9 +47,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
             : base(
                 Convert<TModel, TProvider>(),
                 Convert<TProvider, TModel>(),
-                _defaultHints == null
-                    ? mappingHints
-                    : _defaultHints.With(mappingHints))
+                _defaultHints?.With(mappingHints) ?? mappingHints)
         {
         }
 

--- a/src/EFCore/Storage/ValueConversion/EnumToNumberConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/EnumToNumberConverter.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         where TNumber : struct
     {
         // ReSharper disable once StaticMemberInGenericType
-        private static readonly ConverterMappingHints _defaultHints = CreateDefaultHints();
+        private static readonly ConverterMappingHints? _defaultHints = CreateDefaultHints();
 
         private static ConverterMappingHints? CreateDefaultHints()
         {
@@ -43,9 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
                 ToNumber(),
                 ToEnum(),
 #nullable enable
-                _defaultHints == null
-                    ? mappingHints
-                    : _defaultHints.With(mappingHints))
+                _defaultHints?.With(mappingHints) ?? mappingHints)
         {
         }
 


### PR DESCRIPTION
Issue:
Calling `GetRuntimeProperties().FirstOrDefault()` throws `System.InvalidOperationException: Collection was modified; enumeration operation may not execute.` sometimes, see https://github.com/aspnet/AspNetCore-Internal/issues/1776

I cannot repro this locally and it should not ever happen for 3 reasons:

1. As far as I can tell the test in question doesn't perform any requests in parallel
2. Even if it did `GetRuntimeProperties()` is called during model construction and the results are stored, so the underlying dictionary shouldn't be modified after that point. The stack trace from failing tests is coming from the query pipeline.
3. Even if the underlying dictionary wasn't initialized somehow the memory barrier should prevent returning a dictionary before it has finished being populated.

Solution?
Add another check to avoid overwriting the underlying dictionary if it was initialized in another thread at the same time