### PR TITLE
[WIP] Basic support for non-nullable references

### DIFF
--- a/src/EFCore/Diagnostics/CoreEventId.cs
+++ b/src/EFCore/Diagnostics/CoreEventId.cs
@@ -84,7 +84,9 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             RedundantIndexRemoved,
             IncompatibleMatchingForeignKeyProperties,
             RequiredAttributeOnDependent,
+            NonNullableOnDependent,
             RequiredAttributeOnBothNavigations,
+            NonNullableReferenceOnBothNavigations,
             ConflictingShadowForeignKeysWarning,
             MultiplePrimaryKeyCandidates,
             MultipleNavigationProperties,
@@ -445,6 +447,20 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
         /// <summary>
         ///     <para>
+        ///         The entity type with the navigation property that has non-nullability
+        ///         was configured as the dependent side in the relationship.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Model" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="NavigationEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
+        /// </summary>
+        public static readonly EventId NonNullableOnDependent = MakeModelId(Id.NonNullableOnDependent);
+
+        /// <summary>
+        ///     <para>
         ///         Navigations separated into two relationships as <see cref="RequiredAttribute" /> was specified on both navigations.
         ///     </para>
         ///     <para>
@@ -455,6 +471,19 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     </para>
         /// </summary>
         public static readonly EventId RequiredAttributeOnBothNavigations = MakeModelId(Id.RequiredAttributeOnBothNavigations);
+
+        /// <summary>
+        ///     <para>
+        ///         Navigations separated into two relationships as non-nullability was specified on both navigations.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Model" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="TwoPropertyBaseCollectionsEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
+        /// </summary>
+        public static readonly EventId NonNullableReferenceOnBothNavigations = MakeModelId(Id.NonNullableReferenceOnBothNavigations);
 
         /// <summary>
         ///     <para>

