### PR TITLE
Improve concurrency around Runtime{Properties,Fields}

### DIFF
--- a/src/EFCore/Metadata/Internal/TypeBase.cs
+++ b/src/EFCore/Metadata/Internal/TypeBase.cs
@@ -120,13 +120,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     }
                 }
 
-                // _runtimeProperties should not be mutated after it has been assigned
-                Thread.MemoryBarrier();
-                if (_runtimeProperties == null)
-                {
-                    _runtimeProperties = runtimeProperties;
-                    return runtimeProperties;
-                }
+                Interlocked.CompareExchange(ref _runtimeProperties, runtimeProperties, null);
             }
 
             return _runtimeProperties;
@@ -155,9 +149,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     }
                 }
 
-                // _runtimeFields should not be mutated after it has been assigned
-                Thread.MemoryBarrier();
-                _runtimeFields = runtimeFields;
+                Interlocked.CompareExchange(ref _runtimeFields, runtimeFields, null);
             }
 
             return _runtimeFields;
@@ -171,6 +163,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             _runtimeProperties = null;
             _runtimeFields = null;
+            Thread.MemoryBarrier();
         }
 
         /// <summary>


### PR DESCRIPTION
* Switch to Interlocked.CompareExchange()
* Protect RuntimeFields as well
* Defensively lock after clearing caches to propagate changes

Continues #14742