### PR TITLE
Fix to #15114 - Query/Test: query test infra can obscure errors around ordering

### DIFF
--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -2250,7 +2250,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                                      e.OneToOne_Required_FK1.OneToOne_Optional_PK2,
                                      () => e.OneToOne_Required_FK1.OneToOne_Optional_PK2.Name)) != "Foo")
                     .OrderBy(e => e.Id),
-                expectedIncludes);
+                expectedIncludes,
+                assertOrder: true);
         }
 
         [ConditionalTheory]
@@ -5032,7 +5033,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new List<IExpectedInclude>
                 {
                     new ExpectedInclude<Level2>(e => e.OneToMany_Optional2, "OneToMany_Optional2")
-                });
+                },
+                assertOrder: true);
         }
 
         [ConditionalTheory]
@@ -5051,7 +5053,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new List<IExpectedInclude>
                 {
                     new ExpectedInclude<Level2>(e => e.OneToMany_Optional2, "OneToMany_Optional2")
-                });
+                },
+                assertOrder: true);
         }
 
         [ConditionalTheory]
@@ -5067,7 +5070,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new List<IExpectedInclude>
                 {
                     new ExpectedInclude<Level2>(e => e.OneToMany_Optional2, "OneToMany_Optional2")
-                });
+                },
+                assertOrder: true);
         }
 
         [ConditionalTheory]
@@ -5083,7 +5087,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new List<IExpectedInclude>
                 {
                     new ExpectedInclude<Level2>(e => e.OneToMany_Optional2, "OneToMany_Optional2")
-                });
+                },
+                assertOrder: true);
         }
 
         [ConditionalTheory]
@@ -5099,7 +5104,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new List<IExpectedInclude>
                 {
                     new ExpectedInclude<Level2>(e => e.OneToMany_Optional2, "OneToMany_Optional2")
-                });
+                },
+                assertOrder: true);
         }
 
         [ConditionalFact]
@@ -5344,7 +5350,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 {
                     new ExpectedInclude<Level1>(e => e.OneToOne_Optional_FK1, "OneToOne_Optional_FK1"),
                     new ExpectedInclude<Level2>(e => e.OneToMany_Optional2, "OneToMany_Optional2", "OneToOne_Optional_FK1")
-                });
+                },
+                assertOrder: true);
         }
 
         [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/QueryNavigationsTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/QueryNavigationsTestBase.cs
@@ -563,12 +563,12 @@ namespace Microsoft.EntityFrameworkCore.Query
                            c.CustomerID,
                            c.Orders
                        }).OrderBy(e => e.CustomerID),
-                elementSorter: e => e.CustomerID,
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.CustomerID, a.CustomerID);
                     CollectionAsserter<Order>(o => o.OrderID, (ee, aa) => Assert.Equal(ee.OrderID, aa.OrderID))(e.Orders, a.Orders);
                 },
+                assertOrder: true,
                 entryCount: 30);
         }
 
@@ -798,11 +798,12 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery<Customer>(
                 isAsync,
                 cs => from c in cs
-                      orderby c.Orders.Count()
+                      orderby c.Orders.Count(), c.CustomerID
                       select c,
                 cs => from c in cs
-                      orderby (c.Orders ?? new List<Order>()).Count()
+                      orderby (c.Orders ?? new List<Order>()).Count(), c.CustomerID
                       select c,
+                assertOrder: true,
                 entryCount: 91);
         }
 

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Functions.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Functions.cs
@@ -1423,6 +1423,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery<Customer>(
                 isAsync,
                 cs => cs.OrderBy(c => c.CustomerID.Length).ThenBy(c => c.CustomerID.Length).ThenBy(c => c.CustomerID),
+                assertOrder: true,
                 entryCount: 91);
         }
 
@@ -1478,7 +1479,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery<Order>(
                 isAsync,
                 os => os.Where(o => o.OrderID < 10250).Select(o => new { A = Math.Truncate((double)o.OrderID) }).OrderBy(r => r.A)
-                    .OrderBy(r => r.A));
+                    .OrderBy(r => r.A),
+                assertOrder: true);
         }
 
         [ConditionalTheory]
@@ -1488,7 +1490,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery<Order>(
                 isAsync,
                 os => os.Where(o => o.OrderID < 10250).Select(o => new { A = Math.Truncate((double)o.OrderID) }).OrderBy(r => r.A)
-                    .OrderByDescending(r => r.A));
+                    .OrderByDescending(r => r.A),
+                assertOrder: true);
         }
 
         [ConditionalTheory]
