### PR TITLE
Change publish feed to workaround 'Waiting to obtain an exclusive lock on the feed.'

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,7 +34,7 @@ jobs:
             - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
               - group: DotNet-Blob-Feed
               - _SignType: real
-              - _PublishBlobFeedUrl: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+              - _PublishBlobFeedUrl: https://dotnetfeed.blob.core.windows.net/aspnet-entityframeworkcore/index.json
               - _DotNetPublishToBlobFeed: true
               - _InternalBuildArgs: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName) /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1) /p:DotNetPublishBlobFeedUrl=$(_PublishBlobFeedUrl) /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed) /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
           steps:

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -56,6 +56,7 @@
     <RestoreSources>
       $(RestoreSources);
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
+      https://dotnetfeed.blob.core.windows.net/aspnet-extensions/index.json;
       https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json
     </RestoreSources>
   </PropertyGroup>


### PR DESCRIPTION
We're getting consistent build timeouts. Changing to a unique feed instead. Each upstream partner will need to add this to restore sources.