### PR TITLE
Optimize translation of string.{Starts,Ends}With

### DIFF
--- a/src/EFCore.SqlServer/Query/Pipeline/SqlServerStringMethodTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Pipeline/SqlServerStringMethodTranslator.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Text;
 using Microsoft.EntityFrameworkCore.Relational.Query.Pipeline;
 using Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -53,6 +55,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Pipeline
         private readonly ITypeMappingApplyingExpressionVisitor _typeMappingApplyingExpressionVisitor;
         private readonly RelationalTypeMapping _intTypeMapping;
         private readonly RelationalTypeMapping _boolTypeMapping;
+
+        private const char LikeEscapeChar = '\\';
 
         public SqlServerStringMethodTranslator(IRelationalTypeMappingSource typeMappingSource,
             ITypeMappingApplyingExpressionVisitor typeMappingApplyingExpressionVisitor)
@@ -284,45 +288,76 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Pipeline
 
             if (_startsWithMethodInfo.Equals(method))
             {
-                var pattern = arguments[0];
-                var stringTypeMapping = ExpressionExtensions.InferTypeMapping(instance, pattern);
+                return TranslateStartsEndsWith(instance, arguments[0], true);
+            }
 
-                instance = _typeMappingApplyingExpressionVisitor.ApplyTypeMapping(instance, stringTypeMapping);
-                pattern = _typeMappingApplyingExpressionVisitor.ApplyTypeMapping(pattern, stringTypeMapping);
+            if (_endsWithMethodInfo.Equals(method))
+            {
+                return TranslateStartsEndsWith(instance, arguments[0], false);
+            }
 
+            return null;
+        }
+
+        SqlExpression TranslateStartsEndsWith(SqlExpression instance, SqlExpression pattern, bool startsWith)
+        {
+            var stringTypeMapping = ExpressionExtensions.InferTypeMapping(instance, pattern);
+
+            instance = _typeMappingApplyingExpressionVisitor.ApplyTypeMapping(instance, stringTypeMapping);
+            pattern = _typeMappingApplyingExpressionVisitor.ApplyTypeMapping(pattern, stringTypeMapping);
+
+            if (pattern is SqlConstantExpression constExpr)
+            {
+                // The pattern is constant. Aside from null or empty, we escape all special characters (%, _, \)
+                // in C# and send a simple LIKE
+                if (!(constExpr.Value is string constPattern))
+                {
+                    return new LikeExpression(instance, new SqlConstantExpression(Expression.Constant(null), stringTypeMapping), null, _boolTypeMapping);
+                }
+                if (constPattern.Length == 0)
+                {
+                    return new SqlConstantExpression(Expression.Constant(true), _boolTypeMapping);
+                }
+                return constPattern.Any(c => IsLikeWildChar(c))
+                    ? new LikeExpression(
+                        instance,
+                        new SqlConstantExpression(Expression.Constant(startsWith ? EscapeLikePattern(constPattern) + '%' : '%' + EscapeLikePattern(constPattern)), stringTypeMapping),
+                        new SqlConstantExpression(Expression.Constant(LikeEscapeChar.ToString()), stringTypeMapping),  // SQL Server has no char mapping, avoid value conversion warning
+                        _boolTypeMapping)
+                    : new LikeExpression(
+                        instance,
+                        new SqlConstantExpression(Expression.Constant(startsWith ? constPattern + '%' : '%' + constPattern), stringTypeMapping),
+                        null,
+                        _boolTypeMapping);
+            }
+
+            // The pattern is non-constant, we use LEFT or RIGHT to extract substring and compare.
+            // For StartsWith we also first run a LIKE to quickly filter out most non-matching results (sargable, but imprecise
+            // because of wildchars).
+            if (startsWith)
+            {
                 return new SqlBinaryExpression(
                     ExpressionType.OrElse,
                     new SqlBinaryExpression(
-                        ExpressionType.Equal,
-                        pattern,
-                        new SqlConstantExpression(Expression.Constant(string.Empty), stringTypeMapping),
-                        typeof(bool),
-                        _boolTypeMapping),
-                    new SqlBinaryExpression(
                         ExpressionType.AndAlso,
                         new LikeExpression(
+                            // ReSharper disable once AssignNullToNotNullAttribute
                             instance,
                             new SqlBinaryExpression(
                                 ExpressionType.Add,
-                                pattern,
+                                instance,
                                 new SqlConstantExpression(Expression.Constant("%"), stringTypeMapping),
                                 typeof(string),
                                 stringTypeMapping),
                             null,
-                            stringTypeMapping),
+                            _boolTypeMapping),
                         new SqlBinaryExpression(
                             ExpressionType.Equal,
                             new SqlFunctionExpression(
                                 "LEFT",
-                                new[]
-                                {
+                                new[] {
                                     instance,
-                                    new SqlFunctionExpression(
-                                        "LEN",
-                                        new [] { pattern },
-                                        typeof(int),
-                                        _intTypeMapping,
-                                        false)
+                                    new SqlFunctionExpression("LEN", new[] { pattern }, typeof(int), _intTypeMapping, false)
                                 },
                                 typeof(string),
                                 stringTypeMapping,
@@ -332,51 +367,59 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Pipeline
                             _boolTypeMapping),
                         typeof(bool),
                         _boolTypeMapping),
-                    typeof(bool),
-                    _boolTypeMapping);
-            }
-
-            if (_endsWithMethodInfo.Equals(method))
-            {
-                var pattern = arguments[0];
-                var stringTypeMapping = ExpressionExtensions.InferTypeMapping(instance, pattern);
-
-                instance = _typeMappingApplyingExpressionVisitor.ApplyTypeMapping(instance, stringTypeMapping);
-                pattern = _typeMappingApplyingExpressionVisitor.ApplyTypeMapping(pattern, stringTypeMapping);
-
-                return new SqlBinaryExpression(
-                    ExpressionType.OrElse,
                     new SqlBinaryExpression(
                         ExpressionType.Equal,
                         pattern,
                         new SqlConstantExpression(Expression.Constant(string.Empty), stringTypeMapping),
                         typeof(bool),
-                        _boolTypeMapping),
-                    new SqlBinaryExpression(
-                        ExpressionType.Equal,
-                        new SqlFunctionExpression(
-                            "RIGHT",
-                            new[]
-                            {
-                                instance,
-                                new SqlFunctionExpression(
-                                    "LEN",
-                                    new [] { pattern },
-                                    typeof(int),
-                                    _intTypeMapping,
-                                    false)
-                            },
-                            typeof(string),
-                            stringTypeMapping,
-                            false),
-                        pattern,
-                        typeof(bool),
-                        _boolTypeMapping),
+                        _boolTypeMapping
+                    ),
                     typeof(bool),
                     _boolTypeMapping);
             }
 
-            return null;
+            return new SqlBinaryExpression(
+                ExpressionType.OrElse,
+                new SqlBinaryExpression(
+                    ExpressionType.Equal,
+                    new SqlFunctionExpression(
+                        "RIGHT",
+                        new[] {
+                            instance,
+                            new SqlFunctionExpression("LEN", new[] { pattern }, typeof(int), _intTypeMapping, false)
+                        },
+                        typeof(string),
+                        stringTypeMapping,
+                        false),
+                    pattern,
+                    typeof(bool),
+                    _boolTypeMapping),
+                new SqlBinaryExpression(
+                    ExpressionType.Equal,
+                    pattern,
+                    new SqlConstantExpression(Expression.Constant(string.Empty), stringTypeMapping),
+                    typeof(bool),
+                    _boolTypeMapping),
+                typeof(bool),
+                _boolTypeMapping);
+        }
+
+        // See https://docs.microsoft.com/en-us/sql/t-sql/language-elements/like-transact-sql
+        private bool IsLikeWildChar(char c) => c == '%' || c == '_' || c == '[';
+
+        private string EscapeLikePattern(string pattern)
+        {
+            var builder = new StringBuilder();
+            for (var i = 0; i < pattern.Length; i++)
+            {
+                var c = pattern[i];
+                if (IsLikeWildChar(c) || c == LikeEscapeChar)
+                {
+                    builder.Append(LikeEscapeChar);
+                }
+                builder.Append(c);
+            }
+            return builder.ToString();
         }
 
         private SqlExpression MakeSqlConstant(int value)

