### PR TITLE
Enable table name uniquification

### DIFF
--- a/src/EFCore.Relational/Metadata/Conventions/Internal/SharedTableConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Internal/SharedTableConvention.cs
@@ -107,36 +107,114 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         public virtual InternalModelBuilder Apply(InternalModelBuilder modelBuilder)
         {
             var maxLength = modelBuilder.Relational(ConfigurationSource.Convention).MaxIdentifierLength;
-            var tables = new Dictionary<(string, string),
-                (Dictionary<string, Property> Columns,
-                Dictionary<string, Key> Keys,
-                Dictionary<string, ForeignKey> ForeignKeys,
-                Dictionary<string, Index> Indexes)>();
-            foreach (var entityType in modelBuilder.Metadata.GetEntityTypes())
+            var tables = new Dictionary<(string, string), List<EntityType>>();
+
+            TryUniquifyTableNames(modelBuilder.Metadata, tables, maxLength);
+
+            var columns = new Dictionary<string, Property>(StringComparer.Ordinal);
+            var keys = new Dictionary<string, Key>(StringComparer.Ordinal);
+            var foreignKeys = new Dictionary<string, ForeignKey>(StringComparer.Ordinal);
+            var indexes = new Dictionary<string, Index>(StringComparer.Ordinal);
+            foreach (var entityTypes in tables.Values)
             {
-                if (entityType.IsKeyless)
+                columns.Clear();
+                keys.Clear();
+                foreignKeys.Clear();
+                indexes.Clear();
+
+                foreach (var entityType in entityTypes)
+                {
+                    TryUniquifyColumnNames(entityType, columns, maxLength);
+                    TryUniquifyKeyNames(entityType, keys, maxLength);
+                    TryUniquifyForeignKeyNames(entityType, foreignKeys, maxLength);
+                    TryUniquifyIndexNames(entityType, indexes, maxLength);
+                }
+            }
+
+            return modelBuilder;
+        }
+
+        private static void TryUniquifyTableNames(
+            Model model, Dictionary<(string, string), List<EntityType>> tables, int maxLength)
+        {
+            foreach (var entityType in model.GetEntityTypes())
+            {
+                if (entityType.FindPrimaryKey() == null)
                 {
                     continue;
                 }
 
                 var annotations = entityType.Relational();
                 var tableName = (annotations.Schema, annotations.TableName);
-                if (!tables.TryGetValue(tableName, out var tableObjects))
+                if (!tables.TryGetValue(tableName, out var entityTypes))
                 {
-                    tableObjects = (new Dictionary<string, Property>(StringComparer.Ordinal),
-                        new Dictionary<string, Key>(StringComparer.Ordinal),
-                        new Dictionary<string, ForeignKey>(StringComparer.Ordinal),
-                        new Dictionary<string, Index>(StringComparer.Ordinal));
-                    tables[tableName] = tableObjects;
+                    entityTypes = new List<EntityType>();
+                    tables[tableName] = entityTypes;
                 }
 
-                TryUniquifyColumnNames(entityType, tableObjects.Columns, maxLength);
-                TryUniquifyKeyNames(entityType, tableObjects.Keys, maxLength);
-                TryUniquifyForeignKeyNames(entityType, tableObjects.ForeignKeys, maxLength);
-                TryUniquifyIndexNames(entityType, tableObjects.Indexes, maxLength);
+                if (entityTypes.Count > 0)
+                {
+                    var shouldUniquifyTable = ShouldUniquify(entityType, entityTypes);
+
+                    if (shouldUniquifyTable)
+                    {
+                        if (entityType[RelationalAnnotationNames.TableName] == null)
+                        {
+                            var uniqueName = ConstraintNamer.Uniquify(
+                                tableName.TableName, tables, n => (tableName.Schema, n), maxLength);
+                            if (entityType.Builder.Relational(ConfigurationSource.Convention).ToTable(uniqueName))
+                            {
+                                tables[(tableName.Schema, uniqueName)] = new List<EntityType> { entityType };
+                                continue;
+                            }
+                        }
+
+                        if (entityTypes.Count == 1)
+                        {
+                            var otherEntityType = entityTypes.First();
+                            if (otherEntityType[RelationalAnnotationNames.TableName] == null)
+                            {
+                                var uniqueName = ConstraintNamer.Uniquify(
+                                    tableName.TableName, tables, n => (tableName.Schema, n), maxLength);
+                                if (otherEntityType.Builder.Relational(ConfigurationSource.Convention).ToTable(uniqueName))
+                                {
+                                    entityTypes.Remove(otherEntityType);
+                                    tables[(tableName.Schema, uniqueName)] = new List<EntityType> { otherEntityType };
+                                }
+                            }
+                        }
+                    }
+                }
+
+                entityTypes.Add(entityType);
+            }
+        }
+
+        private static bool ShouldUniquify(EntityType entityType, ICollection<EntityType> entityTypes)
+        {
+            var rootType = entityType.RootType();
+            var pkProperty = entityType.FindPrimaryKey().Properties[0];
+            var rootSharedTableType = pkProperty.FindSharedTableRootPrimaryKeyProperty()?.DeclaringEntityType;
+
+            foreach (var otherEntityType in entityTypes)
+            {
+                if (rootSharedTableType == otherEntityType
+                    || rootType == otherEntityType.RootType())
+                {
+                    return false;
+                }
+
+                var otherPkProperty = otherEntityType.FindPrimaryKey().Properties[0];
+                var otherRootSharedTableType = otherPkProperty.FindSharedTableRootPrimaryKeyProperty()?.DeclaringEntityType;
+                if (otherRootSharedTableType == entityType
+                    || (otherRootSharedTableType == rootSharedTableType
+                        && otherRootSharedTableType != null))
+                {
+                    return false;
+                }
             }
 
-            return modelBuilder;
+            return true;
         }
 
         private static void TryUniquifyColumnNames(EntityType entityType, Dictionary<string, Property> properties, int maxLength)
