### PR TITLE
Turn off automatic client evaluation of queries

### DIFF
--- a/src/EFCore/Infrastructure/CoreOptionsExtension.cs
+++ b/src/EFCore/Infrastructure/CoreOptionsExtension.cs
@@ -47,7 +47,9 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             = new WarningsConfiguration()
                 .TryWithExplicit(CoreEventId.ManyServiceProvidersCreatedWarning, WarningBehavior.Throw)
                 .TryWithExplicit(CoreEventId.LazyLoadOnDisposedContextWarning, WarningBehavior.Throw)
-                .TryWithExplicit(CoreEventId.DetachedLazyLoadingWarning, WarningBehavior.Throw);
+                .TryWithExplicit(CoreEventId.DetachedLazyLoadingWarning, WarningBehavior.Throw)
+                // This is relational client eval warning. Yes, this is ugly and error-prone, but it will be removed before 3.0 ships
+                .TryWithExplicit(CoreEventId.RelationalBaseId + 500, WarningBehavior.Throw);
 
         /// <summary>
         ///     Creates a new set of options with everything set to default values.

--- a/test/EFCore.Relational.Specification.Tests/Query/AsyncFromSqlSprocQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/AsyncFromSqlSprocQueryTestBase.cs
@@ -59,7 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'where [mep].TenMostExpensiveProducts.Contains(\"C\")'")]
         public virtual async Task From_sql_queryable_stored_procedure_composed()
         {
             using (var context = CreateContext())
@@ -77,7 +77,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'where [coh].ProductName.Contains(\"C\")'")]
         public virtual async Task From_sql_queryable_stored_procedure_with_parameter_composed()
         {
             using (var context = CreateContext())
@@ -95,7 +95,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'orderby [mep].UnitPrice desc'")]
         public virtual async Task From_sql_queryable_stored_procedure_take()
         {
             using (var context = CreateContext())
@@ -113,7 +113,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'Min()'")]
         public virtual async Task From_sql_queryable_stored_procedure_min()
         {
             using (var context = CreateContext())

--- a/test/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsQueryRelationalFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsQueryRelationalFixtureBase.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -9,10 +8,5 @@ namespace Microsoft.EntityFrameworkCore.Query
     public abstract class ComplexNavigationsQueryRelationalFixtureBase : ComplexNavigationsQueryFixtureBase
     {
         public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ListLoggerFactory;
-
-        public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
-            => base.AddOptions(builder).ConfigureWarnings(
-                c => c
-                    .Log(RelationalEventId.QueryClientEvaluationWarning));
     }
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsWeakQueryRelationalFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsWeakQueryRelationalFixtureBase.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -40,9 +39,5 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             l4.ToTable(nameof(Level1));
         }
-
-        public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
-            => base.AddOptions(builder).ConfigureWarnings(
-                c => c.Log(RelationalEventId.QueryClientEvaluationWarning));
     }
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/FromSqlSprocQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/FromSqlSprocQueryTestBase.cs
@@ -97,7 +97,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'where [mep].TenMostExpensiveProducts.Contains(\"C\")'")]
         public virtual void From_sql_queryable_stored_procedure_composed()
         {
             using (var context = CreateContext())
@@ -115,7 +115,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'where [coh].ProductName.Contains(\"C\")'")]
         public virtual void From_sql_queryable_stored_procedure_with_parameter_composed()
         {
             using (var context = CreateContext())
@@ -133,7 +133,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'orderby [mep].UnitPrice desc'")]
         public virtual void From_sql_queryable_stored_procedure_take()
         {
             using (var context = CreateContext())
@@ -151,7 +151,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'Min()'")]
         public virtual void From_sql_queryable_stored_procedure_min()
         {
             using (var context = CreateContext())
@@ -180,7 +180,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'from MostExpensiveProduct b in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.MostExpensiveProduct])'")]
         public virtual void From_sql_queryable_with_multiple_stored_procedures()
         {
             using (var context = CreateContext())
@@ -202,7 +202,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'from Product p in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Product])'")]
         public virtual void From_sql_queryable_stored_procedure_and_select()
         {
             using (var context = CreateContext())
@@ -224,7 +224,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'from MostExpensiveProduct mep in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.MostExpensiveProduct])'")]
         public virtual void From_sql_queryable_select_and_stored_procedure()
         {
             using (var context = CreateContext())

--- a/test/EFCore.Relational.Specification.Tests/Query/GearsOfWarQueryRelationalFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/GearsOfWarQueryRelationalFixture.cs
@@ -15,7 +15,6 @@ namespace Microsoft.EntityFrameworkCore.Query
         public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
             => base.AddOptions(builder).ConfigureWarnings(
                 c => c
-                    .Log(RelationalEventId.QueryClientEvaluationWarning)
                     .Log(RelationalEventId.ValueConversionSqlLiteralWarning));
 
         protected override bool ShouldLogCategory(string logCategory)

--- a/test/EFCore.Relational.Specification.Tests/Query/InheritanceRelationalFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/InheritanceRelationalFixture.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestModels.Inheritance;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 
@@ -35,8 +34,5 @@ namespace Microsoft.EntityFrameworkCore.Query
             modelBuilder.Entity<KiwiQuery>().HasDiscriminator().HasValue("Kiwi");
             modelBuilder.Entity<EagleQuery>().HasDiscriminator().HasValue("Eagle");
         }
-
-        public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
-            => base.AddOptions(builder).ConfigureWarnings(c => c.Log(RelationalEventId.QueryClientEvaluationWarning));
     }
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindQueryRelationalFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindQueryRelationalFixture.cs
@@ -18,7 +18,6 @@ namespace Microsoft.EntityFrameworkCore.Query
         public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
             => base.AddOptions(builder).ConfigureWarnings(
                     c => c
-                        .Log(RelationalEventId.QueryClientEvaluationWarning)
                         .Log(RelationalEventId.QueryPossibleUnintendedUseOfEqualsWarning)
                         .Log(RelationalEventId.QueryPossibleExceptionWithAggregateOperator)
                         .Log(RelationalEventId.ValueConversionSqlLiteralWarning))

--- a/test/EFCore.Relational.Specification.Tests/Query/QueryFilterFuncletizationRelationalFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/QueryFilterFuncletizationRelationalFixture.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -9,11 +8,5 @@ namespace Microsoft.EntityFrameworkCore.Query
     public abstract class QueryFilterFuncletizationRelationalFixture : QueryFilterFuncletizationFixtureBase
     {
         public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ListLoggerFactory;
-
-        public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
-        {
-            base.AddOptions(builder);
-            return builder.ConfigureWarnings(w => w.Ignore(RelationalEventId.QueryClientEvaluationWarning));
-        }
     }
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/RelationalOwnedQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/RelationalOwnedQueryTestBase.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -17,9 +16,6 @@ namespace Microsoft.EntityFrameworkCore.Query
         public abstract class RelationalOwnedQueryFixture : OwnedQueryFixtureBase
         {
             public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ListLoggerFactory;
-
-            public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
-                => base.AddOptions(builder).ConfigureWarnings(c => c.Log(RelationalEventId.QueryClientEvaluationWarning));
         }
     }
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/UdfDbFunctionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/UdfDbFunctionTestBase.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
@@ -246,12 +245,6 @@ namespace Microsoft.EntityFrameworkCore.Query
             protected override Type ContextType { get; } = typeof(UDFSqlContext);
 
             public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ListLoggerFactory;
-
-            public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
-            {
-                base.AddOptions(builder);
-                return builder.ConfigureWarnings(w => w.Ignore(RelationalEventId.QueryClientEvaluationWarning));
-            }
 
             protected override bool ShouldLogCategory(string logCategory)
                 => logCategory == DbLoggerCategory.Query.Name;

--- a/test/EFCore.Relational.Specification.Tests/TransactionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/TransactionTestBase.cs
@@ -48,7 +48,11 @@ namespace Microsoft.EntityFrameworkCore
                         Id = 77,
                         Name = "Bobble"
                     });
-                context.Entry(context.Set<TransactionCustomer>().Last()).State = EntityState.Added;
+
+                
+                // Issue #14935. Cannot eval 'Last()'
+                // Added AsEnumerable()
+                context.Entry(context.Set<TransactionCustomer>().AsEnumerable().Last()).State = EntityState.Added;
 
                 Assert.Throws<DbUpdateException>(() => context.SaveChanges());
 
@@ -81,7 +85,10 @@ namespace Microsoft.EntityFrameworkCore
                         Id = 77,
                         Name = "Bobble"
                     });
-                context.Entry(context.Set<TransactionCustomer>().OrderBy(c => c.Id).Last()).State = EntityState.Added;
+                
+                // Issue #14935. Cannot eval 'Last()'
+                // Added AsEnumerable()
+                context.Entry(context.Set<TransactionCustomer>().OrderBy(c => c.Id).AsEnumerable().Last()).State = EntityState.Added;
 
                 await Assert.ThrowsAsync<DbUpdateException>(() => context.SaveChangesAsync());
 
@@ -114,7 +121,10 @@ namespace Microsoft.EntityFrameworkCore
                         Id = 77,
                         Name = "Bobble"
                     });
-                context.Entry(context.Set<TransactionCustomer>().OrderBy(c => c.Id).Last()).State = EntityState.Added;
+                
+                // Issue #14935. Cannot eval 'Last()'
+                // Added AsEnumerable()
+                context.Entry(context.Set<TransactionCustomer>().OrderBy(c => c.Id).AsEnumerable().Last()).State = EntityState.Added;
 
                 Assert.Throws<DbUpdateException>(() => context.SaveChanges());
             }
@@ -135,7 +145,10 @@ namespace Microsoft.EntityFrameworkCore
                         Id = 77,
                         Name = "Bobble"
                     });
-                context.Entry(context.Set<TransactionCustomer>().OrderBy(c => c.Id).Last()).State = EntityState.Added;
+                
+                // Issue #14935. Cannot eval 'Last()'
+                // Added AsEnumerable()
+                context.Entry(context.Set<TransactionCustomer>().OrderBy(c => c.Id).AsEnumerable().Last()).State = EntityState.Added;
 
                 try
                 {
@@ -174,7 +187,10 @@ namespace Microsoft.EntityFrameworkCore
                             Id = 77,
                             Name = "Bobble"
                         });
-                    context.Entry(context.Set<TransactionCustomer>().Last()).State = EntityState.Added;
+
+                    // Issue #14935. Cannot eval 'Last()'
+                    // Use AsEnumerable().
+                    context.Entry(context.Set<TransactionCustomer>().AsEnumerable().Last()).State = EntityState.Added;
 
                     if (async)
                     {
@@ -221,7 +237,10 @@ namespace Microsoft.EntityFrameworkCore
                             Id = 77,
                             Name = "Bobble"
                         });
-                    context.Entry(context.Set<TransactionCustomer>().Last()).State = EntityState.Added;
+
+                    // Issue #14935. Cannot eval 'Last()'
+                    // Use AsEnumerable().
+                    context.Entry(context.Set<TransactionCustomer>().AsEnumerable().Last()).State = EntityState.Added;
 
                     context.Database.AutoTransactionsEnabled = true;
                 }
@@ -272,7 +291,10 @@ namespace Microsoft.EntityFrameworkCore
                             Id = 77,
                             Name = "Bobble"
                         });
-                    context.Entry(context.Set<TransactionCustomer>().Last()).State = EntityState.Added;
+
+                    // Issue #14935. Cannot eval 'Last()'
+                    // Use AsEnumerable().
+                    context.Entry(context.Set<TransactionCustomer>().AsEnumerable().Last()).State = EntityState.Added;
 
                     if (async)
                     {
@@ -329,7 +351,10 @@ namespace Microsoft.EntityFrameworkCore
                             Id = 77,
                             Name = "Bobble"
                         });
-                    context.Entry(context.Set<TransactionCustomer>().Last()).State = EntityState.Added;
+
+                    // Issue #14935. Cannot eval 'Last()'
+                    // Use AsEnumerable().
+                    context.Entry(context.Set<TransactionCustomer>().AsEnumerable().Last()).State = EntityState.Added;
 
                     if (async)
                     {
@@ -387,7 +412,10 @@ namespace Microsoft.EntityFrameworkCore
                             Id = 77,
                             Name = "Bobble"
                         });
-                    context.Entry(context.Set<TransactionCustomer>().Last()).State = EntityState.Added;
+
+                    // Issue #14935. Cannot eval 'Last()'
+                    // Use AsEnumerable().
+                    context.Entry(context.Set<TransactionCustomer>().AsEnumerable().Last()).State = EntityState.Added;
 
                     if (async)
                     {
@@ -429,7 +457,10 @@ namespace Microsoft.EntityFrameworkCore
                             Id = 77,
                             Name = "Bobble"
                         });
-                    context.Entry(context.Set<TransactionCustomer>().Last()).State = EntityState.Added;
+
+                    // Issue #14935. Cannot eval 'Last()'
+                    // Use AsEnumerable().
+                    context.Entry(context.Set<TransactionCustomer>().AsEnumerable().Last()).State = EntityState.Added;
 
                     using (new TransactionScope(TransactionScopeOption.Suppress))
                     {
@@ -464,7 +495,10 @@ namespace Microsoft.EntityFrameworkCore
                             Id = 77,
                             Name = "Bobble"
                         });
-                    context.Entry(context.Set<TransactionCustomer>().Last()).State = EntityState.Added;
+
+                    // Issue #14935. Cannot eval 'Last()'
+                    // Use AsEnumerable().
+                    context.Entry(context.Set<TransactionCustomer>().AsEnumerable().Last()).State = EntityState.Added;
                 }
 
                 using (var transaction = new CommittableTransaction(TimeSpan.FromMinutes(10)))