--- a/src/EFCore/Diagnostics/CoreLoggerExtensions.cs
+++ b/src/EFCore/Diagnostics/CoreLoggerExtensions.cs
@@ -1159,6 +1159,45 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public static void NonNullableOnDependent(
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Model> diagnostics,
+            [NotNull] INavigation navigation)
+        {
+            var definition = CoreResources.LogNonNullableOnDependent(diagnostics);
+
+            var warningBehavior = definition.GetLogBehavior(diagnostics);
+            if (warningBehavior != WarningBehavior.Ignore)
+            {
+                definition.Log(
+                    diagnostics,
+                    warningBehavior,
+                    navigation.Name, navigation.DeclaringEntityType.DisplayName());
+            }
+
+            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            {
+                diagnostics.DiagnosticSource.Write(
+                    definition.EventId.Name,
+                    new NavigationEventData(
+                        definition,
+                        NonNullableOnDependent,
+                        navigation));
+            }
+        }
+
+        private static string NonNullableOnDependent(EventDefinitionBase definition, EventData payload)
+        {
+            var d = (EventDefinition<string, string>)definition;
+            var p = (NavigationEventData)payload;
+            return d.GenerateMessage(p.Navigation.Name, p.Navigation.DeclaringEntityType.DisplayName());
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public static void RequiredAttributeOnBothNavigations(
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Model> diagnostics,
             [NotNull] INavigation firstNavigation,
@@ -1191,6 +1230,56 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         }
 
         private static string RequiredAttributeOnBothNavigations(EventDefinitionBase definition, EventData payload)
+        {
+            var d = (EventDefinition<string, string, string, string>)definition;
+            var p = (TwoPropertyBaseCollectionsEventData)payload;
+            var firstNavigation = p.FirstPropertyCollection[0];
+            var secondNavigation = p.SecondPropertyCollection[0];
+            return d.GenerateMessage(
+                firstNavigation.DeclaringType.DisplayName(),
+                firstNavigation.Name,
+                secondNavigation.DeclaringType.DisplayName(),
+                secondNavigation.Name);
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public static void NonNullableReferenceOnBothNavigations(
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Model> diagnostics,
+            [NotNull] INavigation firstNavigation,
+            [NotNull] INavigation secondNavigation)
+        {
+            var definition = CoreResources.LogNonNullableReferenceOnBothNavigations(diagnostics);
+
+            var warningBehavior = definition.GetLogBehavior(diagnostics);
+            if (warningBehavior != WarningBehavior.Ignore)
+            {
+                definition.Log(
+                    diagnostics,
+                    warningBehavior,
+                    firstNavigation.DeclaringEntityType.DisplayName(),
+                    firstNavigation.Name,
+                    secondNavigation.DeclaringEntityType.DisplayName(),
+                    secondNavigation.Name);
+            }
+
+            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            {
+                diagnostics.DiagnosticSource.Write(
+                    definition.EventId.Name,
+                    new TwoPropertyBaseCollectionsEventData(
+                        definition,
+                        NonNullableReferenceOnBothNavigations,
+                        new[] { firstNavigation },
+                        new[] { secondNavigation }));
+            }
+        }
+
+        private static string NonNullableReferenceOnBothNavigations(EventDefinitionBase definition, EventData payload)
         {
             var d = (EventDefinition<string, string, string, string>)definition;
             var p = (TwoPropertyBaseCollectionsEventData)payload;

--- a/src/EFCore/Diagnostics/LoggingDefinitions.cs
+++ b/src/EFCore/Diagnostics/LoggingDefinitions.cs
@@ -464,7 +464,25 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         [EntityFrameworkInternal]
+        public EventDefinitionBase LogNonNullableOnDependent;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
         public EventDefinitionBase LogRequiredAttributeOnBothNavigations;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public EventDefinitionBase LogNonNullableReferenceOnBothNavigations;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
@@ -113,6 +113,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             var concurrencyCheckAttributeConvention = new ConcurrencyCheckAttributeConvention(logger);
             var databaseGeneratedAttributeConvention = new DatabaseGeneratedAttributeConvention(logger);
             var requiredPropertyAttributeConvention = new RequiredPropertyAttributeConvention(logger);
+            var nonNullableReferencePropertyConvention = new NonNullableReferencePropertyConvention(logger);
             var maxLengthAttributeConvention = new MaxLengthAttributeConvention(logger);
             var stringLengthAttributeConvention = new StringLengthAttributeConvention(logger);
             var timestampAttributeConvention = new TimestampAttributeConvention(logger);
@@ -121,6 +122,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             conventionSet.PropertyAddedConventions.Add(concurrencyCheckAttributeConvention);
             conventionSet.PropertyAddedConventions.Add(databaseGeneratedAttributeConvention);
             conventionSet.PropertyAddedConventions.Add(requiredPropertyAttributeConvention);
+            conventionSet.PropertyAddedConventions.Add(nonNullableReferencePropertyConvention);
             conventionSet.PropertyAddedConventions.Add(maxLengthAttributeConvention);
             conventionSet.PropertyAddedConventions.Add(stringLengthAttributeConvention);
             conventionSet.PropertyAddedConventions.Add(timestampAttributeConvention);
@@ -190,6 +192,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
 
             conventionSet.NavigationAddedConventions.Add(backingFieldConvention);
             conventionSet.NavigationAddedConventions.Add(new RequiredNavigationAttributeConvention(logger));
+            conventionSet.NavigationAddedConventions.Add(new NonNullableNavigationConvention(logger));
             conventionSet.NavigationAddedConventions.Add(inversePropertyAttributeConvention);
             conventionSet.NavigationAddedConventions.Add(foreignKeyPropertyDiscoveryConvention);
             conventionSet.NavigationAddedConventions.Add(relationshipDiscoveryConvention);
@@ -212,6 +215,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             conventionSet.PropertyFieldChangedConventions.Add(concurrencyCheckAttributeConvention);
             conventionSet.PropertyFieldChangedConventions.Add(databaseGeneratedAttributeConvention);
             conventionSet.PropertyFieldChangedConventions.Add(requiredPropertyAttributeConvention);
+            conventionSet.PropertyFieldChangedConventions.Add(nonNullableReferencePropertyConvention);
             conventionSet.PropertyFieldChangedConventions.Add(maxLengthAttributeConvention);
             conventionSet.PropertyFieldChangedConventions.Add(stringLengthAttributeConvention);
             conventionSet.PropertyFieldChangedConventions.Add(timestampAttributeConvention);

--- a/src/EFCore/Metadata/Conventions/Internal/NonNullableNavigationConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/NonNullableNavigationConvention.cs
@@ -58,7 +58,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Check.NotNull(relationshipBuilder, nameof(relationshipBuilder));
             Check.NotNull(navigation, nameof(navigation));
 
-            if (!IsNonNullable(navigation))
+            if (!IsNonNullable(navigation) || navigation.IsCollection())
             {
                 return relationshipBuilder;
             }

--- a/src/EFCore/Metadata/Conventions/Internal/NonNullableNavigationConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/NonNullableNavigationConvention.cs
@@ -1,0 +1,130 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public class NonNullableNavigationConvention : INavigationAddedConvention
+    {
+        private const string NullableAttributeFullName = "System.Runtime.CompilerServices.NullableAttribute";
+        private Type _nullableAttrType;
+        private FieldInfo _nullableFlagsFieldInfo;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public NonNullableNavigationConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+        {
+            Logger = logger;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual InternalRelationshipBuilder Apply(
+            InternalRelationshipBuilder relationshipBuilder,
+            Navigation navigation)
+        {
+            Check.NotNull(relationshipBuilder, nameof(relationshipBuilder));
+            Check.NotNull(navigation, nameof(navigation));
+
+            if (!IsNonNullable(navigation))
+            {
+                return relationshipBuilder;
+            }
+
+            if (!navigation.IsDependentToPrincipal())
+            {
+                var inverse = navigation.FindInverse();
+                if (inverse != null)
+                {
+                    if (IsNonNullable(inverse))
+                    {
+                        Logger.NonNullableReferenceOnBothNavigations(navigation, inverse);
+                        return relationshipBuilder;
+                    }
+                }
+
+                if (!navigation.ForeignKey.IsUnique
+                    || relationshipBuilder.Metadata.GetPrincipalEndConfigurationSource() != null)
+                {
+                    return relationshipBuilder;
+                }
+
+                var newRelationshipBuilder = relationshipBuilder.HasEntityTypes(
+                    relationshipBuilder.Metadata.DeclaringEntityType,
+                    relationshipBuilder.Metadata.PrincipalEntityType,
+                    ConfigurationSource.Convention);
+
+                if (newRelationshipBuilder == null)
+                {
+                    return relationshipBuilder;
+                }
+
+                Logger.NonNullableOnDependent(newRelationshipBuilder.Metadata.DependentToPrincipal);
+                relationshipBuilder = newRelationshipBuilder;
+            }
+
+            return relationshipBuilder.IsRequired(true, ConfigurationSource.Convention) ?? relationshipBuilder;
+        }
+
+        private bool IsNonNullable(Navigation navigation)
+            => navigation.DeclaringEntityType.HasClrType()
+               && navigation.DeclaringEntityType.GetRuntimeProperties().Find(navigation.Name) is PropertyInfo propertyInfo
+               && IsNonNullable(propertyInfo);
+
+        private bool IsNonNullable(MemberInfo memberInfo)
+        {
+            if (Attribute.GetCustomAttributes(memberInfo, true) is Attribute[] attributes
+                && attributes.FirstOrDefault(a => a.GetType().FullName == NullableAttributeFullName) is Attribute attribute)
+            {
+                if (attribute.GetType() != _nullableAttrType)
+                {
+                    _nullableFlagsFieldInfo = attribute.GetType().GetField("NullableFlags");
+                    _nullableAttrType = attribute.GetType();
+                }
+
+                // For the interpretation of NullableFlags, see
+                // https://github.com/dotnet/roslyn/blob/master/docs/features/nullable-reference-types.md#annotations
+                if (_nullableFlagsFieldInfo?.GetValue(attribute) is byte[] flags
+                    && flags.Length >= 0
+                    && flags[0] == 1)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/EFCore/Metadata/Conventions/Internal/NonNullableReferencePropertyConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/NonNullableReferencePropertyConvention.cs
@@ -1,0 +1,99 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public class NonNullableReferencePropertyConvention : IPropertyAddedConvention, IPropertyFieldChangedConvention
+    {
+        private const string NullableAttributeFullName = "System.Runtime.CompilerServices.NullableAttribute";
+        private Type _nullableAttrType;
+        private FieldInfo _nullableFlagsFieldInfo;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public NonNullableReferencePropertyConvention([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
+        {
+            Logger = logger;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual InternalPropertyBuilder Apply(InternalPropertyBuilder propertyBuilder)
+        {
+            // If the model is spread across multiple assemblies, it may contain different NullableAttribute types as
+            // the compiler synthesizes them for each assembly.
+            if (propertyBuilder.Metadata.GetIdentifyingMemberInfo() is MemberInfo memberInfo
+                && IsNonNullable(memberInfo))
+            {
+                propertyBuilder.IsRequired(true, ConfigurationSource.Convention);
+            }
+
+            return propertyBuilder;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool Apply(InternalPropertyBuilder propertyBuilder, FieldInfo oldFieldInfo)
+        {
+            Apply(propertyBuilder);
+            return true;
+        }
+
+        private bool IsNonNullable(MemberInfo memberInfo)
+        {
+            if (Attribute.GetCustomAttributes(memberInfo, true) is Attribute[] attributes
+                && attributes.FirstOrDefault(a => a.GetType().FullName == NullableAttributeFullName) is Attribute attribute)
+            {
+                if (attribute.GetType() != _nullableAttrType)
+                {
+                    _nullableFlagsFieldInfo = attribute.GetType().GetField("NullableFlags");
+                    _nullableAttrType = attribute.GetType();
+                }
+
+                // For the interpretation of NullableFlags, see
+                // https://github.com/dotnet/roslyn/blob/master/docs/features/nullable-reference-types.md#annotations
+                if (_nullableFlagsFieldInfo?.GetValue(attribute) is byte[] flags
+                    && flags.Length >= 0
+                    && flags[0] == 1)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/EFCore/Metadata/Conventions/Internal/RequiredNavigationAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/RequiredNavigationAttributeConvention.cs
@@ -42,6 +42,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Check.NotNull(navigation, nameof(navigation));
             Check.NotNull(attribute, nameof(attribute));
 
+            if (navigation.IsCollection())
+            {
+                return relationshipBuilder;
+            }
+
             if (!navigation.IsDependentToPrincipal())
             {
                 var inverse = navigation.FindInverse();

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -3223,6 +3223,30 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
+        ///     The navigation property '{navigation}' is non-nullable, causing the entity type '{entityType}' to be configured as the dependent side in the corresponding relationship.
+        /// </summary>
+        public static EventDefinition<string, string> LogNonNullableOnDependent([NotNull] IDiagnosticsLogger logger)
+        {
+            var definition = ((LoggingDefinitions)logger.Definitions).LogNonNullableOnDependent;
+            if (definition == null)
+            {
+                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                    ref ((LoggingDefinitions)logger.Definitions).LogNonNullableOnDependent,
+                    () => new EventDefinition<string, string>(
+                        logger.Options,
+                        CoreEventId.NonNullableOnDependent,
+                        LogLevel.Debug,
+                        "CoreEventId.NonNullableOnDependent",
+                        level => LoggerMessage.Define<string, string>(
+                            level,
+                            CoreEventId.NonNullableOnDependent,
+                            _resourceManager.GetString("LogNonNullableOnDependent"))));
+            }
+
+            return (EventDefinition<string, string>)definition;
+        }
+
+        /// <summary>
         ///     The RequiredAttribute on '{principalEntityType}.{principalNavigation}' was ignored because there is also a RequiredAttribute on '{dependentEntityType}.{dependentNavigation}'. RequiredAttribute should only be specified on the dependent side of the relationship.
         /// </summary>
         public static EventDefinition<string, string, string, string> LogRequiredAttributeOnBothNavigations([NotNull] IDiagnosticsLogger logger)
@@ -3241,6 +3265,30 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
                             level,
                             CoreEventId.RequiredAttributeOnBothNavigations,
                             _resourceManager.GetString("LogRequiredAttributeOnBothNavigations"))));
+            }
+
+            return (EventDefinition<string, string, string, string>)definition;
+        }
+
+        /// <summary>
+        ///     '{principalEntityType}.{principalNavigation}' has not been configured as required despite being non-nullable, because '{dependentEntityType}.{dependentNavigation}' is also non-nullable. Non-nullability should only be specified on the dependent side of the relationship.
+        /// </summary>
+        public static EventDefinition<string, string, string, string> LogNonNullableReferenceOnBothNavigations([NotNull] IDiagnosticsLogger logger)
+        {
+            var definition = ((LoggingDefinitions)logger.Definitions).LogNonNullableReferenceOnBothNavigations;
+            if (definition == null)
+            {
+                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                    ref ((LoggingDefinitions)logger.Definitions).LogNonNullableReferenceOnBothNavigations,
+                    () => new EventDefinition<string, string, string, string>(
+                        logger.Options,
+                        CoreEventId.NonNullableReferenceOnBothNavigations,
+                        LogLevel.Debug,
+                        "CoreEventId.NonNullableReferenceOnBothNavigations",
+                        level => LoggerMessage.Define<string, string, string, string>(
+                            level,
+                            CoreEventId.NonNullableReferenceOnBothNavigations,
+                            _resourceManager.GetString("LogNonNullableReferenceOnBothNavigations"))));
             }
 
             return (EventDefinition<string, string, string, string>)definition;

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -995,9 +995,17 @@
     <value>The navigation property '{navigation}' has a RequiredAttribute causing the entity type '{entityType}' to be configured as the dependent side in the corresponding relationship.</value>
     <comment>Debug CoreEventId.RequiredAttributeOnDependent string string</comment>
   </data>
+  <data name="LogNonNullableOnDependent" xml:space="preserve">
+    <value>The navigation property '{navigation}' is non-nullable, causing the entity type '{entityType}' to be configured as the dependent side in the corresponding relationship.</value>
+    <comment>Debug CoreEventId.NonNullableOnDependent string string</comment>
+  </data>
   <data name="LogRequiredAttributeOnBothNavigations" xml:space="preserve">
     <value>The RequiredAttribute on '{principalEntityType}.{principalNavigation}' was ignored because there is also a RequiredAttribute on '{dependentEntityType}.{dependentNavigation}'. RequiredAttribute should only be specified on the dependent side of the relationship.</value>
     <comment>Debug CoreEventId.RequiredAttributeOnBothNavigations string string string string</comment>
+  </data>
+  <data name="LogNonNullableReferenceOnBothNavigations" xml:space="preserve">
+    <value>'{principalEntityType}.{principalNavigation}' has not been configured as required despite being non-nullable, because '{dependentEntityType}.{dependentNavigation}' is also non-nullable. Non-nullability should only be specified on the dependent side of the relationship.</value>
+    <comment>Debug CoreEventId.NonNullableReferenceOnBothNavigations string string string string</comment>
   </data>
   <data name="LogForeignKeyAttributesOnBothNavigations" xml:space="preserve">
     <value>Navigations '{dependentEntityType}.{dependentNavigation}' and '{principalEntityType}.{principalNavigation}' were separated into two relationships as ForeignKeyAttribute was specified on navigations on both sides.</value>

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/NavigationAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/NavigationAttributeConventionTest.cs
@@ -152,19 +152,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var principalEntityTypeBuilder =
                 dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention);
 
-            var relationshipBuilder = dependentEntityTypeBuilder.HasRelationship(
-                principalEntityTypeBuilder.Metadata,
-                nameof(Dependent.Principal),
+            var relationshipBuilder = principalEntityTypeBuilder.HasRelationship(
+                dependentEntityTypeBuilder.Metadata,
                 nameof(Principal.Dependents),
+                nameof(Dependent.Principal),
                 ConfigurationSource.Convention);
 
-            var navigation = dependentEntityTypeBuilder.Metadata.FindNavigation(nameof(Dependent.Principal));
+            var navigation = principalEntityTypeBuilder.Metadata.FindNavigation(nameof(Principal.Dependents));
 
             Assert.False(relationshipBuilder.Metadata.IsRequired);
 
             relationshipBuilder = CreateRequiredNavigationAttributeConvention().Apply(relationshipBuilder, navigation);
 
             Assert.False(relationshipBuilder.Metadata.IsRequired);
+
+            Assert.Empty(ListLoggerFactory.Log);
         }
 
         [Fact]
@@ -939,6 +941,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             [ForeignKey("AnotherPrincipal")]
             public int PrincipalAnotherFk { get; set; }
 
+            [Required]
             [ForeignKey("PrincipalFk")]
             [InverseProperty("Dependent")]
             public Principal Principal { get; set; }

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/NavigationAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/NavigationAttributeConventionTest.cs
@@ -107,7 +107,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 nameof(Blog.Posts),
                 ConfigurationSource.Convention);
 
-            var navigation = dependentEntityTypeBuilder.Metadata.FindNavigation(nameof(BlogDetails.Blog));
+            var navigation = dependentEntityTypeBuilder.Metadata.FindNavigation(nameof(Post.Blog));
 
             relationshipBuilder.IsRequired(false, ConfigurationSource.Convention);
 

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/NonNullableNavigationConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/NonNullableNavigationConventionTest.cs
@@ -1,0 +1,283 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
+using Microsoft.EntityFrameworkCore.InMemory.Storage.Internal;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
+{
+    public class NonNullableNavigationConventionTest
+    {
+        [Fact]
+        public void Non_nullability_does_not_override_configuration_from_explicit_source()
+        {
+            var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<Post>();
+            var principalEntityTypeBuilder = dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Blog), ConfigurationSource.Convention);
+
+            var relationshipBuilder = dependentEntityTypeBuilder.HasRelationship(
+                principalEntityTypeBuilder.Metadata,
+                nameof(Post.Blog),
+                nameof(Blog.Posts),
+                ConfigurationSource.Convention);
+
+            var navigation = dependentEntityTypeBuilder.Metadata.FindNavigation(nameof(Post.Blog));
+
+            relationshipBuilder.IsRequired(false, ConfigurationSource.Explicit);
+
+            Assert.False(relationshipBuilder.Metadata.IsRequired);
+
+            relationshipBuilder = CreateNotNullNavigationConvention().Apply(relationshipBuilder, navigation);
+
+            Assert.False(relationshipBuilder.Metadata.IsRequired);
+            Assert.Contains(principalEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(Blog.Posts));
+            Assert.Contains(dependentEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(Post.Blog));
+        }
+
+        [Fact]
+        public void Non_nullability_does_not_override_configuration_from_data_annotation()
+        {
+            var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<Post>();
+            var principalEntityTypeBuilder = dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Blog), ConfigurationSource.Convention);
+
+            var relationshipBuilder = dependentEntityTypeBuilder.HasRelationship(
+                principalEntityTypeBuilder.Metadata,
+                nameof(Post.Blog),
+                nameof(Blog.Posts),
+                ConfigurationSource.Convention);
+
+            var navigation = dependentEntityTypeBuilder.Metadata.FindNavigation(nameof(Post.Blog));
+
+            relationshipBuilder.IsRequired(false, ConfigurationSource.DataAnnotation);
+
+            Assert.False(relationshipBuilder.Metadata.IsRequired);
+
+            relationshipBuilder = CreateNotNullNavigationConvention().Apply(relationshipBuilder, navigation);
+
+            Assert.False(relationshipBuilder.Metadata.IsRequired);
+            Assert.Contains(principalEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(Blog.Posts));
+            Assert.Contains(dependentEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(Post.Blog));
+        }
+
+        [Fact]
+        public void Non_nullability_does_not_set_is_required_for_collection_navigation()
+        {
+            var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<Dependent>();
+            var principalEntityTypeBuilder =
+                dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention);
+
+            var relationshipBuilder = dependentEntityTypeBuilder.HasRelationship(
+                principalEntityTypeBuilder.Metadata,
+                nameof(Dependent.Principal),
+                nameof(Principal.Dependents),
+                ConfigurationSource.Convention);
+
+            var navigation = dependentEntityTypeBuilder.Metadata.FindNavigation(nameof(Dependent.Principal));
+
+            Assert.False(relationshipBuilder.Metadata.IsRequired);
+
+            relationshipBuilder = CreateNotNullNavigationConvention().Apply(relationshipBuilder, navigation);
+
+            Assert.False(relationshipBuilder.Metadata.IsRequired);
+        }
+
+        [Fact]
+        public void Non_nullability_does_not_set_is_required_for_navigation_to_dependent()
+        {
+            var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<Dependent>();
+            var principalEntityTypeBuilder =
+                dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention);
+
+            var relationshipBuilder = dependentEntityTypeBuilder.HasRelationship(
+                    principalEntityTypeBuilder.Metadata,
+                    nameof(Dependent.Principal),
+                    nameof(Principal.Dependent),
+                    ConfigurationSource.Convention)
+                .HasEntityTypes
+                    (principalEntityTypeBuilder.Metadata, dependentEntityTypeBuilder.Metadata, ConfigurationSource.Explicit);
+
+            var navigation = principalEntityTypeBuilder.Metadata.FindNavigation(nameof(Principal.Dependent));
+
+            Assert.False(relationshipBuilder.Metadata.IsRequired);
+
+            relationshipBuilder = CreateNotNullNavigationConvention().Apply(relationshipBuilder, navigation);
+
+            Assert.False(relationshipBuilder.Metadata.IsRequired);
+        }
+
+        [Fact]
+        public void Non_nullability_inverts_when_navigation_to_dependent()
+        {
+            var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<Dependent>();
+            var principalEntityTypeBuilder =
+                dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention);
+
+            var relationshipBuilder = dependentEntityTypeBuilder.HasRelationship(
+                principalEntityTypeBuilder.Metadata,
+                nameof(Dependent.Principal),
+                nameof(Principal.Dependent),
+                ConfigurationSource.Convention);
+
+            Assert.Equal(nameof(Dependent), relationshipBuilder.Metadata.DeclaringEntityType.DisplayName());
+            Assert.False(relationshipBuilder.Metadata.IsRequired);
+
+            var navigation = principalEntityTypeBuilder.Metadata.FindNavigation(nameof(Principal.Dependent));
+
+            relationshipBuilder = CreateNotNullNavigationConvention().Apply(relationshipBuilder, navigation);
+
+            Assert.Equal(nameof(Principal), relationshipBuilder.Metadata.DeclaringEntityType.DisplayName());
+            Assert.True(relationshipBuilder.Metadata.IsRequired);
+
+            var logEntry = ListLoggerFactory.Log.Single();
+            Assert.Equal(LogLevel.Debug, logEntry.Level);
+            Assert.Equal(
+                CoreResources.LogNonNullableOnDependent(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
+                    nameof(Principal.Dependent), nameof(Principal)), logEntry.Message);
+        }
+
+        [Fact]
+        public void Non_nullability_sets_is_required_with_conventional_builder()
+        {
+            var modelBuilder = CreateModelBuilder();
+            var model = (Model)modelBuilder.Model;
+            modelBuilder.Entity<BlogDetails>();
+
+            Assert.True(
+                model.FindEntityType(typeof(BlogDetails)).GetForeignKeys().Single(fk => fk.PrincipalEntityType?.ClrType == typeof(Blog))
+                    .IsRequired);
+        }
+
+        private NonNullableNavigationConvention CreateNotNullNavigationConvention()
+            => new NonNullableNavigationConvention(CreateLogger());
+
+        public ListLoggerFactory ListLoggerFactory { get; }
+            = new ListLoggerFactory(l => l == DbLoggerCategory.Model.Name);
+
+        private InternalEntityTypeBuilder CreateInternalEntityTypeBuilder<T>()
+        {
+            var conventionSet = new ConventionSet();
+            conventionSet.EntityTypeAddedConventions.Add(
+                new PropertyDiscoveryConvention(
+                    CreateTypeMapper(),
+                    new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()));
+
+            conventionSet.EntityTypeAddedConventions.Add(new KeyDiscoveryConvention(CreateLogger()));
+
+            var modelBuilder = new InternalModelBuilder(new Model(conventionSet));
+
+            return modelBuilder.Entity(typeof(T), ConfigurationSource.Explicit);
+        }
+
+        private static ITypeMappingSource CreateTypeMapper()
+            => TestServiceFactory.Instance.Create<InMemoryTypeMappingSource>();
+
+        private ModelBuilder CreateModelBuilder()
+        {
+            var contextServices = InMemoryTestHelpers.Instance.CreateContextServices();
+            var logger = CreateLogger();
+            var dependencies = contextServices.GetRequiredService<ProviderConventionSetBuilderDependencies>().With(logger);
+
+            return new ModelBuilder(
+                new RuntimeConventionSetBuilder(
+                        new ProviderConventionSetBuilder(dependencies),
+                        Enumerable.Empty<IConventionSetCustomizer>())
+                    .CreateConventionSet());
+        }
+
+        private DiagnosticsLogger<DbLoggerCategory.Model> CreateLogger()
+        {
+            ListLoggerFactory.Clear();
+            var options = new LoggingOptions();
+            options.Initialize(new DbContextOptionsBuilder().EnableSensitiveDataLogging(false).Options);
+            var modelLogger = new DiagnosticsLogger<DbLoggerCategory.Model>(
+                ListLoggerFactory,
+                options,
+                new DiagnosticListener("Fake"),
+                new TestLoggingDefinitions());
+            return modelLogger;
+        }
+
+#nullable enable
+#pragma warning disable CS8618
+
+        private class Blog
+        {
+            public int Id { get; set; }
+
+            [NotMapped]
+            public BlogDetails BlogDetails { get; set; }
+
+            public ICollection<Post> Posts { get; set; }
+        }
+
+        private class BlogDetails
+        {
+            public int Id { get; set; }
+
+            public Blog Blog { get; set; }
+
+            private Post Post { get; set; }
+        }
+
+        private class Post
+        {
+            public int Id { get; set; }
+
+            public Blog Blog { get; set; }
+        }
+
+        private class Principal
+        {
+            public static readonly PropertyInfo DependentIdProperty = typeof(Principal).GetProperty("DependentId");
+
+            public int Id { get; set; }
+
+            public int DependentId { get; set; }
+
+            [ForeignKey("PrincipalFk")]
+            public ICollection<Dependent> Dependents { get; set; }
+
+            public Dependent Dependent { get; set; }
+        }
+
+        private class Dependent
+        {
+            public static readonly PropertyInfo PrincipalIdProperty = typeof(Dependent).GetProperty("PrincipalId");
+
+            public int Id { get; set; }
+
+            public int PrincipalId { get; set; }
+
+            public int PrincipalFk { get; set; }
+
+            [ForeignKey("AnotherPrincipal")]
+            public int PrincipalAnotherFk { get; set; }
+
+            [ForeignKey("PrincipalFk")]
+            [InverseProperty("Dependent")]
+            public Principal? Principal { get; set; }
+
+            public Principal? AnotherPrincipal { get; set; }
+
+            [ForeignKey("PrincipalId, PrincipalFk")]
+            public Principal? CompositePrincipal { get; set; }
+        }
+#pragma warning restore CS8618
+#nullable disable
+    }
+}

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/NonNullableReferencePropertyConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/NonNullableReferencePropertyConventionTest.cs
@@ -1,0 +1,106 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.InMemory.Storage.Internal;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
+{
+    public class NonNullableReferencePropertyConventionTest
+    {
+        [Fact]
+        public void Non_nullability_does_not_override_configuration_from_explicit_source()
+        {
+            var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
+
+            var propertyBuilder = entityTypeBuilder.Property("Name", typeof(string), ConfigurationSource.Explicit);
+
+            propertyBuilder.IsRequired(false, ConfigurationSource.Explicit);
+
+            new NonNullableReferencePropertyConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(propertyBuilder);
+
+            Assert.True(propertyBuilder.Metadata.IsNullable);
+        }
+
+        [Fact]
+        public void Non_nullability_does_not_override_configuration_from_data_annotation_source()
+        {
+            var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
+
+            var propertyBuilder = entityTypeBuilder.Property("Name", typeof(string), ConfigurationSource.Explicit);
+
+            propertyBuilder.IsRequired(false, ConfigurationSource.DataAnnotation);
+
+            new NonNullableReferencePropertyConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(propertyBuilder);
+
+            Assert.True(propertyBuilder.Metadata.IsNullable);
+        }
+
+        [Fact]
+        public void Non_nullability_sets_is_nullable_with_conventional_builder()
+        {
+            var modelBuilder = CreateModelBuilder();
+            var entityTypeBuilder = modelBuilder.Entity<A>();
+
+            Assert.False(entityTypeBuilder.Property(e => e.Name).Metadata.IsNullable);
+        }
+
+        [Theory]
+        [InlineData(nameof(A.NullAwareNonNullable), false)]
+        [InlineData(nameof(A.NullAwareNullable), true)]
+        [InlineData(nameof(A.NullObliviousNonNullable), true)]
+        [InlineData(nameof(A.NullObliviousNullable), true)]
+        [InlineData(nameof(A.RequiredAndNullable), false)]
+        public void Reference_nullability_sets_is_nullable_correctly(string propertyName, bool expectedNullable)
+        {
+            var modelBuilder = CreateModelBuilder();
+            var entityTypeBuilder = modelBuilder.Entity<A>();
+
+            Assert.Equal(expectedNullable, entityTypeBuilder.Property(propertyName).Metadata.IsNullable);
+        }
+
+        private InternalEntityTypeBuilder CreateInternalEntityTypeBuilder<T>()
+        {
+            var conventionSet = new ConventionSet();
+            conventionSet.EntityTypeAddedConventions.Add(
+                new PropertyDiscoveryConvention(
+                    CreateTypeMapper(),
+                    new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()));
+
+            var modelBuilder = new InternalModelBuilder(new Model(conventionSet));
+
+            return modelBuilder.Entity(typeof(T), ConfigurationSource.Explicit);
+        }
+
+        private static ITypeMappingSource CreateTypeMapper()
+            => TestServiceFactory.Instance.Create<InMemoryTypeMappingSource>();
+
+        private class A
+        {
+            public int Id { get; set; }
+
+#nullable enable
+            public string Name { get; set; } = "";
+
+            public string NullAwareNonNullable { get; set; } = "";
+            public string? NullAwareNullable { get; set; }
+
+            [Required]
+            public string? RequiredAndNullable { get; set; }
+#nullable disable
+
+#pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' context.
+            public string NullObliviousNonNullable { get; set; }
+            public string? NullObliviousNullable { get; set; }
+#pragma warning restore CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' context.
+        }
+
+        private static ModelBuilder CreateModelBuilder() => InMemoryTestHelpers.Instance.CreateConventionBuilder();
+    }
+}