@@ -1498,7 +1501,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery<Order>(
                 isAsync,
                 os => os.Where(o => o.OrderID < 10250).Select(o => new { A = Math.Truncate((double)o.OrderID) }).OrderByDescending(r => r.A)
-                    .ThenBy(r => r.A));
+                    .ThenBy(r => r.A),
+                assertOrder: true);
         }
     }
 }

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
@@ -153,7 +153,8 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             await AssertQueryScalar<Customer>(
                 isAsync,
-                cs => cs.Select(c => boolean).OrderBy(e => (bool?)e));
+                cs => cs.Select(c => boolean).OrderBy(e => (bool?)e),
+                assertOrder: true);
         }
 
         [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -2702,8 +2702,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery<Customer>(
                 isAsync,
-                cs => cs.OrderBy(c => true),
-                assertOrder: false,
+                cs => cs.OrderBy(c => true).Select(c => c),
                 entryCount: 91);
         }
 
@@ -2713,8 +2712,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery<Customer>(
                 isAsync,
-                cs => cs.OrderBy(c => 3),
-                assertOrder: false,
+                cs => cs.OrderBy(c => 3).Select(c => c),
                 entryCount: 91);
         }
 
@@ -2725,8 +2723,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             var param = 5;
             return AssertQuery<Customer>(
                 isAsync,
-                cs => cs.OrderBy(c => param),
-                assertOrder: false,
+                cs => cs.OrderBy(c => param).Select(c => c),
                 entryCount: 91);
         }
 
@@ -2835,8 +2832,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 cs => from c in cs
                       where c.CustomerID.StartsWith("A")
-                      orderby cs.Any(c2 => c2.CustomerID == c.CustomerID)
+                      orderby cs.Any(c2 => c2.CustomerID == c.CustomerID), c.CustomerID
                       select c,
+                assertOrder: true,
                 entryCount: 4);
         }
 
@@ -3023,7 +3021,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery<Employee>(
                 isAsync,
-                es => es.OrderBy(e => e.EmployeeID - e.EmployeeID),
+                es => es.OrderBy(e => e.EmployeeID - e.EmployeeID).Select(e => e),
                 entryCount: 9);
         }
 
@@ -3144,7 +3142,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery<Customer>(
                 isAsync,
                 customer => customer
-                    .OrderBy(c => c.Region ?? "ZZ"),
+                    .OrderBy(c => c.Region ?? "ZZ").ThenBy(c => c.CustomerID),
+                assertOrder: true,
                 entryCount: 91);
         }
 
@@ -3160,8 +3159,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                         c.CustomerID,
                         c.CompanyName,
                         Region = c.Region ?? "ZZ"
-                    }).OrderBy(o => o.Region),
-                e => e.CustomerID);
+                    }).OrderBy(o => o.Region).ThenBy(o => o.CustomerID),
+                assertOrder: true);
         }
 
         [ConditionalTheory]
@@ -3174,8 +3173,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                     // ReSharper disable once ConvertConditionalTernaryToNullCoalescing
                     // ReSharper disable once MergeConditionalExpression
 #pragma warning disable IDE0029 // Use coalesce expression
-                    .OrderBy(c => c.Region == null ? "ZZ" : c.Region),
+                    .OrderBy(c => c.Region == null ? "ZZ" : c.Region).ThenBy(c => c.CustomerID),
 #pragma warning restore IDE0029 // Use coalesce expression
+                assertOrder: true,
                 entryCount: 91);
         }
 
@@ -3187,7 +3187,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery<Customer>(
                 isAsync,
                 customer => customer
-                    .OrderBy(c => fakeCustomer.City == "London" ? "ZZ" : c.City),
+                    .OrderBy(c => fakeCustomer.City == "London" ? "ZZ" : c.City)
+                    .Select(c => c),
                 entryCount: 91);
         }
 
@@ -3199,7 +3200,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 customer => customer
                     // ReSharper disable once ConvertConditionalTernaryToNullCoalescing
-                    .OrderBy(c => c.Region == "ASK"),
+                    .OrderBy(c => c.Region == "ASK").Select(c => c),
                 entryCount: 91);
         }
 
@@ -4705,7 +4706,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     {
                         c.CustomerID
                     }).Distinct().OrderBy(n => n.CustomerID),
-                e => e.CustomerID);
+                assertOrder: true);
         }
 
         [ConditionalTheory]
@@ -4751,7 +4752,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     {
                         A = c.CustomerID + c.City
                     }).Distinct().OrderBy(n => n.A),
-                e => e.A);
+                assertOrder: true);
         }
 
         [ConditionalTheory]
@@ -4783,7 +4784,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     {
                         A = c.CustomerID + c.City
                     }).OrderBy(n => n.A),
-                e => e.A);
+                assertOrder: true);
         }
 
         [ConditionalTheory]