@@ -670,7 +704,10 @@ namespace Microsoft.EntityFrameworkCore
                 {
                     var firstEntry = context.Entry(context.Set<TransactionCustomer>().OrderBy(c => c.Id).First());
                     firstEntry.State = EntityState.Deleted;
-                    var lastEntry = context.Entry(context.Set<TransactionCustomer>().OrderBy(c => c.Id).Last());
+
+                    // Issue #14935. Cannot eval 'Last()'
+                    // Use AsEnumerable().
+                    var lastEntry = context.Entry(context.Set<TransactionCustomer>().AsEnumerable().OrderBy(c => c.Id).Last());
                     lastEntry.State = EntityState.Added;
 
                     try
@@ -703,7 +740,10 @@ namespace Microsoft.EntityFrameworkCore
                 {
                     var firstEntry = context.Entry(context.Set<TransactionCustomer>().OrderBy(c => c.Id).First());
                     firstEntry.State = EntityState.Deleted;
-                    var lastEntry = context.Entry(context.Set<TransactionCustomer>().OrderBy(c => c.Id).Last());
+
+                    // Issue #14935. Cannot eval 'Last()'
+                    // Use AsEnumerable().
+                    var lastEntry = context.Entry(context.Set<TransactionCustomer>().OrderBy(c => c.Id).AsEnumerable().Last());
                     lastEntry.State = EntityState.Added;
 
                     try

--- a/test/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
+++ b/test/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
@@ -110,15 +110,32 @@ namespace Microsoft.EntityFrameworkCore
             {
                 Assert.NotNull(
                     context.Set<MaxLengthDataTypes>().Where(e => e.Id == 799 && e.String3 == shortString).ToList().SingleOrDefault());
-                Assert.NotNull(
-                    context.Set<MaxLengthDataTypes>().Where(e => e.Id == 799 && e.ByteArray5.SequenceEqual(shortBinary)).ToList()
-                        .SingleOrDefault());
 
                 Assert.NotNull(
                     context.Set<MaxLengthDataTypes>().Where(e => e.Id == 799 && e.String9000 == longString).ToList().SingleOrDefault());
-                Assert.NotNull(
-                    context.Set<MaxLengthDataTypes>().Where(e => e.Id == 799 && e.ByteArray9000.SequenceEqual(longBinary)).ToList()
-                        .SingleOrDefault());
+
+                if (context.Database.ProviderName == "Microsoft.EntityFrameworkCore.InMemory")
+                {
+                    Assert.NotNull(
+                        context.Set<MaxLengthDataTypes>().Where(e => e.Id == 799 && e.ByteArray5.SequenceEqual(shortBinary)).ToList()
+                            .SingleOrDefault());
+
+                    Assert.NotNull(
+                        context.Set<MaxLengthDataTypes>().Where(e => e.Id == 799 && e.ByteArray9000.SequenceEqual(longBinary)).ToList()
+                            .SingleOrDefault());
+                }
+                else
+                {
+                    // Issue #14935. Cannot eval 'where [e].ByteArray5.SequenceEqual(__shortBinary_0)'
+                    // Uses == operator instead.
+                    Assert.NotNull(
+                        context.Set<MaxLengthDataTypes>().Where(e => e.Id == 799 && e.ByteArray5 == shortBinary).ToList()
+                            .SingleOrDefault());
+
+                    Assert.NotNull(
+                        context.Set<MaxLengthDataTypes>().Where(e => e.Id == 799 && e.ByteArray9000 == longBinary).ToList()
+                            .SingleOrDefault());
+                }
             }
         }
 

--- a/test/EFCore.Specification.Tests/ConcurrencyDetectorTestBase.cs
+++ b/test/EFCore.Specification.Tests/ConcurrencyDetectorTestBase.cs
@@ -90,7 +90,7 @@ namespace Microsoft.EntityFrameworkCore
             return ConcurrencyDetectorTest(c => c.Products.FirstAsync());
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'Last()'")]
         public virtual Task Last_logs_concurrent_access_nonasync()
         {
             return ConcurrencyDetectorTest(

--- a/test/EFCore.Specification.Tests/CustomConvertersTestBase.cs
+++ b/test/EFCore.Specification.Tests/CustomConvertersTestBase.cs
@@ -234,7 +234,7 @@ namespace Microsoft.EntityFrameworkCore
             public static implicit operator string(Email email) => email._value;
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'where [e].Fuel.Equals(value(Microsoft.EntityFrameworkCore.CustomConvertersTestBase`1+Fuel[Microsoft.EntityFrameworkCore.CustomConvertersSqliteTest+CustomConvertersSqliteFixture]))'")]
         public virtual void Can_query_and_update_with_conversion_for_custom_struct()
         {
             using (var context = CreateContext())

--- a/test/EFCore.Specification.Tests/LoadTestBase.cs
+++ b/test/EFCore.Specification.Tests/LoadTestBase.cs
@@ -3254,9 +3254,11 @@ namespace Microsoft.EntityFrameworkCore
 
                 Assert.False(navigationEntry.IsLoaded);
 
+                // Issue #14935. Cannot eval 'OfType<System.Object>()'
+                // Uses test method non-generic IQueryable.ToList instead.
                 var children = async
-                    ? await navigationEntry.Query().OfType<object>().ToListAsync()
-                    : navigationEntry.Query().OfType<object>().ToList();
+                    ? await navigationEntry.Query().ToListAsync<object>()
+                    : navigationEntry.Query().ToList<object>();
 
                 Assert.False(navigationEntry.IsLoaded);
 
@@ -3292,9 +3294,11 @@ namespace Microsoft.EntityFrameworkCore
 
                 Assert.False(navigationEntry.IsLoaded);
 
+                // Issue #14935. Cannot eval 'OfType<System.Object>()'
+                // Uses test method non-generic IQueryable.ToList instead.
                 var parent = async
-                    ? await navigationEntry.Query().OfType<object>().SingleAsync()
-                    : navigationEntry.Query().OfType<object>().Single();
+                    ? (await navigationEntry.Query().ToListAsync<object>()).Single()
+                    : navigationEntry.Query().ToList<object>().Single();
 
                 Assert.True(navigationEntry.IsLoaded);
 
@@ -3329,9 +3333,11 @@ namespace Microsoft.EntityFrameworkCore
 
                 Assert.False(navigationEntry.IsLoaded);
 
+                // Issue #14935. Cannot eval 'OfType<System.Object>()'
+                // Uses test method non-generic IQueryable.ToList instead.
                 var parent = async
-                    ? await navigationEntry.Query().OfType<object>().SingleAsync()
-                    : navigationEntry.Query().OfType<object>().Single();
+                    ? (await navigationEntry.Query().ToListAsync<object>()).Single()
+                    : navigationEntry.Query().ToList<object>().Single();
 
                 Assert.True(navigationEntry.IsLoaded);
 
@@ -3366,9 +3372,11 @@ namespace Microsoft.EntityFrameworkCore
 
                 Assert.False(navigationEntry.IsLoaded);
 
+                // Issue #14935. Cannot eval 'OfType<System.Object>()'
+                // Uses test method non-generic IQueryable.ToList instead.
                 var single = async
-                    ? await navigationEntry.Query().OfType<object>().SingleAsync()
-                    : navigationEntry.Query().OfType<object>().Single();
+                    ? (await navigationEntry.Query().ToListAsync<object>()).Single()
+                    : navigationEntry.Query().ToList<object>().Single();
 
                 Assert.True(navigationEntry.IsLoaded);
 
@@ -3586,9 +3594,11 @@ namespace Microsoft.EntityFrameworkCore
 
                 Assert.False(navigationEntry.IsLoaded);
 
+                // Issue #14935. Cannot eval 'OfType<System.Object>()'
+                // Uses test method non-generic IQueryable.ToList instead.
                 var children = async
-                    ? await navigationEntry.Query().OfType<object>().ToListAsync()
-                    : navigationEntry.Query().OfType<object>().ToList();
+                    ? await navigationEntry.Query().ToListAsync<object>()
+                    : navigationEntry.Query().ToList<object>();
 
                 Assert.False(navigationEntry.IsLoaded);
 
@@ -3627,9 +3637,11 @@ namespace Microsoft.EntityFrameworkCore
 
                 Assert.False(navigationEntry.IsLoaded);
 
+                // Issue #14935. Cannot eval 'OfType<System.Object>()'
+                // Uses test method non-generic IQueryable.ToList instead.
                 var parent = async
-                    ? await navigationEntry.Query().OfType<object>().SingleOrDefaultAsync()
-                    : navigationEntry.Query().OfType<object>().SingleOrDefault();
+                    ? (await navigationEntry.Query().ToListAsync<object>()).SingleOrDefault()
+                    : navigationEntry.Query().ToList<object>().SingleOrDefault();
 
                 Assert.False(navigationEntry.IsLoaded);
 
@@ -3668,9 +3680,11 @@ namespace Microsoft.EntityFrameworkCore
 
                 Assert.False(navigationEntry.IsLoaded);
 
+                // Issue #14935. Cannot eval 'OfType<System.Object>()'
+                // Uses test method non-generic IQueryable.ToList instead.
                 var parent = async
-                    ? await navigationEntry.Query().OfType<object>().SingleOrDefaultAsync()
-                    : navigationEntry.Query().OfType<object>().SingleOrDefault();
+                    ? (await navigationEntry.Query().ToListAsync<object>()).SingleOrDefault()
+                    : navigationEntry.Query().ToList<object>().SingleOrDefault();
 
                 Assert.False(navigationEntry.IsLoaded);
 
@@ -3709,9 +3723,11 @@ namespace Microsoft.EntityFrameworkCore
 
                 Assert.False(navigationEntry.IsLoaded);
 
+                // Issue #14935. Cannot eval 'OfType<System.Object>()'
+                // Uses test method non-generic IQueryable.ToList instead.
                 var single = async
-                    ? await navigationEntry.Query().OfType<object>().SingleOrDefaultAsync()
-                    : navigationEntry.Query().OfType<object>().SingleOrDefault();
+                    ? (await navigationEntry.Query().ToListAsync<object>()).SingleOrDefault()
+                    : navigationEntry.Query().ToList<object>().SingleOrDefault();
 
                 Assert.False(navigationEntry.IsLoaded);
 
@@ -3958,9 +3974,11 @@ namespace Microsoft.EntityFrameworkCore
 
                 Assert.True(navigationEntry.IsLoaded);
 
+                // Issue #14935. Cannot eval 'OfType<System.Object>()'
+                // Uses test method non-generic IQueryable.ToList instead.
                 var children = async
-                    ? await navigationEntry.Query().OfType<object>().ToListAsync()
-                    : navigationEntry.Query().OfType<object>().ToList();
+                    ? await navigationEntry.Query().ToListAsync<object>()
+                    : navigationEntry.Query().ToList<object>();
 
                 Assert.True(navigationEntry.IsLoaded);
 
@@ -3995,9 +4013,11 @@ namespace Microsoft.EntityFrameworkCore
 
                 Assert.True(navigationEntry.IsLoaded);
 
+                // Issue #14935. Cannot eval 'OfType<System.Object>()'
+                // Uses test method non-generic IQueryable.ToList instead.
                 var parent = async
-                    ? await navigationEntry.Query().OfType<object>().SingleAsync()
-                    : navigationEntry.Query().OfType<object>().Single();
+                    ? (await navigationEntry.Query().ToListAsync<object>()).Single()
+                    : navigationEntry.Query().ToList<object>().Single();
 
                 Assert.True(navigationEntry.IsLoaded);
 
@@ -4032,9 +4052,11 @@ namespace Microsoft.EntityFrameworkCore
 
                 Assert.True(navigationEntry.IsLoaded);
 
+                // Issue #14935. Cannot eval 'OfType<System.Object>()'
+                // Uses test method non-generic IQueryable.ToList instead.
                 var parent = async
-                    ? await navigationEntry.Query().OfType<object>().SingleAsync()
-                    : navigationEntry.Query().OfType<object>().Single();
+                    ? (await navigationEntry.Query().ToListAsync<object>()).Single()
+                    : navigationEntry.Query().ToList<object>().Single();
 
                 Assert.True(navigationEntry.IsLoaded);
 
@@ -4078,9 +4100,11 @@ namespace Microsoft.EntityFrameworkCore
 
                 Assert.True(navigationEntry.IsLoaded);
 
+                // Issue #14935. Cannot eval 'OfType<System.Object>()'
+                // Uses test method non-generic IQueryable.ToList instead.
                 var single = async
-                    ? await navigationEntry.Query().OfType<object>().SingleAsync()
-                    : navigationEntry.Query().OfType<object>().Single();
+                    ? (await navigationEntry.Query().ToListAsync<object>()).Single()
+                    : navigationEntry.Query().ToList<object>().Single();
 
                 Assert.True(navigationEntry.IsLoaded);
 

--- a/test/EFCore.Specification.Tests/MonsterFixupTestBase.cs
+++ b/test/EFCore.Specification.Tests/MonsterFixupTestBase.cs
@@ -520,9 +520,12 @@ namespace Microsoft.EntityFrameworkCore
                 var productReview2 = context.ProductReviews.Single(e => e.Review.StartsWith("Good"));
                 var productReview3 = context.ProductReviews.Single(e => e.Review.StartsWith("Eeky"));
 
-                var productPhoto1 = context.ProductPhotos.Single(e => e.Photo[0] == 101);
-                var productPhoto2 = context.ProductPhotos.Single(e => e.Photo[0] == 103);
-                var productPhoto3 = context.ProductPhotos.Single(e => e.Photo[0] == 105);
+                // Issue #14935. Cannot eval 'where (Convert([e].Photo[0], Int32) == 101)'
+                // ToList() added.
+                var productPhotos = context.ProductPhotos.ToList();
+                var productPhoto1 = productPhotos.Single(e => e.Photo[0] == 101);
+                var productPhoto2 = productPhotos.Single(e => e.Photo[0] == 103);
+                var productPhoto3 = productPhotos.Single(e => e.Photo[0] == 105);
 
                 var productWebFeature1 = context.ProductWebFeatures.Single(e => e.Heading.StartsWith("Waffle"));
                 var productWebFeature2 = context.ProductWebFeatures.Single(e => e.Heading.StartsWith("What"));
@@ -834,9 +837,11 @@ namespace Microsoft.EntityFrameworkCore
                     new[] { "Better than Tarqies!", "Eeky says yes!", "Good with maple syrup." },
                     context.ProductReviews.Select(c => c.Review).OrderBy(n => n));
 
+                // Issue #14935. Cannot eval 'orderby {[c].Photo => First()}.ToString() asc'
+                // ToList() added.
                 Assert.Equal(
                     new[] { "101", "103", "105" },
-                    context.ProductPhotos.Select(c => c.Photo.First().ToString()).OrderBy(n => n));
+                    context.ProductPhotos.ToList().Select(c => c.Photo.First().ToString()).OrderBy(n => n));
 
                 Assert.Equal(
                     new[] { "Waffle Style", "What does the waffle say?" },
@@ -846,9 +851,11 @@ namespace Microsoft.EntityFrameworkCore
                     new[] { "Ants By Boris", "Trading As Trent" },
                     context.Suppliers.Select(c => c.Name).OrderBy(n => n));
 
+                // Issue #14935. Cannot eval 'from Byte l in [c].Logo'
+                // ToList() added.
                 Assert.Equal(
                     new[] { "201", "202" },
-                    context.SupplierLogos.SelectMany(c => c.Logo).Select(l => l.ToString()).OrderBy(n => n));
+                    context.SupplierLogos.ToList().SelectMany(c => c.Logo).Select(l => l.ToString()).OrderBy(n => n));
 
                 Assert.Equal(
                     new[] { "Orange fur?", "Seems a bit dodgy.", "Very expensive!" },
@@ -1027,9 +1034,12 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.Equal(product1.ProductId, productReview2.ProductId);
                 Assert.Equal(product2.ProductId, productReview3.ProductId);
 
-                var productPhoto1 = context.ProductPhotos.Single(e => e.Photo[0] == 101);
-                var productPhoto2 = context.ProductPhotos.Single(e => e.Photo[0] == 103);
-                var productPhoto3 = context.ProductPhotos.Single(e => e.Photo[0] == 105);
+                // Issue #14935. Cannot eval 'where (Convert([e].Photo[0], Int32) == 101)'
+                // ToList() added.
+                var productPhotos = context.ProductPhotos.ToList();
+                var productPhoto1 = productPhotos.Single(e => e.Photo[0] == 101);
+                var productPhoto2 = productPhotos.Single(e => e.Photo[0] == 103);
+                var productPhoto3 = productPhotos.Single(e => e.Photo[0] == 105);
 
                 Assert.Equal(product1.ProductId, productPhoto1.ProductId);
                 Assert.Equal(product1.ProductId, productPhoto2.ProductId);
@@ -1048,7 +1058,9 @@ namespace Microsoft.EntityFrameworkCore
                 var supplier1 = context.Suppliers.Single(e => e.Name.StartsWith("Trading"));
                 var supplier2 = context.Suppliers.Single(e => e.Name.StartsWith("Ants"));
 
-                var supplierLogo1 = context.SupplierLogos.Single(e => e.Logo[0] == 201);
+                // Issue #14935. Cannot eval 'where (Convert([e].Logo[0], Int32) == 201)'
+                // ToList() added.
+                var supplierLogo1 = context.SupplierLogos.ToList().Single(e => e.Logo[0] == 201);
 
                 Assert.Equal(supplier1.SupplierId, supplierLogo1.SupplierId);
 
@@ -1292,9 +1304,12 @@ namespace Microsoft.EntityFrameworkCore
 
                 Assert.True(product3.Reviews == null || product3.Reviews.Count == 0);
 
-                var productPhoto1 = context.ProductPhotos.Single(e => e.Photo[0] == 101);
-                var productPhoto2 = context.ProductPhotos.Single(e => e.Photo[0] == 103);
-                var productPhoto3 = context.ProductPhotos.Single(e => e.Photo[0] == 105);
+                // Issue #14935. Cannot eval 'where (Convert([e].Photo[0], Int32) == 101)'
+                // ToList() added.
+                var productPhotos = context.ProductPhotos.ToList();
+                var productPhoto1 = productPhotos.Single(e => e.Photo[0] == 101);
+                var productPhoto2 = productPhotos.Single(e => e.Photo[0] == 103);
+                var productPhoto3 = productPhotos.Single(e => e.Photo[0] == 105);
 
                 Assert.Equal(
                     new[] { productPhoto1, productPhoto2 },
@@ -1324,7 +1339,9 @@ namespace Microsoft.EntityFrameworkCore
                 var supplier1 = context.Suppliers.Single(e => e.Name.StartsWith("Trading"));
                 var supplier2 = context.Suppliers.Single(e => e.Name.StartsWith("Ants"));
 
-                var supplierLogo1 = context.SupplierLogos.Single(e => e.Logo[0] == 201);
+                // Issue #14935. Cannot eval 'where (Convert([e].Logo[0], Int32) == 201)'
+                // ToList() added.
+                var supplierLogo1 = context.SupplierLogos.ToList().Single(e => e.Logo[0] == 201);
 
                 Assert.Same(supplierLogo1, supplier1.Logo);
 

--- a/test/EFCore.Specification.Tests/Query/AsyncGearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AsyncGearsOfWarQueryTestBase.cs
@@ -21,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext();
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'GroupBy([s], Result(_IncludeAsync(queryContext, [s], new [] {}, (queryContext, entity, included, ct) => { ... }, ct)))'")]
         public virtual async Task Include_with_group_by_on_entity_qsre()
         {
             using (var ctx = CreateContext())
@@ -39,7 +39,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'GroupBy([g], Result(_IncludeAsync(queryContext, [g], new [] {}, (queryContext, entity, included, ct) => { ... }, ct)))'")]
         public virtual async Task Include_with_group_by_on_entity_qsre_with_composite_key()
         {
             using (var ctx = CreateContext())
@@ -57,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'GroupBy([l.Commander.DefeatedBy], Result(_IncludeAsync(queryContext, [<generated>_1], new [] {}, (queryContext, entity, included, ct) => { ... }, ct)))'")]
         public virtual async Task Include_with_group_by_on_entity_navigation()
         {
             using (var ctx = CreateContext())
@@ -75,7 +75,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'GroupBy(1, Result(_IncludeAsync(queryContext, [s], new [] {}, (queryContext, entity, included, ct) => { ... }, ct)))'")]
         public virtual async Task Include_groupby_constant()
         {
             using (var ctx = CreateContext())

--- a/test/EFCore.Specification.Tests/Query/AsyncGroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AsyncGroupByQueryTestBase.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #region GroupByAggregateComposition
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'GroupBy([o].CustomerID, [o])'")]
         public virtual async Task GroupBy_Select_sum_over_unmapped_property()
         {
             using (var context = CreateContext())
@@ -45,7 +45,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'GroupBy([o].OrderID, [o])'")]
         public virtual async Task Select_nested_collection_with_groupby()
         {
             using (var context = CreateContext())
@@ -74,7 +74,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'GroupBy([o].CustomerID, new ProjectedType() {Order = [o].OrderID, Customer = [o].CustomerID})'")]
         public virtual async Task Select_GroupBy_All()
         {
             using (var context = CreateContext())
@@ -117,7 +117,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #region GroupByWithoutAggregate
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'GroupBy(new <>f__AnonymousType19`2(CustomerID = [o].CustomerID, OrderDate = [o].OrderDate), [o])'")]
         public virtual async Task GroupBy_anonymous_key_without_aggregate()
         {
             using (var context = CreateContext())
@@ -167,7 +167,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #region GroupByEntityType
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'GroupBy([o].CustomerID, new ProjectedType() {Order = [o].OrderID, Customer = [o].CustomerID})'")]
         public virtual async Task Select_GroupBy()
         {
             using (var context = CreateContext())
@@ -195,7 +195,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'GroupBy([o].OrderID, new ProjectedType() {Order = [o].OrderID, Customer = [o].CustomerID})'")]
         public virtual async Task Select_GroupBy_SelectMany()
         {
             using (var context = CreateContext())
@@ -226,7 +226,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'GroupBy([c], [o])'")]
         public virtual async Task Join_GroupBy_entity_ToList()
         {
             using (var context = CreateContext())

--- a/test/EFCore.Specification.Tests/Query/AsyncSimpleQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AsyncSimpleQueryTestBase.cs
@@ -30,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         protected NorthwindContext CreateContext() => Fixture.CreateContext();
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'Microsoft.EntityFrameworkCore.Query.QueryClientEvaluationWarning: The LINQ expression 'GroupBy([o].CustomerID, [o])' could not be translated and will be evaluated locally.'")]
         public virtual async Task GroupBy_tracking_after_dispose()
         {
             List<IGrouping<string, Order>> groups;
@@ -151,7 +151,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'Average'")]
         public virtual async Task Average_on_nav_subquery_in_projection()
         {
             using (var context = CreateContext())
@@ -203,7 +203,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'join Customer y.Customer in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) on Property([y], \"CustomerID\") equals Property([y.Customer], \"CustomerID\")'")]
         public virtual async Task Mixed_sync_async_query()
         {
             using (var context = CreateContext())
@@ -342,7 +342,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         // Set Operations
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'Concat({value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer])})'")]
         public virtual async Task Concat_dbset()
         {
             using (var context = CreateContext())
@@ -357,7 +357,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'Concat({from Customer s in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) where ([s].ContactTitle == \"Owner\") select [s]})'")]
         public virtual async Task Concat_simple()
         {
             using (var context = CreateContext())
@@ -373,7 +373,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'Concat({from Customer s in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) where ([s].ContactTitle == \"Owner\") select [s].CustomerID})'")]
         public virtual async Task Concat_non_entity()
         {
             using (var context = CreateContext())
@@ -391,7 +391,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'Microsoft.EntityFrameworkCore.Query.QueryClientEvaluationWarning: The LINQ expression 'Except({from Customer c in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) where ([c].City == \"México D.F.\") select [c].CustomerID})'")]
         public virtual async Task Except_non_entity()
         {
             using (var context = CreateContext())
@@ -409,7 +409,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'Intersect({from Customer s in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) where ([s].ContactTitle == \"Owner\") select [s].CustomerID})'")]
         public virtual async Task Intersect_non_entity()
         {
             using (var context = CreateContext())
@@ -427,7 +427,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'Union({from Customer c in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) where ([c].City == \"México D.F.\") select [c].CustomerID})'")]
         public virtual async Task Union_non_entity()
         {
             using (var context = CreateContext())

--- a/test/EFCore.Specification.Tests/Query/CompiledQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/CompiledQueryTestBase.cs
@@ -203,7 +203,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'where ([c].CustomerID == __args[0])'")]
         public virtual void Query_with_array_parameter()
         {
             var query = EF.CompileQuery(
@@ -463,7 +463,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'where ([c].CustomerID == __args[0])'")]
         public virtual async Task Query_with_array_parameter_async()
         {
             var query = EF.CompileAsyncQuery(

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -1920,7 +1920,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: l1 => l1.Id);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'join Level3 l2.OneToOne_Required_PK2 in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel.Level3]) on Property([l2], \"Id\") equals Property([l2.OneToOne_Required_PK2], \"Id\")'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_with_groupjoin_skip_and_take(bool isAsync)
         {
@@ -2319,7 +2319,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             );
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Any()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_on_subquery_and_set_operation_on_grouping_but_nothing_from_grouping_is_projected(bool isAsync)
         {
@@ -2341,7 +2341,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 (e, a) => Assert.Equal(e.Id, a.Id));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Any()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_on_complex_subquery_and_set_operation_on_grouping_but_nothing_from_grouping_is_projected(bool isAsync)
         {
@@ -2363,7 +2363,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 (e, a) => Assert.Equal(e.Id, a.Id));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'join Level2 l2 in {from Level1 l1 in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel.Level1]) join Level2 l1.OneToOne_Required_FK1 in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel.Level2]) on Property([l1], \"Id\") equals Property([l1.OneToOne_Required_FK1], \"Level1_Required_Id\") into IEnumerable`1 l1.OneToOne_Required_FK1_group from Level2 l1.OneToOne_Required_FK1 in {[l1.OneToOne_Required_FK1_group] => DefaultIfEmpty()} select [l1.OneToOne_Required_FK1]} on Convert([l1].Id, Nullable`1) equals MaybeScalar([l2], () => [l2]?.Level1_Optional_Id)'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Null_protection_logic_work_for_inner_key_access_of_manually_created_GroupJoin1(bool isAsync)
         {
@@ -3056,7 +3056,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 (e, a) => Assert.Equal(e.Id, a.Id));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Distict()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task SelectMany_with_navigation_and_Distinct(bool isAsync)
         {
@@ -3476,7 +3476,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 (e, a) => Assert.Equal(e.Id, a.Id));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ([l1.OneToMany_Required1_groupItem].Id > 5)'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task SelectMany_with_navigation_filter_paging_and_explicit_DefaultIfEmpty(bool isAsync)
         {
@@ -3544,7 +3544,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) => Assert.Equal(e.Id, a.Id));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'All(ClientMethod([l2.OneToOne_Optional_FK2.OneToOne_Optional_FK3]?.Id))'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Complex_query_with_optional_navigations_and_client_side_evaluation(bool isAsync)
         {
@@ -3564,7 +3564,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) => Assert.Equal(e.Id, a.Id));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'First()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Required_navigation_on_a_subquery_with_First_in_projection(bool isAsync)
         {
@@ -3575,7 +3575,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Select(l2o => l2s.OrderBy(l2i => l2i.Id).First().OneToOne_Required_FK_Inverse2.Name));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'First()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Required_navigation_on_a_subquery_with_complex_projection_and_First(bool isAsync)
         {
@@ -3596,7 +3596,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                          }).First().Navigation.Name);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'First()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Required_navigation_on_a_subquery_with_First_in_predicate(bool isAsync)
         {
@@ -3880,7 +3880,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select MaybeScalar<int>(subquery, () => subquery.Id));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Any()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_with_complex_subquery_with_joins_with_reference_to_grouping1(bool isAsync)
         {
@@ -3900,7 +3900,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select subquery.Id);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'DefaultIfEmpty()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_with_complex_subquery_with_joins_with_reference_to_grouping2(bool isAsync)
         {
@@ -3948,7 +3948,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select Maybe(l2_outer, () => l2_outer.Name));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'join Level2 l2_outer in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel.Level2]) on [x]?.Id equals [l2_outer].Level1_Optional_Id'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_on_a_subquery_containing_another_GroupJoin_projecting_outer_with_client_method(bool isAsync)
         {
@@ -4120,7 +4120,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select l1.Name);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ({from Level1 l1_inner in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel.Level1]) join Level2 l2_inner in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel.Level2]) on Convert([l1_inner].Id, Nullable`1) equals [l2_inner].Level1_Optional_Id into IEnumerable`1 grouping from Level2 l2_inner in {[grouping] => DefaultIfEmpty()} select ClientStringMethod([l1_inner].Name) => Count()} > 7)'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_in_subquery_with_client_projection(bool isAsync)
         {
@@ -4136,7 +4136,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select l1.Name);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ({from Level1 l1_inner in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel.Level1]) join Level2 l2_inner in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel.Level2]) on Convert([l1_inner].Id, Nullable`1) equals [l2_inner].Level1_Optional_Id into IEnumerable`1 grouping_inner from Level2 l2_inner in {[grouping_inner] => DefaultIfEmpty()} select ClientStringMethod([l1_inner].Name) => Count()} > 7)'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_in_subquery_with_client_projection_nested1(bool isAsync)
         {
@@ -4157,7 +4157,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select l1_outer.Name);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ({from Level1 l1_middle in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel.Level1]) join Level2 l2_middle in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel.Level2]) on Convert([l1_middle].Id, Nullable`1) equals [l2_middle].Level1_Optional_Id into IEnumerable`1 grouping_middle from Level2 l2_middle in {[grouping_middle] => DefaultIfEmpty()} where ({from Level1 l1_inner in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel.Level1]) join Level2 l2_inner in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel.Level2]) on Convert([l1_inner].Id, Nullable`1) equals [l2_inner].Level1_Optional_Id into IEnumerable`1 grouping_inner from Level2 l2_inner in {[grouping_inner] => DefaultIfEmpty()} select [l1_inner].Name => Count()} > 7) select ClientStringMethod([l1_middle].Name) => Count()} > 4)'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_in_subquery_with_client_projection_nested2(bool isAsync)
         {
@@ -4182,7 +4182,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return argument;
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'DefaultIfEmpty()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_reference_to_group_in_OrderBy(bool isAsync)
         {
@@ -4216,7 +4216,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) => Assert.Equal(e.Id + " " + e.client, a.Id + " " + a.client));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'orderby ClientMethodNullableInt(Convert([l1].Id, Nullable`1)) asc, ClientMethodNullableInt(?[l2] | [l2]?.Id?) asc'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_client_method_in_OrderBy(bool isAsync)
         {
@@ -4249,7 +4249,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select l1.Id);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ([gg].Id > 0)'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_with_subquery_on_inner(bool isAsync)
         {
@@ -4262,7 +4262,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select l1.Id);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ([gg].Id > 0)'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_with_subquery_on_inner_and_no_DefaultIfEmpty(bool isAsync)
         {
@@ -4482,7 +4482,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) => Assert.Equal(e.Id, a.Id));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([l2.OneToMany_Required_Self_Inverse2].Name, [l2])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Navigation_filter_navigation_grouping_ordering_by_group_key(bool isAsync)
         {
@@ -4689,7 +4689,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Select(l1 => l1.Id));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'First()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_subquery_with_client_eval_and_navigation1(bool isAsync)
         {
@@ -4698,7 +4698,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 l2s => l2s.Select(l2 => l2s.OrderBy(l => l.Id).First().OneToOne_Required_FK_Inverse2.Name));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'First()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_subquery_with_client_eval_and_navigation2(bool isAsync)
         {
@@ -5008,7 +5008,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ([l1.OneToMany_Required1_groupItem].Id > 5)'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_optional_navigation_property_string_concat(bool isAsync)
         {
@@ -5120,7 +5120,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([l1].Name, _Include(queryContext, [l1], new [] {[l1.OneToOne_Optional_FK1]}, (queryContext, entity, included) => { ... }))'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_reference_with_groupby_in_subquery(bool isAsync)
         {
@@ -5136,7 +5136,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([l1].Name, _Include(queryContext, [l1], new [] {}, (queryContext, entity, included) => { ... }))' could not be translated and will be evaluated locally.'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_with_groupby_in_subquery(bool isAsync)
         {
@@ -5152,7 +5152,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([l1].Name, _Include(queryContext, [l1], new [] {[l1.OneToOne_Optional_FK1]}, (queryContext, entity, included) => { ... }))'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multi_include_with_groupby_in_subquery(bool isAsync)
         {
@@ -5171,7 +5171,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 expectedIncludes);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([l1].Name, _Include(queryContext, [l1], new [] {}, (queryContext, entity, included) => { ... }))'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_with_groupby_in_subquery_and_filter_before_groupby(bool isAsync)
         {
@@ -5188,7 +5188,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([l1].Name, _Include(queryContext, [l1], new [] {}, (queryContext, entity, included) => { ... }))'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_with_groupby_in_subquery_and_filter_after_groupby(bool isAsync)
         {
@@ -5413,7 +5413,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Distinct()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_after_SelectMany_and_reference_navigation_with_another_SelectMany_with_Distinct(bool isAsync)
         {

--- a/test/EFCore.Specification.Tests/Query/FiltersTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/FiltersTestBase.cs
@@ -47,7 +47,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Assert.Null(_context.Find<Customer>("ALFKI"));
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'where ClientMethod([p])'")]
         public virtual void Client_eval()
         {
             Assert.Equal(69, _context.Products.ToList().Count);
@@ -119,7 +119,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Assert.True(results.All(o => o.Customer == null || o.CustomerID.StartsWith("B")));
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'where ClientMethod([p])'")]
         public virtual void Included_one_to_many_query_with_client_eval()
         {
             var results = _context.Products.Include(p => p.OrderDetails).ToList();

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -837,7 +837,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     g => MilitaryRank.Corporal.HasFlag(gs.OrderBy(x => x.Nickname).ThenBy(x => x.SquadId).FirstOrDefault().Rank)));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'First()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_enum_has_flag_subquery_client_eval(bool isAsync)
         {
@@ -1348,7 +1348,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where (IIF(([g].LeaderNickname != null), new <>f__AnonymousType127`1(HasSoulPatch = [g].HasSoulPatch), null) == null)'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_conditional_with_anonymous_type(bool isAsync)
         {
@@ -1385,7 +1385,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ((new <>f__AnonymousType100`1(Name = [g].LeaderNickname) ?? new <>f__AnonymousType100`1(Name = [g].FullName)) != null)'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_coalesce_with_anonymous_types(bool isAsync)
         {
@@ -1584,7 +1584,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 gs => gs.Where(g => g.HasSoulPatch && g.Weapons.Distinct().OrderBy(w => w.Id).FirstOrDefault().IsAutomatic));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'First()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_subquery_distinct_first_boolean(bool isAsync)
         {
@@ -1594,7 +1594,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'SingleOrDefault()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_subquery_distinct_singleordefault_boolean1(bool isAsync)
         {
@@ -1606,7 +1606,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'SingleOrDefault()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_subquery_distinct_singleordefault_boolean2(bool isAsync)
         {
@@ -1618,7 +1618,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'SingleOrDefault()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_subquery_distinct_singleordefault_boolean_with_pushdown(bool isAsync)
         {
@@ -1682,7 +1682,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 gs => gs.Where(g => g.HasSoulPatch && g.Weapons.Distinct().OrderBy(w => w.Id).FirstOrDefault().IsAutomatic));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Union(MaterializeCollectionNavigation(Navigation: Gear.Weapons (<Weapons>k__BackingField, ICollection<Weapon>) Collection ToDependent Weapon Inverse: Owner 4 -1 11 -1 -1, {from Weapon w in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel.Weapon]) where  ?= (Property([g], \"FullName\") == Property([w], \"OwnerFullName\")) =? select [w]}))'")]
         [InlineData(false)]
         //[InlineData(true)] issue #12449
         public virtual Task Where_subquery_union_firstordefault_boolean(bool isAsync)
@@ -1692,7 +1692,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 gs => gs.Where(g => g.HasSoulPatch && g.Weapons.Union(g.Weapons).OrderBy(w => w.Id).FirstOrDefault().IsAutomatic));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Concat(MaterializeCollectionNavigation(Navigation: Gear.Weapons (<Weapons>k__BackingField, ICollection<Weapon>) Collection ToDependent Weapon Inverse: Owner 4 -1 11 -1 -1, {from Weapon w in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel.Weapon]) where  ?= (Property([g], \"FullName\") == Property([w], \"OwnerFullName\")) =? select [w]}))'")]
         [InlineData(false)]
         //[InlineData(true)] issue #12449
         public virtual Task Where_subquery_concat_firstordefault_boolean(bool isAsync)
@@ -1702,7 +1702,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 gs => gs.Where(g => g.HasSoulPatch && g.Weapons.Concat(g.Weapons).OrderBy(w => w.Id).FirstOrDefault().IsAutomatic));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Concat({value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel.Gear])})'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Concat_with_count(bool isAsync)
         {
@@ -1711,7 +1711,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 gs => gs.Concat(gs));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Concat({from Gear g2 in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel.Gear]) select [g2].FullName})'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Concat_scalars_with_count(bool isAsync)
         {
@@ -1720,7 +1720,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 gs => gs.Select(g => g.Nickname).Concat(gs.Select(g2 => g2.FullName)));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Concat({from Gear g2 in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel.Gear]) select new <>f__AnonymousType134`2(Gear = [g2], Name = [g2].FullName)})'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Concat_anonymous_with_count(bool isAsync)
         {
@@ -1753,7 +1753,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([g].LeaderNickname, [g])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Concat_with_groupings(bool isAsync)
         {
@@ -1764,7 +1764,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: GroupingAsserter<string, Gear>(g => g.Nickname, (e, a) => Assert.Equal(e.Nickname, a.Nickname)));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Concat(MaterializeCollectionNavigation(Navigation: Gear.Weapons (<Weapons>k__BackingField, ICollection<Weapon>) Collection ToDependent Weapon Inverse: Owner 4 -1 11 -1 -1, {from Weapon w in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel.Weapon]) where  ?= (Property([g], \"FullName\") == Property([w], \"OwnerFullName\")) =? select [w]}))'")]
         [InlineData(false)]
         //[InlineData(true)] issue #12449
         public virtual Task Select_navigation_with_concat_and_count(bool isAsync)
@@ -1774,7 +1774,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 gs => gs.Where(g => !g.HasSoulPatch).Select(g => g.Weapons.Concat(g.Weapons).Count()));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([g].LeaderNickname, [g])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_subquery_concat_order_by_firstordefault_boolean(bool isAsync)
         {
@@ -1785,7 +1785,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: GroupingAsserter<string, Gear>(g => g.Nickname, (e, a) => Assert.Equal(e.Nickname, a.Nickname)));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Union(MaterializeCollectionNavigation(Navigation: Gear.Weapons (<Weapons>k__BackingField, ICollection<Weapon>) Collection ToDependent Weapon Inverse: Owner 4 -1 11 -1 -1, {from Weapon w in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel.Weapon]) where  ?= (Property([g], \"FullName\") == Property([w], \"OwnerFullName\")) =? select [w]}))'")]
         [InlineData(false)]
         //[InlineData(true)] issue #12449
         public virtual Task Concat_with_collection_navigations(bool isAsync)
@@ -1795,7 +1795,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 gs => gs.Where(g => g.HasSoulPatch).Select(g => g.Weapons.Union(g.Weapons).Count()));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Union(MaterializeCollectionNavigation(Navigation: Officer.Reports (<Reports>k__BackingField, ICollection<Gear>) Collection ToDependent Gear 5 -1 12 -1 -1, {from Gear g in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel.Gear]) where  ?= (new AnonymousObject(new [] {Convert(Property([o], \"Nickname\"), Object), Convert(Property([o], \"SquadId\"), Object)}) == new AnonymousObject(new [] {Convert(Property([g], \"LeaderNickname\"), Object), Convert(Property([g], \"LeaderSquadId\"), Object)})) =? select [g]}))'")]
         [InlineData(false)]
         //[InlineData(true)] issue #12449
         public virtual Task Union_with_collection_navigations(bool isAsync)
@@ -1814,7 +1814,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 gs => gs.Where(g => g.HasSoulPatch).Select(g => g.Weapons.Distinct().OrderBy(w => w.Id).FirstOrDefault().Name));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where (?[t.Gear] | (?[t.Gear] | ([t.Gear]?.IsMarcus == True)? == True)? == True)'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_Where_Navigation_Client(bool isAsync)
         {
@@ -2519,7 +2519,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ts => ts.Where(t => t.Note != "K.I.A.").OrderBy(t => t.Gear.SquadId));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy(Convert([t.Gear]?.SquadId, Int32), [t])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Optional_navigation_type_compensation_works_with_groupby(bool isAsync)
         {
@@ -2915,7 +2915,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'from Gear g in ClientDefaultIfEmpty([grouping])'")]
         [InlineData(false)]
         //[InlineData(true)] issue #12449
         public virtual Task Orderby_added_for_client_side_GroupJoin_composite_dependent_to_principal_LOJ_when_incomplete_key_is_used(
@@ -3000,7 +3000,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                        select g.HasSoulPatch));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Distinct()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Distinct_with_unflattened_groupjoin_is_evaluated_on_client(bool isAsync)
         {
@@ -3022,7 +3022,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Distinct());
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Count()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Count_with_unflattened_groupjoin_is_evaluated_on_client(bool isAsync)
         {
@@ -3080,7 +3080,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 predicate: g => g.Tag.Note != "Foo");
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Count()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Non_flattened_GroupJoin_with_result_operator_evaluates_on_the_client(bool isAsync)
         {
@@ -3101,7 +3101,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     (k, r) => r.Count()));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ClientEquals([g.Tag]?.Note, __prm_0)'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Client_side_equality_with_parameter_works_with_optional_navigations(bool isAsync)
         {
@@ -3441,7 +3441,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.Name);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where (FavoriteWeapon(MaterializeCollectionNavigation(Navigation: Gear.Weapons (<Weapons>k__BackingField, ICollection<Weapon>) Collection ToDependent Weapon Inverse: Owner 4 -1 11 -1 -1, {from Weapon w in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel.Weapon]) where  ?= (Property([g], \"FullName\") == Property([w], \"OwnerFullName\")) =? select [w]})).Name == \"Marcus' Lancer\")'")]
         [InlineData(false)]
         //[InlineData(true)] issue #12449
         public virtual Task Client_method_on_collection_navigation_in_predicate(bool isAsync)
@@ -3453,7 +3453,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       select g.Nickname);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where (FavoriteWeapon(MaterializeCollectionNavigation(Navigation: Gear.Weapons (<Weapons>k__BackingField, ICollection<Weapon>) Collection ToDependent Weapon Inverse: Owner 4 -1 11 -1 -1, {from Weapon w in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel.Weapon]) where  ?= (Property([g], \"FullName\") == Property([w], \"OwnerFullName\")) =? select [w]})).Name == \"Cole's Gnasher\")'")]
         [InlineData(false)]
         //[InlineData(true)] issue #12449
         public virtual Task Client_method_on_collection_navigation_in_predicate_accessed_by_ef_property(bool isAsync)
@@ -3468,7 +3468,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       select g.Nickname);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'orderby FavoriteWeapon(MaterializeCollectionNavigation(Navigation: Gear.Weapons (<Weapons>k__BackingField, ICollection<Weapon>) Collection ToDependent Weapon Inverse: Owner 4 -1 11 -1 -1, {from Weapon w in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel.Weapon]) where  ?= (Property([g], \"FullName\") == Property([w], \"OwnerFullName\")) =? select [w]})).Name desc'")]
         [InlineData(false)]
         //[InlineData(true)] issue #12449
         public virtual Task Client_method_on_collection_navigation_in_order_by(bool isAsync)
@@ -3482,7 +3482,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'from Gear v in Veterans(MaterializeCollectionNavigation(Navigation: Officer.Reports (<Reports>k__BackingField, ICollection<Gear>) Collection ToDependent Gear 5 -1 12 -1 -1, {from Gear g in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel.Gear]) where  ?= (new AnonymousObject(new [] {Convert(Property([g], \"Nickname\"), Object), Convert(Property([g], \"SquadId\"), Object)}) == new AnonymousObject(new [] {Convert(Property([g], \"LeaderNickname\"), Object), Convert(Property([g], \"LeaderSquadId\"), Object)})) =? select [g]}))'")]
         [InlineData(false)]
         //[InlineData(true)] issue #12449
         public virtual Task Client_method_on_collection_navigation_in_additional_from_clause(bool isAsync)
@@ -3499,7 +3499,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.g + e.v);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'join Gear g in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel.Gear]) on FavoriteWeapon(MaterializeCollectionNavigation(Navigation: Gear.Weapons (<Weapons>k__BackingField, ICollection<Weapon>) Collection ToDependent Weapon Inverse: Owner 4 -1 11 -1 -1, {from Weapon w in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel.Weapon]) where  ?= (Property([o], \"FullName\") == Property([w], \"OwnerFullName\")) =? select [w]})).Name equals FavoriteWeapon(MaterializeCollectionNavigation(Navigation: Gear.Weapons (<Weapons>k__BackingField, ICollection<Weapon>) Collection ToDependent Weapon Inverse: Owner 4 -1 11 -1 -1, {from Weapon w in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel.Weapon]) where  ?= (Property([g], \"FullName\") == Property([w], \"OwnerFullName\")) =? select [w]})).Name'")]
         [InlineData(false)]
         //[InlineData(true)] issue #12449
         public virtual Task Client_method_on_collection_navigation_in_outer_join_key(bool isAsync)
@@ -5558,7 +5558,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'GroupBy([g].Rank, new <>f__AnonymousType198`2(Rank = _Include(queryContext, [g], new [] {}, (queryContext, entity, included) => { ... }).Rank, g = [g]))'")]
         public virtual void Include_with_group_by_and_last()
         {
             using (var ctx = CreateContext())
@@ -5604,7 +5604,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'GroupBy(new <>f__AnonymousType199`2(Rank = [g].Rank, HasSoulPatch = [g].HasSoulPatch), _Include(queryContext, [g], new [] {}, (queryContext, entity, included) => { ... }))'")]
         public virtual void Include_with_group_by_with_composite_group_key()
         {
             using (var ctx = CreateContext())
@@ -5650,7 +5650,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'GroupBy([g].HasSoulPatch, _Include(queryContext, [g], new [] {}, (queryContext, entity, included) => { ... }))'")]
         public virtual void Include_with_group_by_order_by_take()
         {
             using (var ctx = CreateContext())
@@ -5668,7 +5668,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'GroupBy([g].HasSoulPatch, _Include(queryContext, [g], new [] {}, (queryContext, entity, included) => { ... }))'")]
         public virtual void Include_with_group_by_distinct()
         {
             using (var ctx = CreateContext())
@@ -5847,7 +5847,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) => CollectionAsserter<string>(elementSorter: ee => ee)(e.Collection, a.Collection));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Concat({value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel.Gear])})'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_with_concat(bool isAsync)
         {
@@ -6031,7 +6031,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.CityName + " " + e.GearNickname);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'join CogTag t in {from CogTag tt in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel.CogTag]) where (([tt].Note == \"Cole's Tag\") OrElse ([tt].Note == \"Dom's Tag\")) select [tt]} on [g] equals {from Gear subQuery in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel.Gear]) where  ?= (new AnonymousObject(new [] {Convert(Property([subQuery], \"Nickname\"), Object), Convert(Property([subQuery], \"SquadId\"), Object)}) == new AnonymousObject(new [] {Convert(Property([t], \"GearNickName\"), Object), Convert(Property([t], \"GearSquadId\"), Object)})) =? select [subQuery] => FirstOrDefault()}'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_on_entity_qsre_keys_inner_key_is_navigation_composite_key(bool isAsync)
         {
@@ -6092,7 +6092,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.SquadName + " " + e.WeaponName);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'join Gear ii in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel.Gear]) on {from Gear v in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel.Gear]) join CogTag v.Tag in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel.CogTag]) on new AnonymousObject(new [] {Convert(Property([v], \"Nickname\"), Object), Convert(Property([v], \"SquadId\"), Object)}) equals new AnonymousObject(new [] {Convert(Property([v.Tag], \"GearNickName\"), Object), Convert(Property([v.Tag], \"GearSquadId\"), Object)}) into IEnumerable`1 v.Tag_group from CogTag v.Tag in {[v.Tag_group] => DefaultIfEmpty()} where (EF.Property(?[v.Tag]?, \"Id\") == Property([i], \"Id\")) where  ?= (Property([o], \"Id\") == Property([v], \"SquadId\")) =? select [v] => FirstOrDefault()} equals [ii]'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_with_complex_key_selector(bool isAsync)
         {
@@ -6124,7 +6124,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.Id + " " + e.TagId);
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'GroupBy([s], _Include(queryContext, [s], new [] {}, (queryContext, entity, included) => { ... }))'")]
         public virtual void Include_with_group_by_on_entity_qsre()
         {
             using (var ctx = CreateContext())
@@ -6142,7 +6142,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'GroupBy([g], _Include(queryContext, [g], new [] {}, (queryContext, entity, included) => { ... }))'")]
         public virtual void Include_with_group_by_on_entity_qsre_with_composite_key()
         {
             using (var ctx = CreateContext())
@@ -6160,7 +6160,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'GroupBy([g.Squad], _Include(queryContext, [g], new [] {}, (queryContext, entity, included) => { ... }))'")]
         public virtual void Include_with_group_by_on_entity_navigation()
         {
             using (var ctx = CreateContext())
@@ -6178,7 +6178,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'GroupBy([l.Commander.DefeatedBy], _Include(queryContext, [<generated>_1], new [] {}, (queryContext, entity, included) => { ... }))'")]
         public virtual void Include_with_group_by_on_entity_navigation_with_inheritance()
         {
             using (var ctx = CreateContext())
@@ -6350,7 +6350,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'GroupBy(1, _Include(queryContext, [s], new [] {}, (queryContext, entity, included) => { ... }))'")]
         public virtual void Include_groupby_constant()
         {
             using (var ctx = CreateContext())
@@ -6450,7 +6450,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'orderby null desc'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collection_order_by_constant_null_of_non_mapped_type(bool isAsync)
         {
@@ -6470,7 +6470,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'GroupBy(new <>f__AnonymousType218`3(Rank = [o].Rank, One = 1, Nickname = [o].Nickname), _Include(queryContext, [o], new [] {}, (queryContext, entity, included) => { ... }))'")]
         public virtual void GroupBy_composite_key_with_Include()
         {
             using (var ctx = CreateContext())
@@ -6652,7 +6652,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 gs => gs.Select(g => (bool?)null));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'SingleOrDefault()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_subquery_distinct_singleordefault_boolean1(bool isAsync)
         {
@@ -6663,7 +6663,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'SingleOrDefault()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_subquery_distinct_singleordefault_boolean2(bool isAsync)
         {
@@ -6674,7 +6674,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'SingleOrDefault()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_subquery_distinct_singleordefault_boolean_with_pushdown(bool isAsync)
         {
@@ -6685,7 +6685,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'SingleOrDefault()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_subquery_distinct_singleordefault_boolean_empty1(bool isAsync)
         {
@@ -6695,7 +6695,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     g => g.Weapons.Where(w => w.Name == "BFG").Distinct().Select(w => w.IsAutomatic).SingleOrDefault()));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'SingleOrDefault()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_subquery_distinct_singleordefault_boolean_empty2(bool isAsync)
         {
@@ -6705,7 +6705,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     g => g.Weapons.Where(w => w.Name == "BFG").Select(w => w.IsAutomatic).Distinct().SingleOrDefault()));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'SingleOrDefault()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_subquery_distinct_singleordefault_boolean_empty_with_pushdown(bool isAsync)
         {
@@ -7014,7 +7014,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([g].Rank, _Include(queryContext, [g], new [] {[g.CityOfBirth]}, (queryContext, entity, included) => { ... }))'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Group_by_with_include_with_entity_in_result_selector(bool isAsync)
         {
@@ -7043,7 +7043,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([g].Rank, _Include(queryContext, [g], new [] {[g.CityOfBirth]}, (queryContext, entity, included) => { ... }))' could not be translated and will be evaluated locally.'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_with_group_by_and_FirstOrDefault_gets_properly_applied(bool isAsync)
         {
@@ -7132,7 +7132,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ws => ws.Where(w => ((int?)w.Id).GetValueOrDefault() == 0));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where (Convert([m].Timeline, Nullable`1).GetValueOrDefault() == __defaultValue_0)'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GetValueOrDefault_on_DateTimeOffset(bool isAsync)
         {

--- a/test/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
@@ -698,7 +698,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Min + " " + e.Max);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy(new NominalType() {CustomerID = [o].CustomerID, EmployeeID = [o].EmployeeID}, [o])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Dto_as_key_Select_Sum(bool isAsync)
         {
@@ -718,7 +718,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         }));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([o].CustomerID, new NominalType() {CustomerID = [o].CustomerID, EmployeeID = [o].EmployeeID})'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Dto_as_element_selector_Select_Sum(bool isAsync)
         {
@@ -1230,7 +1230,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Select(g => g.Sum(e => e.OrderID + 1)));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([o].CustomerID, [o].OrderID)' could not be translated and will be evaluated locally.'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_element_selector_complex_aggregate3(bool isAsync)
         {
@@ -1832,7 +1832,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Select(e => 1));
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'GroupBy([o].CustomerID, [o])'")]
         public virtual void GroupBy_Select_sum_over_unmapped_property()
         {
             using (var context = CreateContext())
@@ -1906,7 +1906,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                             }));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([o].CustomerID, [o])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Aggregate_Join(bool isAsync)
         {
@@ -1931,7 +1931,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 126);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'join Order o in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Order]) on [a].LastOrderID equals [o].OrderID'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_GroupBy_Aggregate_multijoins(bool isAsync)
         {
@@ -2010,7 +2010,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 63);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'join <>f__AnonymousType264`2 i in {from Customer c in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) join <>f__AnonymousType261`2 a in {from IGrouping`2 g in {value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Order]) => GroupBy([o].CustomerID, [o])} where ({[g] => Count()} > 5) select new <>f__AnonymousType261`2(CustomerID = [g].Key, LastOrderID = {from Order o in [g] select [o].OrderID => Max()})} on [c].CustomerID equals [a].CustomerID select new <>f__AnonymousType264`2(c = [c], LastOrderID = [a].LastOrderID)} on [o].CustomerID equals [i].c.CustomerID'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_GroupBy_Aggregate_in_subquery(bool isAsync)
         {
@@ -2128,7 +2128,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true);
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'GroupBy([o].OrderID, [o])'")]
         public virtual void Select_nested_collection_with_groupby()
         {
             using (var context = CreateContext())
@@ -2159,7 +2159,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'GroupBy([o].CustomerID, new ProjectedType() {Order = [o].OrderID, Customer = [o].CustomerID})'")]
         public virtual void Select_GroupBy_All()
         {
             using (var context = CreateContext())
@@ -2198,7 +2198,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             public override int GetHashCode() => Order.GetHashCode();
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy(new <>f__AnonymousType25`1(CustomerID = [o].CustomerID), [o])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Where_in_aggregate(bool isAsync)
         {
@@ -2263,7 +2263,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #region GroupByWithoutAggregate
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([c].City, new <>f__AnonymousType270`2(City = [c].City, CustomerID = [c].CustomerID))'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_anonymous(bool isAsync)
         {
@@ -2279,7 +2279,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: GroupingAsserter<string, dynamic>(d => d.CustomerID));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([c].City, new <>f__AnonymousType270`2(City = [c].City, CustomerID = [c].CustomerID))'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_anonymous_with_where(bool isAsync)
         {
@@ -2315,7 +2315,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([c].Country, new <>f__AnonymousType271`2(Country = [c].Country, CustomerID = [c].CustomerID))'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_nested_order_by_enumerable(bool isAsync)
         {
@@ -2334,7 +2334,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'DefaultIfEmpty()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_join_default_if_empty_anonymous(bool isAsync)
         {
@@ -2357,7 +2357,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: GroupingAsserter<dynamic, dynamic>(d => d.ProductID));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([c].City, [c])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_SelectMany(bool isAsync)
         {
@@ -2367,7 +2367,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 91);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([o].CustomerID, [o])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_simple(bool isAsync)
         {
@@ -2379,7 +2379,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 830);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([o].CustomerID, [o])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_simple2(bool isAsync)
         {
@@ -2391,7 +2391,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 830);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([o].CustomerID, [o])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_first(bool isAsync)
         {
@@ -2402,7 +2402,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 6);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([o].CustomerID, [o].OrderID)'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_with_element_selector(bool isAsync)
         {
@@ -2415,7 +2415,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: CollectionAsserter<int>());
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([o].CustomerID, [o])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_with_element_selector2(bool isAsync)
         {
@@ -2428,7 +2428,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: CollectionAsserter<Order>());
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([e].EmployeeID, [e])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_with_element_selector3(bool isAsync)
         {
@@ -2446,7 +2446,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy(Convert([o].OrderDate, DateTime).Month, [o])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_DateTimeOffset_Property(bool isAsync)
         {
@@ -2458,7 +2458,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 830);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([o].CustomerID, [o])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task OrderBy_GroupBy_SelectMany(bool isAsync)
         {
@@ -2471,7 +2471,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 830);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([e].EmployeeID, [e])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task OrderBy_GroupBy_SelectMany_shadow(bool isAsync)
         {
@@ -2484,7 +2484,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         .Select(g => EF.Property<string>(g, "Title")));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([o].CustomerID, [o])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_with_orderby(bool isAsync)
         {
@@ -2496,7 +2496,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 830);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([o].CustomerID, [o])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_with_orderby_and_anonymous_projection(bool isAsync)
         {
@@ -2519,7 +2519,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 830);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([o].CustomerID, [o])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_with_orderby_take_skip_distinct(bool isAsync)
         {
@@ -2557,7 +2557,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 31);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'from OrderDetail orderDetail in [orderJoin]'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_join_anonymous(bool isAsync)
         {
@@ -2580,7 +2580,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: GroupingAsserter<dynamic, dynamic>(d => d.ProductID));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([o].CustomerID, [o])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Distinct(bool isAsync)
         {
@@ -2591,7 +2591,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     os.GroupBy(o => o.CustomerID).Distinct().Select(g => g.Key));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([o].CustomerID, [o])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task OrderBy_Skip_GroupBy(bool isAsync)
         {
@@ -2603,7 +2603,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 30);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([o].CustomerID, [o])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task OrderBy_Take_GroupBy(bool isAsync)
         {
@@ -2615,7 +2615,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 50);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([o].CustomerID, [o])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task OrderBy_Skip_Take_GroupBy(bool isAsync)
         {
@@ -2627,7 +2627,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 50);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([o].CustomerID, new <>f__AnonymousType236`2(CustomerID = [o].CustomerID, EmployeeID = [o].EmployeeID))'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_Distinct_GroupBy(bool isAsync)
         {
@@ -2643,7 +2643,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: GroupingAsserter<string, dynamic>(d => d.EmployeeID));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([c].EmployeeID, [c])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_with_aggregate_through_navigation_property(bool isAsync)
         {
@@ -2657,7 +2657,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.max);
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'GroupBy(new <>f__AnonymousType19`2(CustomerID = [o].CustomerID, OrderDate = [o].OrderDate), [o])'")]
         public virtual void GroupBy_anonymous_key_without_aggregate()
         {
             using (var context = CreateContext())
@@ -2707,7 +2707,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #region GroupBySelectFirst
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy(Property([e], \"Title\"), [e])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Shadow(bool isAsync)
         {
@@ -2721,7 +2721,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         .Select(g => EF.Property<string>(g.First(), "Title")));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy(Property([e], \"Title\"), [e])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Shadow2(bool isAsync)
         {
@@ -2735,7 +2735,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         .Select(g => g.First()));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([e].EmployeeID, [e])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Shadow3(bool isAsync)
         {
@@ -2747,7 +2747,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         .Select(g => EF.Property<string>(g.First(), "Title")));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([c].City, [c])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Select_First_GroupBy(bool isAsync)
         {
@@ -2781,7 +2781,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #region GroupByEntityType
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'GroupBy([o].CustomerID, new ProjectedType() {Order = [o].OrderID, Customer = [o].CustomerID})'")]
         public virtual void Select_GroupBy()
         {
             using (var context = CreateContext())
@@ -2809,7 +2809,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'GroupBy([o].OrderID, new ProjectedType() {Order = [o].OrderID, Customer = [o].CustomerID})'")]
         public virtual void Select_GroupBy_SelectMany()
         {
             using (var context = CreateContext())
@@ -2840,7 +2840,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'GroupBy([c], [o])'")]
         public virtual void Join_GroupBy_entity_ToList()
         {
             using (var context = CreateContext())
@@ -2883,7 +2883,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #region DoubleGroupBy
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'GroupBy(new <>f__AnonymousType22`2(OrderID = [o].OrderID, OrderDate = [o].OrderDate), [o])'")]
         public virtual void Double_GroupBy_with_aggregate()
         {
             using (var context = CreateContext())
@@ -2944,7 +2944,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 os => os.GroupBy(o => o.CustomerID).Select(g => g.Sum(gg => gg.OrderID)).CountAsync());
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy(new <>f__AnonymousType25`1(CustomerID = [o].CustomerID), [o])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task LongCount_after_client_GroupBy(bool isAsync)
         {

--- a/test/EFCore.Specification.Tests/Query/IncludeAsyncTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/IncludeAsyncTestBase.cs
@@ -296,7 +296,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'Distinct()'")]
         public virtual async Task Include_collection_on_group_join_clause_with_filter()
         {
             using (var context = CreateContext())
@@ -343,7 +343,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'GroupBy([c].City, Result(_IncludeAsync(queryContext, [c], new [] {}, (queryContext, entity, included, ct) => { ... }, ct))))'")]
         public virtual async Task Include_collection_when_groupby()
         {
             using (var context = CreateContext())
@@ -708,7 +708,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'where [c].IsLondon'")]
         public virtual async Task Include_collection_with_client_filter()
         {
             using (var context = CreateContext())

--- a/test/EFCore.Specification.Tests/Query/IncludeTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/IncludeTestBase.cs
@@ -980,7 +980,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Distinct()'")]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Include_collection_on_group_join_clause_with_filter(bool useString)
@@ -1025,7 +1025,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'join Customer o.Customer in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) on Property([o], \"CustomerID\") equals Property([o.Customer], \"CustomerID\")'")]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Include_collection_on_inner_group_join_clause_with_filter(bool useString)
@@ -1073,7 +1073,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([c].City, _Include(queryContext, [c], new [] {}, (queryContext, entity, included) => { ... }))'")]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Include_collection_when_groupby(bool useString)
@@ -1107,7 +1107,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([c].City, _Include(queryContext, [c], new [] {}, (queryContext, entity, included) => { ... }))'")]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Include_collection_when_groupby_subquery(bool useString)
@@ -1988,7 +1988,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where [c].IsLondon'")]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Include_collection_with_client_filter(bool useString)
@@ -3273,7 +3273,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([o].OrderID, _Include(queryContext, [o], new [] {}, (queryContext, entity, included) => { ... }))'")]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Include_collection_GroupBy_Select(bool useString)
@@ -3308,7 +3308,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([o].OrderID, _Include(queryContext, [o], new [] {[o.Customer]}, (queryContext, entity, included) => { ... }))'")]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Include_reference_GroupBy_Select(bool useString)
@@ -3343,7 +3343,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([o].OrderID, _Include(queryContext, [o], new [] {}, (queryContext, entity, included) => { ... }))'")]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Include_collection_Join_GroupBy_Select(bool useString)
@@ -3388,7 +3388,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([o].OrderID, _Include(queryContext, [o], new [] {[o.Customer]}, (queryContext, entity, included) => { ... }))'")]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Include_reference_Join_GroupBy_Select(bool useString)
@@ -3433,7 +3433,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([o].OrderID, _Include(queryContext, [o], new [] {}, (queryContext, entity, included) => { ... }))'")]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Join_Include_collection_GroupBy_Select(bool useString)
@@ -3476,7 +3476,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([o].OrderID, _Include(queryContext, [o], new [] {[o.Customer]}, (queryContext, entity, included) => { ... }))'")]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Join_Include_reference_GroupBy_Select(bool useString)
@@ -3517,7 +3517,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Distinct()'")]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Include_collection_GroupJoin_GroupBy_Select(bool useString)
@@ -3562,7 +3562,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([o].OrderID, _Include(queryContext, [o], new [] {[o.Customer]}, (queryContext, entity, included) => { ... }))'")]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Include_reference_GroupJoin_GroupBy_Select(bool useString)
@@ -3607,7 +3607,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'orderby [o1].OrderID asc'")]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void GroupJoin_Include_collection_GroupBy_Select(bool useString)
@@ -3650,7 +3650,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'orderby [o1].OrderID asc'")]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void GroupJoin_Include_reference_GroupBy_Select(bool useString)
@@ -3693,7 +3693,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([o].OrderID, _Include(queryContext, [o], new [] {}, (queryContext, entity, included) => { ... }))'")]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Include_collection_SelectMany_GroupBy_Select(bool useString)
@@ -3728,7 +3728,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([o].OrderID, _Include(queryContext, [o], new [] {[o.Customer]}, (queryContext, entity, included) => { ... }))'")]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Include_reference_SelectMany_GroupBy_Select(bool useString)
@@ -3763,7 +3763,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([o].OrderID, _Include(queryContext, [o], new [] {}, (queryContext, entity, included) => { ... }))'")]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void SelectMany_Include_collection_GroupBy_Select(bool useString)
@@ -3798,7 +3798,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([o].OrderID, _Include(queryContext, [o], new [] {[o.Customer]}, (queryContext, entity, included) => { ... }))'")]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void SelectMany_Include_reference_GroupBy_Select(bool useString)
@@ -4148,7 +4148,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy(new <>f__AnonymousType22`2(OrderID = [e].OrderID, OrderDate = [e].OrderDate), [e])'")]
         [InlineData(false, false)]
         [InlineData(true, false)]
         // async blocked by issue #11917
@@ -4175,7 +4175,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy(new <>f__AnonymousType22`2(OrderID = [e].OrderID, OrderDate = [e].OrderDate), [e])'")]
         [InlineData(false, false)]
         [InlineData(true, false)]
         // async blocked by issue #11917

--- a/test/EFCore.Specification.Tests/Query/InheritanceTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/InheritanceTestBase.cs
@@ -477,7 +477,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'Concat({value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Inheritance.Eagle])})'")]
         public virtual void Can_concat_kiwis_and_eagles_as_birds()
         {
             using (var context = CreateContext())
@@ -492,7 +492,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'Except({value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Inheritance.Eagle])})'")]
         public virtual void Can_except_kiwis_and_eagles_as_birds()
         {
             using (var context = CreateContext())
@@ -507,7 +507,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'Intersect({value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Inheritance.Eagle])})'")]
         public virtual void Can_intersect_kiwis_and_eagles_as_birds()
         {
             using (var context = CreateContext())
@@ -522,7 +522,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'Union({value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Inheritance.Eagle])})'")]
         public virtual void Can_union_kiwis_and_eagles_as_birds()
         {
             using (var context = CreateContext())

--- a/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         protected TFixture Fixture { get; }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'where ([a.LeafAAddress] == [b.LeafBAddress])'")]
         public virtual void Query_with_owned_entity_equality_operator()
         {
             using (var context = CreateContext())
@@ -125,7 +125,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'GroupBy([op].Id, _Include(queryContext, [op], new [] {[op.PersonAddress], [op.PersonAddress.Country], [op.BranchAddress], [op.BranchAddress.Country], [op.LeafAAddress], [op.LeafAAddress.Country], [op.LeafBAddress], [op.LeafBAddress.Country]}, (queryContext, entity, included) => { ... }))'")]
         public virtual void Query_when_group_by()
         {
             using (var context = CreateContext())

--- a/test/EFCore.Specification.Tests/Query/QueryNavigationsTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/QueryNavigationsTestBase.cs
@@ -40,7 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'oin Order o in {from Order o in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Order]) join Customer o.Customer in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) on Property([o], \"CustomerID\") equals Property([o.Customer], \"CustomerID\") into IEnumerable`1 o.Customer_group from Customer o.Customer in {[o.Customer_group] => DefaultIfEmpty()} select ClientProjection([o], [o.Customer])} on [c].CustomerID equals [o]?.CustomerID'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_with_nav_projected_in_subquery_when_client_eval(bool isAsync)
         {
@@ -53,7 +53,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 89);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'join Order o in {from Order o in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Order]) join Customer o.Customer in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) on Property([o], \"CustomerID\") equals Property([o.Customer], \"CustomerID\") into IEnumerable`1 o.Customer_group from Customer o.Customer in {[o.Customer_group] => DefaultIfEmpty()} select ClientProjection([o], [o.Customer])} on [c].CustomerID equals [o]?.CustomerID'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_with_nav_projected_in_subquery_when_client_eval(bool isAsync)
         {
@@ -70,7 +70,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 89);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ClientPredicate([o], [o.Customer])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_with_nav_in_predicate_in_subquery_when_client_eval(bool isAsync)
         {
@@ -83,7 +83,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 89);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ClientPredicate([o], [o.Customer])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_with_nav_in_predicate_in_subquery_when_client_eval(bool isAsync)
         {
@@ -98,7 +98,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 89);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'orderby ClientOrderBy([o], [o.Customer]) asc'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_with_nav_in_orderby_in_subquery_when_client_eval(bool isAsync)
         {
@@ -111,7 +111,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 89);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'orderby ClientOrderBy([o], [o.Customer]) asc'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_with_nav_in_orderby_in_subquery_when_client_eval(bool isAsync)
         {
@@ -205,7 +205,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.CustomerID + " " + e.C2);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where (?[o.Customer] | (?[o.Customer] | ([o.Customer]?.IsLondon == True)? == True)? == True)'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_Where_Navigation_Client(bool isAsync)
         {
@@ -691,7 +691,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.All);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'All(([o].ShipCity == \"London\"))'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Collection_select_nav_prop_all_client(bool isAsync)
         {
@@ -727,7 +727,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 3);
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'where {from Order o in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Order]) where  ?= (Property([c], \"CustomerID\") == Property([o], \"CustomerID\")) =? select [o] => All(([o].ShipCity == \"London\"))}'")]
         public virtual void Collection_where_nav_prop_all_client()
         {
             using (var context = CreateContext())
@@ -973,7 +973,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Select(c => os.FirstOrDefault(o => o.CustomerID == "ALFKI").Customer.City));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'SingleOrDefault()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Collection_select_nav_prop_single_or_default_then_nav_prop_nested(bool isAsync)
         {
@@ -1090,7 +1090,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 1);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'orderby ClientMethod([o].OrderID) desc'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_subquery_on_navigation_client_eval(bool isAsync)
         {
@@ -1146,7 +1146,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([o.Customer]?.City, [o])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_on_nav_prop(bool isAsync)
         {
@@ -1161,7 +1161,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 830);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval ''")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_nav_prop_group_by(bool isAsync)
         {
@@ -1181,7 +1181,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 12);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([od.Order].CustomerID, [od])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Let_group_by_nav_prop(bool isAsync)
         {
@@ -1346,7 +1346,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 31);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Count()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Client_groupjoin_with_orderby_key_descending(bool isAsync)
         {
@@ -1486,7 +1486,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Count()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Group_join_doesnt_get_bound_directly_to_group_join_qsre(bool isAsync)
         {

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Functions.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Functions.cs
@@ -256,7 +256,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 91);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where (Compare([c].CustomerID, \"ALFKI\") == 42)'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual async Task String_Compare_simple_client(bool isAsync)
         {
@@ -431,7 +431,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 91);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ([c].CustomerID.CompareTo(\"ALFKI\") == 42)'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual async Task String_Compare_to_simple_client(bool isAsync)
         {
@@ -960,7 +960,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 13);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where (Max([od].OrderID, [od].ProductID) == [od].OrderID)'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_math_max(bool isAsync)
         {
@@ -970,7 +970,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 25);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where (Min([od].OrderID, [od].ProductID) == [od].ProductID)'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_math_min(bool isAsync)
         {
@@ -1336,7 +1336,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 17);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ([c].ContactTitle.TrimStart(O) == \"wner\")'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task TrimStart_with_char_argument_in_predicate(bool isAsync)
         {
@@ -1346,7 +1346,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 17);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ([c].ContactTitle.TrimStart(value(System.Char[])) == \"ner\")'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task TrimStart_with_char_array_argument_in_predicate(bool isAsync)
         {
@@ -1366,7 +1366,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 17);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ([c].ContactTitle.TrimEnd(r) == \"Owne\")''")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task TrimEnd_with_char_argument_in_predicate(bool isAsync)
         {
@@ -1376,7 +1376,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 17);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ([c].ContactTitle.TrimEnd(value(System.Char[])) == \"Own\")'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task TrimEnd_with_char_array_argument_in_predicate(bool isAsync)
         {
@@ -1396,7 +1396,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 17);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ([c].ContactTitle.Trim(O) == \"wner\")'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Trim_with_char_argument_in_predicate(bool isAsync)
         {
@@ -1406,7 +1406,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 17);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ([c].ContactTitle.Trim(value(System.Char[])) == \"wne\")'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Trim_with_char_array_argument_in_predicate(bool isAsync)
         {

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.JoinGroupJoin.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.JoinGroupJoin.cs
@@ -68,7 +68,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 928);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'join Employee e2 in {from Employee e in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Employee]) orderby [e].EmployeeID asc select [e] => Take(__p_0)} on [e1].EmployeeID equals GetEmployeeID([e2])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Client_Join_select_many(bool isAsync)
         {
@@ -150,7 +150,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.OrderID);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'join <>f__AnonymousType371`1 o1 in {from Order o2 in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Order]) orderby [o2].OrderID asc select new <>f__AnonymousType371`1(o2 = [o2])} on [c].CustomerID equals [o1].o2.CustomerID'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_customers_orders_with_subquery_anonymous_property_method(bool isAsync)
         {
@@ -175,7 +175,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.o1.o2.OrderID);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'join <>f__AnonymousType371`1 o1 in {from Order o2 in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Order]) orderby [o2].OrderID asc select new <>f__AnonymousType371`1(o2 = [o2]) => Take(__p_0)} on [c].CustomerID equals [o1].o2.CustomerID'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_customers_orders_with_subquery_anonymous_property_method_with_take(bool isAsync)
         {
@@ -277,7 +277,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select c.CustomerID);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'join Order o in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Order]) on new Foo() {Bar = [c].CustomerID} equals new Foo() {Bar = [o].CustomerID}'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_client_new_expression(bool isAsync)
         {
@@ -300,7 +300,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.c.CustomerID);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'join UInt32 id in __p_0 on [e].EmployeeID equals [id]'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual async Task Join_local_collection_int_closure_is_cached_correctly(bool isAsync)
         {
@@ -323,7 +323,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select e.EmployeeID);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'join Char id in __p_0 on [e].EmployeeID equals Convert([id], UInt32)'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual async Task Join_local_string_closure_is_cached_correctly(bool isAsync)
         {
@@ -346,7 +346,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select e.EmployeeID);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'join Byte id in __p_0 on [e].EmployeeID equals Convert([id], UInt32)'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual async Task Join_local_bytes_closure_is_cached_correctly(bool isAsync)
         {
@@ -425,7 +425,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 91);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Count()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_customers_orders_count(bool isAsync)
         {
@@ -443,7 +443,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 91);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Count()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_customers_orders_count_preserves_ordering(bool isAsync)
         {
@@ -935,7 +935,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select o != null ? (object)o.OrderID : null);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'FirstOrDefault()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_with_different_outer_elements_with_same_key(bool isAsync)
         {
@@ -954,7 +954,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.OrderID + " " + e.Name);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'FirstOrDefault()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_with_different_outer_elements_with_same_key_with_predicate(bool isAsync)
         {
@@ -973,7 +973,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.OrderID + " " + e.Name);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'FirstOrDefault()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_with_different_outer_elements_with_same_key_projected_from_another_entity(bool isAsync)
         {
@@ -1010,7 +1010,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.ContactName + " " + e.OrderID);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ([x].OrderID > 5)'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_SelectMany_subquery_with_filter_orderby(bool isAsync)
         {
@@ -1047,7 +1047,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 830);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ([x].OrderID > 5)'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_SelectMany_subquery_with_filter_orderby_and_DefaultIfEmpty(bool isAsync)
         {
@@ -1066,7 +1066,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 830);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Count()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_with_order_by_key_descending1(bool isAsync)
         {
@@ -1081,7 +1081,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Count()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_with_order_by_key_descending2(bool isAsync)
         {

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 {
     public abstract partial class SimpleQueryTestBase<TFixture>
     {
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Union({from Customer c in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) where [c].CompanyName.StartsWith(\"B\") select [c]})'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Union_with_custom_projection(bool isAsync)
         {
@@ -99,7 +99,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             public override int GetHashCode() => Order.GetHashCode();
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'GroupBy([o].CustomerID, [o])'")]
         public virtual void GroupBy_tracking_after_dispose()
         {
             List<IGrouping<string, Order>> groups;
@@ -200,7 +200,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 selector: p => p.UnitPrice ?? 0);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Sum()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Sum_over_subquery_is_client_eval(bool isAsync)
         {
@@ -210,7 +210,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 selector: c => c.Orders.Sum(o => o.OrderID));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Sum()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Sum_over_nested_subquery_is_client_eval(bool isAsync)
         {
@@ -220,7 +220,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 selector: c => c.Orders.Sum(o => 5 + o.OrderDetails.Sum(od => od.ProductID)));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Min()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Sum_over_min_subquery_is_client_eval(bool isAsync)
         {
@@ -326,7 +326,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 asserter: (e, a) => Assert.InRange((decimal)e - (decimal)a, -0.1m, 0.1m));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Average()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Average_over_subquery_is_client_eval(bool isAsync)
         {
@@ -336,7 +336,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 selector: c => c.Orders.Sum(o => o.OrderID));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Average()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Average_over_nested_subquery_is_client_eval(bool isAsync)
         {
@@ -346,7 +346,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 selector: c => (decimal)c.Orders.Average(o => 5 + o.OrderDetails.Average(od => od.ProductID)));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Max()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Average_over_max_subquery_is_client_eval(bool isAsync)
         {
@@ -366,7 +366,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 selector: od => od.Discount);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Average()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Average_on_float_column_in_subquery(bool isAsync)
         {
@@ -486,7 +486,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 selector: p => p.UnitPrice ?? 0);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Min()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Min_over_subquery_is_client_eval(bool isAsync)
         {
@@ -496,7 +496,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 selector: c => c.Orders.Sum(o => o.OrderID));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Min()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Min_over_nested_subquery_is_client_eval(bool isAsync)
         {
@@ -506,7 +506,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 selector: c => c.Orders.Min(o => 5 + o.OrderDetails.Min(od => od.ProductID)));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Max()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Min_over_max_subquery_is_client_eval(bool isAsync)
         {
@@ -545,7 +545,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 selector: p => p.UnitPrice ?? 0);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Max()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Max_over_subquery_is_client_eval(bool isAsync)
         {
@@ -555,7 +555,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 selector: c => c.Orders.Sum(o => o.OrderID));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Max()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Max_over_nested_subquery_is_client_eval(bool isAsync)
         {
@@ -565,7 +565,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 selector: c => c.Orders.Max(o => 5 + o.OrderDetails.Max(od => od.ProductID)));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Max()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Max_over_sum_subquery_is_client_eval(bool isAsync)
         {
@@ -641,7 +641,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 predicate: o => o.CustomerID != "ALFKI");
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ClientEvalPredicate([o])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_OrderBy_Count_client_eval(bool isAsync)
         {
@@ -659,7 +659,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 os => os.Where(o => o.OrderID > 10).OrderBy(o => ClientEvalPredicate(o)));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ClientEvalPredicate([o])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task OrderBy_Where_Count_client_eval(bool isAsync)
         {
@@ -668,7 +668,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 os => os.OrderBy(o => ClientEvalSelectorStateless()).Where(o => ClientEvalPredicate(o)));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ClientEvalPredicate([o])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task OrderBy_Where_Count_client_eval_mixed(bool isAsync)
         {
@@ -677,7 +677,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 os => os.OrderBy(o => o.OrderID).Where(o => ClientEvalPredicate(o)));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ClientEvalPredicate([o])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task OrderBy_Count_with_predicate_client_eval(bool isAsync)
         {
@@ -687,7 +687,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 predicate: o => ClientEvalPredicate(o));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ClientEvalPredicate([o])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task OrderBy_Count_with_predicate_client_eval_mixed(bool isAsync)
         {
@@ -697,7 +697,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 predicate: o => ClientEvalPredicate(o));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ClientEvalPredicate([o])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task OrderBy_Where_Count_with_predicate_client_eval(bool isAsync)
         {
@@ -707,7 +707,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 predicate: o => ClientEvalPredicate(o));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ClientEvalPredicate([o])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task OrderBy_Where_Count_with_predicate_client_eval_mixed(bool isAsync)
         {
@@ -954,7 +954,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 1);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'First()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task First_inside_subquery_gets_client_evaluated(bool isAsync)
         {
@@ -974,7 +974,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 1);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Last()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Last_when_no_order_by(bool isAsync)
         {
@@ -1339,7 +1339,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 asyncQuery: cs => cs.Select(c => c.CustomerID).ContainsAsync("ALFKI"));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where {__ids_0 => Contains(new Tuple`2(Item1 = [o].OrderID, Item2 = [o].ProductID))}'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual async Task Contains_with_local_tuple_array_closure(bool isAsync)
         {
@@ -1356,7 +1356,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 od => od.Where(o => ids.Contains(new Tuple<int, int>(o.OrderID, o.ProductID))));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where {__ids_0 => Contains(new <>f__AnonymousType0`2(Id1 = [o].OrderID, Id2 = [o].ProductID))}'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual async Task Contains_with_local_anonymous_type_array_closure(bool isAsync)
         {
@@ -1436,7 +1436,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'Concat({value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer])})'")]
         public virtual void Concat_dbset()
         {
             using (var context = CreateContext())
@@ -1450,7 +1450,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'Concat({from Customer s in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) where ([s].ContactTitle == \"Owner\") select [s]})'")]
         public virtual void Concat_simple()
         {
             using (var context = CreateContext())
@@ -1466,7 +1466,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Concat({from Customer s in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) where ([s].City == \"Berlin\") select [s]})'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Concat_nested(bool isAsync)
         {
@@ -1478,7 +1478,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 12);
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'Concat({from Customer s in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) where ([s].ContactTitle == \"Owner\") select [s].CustomerID})'")]
         public virtual void Concat_non_entity()
         {
             using (var context = CreateContext())
@@ -1496,7 +1496,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Except({value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer])})'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Except_dbset(bool isAsync)
         {
@@ -1505,7 +1505,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 cs => cs.Where(s => s.ContactTitle == "Owner").Except(cs));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Except({from Customer c in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) where ([c].City == \"México D.F.\") select [c]})'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Except_simple(bool isAsync)
         {
@@ -1526,7 +1526,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 cs => cs.Except(cs).Select(e => 1));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Except({from Customer s in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) where ([s].City == \"México D.F.\") select [s]})'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Except_nested(bool isAsync)
         {
@@ -1538,7 +1538,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 13);
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'Except({from Customer c in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) where ([c].City == \"México D.F.\") select [c].CustomerID})'")]
         public virtual void Except_non_entity()
         {
             using (var context = CreateContext())
@@ -1556,7 +1556,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Intersect({value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer])})'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Intersect_dbset(bool isAsync)
         {
@@ -1566,7 +1566,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 5);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Intersect({from Customer s in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) where ([s].ContactTitle == \"Owner\") select [s]})'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Intersect_simple(bool isAsync)
         {
@@ -1577,7 +1577,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 3);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Intersect({from Customer s in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) where ([s].ContactTitle == \"Owner\") select [s]})'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Intersect_nested(bool isAsync)
         {
@@ -1589,7 +1589,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 1);
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'Intersect({from Customer s in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) where ([s].ContactTitle == \"Owner\") select [s].CustomerID})'")]
         public virtual void Intersect_non_entity()
         {
             using (var context = CreateContext())
@@ -1607,7 +1607,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Union({value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer])})'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Union_dbset(bool isAsync)
         {
@@ -1617,7 +1617,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 91);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Union({from Customer c in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) where ([c].City == \"México D.F.\") select [c]})'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Union_simple(bool isAsync)
         {
@@ -1628,7 +1628,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 19);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Union({from Customer s in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) where ([s].City == \"México D.F.\") select [s]})'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Union_nested(bool isAsync)
         {
@@ -1640,7 +1640,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 25);
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'Union({from Customer c in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) where ([c].City == \"México D.F.\") select [c].CustomerID})'")]
         public virtual void Union_non_entity()
         {
             using (var context = CreateContext())
@@ -1726,7 +1726,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'Contains(__p_0)'")]
         public virtual void Contains_over_entityType_should_materialize_when_composite()
         {
             using (var context = CreateContext())
@@ -1739,7 +1739,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'FirstOrDefault()'")]
         public virtual void Paging_operation_on_string_doesnt_issue_warning()
         {
             using (var context = CreateContext())
@@ -1749,7 +1749,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'Sum()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Project_constant_Sum(bool isAsync)
         {

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
@@ -129,7 +129,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.f);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'orderby Convert(__p_0.f, Nullable`1) asc'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual async Task Select_bool_closure_with_order_by_property_with_cast_to_nullable(bool isAsync)
         {
@@ -858,7 +858,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     c => c.Orders.OrderBy(o => o.OrderID).Select(o => o.CustomerID).Distinct().FirstOrDefault()).Select(e => e.Length));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'SingleOrDefault()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Project_single_element_from_collection_with_OrderBy_Take_and_SingleOrDefault(bool isAsync)
         {

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
@@ -559,7 +559,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 cs => cs.Where(c => c.CustomerID == "ALFKI" & c.CustomerID == "ANATR"));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where (([c].CustomerID == \"ALFKI\") ^ True)'")]
         [InlineData(false)]
         public virtual Task Where_bitwise_xor(bool isAsync)
         {
@@ -632,7 +632,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 1);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where [c].IsLondon'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_client(bool isAsync)
         {
@@ -652,7 +652,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 91);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where {from Customer c2 in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) where (([c1].CustomerID == [c2].CustomerID) AndAlso [c2].IsLondon) select [c2] => Any()}''")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_subquery_correlated_client_eval(bool isAsync)
         {
@@ -662,7 +662,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 1);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where [c].IsLondon'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_client_and_server_top_level(bool isAsync)
         {
@@ -672,7 +672,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 5);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ([c].IsLondon OrElse ([c].CustomerID == \"ALFKI\"))'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_client_or_server_top_level(bool isAsync)
         {
@@ -682,7 +682,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 7);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where (([c].CustomerID != \"ALFKI\") == ([c].IsLondon AndAlso ([c].CustomerID != \"AROUT\")))'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_client_and_server_non_top_level(bool isAsync)
         {
@@ -692,7 +692,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 6);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where (([c].CustomerID == \"MAUMAR\") OrElse (([c].CustomerID != \"AROUT\") AndAlso [c].IsLondon))'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_client_deep_inside_predicate_and_server_top_level(bool isAsync)
         {
@@ -1299,7 +1299,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ps => ps.Where(p => !p.Discontinued), entryCount: 69);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where Not(ClientFunc([p].ProductID))'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_bool_client_side_negated(bool isAsync)
         {
@@ -1719,7 +1719,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         //         AssertQuery<Customer>(cs => cs.Select(c => c != alfki)));
         // }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where (new <>f__AnonymousType409`1(x = [c].City) == { x = London })'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_compare_constructed_equal(bool isAsync)
         {
@@ -1735,7 +1735,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     }));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where (new <>f__AnonymousType410`2(x = [c].City, y = [c].Country) == { x = London, y = UK })'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_compare_constructed_multi_value_equal(bool isAsync)
         {
@@ -1753,7 +1753,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     }));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where (new <>f__AnonymousType410`2(x = [c].City, y = [c].Country) != { x = London, y = UK })'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_compare_constructed_multi_value_not_equal(bool isAsync)
         {
@@ -1772,7 +1772,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 91);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where (new Tuple`1(Item1 = [c].City) == (London))'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_compare_tuple_constructed_equal(bool isAsync)
         {
@@ -1781,7 +1781,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 cs => cs.Where(c => new Tuple<string>(c.City) == new Tuple<string>("London")));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where (new Tuple`2(Item1 = [c].City, Item2 = [c].Country) == (London, UK))'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_compare_tuple_constructed_multi_value_equal(bool isAsync)
         {
@@ -1790,7 +1790,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 cs => cs.Where(c => new Tuple<string, string>(c.City, c.Country) == new Tuple<string, string>("London", "UK")));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where (new Tuple`2(Item1 = [c].City, Item2 = [c].Country) != (London, UK))'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_compare_tuple_constructed_multi_value_not_equal(bool isAsync)
         {
@@ -1800,7 +1800,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 91);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where (Create([c].City) == (London))'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_compare_tuple_create_constructed_equal(bool isAsync)
         {
@@ -1809,7 +1809,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 cs => cs.Where(c => Tuple.Create(c.City) == Tuple.Create("London")));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where (Create([c].City, [c].Country) == (London, UK))'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_compare_tuple_create_constructed_multi_value_equal(bool isAsync)
         {
@@ -1818,7 +1818,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 cs => cs.Where(c => Tuple.Create(c.City, c.Country) == Tuple.Create("London", "UK")));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where (Create([c].City, [c].Country) != (London, UK))'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_compare_tuple_create_constructed_multi_value_not_equal(bool isAsync)
         {
@@ -1867,7 +1867,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Where(o => o.OrderDate > new DateTime(1998, 1, 1)), entryCount: 8);
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'Contains(Property([od], \"OrderID\"))'")]
         public virtual void Where_navigation_contains()
         {
             using (var context = CreateContext())

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -183,7 +183,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'join String _c1 in {from Customer c1 in {from Customer c in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) orderby [c].CustomerID asc select [c] => Take(__p_0)} from Customer c2 in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) select Property([c1], \"CustomerID\") => Distinct()} on Property([c1_Orders], \"CustomerID\") equals [_c1]'")]
         public virtual void Lifting_when_subquery_nested_order_by_simple()
         {
             using (var context = CreateContext())
@@ -207,7 +207,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'orderby [_c1].CustomerID asc'")]
         public virtual void Lifting_when_subquery_nested_order_by_anonymous()
         {
             using (var context = CreateContext())
@@ -537,7 +537,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     }).Take(91).Select(a => a.c));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where [c].IsLondon'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Queryable_reprojection(bool isAsync)
         {
@@ -1094,7 +1094,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 asyncQuery: cs => cs.AllAsync(c1 => cs.Any(c2 => cs.Any(c3 => EF.Property<string>(c1, "CustomerID") == c3.CustomerID))));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'All([c].IsLondon)'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task All_client(bool isAsync)
         {
@@ -1104,7 +1104,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 predicate: c => c.IsLondon);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'All((([c].CustomerID != \"Foo\") AndAlso [c].IsLondon))'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task All_client_and_server_top_level(bool isAsync)
         {
@@ -1114,7 +1114,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 predicate: c => c.CustomerID != "Foo" && c.IsLondon);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'All((([c].CustomerID != \"Foo\") OrElse [c].IsLondon))'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task All_client_or_server_top_level(bool isAsync)
         {
@@ -1167,7 +1167,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 15);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'from <>f__AnonymousType327`2 e in {from Employee e in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Employee]) orderby [e].EmployeeID asc select new <>f__AnonymousType327`2(e2 = [e], Square = ([e].EmployeeID ^ 2)) => Take(2)}'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Projection_when_arithmetic_mixed_subqueries(bool isAsync)
         {
@@ -1239,7 +1239,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 cs => from c in cs.Cast<object>() select c, entryCount: 91);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where [c].IsLondon'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task First_client_predicate(bool isAsync)
         {
@@ -1450,7 +1450,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 5);
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'Distinct()'")]
         public virtual void Select_DTO_distinct_translated_to_server()
         {
             using (var context = CreateContext())
@@ -1699,7 +1699,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: CollectionAsserter<Order>(o => o.OrderID));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'orderby [o].OrderID asc, [c].CustomerID asc'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_correlated_subquery_ordered(bool isAsync)
         {
@@ -1812,7 +1812,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 1);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'SingleOrDefault()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_query_composition_is_null(bool isAsync)
         {
@@ -1825,7 +1825,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 1);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'SingleOrDefault()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_query_composition_is_not_null(bool isAsync)
         {
@@ -1838,7 +1838,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 3);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'SingleOrDefault()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_query_composition_entity_equality_one_element_SingleOrDefault(bool isAsync)
         {
@@ -1862,7 +1862,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select e1);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'SingleOrDefault()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_query_composition_entity_equality_no_elements_SingleOrDefault(bool isAsync)
         {
@@ -1924,7 +1924,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select e1);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ([e1].FirstName == {from Employee e in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Employee]) orderby [e].EmployeeID asc select new <>f__AnonymousType334`1(Foo = [e]) => First()}.Foo.FirstName)'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_query_composition2(bool isAsync)
         {
@@ -1959,7 +1959,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 1);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ([e1].FirstName == {from Employee e in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Employee]) orderby [e].EmployeeID asc select new <>f__AnonymousType334`1(Foo = [e]) => FirstOrDefault()}.Foo.FirstName)'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_query_composition2_FirstOrDefault_with_anonymous(bool isAsync)
         {
@@ -1978,7 +1978,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 1);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where [c].IsLondon'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_query_composition3(bool isAsync)
         {
@@ -1991,7 +1991,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 6);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ([c1].City == {from Customer c in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) orderby [c].CustomerID asc from Customer c3 in {from Customer c in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) orderby [c].IsLondon asc, [c].CustomerID asc select [c]} select new <>f__AnonymousType335`1(c3 = [c3]) => First()}.c3.City)'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_query_composition4(bool isAsync)
         {
@@ -2009,7 +2009,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 1);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ([c1].IsLondon == {from Customer c in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) orderby [c].CustomerID asc select [c].IsLondon => First()})'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_query_composition5(bool isAsync)
         {
@@ -2022,7 +2022,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 85);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ([c1].IsLondon == {from Customer c in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) orderby [c].CustomerID asc select new <>f__AnonymousType334`1(Foo = [c]) => First()}.Foo.IsLondon)'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_query_composition6(bool isAsync)
         {
@@ -2071,7 +2071,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'from String s in value(System.String[])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task SelectMany_mixed(bool isAsync)
         {
@@ -2268,7 +2268,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 15);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ([c1] == [e2].City)'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task SelectMany_correlated_subquery_hard(bool isAsync)
         {
@@ -2552,7 +2552,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select "Foo");
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'DefaultIfEmpty(__p_0)'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Default_if_empty_top_level_arg(bool isAsync)
         {
@@ -2768,7 +2768,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 91);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'orderby [c].IsLondon asc, [c].CompanyName asc'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task OrderBy_client_mixed(bool isAsync)
         {
@@ -2779,7 +2779,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 91);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'join Order o in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Order]) on new Foo() {Bar = [c].CustomerID} equals new Foo() {Bar = [o].CustomerID}'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task OrderBy_multiple_queries(bool isAsync)
         {
@@ -3438,7 +3438,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'First()'")]
         public virtual void Select_Subquery_Single()
         {
             using (var context = CreateContext())
@@ -3457,7 +3457,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'Single()'")]
         public virtual void Select_Where_Subquery_Deep_Single()
         {
             using (var context = CreateContext())
@@ -3507,7 +3507,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'First()'")]
         public virtual void Select_Where_Subquery_Equality()
         {
             using (var context = CreateContext())
@@ -3668,7 +3668,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 267);
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'where ([o].OrderID > value(System.Random).Next())'")]
         public virtual void Random_next_is_not_funcletized_1()
         {
             using (var context = CreateContext())
@@ -3679,7 +3679,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'where ([o].OrderID > value(System.Random).Next(5))'")]
         public virtual void Random_next_is_not_funcletized_2()
         {
             using (var context = CreateContext())
@@ -3690,7 +3690,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'where ([o].OrderID > value(System.Random).Next(0, 10))'")]
         public virtual void Random_next_is_not_funcletized_3()
         {
             using (var context = CreateContext())
@@ -3701,7 +3701,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'where ([o].OrderID > value(System.Random).Next())'")]
         public virtual void Random_next_is_not_funcletized_4()
         {
             using (var context = CreateContext())
@@ -3712,7 +3712,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'where ([o].OrderID > value(System.Random).Next(5))'")]
         public virtual void Random_next_is_not_funcletized_5()
         {
             using (var context = CreateContext())
@@ -3723,7 +3723,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'where ([o].OrderID > value(System.Random).Next(0, 10))'")]
         public virtual void Random_next_is_not_funcletized_6()
         {
             using (var context = CreateContext())
@@ -4043,7 +4043,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'SingleOrDefault()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Subquery_member_pushdown_does_not_change_original_subquery_model(bool isAsync)
         {
@@ -4062,7 +4062,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'SingleOrDefault()'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Subquery_member_pushdown_does_not_change_original_subquery_model2(bool isAsync)
         {
@@ -4546,7 +4546,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.City1 + " " + e.City2);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'from Customer c in ClientDefaultIfEmpty([grouping])'")]
         [InlineData(false)]
         //[InlineData(true)] issue #12449
         public virtual Task No_orderby_added_for_client_side_GroupJoin_dependent_to_principal_LOJ(bool isAsync)
@@ -4567,7 +4567,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Id1 + " " + e.Id2);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'from Customer c in ClientDefaultIfEmpty([grouping])'")]
         [InlineData(false)]
         //[InlineData(true)] issue #12449
         public virtual Task No_orderby_added_for_client_side_GroupJoin_dependent_to_principal_LOJ_with_additional_join_condition1(
@@ -4597,7 +4597,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Id1 + " " + e.Id2);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'from Customer c in ClientDefaultIfEmpty([grouping])'")]
         [InlineData(false)]
         //[InlineData(true)] issue #12449
         public virtual Task No_orderby_added_for_client_side_GroupJoin_dependent_to_principal_LOJ_with_additional_join_condition2(
@@ -4627,7 +4627,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Id1 + " " + e.Id2);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'from Employee e2 in ClientDefaultIfEmpty([grouping])'")]
         [InlineData(false)]
         //[InlineData(true)] issue #12449
         public virtual Task Orderby_added_for_client_side_GroupJoin_principal_to_dependent_LOJ(bool isAsync)
@@ -4967,7 +4967,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return source?.Count() == 0 ? new[] { default(TElement) } : source;
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where {from Customer c in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) where {from Customer cc in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) select [cc].CustomerID => Any()} select {from Customer cc in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) select [cc].CustomerID} => Any()}'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Complex_query_with_repeated_query_model_compiles_correctly(bool isAsync)
         {
@@ -4984,7 +4984,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 1);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where {from Customer c in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) where {from Customer cc in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) where {from Customer inner in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) orderby [inner].CustomerID asc select [inner] => Take(10) => Distinct() => Any()} select [cc].CustomerID => Any()} select {from Customer cc in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) where {from Customer inner in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) orderby [inner].CustomerID asc select [inner] => Take(10) => Distinct() => Any()} select [cc].CustomerID} => Any()}'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Complex_query_with_repeated_nested_query_model_compiles_correctly(bool isAsync)
         {
@@ -5567,7 +5567,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.Id);
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'join Customer y.Customer in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) on Property([y], \"CustomerID\") equals Property([y.Customer], \"CustomerID\")'")]
         public virtual void Streaming_chained_sync_query()
         {
             using (var context = CreateContext())
@@ -5680,7 +5680,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       });
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ({from Order e in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Order]) orderby [e].OrderDate asc where  ?= (Property([c], \"CustomerID\") == Property([e], \"CustomerID\")) =? select [e] => FirstOrDefault()} != null)'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Let_entity_equality_to_null(bool isAsync)
         {
@@ -5696,7 +5696,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       });
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ({from Order e in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Order]) orderby [e].OrderDate asc where  ?= (Property([c], \"CustomerID\") == Property([e], \"CustomerID\")) =? select [e] => FirstOrDefault()} != Order 0)'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Let_entity_equality_to_other_entity(bool isAsync)
         {
@@ -5714,7 +5714,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       });
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'orderby ClientOrderBy([c]) asc'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task SelectMany_after_client_method(bool isAsync)
         {
@@ -5731,7 +5731,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return c.CustomerID;
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([o].CustomerID, [o])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Client_where_GroupBy_Group_ordering_works(bool isAsync)
         {
@@ -5753,7 +5753,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: CollectionAsserter<Order>(elementAsserter: (e, a) => Assert.Equal(e.OrderID, a.OrderID)));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'where ClientEvalPredicate([o])'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Client_where_GroupBy_Group_ordering_works_2(bool isAsync)
         {
@@ -5769,7 +5769,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: CollectionAsserter<Order>(elementAsserter: (e, a) => Assert.Equal(e.OrderID, a.OrderID)));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'orderby value(Microsoft.EntityFrameworkCore.Query.SimpleQuerySqlServerTest).ClientEvalSelector([o]) asc'")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Client_OrderBy_GroupBy_Group_ordering_works(bool isAsync)
         {

--- a/test/EFCore.Specification.Tests/TestUtilities/QueryableExtensions.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/QueryableExtensions.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Extensions.Internal;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities
+{
+    public static class QueryableExtensions
+    {
+        public static List<TSource> ToList<TSource>(this System.Collections.IEnumerable source)
+            => source.OfType<TSource>().ToList();
+
+        public static async Task<List<TSource>> ToListAsync<TSource>(this IQueryable source, CancellationToken cancellationToken = default)
+        {
+            var list = new List<TSource>();
+
+            using (var e = ((IQueryable<TSource>)source).AsAsyncEnumerable().GetEnumerator())
+            {
+                while (await e.MoveNext(cancellationToken).ConfigureAwait(false))
+                {
+                    list.Add(e.Current);
+                }
+            }
+
+            return list;
+        }
+    }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
@@ -298,11 +298,15 @@ WHERE [e].[TimeSpanAsTime] = @__timeSpan_0",
                 StringEnum16? param60 = StringEnum16.Value2;
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.EnumAsVarcharMax == param60));
 
+                // Issue #14935. Cannot eval 'where [e].SqlVariantString.Equals(__param61_0)'
+                // Added AsEnumerable()
                 object param61 = "Bang!";
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.SqlVariantString.Equals(param61)));
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().AsEnumerable().Single(e => e.Int == 999 && e.SqlVariantString.Equals(param61)));
 
+                // Issue #14935. Cannot eval 'where [e].SqlVariantInt.Equals(__param62_0)'
+                // Added AsEnumerable()
                 object param62 = 887876;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.SqlVariantInt.Equals(param62)));
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().AsEnumerable().Single(e => e.Int == 999 && e.SqlVariantInt.Equals(param62)));
             }
         }
 
@@ -489,11 +493,15 @@ WHERE [e].[TimeSpanAsTime] = @__timeSpan_0",
                 StringEnum16? param60 = null;
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.EnumAsVarcharMax == param60));
 
+                // Issue #14935. Cannot eval 'where ([e].SqlVariantString == __param61_0)'
+                // Added AsEnumerable()
                 object param61 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.SqlVariantString == param61));
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().AsEnumerable().Single(e => e.Int == 911 && e.SqlVariantString == param61));
 
+                // Issue #14935. Cannot eval 'where ([e].SqlVariantInt == __param62_0)'
+                // Added AsEnumerable()
                 object param62 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.SqlVariantInt == param62));
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().AsEnumerable().Single(e => e.Int == 911 && e.SqlVariantInt == param62));
             }
         }
 
@@ -2949,7 +2957,6 @@ UnicodeDataTypes.StringUnicode ---> [nullable nvarchar] [MaxLength = -1]
             {
                 var options = base.AddOptions(builder).ConfigureWarnings(
                     c => c
-                        .Log(RelationalEventId.QueryClientEvaluationWarning)
                         .Log(SqlServerEventId.DecimalTypeDefaultWarning));
 
                 new SqlServerDbContextOptionsBuilder(options).MinBatchSize(1);

--- a/test/EFCore.SqlServer.FunctionalTests/ConvertToProviderTypesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ConvertToProviderTypesSqlServerTest.cs
@@ -194,8 +194,7 @@ UnicodeDataTypes.StringUnicode ---> [nullable nvarchar] [MaxLength = -1]
                 => base
                     .AddOptions(builder)
                     .ConfigureWarnings(
-                        c => c.Log(RelationalEventId.QueryClientEvaluationWarning)
-                            .Log(SqlServerEventId.DecimalTypeDefaultWarning));
+                        c => c.Log(SqlServerEventId.DecimalTypeDefaultWarning));
 
             protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
             {

--- a/test/EFCore.SqlServer.FunctionalTests/CustomConvertersSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/CustomConvertersSqlServerTest.cs
@@ -187,8 +187,7 @@ User.Id ---> [uniqueidentifier]
                 => base
                     .AddOptions(builder)
                     .ConfigureWarnings(
-                        c => c.Log(RelationalEventId.QueryClientEvaluationWarning)
-                            .Log(SqlServerEventId.DecimalTypeDefaultWarning));
+                        c => c.Log(SqlServerEventId.DecimalTypeDefaultWarning));
 
             protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
             {

--- a/test/EFCore.SqlServer.FunctionalTests/EverythingIsBytesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/EverythingIsBytesSqlServerTest.cs
@@ -181,8 +181,7 @@ UnicodeDataTypes.StringUnicode ---> [nullable varbinary] [MaxLength = -1]
                 => base
                     .AddOptions(builder)
                     .ConfigureWarnings(
-                        c => c.Log(RelationalEventId.QueryClientEvaluationWarning)
-                            .Log(SqlServerEventId.DecimalTypeDefaultWarning));
+                        c => c.Log(SqlServerEventId.DecimalTypeDefaultWarning));
         }
 
         public class SqlServerBytesTestStoreFactory : SqlServerTestStoreFactory

--- a/test/EFCore.SqlServer.FunctionalTests/EverythingIsStringsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/EverythingIsStringsSqlServerTest.cs
@@ -182,8 +182,7 @@ UnicodeDataTypes.StringUnicode ---> [nullable nvarchar] [MaxLength = -1]
                 => base
                     .AddOptions(builder)
                     .ConfigureWarnings(
-                        c => c.Log(RelationalEventId.QueryClientEvaluationWarning)
-                            .Log(SqlServerEventId.DecimalTypeDefaultWarning));
+                        c => c.Log(SqlServerEventId.DecimalTypeDefaultWarning));
 
             protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
             {

--- a/test/EFCore.SqlServer.FunctionalTests/LazyLoadProxySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/LazyLoadProxySqlServerTest.cs
@@ -3,7 +3,6 @@
 
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
@@ -440,11 +439,6 @@ WHERE [e].[ParentId] = @__p_0",
         {
             public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ListLoggerFactory;
             protected override ITestStoreFactory TestStoreFactory => SqlServerTestStoreFactory.Instance;
-
-            public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
-                => base.AddOptions(builder).ConfigureWarnings(
-                    c => c
-                        .Log(RelationalEventId.QueryClientEvaluationWarning));
         }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/LoadSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/LoadSqlServerTest.cs
@@ -3,7 +3,6 @@
 
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
@@ -1921,11 +1920,6 @@ WHERE 0 = 1",
         {
             public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ListLoggerFactory;
             protected override ITestStoreFactory TestStoreFactory => SqlServerTestStoreFactory.Instance;
-
-            public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
-                => base.AddOptions(builder).ConfigureWarnings(
-                    c => c
-                        .Log(RelationalEventId.QueryClientEvaluationWarning));
         }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/MonsterFixupChangedChangingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/MonsterFixupChangedChangingSqlServerTest.cs
@@ -18,9 +18,6 @@ namespace Microsoft.EntityFrameworkCore
         {
             protected override ITestStoreFactory TestStoreFactory => SqlServerTestStoreFactory.Instance;
 
-            public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
-                => base.AddOptions(builder).ConfigureWarnings(w => w.Log(RelationalEventId.QueryClientEvaluationWarning));
-
             protected override void OnModelCreating<TMessage, TProduct, TProductPhoto, TProductReview, TComputerDetail, TDimensions>(
                 ModelBuilder builder)
             {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AsyncSimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AsyncSimpleQuerySqlServerTest.cs
@@ -100,7 +100,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'Except({from Customer c in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) where ([c].City == \"México D.F.\") select [c].CustomerID})'")]
         public async Task Concurrent_async_queries_are_serialized2()
         {
             using (var context = CreateContext())

--- a/test/EFCore.SqlServer.FunctionalTests/Query/DbFunctionsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/DbFunctionsSqlServerTest.cs
@@ -167,7 +167,7 @@ WHERE (FREETEXT([c].[City], N'London')) AND (FREETEXT([c].[Title], N'Manager', L
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'LastOrDefault()'")]
         [SqlServerCondition(SqlServerCondition.SupportsFullTextSearch)]
         public void FreeText_through_navigation()
         {
@@ -190,7 +190,7 @@ WHERE ((FREETEXT([c.Manager].[Title], N'President')) AND (FREETEXT([c].[Title], 
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'LastOrDefault()'")]
         [SqlServerCondition(SqlServerCondition.SupportsFullTextSearch)]
         public void FreeText_through_navigation_with_language_terms()
         {
@@ -388,7 +388,7 @@ WHERE CONTAINS([c].[Title], N'NEAR((Sales, President), 1)', LANGUAGE 1033)");
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue #14935. Cannot eval 'LastOrDefault()'")]
         [SqlServerCondition(SqlServerCondition.SupportsFullTextSearch)]
         public void Contains_through_navigation()
         {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -516,7 +516,7 @@ LEFT JOIN [Customer] AS [o.Customer] ON ([o].[CustomerFirstName] = [o.Customer].
 
         #region Bug7293
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'where (new ProjectView() {Permissions = {from ProjectUser u in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.Query.QueryBugsTest+ProjectUser]) join User u.User in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.Query.QueryBugsTest+User]) on Property([u], \"UserId\") equals Property([u.User], \"Id\") where  ?= (Property([p], \"Id\") == Property([u], \"ProjectId\")) =? select new PermissionView() {UserName = [u.User].Name}}}.Id == __target_ProjectId_0)'")]
         public void GroupJoin_expansion_when_optional_nav_in_projection()
         {
             using (CreateDatabase7293())
@@ -3078,7 +3078,7 @@ ORDER BY [t0].[c], [t0].[c0], [t0].[Id]");
 
         #region Bug9892
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'join <>f__AnonymousType12`2 c in {from Child9892 x in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.Query.QueryBugsTest+Child9892]) join OtherParent9892 x.OtherParent in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.Query.QueryBugsTest+OtherParent9892]) on Property([x], \"OtherParentId\") equals Property([x.OtherParent], \"Id\") select new <>f__AnonymousType12`2(ParentId = [x].ParentId, OtherParent = [x.OtherParent].Name)} on [p].Id equals [c].ParentId'")]
         public virtual void GroupJoin_to_parent_with_no_child_works_9892()
         {
             using (CreateDatabase9892())
@@ -4112,7 +4112,7 @@ WHERE ([t].[Name] <> N'Bar') OR [t].[Name] IS NULL");
 
         public static bool ClientMethod11923(int id) => true;
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'First()'")]
         public virtual void Collection_without_setter_materialized_correctly()
         {
             using (CreateDatabase11923())
@@ -4483,7 +4483,7 @@ FROM [Prices] AS [e]");
 
         #region Bug12582
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'OfType<Microsoft.EntityFrameworkCore.Query.QueryBugsTest+IEmployee12582>()'")]
         public virtual void Include_collection_with_OfType_base()
         {
             using (CreateDatabase12582())

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryLoggingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryLoggingSqlServerTest.cs
@@ -116,7 +116,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'Concat({from Order o in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Order]) where ([o].CustomerID == \"ALFKI\") select [o]})'")]
         public virtual void Concat_Include_collection_ignored()
         {
             using (var context = CreateContext())
@@ -134,7 +134,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'Union({from Order o in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Order]) where ([o].CustomerID == \"ALFKI\") select [o]})'")]
         public virtual void Union_Include_collection_ignored()
         {
             using (var context = CreateContext())
@@ -152,7 +152,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'GroupBy([o].OrderID, [o])'")]
         public virtual void GroupBy_Include_collection_ignored()
         {
             using (var context = CreateContext())

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryNoClientEvalSqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryNoClientEvalSqlServerFixture.cs
@@ -1,14 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
     public class QueryNoClientEvalSqlServerFixture : NorthwindQuerySqlServerFixture<NoopModelCustomizer>
     {
-        public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
-            => base.AddOptions(builder).ConfigureWarnings(c => c.Throw(RelationalEventId.QueryClientEvaluationWarning));
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -357,7 +357,7 @@ WHERE [e20].[EmployeeID] = @_outer_ReportsTo");
 
         public override async Task Where_query_composition_is_not_null(bool isAsync)
         {
-            await base.Where_query_composition_is_null(isAsync);
+            await base.Where_query_composition_is_not_null(isAsync);
 
             AssertSql(
                 @"@__p_0='3'

--- a/test/EFCore.SqlServer.FunctionalTests/Query/UdfDbFunctionSqlServerTests.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/UdfDbFunctionSqlServerTests.cs
@@ -213,7 +213,7 @@ FROM [Customers] AS [c]
 WHERE [c].[Id] = @__customerId_1");
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'where (2 == AddOneStatic([c].Id))'")]
         public override void Scalar_Nested_Function_Unwind_Client_Eval_Where_Static()
         {
             base.Scalar_Nested_Function_Unwind_Client_Eval_Where_Static();
@@ -223,7 +223,7 @@ WHERE [c].[Id] = @__customerId_1");
 FROM [Customers] AS [c]");
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'orderby AddOneStatic([c].Id) asc'")]
         public override void Scalar_Nested_Function_Unwind_Client_Eval_OrderBy_Static()
         {
             base.Scalar_Nested_Function_Unwind_Client_Eval_OrderBy_Static();
@@ -244,7 +244,7 @@ FROM [Customers] AS [c]
 ORDER BY [c].[Id]");
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'where (2 == AddOneStatic(Abs(CustomerOrderCountWithClientStatic([c].Id))))'")]
         public override void Scalar_Nested_Function_Client_BCL_UDF_Static()
         {
             base.Scalar_Nested_Function_Client_BCL_UDF_Static();
@@ -254,7 +254,7 @@ ORDER BY [c].[Id]");
 FROM [Customers] AS [c]");
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'where (2 == AddOneStatic(CustomerOrderCountWithClientStatic(Abs([c].Id))))'")]
         public override void Scalar_Nested_Function_Client_UDF_BCL_Static()
         {
             base.Scalar_Nested_Function_Client_UDF_BCL_Static();
@@ -264,7 +264,7 @@ FROM [Customers] AS [c]");
 FROM [Customers] AS [c]");
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'where (2 == Abs(AddOneStatic(CustomerOrderCountWithClientStatic([c].Id))))'")]
         public override void Scalar_Nested_Function_BCL_Client_UDF_Static()
         {
             base.Scalar_Nested_Function_BCL_Client_UDF_Static();
@@ -274,7 +274,7 @@ FROM [Customers] AS [c]");
 FROM [Customers] AS [c]");
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'where (1 == Abs(CustomerOrderCountWithClientStatic(AddOneStatic([c].Id))))'")]
         public override void Scalar_Nested_Function_BCL_UDF_Client_Static()
         {
             base.Scalar_Nested_Function_BCL_UDF_Client_Static();
@@ -284,7 +284,7 @@ FROM [Customers] AS [c]");
 FROM [Customers] AS [c]");
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'where (1 == CustomerOrderCountWithClientStatic(Abs(AddOneStatic([c].Id))))'")]
         public override void Scalar_Nested_Function_UDF_BCL_Client_Static()
         {
             base.Scalar_Nested_Function_UDF_BCL_Client_Static();
@@ -294,7 +294,7 @@ FROM [Customers] AS [c]");
 FROM [Customers] AS [c]");
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'where (1 == CustomerOrderCountWithClientStatic(AddOneStatic(Abs([c].Id))))'")]
         public override void Scalar_Nested_Function_UDF_Client_BCL_Static()
         {
             base.Scalar_Nested_Function_UDF_Client_BCL_Static();
@@ -304,7 +304,7 @@ FROM [Customers] AS [c]");
 FROM [Customers] AS [c]");
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'where (3 == AddOneStatic(Abs([c].Id)))'")]
         public override void Scalar_Nested_Function_Client_BCL_Static()
         {
             base.Scalar_Nested_Function_Client_BCL_Static();
@@ -314,7 +314,7 @@ FROM [Customers] AS [c]");
 FROM [Customers] AS [c]");
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'where (2 == AddOneStatic(CustomerOrderCountWithClientStatic([c].Id)))'")]
         public override void Scalar_Nested_Function_Client_UDF_Static()
         {
             base.Scalar_Nested_Function_Client_UDF_Static();
@@ -324,7 +324,7 @@ FROM [Customers] AS [c]");
 FROM [Customers] AS [c]");
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'where (3 == Abs(AddOneStatic([c].Id)))'")]
         public override void Scalar_Nested_Function_BCL_Client_Static()
         {
             base.Scalar_Nested_Function_BCL_Client_Static();
@@ -345,7 +345,7 @@ FROM [Customers] AS [c]
 WHERE 3 = ABS([dbo].[CustomerOrderCount]([c].[Id]))");
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'where (2 == CustomerOrderCountWithClientStatic(AddOneStatic([c].Id)))'")]
         public override void Scalar_Nested_Function_UDF_Client_Static()
         {
             base.Scalar_Nested_Function_UDF_Client_Static();
@@ -578,7 +578,7 @@ FROM [Customers] AS [c]
 WHERE [c].[Id] = @__customerId_2");
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'where (2 == __context_0.AddOneInstance([c].Id))'")]
         public override void Scalar_Nested_Function_Unwind_Client_Eval_Where_Instance()
         {
             base.Scalar_Nested_Function_Unwind_Client_Eval_Where_Instance();
@@ -588,7 +588,7 @@ WHERE [c].[Id] = @__customerId_2");
 FROM [Customers] AS [c]");
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'orderby __context_0.AddOneInstance([c].Id) asc'")]
         public override void Scalar_Nested_Function_Unwind_Client_Eval_OrderBy_Instance()
         {
             base.Scalar_Nested_Function_Unwind_Client_Eval_OrderBy_Instance();
@@ -609,7 +609,7 @@ FROM [Customers] AS [c]
 ORDER BY [c].[Id]");
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'where (2 == __context_0.AddOneInstance(Abs(__context_0.CustomerOrderCountWithClientInstance([c].Id))))'")]
         public override void Scalar_Nested_Function_Client_BCL_UDF_Instance()
         {
             base.Scalar_Nested_Function_Client_BCL_UDF_Instance();
@@ -619,7 +619,7 @@ ORDER BY [c].[Id]");
 FROM [Customers] AS [c]");
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'where (2 == __context_0.AddOneInstance(__context_0.CustomerOrderCountWithClientInstance(Abs([c].Id))))'")]
         public override void Scalar_Nested_Function_Client_UDF_BCL_Instance()
         {
             base.Scalar_Nested_Function_Client_UDF_BCL_Instance();
@@ -629,7 +629,7 @@ FROM [Customers] AS [c]");
 FROM [Customers] AS [c]");
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'where (2 == Abs(__context_0.AddOneInstance(__context_0.CustomerOrderCountWithClientInstance([c].Id))))'")]
         public override void Scalar_Nested_Function_BCL_Client_UDF_Instance()
         {
             base.Scalar_Nested_Function_BCL_Client_UDF_Instance();
@@ -639,7 +639,7 @@ FROM [Customers] AS [c]");
 FROM [Customers] AS [c]");
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'where (1 == Abs(__context_0.CustomerOrderCountWithClientInstance(__context_0.AddOneInstance([c].Id))))'")]
         public override void Scalar_Nested_Function_BCL_UDF_Client_Instance()
         {
             base.Scalar_Nested_Function_BCL_UDF_Client_Instance();
@@ -649,7 +649,7 @@ FROM [Customers] AS [c]");
 FROM [Customers] AS [c]");
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'where (1 == __context_0.CustomerOrderCountWithClientInstance(Abs(__context_0.AddOneInstance([c].Id))))'")]
         public override void Scalar_Nested_Function_UDF_BCL_Client_Instance()
         {
             base.Scalar_Nested_Function_UDF_BCL_Client_Instance();
@@ -659,7 +659,7 @@ FROM [Customers] AS [c]");
 FROM [Customers] AS [c]");
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'where (1 == __context_0.CustomerOrderCountWithClientInstance(__context_0.AddOneInstance(Abs([c].Id))))'")]
         public override void Scalar_Nested_Function_UDF_Client_BCL_Instance()
         {
             base.Scalar_Nested_Function_UDF_Client_BCL_Instance();
@@ -669,7 +669,7 @@ FROM [Customers] AS [c]");
 FROM [Customers] AS [c]");
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'where (3 == __context_0.AddOneInstance(Abs([c].Id)))'")]
         public override void Scalar_Nested_Function_Client_BCL_Instance()
         {
             base.Scalar_Nested_Function_Client_BCL_Instance();
@@ -679,7 +679,7 @@ FROM [Customers] AS [c]");
 FROM [Customers] AS [c]");
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'where (2 == __context_0.AddOneInstance(__context_0.CustomerOrderCountWithClientInstance([c].Id)))'")]
         public override void Scalar_Nested_Function_Client_UDF_Instance()
         {
             base.Scalar_Nested_Function_Client_UDF_Instance();
@@ -689,7 +689,7 @@ FROM [Customers] AS [c]");
 FROM [Customers] AS [c]");
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'where (3 == Abs(__context_0.AddOneInstance([c].Id)))'")]
         public override void Scalar_Nested_Function_BCL_Client_Instance()
         {
             base.Scalar_Nested_Function_BCL_Client_Instance();
@@ -710,7 +710,7 @@ FROM [Customers] AS [c]
 WHERE 3 = ABS([dbo].[CustomerOrderCount]([c].[Id]))");
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'where (2 == __context_0.CustomerOrderCountWithClientInstance(__context_0.AddOneInstance([c].Id)))'")]
         public override void Scalar_Nested_Function_UDF_Client_Instance()
         {
             base.Scalar_Nested_Function_UDF_Client_Instance();

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerFixture.cs
@@ -21,7 +21,6 @@ namespace Microsoft.EntityFrameworkCore
             => base.AddOptions(builder).ConfigureWarnings(
                 w =>
                 {
-                    w.Log(RelationalEventId.QueryClientEvaluationWarning);
                     w.Log(SqlServerEventId.ByteIdentityColumnWarning);
                 });
     }

--- a/test/EFCore.SqlServer.FunctionalTests/TransactionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TransactionSqlServerTest.cs
@@ -66,8 +66,7 @@ namespace Microsoft.EntityFrameworkCore
                 new SqlServerDbContextOptionsBuilder(
                         base.AddOptions(builder)
                             .ConfigureWarnings(
-                                w => w.Log(RelationalEventId.QueryClientEvaluationWarning)
-                                    .Log(CoreEventId.FirstWithoutOrderByAndFilterWarning)))
+                                w => w.Log(CoreEventId.FirstWithoutOrderByAndFilterWarning)))
                     .MaxBatchSize(1);
                 return builder;
             }

--- a/test/EFCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
@@ -922,7 +922,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'Min()'")]
         public virtual void Can_query_Min_of_converted_types()
         {
             using (var context = CreateContext())
@@ -980,7 +980,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'Max()'")]
         public virtual void Can_query_Max_of_converted_types()
         {
             using (var context = CreateContext())
@@ -1037,7 +1037,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'Average()'")]
         public virtual void Can_query_Average_of_converted_types()
         {
             using (var context = CreateContext())
@@ -1068,7 +1068,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Issue #14935. Cannot eval 'Sum()'")]
         public virtual void Can_query_Sum_of_converted_types()
         {
             using (var context = CreateContext())
@@ -1607,8 +1607,7 @@ namespace Microsoft.EntityFrameworkCore
 
             public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
                 => base.AddOptions(builder).ConfigureWarnings(
-                    c => c.Log(RelationalEventId.QueryClientEvaluationWarning)
-                        .Log(RelationalEventId.ValueConversionSqlLiteralWarning));
+                    c => c.Log(RelationalEventId.ValueConversionSqlLiteralWarning));
 
             public override bool SupportsBinaryKeys => true;
 

--- a/test/EFCore.Sqlite.FunctionalTests/ConvertToProviderTypesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/ConvertToProviderTypesSqliteTest.cs
@@ -33,8 +33,7 @@ namespace Microsoft.EntityFrameworkCore
 
             public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
                 => base.AddOptions(builder).ConfigureWarnings(
-                    c => c.Log(RelationalEventId.QueryClientEvaluationWarning)
-                        .Log(RelationalEventId.ValueConversionSqlLiteralWarning));
+                    c => c.Log(RelationalEventId.ValueConversionSqlLiteralWarning));
 
             public override bool SupportsBinaryKeys => true;
 

--- a/test/EFCore.Sqlite.FunctionalTests/CustomConvertersSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/CustomConvertersSqliteTest.cs
@@ -40,8 +40,7 @@ namespace Microsoft.EntityFrameworkCore
                 => base
                     .AddOptions(builder)
                     .ConfigureWarnings(
-                        c => c.Log(RelationalEventId.QueryClientEvaluationWarning)
-                            .Log(RelationalEventId.ValueConversionSqlLiteralWarning));
+                        c => c.Log(RelationalEventId.ValueConversionSqlLiteralWarning));
         }
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/LazyLoadProxySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/LazyLoadProxySqliteTest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 
 namespace Microsoft.EntityFrameworkCore
@@ -16,10 +15,6 @@ namespace Microsoft.EntityFrameworkCore
         public class LoadSqliteFixture : LoadFixtureBase
         {
             protected override ITestStoreFactory TestStoreFactory => SqliteTestStoreFactory.Instance;
-
-            public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
-                => base.AddOptions(builder).ConfigureWarnings(
-                    c => c.Log(RelationalEventId.QueryClientEvaluationWarning));
         }
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/LoadSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/LoadSqliteTest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 
 namespace Microsoft.EntityFrameworkCore
@@ -16,11 +15,6 @@ namespace Microsoft.EntityFrameworkCore
         public class LoadSqliteFixture : LoadFixtureBase
         {
             protected override ITestStoreFactory TestStoreFactory => SqliteTestStoreFactory.Instance;
-
-            public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
-                => base.AddOptions(builder).ConfigureWarnings(
-                    c => c
-                        .Log(RelationalEventId.QueryClientEvaluationWarning));
         }
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/MonsterFixupChangedOnlySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/MonsterFixupChangedOnlySqliteTest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 
 namespace Microsoft.EntityFrameworkCore
@@ -17,9 +16,6 @@ namespace Microsoft.EntityFrameworkCore
         public class MonsterFixupChangedOnlySqliteFixture : MonsterFixupChangedOnlyFixtureBase
         {
             protected override ITestStoreFactory TestStoreFactory => SqliteTestStoreFactory.Instance;
-
-            public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
-                => base.AddOptions(builder).ConfigureWarnings(w => w.Log(RelationalEventId.QueryClientEvaluationWarning));
 
             protected override void OnModelCreating<TMessage, TProduct, TProductPhoto, TProductReview, TComputerDetail, TDimensions>(
                 ModelBuilder builder)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsQuerySqliteTest.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
+
 namespace Microsoft.EntityFrameworkCore.Query
 {
     public class ComplexNavigationsQuerySqliteTest : ComplexNavigationsQueryTestBase<ComplexNavigationsQuerySqliteFixture>
@@ -9,5 +11,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             : base(fixture)
         {
         }
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'from <>f__AnonymousType100`1 <generated>_1 in {from Level2 l2 in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel.Level2]) where  ?= (Convert(Property([l1], \"Id\"), Nullable`1) == Property([l2], \"OneToMany_Optional_Inverse2Id\")) =? select new <>f__AnonymousType100`1(Name = [l2].Name)}'
+        public override Task SelectMany_subquery_with_custom_projection(bool isAsync) => null;
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsWeakQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsWeakQuerySqliteTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -11,5 +12,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             : base(fixture)
         {
         }
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'from <>f__AnonymousType100`1 <generated>_1 in {from Level2 l2 in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel.Level2]) where  ?= (Convert(Property([l1], \"Id\"), Nullable`1) == Property([l2], \"OneToMany_Optional_Inverse2Id\")) =? select new <>f__AnonymousType100`1(Name = [l2].Name)}'
+        public override Task SelectMany_subquery_with_custom_projection(bool isAsync) => null;
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
+
 namespace Microsoft.EntityFrameworkCore.Query
 {
     public class GearsOfWarQuerySqliteTest : GearsOfWarQueryTestBase<GearsOfWarQuerySqliteFixture>
@@ -9,5 +11,41 @@ namespace Microsoft.EntityFrameworkCore.Query
             : base(fixture)
         {
         }
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where ([m].Timeline.Date > 1/1/0001 12:00:00 AM)'
+        public override Task String_concat_with_null_conditional_argument2(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where ([m].Timeline.Date > 1/1/0001 12:00:00 AM)'
+        public override Task Where_datetimeoffset_date_component(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where ([m].Timeline.Day == 2)'
+        public override Task Where_datetimeoffset_day_component(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where ([m].Timeline.DayOfYear == 2)'
+        public override Task Where_datetimeoffset_dayofyear_component(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where ([m].Timeline.Hour == 10)'
+        public override Task Where_datetimeoffset_hour_component(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where ([m].Timeline.Millisecond == 0)'
+        public override Task Where_datetimeoffset_millisecond_component(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where ([m].Timeline.Minute == 0)'
+        public override Task Where_datetimeoffset_minute_component(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where ([m].Timeline.Month == 1)'
+        public override Task Where_datetimeoffset_month_component(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where ([m].Timeline != DateTimeOffset.Now)'
+        public override Task Where_datetimeoffset_now(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where ([m].Timeline.Second == 0)'
+        public override Task Where_datetimeoffset_second_component(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where ([m].Timeline != DateTimeOffset.UtcNow)'
+        public override Task Where_datetimeoffset_utcnow(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where ([m].Timeline.Year == 2)'
+        public override Task Where_datetimeoffset_year_component(bool isAsync) => null;
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/QueryNavigationsSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/QueryNavigationsSqliteTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -11,5 +12,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             : base(fixture)
         {
         }
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where ([od].UnitPrice > 10)'
+        public override Task Select_multiple_complex_projections(bool isAsync) => null;
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/QueryNoClientEvalSqliteFixture.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/QueryNoClientEvalSqliteFixture.cs
@@ -1,14 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
     public class QueryNoClientEvalSqliteFixture : NorthwindQuerySqliteFixture<NoopModelCustomizer>
     {
-        public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
-            => base.AddOptions(builder).ConfigureWarnings(c => c.Throw(RelationalEventId.QueryClientEvaluationWarning));
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
@@ -21,6 +21,150 @@ namespace Microsoft.EntityFrameworkCore.Query
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
+        // Skip for SQLite. Issue #14935. Cannot eval 'Average()'
+        public override Task Average_with_coalesce(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'Average()'
+        public override Task Average_with_division_on_decimal(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'Average()'
+        public override Task Average_with_division_on_decimal_no_significant_digits(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where (Convert(ToByte(ToByte(([o].OrderID % 1))), Int32) >= 0)'
+        public override Task Convert_ToByte(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where (ToDecimal(ToByte(([o].OrderID % 1))) >= 0)'
+        public override Task Convert_ToDecimal(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where (ToDouble(ToByte(([o].OrderID % 1))) >= 0)'
+        public override Task Convert_ToDouble(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where (Convert(ToInt16(ToByte(([o].OrderID % 1))), Int32) >= 0)'
+        public override Task Convert_ToInt16(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where (ToInt32(ToByte(([o].OrderID % 1))) >= 0)'
+        public override Task Convert_ToInt32(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where (ToInt64(ToByte(([o].OrderID % 1))) >= 0)'
+        public override Task Convert_ToInt64(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where (ToString(ToByte(([o].OrderID % 1))) != \"10\")'
+        public override Task Convert_ToString(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'from Order o in {from Order o in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Order]) where ([o].CustomerID == [c].CustomerID) select [o] => DefaultIfEmpty()}'
+        public override Task DefaultIfEmpty_in_subquery(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'from Order o1 in {from Order o in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Order]) where ([o].OrderID > 11000) select [o] => DefaultIfEmpty()}'
+        public override Task DefaultIfEmpty_in_subquery_nested(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'Max()'
+        public override Task Max_with_coalesce(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'Min()'
+        public override Task Min_with_coalesce(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'orderby Truncate(Convert([o].OrderID, Double)) asc'
+        public override Task Projecting_Math_Truncate_and_ordering_by_it_twice(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'orderby Truncate(Convert([o].OrderID, Double)) asc'
+        public override Task Projecting_Math_Truncate_and_ordering_by_it_twice2(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'orderby Truncate(Convert([o].OrderID, Double)) desc, Truncate(Convert([o].OrderID, Double)) asc'
+        public override Task Projecting_Math_Truncate_and_ordering_by_it_twice3(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where Convert([o].EmployeeID, UInt32).ToString().Contains(\"10\")'
+        public override Task Query_expression_with_to_string_and_contains(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'from Order o in {from Order o in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Order]) where ([o].CustomerID == [c].CustomerID) select [o] => DefaultIfEmpty()}'
+        public override Task SelectMany_Joined_DefaultIfEmpty(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'from Order o in {from Order o in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Order]) where ([o].CustomerID == [c].CustomerID) select [o] => DefaultIfEmpty()}'
+        public override Task SelectMany_Joined_DefaultIfEmpty2(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'from Order o in {from Order o in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Order]) where ([o].CustomerID == [c].CustomerID) select [o] => Take(1000)}'
+        public override Task SelectMany_Joined_Take(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'Sum()'
+        public override Task Sum_with_division_on_decimal(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'Sum()'
+        public override Task Sum_with_division_on_decimal_no_significant_digits(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where (Convert([o].OrderDate, Nullable`1) == Convert(DateTimeOffset.Now, Nullable`1))'
+        public override Task Where_datetimeoffset_now_component(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where (Convert([o].OrderDate, Nullable`1) == Convert(DateTimeOffset.UtcNow, Nullable`1))'
+        public override Task Where_datetimeoffset_utcnow_component(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where (Pow(Convert([c].CustomerID.Length, Double), 2) == 25)'
+        public override Task Where_functions_nested(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where (NewGuid() != 00000000-0000-0000-0000-000000000000)'
+        public override Task Where_guid_newguid(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where (Abs([od].UnitPrice) > 10)'
+        public override Task Where_math_abs3(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where (Acos(Convert([od].Discount, Double)) > 1)'
+        public override Task Where_math_acos(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where (Asin(Convert([od].Discount, Double)) > 0)'
+        public override Task Where_math_asin(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where (Atan(Convert([od].Discount, Double)) > 0)'
+        public override Task Where_math_atan(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where (Atan2(Convert([od].Discount, Double), 1) > 0)'
+        public override Task Where_math_atan2(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where (Ceiling(Convert([od].Discount, Double)) > 0)'
+        public override Task Where_math_ceiling1(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where (Ceiling([od].UnitPrice) > 10)'
+        public override Task Where_math_ceiling2(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where (Cos(Convert([od].Discount, Double)) > 0)'
+        public override Task Where_math_cos(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where (Exp(Convert([od].Discount, Double)) > 1)'
+        public override Task Where_math_exp(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where (Floor([od].UnitPrice) > 10)'
+        public override Task Where_math_floor(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where (Log(Convert([od].Discount, Double)) < 0)'
+        public override Task Where_math_log(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where (Log(Convert([od].Discount, Double), 7) < 0)'
+        public override Task Where_math_log_new_base(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where (Log10(Convert([od].Discount, Double)) < 0)'
+        public override Task Where_math_log10(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where (Pow(Convert([od].Discount, Double), 2) > 0.05000000074505806)'
+        public override Task Where_math_power(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where (Round([od].UnitPrice) > 10'
+        public override Task Where_math_round(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where (Round([od].UnitPrice, 2) > 100)'
+        public override Task Where_math_round2(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where (Sign([od].Discount) > 0)'
+        public override Task Where_math_sign(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where (Sin(Convert([od].Discount, Double)) > 0'
+        public override Task Where_math_sin(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where (Sqrt(Convert([od].Discount, Double)) > 0)'
+        public override Task Where_math_sqrt(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where (Tan(Convert([od].Discount, Double)) > 0)'
+        public override Task Where_math_tan(bool isAsync) => null;
+
+        // Skip for SQLite. Issue #14935. Cannot eval 'where (Truncate([od].UnitPrice) > 10)'
+        public override Task Where_math_truncate(bool isAsync) => null;
+
         public override void Query_backed_by_database_view()
         {
             // Not present on SQLite
@@ -583,15 +727,8 @@ FROM ""Customers"" AS ""c""
 WHERE trim(""c"".""ContactTitle"", 'Or') = 'wne'");
         }
 
-        public override async Task Sum_with_coalesce(bool isAsync)
-        {
-            await base.Sum_with_coalesce(isAsync);
-
-            AssertSql(
-                @"SELECT COALESCE(""p"".""UnitPrice"", '0.0')
-FROM ""Products"" AS ""p""
-WHERE ""p"".""ProductID"" < 40");
-        }
+        // Skip for SQLite. Issue #14935. Cannot eval 'Sum()'
+        public override Task Sum_with_coalesce(bool isAsync) => null;
 
         public override async Task Select_datetime_year_component(bool isAsync)
         {

--- a/test/EFCore.Sqlite.FunctionalTests/TransactionSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/TransactionSqliteTest.cs
@@ -43,9 +43,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 return base.AddOptions(builder)
                     .ConfigureWarnings(
-                        w
-                            => w.Log(RelationalEventId.QueryClientEvaluationWarning)
-                                .Log(CoreEventId.FirstWithoutOrderByAndFilterWarning));
+                        w => w.Log(CoreEventId.FirstWithoutOrderByAndFilterWarning));
             }
         }
     }


### PR DESCRIPTION
Issue #14935

* Tests are disabled if their primary purpose is to test queries.
* Queries are re-written if the purpose of the test was not primarily to test the query.
* All are tagged with this issue number so they can easily be found.
