### PR TITLE
[2.2.x] Query: Add explicitCast for projection more robustly

### DIFF
--- a/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -849,12 +849,17 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
 
                     if (operand != null)
                     {
+                        var operandWithoutConvert
+                            = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue14604", out var isEnabled) && isEnabled
+                            ? operand
+                            : operand.RemoveConvert();
+
                         return _isTopLevelProjection
-                               && operand.Type.IsValueType
+                               && operandWithoutConvert.Type.IsValueType
                                && expression.Type.IsValueType
-                               && expression.Type.UnwrapNullableType() != operand.Type.UnwrapNullableType()
-                               && expression.Type.UnwrapEnumType() != operand.Type.UnwrapEnumType()
-                            ? (Expression)new ExplicitCastExpression(operand, expression.Type)
+                               && expression.Type.UnwrapNullableType() != operandWithoutConvert.Type.UnwrapNullableType()
+                               && expression.Type.UnwrapEnumType() != operandWithoutConvert.Type.UnwrapEnumType()
+                            ? (Expression)new ExplicitCastExpression(operandWithoutConvert, expression.Type)
                             : Expression.Convert(operand, expression.Type);
                     }
 

--- a/src/EFCore.Specification.Tests/Query/QueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/QueryTestBase.cs
@@ -1255,11 +1255,26 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         public Task AssertQueryScalar<TItem1>(
             bool isAsync,
+            Func<IQueryable<TItem1>, IQueryable<double?>> query,
+            bool assertOrder = false)
+            where TItem1 : class
+            => AssertQueryScalar(isAsync, query, query, assertOrder);
+
+        public Task AssertQueryScalar<TItem1>(
+            bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<int?>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<int?>> expectedQuery,
             bool assertOrder = false)
             where TItem1 : class
             => AssertQueryScalar<TItem1, int>(isAsync, actualQuery, expectedQuery, assertOrder);
+
+        public Task AssertQueryScalar<TItem1>(
+            bool isAsync,
+            Func<IQueryable<TItem1>, IQueryable<double?>> actualQuery,
+            Func<IQueryable<TItem1>, IQueryable<double?>> expectedQuery,
+            bool assertOrder = false)
+            where TItem1 : class
+            => AssertQueryScalar<TItem1, double>(isAsync, actualQuery, expectedQuery, assertOrder);
 
         public Task AssertQueryScalar<TItem1>(
             bool isAsync,

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
@@ -1852,5 +1852,14 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 cs => cs.Cast<Customer>());
         }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Cast_before_aggregate_is_preserved(bool isAsync)
+        {
+            return AssertQueryScalar<Customer>(
+                isAsync,
+                cs => cs.Select(c => c.Orders.Select(o => (double?)o.OrderID).Average()));
+        }
     }
 }

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
@@ -1139,5 +1139,16 @@ namespace Microsoft.EntityFrameworkCore.Query
                             from o in grouping.DefaultIfEmpty()
                             select o != null ? o.OrderDate.Value : new DateTime(1753, 1, 1));
         }
+
+
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Cast_on_top_level_projection_brings_explicit_Cast(bool isAsync)
+        {
+            return AssertQueryScalar<Order>(
+                isAsync,
+                os => os.Select(o => (double?)o.OrderID));
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.ResultOperators.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.ResultOperators.cs
@@ -1247,5 +1247,18 @@ WHERE ([c].[City] = N'México D.F.') AND [c].[CustomerID] NOT IN (N'ABCDE', N'AL
                 @"SELECT COUNT(*)
 FROM [Customers] AS [c]");
         }
+
+        public override async Task Cast_before_aggregate_is_preserved(bool isAsync)
+        {
+            await base.Cast_before_aggregate_is_preserved(isAsync);
+
+            AssertSql(
+                @"SELECT (
+    SELECT AVG(CAST([o].[OrderID] AS float))
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+)
+FROM [Customers] AS [c]");
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
@@ -971,5 +971,14 @@ FROM [Orders] AS [o]");
 FROM [Customers] AS [c]
 LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]");
         }
+
+        public override async Task Cast_on_top_level_projection_brings_explicit_Cast(bool isAsync)
+        {
+            await base.Cast_on_top_level_projection_brings_explicit_Cast(isAsync);
+
+            AssertSql(
+                @"SELECT CAST([o].[OrderID] AS float)
+FROM [Orders] AS [o]");
+        }
     }
 }


### PR DESCRIPTION
Issue: When top level projection has convert node, we introduce explicit cast since we read exact type from DataReader.
Though we don't add cast when it is just nullability change or if the convert node is not on top level.
In this particular case, compiler generated expression tree contained, int to double to double? convert since int cannot be cast to double? directly. But when translating we did not introduce explicit cast for first level since _not top level_ and for second level it was nullability change only. Hence lack of explicit cast during projection caused error.

Fix: Remove any convert nodes to figure out if we need to apply explicit cast.

Resolves #14604