### PR TITLE
Allow optional foreign keys on non-nullable properties

### DIFF
--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -913,14 +913,23 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     }
                 }
 
-                if (foreignKey.DeleteBehavior != DeleteBehavior.ClientSetNull
-                        && !foreignKey.IsOwnership)
+                if (!foreignKey.IsOwnership)
                 {
-                    stringBuilder
-                        .AppendLine()
-                        .Append(".OnDelete(")
-                        .Append(Code.Literal(foreignKey.DeleteBehavior))
-                        .Append(")");
+                    if (foreignKey.DeleteBehavior != DeleteBehavior.ClientSetNull)
+                    {
+                        stringBuilder
+                            .AppendLine()
+                            .Append(".OnDelete(")
+                            .Append(Code.Literal(foreignKey.DeleteBehavior))
+                            .Append(")");
+                    }
+
+                    if (foreignKey.IsRequired)
+                    {
+                        stringBuilder
+                            .AppendLine()
+                            .Append(".IsRequired()");
+                    }
                 }
             }
 

--- a/src/EFCore/Internal/Reference.cs
+++ b/src/EFCore/Internal/Reference.cs
@@ -13,6 +13,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
     public class Reference<T> : IDisposable
     {
         private readonly IReferenceRoot<T> _root;
+        private int _referenceCount = 1;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -45,8 +46,20 @@ namespace Microsoft.EntityFrameworkCore.Internal
         /// </summary>
         public virtual void Dispose()
         {
-            _root?.Release(this);
-            Object = default;
+            if (_referenceCount-- == 1)
+            {
+                _root?.Release(this);
+                Object = default;
+            }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual void IncreaseReferenceCount()
+        {
+            _referenceCount++;
         }
     }
 }

--- a/src/EFCore/Metadata/Builders/InvertibleRelationshipBuilderBase.cs
+++ b/src/EFCore/Metadata/Builders/InvertibleRelationshipBuilderBase.cs
@@ -86,7 +86,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                     _foreignKeyProperties,
                     _principalKeyProperties,
                     foreignKey.IsUnique,
-                    _required,
                     shouldThrow: true);
             }
         }

--- a/src/EFCore/Metadata/Builders/RelationshipBuilderBase.cs
+++ b/src/EFCore/Metadata/Builders/RelationshipBuilderBase.cs
@@ -70,7 +70,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                     _foreignKeyProperties,
                     _principalKeyProperties,
                     foreignKey.IsUnique,
-                    _required,
                     shouldThrow: true);
             }
         }

--- a/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.cs
@@ -310,8 +310,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 }
             }
 
-            private void Run()
+            public void Run()
             {
+                if (_runCount == null)
+                {
+                    return;
+                }
+
                 while (true)
                 {
                     if (_runCount++ == short.MaxValue)

--- a/src/EFCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
@@ -187,6 +187,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             conventionSet.PrincipalEndChangedConventions.Add(foreignKeyPropertyDiscoveryConvention);
 
+            conventionSet.PropertyNullabilityChangedConventions.Add(foreignKeyPropertyDiscoveryConvention);
+
             conventionSet.PropertyFieldChangedConventions.Add(keyDiscoveryConvention);
             conventionSet.PropertyFieldChangedConventions.Add(foreignKeyPropertyDiscoveryConvention);
             conventionSet.PropertyFieldChangedConventions.Add(keyAttributeConvention);

--- a/src/EFCore/Metadata/Conventions/Internal/IConventionBatch.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/IConventionBatch.cs
@@ -17,6 +17,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        void Run();
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         ForeignKey Run([NotNull] ForeignKey foreignKey);
     }
 }

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -900,7 +900,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 dependentProperties: properties,
                 principalProperties: principalKey.Properties,
                 unique: null,
-                required: null,
                 shouldThrow: true);
 
             var duplicateForeignKey = FindForeignKeysInHierarchy(properties, principalKey, principalEntityType).FirstOrDefault();

