### PR TITLE
CosmosDb provider support for a current region option

### DIFF
--- a/src/EFCore.Cosmos/Extensions/CosmosDbContextOptionsExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosDbContextOptionsExtensions.cs
@@ -52,5 +52,36 @@ namespace Microsoft.EntityFrameworkCore
 
             return optionsBuilder;
         }
+
+        public static DbContextOptionsBuilder UseCosmos(
+            [NotNull] this DbContextOptionsBuilder optionsBuilder,
+            [NotNull] string serviceEndPoint,
+            [NotNull] string authKeyOrResourceToken,
+            [NotNull] string databaseName,
+            [NotNull] string regionName,
+            [CanBeNull] Action<CosmosDbContextOptionsBuilder> cosmosOptionsAction = null)
+        {
+            Check.NotNull(optionsBuilder, nameof(optionsBuilder));
+            Check.NotNull(serviceEndPoint, nameof(serviceEndPoint));
+            Check.NotEmpty(authKeyOrResourceToken, nameof(authKeyOrResourceToken));
+            Check.NotEmpty(databaseName, nameof(databaseName));
+            Check.NotEmpty(regionName, nameof(regionName));
+
+            var extension = optionsBuilder.Options.FindExtension<CosmosDbOptionsExtension>()
+                            ?? new CosmosDbOptionsExtension();
+
+            extension = extension
+                .WithServiceEndPoint(serviceEndPoint)
+                .WithAuthKeyOrResourceToken(authKeyOrResourceToken)
+                .WithDatabaseName(databaseName)
+                .WithCurrentRegion(regionName)
+                ;
+
+            ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
+
+            cosmosOptionsAction?.Invoke(new CosmosDbContextOptionsBuilder(optionsBuilder));
+
+            return optionsBuilder;
+        }
     }
 }

--- a/src/EFCore.Cosmos/Extensions/CosmosDbContextOptionsExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosDbContextOptionsExtensions.cs
@@ -52,36 +52,5 @@ namespace Microsoft.EntityFrameworkCore
 
             return optionsBuilder;
         }
-
-        public static DbContextOptionsBuilder UseCosmos(
-            [NotNull] this DbContextOptionsBuilder optionsBuilder,
-            [NotNull] string serviceEndPoint,
-            [NotNull] string authKeyOrResourceToken,
-            [NotNull] string databaseName,
-            [NotNull] string regionName,
-            [CanBeNull] Action<CosmosDbContextOptionsBuilder> cosmosOptionsAction = null)
-        {
-            Check.NotNull(optionsBuilder, nameof(optionsBuilder));
-            Check.NotNull(serviceEndPoint, nameof(serviceEndPoint));
-            Check.NotEmpty(authKeyOrResourceToken, nameof(authKeyOrResourceToken));
-            Check.NotEmpty(databaseName, nameof(databaseName));
-            Check.NotEmpty(regionName, nameof(regionName));
-
-            var extension = optionsBuilder.Options.FindExtension<CosmosDbOptionsExtension>()
-                            ?? new CosmosDbOptionsExtension();
-
-            extension = extension
-                .WithServiceEndPoint(serviceEndPoint)
-                .WithAuthKeyOrResourceToken(authKeyOrResourceToken)
-                .WithDatabaseName(databaseName)
-                .WithCurrentRegion(regionName)
-                ;
-
-            ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
-
-            cosmosOptionsAction?.Invoke(new CosmosDbContextOptionsBuilder(optionsBuilder));
-
-            return optionsBuilder;
-        }
     }
 }

--- a/src/EFCore.Cosmos/Infrastructure/CosmosDbContextOptionsBuilder.cs
+++ b/src/EFCore.Cosmos/Infrastructure/CosmosDbContextOptionsBuilder.cs
@@ -31,6 +31,13 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Infrastructure
             => WithOption(e => e.WithExecutionStrategyFactory(Check.NotNull(getExecutionStrategy, nameof(getExecutionStrategy))));
 
         /// <summary>
