### PR TITLE
More robust reflection lookups on non-EF types

### DIFF
--- a/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
@@ -217,12 +217,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 { typeof(string), GetDataReaderMethod(nameof(DbDataReader.GetString)) }
             };
 
-        private static MethodInfo GetDataReaderMethod(string name) =>
-            typeof(DbDataReader)
-                .GetRuntimeMethods()
-                .Single(m => m.GetParameters().Length == 1
-                             && m.GetParameters()[0].ParameterType == typeof(int)
-                             && m.Name.Equals(name, StringComparison.Ordinal));
+        private static MethodInfo GetDataReaderMethod(string name)
+            => typeof(DbDataReader).GetRuntimeMethod(name, new[] { typeof(int) });
 
         /// <summary>
         ///     Gets the mapping to be used when the only piece of information is that there is a null value.

--- a/src/EFCore.Relational/Storage/TypedRelationalValueBufferFactoryFactory.cs
+++ b/src/EFCore.Relational/Storage/TypedRelationalValueBufferFactoryFactory.cs
@@ -48,22 +48,15 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public static readonly ParameterExpression DataReaderParameter
             = Expression.Parameter(typeof(DbDataReader), "dataReader");
 
-        private static readonly MethodInfo _getFieldValueMethod
-            = GetDataReaderMethod(nameof(DbDataReader.GetFieldValue));
+        private static readonly MethodInfo _getFieldValueMethod =
+            typeof(DbDataReader).GetRuntimeMethod(nameof(DbDataReader.GetFieldValue), new[] { typeof(int) });
 
-        private static readonly MethodInfo _isDbNullMethod
-            = GetDataReaderMethod(nameof(DbDataReader.IsDBNull));
+        private static readonly MethodInfo _isDbNullMethod =
+            typeof(DbDataReader).GetRuntimeMethod(nameof(DbDataReader.IsDBNull), new[] { typeof(int) });
 
         private static readonly MethodInfo _throwReadValueExceptionMethod
-            = typeof(TypedRelationalValueBufferFactoryFactory).GetTypeInfo()
-                .GetDeclaredMethod(nameof(ThrowReadValueException));
+            = typeof(TypedRelationalValueBufferFactoryFactory).GetTypeInfo().GetDeclaredMethod(nameof(ThrowReadValueException));
 
-        private static MethodInfo GetDataReaderMethod(string name) =>
-            typeof(DbDataReader)
-                .GetRuntimeMethods()
-                .Single(m => m.GetParameters().Length == 1
-                             && m.GetParameters()[0].ParameterType == typeof(int)
-                             && m.Name.Equals(name, StringComparison.Ordinal));
         /// <summary>
         ///     Initializes a new instance of the <see cref="TypedRelationalValueBufferFactoryFactory" /> class.
         /// </summary>