--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -2034,6 +2034,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 {
                     relationship = relationship
                         .RelatedEntityTypes(targetEntityTypeBuilder.Metadata, Metadata, configurationSource);
+
+                    if (required.HasValue)
+                    {
+                        relationship = relationship.IsRequired(required.Value, configurationSource);
+                    }
                 }
 
                 var inverseProperty = inverseNavigation?.Property;
@@ -2552,7 +2557,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 if (isRequired.HasValue
                     && foreignKey.IsRequired == isRequired.Value)
                 {
-                    foreignKey.SetIsRequired(isRequired.Value, configurationSource);
+                    foreignKey = foreignKey.SetIsRequired(isRequired.Value, configurationSource);
                 }
 
                 principalType.UpdateConfigurationSource(configurationSource);

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -1366,14 +1366,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 property, entityType);
 
         /// <summary>
-        ///     The foreign key {foreignKey} on entity type '{entityType}' cannot be marked as optional because it does not contain any property of a nullable type. Any foreign key can be marked as required, but only foreign keys with at least one property of a nullable type and which is not part of primary key can be marked as optional.
-        /// </summary>
-        public static string ForeignKeyCannotBeOptional([CanBeNull] object foreignKey, [CanBeNull] object entityType)
-            => string.Format(
-                GetString("ForeignKeyCannotBeOptional", nameof(foreignKey), nameof(entityType)),
-                foreignKey, entityType);
-
-        /// <summary>
         ///     Entity type '{entityType}' is in shadow-state. A valid model requires all entity types to have corresponding CLR type.
         /// </summary>
         public static string ShadowEntity([CanBeNull] object entityType)
@@ -2690,20 +2682,20 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 failedBinds, parameters);
 
         /// <summary>
-        ///     Property '{property}' on entity type '{entityType}' matches both '{field1}' and '{field2}' by convention. Explicitly specify the backing field to use with '.HasField()' in 'OnModelCreating()'.
-        /// </summary>
-        public static string ConflictingBackingFields([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object field1, [CanBeNull] object field2)
-            => string.Format(
-                GetString("ConflictingBackingFields", nameof(property), nameof(entityType), nameof(field1), nameof(field2)),
-                property, entityType, field1, field2);
-
-        /// <summary>
         ///     The navigation '{navigation}' cannot be added because it targets the keyless entity type '{entityType}'. Navigations can only target entity types with keys.
         /// </summary>
         public static string NavigationToKeylessType([CanBeNull] object navigation, [CanBeNull] object entityType)
             => string.Format(
                 GetString("NavigationToKeylessType", nameof(navigation), nameof(entityType)),
                 navigation, entityType);
+
+        /// <summary>
+        ///     Property '{property}' on entity type '{entityType}' matches both '{field1}' and '{field2}' by convention. Explicitly specify the backing field to use with '.HasField()' in 'OnModelCreating()'.
+        /// </summary>
+        public static string ConflictingBackingFields([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object field1, [CanBeNull] object field2)
+            => string.Format(
+                GetString("ConflictingBackingFields", nameof(property), nameof(entityType), nameof(field1), nameof(field2)),
+                property, entityType, field1, field2);
 
         /// <summary>
         ///     The entity type '{entityType}' cannot be marked as keyless because it contains a key.

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -604,9 +604,6 @@
   <data name="CannotBeNullablePK" xml:space="preserve">
     <value>The property '{property}' on entity type '{entityType}' cannot be marked as nullable/optional because the property is a part of a key. Any property can be marked as non-nullable/required, but only properties of nullable types and which are not part of a key can be marked as nullable/optional.</value>
   </data>
-  <data name="ForeignKeyCannotBeOptional" xml:space="preserve">
-    <value>The foreign key {foreignKey} on entity type '{entityType}' cannot be marked as optional because it does not contain any property of a nullable type. Any foreign key can be marked as required, but only foreign keys with at least one property of a nullable type and which is not part of primary key can be marked as optional.</value>
-  </data>
   <data name="ShadowEntity" xml:space="preserve">
     <value>Entity type '{entityType}' is in shadow-state. A valid model requires all entity types to have corresponding CLR type.</value>
   </data>

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -696,7 +696,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", ""EntityWithOneProperty"")
                         .WithOne(""EntityWithTwoProperties"")
                         .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""AlternateId"")
-                        .OnDelete(DeleteBehavior.Cascade);
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
                 });"),
                 o =>
                 {
@@ -2152,7 +2153,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                         .WithOne(""EntityWithTwoProperties"")
                         .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""AlternateId"")
                         .HasAnnotation(""AnnotationName"", ""AnnotationValue"")
