### PR TITLE
SQLite: Change fallback type to BLOB

### DIFF
--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteTypeMappingSource.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteTypeMappingSource.cs
@@ -123,8 +123,8 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal
                 ? mapping
                 : storeTypeName != null
                     ? storeTypeName.Length != 0
-                        ? _typeRules.Select(r => r(storeTypeName)).FirstOrDefault(r => r != null) ?? _text
-                        : _text // This may seem odd, but it's okay because we are matching SQLite's loose typing.
+                        ? _typeRules.Select(r => r(storeTypeName)).FirstOrDefault(r => r != null) ?? _blob
+                        : _blob // This may seem odd, but it's okay because we are matching SQLite's loose typing.
                     : null;
         }
 

--- a/src/Microsoft.Data.Sqlite.Core/SqliteDataRecord.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteDataRecord.cs
@@ -129,15 +129,11 @@ namespace Microsoft.Data.Sqlite
                 case SQLITE_TEXT:
                     return "TEXT";
 
-                case SQLITE_BLOB:
-                    return "BLOB";
-
-                case SQLITE_NULL:
-                    return "INTEGER";
-
                 default:
-                    Debug.Assert(false, "Unexpected column type: " + sqliteType);
-                    return "INTEGER";
+                    Debug.Assert(
+                        sqliteType == SQLITE_BLOB || sqliteType == SQLITE_NULL,
+                        "Unexpected column type: " + sqliteType);
+                    return "BLOB";
             }
         }
 
@@ -155,15 +151,11 @@ namespace Microsoft.Data.Sqlite
                 case SQLITE_TEXT:
                     return typeof(string);
 
-                case SQLITE_BLOB:
-                    return typeof(byte[]);
-
-                case SQLITE_NULL:
-                    return typeof(int);
-
                 default:
-                    Debug.Assert(false, "Unexpected column type: " + sqliteType);
-                    return typeof(int);
+                    Debug.Assert(
+                        sqliteType == SQLITE_BLOB || sqliteType == SQLITE_NULL,
+                        "Unexpected column type: " + sqliteType);
+                    return typeof(byte[]);
             }
         }
 
@@ -180,15 +172,9 @@ namespace Microsoft.Data.Sqlite
                 case "text":
                     return typeof(string);
 
-                case "blob":
-                    return typeof(byte[]);
-
-                case null:
-                    return typeof(int);
-
                 default:
-                    Debug.Assert(false, "Unexpected column type: " + type);
-                    return typeof(int);
+                    Debug.Assert(type == "blob" || type == null, "Unexpected column type: " + type);
+                    return typeof(byte[]);
             }
         }
 

--- a/src/Microsoft.Data.Sqlite.Core/SqliteValueReader.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteValueReader.cs
@@ -258,15 +258,12 @@ namespace Microsoft.Data.Sqlite
                 case SQLITE_TEXT:
                     return GetString(ordinal);
 
-                case SQLITE_BLOB:
-                    return GetBlob(ordinal);
-
                 case SQLITE_NULL:
                     return GetNull<object>(ordinal);
 
                 default:
-                    Debug.Assert(false, "Unexpected column type: " + sqliteType);
-                    return GetInt32(ordinal);
+                    Debug.Assert(sqliteType == SQLITE_BLOB, "Unexpected column type: " + sqliteType);
+                    return GetBlob(ordinal);
             }
         }
 

--- a/test/EFCore.Sqlite.Tests/Storage/SqliteTypeMappingTest.cs
+++ b/test/EFCore.Sqlite.Tests/Storage/SqliteTypeMappingTest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         [InlineData("TEXT", typeof(string))]
         [InlineData("Integer", typeof(long))]
         [InlineData("Blob", typeof(byte[]))]
-        [InlineData("numeric", typeof(string))]
+        [InlineData("numeric", typeof(byte[]))]
         [InlineData("real", typeof(double))]
         [InlineData("doub", typeof(double))]
         [InlineData("int", typeof(long))]
@@ -42,11 +42,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         [InlineData("UNSIGNED BIG INT", typeof(long))]
         [InlineData("VARCHAR(255)", typeof(string))]
         [InlineData("nchar(55)", typeof(string))]
-        [InlineData("datetime", typeof(string))]
-        [InlineData("decimal(10,4)", typeof(string))]
-        [InlineData("boolean", typeof(string))]
-        [InlineData("unknown_type", typeof(string))]
-        [InlineData("", typeof(string))]
+        [InlineData("datetime", typeof(byte[]))]
+        [InlineData("decimal(10,4)", typeof(byte[]))]
+        [InlineData("boolean", typeof(byte[]))]
+        [InlineData("unknown_type", typeof(byte[]))]
+        [InlineData("", typeof(byte[]))]
         public void It_maps_strings_to_not_null_types(string typeName, Type clrType)
         {
             Assert.Equal(clrType, CreateTypeMapper().FindMapping(typeName).ClrType);

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteDataReaderTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteDataReaderTest.cs
@@ -444,7 +444,7 @@ namespace Microsoft.Data.Sqlite
         [InlineData("SELECT 3.14;", "REAL")]
         [InlineData("SELECT 'test';", "TEXT")]
         [InlineData("SELECT X'7E57';", "BLOB")]
-        [InlineData("SELECT NULL;", "INTEGER")]
+        [InlineData("SELECT NULL;", "BLOB")]
         public void GetDataTypeName_works(string sql, string expected)
         {
             using (var connection = new SqliteConnection("Data Source=:memory:"))
@@ -701,7 +701,7 @@ namespace Microsoft.Data.Sqlite
         [InlineData("SELECT 3.14;", typeof(double))]
         [InlineData("SELECT 'test';", typeof(string))]
         [InlineData("SELECT X'7E57';", typeof(byte[]))]
-        [InlineData("SELECT NULL;", typeof(int))]
+        [InlineData("SELECT NULL;", typeof(byte[]))]
         public void GetFieldType_works(string sql, Type expected)
         {
             using (var connection = new SqliteConnection("Data Source=:memory:"))
@@ -1480,7 +1480,7 @@ namespace Microsoft.Data.Sqlite
         [InlineData("('Z'), (1), ('A')", typeof(string))]
         [InlineData("(0.1), (0.01), ('A')", typeof(double))]
         [InlineData("(X'7E57'), (X'577E'), ('A')", typeof(byte[]))]
-        [InlineData("(NULL), (NULL), (NULL)", typeof(int))]
+        [InlineData("(NULL), (NULL), (NULL)", typeof(byte[]))]
         [InlineData("(NULL), ('A'), ('B')", typeof(string))]
         public void GetSchemaTable_DataType_works(string values, Type expectedType)
         {


### PR DESCRIPTION
It was previously a mixture of INTEGER and TEXT.

Resolves #13253, resolves #13841

cc @AlexanderTaeschner

Additional type-related improvements are tracked by #8824, #13831 & #13839 