+        /// Configures the context to use the provided Region.
+        /// </summary>
+        /// <param name="region">CosmosDB region name</param>
+        public virtual CosmosDbContextOptionsBuilder Region(string region)
+            => WithOption(e => e.WithRegion(Check.NotNull(region, nameof(region))));
+
+        /// <summary>
         ///     Sets an option by cloning the extension used to store the settings. This ensures the builder
         ///     does not modify options that are already in use elsewhere.
         /// </summary>

--- a/src/EFCore.Cosmos/Infrastructure/Internal/CosmosDbOptionExtension.cs
+++ b/src/EFCore.Cosmos/Infrastructure/Internal/CosmosDbOptionExtension.cs
@@ -18,7 +18,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal
         private string _databaseName;
         private Func<ExecutionStrategyDependencies, IExecutionStrategy> _executionStrategyFactory;
         private string _logFragment;
-        private string _currentRegion;
 
         public CosmosDbOptionsExtension()
         {
@@ -30,7 +29,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal
             _authKeyOrResourceToken = copyFrom._authKeyOrResourceToken;
             _databaseName = copyFrom._databaseName;
             _executionStrategyFactory = copyFrom._executionStrategyFactory;
-            _currentRegion = copyFrom._currentRegion;
         }
 
         public virtual string ServiceEndPoint => _serviceEndPoint;
@@ -62,17 +60,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal
             var clone = Clone();
 
             clone._databaseName = database;
-
-            return clone;
-        }
-
-        public virtual string CurrentRegion => _currentRegion;
-
-        public virtual CosmosDbOptionsExtension WithCurrentRegion(string currentRegion)
-        {
-            var clone = Clone();
-
-            clone._currentRegion = currentRegion;
 
             return clone;
         }
@@ -133,11 +120,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal
                     builder.Append("ServiceEndPoint=").Append(_serviceEndPoint).Append(' ');
 
                     builder.Append("Database=").Append(_databaseName).Append(' ');
-
-                    if (_currentRegion != null)
-                    {
-                        builder.Append("CurrentRegion=").Append(_currentRegion).Append(' ');
-                    }
 
                     _logFragment = builder.ToString();
                 }

--- a/src/EFCore.Cosmos/Infrastructure/Internal/CosmosDbOptionExtension.cs
+++ b/src/EFCore.Cosmos/Infrastructure/Internal/CosmosDbOptionExtension.cs
@@ -18,6 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal
         private string _databaseName;
         private Func<ExecutionStrategyDependencies, IExecutionStrategy> _executionStrategyFactory;
         private string _logFragment;
+        private string _currentRegion;
 
         public CosmosDbOptionsExtension()
         {
@@ -29,6 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal
             _authKeyOrResourceToken = copyFrom._authKeyOrResourceToken;
             _databaseName = copyFrom._databaseName;
             _executionStrategyFactory = copyFrom._executionStrategyFactory;
+            _currentRegion = copyFrom._currentRegion;
         }
 
         public virtual string ServiceEndPoint => _serviceEndPoint;
@@ -60,6 +62,17 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal
             var clone = Clone();
 
             clone._databaseName = database;
+
+            return clone;
+        }
+
+        public virtual string CurrentRegion => _currentRegion;
+
+        public virtual CosmosDbOptionsExtension WithCurrentRegion(string currentRegion)
+        {
+            var clone = Clone();
+
+            clone._currentRegion = currentRegion;
 
             return clone;
         }
@@ -120,6 +133,11 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal
                     builder.Append("ServiceEndPoint=").Append(_serviceEndPoint).Append(' ');
 
                     builder.Append("Database=").Append(_databaseName).Append(' ');
+
+                    if (_currentRegion != null)
+                    {
+                        builder.Append("CurrentRegion=").Append(_currentRegion).Append(' ');
+                    }
 
                     _logFragment = builder.ToString();
                 }

--- a/src/EFCore.Cosmos/Infrastructure/Internal/CosmosDbOptionExtension.cs
+++ b/src/EFCore.Cosmos/Infrastructure/Internal/CosmosDbOptionExtension.cs
@@ -18,6 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal
         private string _databaseName;
         private Func<ExecutionStrategyDependencies, IExecutionStrategy> _executionStrategyFactory;
         private string _logFragment;