--- a/test/EFCore.Relational.Specification.Tests/TestUtilities/TestSqlLoggerFactory.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestUtilities/TestSqlLoggerFactory.cs
@@ -100,7 +100,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 //File.AppendAllText(logFile, contents);
 
-                //throw;
+                throw;
             }
         }
 

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Functions.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Functions.cs
@@ -682,15 +682,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 3);
         }
 
-        protected static string LocalMethod1()
-        {
-            return "M";
-        }
-
-        protected static string LocalMethod2()
-        {
-            return "m";
-        }
+        protected static string LocalMethod1() => "M";
+        protected static string LocalMethod2() => "m";
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -311,7 +311,7 @@ WHERE [e2].[Id] > 5");
                 @"SELECT [e1].[Id], [e1].[Date], [e1].[Name], [e1].[OneToMany_Optional_Self_Inverse1Id], [e1].[OneToMany_Required_Self_Inverse1Id], [e1].[OneToOne_Optional_Self1Id]
 FROM [LevelOne] AS [e1]
 LEFT JOIN [LevelTwo] AS [e1.OneToOne_Required_FK1] ON [e1].[Id] = [e1.OneToOne_Required_FK1].[Level1_Required_Id]
-WHERE [e1.OneToOne_Required_FK1].[Name] LIKE N'L' + N'%' AND (LEFT([e1.OneToOne_Required_FK1].[Name], LEN(N'L')) = N'L')");
+WHERE [e1.OneToOne_Required_FK1].[Name] LIKE N'L%'");
         }
 
         public override async Task Navigation_inside_method_call_translated_to_join2(bool isAsync)
