### PR TITLE
Stop calling `AddLogging` and `AddMemoryCache` from `AddDbContext`

### DIFF
--- a/src/EFCore/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/EFCore/EntityFrameworkServiceCollectionExtensions.cs
@@ -506,10 +506,6 @@ namespace Microsoft.Extensions.DependencyInjection
             ServiceLifetime optionsLifetime)
             where TContextImplementation : DbContext
         {
-            serviceCollection	
-                .AddMemoryCache()	
-                .AddLogging();
-
             serviceCollection.TryAdd(
                 new ServiceDescriptor(
                     typeof(DbContextOptions<TContextImplementation>),

--- a/src/EFCore/Internal/ScopedLoggerFactory.cs
+++ b/src/EFCore/Internal/ScopedLoggerFactory.cs
@@ -50,7 +50,11 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 if (applicationServiceProvider != null
                     && applicationServiceProvider != internalServiceProvider)
                 {
-                    return new ScopedLoggerFactory(applicationServiceProvider.GetService<ILoggerFactory>(), dispose: false);
+                    var loggerFactory = applicationServiceProvider.GetService<ILoggerFactory>();
+                    if (loggerFactory != null)
+                    {
+                        return new ScopedLoggerFactory(loggerFactory, dispose: false);
+                    }
                 }
             }
 

--- a/test/EFCore.Tests/DbContextServicesTest.cs
+++ b/test/EFCore.Tests/DbContextServicesTest.cs
@@ -185,7 +185,10 @@ namespace Microsoft.EntityFrameworkCore
             {
                 ILoggerFactory loggerFactory;
 
-                var serviceCollection = new ServiceCollection().AddScoped<Random>();
+                var serviceCollection
+                    = new ServiceCollection()
+                        .AddScoped<Random>()
+                        .AddLogging();
 
                 if (pool)
                 {


### PR DESCRIPTION
Issue #14756

This will break some ASP.NET tests/samples when this change is consumed. (I tried to get ASP.NET tests to run locally with updated EF Core; no luck.)