### PR TITLE
Improve perf for iterating over tracked entities

### DIFF
--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -1725,12 +1725,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         {
             if (_sourceStateManager != null)
             {
-                foreach (var sourceEntry in _sourceStateManager.Entries.ToList())
+                foreach (var sourceEntry in _sourceStateManager.ToListForState(added: true))
                 {
-                    if (sourceEntry.EntityState == EntityState.Added)
-                    {
-                        sourceEntry.SetEntityState(EntityState.Detached);
-                    }
+                    sourceEntry.SetEntityState(EntityState.Detached);
                 }
             }
 

--- a/src/EFCore/ChangeTracking/Internal/ChangeDetector.cs
+++ b/src/EFCore/ChangeTracking/Internal/ChangeDetector.cs
@@ -127,12 +127,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             _logger.DetectChangesStarting(stateManager.Context);
 
-            foreach (var entry in stateManager.Entries.Where(
-                e => e.EntityState != EntityState.Detached
-                     && e.EntityType.GetChangeTrackingStrategy() == ChangeTrackingStrategy.Snapshot).ToList())
+            foreach (var entry in stateManager.ToList()) // Might be too big, but usually _all_ entities are using Snapshot tracking
+
             {
-                // State might change while detecting changes on other entries
-                if (entry.EntityState != EntityState.Detached)
+                if (entry.EntityType.GetChangeTrackingStrategy() == ChangeTrackingStrategy.Snapshot
+                    && entry.EntityState != EntityState.Detached)
                 {
                     LocalDetectChanges(entry);
                 }

--- a/src/EFCore/ChangeTracking/Internal/EntityReferenceMap.cs
+++ b/src/EFCore/ChangeTracking/Internal/EntityReferenceMap.cs
@@ -1,0 +1,474 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class EntityReferenceMap
+    {
+        private readonly bool _hasSubMap;
+        private Dictionary<object, InternalEntityEntry> _detachedReferenceMap;
+        private Dictionary<object, InternalEntityEntry> _unchangedReferenceMap;
+        private Dictionary<object, InternalEntityEntry> _addedReferenceMap;
+        private Dictionary<object, InternalEntityEntry> _modifiedReferenceMap;
+        private Dictionary<object, InternalEntityEntry> _deletedReferenceMap;
+        private Dictionary<IEntityType, EntityReferenceMap> _dependentTypeReferenceMap;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public EntityReferenceMap(bool hasSubMap)
+        {
+            _hasSubMap = hasSubMap;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual void Update(
+            [NotNull] InternalEntityEntry entry,
+            EntityState state,
+            EntityState? oldState)
+        {
+            var mapKey = entry.Entity ?? entry;
+            var entityType = entry.EntityType;
+            if (_hasSubMap
+                && entityType.HasDefiningNavigation())
+            {
+                if (_dependentTypeReferenceMap == null)
+                {
+                    _dependentTypeReferenceMap = new Dictionary<IEntityType, EntityReferenceMap>();
+                }
+
+                if (!_dependentTypeReferenceMap.TryGetValue(entityType, out var dependentMap))
+                {
+                    dependentMap = new EntityReferenceMap(hasSubMap: false);
+                    _dependentTypeReferenceMap[entityType] = dependentMap;
+                }
+
+                dependentMap.Update(entry, state, oldState);
+            }
+            else
+            {
+                if (oldState.HasValue)
+                {
+                    Remove(mapKey, entityType, oldState.Value);
+                }
+
+                if (!oldState.HasValue
+                    || state != EntityState.Detached)
+                {
+                    switch (state)
+                    {
+                        case EntityState.Detached:
+                            if (_detachedReferenceMap == null)
+                            {
+                                _detachedReferenceMap =
+                                    new Dictionary<object, InternalEntityEntry>(ReferenceEqualityComparer.Instance);
+                            }
+
+                            _detachedReferenceMap[mapKey] = entry;
+                            break;
+                        case EntityState.Unchanged:
+                            if (_unchangedReferenceMap == null)
+                            {
+                                _unchangedReferenceMap =
+                                    new Dictionary<object, InternalEntityEntry>(ReferenceEqualityComparer.Instance);
+                            }
+
+                            _unchangedReferenceMap[mapKey] = entry;
+                            break;
+                        case EntityState.Deleted:
+                            if (_deletedReferenceMap == null)
+                            {
+                                _deletedReferenceMap =
+                                    new Dictionary<object, InternalEntityEntry>(ReferenceEqualityComparer.Instance);
+                            }
+
+                            _deletedReferenceMap[mapKey] = entry;
+                            break;
+                        case EntityState.Modified:
+                            if (_modifiedReferenceMap == null)
+                            {
+                                _modifiedReferenceMap =
+                                    new Dictionary<object, InternalEntityEntry>(ReferenceEqualityComparer.Instance);
+                            }
+
+                            _modifiedReferenceMap[mapKey] = entry;
+                            break;
+                        case EntityState.Added:
+                            if (_addedReferenceMap == null)
+                            {
+                                _addedReferenceMap =
+                                    new Dictionary<object, InternalEntityEntry>(ReferenceEqualityComparer.Instance);
+                            }
+
+                            _addedReferenceMap[mapKey] = entry;
+                            break;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual bool TryGet(
+            [NotNull] object entity,
+            [CanBeNull] IEntityType entityType,
+            [CanBeNull] out InternalEntityEntry entry,
+            bool throwOnNonUniqueness)
+        {
+            entry = null;
+            var found = _unchangedReferenceMap?.TryGetValue(entity, out entry) == true
+                        || _modifiedReferenceMap?.TryGetValue(entity, out entry) == true
+                        || _addedReferenceMap?.TryGetValue(entity, out entry) == true
+                        || _deletedReferenceMap?.TryGetValue(entity, out entry) == true
+                        || _detachedReferenceMap?.TryGetValue(entity, out entry) == true;
+
+            if (!found
+                && _hasSubMap
+                && _dependentTypeReferenceMap != null)
+            {
+                if (entityType != null)
+                {
+                    if (_dependentTypeReferenceMap.TryGetValue(entityType, out var subMap))
+                    {
+                        return subMap.TryGet(entity, entityType, out entry, throwOnNonUniqueness);
+                    }
+                }
+                else
+                {
+                    var type = entity.GetType();
+                    foreach (var keyValue in _dependentTypeReferenceMap)
+                    {
+                        // ReSharper disable once CheckForReferenceEqualityInstead.2
+                        if (keyValue.Key.ClrType.IsAssignableFrom(type)
+                            && keyValue.Value.TryGet(entity, entityType, out var foundEntry, throwOnNonUniqueness))
+                        {
+                            if (found)
+                            {
+                                if (!throwOnNonUniqueness)
+                                {
+                                    entry = null;
+                                    return false;
+                                }
+
+                                throw new InvalidOperationException(
+                                    CoreStrings.AmbiguousDependentEntity(
+                                        entity.GetType().ShortDisplayName(),
+                                        "." + nameof(EntityEntry.Reference) + "()." + nameof(ReferenceEntry.TargetEntry)));
+                            }
+
+                            entry = foundEntry;
+                            found = true;
+                        }
+                    }
+                }
+            }
+
+            return found;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual int GetCountForState(
+            bool added = false,
+            bool modified = false,
+            bool deleted = false,
+            bool unchanged = false)
+        {
+            var count = 0;
+
+            if (added
+                && _addedReferenceMap != null)
+            {
+                count = _addedReferenceMap.Count;
+            }
+
+            if (modified
+                && _modifiedReferenceMap != null)
+            {
+                count += _modifiedReferenceMap.Count;
+            }
+
+            if (deleted
+                && _deletedReferenceMap != null)
+            {
+                count += _deletedReferenceMap.Count;
+            }
+
+            if (unchanged
+                && _unchangedReferenceMap != null)
+            {
+                count += _unchangedReferenceMap.Count;
+            }
+
+            if (_dependentTypeReferenceMap != null)
+            {
+                foreach (var map in _dependentTypeReferenceMap)
+                {
+                    count += map.Value.GetCountForState(added, modified, deleted, unchanged);
+                }
+            }
+
+            return count;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual IEnumerable<InternalEntityEntry> GetEntriesForState(
+            bool added = false,
+            bool modified = false,
+            bool deleted = false,
+            bool unchanged = false)
+        {
+            // Perf sensitive
+
+            var returnAdded
+                = added
+                  && _addedReferenceMap != null
+                  && _addedReferenceMap.Count > 0;
+
+            var returnModified
+                = modified
+                  && _modifiedReferenceMap != null
+                  && _modifiedReferenceMap.Count > 0;
+
+            var returnDeleted
+                = deleted
+                  && _deletedReferenceMap != null
+                  && _deletedReferenceMap.Count > 0;
+
+            var returnUnchanged
+                = unchanged
+                  && _unchangedReferenceMap != null
+                  && _unchangedReferenceMap.Count > 0;
+
+            var hasDependentTypes
+                = _dependentTypeReferenceMap != null
+                  && _dependentTypeReferenceMap.Count > 0;
+
+            if (!hasDependentTypes)
+            {
+                var numberOfStates
+                    = (returnAdded ? 1 : 0)
+                      + (returnModified ? 1 : 0)
+                      + (returnDeleted ? 1 : 0)
+                      + (returnUnchanged ? 1 : 0);
+
+                if (numberOfStates == 1)
+                {
+                    if (returnUnchanged)
+                    {
+                        return _unchangedReferenceMap.Values;
+                    }
+                    if (returnAdded)
+                    {
+                        return _addedReferenceMap.Values;
+                    }
+                    if (returnModified)
+                    {
+                        return _modifiedReferenceMap.Values;
+                    }
+                    if (returnDeleted)
+                    {
+                        return _deletedReferenceMap.Values;
+                    }
+                }
+
+                if (numberOfStates == 0)
+                {
+                    return Enumerable.Empty<InternalEntityEntry>();
+                }
+            }
+
+            return GetEntriesForState(
+                added, modified, deleted, unchanged,
+                hasDependentTypes,
+                returnAdded, returnModified, returnDeleted, returnUnchanged);
+        }
+
+        private IEnumerable<InternalEntityEntry> GetEntriesForState(
+            bool added,
+            bool modified,
+            bool deleted,
+            bool unchanged,
+            bool hasDependentTypes,
+            bool returnAdded,
+            bool returnModified,
+            bool returnDeleted,
+            bool returnUnchanged)
+        {
+            if (returnAdded)
+            {
+                foreach (var entry in _addedReferenceMap.Values)
+                {
+                    yield return entry;
+                }
+            }
+
+            if (returnModified)
+            {
+                foreach (var entry in _modifiedReferenceMap.Values)
+                {
+                    yield return entry;
+                }
+            }
+
+            if (returnDeleted)
+            {
+                foreach (var entry in _deletedReferenceMap.Values)
+                {
+                    yield return entry;
+                }
+            }
+
+            if (returnUnchanged)
+            {
+                foreach (var entry in _unchangedReferenceMap.Values)
+                {
+                    yield return entry;
+                }
+            }
+
+            if (hasDependentTypes)
+            {
+                foreach (var subMap in _dependentTypeReferenceMap.Values)
+                {
+                    foreach (var entry in subMap.GetEntriesForState(added, modified, deleted, unchanged))
+                    {
+                        if ((entry.SharedIdentityEntry == null
+                             || entry.EntityState != EntityState.Deleted))
+                        {
+                            yield return entry;
+                        }
+                    }
+                }
+            }
+        }
+
+        private void Remove(
+            object entity,
+            IEntityType entityType,
+            EntityState oldState)
+        {
+            if (_dependentTypeReferenceMap != null
+                && entityType.HasDefiningNavigation())
+            {
+                _dependentTypeReferenceMap[entityType].Remove(entity, entityType, oldState);
+            }
+            else
+            {
+                switch (oldState)
+                {
+                    case EntityState.Detached:
+                        _detachedReferenceMap?.Remove(entity);
+                        break;
+                    case EntityState.Unchanged:
+                        _unchangedReferenceMap.Remove(entity);
+                        break;
+                    case EntityState.Deleted:
+                        _deletedReferenceMap.Remove(entity);
+                        break;
+                    case EntityState.Modified:
+                        _modifiedReferenceMap.Remove(entity);
+                        break;
+                    case EntityState.Added:
+                        _addedReferenceMap.Remove(entity);
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual void Clear()
+        {
+            _unchangedReferenceMap = null;
+            _detachedReferenceMap = null;
+            _deletedReferenceMap = null;
+            _addedReferenceMap = null;
+            _modifiedReferenceMap = null;
+            _dependentTypeReferenceMap?.Clear();
+            _dependentTypeReferenceMap = null;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual IEnumerable<TEntity> GetNonDeletedEntities<TEntity>()
+            where TEntity : class
+        {
+            // Perf sensitive
+
+            if (_addedReferenceMap != null
+                && _addedReferenceMap.Count > 0)
+            {
+                foreach (var entry in _addedReferenceMap.Values)
+                {
+                    if (entry.Entity is TEntity entity)
+                    {
+                        yield return entity;
+                    }
+                }
+            }
+
+            if (_modifiedReferenceMap != null
+                && _modifiedReferenceMap.Count > 0)
+            {
+                foreach (var entry in _modifiedReferenceMap.Values)
+                {
+                    if (entry.Entity is TEntity entity)
+                    {
+                        yield return entity;
+                    }
+                }
+            }
+
+            if (_unchangedReferenceMap != null
+                && _unchangedReferenceMap.Count > 0)
+            {
+                foreach (var entry in _unchangedReferenceMap.Values)
+                {
+                    if (entry.Entity is TEntity entity)
+                    {
+                        yield return entity;
+                    }
+                }
+            }
+
+            if (_dependentTypeReferenceMap != null
+                && _dependentTypeReferenceMap.Count > 0)
+            {
+                foreach (var subMap in _dependentTypeReferenceMap.Values)
+                {
+                    foreach (var entity in subMap.GetNonDeletedEntities<TEntity>())
+                    {
+                        yield return entity;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/EFCore/ChangeTracking/Internal/IStateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/IStateManager.cs
@@ -99,6 +99,39 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        IEnumerable<InternalEntityEntry> GetEntriesForState(
+            bool added = false,
+            bool modified = false,
+            bool deleted = false,
+            bool unchanged = false);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        int GetCountForState(
+            bool added = false,
+            bool modified = false,
+            bool deleted = false,
+            bool unchanged = false);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        int Count { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        IEnumerable<TEntity> GetNonDeletedEntities<TEntity>()
+            where TEntity : class;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         int ChangedCount { get; set; }
 
         /// <summary>
@@ -106,6 +139,12 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         IInternalEntityEntryNotifier InternalEntityEntryNotifier { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        void StateChanging([NotNull] InternalEntityEntry entry, EntityState newState);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -135,7 +174,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        void StopTracking([NotNull] InternalEntityEntry entry);
+        void StopTracking([NotNull] InternalEntityEntry entry, EntityState oldState);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -222,7 +222,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 _stateData.EntityState = oldState;
             }
 
-            StateManager.InternalEntityEntryNotifier.StateChanging(this, newState);
+            StateManager.StateChanging(this, newState);
 
             if (newState == EntityState.Unchanged
                 && oldState == EntityState.Modified)
@@ -247,7 +247,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             }
             else if (newState == EntityState.Detached)
             {
-                StateManager.StopTracking(this);
+                StateManager.StopTracking(this, oldState);
             }
 
             if ((newState == EntityState.Deleted
@@ -435,11 +435,16 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             {
                 if (changeState)
                 {
-                    StateManager.InternalEntityEntryNotifier.StateChanging(this, EntityState.Modified);
+                    StateManager.StateChanging(this, EntityState.Modified);
 
                     SetServiceProperties(currentState, EntityState.Modified);
 
                     _stateData.EntityState = EntityState.Modified;
+
+                    if (currentState == EntityState.Detached)
+                    {
+                        StateManager.StartTracking(this);
+                    }
                 }
 
                 StateManager.EndSingleQueryMode();
@@ -455,7 +460,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                      && !isModified
                      && !_stateData.AnyPropertiesFlagged(PropertyFlag.Modified))
             {
-                StateManager.InternalEntityEntryNotifier.StateChanging(this, EntityState.Unchanged);
+                StateManager.StateChanging(this, EntityState.Unchanged);
                 _stateData.EntityState = EntityState.Unchanged;
                 StateManager.ChangedCount--;
                 FireStateChanged(currentState);

--- a/src/EFCore/ChangeTracking/Internal/StateManagerExtensions.cs
+++ b/src/EFCore/ChangeTracking/Internal/StateManagerExtensions.cs
@@ -1,0 +1,45 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public static class StateManagerExtensions
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static IReadOnlyList<InternalEntityEntry> ToListForState(
+            [NotNull] this IStateManager stateManager,
+            bool added = false,
+            bool modified = false,
+            bool deleted = false,
+            bool unchanged = false)
+        {
+            var list = new List<InternalEntityEntry>(
+                stateManager.GetCountForState(added, modified, deleted, unchanged));
+
+            foreach (var entry in stateManager.GetEntriesForState(added, modified, deleted, unchanged))
+            {
+                list.Add(entry);
+            }
+
+            return list;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static IReadOnlyList<InternalEntityEntry> ToList(
+            [NotNull] this IStateManager stateManager)
+            => stateManager.ToListForState(added: true, modified: true, deleted: true, unchanged: true);
+    }
+}

--- a/test/EFCore.InMemory.FunctionalTests/DatabaseErrorLogStateTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/DatabaseErrorLogStateTest.cs
@@ -120,7 +120,7 @@ namespace Microsoft.EntityFrameworkCore
                     });
                 context.SaveChanges();
                 var entry = context.ChangeTracker.Entries().Single().GetInfrastructure();
-                context.GetService<IStateManager>().StopTracking(entry);
+                context.GetService<IStateManager>().StopTracking(entry, entry.EntityState);
 
                 var ex = await Assert.ThrowsAnyAsync<Exception>(() => test(context));
                 while (ex.InnerException != null)

--- a/test/EFCore.Specification.Tests/Query/ChangeTrackingTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ChangeTrackingTestBase.cs
@@ -63,7 +63,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Assert.Equal("98052", context.Customers.First().PostalCode);
                 Assert.Equal("'Murica", context.Customers.First().Region);
 
-                foreach (var entityEntry in context.ChangeTracker.Entries())
+                foreach (var entityEntry in context.ChangeTracker.Entries().ToList())
                 {
                     entityEntry.State = EntityState.Unchanged;
                 }

--- a/test/EFCore.Tests/ChangeTracking/ChangeTrackerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/ChangeTrackerTest.cs
@@ -866,8 +866,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                 Assert.Equal(2, tracked.Count);
                 Assert.Equal(3, changed.Count);
 
-                AssertChangedEvent(context, 1, EntityState.Modified, EntityState.Unchanged, changed[1]);
-                AssertChangedEvent(context, 3, EntityState.Added, EntityState.Unchanged, changed[2]);
+                AssertChangedEvent(context, 1, EntityState.Modified, EntityState.Unchanged, changed[2]);
+                AssertChangedEvent(context, 3, EntityState.Added, EntityState.Unchanged, changed[1]);
 
                 context.Database.EnsureDeleted();
             }

--- a/test/EFCore.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
@@ -2355,12 +2355,13 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             return builder.Model;
         }
 
-        private static InternalClrEntityEntry CreateInternalEntry<TEntity>(IServiceProvider contextServices, TEntity entity = null)
+        private static InternalEntityEntry CreateInternalEntry<TEntity>(IServiceProvider contextServices,
+            TEntity entity = null)
             where TEntity : class, new()
-            => new InternalClrEntityEntry(
-                contextServices.GetRequiredService<IStateManager>(),
-                contextServices.GetRequiredService<IModel>().FindEntityType(typeof(TEntity)),
-                entity ?? new TEntity());
+            => contextServices.GetRequiredService<IStateManager>()
+                .GetOrCreateEntry(
+                    entity ?? new TEntity(),
+                    contextServices.GetRequiredService<IModel>().FindEntityType(typeof(TEntity)));
 
         private static IServiceProvider CreateContextServices(IModel model = null)
         {

--- a/test/EFCore.Tests/ChangeTracking/Internal/InternalShadowEntityEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/InternalShadowEntityEntryTest.cs
@@ -4,30 +4,12 @@
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
-using Microsoft.EntityFrameworkCore.Storage;
-using Microsoft.EntityFrameworkCore.TestUtilities;
-using Xunit;
 
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 {
     public class InternalShadowEntityEntryTest : InternalEntityEntryTestBase
     {
-        [Fact]
-        public void Entity_is_null()
-        {
-            var model = BuildModel();
-            var configuration = InMemoryTestHelpers.Instance.CreateContextServices(model);
-
-            var entry = CreateInternalEntry(
-                configuration,
-                model.FindEntityType(typeof(SomeEntity).FullName),
-                null,
-                new ValueBuffer(new object[] { 1, "Kool" }));
-
-            Assert.Null(entry.Entity);
-        }
-
         protected override Model BuildModel()
         {
             var modelBuilder = new ModelBuilder(new ConventionSet());

--- a/test/EFCore.Tests/ChangeTracking/Internal/StateManagerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/StateManagerTest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -667,9 +666,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             };
 
             var entry = stateManager.GetOrCreateEntry(category);
-            stateManager.StartTracking(entry);
-            stateManager.StopTracking(entry);
-            stateManager.StartTracking(entry);
+            entry.SetEntityState(EntityState.Added);
+            entry.SetEntityState(EntityState.Detached);
+            entry.SetEntityState(EntityState.Added);
 
             var entry2 = stateManager.GetOrCreateEntry(category);
             Assert.Same(entry, entry2);
@@ -686,13 +685,13 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             };
 
             var entry = stateManager.GetOrCreateEntry(category);
-            stateManager.StartTracking(entry);
-            stateManager.StopTracking(entry);
+            entry.SetEntityState(EntityState.Added);
+            entry.SetEntityState(EntityState.Detached);
 
             var entry2 = stateManager.GetOrCreateEntry(category);
             Assert.NotSame(entry, entry2);
 
-            stateManager.StartTracking(entry2);
+            entry2.SetEntityState(EntityState.Added);
         }
 
         [Fact]
@@ -706,11 +705,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             };
 
             var entry = stateManager.GetOrCreateEntry(category);
-            stateManager.StartTracking(entry);
-            stateManager.StopTracking(entry);
+            entry.SetEntityState(EntityState.Added);
+            entry.SetEntityState(EntityState.Detached);
 
             var entry2 = stateManager.GetOrCreateEntry(category);
-            stateManager.StartTracking(entry2);
+            entry2.SetEntityState(EntityState.Added);
 
             Assert.NotSame(entry, entry2);
             Assert.Equal(EntityState.Detached, entry.EntityState);

--- a/test/EFCore.Tests/TestUtilities/FakeStateManager.cs
+++ b/test/EFCore.Tests/TestUtilities/FakeStateManager.cs
@@ -49,7 +49,27 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             return Task.FromResult(1);
         }
 
-        public IEnumerable<InternalEntityEntry> Entries => Entries ?? Enumerable.Empty<InternalEntityEntry>();
+        public IEnumerable<InternalEntityEntry> Entries => InternalEntries ?? Enumerable.Empty<InternalEntityEntry>();
+
+        public IEnumerable<InternalEntityEntry> GetEntriesForState(
+            bool added = false,
+            bool modified = false,
+            bool deleted = false,
+            bool unchanged = false)
+            => throw new NotImplementedException();
+
+        public int GetCountForState(
+            bool added = false,
+            bool modified = false,
+            bool deleted = false,
+            bool unchanged = false)
+            => throw new NotImplementedException();
+
+        public int Count => throw new NotImplementedException();
+
+        public IEnumerable<TEntity> GetNonDeletedEntities<TEntity>()
+            where TEntity : class
+            => throw new NotImplementedException();
 
         public int ChangedCount { get; set; }
 
@@ -87,10 +107,11 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         public InternalEntityEntry TryGetEntry(object entity, bool throwOnNonUniqueness = true) => throw new NotImplementedException();
         public InternalEntityEntry TryGetEntry(object entity, IEntityType type) => throw new NotImplementedException();
         public IInternalEntityEntryNotifier InternalEntityEntryNotifier => throw new NotImplementedException();
+        public void StateChanging(InternalEntityEntry entry, EntityState newState) => throw new NotImplementedException();
         public IValueGenerationManager ValueGenerationManager => throw new NotImplementedException();
         public IEntityMaterializerSource EntityMaterializerSource { get; }
         public InternalEntityEntry StartTracking(InternalEntityEntry entry) => throw new NotImplementedException();
-        public void StopTracking(InternalEntityEntry entry) => throw new NotImplementedException();
+        public void StopTracking(InternalEntityEntry entry, EntityState oldState) => throw new NotImplementedException();
 
         public void RecordReferencedUntrackedEntity(
             object referencedEntity, INavigation navigation, InternalEntityEntry referencedFromEntry) =>


### PR DESCRIPTION
Part of #8898
Fixes #14231

Investigation into DbSet.Local shows that:
* Iteration over tracked entities had a lot of LINQ code; fixed by un-LINQing
* Multiple composed iterators cause slow-down; fixed by giving LocalView it's only IStateManager method
* Filtering causes slow-down; fixed by splitting storage into multiple dictionaries. Makes lookup for entity instance slightly slower.
* Calculate Count lazily

This means that DbSet.Local iteration is now about 3x faster, although it depends a lot on what is being tracked. Getting an ObservableCollection and then iterating over that _once_ is slower than just iterating over the entries once. Iterating over the ObservableCollection multiple times is still faster than iterating over DbSet.Local multiple times. This seems like a reasonable trade-off. If the application does heavy iteration, then creating a new collection for that seems reasonable.

With regard to #8898, the layering we have still seems correct, so moving forward with the breaking changes there.