@@ -322,7 +322,7 @@ WHERE [e1.OneToOne_Required_FK1].[Name] LIKE N'L' + N'%' AND (LEFT([e1.OneToOne_
                 @"SELECT [e3].[Id], [e3].[Level2_Optional_Id], [e3].[Level2_Required_Id], [e3].[Name], [e3].[OneToMany_Optional_Inverse3Id], [e3].[OneToMany_Optional_Self_Inverse3Id], [e3].[OneToMany_Required_Inverse3Id], [e3].[OneToMany_Required_Self_Inverse3Id], [e3].[OneToOne_Optional_PK_Inverse3Id], [e3].[OneToOne_Optional_Self3Id]
 FROM [LevelThree] AS [e3]
 INNER JOIN [LevelTwo] AS [e3.OneToOne_Required_FK_Inverse3] ON [e3].[Level2_Required_Id] = [e3.OneToOne_Required_FK_Inverse3].[Id]
-WHERE [e3.OneToOne_Required_FK_Inverse3].[Name] LIKE N'L' + N'%' AND (LEFT([e3.OneToOne_Required_FK_Inverse3].[Name], LEN(N'L')) = N'L')");
+WHERE [e3.OneToOne_Required_FK_Inverse3].[Name] LIKE N'L%'");
         }
 
         public override async Task Optional_navigation_inside_method_call_translated_to_join(bool isAsync)
@@ -333,7 +333,7 @@ WHERE [e3.OneToOne_Required_FK_Inverse3].[Name] LIKE N'L' + N'%' AND (LEFT([e3.O
                 @"SELECT [e1].[Id], [e1].[Date], [e1].[Name], [e1].[OneToMany_Optional_Self_Inverse1Id], [e1].[OneToMany_Required_Self_Inverse1Id], [e1].[OneToOne_Optional_Self1Id]
 FROM [LevelOne] AS [e1]
 LEFT JOIN [LevelTwo] AS [e1.OneToOne_Optional_FK1] ON [e1].[Id] = [e1.OneToOne_Optional_FK1].[Level1_Optional_Id]
-WHERE [e1.OneToOne_Optional_FK1].[Name] LIKE N'L' + N'%' AND (LEFT([e1.OneToOne_Optional_FK1].[Name], LEN(N'L')) = N'L')");
+WHERE [e1.OneToOne_Optional_FK1].[Name] LIKE N'L%'");
         }
 
         public override async Task Optional_navigation_inside_property_method_translated_to_join(bool isAsync)
@@ -355,7 +355,7 @@ WHERE [e1.OneToOne_Optional_FK1].[Name] = N'L2 01'");
                 @"SELECT [e1].[Id], [e1].[Date], [e1].[Name], [e1].[OneToMany_Optional_Self_Inverse1Id], [e1].[OneToMany_Required_Self_Inverse1Id], [e1].[OneToOne_Optional_Self1Id]
 FROM [LevelOne] AS [e1]
 LEFT JOIN [LevelTwo] AS [e1.OneToOne_Optional_FK1] ON [e1].[Id] = [e1.OneToOne_Optional_FK1].[Level1_Optional_Id]
-WHERE UPPER([e1.OneToOne_Optional_FK1].[Name]) LIKE N'L' + N'%' AND (LEFT(UPPER([e1.OneToOne_Optional_FK1].[Name]), LEN(N'L')) = N'L')");
+WHERE UPPER([e1.OneToOne_Optional_FK1].[Name]) LIKE N'L%'");
         }
 
         public override async Task Method_call_on_optional_navigation_translates_to_null_conditional_properly_for_arguments(bool isAsync)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -1056,7 +1056,7 @@ WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[LeaderNickname] = N
             AssertSql(
                 @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
-WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND (RIGHT([g].[LeaderNickname], LEN(N'us')) = N'us')");
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND [g].[LeaderNickname] LIKE N'%us'");
         }
 
         public override async Task Null_propagation_optimization3(bool isAsync)
@@ -1066,7 +1066,7 @@ WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND (RIGHT([g].[LeaderNicknam
             AssertSql(
                 @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
-WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND (RIGHT([g].[LeaderNickname], LEN(N'us')) = N'us')");
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND [g].[LeaderNickname] LIKE N'%us'");
         }
 
         public override async Task Null_propagation_optimization4(bool isAsync)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
@@ -1402,7 +1402,7 @@ ORDER BY [Key]");
     END
 ), [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')",
+WHERE [c].[CustomerID] LIKE N'A%'",
                 //
                 @"@_outer_CustomerID='ALFKI' (Size = 5)
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/IncludeSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/IncludeSqlServerTest.cs
@@ -337,7 +337,7 @@ ORDER BY [t].[OrderID]");
             AssertSql(
                 @"SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'W' + N'%' AND (LEFT([c].[CustomerID], LEN(N'W')) = N'W')
+WHERE [c].[CustomerID] LIKE N'W%'
 ORDER BY (
     SELECT TOP(1) [oo].[OrderDate]
     FROM [Orders] AS [oo]
@@ -355,7 +355,7 @@ INNER JOIN (
         ORDER BY [oo1].[OrderDate] DESC
     ) AS [c]
     FROM [Customers] AS [c0]
-    WHERE [c0].[CustomerID] LIKE N'W' + N'%' AND (LEFT([c0].[CustomerID], LEN(N'W')) = N'W')
+    WHERE [c0].[CustomerID] LIKE N'W%'
     ORDER BY (
         SELECT TOP(1) [oo0].[OrderDate]
         FROM [Orders] AS [oo0]
@@ -1347,7 +1347,7 @@ ORDER BY [t].[ContactName], [t].[CustomerID]");
             AssertSql(
                 @"SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'W' + N'%' AND (LEFT([c].[CustomerID], LEN(N'W')) = N'W')
+WHERE [c].[CustomerID] LIKE N'W%'
 ORDER BY (
     SELECT TOP(1) [oo].[OrderDate]
     FROM [Orders] AS [oo]
@@ -1365,7 +1365,7 @@ INNER JOIN (
         ORDER BY [oo1].[OrderDate] DESC
     ) AS [c]
     FROM [Customers] AS [c0]
-    WHERE [c0].[CustomerID] LIKE N'W' + N'%' AND (LEFT([c0].[CustomerID], LEN(N'W')) = N'W')
+    WHERE [c0].[CustomerID] LIKE N'W%'
     ORDER BY (
         SELECT TOP(1) [oo0].[OrderDate]
         FROM [Orders] AS [oo0]
@@ -1388,7 +1388,7 @@ INNER JOIN (
             ORDER BY [oo3].[OrderDate] DESC
         ) AS [c]
         FROM [Customers] AS [c1]
-        WHERE [c1].[CustomerID] LIKE N'W' + N'%' AND (LEFT([c1].[CustomerID], LEN(N'W')) = N'W')
+        WHERE [c1].[CustomerID] LIKE N'W%'
         ORDER BY (
             SELECT TOP(1) [oo2].[OrderDate]
             FROM [Orders] AS [oo2]
@@ -1408,7 +1408,7 @@ ORDER BY [t1].[c] DESC, [t1].[CustomerID], [t1].[OrderID]");
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY CASE
-    WHEN [c].[CustomerID] LIKE N'S' + N'%' AND (LEFT([c].[CustomerID], LEN(N'S')) = N'S')
+    WHEN [c].[CustomerID] LIKE N'S%'
     THEN 1 ELSE 2
 END, [c].[CustomerID]",
                 //
@@ -1416,7 +1416,7 @@ END, [c].[CustomerID]",
 FROM [Orders] AS [c.Orders]
 INNER JOIN (
     SELECT [c0].[CustomerID], CASE
-        WHEN [c0].[CustomerID] LIKE N'S' + N'%' AND (LEFT([c0].[CustomerID], LEN(N'S')) = N'S')
+        WHEN [c0].[CustomerID] LIKE N'S%'
         THEN 1 ELSE 2
     END AS [c]
     FROM [Customers] AS [c0]
@@ -1442,7 +1442,7 @@ WHERE [o].[OrderID] < 10250");
             AssertSql(
                 @"SELECT DISTINCT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
+WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY [c].[CustomerID]",
                 //
                 @"SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
@@ -1450,7 +1450,7 @@ FROM [Orders] AS [c.Orders]
 INNER JOIN (
     SELECT DISTINCT [c0].[CustomerID]
     FROM [Customers] AS [c0]
-    WHERE [c0].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c0].[CustomerID], LEN(N'A')) = N'A')
+    WHERE [c0].[CustomerID] LIKE N'A%'
 ) AS [t] ON [c.Orders].[CustomerID] = [t].[CustomerID]
 ORDER BY [t].[CustomerID]");
         }
@@ -1484,7 +1484,7 @@ ORDER BY [t].[OrderID]");
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
+WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY (SELECT 1), [c].[CustomerID]
 OFFSET @__p_1 ROWS",
                 //
@@ -1495,7 +1495,7 @@ FROM [Orders] AS [c.Orders]
 INNER JOIN (
     SELECT [c0].[CustomerID], CAST(0 AS bit) AS [c]
     FROM [Customers] AS [c0]
-    WHERE [c0].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c0].[CustomerID], LEN(N'A')) = N'A')
+    WHERE [c0].[CustomerID] LIKE N'A%'
     ORDER BY [c], [c0].[CustomerID]
     OFFSET @__p_1 ROWS
 ) AS [t] ON [c.Orders].[CustomerID] = [t].[CustomerID]
@@ -1511,7 +1511,7 @@ ORDER BY [t].[c], [t].[CustomerID]");
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
+WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY (SELECT 1), [c].[CustomerID]
 OFFSET @__p_1 ROWS",
                 //
@@ -1522,7 +1522,7 @@ FROM [Orders] AS [c.Orders]
 INNER JOIN (
     SELECT [c0].[CustomerID], CAST(1 AS bit) AS [c]
     FROM [Customers] AS [c0]
-    WHERE [c0].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c0].[CustomerID], LEN(N'A')) = N'A')
+    WHERE [c0].[CustomerID] LIKE N'A%'
     ORDER BY [c], [c0].[CustomerID]
     OFFSET @__p_1 ROWS
 ) AS [t] ON [c.Orders].[CustomerID] = [t].[CustomerID]
@@ -1538,7 +1538,7 @@ ORDER BY [t].[c], [t].[CustomerID]");
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
+WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY CASE
     WHEN [c].[CustomerID] IN (N'ALFKI')
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
@@ -1555,7 +1555,7 @@ INNER JOIN (
         THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
     END AS [c]
     FROM [Customers] AS [c0]
-    WHERE [c0].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c0].[CustomerID], LEN(N'A')) = N'A')
+    WHERE [c0].[CustomerID] LIKE N'A%'
     ORDER BY [c], [c0].[CustomerID]
     OFFSET @__p_1 ROWS
 ) AS [t] ON [c.Orders].[CustomerID] = [t].[CustomerID]
@@ -1571,7 +1571,7 @@ ORDER BY [t].[c], [t].[CustomerID]");
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
+WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY CASE
     WHEN [c].[CustomerID] NOT IN (N'ALFKI')
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
@@ -1588,7 +1588,7 @@ INNER JOIN (
         THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
     END AS [c]
     FROM [Customers] AS [c0]
-    WHERE [c0].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c0].[CustomerID], LEN(N'A')) = N'A')
+    WHERE [c0].[CustomerID] LIKE N'A%'
     ORDER BY [c], [c0].[CustomerID]
     OFFSET @__p_1 ROWS
 ) AS [t] ON [c.Orders].[CustomerID] = [t].[CustomerID]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceSqlServerTest.cs