-                        .OnDelete(DeleteBehavior.Cascade);
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
                 });"),
                 o => Assert.Equal(
                     "AnnotationValue", o.FindEntityType(typeof(EntityWithTwoProperties)).GetForeignKeys().First()["AnnotationName"]));
@@ -2204,7 +2206,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringKey"", null)
                         .WithOne()
                         .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", ""Name"")
-                        .OnDelete(DeleteBehavior.Cascade);
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
                 });"),
                 o => Assert.False(o.FindEntityType(typeof(EntityWithStringProperty)).FindProperty("Name").IsNullable));
         }
@@ -2296,7 +2299,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""EntityWithTwoProperties"")
                         .WithMany()
                         .HasForeignKey(""Id"")
-                        .OnDelete(DeleteBehavior.Cascade);
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
                 });"),
                 o => Assert.Equal(
                     DeleteBehavior.Cascade, o.FindEntityType(typeof(EntityWithOneProperty)).GetForeignKeys().First().DeleteBehavior));
@@ -2342,7 +2346,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""EntityWithTwoProperties"")
                         .WithOne(""EntityWithOneProperty"")
                         .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", ""Id"")
-                        .OnDelete(DeleteBehavior.Cascade);
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
                 });"),
                 o => Assert.Equal(
                     DeleteBehavior.Cascade, o.FindEntityType(typeof(EntityWithOneProperty)).GetForeignKeys().First().DeleteBehavior));
@@ -2393,7 +2398,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithGenericKey<System.Guid>"", null)
                         .WithMany()
                         .HasForeignKey(""Property"")
-                        .OnDelete(DeleteBehavior.Cascade);
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
                 });", usingSystem: true),
                 model =>
                 {
@@ -2470,7 +2476,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                         .WithOne(""EntityWithTwoProperties"")
                         .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""AlternateId"")
                         .HasConstraintName(""Constraint"")
-                        .OnDelete(DeleteBehavior.Cascade);
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
                 });"),
                 o => Assert.Equal(
                     "Constraint", o.FindEntityType(typeof(EntityWithTwoProperties)).GetForeignKeys().First()["Relational:Name"]));
@@ -2525,7 +2532,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                         .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""AlternateId"")
                         .HasConstraintName(""Constraint"")
                         .HasAnnotation(""AnnotationName"", ""AnnotationValue"")
-                        .OnDelete(DeleteBehavior.Cascade);
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
                 });"),
                 o =>
                 {
@@ -2596,7 +2604,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         }
 
         [Fact]
-        public virtual void Relationship_principal_key_is_stored_in_snapshot()
+        public virtual void ForeignKey_principal_key_is_stored_in_snapshot()
         {
             Test(
                 builder =>
@@ -2637,7 +2645,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                         .WithOne(""EntityWithOneProperty"")
                         .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", ""Id"")
                         .HasPrincipalKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""AlternateId"")
-                        .OnDelete(DeleteBehavior.Cascade);
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
                 });"),
                 o =>
                 {
@@ -2647,7 +2656,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         }
 
         [Fact]