+        private string _region;
 
         public CosmosDbOptionsExtension()
         {
@@ -60,6 +61,17 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal
             var clone = Clone();
 
             clone._databaseName = database;
+
+            return clone;
+        }
+
+        public virtual string Region => _region;
+
+        public virtual CosmosDbOptionsExtension WithRegion(string region)
+        {
+            var clone = Clone();
+
+            clone._region = region;
 
             return clone;
         }

--- a/src/EFCore.Cosmos/Infrastructure/Internal/CosmosDbOptionExtension.cs
+++ b/src/EFCore.Cosmos/Infrastructure/Internal/CosmosDbOptionExtension.cs
@@ -30,6 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal
             _authKeyOrResourceToken = copyFrom._authKeyOrResourceToken;
             _databaseName = copyFrom._databaseName;
             _executionStrategyFactory = copyFrom._executionStrategyFactory;
+            _region = copyFrom._region;
         }
 
         public virtual string ServiceEndPoint => _serviceEndPoint;

--- a/src/EFCore.Cosmos/Storage/Internal/CosmosClientWrapper.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosClientWrapper.cs
@@ -33,7 +33,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
 
         private static readonly string _userAgent = " Microsoft.EntityFrameworkCore.Cosmos/" + ProductInfo.GetVersion();
         public static readonly JsonSerializer Serializer = new JsonSerializer();
-        private readonly string _currentRegion;
 
         static CosmosClientWrapper()
         {
@@ -51,30 +50,18 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
             _databaseId = options.DatabaseName;
             _endPoint = options.ServiceEndPoint;
             _authKey = options.AuthKeyOrResourceToken;
-            _currentRegion = options.CurrentRegion;
             _executionStrategyFactory = executionStrategyFactory;
             _commandLogger = commandLogger;
         }
 
         private CosmosClient Client =>
             _client
-            ?? (_client = BuildCosmosClient());
-
-        private CosmosClient BuildCosmosClient()
-        {
-            var configuration = new CosmosConfiguration(_endPoint, _authKey)
-            {
-                UserAgentSuffix = _userAgent,
-                ConnectionMode = ConnectionMode.Direct,
-            };
-
-            if (_currentRegion != null)
-            {
-                configuration.UseCurrentRegion(_currentRegion);
-            }
-
-            return new CosmosClient(configuration);
-        }
+            ?? (_client = new CosmosClient(
+                new CosmosConfiguration(_endPoint, _authKey)
+                {
+                    UserAgentSuffix = _userAgent,
+                    ConnectionMode = ConnectionMode.Direct
+                }));
 
         public bool CreateDatabaseIfNotExists()
             => _executionStrategyFactory.Create().Execute(

--- a/test/EFCore.Cosmos.FunctionalTests/CosmosEndToEndTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/CosmosEndToEndTest.cs
@@ -365,19 +365,25 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
         }
 
         [ConditionalFact]
-        public void Can_create_options_with_specified_region()
+        public void Should_not_throw_if_specified_region_is_right()
         {
-            var regionName = CosmosRegions.EastAsia;
-            var options = new DbContextOptionsBuilder().UseCosmos(
-                "serviceEndPoint",
-                "authKeyOrResourceToken",
-                "databaseName",
-                o => { o.Region(regionName); });
+            var regionName = CosmosRegions.AustraliaCentral;
 
-            var extension = options
-                .Options.FindExtension<CosmosDbOptionsExtension>();
+            using (var testDatabase = CosmosTestStore.CreateInitialized(DatabaseName, o => o.Region(regionName)))
+            {
+                var options = Fixture.CreateOptions(testDatabase);
 
-            Assert.Equal(regionName, extension.Region);
+                var customer = new Customer { Id = 42, Name = "Theon" };
+
+                using (var context = new CustomerContext(options))
+                {
+                    context.Database.EnsureCreated();
+
+                    context.Add(customer);
+
+                    context.SaveChanges();
+                }
+            }
         }
 
         [ConditionalFact]

--- a/test/EFCore.Cosmos.FunctionalTests/CosmosEndToEndTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/CosmosEndToEndTest.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
+using Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal;
 using Microsoft.EntityFrameworkCore.Cosmos.TestUtilities;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
@@ -360,6 +362,40 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
             {
                 modelBuilder.Entity<ConflictingIncompatibleId>();
             }