@@ -389,7 +389,7 @@ VALUES (@p0, @p1, @p2, @p3, @p4, @p5, @p6);",
                 //
                 @"SELECT TOP(2) [k].[Species], [k].[CountryId], [k].[Discriminator], [k].[Name], [k].[EagleId], [k].[IsFlightless], [k].[FoundOn]
 FROM [Animal] AS [k]
-WHERE ([k].[Discriminator] = N'Kiwi') AND (RIGHT([k].[Species], LEN(N'owenii')) = N'owenii')",
+WHERE ([k].[Discriminator] = N'Kiwi') AND [k].[Species] LIKE N'%owenii'",
                 //
                 @"@p1='Apteryx owenii' (Nullable = false) (Size = 100)
 @p0='Aquila chrysaetos canadensis' (Size = 100)
@@ -401,7 +401,7 @@ SELECT @@ROWCOUNT;",
                 //
                 @"SELECT TOP(2) [k].[Species], [k].[CountryId], [k].[Discriminator], [k].[Name], [k].[EagleId], [k].[IsFlightless], [k].[FoundOn]
 FROM [Animal] AS [k]
-WHERE ([k].[Discriminator] = N'Kiwi') AND (RIGHT([k].[Species], LEN(N'owenii')) = N'owenii')",
+WHERE ([k].[Discriminator] = N'Kiwi') AND [k].[Species] LIKE N'%owenii'",
                 //
                 @"@p0='Apteryx owenii' (Nullable = false) (Size = 100)
 
@@ -412,7 +412,7 @@ SELECT @@ROWCOUNT;",
                 //
                 @"SELECT COUNT(*)
 FROM [Animal] AS [k]
-WHERE ([k].[Discriminator] = N'Kiwi') AND (RIGHT([k].[Species], LEN(N'owenii')) = N'owenii')");
+WHERE ([k].[Discriminator] = N'Kiwi') AND [k].[Species] LIKE N'%owenii'");
         }
 
         public override void Byte_enum_value_constant_used_in_projection()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -985,7 +985,7 @@ FROM [Entities1] AS [e]
 WHERE CASE
     WHEN @__p_0 = 1
     THEN CAST(1 AS BIT) ELSE CASE
-        WHEN [e].[StringA] LIKE N'A' + N'%' AND (LEFT([e].[StringA], LEN(N'A')) = N'A')
+        WHEN [e].[StringA] LIKE N'A%'
         THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
     END
 END = 1");
@@ -1008,7 +1008,7 @@ WHERE CASE
         THEN CASE
             WHEN [e].[BoolA] = 1
             THEN CASE
-                WHEN [e].[StringA] LIKE N'A' + N'%' AND (LEFT([e].[StringA], LEN(N'A')) = N'A')
+                WHEN [e].[StringA] LIKE N'A%'
                 THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
             END ELSE CAST(0 AS BIT)
         END ELSE CAST(1 AS BIT)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryNavigationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryNavigationsSqlServerTest.cs
@@ -445,7 +445,7 @@ WHERE (([o].[OrderID] < 10300) AND ([o0].[OrderID] < 10400)) AND (([o.Customer].
                 @"SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate]
 FROM [Orders] AS [o1]
 CROSS JOIN [Orders] AS [o2]
-WHERE (([o1].[CustomerID] LIKE N'A' + N'%' AND (LEFT([o1].[CustomerID], LEN(N'A')) = N'A')) AND ([o2].[CustomerID] LIKE N'A' + N'%' AND (LEFT([o2].[CustomerID], LEN(N'A')) = N'A'))) AND (([o1].[CustomerID] = [o2].[CustomerID]) OR ([o1].[CustomerID] IS NULL AND [o2].[CustomerID] IS NULL))");
+WHERE ([o1].[CustomerID] LIKE N'A%' AND [o2].[CustomerID] LIKE N'A%') AND (([o1].[CustomerID] = [o2].[CustomerID]) OR ([o1].[CustomerID] IS NULL AND [o2].[CustomerID] IS NULL))");
         }
 
         public override async Task Select_Where_Navigation_Null(bool isAsync)
@@ -486,7 +486,7 @@ WHERE [e].[ReportsTo] IS NULL");
             AssertSql(
                 @"SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
+WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY [c].[CustomerID]",
                 //
                 @"SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate], [t].[CustomerID]
@@ -494,7 +494,7 @@ FROM [Orders] AS [c.Orders]
 INNER JOIN (
     SELECT [c0].[CustomerID]
     FROM [Customers] AS [c0]
-    WHERE [c0].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c0].[CustomerID], LEN(N'A')) = N'A')
+    WHERE [c0].[CustomerID] LIKE N'A%'
 ) AS [t] ON [c.Orders].[CustomerID] = [t].[CustomerID]
 ORDER BY [t].[CustomerID]");
         }
@@ -506,7 +506,7 @@ ORDER BY [t].[CustomerID]");
             AssertSql(
                 @"SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
+WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY [c].[CustomerID]",
                 //
                 @"SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate], [t].[CustomerID]
@@ -514,7 +514,7 @@ FROM [Orders] AS [c.Orders]
 INNER JOIN (
     SELECT [c0].[CustomerID]
     FROM [Customers] AS [c0]
-    WHERE [c0].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c0].[CustomerID], LEN(N'A')) = N'A')
+    WHERE [c0].[CustomerID] LIKE N'A%'
 ) AS [t] ON [c.Orders].[CustomerID] = [t].[CustomerID]
 ORDER BY [t].[CustomerID]");
         }
@@ -800,7 +800,7 @@ END AS [conditional], [o].[OrderID] AS [scalar2], (
     WHERE [o].[OrderID] = [o1].[OrderID]
 ) AS [collection2]
 FROM [Orders] AS [o]
-WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (LEFT([o].[CustomerID], LEN(N'A')) = N'A')");
+WHERE [o].[CustomerID] LIKE N'A%'");
         }
 
         public override async Task Collection_select_nav_prop_sum(bool isAsync)
@@ -869,7 +869,7 @@ ORDER BY [o].[OrderID]");
             AssertSql(
                 @"SELECT [e].[CustomerID]
 FROM [Customers] AS [e]
-WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (LEFT([e].[CustomerID], LEN(N'A')) = N'A')
+WHERE [e].[CustomerID] LIKE N'A%'
 ORDER BY [e].[CustomerID]",
                 //
                 @"@_outer_CustomerID='ALFKI' (Size = 5)
@@ -913,7 +913,7 @@ WHERE [e0].[OrderID] IN (10643, 10692, 10702, 10835, 10952, 11011) AND (@_outer_
     WHERE [o].[CustomerID] = N'ALFKI'
 )
 FROM [Customers] AS [e]
-WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (LEFT([e].[CustomerID], LEN(N'A')) = N'A')");
+WHERE [e].[CustomerID] LIKE N'A%'");
         }
 
         public override async Task Collection_select_nav_prop_single_or_default_then_nav_prop_nested(bool isAsync)
@@ -923,7 +923,7 @@ WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (LEFT([e].[CustomerID], LEN(N'A')) =
             AssertSql(
                 @"SELECT 1
 FROM [Customers] AS [e]
-WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (LEFT([e].[CustomerID], LEN(N'A')) = N'A')",
+WHERE [e].[CustomerID] LIKE N'A%'",
                 //
                 @"SELECT TOP(2) [o.Customer0].[City]
 FROM [Orders] AS [o0]
@@ -958,7 +958,7 @@ WHERE [o0].[OrderID] = 10643");
     WHERE [oo].[CustomerID] = N'ALFKI'
 )
 FROM [Customers] AS [e]
-WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (LEFT([e].[CustomerID], LEN(N'A')) = N'A')");
+WHERE [e].[CustomerID] LIKE N'A%'");
         }
 
         public override async Task Collection_select_nav_prop_first_or_default_then_nav_prop_nested_with_orderby(bool isAsync)
@@ -974,7 +974,7 @@ WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (LEFT([e].[CustomerID], LEN(N'A')) =
     ORDER BY [o].[CustomerID]
 )
 FROM [Customers] AS [e]
-WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (LEFT([e].[CustomerID], LEN(N'A')) = N'A')");
+WHERE [e].[CustomerID] LIKE N'A%'");
         }
 
         public override async Task Navigation_fk_based_inside_contains(bool isAsync)
@@ -1184,7 +1184,7 @@ FROM [Customers] AS [c]");
             AssertSql(
                 @"SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
+WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY [c].[CustomerID]",
                 //
                 @"@_outer_CustomerID='ALFKI' (Size = 5)
@@ -1287,7 +1287,7 @@ WHERE (
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Customers] AS [c]
 LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
+WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY [c].[CustomerID] DESC");
         }
 
@@ -1399,7 +1399,7 @@ LEFT JOIN (
     FROM [Orders] AS [oo]
     WHERE [oo].[OrderID] NOT IN (10308, 10625, 10759, 10926)
 ) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
+WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY [c].[CustomerID]",
                 //
                 @"@_outer_OrderID='10643'
@@ -1561,7 +1561,7 @@ WHERE @_outer_OrderID = [o0].[OrderID]");
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Customers] AS [c]
 LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
+WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY [c].[CustomerID]");
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/RowNumberPagingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/RowNumberPagingTest.cs
@@ -506,7 +506,7 @@ SELECT CASE
             ) AS [t0]
             WHERE ([t0].[__RowNumber__] > @__p_0) AND ([t0].[__RowNumber__] <= (@__p_0 + @__p_1))
         ) AS [t]
-        WHERE NOT ([t].[CustomerID] LIKE N'B' + N'%') OR (LEFT([t].[CustomerID], LEN(N'B')) <> N'B'))
+        WHERE NOT ([t].[CustomerID] LIKE N'B%'))
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END");
         }
@@ -526,7 +526,7 @@ SELECT CASE
             FROM [Customers] AS [c]
             ORDER BY [c].[CustomerID]
         ) AS [t]
-        WHERE NOT ([t].[CustomerID] LIKE N'A' + N'%') OR (LEFT([t].[CustomerID], LEN(N'A')) <> N'A'))
+        WHERE NOT ([t].[CustomerID] LIKE N'A%'))
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END");
         }
@@ -550,7 +550,7 @@ SELECT CASE
             ) AS [t0]
             WHERE ([t0].[__RowNumber__] > @__p_0) AND ([t0].[__RowNumber__] <= (@__p_0 + @__p_1))
         ) AS [t]
-        WHERE [t].[CustomerID] LIKE N'C' + N'%' AND (LEFT([t].[CustomerID], LEN(N'C')) = N'C'))
+        WHERE [t].[CustomerID] LIKE N'C%')
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END");
         }
@@ -570,7 +570,7 @@ SELECT CASE
             FROM [Customers] AS [c]
             ORDER BY [c].[CustomerID]
         ) AS [t]
-        WHERE [t].[CustomerID] LIKE N'B' + N'%' AND (LEFT([t].[CustomerID], LEN(N'B')) = N'B'))
+        WHERE [t].[CustomerID] LIKE N'B%')
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END");
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Functions.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Functions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] LIKE N'M' + N'%' AND (LEFT([c].[ContactName], LEN(N'M')) = N'M')");
+WHERE [c].[ContactName] LIKE N'M%'");
         }
 
         public override async Task String_StartsWith_Identity(bool isAsync)
@@ -47,7 +47,7 @@ WHERE ([c].[ContactName] LIKE [c].[ContactName] + N'%' AND (LEFT([c].[ContactNam
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] LIKE N'M' + N'%' AND (LEFT([c].[ContactName], LEN(N'M')) = N'M')");
+WHERE [c].[ContactName] LIKE N'M%'");
         }
 
         public override async Task String_EndsWith_Literal(bool isAsync)
@@ -57,7 +57,7 @@ WHERE [c].[ContactName] LIKE N'M' + N'%' AND (LEFT([c].[ContactName], LEN(N'M'))
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE RIGHT([c].[ContactName], LEN(N'b')) = N'b'");
+WHERE [c].[ContactName] LIKE N'%b'");
         }
 
         public override async Task String_EndsWith_Identity(bool isAsync)
@@ -87,7 +87,7 @@ WHERE (RIGHT([c].[ContactName], LEN([c].[ContactName])) = [c].[ContactName]) OR 
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE RIGHT([c].[ContactName], LEN(N'm')) = N'm'");
+WHERE [c].[ContactName] LIKE N'%m'");
         }
 
         public override async Task String_Contains_Literal(bool isAsync)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.JoinGroupJoin.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.JoinGroupJoin.cs
@@ -539,7 +539,7 @@ ORDER BY [c].[CustomerID]");
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Customers] AS [c]
 LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
+WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY [c].[CustomerID] DESC");
         }
 
@@ -551,7 +551,7 @@ ORDER BY [c].[CustomerID] DESC");
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Customers] AS [c]
 LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
+WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY [c].[CustomerID] DESC");
         }
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.ResultOperators.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.ResultOperators.cs
@@ -17,11 +17,11 @@ namespace Microsoft.EntityFrameworkCore.Query
             AssertSql(
                 @"SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
 FROM [Customers] AS [c1]
-WHERE [c1].[CompanyName] LIKE N'A' + N'%' AND (LEFT([c1].[CompanyName], LEN(N'A')) = N'A')",
+WHERE [c1].[CompanyName] LIKE N'A%'",
                 //
                 @"SELECT [c2].[CustomerID], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region]
 FROM [Customers] AS [c2]
-WHERE [c2].[CompanyName] LIKE N'B' + N'%' AND (LEFT([c2].[CompanyName], LEN(N'B')) = N'B')");
+WHERE [c2].[CompanyName] LIKE N'B%'");
         }
 
         public override void Select_All()
@@ -1070,7 +1070,7 @@ ORDER BY [o].[OrderID]");
             AssertSql(
                 @"SELECT AVG(CAST(CAST([o].[OrderID] AS bigint) AS float))
 FROM [Orders] AS [o]
-WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (LEFT([o].[CustomerID], LEN(N'A')) = N'A')");
+WHERE [o].[CustomerID] LIKE N'A%'");
         }
 
         public override async Task Max_with_non_matching_types_in_projection_introduces_explicit_cast(bool isAsync)
@@ -1080,7 +1080,7 @@ WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (LEFT([o].[CustomerID], LEN(N'A')) =
             AssertSql(
                 @"SELECT MAX(CAST([o].[OrderID] AS bigint))
 FROM [Orders] AS [o]
-WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (LEFT([o].[CustomerID], LEN(N'A')) = N'A')");
+WHERE [o].[CustomerID] LIKE N'A%'");
         }
 
         public override async Task Min_with_non_matching_types_in_projection_introduces_explicit_cast(bool isAsync)
@@ -1090,7 +1090,7 @@ WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (LEFT([o].[CustomerID], LEN(N'A')) =
             AssertSql(
                 @"SELECT MIN(CAST([o].[OrderID] AS bigint))
 FROM [Orders] AS [o]
-WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (LEFT([o].[CustomerID], LEN(N'A')) = N'A')");
+WHERE [o].[CustomerID] LIKE N'A%'");
         }
 
         public override async Task OrderBy_Take_Last_gives_correct_result(bool isAsync)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
@@ -325,7 +325,7 @@ ORDER BY [o].[OrderID]");
             AssertSql(
                 @"SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')",
+WHERE [c].[CustomerID] LIKE N'A%'",
                 //
                 @"@_outer_CustomerID='ALFKI' (Size = 5)
 
@@ -363,7 +363,7 @@ WHERE ([o].[OrderID] < 10500) AND (@_outer_CustomerID = [o].[CustomerID])");
     WHERE ([o].[OrderID] < 10500) AND ([c].[CustomerID] = [o].[CustomerID])
 ) AS [OrderDates]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')");
+WHERE [c].[CustomerID] LIKE N'A%'");
         }
 
         public override void Select_nested_collection_multi_level3()
@@ -377,7 +377,7 @@ WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) =
     WHERE ([o].[OrderID] < 10500) AND ([c].[CustomerID] = [o].[CustomerID])
 ) AS [OrderDates]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')");
+WHERE [c].[CustomerID] LIKE N'A%'");
         }
 
         public override void Select_nested_collection_multi_level4()
@@ -395,7 +395,7 @@ WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) =
     WHERE ([o].[OrderID] < 10500) AND ([c].[CustomerID] = [o].[CustomerID])
 ), 0) AS [Order]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')");
+WHERE [c].[CustomerID] LIKE N'A%'");
         }
 
         public override void Select_nested_collection_multi_level5()
@@ -417,7 +417,7 @@ WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) =
     WHERE ([o].[OrderID] < 10500) AND ([c].[CustomerID] = [o].[CustomerID])
 ), 0) AS [Order]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')");
+WHERE [c].[CustomerID] LIKE N'A%'");
         }
 
         public override void Select_nested_collection_multi_level6()
@@ -435,7 +435,7 @@ WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) =
     WHERE ([o].[OrderID] < 10500) AND ([c].[CustomerID] = [o].[CustomerID])
 ), 0) AS [Order]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')");
+WHERE [c].[CustomerID] LIKE N'A%'");
         }
 
         public override async Task Select_nested_collection_count_using_anonymous_type(bool isAsync)
@@ -449,7 +449,7 @@ WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) =
     WHERE [c].[CustomerID] = [o].[CustomerID]
 ) AS [Count]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')");
+WHERE [c].[CustomerID] LIKE N'A%'");
         }
 
         public override async Task New_date_time_in_anonymous_type_works(bool isAsync)
@@ -459,7 +459,7 @@ WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) =
             AssertSql(
                 @"SELECT 1
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')");
+WHERE [c].[CustomerID] LIKE N'A%'");
         }
 
         public override async Task Select_non_matching_value_types_int_to_long_introduces_explicit_cast(bool isAsync)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Where.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Where.cs
@@ -1317,7 +1317,7 @@ WHERE [p].[UnitsInStock] > CAST(10 AS smallint)");
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE RIGHT([c].[CustomerID], LEN(N'KI')) = N'KI'");
+WHERE [c].[CustomerID] LIKE N'%KI'");
         }
 
         public override async Task Where_true(bool isAsync)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -756,7 +756,7 @@ ORDER BY [c].[CustomerID]");
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
+WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY [c].[CustomerID]",
                 //
                 @"@_outer_CustomerID='ALFKI' (Size = 5)
@@ -1249,7 +1249,7 @@ END");
     WHEN EXISTS (
         SELECT 1
         FROM [Customers] AS [c]
-        WHERE [c].[ContactName] LIKE N'A' + N'%' AND (LEFT([c].[ContactName], LEN(N'A')) = N'A'))
+        WHERE [c].[ContactName] LIKE N'A%')
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END");
         }
@@ -1264,7 +1264,7 @@ FROM [Customers] AS [c]
 WHERE NOT EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (LEFT([o].[CustomerID], LEN(N'A')) = N'A'))");
+    WHERE [o].[CustomerID] LIKE N'A%')");
         }
 
         public override async Task Any_nested_negated2(bool isAsync)
@@ -1277,7 +1277,7 @@ FROM [Customers] AS [c]
 WHERE (([c].[City] <> N'London') OR [c].[City] IS NULL) AND NOT EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (LEFT([o].[CustomerID], LEN(N'A')) = N'A'))");
