### PR TITLE
Remove 2.1 provider fallback behavior

### DIFF
--- a/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
@@ -68,24 +68,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 Precision = precision ?? converterHints?.Precision;
                 Scale = scale ?? converterHints?.Scale;
                 FixedLength = fixedLength;
-                PrecisionAndScaleOverriden = false;
-            }
-
-            // #12405
-            private RelationalTypeMappingParameters(
-                CoreTypeMappingParameters coreParameters,
-                [NotNull] string storeType,
-                StoreTypePostfix storeTypePostfix = StoreTypePostfix.None,
-                DbType? dbType = null,
-                bool unicode = false,
-                int? size = null,
-                bool fixedLength = false,
-                int? precision = null,
-                int? scale = null,
-                bool precisionAndScaleOverriden = false)
-                : this(coreParameters, storeType, storeTypePostfix, dbType, unicode, size, fixedLength, precision, scale)
-            {
-                PrecisionAndScaleOverriden = precisionAndScaleOverriden;
             }
 
             /// <summary>
@@ -124,14 +106,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
             public int? Scale { get; }
 
             /// <summary>
-            ///     This is provided for compatibility with 2.1 providers and shouldn't be used
-            /// </summary>
-            // If not set fallback to 2.1 behavior by using Precision and Scale from the converter
-            // #12405
-            [Obsolete("This is provided for compatibility with 2.1 providers and shouldn't be used")]
-            public bool PrecisionAndScaleOverriden { get; }
-
-            /// <summary>
             ///     The mapping fixed-length flag.
             /// </summary>
             public bool FixedLength { get; }
@@ -157,8 +131,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                     mappingInfo.Size ?? Size,
                     mappingInfo.IsFixedLength ?? FixedLength,
                     mappingInfo.Precision ?? Precision,
-                    mappingInfo.Scale ?? Scale,
-                    PrecisionAndScaleOverriden);
+                    mappingInfo.Scale ?? Scale);
 
             /// <summary>
             ///     Creates a new <see cref="RelationalTypeMappingParameters" /> parameter object with the given
@@ -181,8 +154,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                     size,
                     FixedLength,
                     Precision,
-                    Scale,
-                    PrecisionAndScaleOverriden);
+                    Scale);
 
             /// <summary>
             ///     Creates a new <see cref="RelationalTypeMappingParameters" /> parameter object with the given
@@ -203,8 +175,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                     Size,
                     FixedLength,
                     precision,
-                    scale,
-                    precisionAndScaleOverriden: true);
+                    scale);
 
             /// <summary>
             ///     Creates a new <see cref="RelationalTypeMappingParameters" /> parameter object with the given
@@ -222,8 +193,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                     Size,
                     FixedLength,
                     Precision,
-                    Scale,
-                    PrecisionAndScaleOverriden);
+                    Scale);
         }
 
         private static readonly MethodInfo _getFieldValueMethod
@@ -251,8 +221,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         public static readonly RelationalTypeMapping NullMapping = new NullTypeMapping("NULL");
 