@@ -150,30 +228,53 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     continue;
                 }
 
+                var usePrefix = property.DeclaringEntityType != otherProperty.DeclaringEntityType
+                    || property.IsPrimaryKey()
+                    || otherProperty.IsPrimaryKey();
                 if (!property.IsPrimaryKey())
                 {
-                    var relationalPropertyBuilder = property.Builder.Relational(ConfigurationSource.Convention);
-                    if (relationalPropertyBuilder.CanSetColumnName(null))
+                    var newColumnName = TryUniquify(property, columnName, properties, usePrefix, maxLength);
+                    if (newColumnName != null)
                     {
-                        columnName = Uniquify(columnName, property.DeclaringEntityType.ShortName(), properties, maxLength);
-                        relationalPropertyBuilder.ColumnName = columnName;
-                        properties[columnName] = property;
+                        properties[newColumnName] = property;
                         continue;
                     }
                 }
 
                 if (!otherProperty.IsPrimaryKey())
                 {
-                    var otherRelationalPropertyBuilder = otherProperty.Builder.Relational(ConfigurationSource.Convention);
-                    if (otherRelationalPropertyBuilder.CanSetColumnName(null))
+                    var newColumnName = TryUniquify(otherProperty, columnName, properties, usePrefix, maxLength);
+                    if (newColumnName != null)
                     {
                         properties[columnName] = property;
-                        columnName = Uniquify(columnName, otherProperty.DeclaringEntityType.ShortName(), properties, maxLength);
-                        otherRelationalPropertyBuilder.ColumnName = columnName;
-                        properties[columnName] = otherProperty;
+                        properties[newColumnName] = otherProperty;
                     }
                 }
             }
