### PR TITLE
[WIP] Better store type management

### DIFF
--- a/src/EFCore.Relational/Storage/RelationalTypeMappingSource.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMappingSource.cs
@@ -175,10 +175,17 @@ namespace Microsoft.EntityFrameworkCore.Storage
                         }
                     }
 
-                    if (mapping != null
-                        && converter != null)
+                    if (mapping != null)
                     {
-                        mapping = (RelationalTypeMapping)mapping.Clone(converter);
+                        if (info.StoreTypeName != null && info.StoreTypeName != mapping.StoreType)
+                        {
+                            mapping = mapping.Clone(info.StoreTypeName);
+                        }
+
+                        if (converter != null)
+                        {
+                            mapping = (RelationalTypeMapping)mapping.Clone(converter);
+                        }
                     }
 
                     return mapping;

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerStringTypeMapping.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerStringTypeMapping.cs
@@ -33,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
             : this(
                 new RelationalTypeMappingParameters(
                     new CoreTypeMappingParameters(typeof(string)),
-                    storeType ?? GetStoreName(unicode, fixedLength),
+                    storeType ?? GenerateDefaultStoreName(unicode, fixedLength),
                     storeTypePostfix ?? StoreTypePostfix.Size,
                     GetDbType(unicode, fixedLength),
                     unicode,
@@ -42,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
         {
         }
 
-        private static string GetStoreName(bool unicode, bool fixedLength) => unicode
+        private static string GenerateDefaultStoreName(bool unicode, bool fixedLength) => unicode
             ? fixedLength ? "nchar" : "nvarchar"
             : fixedLength
                 ? "char"

--- a/test/EFCore.Relational.Tests/Storage/RelationalTypeMapperTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalTypeMapperTest.cs
@@ -9,7 +9,7 @@ using Xunit;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Storage
 {
-    public class RelationalTypeMapperTest : RelationalTypeMapperTestBase
+    public class RelationalTypeMappingSourceTest : RelationalTypeMappingSourceTestBase
     {
         [Fact]
         public void Does_simple_mapping_from_CLR_type()
@@ -134,35 +134,35 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public void Key_with_store_type_is_picked_up_by_FK()
         {
             var model = CreateModel();
-            var mapper = CreateTestTypeMapper();
+            var typeMappingSource = CreateTestTypeMappingSource();
 
             Assert.Equal(
                 "money",
-                GetMapping(mapper, model.FindEntityType(typeof(MyType)).FindProperty("Id")).StoreType);
+                GetMapping(typeMappingSource, model.FindEntityType(typeof(MyType)).FindProperty("Id")).StoreType);
 
             Assert.Equal(
                 "money",
-                GetMapping(mapper, model.FindEntityType(typeof(MyRelatedType1)).FindProperty("Relationship1Id")).StoreType);
+                GetMapping(typeMappingSource, model.FindEntityType(typeof(MyRelatedType1)).FindProperty("Relationship1Id")).StoreType);
         }
 
-        private static IRelationalTypeMappingSource CreateTestTypeMapper()
+        private static IRelationalTypeMappingSource CreateTestTypeMappingSource()
             => new TestRelationalTypeMappingSource(
                 TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
                 TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>());
 
         public static RelationalTypeMapping GetMapping(
             Type type)
-            => CreateTestTypeMapper().FindMapping(type);
+            => CreateTestTypeMappingSource().FindMapping(type);
 
         public static RelationalTypeMapping GetMapping(
             IProperty property)
-            => CreateTestTypeMapper().FindMapping(property);
+            => CreateTestTypeMappingSource().FindMapping(property);
 
         [Fact]
         public void String_key_with_max_length_is_picked_up_by_FK()
         {
             var model = CreateModel();
-            var mapper = CreateTestTypeMapper();
+            var mapper = CreateTestTypeMappingSource();
 
             Assert.Equal(
                 "just_string(200)",
@@ -177,7 +177,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public void Binary_key_with_max_length_is_picked_up_by_FK()
         {
             var model = CreateModel();
-            var mapper = CreateTestTypeMapper();
+            var mapper = CreateTestTypeMappingSource();
 
             Assert.Equal(
                 "just_binary(100)",
@@ -192,7 +192,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public void String_key_with_unicode_is_picked_up_by_FK()
         {
             var model = CreateModel();
-            var mapper = CreateTestTypeMapper();
+            var mapper = CreateTestTypeMappingSource();
 
             Assert.Equal(
                 "ansi_string(900)",
@@ -207,7 +207,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public void Key_store_type_is_preferred_if_specified()
         {
             var model = CreateModel();
-            var mapper = CreateTestTypeMapper();
+            var mapper = CreateTestTypeMappingSource();
 
             Assert.Equal(
                 "money",
@@ -222,7 +222,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public void String_FK_max_length_is_preferred_if_specified()
         {
             var model = CreateModel();
-            var mapper = CreateTestTypeMapper();
+            var mapper = CreateTestTypeMappingSource();
 
             Assert.Equal(
                 "just_string(200)",
@@ -237,7 +237,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public void Binary_FK_max_length_is_preferred_if_specified()
         {
             var model = CreateModel();
-            var mapper = CreateTestTypeMapper();
+            var mapper = CreateTestTypeMappingSource();
 
             Assert.Equal(
                 "just_binary(100)",
@@ -252,7 +252,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public void String_FK_unicode_is_preferred_if_specified()
         {
             var model = CreateModel();
-            var mapper = CreateTestTypeMapper();
+            var mapper = CreateTestTypeMappingSource();
 
             Assert.Equal(
                 "ansi_string(900)",

--- a/test/EFCore.Relational.Tests/Storage/RelationalTypeMapperTestBase.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalTypeMapperTestBase.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Storage
 {
-    public abstract class RelationalTypeMapperTestBase
+    public abstract class RelationalTypeMappingSourceTestBase
     {
         protected EntityType CreateEntityType()
             => (EntityType)CreateModel().FindEntityType(typeof(MyType));

--- a/test/EFCore.Relational.Tests/Storage/RelationalTypeMappingTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalTypeMappingTest.cs
@@ -65,7 +65,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 null,
                 null);
 
-            var clone = mapping.Clone("<clone>", null);
+            var clone = mapping.Clone("<clone>");
 
             Assert.NotSame(mapping, clone);
             Assert.Same(mapping.GetType(), clone.GetType());
@@ -113,7 +113,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 null,
                 null);
 
-            var clone = mapping.Clone("<clone>", 66);
+            var clone = mapping.Clone("<clone>").Clone(66);
 
             Assert.NotSame(mapping, clone);
             Assert.Same(mapping.GetType(), clone.GetType());
@@ -170,7 +170,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 null,
                 null);
 
-            var clone = mapping.Clone("<clone>", 66);
+            var clone = mapping.Clone("<clone>").Clone(66);
 
             Assert.NotSame(mapping, clone);
             Assert.Same(mapping.GetType(), clone.GetType());

--- a/test/EFCore.Relational.Tests/TestUtilities/TestRelationalTypeMappingSource.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/TestRelationalTypeMappingSource.cs
@@ -185,10 +185,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 if (_simpleMappings.TryGetValue(clrType, out var mapping))
                 {
-                    return storeTypeName != null
-                           && !mapping.StoreType.Equals(storeTypeName, StringComparison.Ordinal)
-                        ? mapping.Clone(storeTypeName, mapping.Size)
-                        : mapping;
+                    return mapping;
                 }
             }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeographyFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeographyFixture.cs
@@ -53,7 +53,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 => mappingInfo.ClrType == typeof(GeoPoint)
                     ? ((RelationalTypeMapping)base.FindMapping(typeof(IPoint))
                         .Clone(new GeoPointConverter(CreateGeometryServices().CreateGeometryFactory())))
-                    .Clone("geography", null)
+                    .Clone("geography")
                     : base.FindMapping(mappingInfo);
         }
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeometryFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeometryFixture.cs
@@ -44,7 +44,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             protected override RelationalTypeMapping FindMapping(in RelationalTypeMappingInfo mappingInfo)
                 => mappingInfo.ClrType == typeof(GeoPoint)
                     ? ((RelationalTypeMapping)base.FindMapping(typeof(IPoint))
-                        .Clone(new GeoPointConverter())).Clone("geometry", null)
+                        .Clone(new GeoPointConverter())).Clone("geometry")
                     : base.FindMapping(mappingInfo);
         }
     }

--- a/test/EFCore.SqlServer.Tests/Storage/SqlServerTypeMappingSourceTest.cs
+++ b/test/EFCore.SqlServer.Tests/Storage/SqlServerTypeMappingSourceTest.cs
@@ -700,7 +700,7 @@ namespace Microsoft.EntityFrameworkCore
         [InlineData("VarCHaR(333)", typeof(string), 333, false)] // case-insensitive
         [InlineData("varchar(333)", typeof(string), 333, false)]
         [InlineData("varchar(max)", typeof(string), null, false)]
-        [InlineData("VARCHAR(max)", typeof(string), null, false, "varchar(max)")]
+        [InlineData("VARCHAR(max)", typeof(string), null, false)]
         public void Can_map_by_type_name(string typeName, Type clrType, int? size, bool unicode, string expectedType = null)
         {
             var mapping = CreateTypeMappingSource().FindMapping(typeName);

--- a/test/EFCore.SqlServer.Tests/Storage/SqlServerTypeMappingSourceTest.cs
+++ b/test/EFCore.SqlServer.Tests/Storage/SqlServerTypeMappingSourceTest.cs
@@ -16,7 +16,7 @@ using Xunit;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore
 {
-    public class SqlServerTypeMapperTest : RelationalTypeMapperTestBase
+    public class SqlServerTypeMappingSourceTest : RelationalTypeMappingSourceTestBase
     {
         [Fact]
         public void Does_simple_SQL_Server_mappings_to_DDL_types()
@@ -206,7 +206,7 @@ namespace Microsoft.EntityFrameworkCore
             property.IsUnicode(unicode);
             property.DeclaringEntityType.SetPrimaryKey(property);
 
-            var typeMapping = CreateTypeMapper().GetMapping(property);
+            var typeMapping = CreateTypeMappingSource().GetMapping(property);
 
             Assert.Null(typeMapping.DbType);
             Assert.Equal("nvarchar(450)", typeMapping.StoreType);
@@ -215,7 +215,7 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(450, typeMapping.CreateParameter(new TestCommand(), "Name", "Value").Size);
         }
 
-        private static IRelationalTypeMappingSource CreateTypeMapper()
+        private static IRelationalTypeMappingSource CreateTypeMappingSource()
             => new SqlServerTypeMappingSource(
                 TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
                 TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>());
@@ -232,7 +232,7 @@ namespace Microsoft.EntityFrameworkCore
             var pk = property.DeclaringEntityType.SetPrimaryKey(property);
             property.DeclaringEntityType.AddForeignKey(fkProperty, pk, property.DeclaringEntityType);
 
-            var typeMapping = CreateTypeMapper().GetMapping(fkProperty);
+            var typeMapping = CreateTypeMappingSource().GetMapping(fkProperty);
 
             Assert.Null(typeMapping.DbType);
             Assert.Equal("nvarchar(450)", typeMapping.StoreType);
@@ -254,7 +254,7 @@ namespace Microsoft.EntityFrameworkCore
             property.DeclaringEntityType.AddForeignKey(fkProperty, pk, property.DeclaringEntityType);
             fkProperty.IsNullable = false;
 
-            var typeMapping = CreateTypeMapper().GetMapping(fkProperty);
+            var typeMapping = CreateTypeMappingSource().GetMapping(fkProperty);
 
             Assert.Null(typeMapping.DbType);
             Assert.Equal("nvarchar(450)", typeMapping.StoreType);
@@ -273,7 +273,7 @@ namespace Microsoft.EntityFrameworkCore
             property.IsUnicode(unicode);
             entityType.AddIndex(property);
 
-            var typeMapping = CreateTypeMapper().GetMapping(property);
+            var typeMapping = CreateTypeMappingSource().GetMapping(property);
 
             Assert.Null(typeMapping.DbType);
             Assert.Equal("nvarchar(450)", typeMapping.StoreType);
@@ -350,7 +350,7 @@ namespace Microsoft.EntityFrameworkCore
             property.IsUnicode(false);
             property.DeclaringEntityType.SetPrimaryKey(property);
 
-            var typeMapping = CreateTypeMapper().GetMapping(property);
+            var typeMapping = CreateTypeMappingSource().GetMapping(property);
 
             Assert.Equal(DbType.AnsiString, typeMapping.DbType);
             Assert.Equal("varchar(900)", typeMapping.StoreType);
@@ -369,7 +369,7 @@ namespace Microsoft.EntityFrameworkCore
             var pk = property.DeclaringEntityType.SetPrimaryKey(property);
             property.DeclaringEntityType.AddForeignKey(fkProperty, pk, property.DeclaringEntityType);
 
-            var typeMapping = CreateTypeMapper().GetMapping(fkProperty);
+            var typeMapping = CreateTypeMappingSource().GetMapping(fkProperty);
 
             Assert.Equal(DbType.AnsiString, typeMapping.DbType);
             Assert.Equal("varchar(900)", typeMapping.StoreType);
@@ -389,7 +389,7 @@ namespace Microsoft.EntityFrameworkCore
             property.DeclaringEntityType.AddForeignKey(fkProperty, pk, property.DeclaringEntityType);
             fkProperty.IsNullable = false;
 
-            var typeMapping = CreateTypeMapper().GetMapping(fkProperty);
+            var typeMapping = CreateTypeMappingSource().GetMapping(fkProperty);
 
             Assert.Equal(DbType.AnsiString, typeMapping.DbType);
             Assert.Equal("varchar(900)", typeMapping.StoreType);
@@ -406,7 +406,7 @@ namespace Microsoft.EntityFrameworkCore
             property.IsUnicode(false);
             entityType.AddIndex(property);
 
-            var typeMapping = CreateTypeMapper().GetMapping(property);
+            var typeMapping = CreateTypeMappingSource().GetMapping(property);
 
             Assert.Equal(DbType.AnsiString, typeMapping.DbType);
             Assert.Equal("varchar(900)", typeMapping.StoreType);
@@ -476,7 +476,7 @@ namespace Microsoft.EntityFrameworkCore
             var property = CreateEntityType().AddProperty("MyBinaryProp", typeof(byte[]));
             property.Relational().ColumnType = "binary(100)";
 
-            var typeMapping = CreateTypeMapper().GetMapping(property);
+            var typeMapping = CreateTypeMappingSource().GetMapping(property);
 
             Assert.Equal(DbType.Binary, typeMapping.DbType);
             Assert.Equal("binary(100)", typeMapping.StoreType);
@@ -489,7 +489,7 @@ namespace Microsoft.EntityFrameworkCore
             property.IsNullable = false;
             property.DeclaringEntityType.SetPrimaryKey(property);
 
-            var typeMapping = CreateTypeMapper().GetMapping(property);
+            var typeMapping = CreateTypeMappingSource().GetMapping(property);
 
             Assert.Equal(DbType.Binary, typeMapping.DbType);
             Assert.Equal("varbinary(900)", typeMapping.StoreType);
@@ -505,7 +505,7 @@ namespace Microsoft.EntityFrameworkCore
             var pk = property.DeclaringEntityType.SetPrimaryKey(property);
             property.DeclaringEntityType.AddForeignKey(fkProperty, pk, property.DeclaringEntityType);
 
-            var typeMapping = CreateTypeMapper().GetMapping(fkProperty);
+            var typeMapping = CreateTypeMappingSource().GetMapping(fkProperty);
 
             Assert.Equal(DbType.Binary, typeMapping.DbType);
             Assert.Equal("varbinary(900)", typeMapping.StoreType);
@@ -522,7 +522,7 @@ namespace Microsoft.EntityFrameworkCore
             property.DeclaringEntityType.AddForeignKey(fkProperty, pk, property.DeclaringEntityType);
             fkProperty.IsNullable = false;
 
-            var typeMapping = CreateTypeMapper().GetMapping(fkProperty);
+            var typeMapping = CreateTypeMappingSource().GetMapping(fkProperty);
 
             Assert.Equal(DbType.Binary, typeMapping.DbType);
             Assert.Equal("varbinary(900)", typeMapping.StoreType);
@@ -536,7 +536,7 @@ namespace Microsoft.EntityFrameworkCore
             var property = entityType.AddProperty("MyProp", typeof(byte[]));
             entityType.AddIndex(property);
 
-            var typeMapping = CreateTypeMapper().GetMapping(property);
+            var typeMapping = CreateTypeMappingSource().GetMapping(property);
 
             Assert.Equal(DbType.Binary, typeMapping.DbType);
             Assert.Equal("varbinary(900)", typeMapping.StoreType);
@@ -550,7 +550,7 @@ namespace Microsoft.EntityFrameworkCore
             property.IsConcurrencyToken = true;
             property.ValueGenerated = ValueGenerated.OnAddOrUpdate;
 
-            var typeMapping = CreateTypeMapper().GetMapping(property);
+            var typeMapping = CreateTypeMappingSource().GetMapping(property);
 
             Assert.Equal(DbType.Binary, typeMapping.DbType);
             Assert.Equal("rowversion", typeMapping.StoreType);
@@ -566,7 +566,7 @@ namespace Microsoft.EntityFrameworkCore
             property.ValueGenerated = ValueGenerated.OnAddOrUpdate;
             property.IsNullable = false;
 
-            var typeMapping = CreateTypeMapper().GetMapping(property);
+            var typeMapping = CreateTypeMappingSource().GetMapping(property);
 
             Assert.Equal(DbType.Binary, typeMapping.DbType);
             Assert.Equal("rowversion", typeMapping.StoreType);
@@ -580,7 +580,7 @@ namespace Microsoft.EntityFrameworkCore
             var property = CreateEntityType().AddProperty("MyProp", typeof(byte[]));
             property.IsConcurrencyToken = true;
 
-            var typeMapping = CreateTypeMapper().GetMapping(property);
+            var typeMapping = CreateTypeMappingSource().GetMapping(property);
 
             Assert.Equal(DbType.Binary, typeMapping.DbType);
             Assert.Equal("varbinary(max)", typeMapping.StoreType);
@@ -609,45 +609,45 @@ namespace Microsoft.EntityFrameworkCore
                 property.IsUnicode(unicode);
             }
 
-            return CreateTypeMapper().GetMapping(property);
+            return CreateTypeMappingSource().GetMapping(property);
         }
 
         [Fact]
         public void Does_default_mappings_for_sequence_types()
         {
-            Assert.Equal("int", CreateTypeMapper().GetMapping(typeof(int)).StoreType);
-            Assert.Equal("smallint", CreateTypeMapper().GetMapping(typeof(short)).StoreType);
-            Assert.Equal("bigint", CreateTypeMapper().GetMapping(typeof(long)).StoreType);
-            Assert.Equal("tinyint", CreateTypeMapper().GetMapping(typeof(byte)).StoreType);
+            Assert.Equal("int", CreateTypeMappingSource().GetMapping(typeof(int)).StoreType);
+            Assert.Equal("smallint", CreateTypeMappingSource().GetMapping(typeof(short)).StoreType);
+            Assert.Equal("bigint", CreateTypeMappingSource().GetMapping(typeof(long)).StoreType);
+            Assert.Equal("tinyint", CreateTypeMappingSource().GetMapping(typeof(byte)).StoreType);
         }
 
         [Fact]
         public void Does_default_mappings_for_strings_and_byte_arrays()
         {
-            Assert.Equal("nvarchar(max)", CreateTypeMapper().GetMapping(typeof(string)).StoreType);
-            Assert.Equal("varbinary(max)", CreateTypeMapper().GetMapping(typeof(byte[])).StoreType);
+            Assert.Equal("nvarchar(max)", CreateTypeMappingSource().GetMapping(typeof(string)).StoreType);
+            Assert.Equal("varbinary(max)", CreateTypeMappingSource().GetMapping(typeof(byte[])).StoreType);
         }
 
         [Fact]
         public void Does_default_mappings_for_values()
         {
-            Assert.Equal("nvarchar(max)", CreateTypeMapper().GetMappingForValue("Cheese").StoreType);
-            Assert.Equal("varbinary(max)", CreateTypeMapper().GetMappingForValue(new byte[1]).StoreType);
-            Assert.Equal("datetime2", CreateTypeMapper().GetMappingForValue(new DateTime()).StoreType);
+            Assert.Equal("nvarchar(max)", CreateTypeMappingSource().GetMappingForValue("Cheese").StoreType);
+            Assert.Equal("varbinary(max)", CreateTypeMappingSource().GetMappingForValue(new byte[1]).StoreType);
+            Assert.Equal("datetime2", CreateTypeMappingSource().GetMappingForValue(new DateTime()).StoreType);
         }
 
         [Fact]
         public void Does_default_mappings_for_null_values()
         {
-            Assert.Equal("NULL", CreateTypeMapper().GetMappingForValue(null).StoreType);
-            Assert.Equal("NULL", CreateTypeMapper().GetMappingForValue(DBNull.Value).StoreType);
+            Assert.Equal("NULL", CreateTypeMappingSource().GetMappingForValue(null).StoreType);
+            Assert.Equal("NULL", CreateTypeMappingSource().GetMappingForValue(DBNull.Value).StoreType);
         }
 
         [Fact]
         public void Throws_for_unrecognized_property_types()
         {
             var property = new Model().AddEntityType("Entity1").AddProperty("Strange", typeof(object));
-            var ex = Assert.Throws<InvalidOperationException>(() => CreateTypeMapper().GetMapping(property));
+            var ex = Assert.Throws<InvalidOperationException>(() => CreateTypeMappingSource().GetMapping(property));
             Assert.Equal(RelationalStrings.UnsupportedPropertyType("Entity1", "Strange", "object"), ex.Message);
         }
 
@@ -703,7 +703,7 @@ namespace Microsoft.EntityFrameworkCore
         [InlineData("VARCHAR(max)", typeof(string), null, false, "varchar(max)")]
         public void Can_map_by_type_name(string typeName, Type clrType, int? size, bool unicode, string expectedType = null)
         {
-            var mapping = CreateTypeMapper().FindMapping(typeName);
+            var mapping = CreateTypeMappingSource().FindMapping(typeName);
 
             Assert.Equal(clrType, mapping.ClrType);
             Assert.Equal(size, mapping.Size);
@@ -729,7 +729,7 @@ namespace Microsoft.EntityFrameworkCore
         [InlineData("VARCHAR")]
         public void Throws_for_naked_type_name(string typeName)
         {
-            var mapper = CreateTypeMapper();
+            var mapper = CreateTypeMappingSource();
 
             Assert.Equal(
                 SqlServerStrings.UnqualifiedDataType(typeName),
@@ -761,7 +761,7 @@ namespace Microsoft.EntityFrameworkCore
                 .HasColumnType(typeName)
                 .Metadata;
 
-            var mapper = CreateTypeMapper();
+            var mapper = CreateTypeMappingSource();
 
             Assert.Equal(
                 SqlServerStrings.UnqualifiedDataTypeOnProperty(typeName, nameof(StringCheese.StringWithSize)),
@@ -791,7 +791,7 @@ namespace Microsoft.EntityFrameworkCore
                 .HasMaxLength(2018)
                 .Metadata;
 
-            var mapping = CreateTypeMapper().FindMapping(property);
+            var mapping = CreateTypeMappingSource().FindMapping(property);
 
             Assert.Same(typeof(string), mapping.ClrType);
             Assert.Equal(2018, mapping.Size);
@@ -813,7 +813,7 @@ namespace Microsoft.EntityFrameworkCore
                 .HasMaxLength(2018)
                 .Metadata;
 
-            var mapping = CreateTypeMapper().FindMapping(property);
+            var mapping = CreateTypeMappingSource().FindMapping(property);
 
             Assert.Same(typeof(byte[]), mapping.ClrType);
             Assert.Equal(2018, mapping.Size);
@@ -831,7 +831,7 @@ namespace Microsoft.EntityFrameworkCore
         public void Key_with_store_type_is_picked_up_by_FK()
         {
             var model = CreateModel();
-            var mapper = CreateTypeMapper();
+            var mapper = CreateTypeMappingSource();
 
             Assert.Equal(
                 "money",
@@ -846,7 +846,7 @@ namespace Microsoft.EntityFrameworkCore
         public void String_key_with_max_length_is_picked_up_by_FK()
         {
             var model = CreateModel();
-            var mapper = CreateTypeMapper();
+            var mapper = CreateTypeMappingSource();
 
             Assert.Equal(
                 "nvarchar(200)",
@@ -861,7 +861,7 @@ namespace Microsoft.EntityFrameworkCore
         public void Binary_key_with_max_length_is_picked_up_by_FK()
         {
             var model = CreateModel();
-            var mapper = CreateTypeMapper();
+            var mapper = CreateTypeMappingSource();
 
             Assert.Equal(
                 "varbinary(100)",
@@ -876,7 +876,7 @@ namespace Microsoft.EntityFrameworkCore
         public void String_key_with_unicode_is_picked_up_by_FK()
         {
             var model = CreateModel();
-            var mapper = CreateTypeMapper();
+            var mapper = CreateTypeMappingSource();
 
             Assert.Equal(
                 "varchar(900)",
@@ -891,7 +891,7 @@ namespace Microsoft.EntityFrameworkCore
         public void Key_store_type_if_preferred_if_specified()
         {
             var model = CreateModel();
-            var mapper = CreateTypeMapper();
+            var mapper = CreateTypeMappingSource();
 
             Assert.Equal(
                 "money",
@@ -906,7 +906,7 @@ namespace Microsoft.EntityFrameworkCore
         public void String_FK_max_length_is_preferred_if_specified()
         {
             var model = CreateModel();
-            var mapper = CreateTypeMapper();
+            var mapper = CreateTypeMappingSource();
 
             Assert.Equal(
                 "nvarchar(200)",
@@ -921,7 +921,7 @@ namespace Microsoft.EntityFrameworkCore
         public void Binary_FK_max_length_is_preferred_if_specified()
         {
             var model = CreateModel();
-            var mapper = CreateTypeMapper();
+            var mapper = CreateTypeMappingSource();
 
             Assert.Equal(
                 "varbinary(100)",
@@ -936,7 +936,7 @@ namespace Microsoft.EntityFrameworkCore
         public void String_FK_unicode_is_preferred_if_specified()
         {
             var model = CreateModel();
-            var mapper = CreateTypeMapper();
+            var mapper = CreateTypeMappingSource();
 
             Assert.Equal(
                 "varchar(900)",

--- a/test/EFCore.SqlServer.Tests/Storage/SqlServerTypeMappingTest.cs
+++ b/test/EFCore.SqlServer.Tests/Storage/SqlServerTypeMappingTest.cs
@@ -137,7 +137,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 33,
                 true);
 
-            var clone = (SqlServerUdtTypeMapping)mapping.Clone("<clone>", 66);
+            var clone = (SqlServerUdtTypeMapping)mapping.Clone("<clone>").Clone(66);
 
             Assert.NotSame(mapping, clone);
             Assert.Same(mapping.GetType(), clone.GetType());

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SpatialQuerySqliteFixture.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SpatialQuerySqliteFixture.cs
@@ -56,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 => mappingInfo.ClrType == typeof(GeoPoint)
                     ? ((RelationalTypeMapping)base.FindMapping(typeof(IPoint))
                         .Clone(new GeoPointConverter()))
-                    .Clone("geometry", null)
+                    .Clone("geometry")
                     : base.FindMapping(mappingInfo);
         }
     }

--- a/test/EFCore.Sqlite.Tests/Storage/SqliteTypeMappingTest.cs
+++ b/test/EFCore.Sqlite.Tests/Storage/SqliteTypeMappingTest.cs
@@ -50,15 +50,15 @@ namespace Microsoft.EntityFrameworkCore.Storage
         [InlineData("", typeof(string))]
         public void It_maps_strings_to_not_null_types(string typeName, Type clrType)
         {
-            Assert.Equal(clrType, CreateTypeMapper().FindMapping(typeName).ClrType);
+            Assert.Equal(clrType, CreateTypeMappingSource().FindMapping(typeName).ClrType);
         }
 
-        private static IRelationalTypeMappingSource CreateTypeMapper()
+        private static IRelationalTypeMappingSource CreateTypeMappingSource()
             => TestServiceFactory.Instance.Create<SqliteTypeMappingSource>();
 
         public static RelationalTypeMapping GetMapping(
             Type type)
-            => CreateTypeMapper().FindMapping(type);
+            => CreateTypeMappingSource().FindMapping(type);
 
         public override void Char_literal_generated_correctly()
         {


### PR DESCRIPTION
Cases we want to support:

1. `int`: no facets.
2. `varchar(4)`: standard facet (size), standard rendering.
3. `timestamp(3) with time zone`, `varchar(max)`: standard facet (size), non-standard rendering.
4. PostGIS `geometry(Point, 4326)`, MySQL `TEXT(4) CHARACTER SET latin1 COLLATE latin1_german1_ci`: Non-standard facets (to fully support this we also need to flow annotations, see #14000).

Notes:

* Mappings with standard facets but non-standard rendering (e.g. `timestamp(3) with time zone`) can override the new `GenerateStoreType()` 
* Mappings with non-standard facets should set `StoreTypePostfix` to `None` and simply set the mapping's `StoreType` themselves in their own constructor - `StoreType` has been made settable for this. This provides them access to the extra facet properties (SRID, collation...) for constructing their store type.
* We previously had slightly inconsistent behavior, where the user-specified StoreType was sometimes respected to the letter, sometimes not. For example, VarCHaR(333) came back as VarCHaR(333), but VARCHAR(max) came back as varchar(max). RelationalTypeMappingSource now manages cloning the mapping if the StoreType specified by the user is different from the mapping given back by the provider, ensuring that the name always corresponds.
* Removed `RelationalTypeMapping.StoreTypeNameBase` which is no longer needed.

Issues/open questions:

There's a confusing/inconsistent situation around decimal/datetime/float mappings and facets... SqlServerDecimalTypeMapping has `StoreTypePostfix.PrecisionAndScale`, but its `ConfigureParameter()` method sets *`SqlParameter.Size()`* - you can see this in failing test `Can_insert_and_read_back_all_mapped_data_types_with_precision_with_identity`. I'm guessing there's a nice SQL Server story behind this, but does this mean that `StoreTypePrefix` can't actually express what facets are supported by a mapping, only which facets are *rendered* in its store type? In other words, I assumed that if a mapping's StoreTypePrefix isn't Size, then its Size property shouldn't get set, but this doesn't seem to hold (see also [this comment](https://github.com/aspnet/EntityFrameworkCore/issues/12405#issue-333479236)).

The reason this currently works, is that if the store type changes, the mapping is cloned for size as well, regardless of its StoreTypePrefix ([see here](https://github.com/aspnet/EntityFrameworkCore/blob/master/src/EFCore.Relational/Storage/RelationalTypeMapping.cs#L377)). This seems a bit arbitrary and possibly bug-prone - if the store type happens to not change, then the user-provided size wouldn't be taken into account. Also, the same logic doesn't exist for precision/scale.

If this situation is real and SQL Server decimal/datetime/float support one thing in the store type (precision/scale) and another on SqlParameter (size), then these mappings would have to override `Clone(RelationalTypeMappingInfo)`. However, in that case we may consider dropping the StoreTypePrefix altogether and just have every mapping just do what they need - there are too many special cases, the general mechanism adds complexity and doesn't actually seem to cover many actual cases... if we go down this route, it feels like a lot could be simplified (e.g. removing `{Relational,}TypeMappingParameters` altogether). I'd be happy to take a stab at this.