### PR DESCRIPTION
This WIP PR adds first support for taking the new C# 8.0 non-nullable references into account in model building. This adds convention logic that interprets non-nullable references in the same way as `[Required]` - for both regular and navigation properties.

Some notes:

* No scaffolding work done yet, we still have to decide what our scaffolding strategy is for this.
* The ConfigurationSource for non-nullable references is currently Convention, as non-nullability reference nullability seems weaker than [Required] or the fluent API, and should be overridden by them (there's a test for that).
* For now I integrated the nullability support into the existing RequiredPropertyAttributeConvention and RequiredNavigationAttributeConvention (which I renamed to RequiredPropertyConvention and RequiredNavigationConvention respectively). I'm not sure how fine-grained we like our conventions to be, in theory it may be worth separating them in case somebody doesn't want the new nullability support. Also, we can consider removing NavigationAttributeNavigationConvention as it's no longer used by us - although users may still use it for their own custom attributes?
* Some tests are missing (for non-nullable navigation properties) as well as log message changes.
* Weirdly, the tests pass from the cmdline but `Reference_nullability_sets_is_nullable_correctly(NullAwareNonNullable)` fails in VS2019 - this is a result of seeing a `[Nullable]` version from before dotnet/roslyn#30143 (VS is somehow stuck behind, not using the latest Roslyn or something)? @bricelam we briefly discussed this, if you feel like taking a quick look to make sure I'm not crazy....