+        }
+
+        private static string TryUniquify(
+            Property property, string columnName, Dictionary<string, Property> properties, bool usePrefix, int maxLength)
+        {
+            var relationalPropertyBuilder = property.Builder.Relational(ConfigurationSource.Convention);
+            if (relationalPropertyBuilder.CanSetColumnName(null))
+            {
+                if (usePrefix)
+                {
+                    var prefix = property.DeclaringEntityType.ShortName();
+                    if (!columnName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                    {
+                        columnName = prefix + "_" + columnName;
+                    }
+                }
+
+                columnName = ConstraintNamer.Uniquify(columnName, properties, maxLength);
+                relationalPropertyBuilder.ColumnName = columnName;
+                properties[columnName] = property;
+                return columnName;
+            }
+
+            return null;
         }
 
         private static void TryUniquifyKeyNames(EntityType entityType, Dictionary<string, Key> keys, int maxLength)
@@ -189,28 +290,38 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
                 if (!key.IsPrimaryKey())
                 {
-                    var relationalKeyBuilder = key.Builder.Relational(ConfigurationSource.Convention);
-                    if (relationalKeyBuilder.CanSetName(null))
+                    var newKeyName = TryUniquify(key, keyName, keys, maxLength);
+                    if (newKeyName != null)
                     {
-                        keyName = Uniquify(keyName, null, keys, maxLength);
-                        relationalKeyBuilder.Name = keyName;
-                        keys[keyName] = key;
+                        keys[newKeyName] = key;
                         continue;
                     }
                 }
 
                 if (!otherKey.IsPrimaryKey())
                 {
-                    var otherRelationalKeyBuilder = otherKey.Builder.Relational(ConfigurationSource.Convention);
-                    if (otherRelationalKeyBuilder.CanSetName(null))
+                    var newKeyName = TryUniquify(otherKey, keyName, keys, maxLength);
+                    if (newKeyName != null)
                     {
                         keys[keyName] = key;
-                        keyName = Uniquify(keyName, null, keys, maxLength);
-                        otherRelationalKeyBuilder.Name = keyName;
-                        keys[keyName] = otherKey;
+                        keys[newKeyName] = otherKey;
                     }
                 }
             }
+        }
+
+        private static string TryUniquify<T>(
+           Key key, string keyName, Dictionary<string, T> keys, int maxLength)
+        {
+            var relationalKeyBuilder = key.Builder.Relational(ConfigurationSource.Convention);
+            if (relationalKeyBuilder.CanSetName(null))
+            {
+                keyName = ConstraintNamer.Uniquify(keyName, keys, maxLength);
+                relationalKeyBuilder.Name = keyName;
+                return keyName;
+            }
+
+            return null;
         }
 
         private static void TryUniquifyIndexNames(EntityType entityType, Dictionary<string, Index> indexes, int maxLength)
@@ -243,20 +354,32 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                         }
                     }
 
-                    indexName = Uniquify(indexName, null, indexes, maxLength);
-                    relationalIndexBuilder.Name = indexName;
-                    indexes[indexName] = index;
+                    var newIndexName = TryUniquify(index, indexName, indexes, maxLength);
+                    indexes[newIndexName] = index;
                     continue;
                 }
 
-                if (otherRelationalIndexBuilder.CanSetName(null))
+                var newOtherIndexName = TryUniquify(otherIndex, indexName, indexes, maxLength);
+                if (newOtherIndexName != null)
                 {
                     indexes[indexName] = index;
-                    indexName = Uniquify(indexName, null, indexes, maxLength);
-                    otherRelationalIndexBuilder.Name = indexName;
-                    indexes[indexName] = otherIndex;
+                    indexes[newOtherIndexName] = otherIndex;
                 }
             }
+        }
+
+        private static string TryUniquify<T>(
+           Index index, string indexName, Dictionary<string, T> indexes, int maxLength)
+        {
+            var relationalIndexBuilder = index.Builder.Relational(ConfigurationSource.Convention);
+            if (relationalIndexBuilder.CanSetName(null))
+            {
+                indexName = ConstraintNamer.Uniquify(indexName, indexes, maxLength);
+                relationalIndexBuilder.Name = indexName;
+                return indexName;
+            }
+
+            return null;
         }
 
         private static void TryUniquifyForeignKeyNames(EntityType entityType, Dictionary<string, ForeignKey> foreignKeys, int maxLength)
@@ -294,38 +417,32 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                         continue;
                     }
 
