### PR TITLE
Improve experience for HasOne/HasMany used with single string

### DIFF
--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -821,14 +821,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 stringBuilder
                     .Append(builderName)
                     .Append(".HasOne(")
-                    .Append(Code.Literal(foreignKey.PrincipalEntityType.Name));
-
-                if (foreignKey.DependentToPrincipal != null)
-                {
-                    stringBuilder
-                        .Append(", ")
-                        .Append(Code.Literal(foreignKey.DependentToPrincipal.Name));
-                }
+                    .Append(Code.Literal(foreignKey.PrincipalEntityType.Name))
+                    .Append(", ")
+                    .Append(
+                        foreignKey.DependentToPrincipal == null
+                            ? Code.UnknownLiteral(null)
+                            : Code.Literal(foreignKey.DependentToPrincipal.Name));
             }
             else
             {

--- a/src/EFCore.Design/Migrations/Design/MigrationsCodeGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/MigrationsCodeGenerator.cs
@@ -18,16 +18,13 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
     /// <summary>
     ///     Used to generate code for migrations.
     /// </summary>
-#pragma warning disable CA1012 // Abstract types should not have constructors
-    // Already shipped
     public abstract class MigrationsCodeGenerator : IMigrationsCodeGenerator
-#pragma warning restore CA1012 // Abstract types should not have constructors
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="MigrationsCodeGenerator" /> class.
         /// </summary>
         /// <param name="dependencies"> The dependencies. </param>
-        public MigrationsCodeGenerator([NotNull] MigrationsCodeGeneratorDependencies dependencies)
+        protected MigrationsCodeGenerator([NotNull] MigrationsCodeGeneratorDependencies dependencies)
         {
             Check.NotNull(dependencies, nameof(dependencies));
 

--- a/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
+++ b/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
@@ -30,6 +30,25 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public static MemberInfo GetNavigationMemberInfo(
+            [NotNull] this IEntityType entityType,
+            [NotNull] string navigationName)
+        {
+            var memberInfo = entityType.ClrType.GetMembersInHierarchy(navigationName).FirstOrDefault();
+
+            if (memberInfo == null)
+            {
+                throw new InvalidOperationException(
+                    CoreStrings.NoClrNavigation(navigationName, entityType.DisplayName()));
+            }
+
+            return memberInfo;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         [DebuggerStepThrough]
         public static string ShortName([NotNull] this IEntityType type)
         {

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -970,7 +970,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 navigation, entityType, foundType, targetType);
 
         /// <summary>
-        ///     The type of navigation property '{navigation}' on the entity type '{entityType}' is '{foundType}' which is an array type.. Collection navigation properties cannot be arrays.
+        ///     The type of navigation property '{navigation}' on the entity type '{entityType}' is '{foundType}' which is an array type. Collection navigation properties cannot be arrays.
         /// </summary>
         public static string NavigationArray([CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object foundType)
             => string.Format(

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -454,7 +454,7 @@
     <value>The type of navigation property '{navigation}' on the entity type '{entityType}' is '{foundType}' which does not implement ICollection&lt;{targetType}&gt;. Collection navigation properties must implement ICollection&lt;&gt; of the target type.</value>
   </data>
   <data name="NavigationArray" xml:space="preserve">
-    <value>The type of navigation property '{navigation}' on the entity type '{entityType}' is '{foundType}' which is an array type.. Collection navigation properties cannot be arrays.</value>
+    <value>The type of navigation property '{navigation}' on the entity type '{entityType}' is '{foundType}' which is an array type. Collection navigation properties cannot be arrays.</value>
   </data>
   <data name="NavigationNoSetter" xml:space="preserve">
     <value>The navigation property '{navigation}' on the entity type '{entityType}' does not have a setter and no writable backing field was found or specified. Read-only collection navigation properties must be initialized before use.</value>

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -2201,7 +2201,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", b =>
                 {
-                    b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringKey"")
+                    b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringKey"", null)
                         .WithOne()
                         .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", ""Name"")
                         .OnDelete(DeleteBehavior.Cascade);
@@ -2248,7 +2248,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", b =>
                 {
-                    b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringKey"")
+                    b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringKey"", null)
                         .WithMany(""Properties"")
                         .HasForeignKey(""Name"");
                 });"),
@@ -2390,7 +2390,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithGenericProperty<System.Guid>"", b =>
                 {
-                    b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithGenericKey<System.Guid>"")
+                    b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithGenericKey<System.Guid>"", null)
                         .WithMany()
                         .HasForeignKey(""Property"")
                         .OnDelete(DeleteBehavior.Cascade);

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilder.Other.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilder.Other.cs
@@ -16,6 +16,81 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 {
     public class ModelBuilderOtherTest
     {
+        [Fact]
+        public virtual void HasOne_with_just_string_navigation_for_non_CLR_property_throws()
+        {
+            using (var context = new CustomModelBuildingContext(
+                Configure(),
+                b =>
+                {
+                    b.Entity<Dr>().HasOne("Snoop");
+                }))
+            {
+                Assert.Equal(
+                    CoreStrings.NoClrNavigation("Snoop", nameof(Dr)),
+                    Assert.Throws<InvalidOperationException>(() => context.Model).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void HasMany_with_just_string_navigation_for_non_CLR_property_throws()
+        {
+            using (var context = new CustomModelBuildingContext(
+                Configure(),
+                b =>
+                {
+                    b.Entity<Dr>().HasMany("Snoop");
+                }))
+            {
+                Assert.Equal(
+                    CoreStrings.NoClrNavigation("Snoop", nameof(Dr)),
+                    Assert.Throws<InvalidOperationException>(() => context.Model).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void HasMany_with_a_non_collection_just_string_navigation_CLR_property_throws()
+        {
+            using (var context = new CustomModelBuildingContext(
+                Configure(),
+                b =>
+                {
+                    b.Entity<Dr>().HasMany("Dre");
+                }))
+            {
+                Assert.Equal(
+                    CoreStrings.NavigationCollectionWrongClrType("Dre", nameof(Dr), nameof(Dre), "T"),
+                    Assert.Throws<InvalidOperationException>(() => context.Model).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void OwnsOne_HasOne_with_just_string_navigation_for_non_CLR_property_throws()
+        {
+            using (var context = new CustomModelBuildingContext(
+                Configure(),
+                b =>
+                {
+                    b.Entity<Dr>().OwnsOne(e =>e.Dre).HasOne("Snoop");
+                }))
+            {
+                Assert.Equal(
+                    CoreStrings.NoClrNavigation("Snoop", nameof(Dre)),
+                    Assert.Throws<InvalidOperationException>(() => context.Model).Message);
+            }
+        }
+
+        protected class Dr
+        {
+            public int Id { get; set; }
+
+            public Dre Dre { get; set; }
+        }
+
+        protected class Dre
+        {
+        }
+
         [Fact] //Issue#13108
         public virtual void HasForeignKey_infers_type_for_shadow_property_when_not_specified()
         {

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericUnqualifiedStringTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericUnqualifiedStringTest.cs
@@ -91,15 +91,25 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public override TestReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne<TRelatedEntity>(
                 Expression<Func<TEntity, TRelatedEntity>> navigationExpression = null)
-                => new NonGenericStringTestReferenceNavigationBuilder<TEntity, TRelatedEntity>(
-                    EntityTypeBuilder.HasOne(
-                        typeof(TRelatedEntity).FullName, navigationExpression?.GetPropertyAccess().GetSimpleMemberName()));
+            {
+                var navigationName = navigationExpression?.GetPropertyAccess().GetSimpleMemberName();
+
+                return new NonGenericStringTestReferenceNavigationBuilder<TEntity, TRelatedEntity>(
+                    navigationName == null
+                        ? EntityTypeBuilder.HasOne(typeof(TRelatedEntity).FullName, navigationName)
+                        : EntityTypeBuilder.HasOne(navigationName));
+            }
 
             public override TestCollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany<TRelatedEntity>(
                 Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression = null)
-                => new NonGenericTestCollectionNavigationBuilder<TEntity, TRelatedEntity>(
-                    EntityTypeBuilder.HasMany(
-                        typeof(TRelatedEntity).FullName, navigationExpression?.GetPropertyAccess().GetSimpleMemberName()));
+            {
+                var navigationName = navigationExpression?.GetPropertyAccess().GetSimpleMemberName();
+
+                return new NonGenericTestCollectionNavigationBuilder<TEntity, TRelatedEntity>(
+                    navigationName == null
+                    ? EntityTypeBuilder.HasMany(typeof(TRelatedEntity).FullName, navigationName)
+                    : EntityTypeBuilder.HasMany(navigationName));
+            }
         }
 
         private class NonGenericStringTestReferenceNavigationBuilder<TEntity, TRelatedEntity> : NonGenericTestReferenceNavigationBuilder<
@@ -171,9 +181,14 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public override TestReferenceNavigationBuilder<TDependentEntity, TNewDependentEntity> HasOne<TNewDependentEntity>(
                 Expression<Func<TDependentEntity, TNewDependentEntity>> navigationExpression = null)
-                => new NonGenericStringTestReferenceNavigationBuilder<TDependentEntity, TNewDependentEntity>(
-                    OwnedNavigationBuilder.HasOne(
-                        typeof(TNewDependentEntity).FullName, navigationExpression?.GetPropertyAccess().GetSimpleMemberName()));
+            {
+                var navigationName = navigationExpression?.GetPropertyAccess().GetSimpleMemberName();
+
+                return new NonGenericStringTestReferenceNavigationBuilder<TDependentEntity, TNewDependentEntity>(
+                    navigationName == null
+                    ? OwnedNavigationBuilder.HasOne(typeof(TNewDependentEntity).FullName, navigationName)
+                    : OwnedNavigationBuilder.HasOne(navigationName));
+            }
         }
     }
 }


### PR DESCRIPTION
Issue #9171

Now if these methods are called with a single string, then that string represents the navigation property name. If there is no CLR property with the given name, then an exception is thrown.

The exception is when the entity type has no CLR type, in which case the old behavior is preserved so as not to break existing model snapshots. Entity types with no CLR type are only valid in model snapshots.