-        public virtual void Relationship_principal_key_with_non_default_name_is_stored_in_snapshot()
+        public virtual void ForeignKey_principal_key_with_non_default_name_is_stored_in_snapshot()
         {
             Test(
                 builder =>
@@ -2693,7 +2702,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                         .WithOne(""EntityWithOneProperty"")
                         .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", ""Id"")
                         .HasPrincipalKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""AlternateId"")
-                        .OnDelete(DeleteBehavior.Cascade);
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
                 });"),
                 o =>
                 {

--- a/test/EFCore.Tests/ChangeTracking/Internal/FixupCompositeTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/FixupCompositeTest.cs
@@ -4644,7 +4644,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                                 {
                                     e.CategoryId1,
                                     e.CategoryId2
-                                });
+                                })
+                            .IsRequired(false);
                     });
 
                 modelBuilder.Entity<ProductDN>(
@@ -4674,7 +4675,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                                 {
                                     e.CategoryId1,
                                     e.CategoryId2
-                                });
+                                })
+                            .IsRequired(false);
                     });
 
                 modelBuilder.Entity<ProductPN>(
@@ -4704,7 +4706,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                                 {
                                     e.CategoryId1,
                                     e.CategoryId2
-                                });
+                                })
+                            .IsRequired(false);
                     });
 
                 modelBuilder.Entity<ProductNN>(
@@ -4734,7 +4737,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                                 {
                                     e.CategoryId1,
                                     e.CategoryId2
-                                });
+                                })
+                            .IsRequired(false);
                     });
 
                 modelBuilder.Entity<Product>(

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConventionTest.cs
@@ -134,7 +134,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(PrimaryKey, fk.PrincipalKey.Properties.Single());
             Assert.False(fk.IsUnique);
-            Assert.True(fk.IsRequired);
+            Assert.False(fk.IsRequired);
 
             convention.Apply(relationshipBuilder.Metadata.DeclaringEntityType.Model.Builder);
         }
@@ -198,7 +198,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(PrimaryKey, fk.PrincipalKey.Properties.Single());
             Assert.False(fk.IsUnique);
-            Assert.True(fk.IsRequired);
+            Assert.False(fk.IsRequired);
 
             convention.Apply(relationshipBuilder.Metadata.DeclaringEntityType.Model.Builder);
         }
@@ -408,7 +408,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(PrimaryKey, fk.PrincipalKey.Properties.Single());
             Assert.True(fk.IsUnique);
-            Assert.True(fk.IsRequired);
+            Assert.False(fk.IsRequired);
 
             convention.Apply(relationshipBuilder.Metadata.DeclaringEntityType.Model.Builder);
         }
@@ -524,7 +524,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Same(fkProperty2, fk.Properties[1]);
             Assert.Same(PrincipalTypeWithCompositeKey.Metadata.FindPrimaryKey(), fk.PrincipalKey);
             Assert.True(fk.IsUnique);
-            Assert.True(fk.IsRequired);
+            Assert.False(fk.IsRequired);
 
             convention.Apply(relationshipBuilder.Metadata.DeclaringEntityType.Model.Builder);
         }
@@ -777,7 +777,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(PrimaryKey, fk.PrincipalKey.Properties.Single());
             Assert.True(fk.IsUnique);
-            Assert.True(fk.IsRequired);
+            Assert.False(fk.IsRequired);
 
             convention.Apply(relationshipBuilder.Metadata.DeclaringEntityType.Model.Builder);
         }

--- a/test/EFCore.Tests/Metadata/Internal/InternalRelationshipBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalRelationshipBuilderTest.cs
@@ -172,7 +172,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         [Fact]
-        public void ForeignKey_overrides_incompatible_lower_or_equal_source_required()
+        public void ForeignKey_can_be_set_independently_from_requiredness()
         {
             var modelBuilder = CreateInternalModelBuilder();
             var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
@@ -188,14 +188,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 new[] { nullableId.Metadata.Name },
                 relationshipBuilder.Metadata.Properties.Select(p => p.Name));
 
-            Assert.Null(relationshipBuilder.HasForeignKey(new[] { Order.CustomerIdProperty }, ConfigurationSource.Convention));
+            relationshipBuilder = relationshipBuilder.HasForeignKey(new[] { Order.CustomerIdProperty }, ConfigurationSource.Convention);
             Assert.False(((IForeignKey)relationshipBuilder.Metadata).IsRequired);