-                    foreignKeyName = Uniquify(foreignKeyName, null, foreignKeys, maxLength);
-                    relationalKeyBuilder.Name = foreignKeyName;
-                    foreignKeys[foreignKeyName] = foreignKey;
+                    var newForeignKeyName = TryUniquify(foreignKey, foreignKeyName, foreignKeys, maxLength);
+                    foreignKeys[newForeignKeyName] = foreignKey;
                     continue;
                 }
 
-                if (otherRelationalKeyBuilder.CanSetName(null))
+                var newOtherForeignKeyName = TryUniquify(otherForeignKey, foreignKeyName, foreignKeys, maxLength);
+                if (newOtherForeignKeyName != null)
                 {
                     foreignKeys[foreignKeyName] = foreignKey;
-                    foreignKeyName = Uniquify(foreignKeyName, null, foreignKeys, maxLength);
-                    otherRelationalKeyBuilder.Name = foreignKeyName;
-                    foreignKeys[foreignKeyName] = otherForeignKey;
+                    foreignKeys[newOtherForeignKeyName] = otherForeignKey;
                 }
             }
         }
 
-        private static string Uniquify<T>(string baseIdentifier, string prefix, Dictionary<string, T> existingIdentifiers, int maxLength)
+        private static string TryUniquify<T>(
+           ForeignKey foreignKey, string foreignKeyName, Dictionary<string, T> foreignKeys, int maxLength)
         {
-            if (!string.IsNullOrEmpty(prefix)
-                && !baseIdentifier.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            var relationalKeyBuilder = foreignKey.Builder.Relational(ConfigurationSource.Convention);
+            if (relationalKeyBuilder.CanSetName(null))
             {
-                baseIdentifier = prefix + "_" + baseIdentifier;
+                foreignKeyName = ConstraintNamer.Uniquify(foreignKeyName, foreignKeys, maxLength);
+                relationalKeyBuilder.Name = foreignKeyName;
+                return foreignKeyName;
             }
 
-            var finalIdentifier = ConstraintNamer.Truncate(baseIdentifier, null, maxLength);
-            var suffix = 1;
-            while (existingIdentifiers.ContainsKey(finalIdentifier))
-            {
-                finalIdentifier = ConstraintNamer.Truncate(baseIdentifier, suffix++, maxLength);
-            }
-
-            return finalIdentifier;
+            return null;
         }
     }
 }

--- a/src/EFCore.Relational/Metadata/Internal/ConstraintNamer.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ConstraintNamer.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
@@ -134,6 +136,43 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             return Truncate(baseName, null, property.DeclaringEntityType.Model.GetMaxIdentifierLength());
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string Uniquify<T>(
+            [NotNull] string currentIdentifier, [NotNull] IReadOnlyDictionary<string, T> otherIdentifiers, int maxLength)
+        {
+            var finalIdentifier = Truncate(currentIdentifier, null, maxLength);
+            var suffix = 1;
+            while (otherIdentifiers.ContainsKey(finalIdentifier))
+            {
+                finalIdentifier = Truncate(currentIdentifier, suffix++, maxLength);
+            }
+
+            return finalIdentifier;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string Uniquify<TKey, TValue>(
+            [NotNull] string currentIdentifier,
+            [NotNull] IReadOnlyDictionary<TKey, TValue> otherIdentifiers,
+            Func<string, TKey> keySelector,
+            int maxLength)
+        {
+            var finalIdentifier = Truncate(currentIdentifier, null, maxLength);
+            var suffix = 1;
+            while (otherIdentifiers.ContainsKey(keySelector(finalIdentifier)))
+            {
+                finalIdentifier = Truncate(currentIdentifier, suffix++, maxLength);
+            }
+
+            return finalIdentifier;
         }
 
         /// <summary>

--- a/test/EFCore.Relational.Specification.Tests/UpdatesRelationalFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/UpdatesRelationalFixture.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.EntityFrameworkCore.TestModels.UpdatesModel;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 
 namespace Microsoft.EntityFrameworkCore
@@ -8,5 +9,28 @@ namespace Microsoft.EntityFrameworkCore
     public abstract class UpdatesRelationalFixture : UpdatesFixtureBase
     {
         public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ListLoggerFactory;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+        {
+            base.OnModelCreating(modelBuilder, context);
+
+            modelBuilder
+                .Entity<
+                    LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWorkingCorrectlyDetails
+                >(
+                    eb =>
+                    {
+                        eb.HasKey(
+                            l => new
+                            {
+                                l.ProfileId
+                            })
+                            .HasName("PK_LoginDetails");
+
+                        eb.HasOne(d => d.Login).WithOne()
+                          .HasConstraintName("FK_LoginDetails_Login");
+                    });
+
+        }
     }
 }