--- a/src/EFCore.SqlServer.NTS/Storage/Internal/SqlServerGeometryTypeMapping.cs
+++ b/src/EFCore.SqlServer.NTS/Storage/Internal/SqlServerGeometryTypeMapping.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
         where TGeometry : IGeometry
     {
         private static readonly MethodInfo _getSqlBytes
-            = typeof(SqlDataReader).GetTypeInfo().GetDeclaredMethod(nameof(SqlDataReader.GetSqlBytes));
+            = typeof(SqlDataReader).GetRuntimeMethod(nameof(SqlDataReader.GetSqlBytes), new[] { typeof(int) });
 
         private readonly bool _isGeography;
 

--- a/src/EFCore.Sqlite.NTS/Storage/Internal/SqliteGeometryTypeMapping.cs
+++ b/src/EFCore.Sqlite.NTS/Storage/Internal/SqliteGeometryTypeMapping.cs
@@ -24,11 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal
         where TGeometry : IGeometry
     {
         private static readonly MethodInfo _getBytes
-            = typeof(DbDataReader)
-                .GetRuntimeMethods()
-                .Single(m => m.GetParameters().Length == 1
-                             && m.GetParameters()[0].ParameterType == typeof(int)
-                             && m.Name.Equals(nameof(DbDataReader.GetFieldValue), StringComparison.Ordinal))
+            = typeof(DbDataReader).GetRuntimeMethod(nameof(DbDataReader.GetFieldValue), new[] { typeof(int) })
                 .MakeGenericMethod(typeof(byte[]));
 
         /// <summary>

--- a/src/EFCore/ChangeTracking/ValueComparer.cs
+++ b/src/EFCore/ChangeTracking/ValueComparer.cs
@@ -29,27 +29,16 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     public abstract class ValueComparer : IEqualityComparer
     {
         internal static readonly MethodInfo EqualityComparerHashCodeMethod
-            = typeof(IEqualityComparer).GetTypeInfo()
-                .GetDeclaredMethod(nameof(IEqualityComparer.GetHashCode));
+            = typeof(IEqualityComparer).GetRuntimeMethod(nameof(IEqualityComparer.GetHashCode), new[] { typeof(object) });
 
         internal static readonly MethodInfo EqualityComparerEqualsMethod
-            = typeof(IEqualityComparer).GetTypeInfo()
-                .GetDeclaredMethod(nameof(IEqualityComparer.Equals));
+            = typeof(IEqualityComparer).GetRuntimeMethod(nameof(IEqualityComparer.Equals), new[] { typeof(object), typeof(object) });
 
-        internal static readonly MethodInfo ObjectEqualsMethod = typeof(object).GetTypeInfo().DeclaredMethods.Single(
-            m => m.IsStatic
-                 && m.ReturnType == typeof(bool)
-                 && nameof(object.Equals).Equals(m.Name, StringComparison.Ordinal)
-                 && m.IsPublic
-                 && m.GetParameters().Length == 2
-                 && m.GetParameters()[0].ParameterType == typeof(object)
-                 && m.GetParameters()[1].ParameterType == typeof(object));
+        internal static readonly MethodInfo ObjectEqualsMethod
+            = typeof(object).GetRuntimeMethod(nameof(object.Equals), new[] { typeof(object), typeof(object) });
 
-        internal static readonly MethodInfo ObjectGetHashCodeMethod = typeof(object).GetTypeInfo().DeclaredMethods.Single(
-            m => m.ReturnType == typeof(int)
-                 && nameof(GetHashCode).Equals(m.Name, StringComparison.Ordinal)
-                 && m.IsPublic
-                 && m.GetParameters().Length == 0);
+        internal static readonly MethodInfo ObjectGetHashCodeMethod
+            = typeof(object).GetRuntimeMethod(nameof(object.GetHashCode), Type.EmptyTypes);
 
         /// <summary>
         ///     Creates a new <see cref="ValueComparer" /> with the given comparison and

--- a/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
+++ b/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
@@ -469,9 +469,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
             = typeof(Expression).Assembly.GetType("System.Linq.Expressions.AssignBinaryExpression");
 
         private static readonly MethodInfo _fieldInfoSetValueMethod
-            = typeof(FieldInfo)
-                .GetTypeInfo()
-                .GetDeclaredMethods(nameof(FieldInfo.SetValue))
-                .Single(m => m.GetParameters().Length == 2);
+            = typeof(FieldInfo).GetRuntimeMethod(nameof(FieldInfo.SetValue), new[] { typeof(object), typeof(object) });
     }
 }

--- a/src/EFCore/Query/ExpressionVisitors/Internal/CollectionNavigationSubqueryInjector.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/CollectionNavigationSubqueryInjector.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -36,7 +37,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
         private static readonly List<MethodInfo> _collectionMaterializingMethods
             = typeof(Enumerable).GetRuntimeMethods().Where(m => _collectionMaterializingMethodNames.Contains(m.Name))
-                .Concat(typeof(AsyncEnumerable).GetRuntimeMethods().Where(m => _collectionMaterializingMethodNames.Contains(m.Name))).ToList();
+                .Concat(typeof(AsyncEnumerable).GetRuntimeMethods().Where(m => _collectionMaterializingMethodNames.Contains(m.Name)))
+            .Where(m => m.GetParameters().Length == 1).ToList();
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Query/ExpressionVisitors/Internal/CorrelatedCollectionFindingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/CorrelatedCollectionFindingExpressionVisitor.cs
@@ -26,11 +26,17 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
     {
         private readonly EntityQueryModelVisitor _queryModelVisitor;
 
-        private static readonly MethodInfo _toListMethodInfo
-            = typeof(Enumerable).GetTypeInfo().GetDeclaredMethod(nameof(Enumerable.ToList));
+        private static readonly MethodInfo _toListMethodInfo = GetEnumerableMethod(nameof(Enumerable.ToList));
 
-        private static readonly MethodInfo _toArrayMethodInfo
-            = typeof(Enumerable).GetTypeInfo().GetDeclaredMethod(nameof(Enumerable.ToArray));
+        private static readonly MethodInfo _toArrayMethodInfo = GetEnumerableMethod(nameof(Enumerable.ToArray));
+
+        static MethodInfo GetEnumerableMethod(string name) =>
+            typeof(Enumerable)
+                .GetRuntimeMethods()
+                .Single(m => m.Name.Equals(name, StringComparison.Ordinal)
+                             && m.GetParameters().Length == 1
+                             && m.GetParameters()[0].ParameterType.IsGenericType
+                             && m.GetParameters()[0].ParameterType.GetGenericTypeDefinition() == typeof(IEnumerable<>));
 
         private readonly bool _trackingQuery;
 

--- a/src/EFCore/Query/ExpressionVisitors/Internal/CorrelatedCollectionOptimizingVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/CorrelatedCollectionOptimizingVisitor.cs
@@ -46,7 +46,13 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             = typeof(IClrCollectionAccessor).GetRuntimeMethod(nameof(IClrCollectionAccessor.Create), Array.Empty<Type>());
 
         private static readonly MethodInfo _toListMethodInfo
-            = typeof(Enumerable).GetTypeInfo().GetDeclaredMethod(nameof(Enumerable.ToList));
+            = typeof(Enumerable)
+                .GetRuntimeMethods()
+                .Single(m => m.Name.Equals(nameof(Enumerable.ToList), StringComparison.Ordinal)
+                             && m.GetParameters().Length == 1
+                             && m.GetParameters()[0].ParameterType.IsGenericType
+                             && m.GetParameters()[0].ParameterType.GetGenericTypeDefinition() == typeof(IEnumerable<>)
+                );
 
         private List<Ordering> _parentOrderings { get; } = new List<Ordering>();
 

--- a/src/EFCore/Query/ExpressionVisitors/ProjectionExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/ProjectionExpressionVisitor.cs
@@ -142,7 +142,10 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
         private static readonly MethodInfo _toArrayAsync
             = typeof(AsyncEnumerable).GetTypeInfo()
                 .GetDeclaredMethods(nameof(AsyncEnumerable.ToArray))
-                .Single(mi => mi.GetParameters().Length == 2);
+                .Single(m => m.GetParameters().Length == 2
+                             && m.GetParameters()[0].ParameterType.IsGenericType
+                             && m.GetParameters()[0].ParameterType.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>)
+                             && m.GetParameters()[1].ParameterType == typeof(CancellationToken));
 
         private static readonly MethodInfo _materializeCollectionNavigationAsyncMethodInfo
             = typeof(ProjectionExpressionVisitor).GetTypeInfo()

--- a/src/EFCore/Query/Internal/IncludeCompiler.CollectionQueryModelRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/IncludeCompiler.CollectionQueryModelRewritingExpressionVisitor.cs
@@ -30,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             private readonly IncludeCompiler _includeCompiler;
 
             private static readonly MethodInfo _emptyMethodInfo
-                = typeof(Enumerable).GetTypeInfo().GetDeclaredMethod(nameof(Enumerable.Empty));
+                = typeof(Enumerable).GetRuntimeMethod(nameof(Enumerable.Empty), Type.EmptyTypes);
 
             public CollectionQueryModelRewritingExpressionVisitor(
                 QueryCompilationContext queryCompilationContext,

--- a/src/EFCore/Query/Internal/IncludeCompiler.IncludeLoadTreeNode.cs
+++ b/src/EFCore/Query/Internal/IncludeCompiler.IncludeLoadTreeNode.cs
@@ -33,8 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         private sealed class IncludeLoadTreeNode : IncludeLoadTreeNodeBase
         {
             private static readonly MethodInfo _referenceEqualsMethodInfo
-                = typeof(object).GetTypeInfo()
-                    .GetDeclaredMethod(nameof(ReferenceEquals));
+                = typeof(object).GetRuntimeMethod(nameof(ReferenceEquals), new[] { typeof(object), typeof(object) });
 
             private static readonly MethodInfo _collectionAccessorAddMethodInfo
                 = typeof(IClrCollectionAccessor).GetTypeInfo()

--- a/src/EFCore/Query/Internal/ReLinqEvaluatableExpressionFilter.cs
+++ b/src/EFCore/Query/Internal/ReLinqEvaluatableExpressionFilter.cs
@@ -33,10 +33,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             = typeof(DateTimeOffset).GetTypeInfo().GetDeclaredProperty(nameof(DateTimeOffset.UtcNow));
 
         private static readonly MethodInfo _guidNewGuid
-            = typeof(Guid).GetTypeInfo().GetDeclaredMethod(nameof(Guid.NewGuid));
+            = typeof(Guid).GetRuntimeMethod(nameof(Guid.NewGuid), Type.EmptyTypes);
 
         private static readonly MethodInfo _randomNextNoArgs
-            = typeof(Random).GetRuntimeMethod(nameof(Random.Next), Array.Empty<Type>());
+            = typeof(Random).GetRuntimeMethod(nameof(Random.Next), Type.EmptyTypes);
 
         private static readonly MethodInfo _randomNextOneArg
             = typeof(Random).GetRuntimeMethod(nameof(Random.Next), new[] { typeof(int) });


### PR DESCRIPTION
Here are some fixes for reflection lookups to make them more robust - I may not have caught them all. Note that I didn't touch reflection on EF Core's types, or some wonky stuff happening in our tests (e.g. [SqlExceptionFactory.cs](https://github.com/aspnet/EntityFrameworkCore/blob/9afed5819d71ab1751741a591d81aa31d179c60b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlExceptionFactory.cs#L11).

Also simplified some lookups by using `GetRuntimeMethod()` rather than elaborate LINQ checks, it seems robust enough but let me know if there's some issue with that.

Fixes #14878