+    WHERE [o].[CustomerID] LIKE N'A%')");
         }
 
         public override async Task Any_nested_negated3(bool isAsync)
@@ -1290,7 +1290,7 @@ FROM [Customers] AS [c]
 WHERE NOT EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (LEFT([o].[CustomerID], LEN(N'A')) = N'A')) AND (([c].[City] <> N'London') OR [c].[City] IS NULL)");
+    WHERE [o].[CustomerID] LIKE N'A%') AND (([c].[City] <> N'London') OR [c].[City] IS NULL)");
         }
 
         public override async Task Any_nested(bool isAsync)
@@ -1303,7 +1303,7 @@ FROM [Customers] AS [c]
 WHERE EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (LEFT([o].[CustomerID], LEN(N'A')) = N'A'))");
+    WHERE [o].[CustomerID] LIKE N'A%')");
         }
 
         public override async Task Any_nested2(bool isAsync)
@@ -1316,7 +1316,7 @@ FROM [Customers] AS [c]
 WHERE (([c].[City] <> N'London') OR [c].[City] IS NULL) AND EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (LEFT([o].[CustomerID], LEN(N'A')) = N'A'))");
+    WHERE [o].[CustomerID] LIKE N'A%')");
         }
 
         public override async Task Any_nested3(bool isAsync)
@@ -1329,7 +1329,7 @@ FROM [Customers] AS [c]
 WHERE EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (LEFT([o].[CustomerID], LEN(N'A')) = N'A')) AND (([c].[City] <> N'London') OR [c].[City] IS NULL)");
+    WHERE [o].[CustomerID] LIKE N'A%') AND (([c].[City] <> N'London') OR [c].[City] IS NULL)");
         }
 
         public override void Any_with_multiple_conditions_still_uses_exists()
@@ -1354,7 +1354,7 @@ WHERE ([c].[City] = N'London') AND EXISTS (
     WHEN NOT EXISTS (
         SELECT 1
         FROM [Customers] AS [c]
-        WHERE NOT ([c].[ContactName] LIKE N'A' + N'%') OR (LEFT([c].[ContactName], LEN(N'A')) <> N'A'))
+        WHERE NOT ([c].[ContactName] LIKE N'A%'))
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END");
         }
@@ -2004,7 +2004,7 @@ SELECT CASE
             ORDER BY [c].[CustomerID]
             OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
         ) AS [t]
-        WHERE NOT ([t].[CustomerID] LIKE N'B' + N'%') OR (LEFT([t].[CustomerID], LEN(N'B')) <> N'B'))
+        WHERE NOT ([t].[CustomerID] LIKE N'B%'))
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END");
         }
@@ -2025,7 +2025,7 @@ SELECT CASE
             FROM [Customers] AS [c]
             ORDER BY [c].[CustomerID]
         ) AS [t]
-        WHERE NOT ([t].[CustomerID] LIKE N'A' + N'%') OR (LEFT([t].[CustomerID], LEN(N'A')) <> N'A'))
+        WHERE NOT ([t].[CustomerID] LIKE N'A%'))
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END");
         }
@@ -2048,7 +2048,7 @@ SELECT CASE
             ORDER BY [c].[CustomerID]
             OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
         ) AS [t]
-        WHERE [t].[CustomerID] LIKE N'C' + N'%' AND (LEFT([t].[CustomerID], LEN(N'C')) = N'C'))
+        WHERE [t].[CustomerID] LIKE N'C%')
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END");
         }
@@ -2069,7 +2069,7 @@ SELECT CASE
             FROM [Customers] AS [c]
             ORDER BY [c].[CustomerID]
         ) AS [t]
-        WHERE [t].[CustomerID] LIKE N'B' + N'%' AND (LEFT([t].[CustomerID], LEN(N'B')) = N'B'))
+        WHERE [t].[CustomerID] LIKE N'B%')
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END");
         }
@@ -2236,7 +2236,7 @@ END");
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
+WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY (
     SELECT CASE
         WHEN EXISTS (
@@ -2356,7 +2356,7 @@ WHERE [o].[OrderID] < 10300");
     WHERE [c].[CustomerID] = [o].[CustomerID]
 ) AS [Count]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')");
+WHERE [c].[CustomerID] LIKE N'A%'");
         }
 
         public override async Task Select_DTO_with_member_init_distinct_in_subquery_translated_to_server(bool isAsync)
@@ -2386,7 +2386,7 @@ CROSS JOIN (
     FROM [Orders] AS [o]
     WHERE [o].[OrderID] < 10300
 ) AS [t]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')");
+WHERE [c].[CustomerID] LIKE N'A%'");
         }
 
         public override async Task Select_correlated_subquery_projection(bool isAsync)
@@ -2426,7 +2426,7 @@ WHERE [o].[CustomerID] = @_outer_CustomerID");
             AssertSql(
                 @"SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
+WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY [c].[CustomerID]",
                 //
                 @"@_outer_CustomerID='ALFKI' (Size = 5)
@@ -3774,7 +3774,7 @@ FROM (
     SELECT DISTINCT [c].[CustomerID]
     FROM [Customers] AS [c]
 ) AS [t]
-WHERE [t].[CustomerID] LIKE N'A' + N'%' AND (LEFT([t].[CustomerID], LEN(N'A')) = N'A')");
+WHERE [t].[CustomerID] LIKE N'A%'");
         }
 
         public override async Task Anonymous_complex_distinct_where(bool isAsync)
@@ -3813,7 +3813,7 @@ FROM (
     SELECT DISTINCT [c].[CustomerID] + [c].[City] AS [A]
     FROM [Customers] AS [c]
 ) AS [t]
-WHERE [t].[A] LIKE N'A' + N'%' AND (LEFT([t].[A], LEN(N'A')) = N'A')");
+WHERE [t].[A] LIKE N'A%'");
         }
 
         public override async Task Anonymous_complex_orderby(bool isAsync)
@@ -3887,7 +3887,7 @@ FROM (
     SELECT DISTINCT [c].[CustomerID] AS [Property]
     FROM [Customers] AS [c]
 ) AS [t]
-WHERE [t].[Property] LIKE N'A' + N'%' AND (LEFT([t].[Property], LEN(N'A')) = N'A')");
+WHERE [t].[Property] LIKE N'A%'");
         }
 
         public override async Task DTO_complex_distinct_where(bool isAsync)
@@ -3926,7 +3926,7 @@ FROM (
     SELECT DISTINCT [c].[CustomerID] + [c].[City] AS [Property]
     FROM [Customers] AS [c]
 ) AS [t]
-WHERE [t].[Property] LIKE N'A' + N'%' AND (LEFT([t].[Property], LEN(N'A')) = N'A')");
+WHERE [t].[Property] LIKE N'A%'");
         }
 
         public override async Task DTO_complex_orderby(bool isAsync)