--- a/test/EFCore.Specification.Tests/TestModels/UpdatesModel/LoginDetails.cs
+++ b/test/EFCore.Specification.Tests/TestModels/UpdatesModel/LoginDetails.cs
@@ -1,0 +1,31 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.EntityFrameworkCore.TestModels.UpdatesModel
+{
+    public class
+        LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWorkingCorrectlyDetails
+    {
+        public int ProfileId { get; set; }
+        public string ProfileId1 { get; set; }
+        public Guid ProfileId2 { get; set; }
+        public decimal ProfileId3 { get; set; }
+        public bool ProfileId4 { get; set; }
+        public byte ProfileId5 { get; set; }
+        public short ProfileId6 { get; set; }
+        public long ProfileId7 { get; set; }
+        public DateTime ProfileId8 { get; set; }
+        public DateTimeOffset ProfileId9 { get; set; }
+        public TimeSpan ProfileId10 { get; set; }
+        public byte? ProfileId11 { get; set; }
+        public short? ProfileId12 { get; set; }
+        public int? ProfileId13 { get; set; }
+        public long? ProfileId14 { get; set; }
+        public int ExtraPropertyWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWorkingCorrectly { get; set; }
+        public string ExtraPropertyWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWorkingCorrectlyWhenTruncatedNamesCollide { get; set; }
+
+        public virtual LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWorkingCorrectly Login { get; set; }
+    }
+}

--- a/test/EFCore.Specification.Tests/UpdatesFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/UpdatesFixtureBase.cs
@@ -76,6 +76,38 @@ namespace Microsoft.EntityFrameworkCore
                             });
                     });
 
+            modelBuilder
+                .Entity<
+                    LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWorkingCorrectlyDetails
+                >(
+                    eb =>
+                    {
+                        eb.HasKey(
+                            l => new
+                            {
+                                l.ProfileId
+                            });
+                        eb.HasOne(d => d.Login).WithOne()
+                        .HasForeignKey<LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWorkingCorrectlyDetails>(
+                            l => new
+                            {
+                                l.ProfileId,
+                                l.ProfileId1,
+                                l.ProfileId3,
+                                l.ProfileId4,
+                                l.ProfileId5,
+                                l.ProfileId6,
+                                l.ProfileId7,
+                                l.ProfileId8,
+                                l.ProfileId9,
+                                l.ProfileId10,
+                                l.ProfileId11,
+                                l.ProfileId12,
+                                l.ProfileId13,
+                                l.ProfileId14
+                            });
+                    });
+
             modelBuilder.Entity<Profile>(
                 pb =>
                 {

--- a/test/EFCore.SqlServer.FunctionalTests/UpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/UpdatesSqlServerTest.cs
@@ -55,6 +55,23 @@ SELECT @@ROWCOUNT;"
                 Assert.Equal(
                     "IX_LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWork~",
                     entityType.GetIndexes().Single().Relational().Name);
+
+                var entityType2 = context.Model.FindEntityType(
+                    typeof(
+                        LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWorkingCorrectlyDetails
+                    ));
+
+                Assert.Equal(
+                    "LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWorkin~1",
+                    entityType2.Relational().TableName);
+
+                Assert.Equal(
+                    "ExtraPropertyWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWorkingCo~",
+                    entityType2.GetProperties().ElementAt(1).Relational().ColumnName);
+
+                Assert.Equal(
+                    "ExtraPropertyWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWorkingC~1",
+                    entityType2.GetProperties().ElementAt(2).Relational().ColumnName);
             }
         }
     }


### PR DESCRIPTION
Don't prefix columns on the same type when uniquifying

Fixes #14055