### PR TITLE
Enable ambient transaction tests on .NET Core

### DIFF
--- a/test/EFCore.SqlServer.FunctionalTests/TransactionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TransactionSqlServerTest.cs
@@ -18,9 +18,7 @@ namespace Microsoft.EntityFrameworkCore
 
         protected override bool SnapshotSupported => true;
 
-#if NET461
         protected override bool AmbientTransactionsSupported => true;
-#endif
 
         public virtual void Dispose()
         {


### PR DESCRIPTION
Part of #15016