-            Assert.Equal(
-                new[] { nullableId.Metadata.Name },
-                relationshipBuilder.Metadata.Properties.Select(p => p.Name));
-
-            relationshipBuilder = relationshipBuilder.HasForeignKey(new[] { Order.CustomerIdProperty }, ConfigurationSource.DataAnnotation);
-            Assert.True(((IForeignKey)relationshipBuilder.Metadata).IsRequired);
             Assert.Equal(
                 new[] { Order.CustomerIdProperty.Name },
                 relationshipBuilder.Metadata.Properties.Select(p => p.Name));
@@ -454,7 +448,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         [Fact]
-        public void Can_only_override_existing_Required_value_explicitly()
+        public void Can_set_Required_independently_from_nullability()
         {
             var modelBuilder = CreateInternalModelBuilder();
             var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
@@ -472,16 +466,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Assert.Equal(ConfigurationSource.Explicit, fk.GetIsRequiredConfigurationSource());
 
             var relationshipBuilder = orderEntityBuilder.HasForeignKey(customerEntityBuilder, fk.Properties, ConfigurationSource.Explicit);
-            Assert.Null(relationshipBuilder.IsRequired(false, ConfigurationSource.Convention));
-            Assert.True(fk.IsRequired);
+            relationshipBuilder = relationshipBuilder.IsRequired(false, ConfigurationSource.Convention);
+            Assert.False(((IForeignKey)relationshipBuilder.Metadata).IsRequired);
             Assert.False(customerIdProperty.IsNullable);
-            Assert.False(customerUniqueProperty.IsNullable);
+            Assert.True(customerUniqueProperty.IsNullable);
 
             relationshipBuilder = relationshipBuilder.IsRequired(true, ConfigurationSource.Convention);
-            Assert.NotNull(relationshipBuilder);
             Assert.True(((IForeignKey)relationshipBuilder.Metadata).IsRequired);
             Assert.False(customerIdProperty.IsNullable);
-            Assert.False(customerUniqueProperty.IsNullable);
+            Assert.True(customerUniqueProperty.IsNullable);
 
             relationshipBuilder = relationshipBuilder.IsRequired(false, ConfigurationSource.Explicit);
             Assert.NotNull(relationshipBuilder);
@@ -494,7 +487,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         [Fact]
-        public void Required_overrides_incompatible_lower_or_equal_source_properties()
+        public void Can_set_Required_false_on_non_nullable_properties()
         {
             var modelBuilder = CreateInternalModelBuilder();
             var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
@@ -513,15 +506,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 new[] { Order.CustomerIdProperty.Name },
                 relationshipBuilder.Metadata.Properties.Select(p => p.Name));
 
-            Assert.Null(relationshipBuilder.IsRequired(false, ConfigurationSource.Convention));
-            Assert.True(relationshipBuilder.Metadata.IsRequired);
+            relationshipBuilder = relationshipBuilder.IsRequired(false, ConfigurationSource.Convention);
+            Assert.False(relationshipBuilder.Metadata.IsRequired);
             Assert.Equal(
                 new[] { Order.CustomerIdProperty.Name },
                 relationshipBuilder.Metadata.Properties.Select(p => p.Name));
 
             relationshipBuilder = relationshipBuilder.IsRequired(false, ConfigurationSource.DataAnnotation);
             Assert.False(relationshipBuilder.Metadata.IsRequired);
-            Assert.NotEqual(
+            Assert.Equal(
                 new[] { Order.CustomerIdProperty.Name },
                 relationshipBuilder.Metadata.Properties.Select(p => p.Name));
         }


### PR DESCRIPTION
FK requiredness would still be the same as before when running conventions or in the snapshot, so this isn't really a breaking change.
Generate `IsRequired()` in the snapshot to avoid a breaking change in the future

Fixes #14197