### PR TITLE
Throw when tracking an owned entity as the owned type its base is mapped to.

### DIFF
--- a/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
@@ -33,14 +33,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
                 entityType, missingEntityType, keyValue);
 
         /// <summary>
-        ///     The entity of type '{entityType}' cannot be queried directly because it is mapped as a part of the document mapped to '{principalEntityType}'. Rewrite the query to start with '{principalEntityType}'.
-        /// </summary>
-        public static string QueryRootNestedEntityType([CanBeNull] object entityType, [CanBeNull] object principalEntityType)
-            => string.Format(
-                GetString("QueryRootNestedEntityType", nameof(entityType), nameof(principalEntityType)),
-                entityType, principalEntityType);
-
-        /// <summary>
         ///     No matching discriminator values where found for this instance of '{entityType}'.
         /// </summary>
         public static string UnableToDiscriminate([CanBeNull] object entityType)

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.resx
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.resx
@@ -123,9 +123,6 @@
   <data name="OrphanedNestedDocumentSensitive" xml:space="preserve">
     <value>The entity of type '{entityType}' is mapped as a part of the document mapped to '{missingEntityType}', but there is no tracked entity of this type with the key value '{keyValue}'.</value>
   </data>
-  <data name="QueryRootNestedEntityType" xml:space="preserve">
-    <value>The entity of type '{entityType}' cannot be queried directly because it is mapped as a part of the document mapped to '{principalEntityType}'. Rewrite the query to start with '{principalEntityType}'.</value>
-  </data>
   <data name="UnableToDiscriminate" xml:space="preserve">
     <value>No matching discriminator values where found for this instance of '{entityType}'.</value>
   </data>