@@ -4797,7 +4798,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     {
                         A = c.Orders.OrderByDescending(o => o.OrderID).FirstOrDefault().OrderDate
                     }).OrderBy(n => n.A),
-                e => e.A);
+                assertOrder: true);
         }
 
         protected class DTO<T>
@@ -5619,7 +5620,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             return AssertQuery<Customer>(
                 isAsync,
-                cs => cs.OrderBy(c => list.Contains(c.CustomerID)),
+                cs => cs.OrderBy(c => list.Contains(c.CustomerID)).Select(c => c),
                 entryCount: 91);
         }
 
@@ -5631,7 +5632,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             return AssertQuery<Customer>(
                 isAsync,
-                cs => cs.OrderBy(c => !list.Contains(c.CustomerID)),
+                cs => cs.OrderBy(c => !list.Contains(c.CustomerID)).Select(c => c),
                 entryCount: 91);
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -3846,7 +3846,7 @@ WHERE [c].[Nation] = N'Tyrus'");
             AssertSql(
                 @"SELECT [c].[Name], [c].[Location], [c].[Nation]
 FROM [Cities] AS [c]
-ORDER BY [c].[Nation]");
+ORDER BY [c].[Nation], [c].[Name]");
         }
 
         public override async Task Can_group_by_indexed_property_on_query(bool isAsync)
@@ -7730,7 +7730,7 @@ ORDER BY [t].[c] DESC, [t].[Nickname], [t].[SquadId], [t].[FullName]");
                 @"SELECT [w.SynergyWith].[Id], [w.SynergyWith].[AmmunitionType], [w.SynergyWith].[IsAutomatic], [w.SynergyWith].[Name], [w.SynergyWith].[OwnerFullName], [w.SynergyWith].[SynergyWithId]
 FROM [Weapons] AS [w]
 LEFT JOIN [Weapons] AS [w.SynergyWith] ON [w].[SynergyWithId] = [w.SynergyWith].[Id]
-ORDER BY [w.SynergyWith].[IsAutomatic]");
+ORDER BY [w.SynergyWith].[IsAutomatic], [w.SynergyWith].[Id]");
         }
 
         public override async Task Double_order_by_on_Like(bool isAsync)
@@ -7771,7 +7771,7 @@ FROM [Weapons] AS [w]
 ORDER BY CASE
     WHEN [w].[Name] = N'Marcus'' Lancer'
     THEN CAST(1 AS bit) ELSE CAST(0 AS bit)
-END");
+END, [w].[Id]");
         }
 
         public override async Task Double_order_by_binary_expression(bool isAsync)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryNavigationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryNavigationsSqlServerTest.cs
@@ -750,7 +750,7 @@ ORDER BY (
     SELECT COUNT(*)
     FROM [Orders] AS [o]
     WHERE [c].[CustomerID] = [o].[CustomerID]
-)");
+), [c].[CustomerID]");
         }
 
         public override async Task Collection_select_nav_prop_long_count(bool isAsync)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -2245,7 +2245,7 @@ ORDER BY (
             WHERE [c2].[CustomerID] = [c].[CustomerID])
         THEN CAST(1 AS bit) ELSE CAST(0 AS bit)
     END
-)");
+), [c].[CustomerID]");
         }
 
         public override async Task OrderBy_correlated_subquery2(bool isAsync)
@@ -2519,7 +2519,7 @@ CROSS JOIN [Customers] AS [c0]");
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-ORDER BY COALESCE([c].[Region], N'ZZ')");
+ORDER BY COALESCE([c].[Region], N'ZZ'), [c].[CustomerID]");
         }
 
         public override async Task Select_null_coalesce_operator(bool isAsync)
@@ -2529,7 +2529,7 @@ ORDER BY COALESCE([c].[Region], N'ZZ')");
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[CompanyName], COALESCE([c].[Region], N'ZZ') AS [Region]
 FROM [Customers] AS [c]
-ORDER BY [Region]");
+ORDER BY [Region], [c].[CustomerID]");
         }
 
         public override async Task OrderBy_conditional_operator(bool isAsync)
@@ -2542,7 +2542,7 @@ FROM [Customers] AS [c]
 ORDER BY CASE
     WHEN [c].[Region] IS NULL
     THEN N'ZZ' ELSE [c].[Region]
-END");
+END, [c].[CustomerID]");
         }
 
         public override async Task Null_Coalesce_Short_Circuit(bool isAsync)


### PR DESCRIPTION
Added test logic that checks if queries have top-level ordering, and if so throws exception if they are not asserting order OR using a client-side element sorter. Fixed all tests that were caught by the check.
In order to circumvent then check (in case of non-deterministic orderby) one can add a top level identity projection: .Select(c => c)