### PR TITLE
Skip first run experience on azure pipelines.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,8 @@ variables:
     value: Release
   - name: _TeamName
     value: AspNetCore
+  - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
+    value: true
 
 trigger:
   - master


### PR DESCRIPTION
- Suppresses the 'Welcome to .NET Core!' output that times out tests and causes locked file issues. When using dotnet we're not guarunteed to run in an environment where the dotnet.exe has had its first run experience already invoked. This would cause various functional tests to time out in AspNetCore and AspNetCore-Tooling and occasionally crash due to dotnet first run experience sentinels being locked.

aspnet/AspNetCore-Internal#1859