### PR TITLE
Microsoft.Data.Sqlite: Add LoadExtension() to SqliteConnection

### DIFF
--- a/src/EFCore.Sqlite.Core/Infrastructure/SpatialiteLoader.cs
+++ b/src/EFCore.Sqlite.Core/Infrastructure/SpatialiteLoader.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Data.Common;
+using System.Data;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -50,8 +50,15 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// </summary>
         /// <param name="connection"> The connection. </param>
         /// <returns> true if the extension was loaded; otherwise, false. </returns>
-        public static bool TryLoad([NotNull] DbConnection connection)
+        public static bool TryLoad([NotNull] SqliteConnection connection)
         {
+            var opened = false;
+            if (connection.State != ConnectionState.Open)
+            {
+                // NB: If closed, LoadExtension won't throw immidiately
+                connection.Open();
+                opened = true;
+            }
             try
             {
                 Load(connection);
@@ -61,6 +68,13 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             catch (SqliteException ex) when (ex.SqliteErrorCode == 1)
             {
                 return false;
+            }
+            finally
+            {
+                if (opened)
+                {
+                    connection.Close();
+                }
             }
         }
 
@@ -73,17 +87,13 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     </para>
         /// </summary>
         /// <param name="connection"> The connection. </param>
-        public static void Load([NotNull] DbConnection connection)
+        public static void Load([NotNull] SqliteConnection connection)
         {
             Check.NotNull(connection, nameof(connection));
 
             FindExtension();
 
-            using (var command = connection.CreateCommand())
-            {
-                command.CommandText = "SELECT load_extension('mod_spatialite');";
-                command.ExecuteNonQuery();
-            }
+            connection.LoadExtension("mod_spatialite");
         }
 
         private static void FindExtension()

--- a/src/EFCore.Sqlite.Core/Scaffolding/Internal/SqliteDatabaseModelFactory.cs
+++ b/src/EFCore.Sqlite.Core/Scaffolding/Internal/SqliteDatabaseModelFactory.cs
@@ -84,8 +84,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Scaffolding.Internal
             {
                 connection.Open();
 
-                ((SqliteConnection)connection).EnableExtensions();
-                SpatialiteLoader.TryLoad(connection);
+                SpatialiteLoader.TryLoad((SqliteConnection)connection);
             }
 
             try

--- a/src/Microsoft.Data.Sqlite.Core/Extensions/SqliteConnectionExtensions.cs
+++ b/src/Microsoft.Data.Sqlite.Core/Extensions/SqliteConnectionExtensions.cs
@@ -7,11 +7,13 @@ namespace Microsoft.Data.Sqlite
     {
         public static int ExecuteNonQuery(
             this SqliteConnection connection,
-            string commandText)
+            string commandText,
+            params SqliteParameter[] parameters)
         {
             using (var command = connection.CreateCommand())
             {
                 command.CommandText = commandText;
+                command.Parameters.AddRange(parameters);
 
                 return command.ExecuteNonQuery();
             }

--- a/src/Microsoft.Data.Sqlite.Core/Microsoft.Data.Sqlite.Core.csproj
+++ b/src/Microsoft.Data.Sqlite.Core/Microsoft.Data.Sqlite.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AssemblyName>Microsoft.Data.Sqlite</AssemblyName>
@@ -52,9 +52,6 @@ Microsoft.Data.Sqlite.SqliteTransaction</Description>
       <AutoGen>True</AutoGen>
       <DependentUpon>Resources.Designer.tt</DependentUpon>
     </Compile>
-    <Compile Update="SqliteCommand.cs">
-      <SubType>Component</SubType>
-    </Compile>
     <Compile Update="SqliteConnection.CreateAggregate.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
@@ -64,9 +61,6 @@ Microsoft.Data.Sqlite.SqliteTransaction</Description>
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
       <DependentUpon>SqliteConnection.CreateFunction.tt</DependentUpon>
-    </Compile>
-    <Compile Update="SqliteConnection.cs">
-      <SubType>Component</SubType>
     </Compile>
   </ItemGroup>
 

--- a/test/EFCore.InMemory.Tests/EFCore.InMemory.Tests.csproj
+++ b/test/EFCore.InMemory.Tests/EFCore.InMemory.Tests.csproj
@@ -19,10 +19,4 @@
     <ProjectReference Include="..\EFCore.Tests\EFCore.Tests.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Update="TestUtilities\FakeProvider\FakeDbCommand.cs">
-      <SubType>Component</SubType>
-    </Compile>
-  </ItemGroup>
-
 </Project>

--- a/test/EFCore.Proxies.Tests/EFCore.Proxies.Tests.csproj
+++ b/test/EFCore.Proxies.Tests/EFCore.Proxies.Tests.csproj
@@ -18,10 +18,4 @@
     <ProjectReference Include="..\EFCore.Tests\EFCore.Tests.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Update="TestUtilities\FakeProvider\FakeDbCommand.cs">
-      <SubType>Component</SubType>
-    </Compile>
-  </ItemGroup>
-
 </Project>

--- a/test/EFCore.Relational.Tests/EFCore.Relational.Tests.csproj
+++ b/test/EFCore.Relational.Tests/EFCore.Relational.Tests.csproj
@@ -26,13 +26,4 @@
     <Reference Include="System.Transactions" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Update="TestUtilities\FakeProvider\FakeDbCommand.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="TestUtilities\FakeProvider\FakeDbConnection.cs">
-      <SubType>Component</SubType>
-    </Compile>
-  </ItemGroup>
-
 </Project>

--- a/test/EFCore.Sqlite.FunctionalTests/TestUtilities/SpatialiteRequiredAttribute.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/TestUtilities/SpatialiteRequiredAttribute.cs
@@ -17,9 +17,6 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 {
                     using (var connection = new SqliteConnection("Data Source=:memory:"))
                     {
-                        connection.Open();
-                        connection.EnableExtensions();
-
                         return SpatialiteLoader.TryLoad(connection);
                     }
                 });

--- a/test/EFCore.Sqlite.FunctionalTests/TestUtilities/SqliteDatabaseCleaner.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/TestUtilities/SqliteDatabaseCleaner.cs
@@ -47,8 +47,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         {
             connection.Open();
 
-            ((SqliteConnection)connection.DbConnection).EnableExtensions();
-            SpatialiteLoader.TryLoad(connection.DbConnection);
+            SpatialiteLoader.TryLoad((SqliteConnection)connection.DbConnection);
         }
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/TestUtilities/SqliteTestStore.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/TestUtilities/SqliteTestStore.cs
@@ -41,7 +41,9 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 Cache = sharedCache ? SqliteCacheMode.Shared : SqliteCacheMode.Private
             }.ToString();
 