+        }
+
+        [ConditionalFact]
+        public void Can_create_options_with_specified_region()
+        {
+            var regionName = CosmosRegions.EastAsia;
+            var options = new DbContextOptionsBuilder().UseCosmos(
+                "serviceEndPoint",
+                "authKeyOrResourceToken",
+                "databaseName",
+                o => { o.Region(regionName); });
+
+            var extension = options
+                .Options.FindExtension<CosmosDbOptionsExtension>();
+
+            Assert.Equal(regionName, extension.Region);
+        }
+
+        [ConditionalFact]
+        public void Should_throw_if_specified_region_is_wrong()
+        {
+            var regionName = "FakeRegion";
+
+            Action a = () =>
+            {
+                var options = new DbContextOptionsBuilder().UseCosmos(
+                    "serviceEndPoint",
+                    "authKeyOrResourceToken",
+                    "databaseName",
+                    o => { o.Region(regionName); });
+            };
+
+            var ex = Assert.Throws<ArgumentException>(a);
+            Assert.Equal("Current location is not a valid Azure region.", ex.Message);
         }
 
         [ConditionalFact]

--- a/test/EFCore.Cosmos.FunctionalTests/CosmosEndToEndTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/CosmosEndToEndTest.cs
@@ -387,11 +387,21 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
 
             Action a = () =>
             {
-                var options = new DbContextOptionsBuilder().UseCosmos(
-                    "serviceEndPoint",
-                    "authKeyOrResourceToken",
-                    "databaseName",
-                    o => { o.Region(regionName); });
+                using (var testDatabase = CosmosTestStore.CreateInitialized(DatabaseName, o => o.Region(regionName)))
+                {
+                    var options = Fixture.CreateOptions(testDatabase);
+
+                    var customer = new Customer {Id = 42, Name = "Theon"};
+
+                    using (var context = new CustomerContext(options))
+                    {
+                        context.Database.EnsureCreated();
+
+                        context.Add(customer);
+
+                        context.SaveChanges();
+                    }
+                }
             };
 
             var ex = Assert.Throws<ArgumentException>(a);

--- a/test/EFCore.Cosmos.Tests/Configuration/CosmosDbContextOptionsExtensionsTests.cs
+++ b/test/EFCore.Cosmos.Tests/Configuration/CosmosDbContextOptionsExtensionsTests.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.Azure.Cosmos;
+using Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Cosmos.Configuration
+{
+    public class CosmosDbContextOptionsExtensionsTests
+    {
+        [Fact]
+        public void Can_create_options_with_specified_region()
+        {
+            var regionName = CosmosRegions.EastAsia;
+            var options = new DbContextOptionsBuilder().UseCosmos(
+                "serviceEndPoint",
+                "authKeyOrResourceToken",
+                "databaseName",
+                o => { o.Region(regionName); });
+
+            var extension = options
+                .Options.FindExtension<CosmosDbOptionsExtension>();
+
+            Assert.Equal(regionName, extension.Region);
+        }
+
+        /// <summary>
+        /// The region will be checked by the cosmosdb sdk, because the region list is not constant
+        /// </summary>
+        [Fact]
+        public void Can_create_options_with_wrong_region()
+        {
+            var regionName = "FakeRegion";
+            var options = new DbContextOptionsBuilder().UseCosmos(
+                "serviceEndPoint",
+                "authKeyOrResourceToken",
+                "databaseName",
+                o => { o.Region(regionName); });
+
+            var extension = options
+                .Options.FindExtension<CosmosDbOptionsExtension>();
+
+            Assert.Equal(regionName, extension.Region);
+        }
+    }
+}


### PR DESCRIPTION
CosmosDb provider doesn't support a configuration option for a current region

Fix #15007


**Please check if the PR fulfills these requirements**

- [x] The code builds and tests pass (verified by our automated build checks)
- [x] Commit messages follow this format
```
    Summary of the changes
    - Detail 1
    - Detail 2

    Fixes #bugnumber
```
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code meets the expectations our engineering guidelines. https://github.com/aspnet/Home/wiki/Engineering-guidelines.

Please review the guidelines for CONTRIBUTING.md for more details.