--- a/src/EFCore.Cosmos/Query/ExpressionVisitors/Internal/CosmosEntityQueryableExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/ExpressionVisitors/Internal/CosmosEntityQueryableExpressionVisitor.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Cosmos.Internal;
@@ -42,11 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.ExpressionVisitors.Internal
         protected override Expression VisitEntityQueryable([NotNull] Type elementType)
         {
             var entityType = _model.FindEntityType(elementType);
-            if (!entityType.IsDocumentRoot())
-            {
-                throw new InvalidOperationException(
-                    CosmosStrings.QueryRootNestedEntityType(entityType.DisplayName(), entityType.FindOwnership().PrincipalEntityType.DisplayName()));
-            }
+            Debug.Assert(entityType.IsDocumentRoot());
 
             return new QueryShaperExpression(
                 QueryModelVisitor.QueryCompilationContext.IsAsyncQuery,

--- a/src/EFCore/ChangeTracking/Internal/EntityEntryGraphIterator.cs
+++ b/src/EFCore/ChangeTracking/Internal/EntityEntryGraphIterator.cs
@@ -53,9 +53,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     {
                         foreach (var relatedEntity in ((IEnumerable)navigationValue).Cast<object>().ToList())
                         {
-                            var targetEntry = targetEntityType.HasDefiningNavigation()
-                                ? stateManager.GetOrCreateEntry(relatedEntity, targetEntityType)
-                                : stateManager.GetOrCreateEntry(relatedEntity);
+                            var targetEntry = stateManager.GetOrCreateEntry(relatedEntity, targetEntityType);
                             TraverseGraph(
                                 (EntityEntryGraphNode<TState>)node.CreateNode(node, targetEntry, navigation),
                                 handleNode);
@@ -63,9 +61,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     }
                     else
                     {
-                        var targetEntry = targetEntityType.HasDefiningNavigation()
-                            ? stateManager.GetOrCreateEntry(navigationValue, targetEntityType)
-                            : stateManager.GetOrCreateEntry(navigationValue);
+                        var targetEntry = stateManager.GetOrCreateEntry(navigationValue, targetEntityType);
                         TraverseGraph(
                             (EntityEntryGraphNode<TState>)node.CreateNode(node, targetEntry, navigation),
                             handleNode);
@@ -103,9 +99,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     {
                         foreach (var relatedEntity in ((IEnumerable)navigationValue).Cast<object>().ToList())
                         {
-                            var targetEntry = targetType.HasDefiningNavigation()
-                                ? stateManager.GetOrCreateEntry(relatedEntity, targetType)
-                                : stateManager.GetOrCreateEntry(relatedEntity);
+                            var targetEntry = stateManager.GetOrCreateEntry(relatedEntity, targetType);
                             await TraverseGraphAsync(
                                 (EntityEntryGraphNode<TState>)node.CreateNode(node, targetEntry, navigation),
                                 handleNode,
@@ -114,9 +108,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     }
                     else
                     {
-                        var targetEntry = targetType.HasDefiningNavigation()
-                            ? stateManager.GetOrCreateEntry(navigationValue, targetType)
-                            : stateManager.GetOrCreateEntry(navigationValue);
+                        var targetEntry = stateManager.GetOrCreateEntry(navigationValue, targetType);
                         await TraverseGraphAsync(
                             (EntityEntryGraphNode<TState>)node.CreateNode(node, targetEntry, navigation),
                             handleNode,

--- a/src/EFCore/ChangeTracking/Internal/IStateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/IStateManager.cs
@@ -87,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        InternalEntityEntry TryGetEntry([NotNull] object entity, [NotNull] IEntityType type);
+        InternalEntityEntry TryGetEntry([NotNull] object entity, [NotNull] IEntityType type, bool throwOnTypeMismatch = true);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/ChangeTracking/Internal/KeyPropagator.cs
+++ b/src/EFCore/ChangeTracking/Internal/KeyPropagator.cs
@@ -123,7 +123,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                         InternalEntityEntry principalEntry = null;
                         if (principal != null)
                         {
-                            principalEntry = stateManager.GetOrCreateEntry(principal);
+                            principalEntry = stateManager.GetOrCreateEntry(principal, foreignKey.PrincipalEntityType);
                         }
                         else if (foreignKey.PrincipalToDependent != null)
                         {

--- a/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
@@ -94,7 +94,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
                                     if (ReferenceEquals(victimDependentEntry[navigation], newTargetEntry.Entity)
                                         && victimDependentEntry.StateManager
-                                            .TryGetEntry(victimDependentEntry.Entity, targetEntityType) != null)
+                                            .TryGetEntry(victimDependentEntry.Entity, navigation.DeclaringEntityType) != null)
                                     {
                                         SetNavigation(victimDependentEntry, navigation, null);
                                     }
@@ -185,9 +185,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 stateManager.RecordReferencedUntrackedEntity(newValue, navigation, entry);
                 entry.SetRelationshipSnapshotValue(navigation, newValue);
 
-                newTargetEntry = targetEntityType.HasDefiningNavigation()
-                    ? stateManager.GetOrCreateEntry(newValue, targetEntityType)
-                    : stateManager.GetOrCreateEntry(newValue);
+                newTargetEntry = stateManager.GetOrCreateEntry(newValue, targetEntityType);
 
                 _attacher.AttachGraph(
                     newTargetEntry,
@@ -250,9 +248,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             foreach (var newValue in added)
             {
-                var newTargetEntry = targetEntityType.HasDefiningNavigation()
-                    ? stateManager.GetOrCreateEntry(newValue, targetEntityType)
-                    : stateManager.GetOrCreateEntry(newValue);
+                var newTargetEntry = stateManager.GetOrCreateEntry(newValue, targetEntityType);
 
                 if (newTargetEntry.EntityState != EntityState.Detached)
                 {
@@ -364,7 +360,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                                     ConditionallyNullForeignKeyProperties(targetDependentEntry, newPrincipalEntry, foreignKey);
 
                                     if (ReferenceEquals(targetDependentEntry[dependentToPrincipal], newPrincipalEntry.Entity)
-                                        && targetDependentEntry.StateManager.TryGetEntry(targetDependentEntry.Entity, foreignKey.DeclaringEntityType) != null)
+                                        && targetDependentEntry.StateManager.TryGetEntry(
+                                            targetDependentEntry.Entity, foreignKey.DeclaringEntityType) != null)
                                     {
                                         SetNavigation(targetDependentEntry, dependentToPrincipal, null);
                                     }

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2782,6 +2782,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 GetString("DerivedEntityCannotBeKeyless", nameof(entityType)),
                 entityType);
 
+        /// <summary>
+        ///     The instance of entity type '{runtimeEntityType}' cannot be tracked as the entity type '{entityType}' because they are not in the same hierarchy.
+        /// </summary>
+        public static string TrackingTypeMismatch([CanBeNull] object runtimeEntityType, [CanBeNull] object entityType)
+            => string.Format(
+                GetString("TrackingTypeMismatch", nameof(runtimeEntityType), nameof(entityType)),
+                runtimeEntityType, entityType);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1120,4 +1120,7 @@
   <data name="DerivedEntityCannotBeKeyless" xml:space="preserve">
     <value>Unable to set a base type for entity type '{entityType}' because it has been configured as having no keys.</value>
   </data>
+  <data name="TrackingTypeMismatch" xml:space="preserve">
+    <value>The instance of entity type '{runtimeEntityType}' cannot be tracked as the entity type '{entityType}' because they are not in the same hierarchy.</value>
+  </data>
 </root>

--- a/src/EFCore/Query/Internal/IncludeCompiler.IncludeLoadTreeNode.cs
+++ b/src/EFCore/Query/Internal/IncludeCompiler.IncludeLoadTreeNode.cs
@@ -539,8 +539,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 IPropertyBase navigation,
                 object entity)
                 => stateManager
-                    .TryGetEntry(entity, (IEntityType)navigation.DeclaringType)
-                    .SetIsLoaded((INavigation)navigation);
+                    .TryGetEntry(entity, (IEntityType)navigation.DeclaringType, throwOnTypeMismatch: false)
+                    ?.SetIsLoaded((INavigation)navigation);
 
             private static readonly MethodInfo _setRelationshipIsLoadedNoTrackingMethodInfo
                 = typeof(IncludeLoadTreeNode).GetTypeInfo()

--- a/test/EFCore.Specification.Tests/TestModels/TransportationModel/TransportationContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/TransportationModel/TransportationContext.cs
@@ -18,7 +18,6 @@ namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
         }
 
         public DbSet<Vehicle> Vehicles { get; set; }
-        public DbSet<Operator> Operators { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/test/EFCore.Tests/ChangeTracking/ChangeTrackerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/ChangeTrackerTest.cs
@@ -1435,8 +1435,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                 {
                     Dreams = new Dreams
                     {
-                        AreMade = new AreMadeOfThis(),
-                        OfThis = new AreMadeOfThis()
+                        Are = new AreMade(),
+                        Made = new AreMade()
                     }
                 };
 
@@ -1449,8 +1449,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                 {
                     var dreamsEntry = context.Entry(sweet).Reference(e => e.Dreams).TargetEntry;
                     dreamsEntry.Property("SweetId").CurrentValue = 1;
-                    dreamsEntry.Reference(e => e.AreMade).TargetEntry.Property("DreamsSweetId").CurrentValue = 1;
-                    dreamsEntry.Reference(e => e.OfThis).TargetEntry.Property("DreamsSweetId").CurrentValue = 1;
+                    dreamsEntry.Reference(e => e.Are).TargetEntry.Property("DreamsSweetId").CurrentValue = 1;
+                    dreamsEntry.Reference(e => e.Made).TargetEntry.Property("DreamsSweetId").CurrentValue = 1;
                 }
 
                 if (useAttach)
@@ -1481,8 +1481,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                         {
                             "<None> -----> Sweet:1",
                             "Sweet:1 ---Dreams--> Dreams:1",
-                            "Dreams:1 ---AreMade--> Dreams.AreMade#AreMadeOfThis:1",
-                            "Dreams:1 ---OfThis--> Dreams.OfThis#AreMadeOfThis:1"
+                            "Dreams:1 ---Are--> Dreams.Are#AreMade:1",
+                            "Dreams:1 ---Made--> Dreams.Made#AreMade:1"
                         },
                         traversal);
                 }
@@ -1490,8 +1490,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                 Assert.Equal(4, context.ChangeTracker.Entries().Count());
 
                 var dependentEntry = context.Entry(sweet.Dreams);
-                var dependentEntry2a = context.Entry(sweet.Dreams.AreMade);
-                var dependentEntry2b = context.Entry(sweet.Dreams.OfThis);
+                var dependentEntry2a = context.Entry(sweet.Dreams.Are);
+                var dependentEntry2b = context.Entry(sweet.Dreams.Made);
 
                 var expectedPrincipalState = setPrincipalKey ? EntityState.Unchanged : EntityState.Added;
                 var expectedDependentState = setPrincipalKey || (setDependentKey && useAttach) ? EntityState.Unchanged : EntityState.Added;
@@ -1523,16 +1523,16 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                     {
                         Id = 1
                     },
-                    AreMade = new AreMadeOfThis(),
-                    OfThis = new AreMadeOfThis()
+                    Are = new AreMade(),
+                    Made = new AreMade()
                 };
 
                 if (setDependentKey)
                 {
                     var dreamsEntry = context.Entry(dreams);
                     dreamsEntry.Property("SweetId").CurrentValue = 1;
-                    dreamsEntry.Reference(e => e.AreMade).TargetEntry.Property("DreamsSweetId").CurrentValue = 1;
-                    dreamsEntry.Reference(e => e.OfThis).TargetEntry.Property("DreamsSweetId").CurrentValue = 1;
+                    dreamsEntry.Reference(e => e.Are).TargetEntry.Property("DreamsSweetId").CurrentValue = 1;
+                    dreamsEntry.Reference(e => e.Made).TargetEntry.Property("DreamsSweetId").CurrentValue = 1;
                 }
 
                 if (useAttach)
@@ -1555,8 +1555,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                         new List<string>
                         {
                             "<None> -----> Dreams:1",
-                            "Dreams:1 ---AreMade--> Dreams.AreMade#AreMadeOfThis:1",
-                            "Dreams:1 ---OfThis--> Dreams.OfThis#AreMadeOfThis:1",
+                            "Dreams:1 ---Are--> Dreams.Are#AreMade:1",
+                            "Dreams:1 ---Made--> Dreams.Made#AreMade:1",
                             "Dreams:1 ---Sweet--> Sweet:1"
                         },
                         traversal);
@@ -1565,8 +1565,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                 Assert.Equal(4, context.ChangeTracker.Entries().Count());
 
                 var dependentEntry = context.Entry(dreams);
-                var dependentEntry2a = context.Entry(dreams.AreMade);
-                var dependentEntry2b = context.Entry(dreams.OfThis);
+                var dependentEntry2a = context.Entry(dreams.Are);
+                var dependentEntry2b = context.Entry(dreams.Made);
 
                 var expectedPrincipalState = EntityState.Unchanged;
                 var expectedDependentState = setDependentKey ? EntityState.Unchanged : EntityState.Added;
@@ -2194,8 +2194,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                     {
                         Id = 1
                     },
-                    AreMade = new AreMadeOfThis(),
-                    OfThis = new AreMadeOfThis()
+                    Are = new AreMade(),
+                    Made = new AreMade()
                 };
 
                 context.Entry(dreams.Sweet).State = EntityState.Unchanged;
@@ -2204,8 +2204,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                 {
                     var dreamsEntry = context.Entry(dreams);
                     dreamsEntry.Property("SweetId").CurrentValue = 1;
-                    dreamsEntry.Reference(e => e.AreMade).TargetEntry.Property("DreamsSweetId").CurrentValue = 1;
-                    dreamsEntry.Reference(e => e.OfThis).TargetEntry.Property("DreamsSweetId").CurrentValue = 1;
+                    dreamsEntry.Reference(e => e.Are).TargetEntry.Property("DreamsSweetId").CurrentValue = 1;
+                    dreamsEntry.Reference(e => e.Made).TargetEntry.Property("DreamsSweetId").CurrentValue = 1;
                 }
 
                 if (useAdd)
@@ -2230,8 +2230,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                         new List<string>
                         {
                             "<None> -----> Dreams:1",
-                            "Dreams:1 ---AreMade--> Dreams.AreMade#AreMadeOfThis:1",
-                            "Dreams:1 ---OfThis--> Dreams.OfThis#AreMadeOfThis:1"
+                            "Dreams:1 ---Are--> Dreams.Are#AreMade:1",
+                            "Dreams:1 ---Made--> Dreams.Made#AreMade:1"
                         },
                         traversal);
                 }
@@ -2239,8 +2239,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                 Assert.Equal(4, context.ChangeTracker.Entries().Count());
 
                 var dependentEntry = context.Entry(dreams);
-                var dependentEntry2a = context.Entry(dreams.AreMade);
-                var dependentEntry2b = context.Entry(dreams.OfThis);
+                var dependentEntry2a = context.Entry(dreams.Are);
+                var dependentEntry2b = context.Entry(dreams.Made);
 
                 var expectedPrincipalState = EntityState.Unchanged;
                 var expectedDependentState = EntityState.Added;
@@ -2254,6 +2254,69 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                 Assert.Equal(1, dependentEntry.Property(dependentEntry.Metadata.FindPrimaryKey().Properties[0].Name).CurrentValue);
                 Assert.Equal(1, dependentEntry2a.Property(dependentEntry2a.Metadata.FindPrimaryKey().Properties[0].Name).CurrentValue);
                 Assert.Equal(1, dependentEntry2b.Property(dependentEntry2b.Metadata.FindPrimaryKey().Properties[0].Name).CurrentValue);
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Adding_derived_owned_throws(bool useAdd)
+        {
+            using (var context = new EarlyLearningCenter())
+            {
+                var dreams = new Dreams
+                {
+                    Sweet = new Sweet
+                    {
+                        Id = 1
+                    },
+                    Are = new OfThis()
+                };
+
+                context.Entry(dreams.Sweet).State = EntityState.Unchanged;
+
+                if (useAdd)
+                {
+                    Assert.Equal(CoreStrings.TrackingTypeMismatch(nameof(OfThis), "Dreams.Are#AreMade"),
+                        Assert.Throws<InvalidOperationException>(() => context.Add(dreams)).Message);
+                }
+                else
+                {
+                    Assert.Equal(CoreStrings.TrackingTypeMismatch(nameof(OfThis), "Dreams.Are#AreMade"),
+                        Assert.Throws<InvalidOperationException>(() =>
+                            context.ChangeTracker.TrackGraph(
+                                dreams, e =>
+                                {
+                                    e.Entry.State = e.Entry.IsKeySet && !e.Entry.Metadata.IsOwned()
+                                        ? EntityState.Unchanged
+                                        : EntityState.Added;
+                                })).Message);
+                }
+            }
+        }
+
+        [Fact]
+        public void Moving_derived_owned_to_non_derived_reference_throws()
+        {
+            using (var context = new EarlyLearningCenter())
+            {
+                var dreams = new Dreams
+                {
+                    Sweet = new Sweet
+                    {
+                        Id = 1
+                    },
+                    OfThis = new OfThis()
+                };
+
+                context.Entry(dreams.Sweet).State = EntityState.Unchanged;
+                context.Add(dreams);
+
+                dreams.Are = dreams.OfThis;
+                dreams.OfThis = null;
+
+                Assert.Equal(CoreStrings.TrackingTypeMismatch(nameof(OfThis), "Dreams.Are#AreMade"),
+                    Assert.Throws<InvalidOperationException>(() => context.Entry(dreams)).Message);
             }
         }
 
@@ -3230,11 +3293,16 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         private class Dreams
         {
             public Sweet Sweet { get; set; }
-            public AreMadeOfThis AreMade { get; set; }
-            public AreMadeOfThis OfThis { get; set; }
+            public AreMade Are { get; set; }
+            public AreMade Made { get; set; }
+            public OfThis OfThis { get; set; }
         }
 
-        private class AreMadeOfThis
+        private class AreMade
+        {
+        }
+
+        private class OfThis : AreMade
         {
         }
 
@@ -3290,8 +3358,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                 modelBuilder.Entity<Sweet>().OwnsOne(
                     e => e.Dreams, b =>
                     {
-                        b.HasOne(e => e.Sweet).WithOne(e => e.Dreams);
-                        b.OwnsOne(e => e.AreMade);
+                        b.WithOwner(e => e.Sweet);
+                        b.OwnsOne(e => e.Are);
+                        b.OwnsOne(e => e.Made);
                         b.OwnsOne(e => e.OfThis);
                     });
 

--- a/test/EFCore.Tests/TestUtilities/FakeStateManager.cs
+++ b/test/EFCore.Tests/TestUtilities/FakeStateManager.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -105,7 +106,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             throw new NotImplementedException();
 
         public InternalEntityEntry TryGetEntry(object entity, bool throwOnNonUniqueness = true) => throw new NotImplementedException();
-        public InternalEntityEntry TryGetEntry(object entity, IEntityType type) => throw new NotImplementedException();
+        public InternalEntityEntry TryGetEntry(object entity, IEntityType type, bool throwOnTypeMismatch = true)
+            => throw new NotImplementedException();
         public IInternalEntityEntryNotifier InternalEntityEntryNotifier => throw new NotImplementedException();
         public void StateChanging(InternalEntityEntry entry, EntityState newState) => throw new NotImplementedException();
         public IValueGenerationManager ValueGenerationManager => throw new NotImplementedException();
@@ -141,6 +143,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         public bool SensitiveLoggingEnabled { get; }
         public void CascadeChanges(bool force) => throw new NotImplementedException();
         public void CascadeDelete(InternalEntityEntry entry, bool force) => throw new NotImplementedException();
+
         public IDiagnosticsLogger<DbLoggerCategory.Update> UpdateLogger { get; }
     }
 }


### PR DESCRIPTION
Remove unsupported Cosmos tests.