-            Connection = new SqliteConnection(ConnectionString);
+            var connection = new SqliteConnection(ConnectionString);
+            SpatialiteLoader.TryLoad(connection);
+            Connection = connection;
         }
 
         public override DbContextOptionsBuilder AddProviderOptions(DbContextOptionsBuilder builder)
@@ -74,14 +76,6 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
         public override void Clean(DbContext context)
             => context.Database.EnsureClean();
-
-        public override void OpenConnection()
-        {
-            Connection.Open();
-
-            ((SqliteConnection)Connection).EnableExtensions();
-            SpatialiteLoader.TryLoad(Connection);
-        }
 
         public int ExecuteNonQuery(string sql, params object[] parameters)
         {

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionTest.cs
@@ -1110,6 +1110,46 @@ namespace Microsoft.Data.Sqlite
         }
 
         [Fact]
+        public void LoadExtension_works()
+        {
+            using (var connection = new SqliteConnection("Data Source=:memory:"))
+            {
+                connection.EnableExtensions(false);
+                connection.Open();
+
+                var ex = Assert.Throws<SqliteException>(
+                    () => connection.ExecuteNonQuery("SELECT load_extension('unknown');"));
+                var extensionsDisabledError = ex.Message;
+
+                ex = Assert.Throws<SqliteException>(() => connection.LoadExtension("unknown"));
+
+                Assert.NotEqual(extensionsDisabledError, ex.Message);
+            }
+        }
+
+        [Fact]
+        public void LoadExtension_works_when_closed()
+        {
+            using (var connection = new SqliteConnection("Data Source=:memory:"))
+            {
+                connection.EnableExtensions(false);
+                connection.Open();
+
+                var ex = Assert.Throws<SqliteException>(
+                    () => connection.ExecuteNonQuery("SELECT load_extension('unknown');"));
+                var extensionsDisabledError = ex.Message;
+
+                connection.Close();
+
+                connection.LoadExtension("unknown");
+
+                ex = Assert.Throws<SqliteException>(() => connection.Open());
+
+                Assert.NotEqual(extensionsDisabledError, ex.Message);
+            }
+        }
+
+        [Fact]
         public void DbProviderFactory_works()
         {
             var connection = new SqliteConnection();

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteFactoryTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteFactoryTest.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace Microsoft.Data.Sqlite.Tests
+namespace Microsoft.Data.Sqlite
 {
     public class SqliteFactoryTest
     {


### PR DESCRIPTION
This also updates EFCore.Sqlite to use the new method.

There is a breaking change in SpatialiteLoader. The methods used to take a DbConnection (I guess 'cause we could) but now take a SqliteConnection.

You no longer need to call SqliteConnection.EnableExtensions() before using SpatialiteLoader since the new LoadExtension method will bypass the connection setting. This greatly improves usability and makes EnableExtensions only apply to the load_extension SQL function. Given this, EnableExtensions should probably have been a connection string keyword.

In fact, SpatialiteLoader isn't really needed anymore since calling UseNetTopologySuite now loads the extension for open external connections. Maybe we should make it internal. (See #14821)

LoadExtension has some unusual behavior when the connection is closed. Any exceptions will be delayed until the connection is opened, and there is no way to remove an extension you tried to load, so you'll have to create a new connection object to get back in a good state.

Resolves #13826 

~~I'll review these changes in a design meeting to make sure we're OK with them all.~~ ✔