-        private readonly bool _precisionAndScaleOverriden;
-
         private class NullTypeMapping : RelationalTypeMapping
         {
             public NullTypeMapping(string storeType)
@@ -272,7 +240,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
             : base(parameters.CoreParameters)
         {
             Parameters = parameters;
-            _precisionAndScaleOverriden = parameters.PrecisionAndScaleOverriden;
 
             var size = parameters.Size;
             var storeType = parameters.StoreType;
@@ -280,8 +247,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             if (storeType != null)
             {
                 StoreTypeNameBase = GetBaseName(storeType);
-                if (size != null
-                    && parameters.StoreTypePostfix == StoreTypePostfix.Size)
+                if (size != null && parameters.StoreTypePostfix == StoreTypePostfix.Size)
                 {
                     storeType = StoreTypeNameBase + "(" + size + ")";
                 }
@@ -289,23 +255,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
                          || parameters.StoreTypePostfix == StoreTypePostfix.Precision)
                 {
                     var precision = parameters.Precision;
-                    var converter = parameters.CoreParameters.Converter;
-                    // Fallback to 2.1 behavior
-                    // #12405
-                    var oldBehavior = !_precisionAndScaleOverriden;
-                    if (oldBehavior)
-                    {
-                        precision = converter?.MappingHints?.Precision;
-                    }
-
                     if (precision != null)
                     {
                         var scale = parameters.Scale;
-                        if (oldBehavior)
-                        {
-                            scale = converter.MappingHints?.Scale;
-                        }
-
                         storeType = StoreTypeNameBase
                                     + "("
                                     + (scale == null || parameters.StoreTypePostfix == StoreTypePostfix.Precision
@@ -360,8 +312,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="parameters"> The parameters for this mapping. </param>
         /// <returns> The newly created mapping. </returns>
-        protected virtual RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
-            => throw new NotImplementedException(CoreStrings.ConverterCloneNotImplemented(GetType().ShortDisplayName()));
+        protected abstract RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters);
 
         /// <summary>
         ///     Creates a copy of this mapping.
@@ -397,8 +348,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <returns> The cloned mapping, or the original mapping if no clone was needed. </returns>
         public virtual RelationalTypeMapping Clone(in RelationalTypeMappingInfo mappingInfo)
         {
-            var checkStoreTypeAndSize = true;
-            RelationalTypeMapping clone = null;
             if ((mappingInfo.Scale != null
                  && mappingInfo.Scale != Parameters.Scale
                  && StoreTypePostfix == StoreTypePostfix.PrecisionAndScale)
@@ -407,47 +356,27 @@ namespace Microsoft.EntityFrameworkCore.Storage
                     && (StoreTypePostfix == StoreTypePostfix.PrecisionAndScale
                         || StoreTypePostfix == StoreTypePostfix.Precision)))
             {
-                var oldBehavior = !_precisionAndScaleOverriden;
-                if (!oldBehavior)
-                {
-                    var storeTypeChanged = mappingInfo.StoreTypeNameBase != null
-                                           && !string.Equals(mappingInfo.StoreTypeNameBase, StoreTypeNameBase, StringComparison.OrdinalIgnoreCase);
+                var storeTypeChanged = mappingInfo.StoreTypeNameBase != null
+                                        && !string.Equals(mappingInfo.StoreTypeNameBase, StoreTypeNameBase, StringComparison.OrdinalIgnoreCase);
 
-                    clone = storeTypeChanged
-                        ? Clone(Parameters.WithTypeMappingInfo(mappingInfo))
-                        : Clone(
-                            mappingInfo.Precision ?? Parameters.Precision,
-                            mappingInfo.Scale ?? Parameters.Scale);
-
-                    // Fallback to 2.1 behavior if Clone is not overriden
-                    // #12405
-                    oldBehavior = clone.GetType() != GetType();
-                }
-
-                checkStoreTypeAndSize = oldBehavior;
+                return storeTypeChanged
+                    ? Clone(Parameters.WithTypeMappingInfo(mappingInfo))
+                    : Clone(
+                        mappingInfo.Precision ?? Parameters.Precision,
+                        mappingInfo.Scale ?? Parameters.Scale);
             }
 
-            if (checkStoreTypeAndSize)
-            {
-                var storeTypeOrSizeChanged = (mappingInfo.Size != null
-                                              && mappingInfo.Size != Size
-                                              && StoreTypePostfix == StoreTypePostfix.Size)
-                                             || (mappingInfo.StoreTypeName != null
-                                                 && !string.Equals(mappingInfo.StoreTypeName, StoreType, StringComparison.OrdinalIgnoreCase));
+            var storeTypeOrSizeChanged = (mappingInfo.Size != null
+                                            && mappingInfo.Size != Size
+                                            && StoreTypePostfix == StoreTypePostfix.Size)
+                                            || (mappingInfo.StoreTypeName != null
+                                                && !string.Equals(mappingInfo.StoreTypeName, StoreType, StringComparison.OrdinalIgnoreCase));
 
-                clone = storeTypeOrSizeChanged
-                    ? Clone(
-                        mappingInfo.StoreTypeName ?? StoreType,
-                        mappingInfo.Size ?? Size)
-                    : this;
-            }
-
-            if (clone.GetType() != GetType())
-            {
-                throw new NotImplementedException(CoreStrings.ConverterCloneNotImplemented(GetType().ShortDisplayName()));
-            }
-
-            return clone;
+            return storeTypeOrSizeChanged
+                ? Clone(
+                    mappingInfo.StoreTypeName ?? StoreType,
+                    mappingInfo.Size ?? Size)
+                : this;
         }
 
         /// <summary>

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2207,14 +2207,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 typeOneIn, typeOneOut, typeTwoIn, typeTwoOut);
 
         /// <summary>
-        ///     The '{mapping}' does not support value conversions. Support for value conversions typically requires changes in the database provider.
-        /// </summary>
-        public static string ConverterCloneNotImplemented([CanBeNull] object mapping)
-            => string.Format(
-                GetString("ConverterCloneNotImplemented", nameof(mapping)),
-                mapping);
-
-        /// <summary>
         ///     The value converter '{converter}' cannot be used with type '{type}'. This converter can only be used with {allowed}.
         /// </summary>
         public static string ConverterBadType([CanBeNull] object converter, [CanBeNull] object type, [CanBeNull] object allowed)

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -920,9 +920,6 @@
   <data name="ConvertersCannotBeComposed" xml:space="preserve">
     <value>Cannot compose converter from '{typeOneIn}' to '{typeOneOut}' with converter from '{typeTwoIn}' to '{typeTwoOut}' because the output type of the first converter is different from the input type of the second converter.</value>
   </data>
-  <data name="ConverterCloneNotImplemented" xml:space="preserve">
-    <value>The '{mapping}' does not support value conversions. Support for value conversions typically requires changes in the database provider.</value>
-  </data>
   <data name="ConverterBadType" xml:space="preserve">
     <value>The value converter '{converter}' cannot be used with type '{type}'. This converter can only be used with {allowed}.</value>
   </data>

--- a/test/EFCore.Design.Tests/Design/Internal/CSharpHelperTest.cs
+++ b/test/EFCore.Design.Tests/Design/Internal/CSharpHelperTest.cs
@@ -634,6 +634,9 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
 
             public override Expression GenerateCodeLiteral(object value)
                 => _literalExpressionFunc((T)value);
+
+            protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+                => throw new NotSupportedException();
         }
 
         private class SimpleTestNonImplementedTypeMapping : RelationalTypeMapping
@@ -642,6 +645,9 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
                 : base("storeType", typeof(SimpleTestType))
             {
             }
+
+            protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+                => throw new NotSupportedException();
         }
     }
 

--- a/test/EFCore.Relational.Tests/Storage/RelationalTypeMappingTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalTypeMappingTest.cs
@@ -243,6 +243,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
                     unicode: unicide,
                     fixedLength: fixedLength);
             }
+
+            protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+                => new FakeTypeMapping(parameters);
         }
 
         [Fact]


### PR DESCRIPTION
@AndriySvyryd am not sure I fully understood the 2.1 backwards compatibility implemented (was not involved) so I'd appreciate a good review on this to make sure it's good... Note that it's only part of #12405, I intend to look at the StoreTypePostFix later part as part of #11896.

* Removed precision/scale 2.1 fallback behavior
* Made RelationalTypeMapping.Clone() abstract

Part of #12405