@@ -4371,7 +4371,7 @@ WHERE ([c].[CustomerID] LIKE @__prefix_0 + N'%' AND (LEFT([c].[CustomerID], LEN(
                 @"SELECT [c1].[CustomerID] AS [Id1], [c2].[CustomerID] AS [Id2]
 FROM [Customers] AS [c1]
 CROSS JOIN [Customers] AS [c2]
-WHERE ([c1].[CustomerID] LIKE N'ALFKI' + N'%' AND (LEFT([c1].[CustomerID], LEN(N'ALFKI')) = N'ALFKI')) AND ([c1].[CustomerID] = [c2].[CustomerID])
+WHERE [c1].[CustomerID] LIKE N'ALFKI%' AND ([c1].[CustomerID] = [c2].[CustomerID])
 ORDER BY [Id1]");
         }
 
@@ -4393,7 +4393,7 @@ WHERE 0 = 1");
             AssertSql(
                 @"SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE ([c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')) AND [c].[CustomerID] IS NOT NULL
+WHERE [c].[CustomerID] LIKE N'A%' AND [c].[CustomerID] IS NOT NULL
 ORDER BY [c].[CustomerID]");
         }
 
@@ -4405,7 +4405,7 @@ ORDER BY [c].[CustomerID]");
                 @"SELECT [o1].[OrderID] AS [Id1], [o2].[OrderID] AS [Id2]
 FROM [Orders] AS [o1]
 CROSS JOIN [Orders] AS [o2]
-WHERE ([o1].[CustomerID] LIKE N'A' + N'%' AND (LEFT([o1].[CustomerID], LEN(N'A')) = N'A')) AND (([o1].[CustomerID] = [o2].[CustomerID]) OR ([o1].[CustomerID] IS NULL AND [o2].[CustomerID] IS NULL))
+WHERE [o1].[CustomerID] LIKE N'A%' AND (([o1].[CustomerID] = [o2].[CustomerID]) OR ([o1].[CustomerID] IS NULL AND [o2].[CustomerID] IS NULL))
 ORDER BY [Id1], [Id2]");
         }
 
@@ -4417,7 +4417,7 @@ ORDER BY [Id1], [Id2]");
                 @"SELECT [o1].[OrderID] AS [Id1], [o2].[OrderID] AS [Id2]
 FROM [Orders] AS [o1]
 CROSS JOIN [Orders] AS [o2]
-WHERE ([o1].[CustomerID] LIKE N'A' + N'%' AND (LEFT([o1].[CustomerID], LEN(N'A')) = N'A')) AND (([o1].[CustomerID] = [o2].[CustomerID]) OR ([o1].[CustomerID] IS NULL AND [o2].[CustomerID] IS NULL))
+WHERE [o1].[CustomerID] LIKE N'A%' AND (([o1].[CustomerID] = [o2].[CustomerID]) OR ([o1].[CustomerID] IS NULL AND [o2].[CustomerID] IS NULL))
 ORDER BY [Id1], [Id2]");
         }
 
@@ -4472,7 +4472,7 @@ ORDER BY [od].[OrderID], [od].[ProductID]");
             AssertSql(
                 @"SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE ([c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')) AND ([c].[CustomerID] = [c].[CustomerID])");
+WHERE [c].[CustomerID] LIKE N'A%' AND ([c].[CustomerID] = [c].[CustomerID])");
         }
 
         public override async Task Compare_two_collection_navigations_with_different_query_sources(bool isAsync)
@@ -4516,7 +4516,7 @@ ORDER BY [Id1], [Id2]");
             AssertSql(
                 @"SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
+WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY [c].[CustomerID]");
         }
 
@@ -4527,7 +4527,7 @@ ORDER BY [c].[CustomerID]");
             AssertSql(
                 @"SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
+WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY [c].[CustomerID] DESC");
         }
 
@@ -4690,7 +4690,7 @@ WHERE EXISTS (
     ORDER BY [e0].[OrderDate]
 ) AS [OrderDate]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')",
+WHERE [c].[CustomerID] LIKE N'A%'",
                 //
                 @"@_outer_CustomerID='ALFKI' (Size = 5)
 
@@ -4733,7 +4733,7 @@ ORDER BY [e].[OrderDate]");
     ORDER BY [e2].[OrderDate]
 )
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')",
+WHERE [c].[CustomerID] LIKE N'A%'",
                 //
                 @"@_outer_CustomerID='ALFKI' (Size = 5)
 
@@ -4841,7 +4841,7 @@ WHERE (
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ([c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')) AND ((
+WHERE [c].[CustomerID] LIKE N'A%' AND ((
     SELECT TOP(1) [o].[OrderID]
     FROM [Orders] AS [o]
     WHERE [o].[OrderID] < 10300

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
@@ -178,7 +178,7 @@ WHERE ((CAST(strftime('%f', ""o"".""OrderDate"") AS REAL) * 1000) % 1000) = 88")
             AssertSql(
                 @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
 FROM ""Customers"" AS ""c""
-WHERE ""c"".""ContactName"" LIKE 'M' || '%' AND (substr(""c"".""ContactName"", 1, length('M')) = 'M')");
+WHERE ""c"".""ContactName"" LIKE 'M%'");
         }
 
         public override async Task String_StartsWith_Identity(bool isAsync)
@@ -208,7 +208,7 @@ WHERE (""c"".""ContactName"" LIKE ""c"".""ContactName"" || '%' AND (substr(""c""
             AssertSql(
                 @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
 FROM ""Customers"" AS ""c""
-WHERE ""c"".""ContactName"" LIKE 'M' || '%' AND (substr(""c"".""ContactName"", 1, length('M')) = 'M')");
+WHERE ""c"".""ContactName"" LIKE 'M%'");
         }
 
         public override async Task String_EndsWith_Literal(bool isAsync)
@@ -218,7 +218,7 @@ WHERE ""c"".""ContactName"" LIKE 'M' || '%' AND (substr(""c"".""ContactName"", 1
             AssertSql(
                 @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
 FROM ""Customers"" AS ""c""
-WHERE substr(""c"".""ContactName"", -length('b')) = 'b'");
+WHERE ""c"".""ContactName"" LIKE '%b'");
         }
 
         public override async Task String_EndsWith_Identity(bool isAsync)
@@ -248,7 +248,7 @@ WHERE (substr(""c"".""ContactName"", -length(""c"".""ContactName"")) = ""c"".""C
             AssertSql(
                 @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
 FROM ""Customers"" AS ""c""
-WHERE substr(""c"".""ContactName"", -length('m')) = 'm'");
+WHERE ""c"".""ContactName"" LIKE '%m'");
         }
 
         public override async Task String_Contains_Literal(bool isAsync)


### PR DESCRIPTION
If the pattern is constant, we now escape it client-side and send a simple LIKE expression - no need for fancy concatenation and an additional LEFT(LEN()) check.

Fixes #14657
Replaces #14820