### PR TITLE
Propagate store generated values to all entries sharing a row.

### DIFF
--- a/src/EFCore.Cosmos/Storage/Internal/CosmosDatabaseWrapper.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosDatabaseWrapper.cs
@@ -42,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
             }
         }
 
-        public override int SaveChanges(IReadOnlyList<IUpdateEntry> entries)
+        public override int SaveChanges(IList<IUpdateEntry> entries)
         {
             var rowsAffected = 0;
             var entriesSaved = new HashSet<IUpdateEntry>();
@@ -89,7 +89,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         }
 
         public override async Task<int> SaveChangesAsync(
-            IReadOnlyList<IUpdateEntry> entries, CancellationToken cancellationToken = default)
+            IList<IUpdateEntry> entries, CancellationToken cancellationToken = default)
         {
             var rowsAffected = 0;
             var entriesSaved = new HashSet<IUpdateEntry>();

--- a/src/EFCore.InMemory/Storage/Internal/IInMemoryStore.cs
+++ b/src/EFCore.InMemory/Storage/Internal/IInMemoryStore.cs
@@ -48,6 +48,6 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         int ExecuteTransaction(
-            [NotNull] IReadOnlyList<IUpdateEntry> entries, [NotNull] IDiagnosticsLogger<DbLoggerCategory.Update> updateLogger);
+            [NotNull] IList<IUpdateEntry> entries, [NotNull] IDiagnosticsLogger<DbLoggerCategory.Update> updateLogger);
     }
 }

--- a/src/EFCore.InMemory/Storage/Internal/InMemoryDatabase.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryDatabase.cs
@@ -65,7 +65,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public override int SaveChanges(IReadOnlyList<IUpdateEntry> entries)
+        public override int SaveChanges(IList<IUpdateEntry> entries)
             => _store.ExecuteTransaction(Check.NotNull(entries, nameof(entries)), _updateLogger);
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override Task<int> SaveChangesAsync(
-            IReadOnlyList<IUpdateEntry> entries,
+            IList<IUpdateEntry> entries,
             CancellationToken cancellationToken = default)
             => Task.FromResult(_store.ExecuteTransaction(Check.NotNull(entries, nameof(entries)), _updateLogger));
 

--- a/src/EFCore.InMemory/Storage/Internal/InMemoryStore.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryStore.cs
@@ -154,7 +154,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual int ExecuteTransaction(
-            IReadOnlyList<IUpdateEntry> entries,
+            IList<IUpdateEntry> entries,
             IDiagnosticsLogger<DbLoggerCategory.Update> updateLogger)
         {
             var rowsAffected = 0;

--- a/src/EFCore.Relational/Metadata/Conventions/Internal/RelationalConventionSetBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Internal/RelationalConventionSetBuilder.cs
@@ -65,16 +65,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             var discriminatorConvention = new DiscriminatorConvention(logger);
             conventionSet.EntityTypeAddedConventions.Add(new RelationalTableAttributeConvention(logger));
-            conventionSet.EntityTypeAddedConventions.Add(sharedTableConvention);
             conventionSet.EntityTypeRemovedConventions.Add(discriminatorConvention);
             conventionSet.BaseEntityTypeChangedConventions.Add(discriminatorConvention);
             conventionSet.BaseEntityTypeChangedConventions.Add(
                 new TableNameFromDbSetConvention(Dependencies.Context?.Context, Dependencies.SetFinder, logger));
-            conventionSet.EntityTypeAnnotationChangedConventions.Add(sharedTableConvention);
             conventionSet.PropertyFieldChangedConventions.Add(relationalColumnAttributeConvention);
             conventionSet.PropertyAnnotationChangedConventions.Add((RelationalValueGeneratorConvention)valueGeneratorConvention);
-            conventionSet.ForeignKeyUniquenessChangedConventions.Add(sharedTableConvention);
-            conventionSet.ForeignKeyOwnershipChangedConventions.Add(sharedTableConvention);
 
             conventionSet.ModelBuiltConventions.Add(sharedTableConvention);
 

--- a/src/EFCore.Relational/Metadata/Conventions/Internal/SharedTableConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Internal/SharedTableConvention.cs
@@ -17,10 +17,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
     public class SharedTableConvention :
-        IEntityTypeAddedConvention,
-        IEntityTypeAnnotationChangedConvention,
-        IForeignKeyOwnershipChangedConvention,
-        IForeignKeyUniquenessChangedConvention,
         IModelBuiltConvention
     {
         /// <summary>
@@ -37,68 +33,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected virtual IDiagnosticsLogger<DbLoggerCategory.Model> Logger { get; }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public virtual InternalEntityTypeBuilder Apply(InternalEntityTypeBuilder entityTypeBuilder)
-        {
-            var ownership = entityTypeBuilder.Metadata.GetForeignKeys().SingleOrDefault(fk => fk.IsOwnership && fk.IsUnique);
-            if (ownership != null)
-            {
-                SetOwnedTable(ownership);
-            }
-
-            return entityTypeBuilder;
-        }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public virtual Annotation Apply(
-            InternalEntityTypeBuilder entityTypeBuilder, string name, Annotation annotation, Annotation oldAnnotation)
-        {
-            var entityType = entityTypeBuilder.Metadata;
-            if (name == RelationalAnnotationNames.TableName
-                || name == RelationalAnnotationNames.Schema)
-            {
-                foreach (var foreignKey in entityType.GetReferencingForeignKeys())
-                {
-                    if (foreignKey.IsOwnership
-                        && foreignKey.IsUnique)
-                    {
-                        SetOwnedTable(foreignKey);
-                    }
-                }
-            }
-
-            return annotation;
-        }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public virtual InternalRelationshipBuilder Apply(InternalRelationshipBuilder relationshipBuilder)
-        {
-            var foreignKey = relationshipBuilder.Metadata;
-            if (foreignKey.IsOwnership
-                && foreignKey.IsUnique)
-            {
-                SetOwnedTable(foreignKey);
-            }
-
-            return relationshipBuilder;
-        }
-
-        private static void SetOwnedTable(ForeignKey foreignKey)
-        {
-            var ownerType = foreignKey.PrincipalEntityType;
-            foreignKey.DeclaringEntityType.Builder.Relational(ConfigurationSource.Convention)
-                .ToTable(ownerType.Relational().TableName, ownerType.Relational().Schema);
-        }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Relational/Metadata/Internal/RelationalEntityTypeBuilderAnnotations.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalEntityTypeBuilderAnnotations.cs
@@ -239,7 +239,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             propertyBuilder.IsRequired(true, configurationSource);
-            propertyBuilder.AfterSave(PropertySaveBehavior.Throw, configurationSource);
             propertyBuilder.HasValueGenerator(
                 (property, entityType) => new DiscriminatorValueGenerator(GetAnnotations(entityType).DiscriminatorValue),
                 configurationSource);

--- a/src/EFCore.Relational/Migrations/Operations/DeleteDataOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/DeleteDataOperation.cs
@@ -59,10 +59,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
                 {
                     modifications[j] = new ColumnModification(
                         KeyColumns[j], originalValue: null, value: KeyValues[i, j], property: properties?.Find(KeyColumns[j]),
-                        isRead: false, isWrite: true, isKey: true, isCondition: true);
+                        isRead: false, isWrite: true, isKey: true, isCondition: true, sensitiveLoggingEnabled: true);
                 }
 
-                yield return new ModificationCommand(Table, Schema, modifications);
+                yield return new ModificationCommand(Table, Schema, modifications, sensitiveLoggingEnabled: true);
             }
         }
     }

--- a/src/EFCore.Relational/Migrations/Operations/InsertDataOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/InsertDataOperation.cs
@@ -58,10 +58,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
                 {
                     modifications[j] = new ColumnModification(
                         Columns[j], originalValue: null, value: Values[i, j], property: properties?.Find(Columns[j]),
-                        isRead: false, isWrite: true, isKey: true, isCondition: false);
+                        isRead: false, isWrite: true, isKey: true, isCondition: false, sensitiveLoggingEnabled: true);
                 }
 
-                yield return new ModificationCommand(Table, Schema, modifications);
+                yield return new ModificationCommand(Table, Schema, modifications, sensitiveLoggingEnabled: true);
             }
         }
     }

--- a/src/EFCore.Relational/Migrations/Operations/UpdateDataOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/UpdateDataOperation.cs
@@ -77,7 +77,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
                 {
                     keys[j] = new ColumnModification(
                         KeyColumns[j], originalValue: null, value: KeyValues[i, j], property: properties?.Find(KeyColumns[j]),
-                        isRead: false, isWrite: false, isKey: true, isCondition: true);
+                        isRead: false, isWrite: false, isKey: true, isCondition: true, sensitiveLoggingEnabled: true);
                 }
 
                 var modifications = new ColumnModification[Columns.Length];
@@ -85,10 +85,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
                 {
                     modifications[j] = new ColumnModification(
                         Columns[j], originalValue: null, value: Values[i, j], property: properties?.Find(Columns[j]),
-                        isRead: false, isWrite: true, isKey: true, isCondition: false);
+                        isRead: false, isWrite: true, isKey: true, isCondition: false, sensitiveLoggingEnabled: true);
                 }
 
-                yield return new ModificationCommand(Table, Schema, keys.Concat(modifications).ToArray());
+                yield return new ModificationCommand(Table, Schema, keys.Concat(modifications).ToArray(), sensitiveLoggingEnabled: true);
             }
         }
     }

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -606,6 +606,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public static string SqlFunctionUnexpectedInstanceMapping
             => GetString("SqlFunctionUnexpectedInstanceMapping");
 
+        /// <summary>
+        ///     Entity type '{entityType}' doesn't contain a property mapped to the store-generated concurrency token column '{missingColumn}' that is used by another entity type sharing the table '{table}'. Add a compatible property, that can be in shadow state, to '{entityType}'.
+        /// </summary>
+        public static string MissingConcurrencyColumn([CanBeNull] object entityType, [CanBeNull] object missingColumn, [CanBeNull] object table)
+            => string.Format(
+                GetString("MissingConcurrencyColumn", nameof(entityType), nameof(missingColumn), nameof(table)),
+                entityType, missingColumn, table);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -501,4 +501,7 @@
   <data name="SqlFunctionUnexpectedInstanceMapping" xml:space="preserve">
     <value>An instance type mapping was specified without an instance expression.</value>
   </data>
+  <data name="MissingConcurrencyColumn" xml:space="preserve">
+    <value>Entity type '{entityType}' doesn't contain a property mapped to the store-generated concurrency token column '{missingColumn}' that is used by another entity type sharing the table '{table}'. Add a compatible property, that can be in shadow state, to '{entityType}'.</value>
+  </data>
 </root>

--- a/src/EFCore.Relational/Storage/RelationalDatabase.cs
+++ b/src/EFCore.Relational/Storage/RelationalDatabase.cs
@@ -54,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="entries"> Entries representing the changes to be persisted. </param>
         /// <returns> The number of state entries persisted to the database. </returns>
         public override int SaveChanges(
-            IReadOnlyList<IUpdateEntry> entries)
+            IList<IUpdateEntry> entries)
             => RelationalDependencies.BatchExecutor.Execute(
                 RelationalDependencies.BatchPreparer.BatchCommands(
                     Check.NotNull(entries, nameof(entries))),
@@ -70,7 +70,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     number of entries persisted to the database.
         /// </returns>
         public override Task<int> SaveChangesAsync(
-            IReadOnlyList<IUpdateEntry> entries,
+            IList<IUpdateEntry> entries,
             CancellationToken cancellationToken = default)
             => RelationalDependencies.BatchExecutor.ExecuteAsync(
                 RelationalDependencies.BatchPreparer.BatchCommands(

--- a/src/EFCore.Relational/Update/ColumnModification.cs
+++ b/src/EFCore.Relational/Update/ColumnModification.cs
@@ -2,7 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -25,6 +29,8 @@ namespace Microsoft.EntityFrameworkCore.Update
         private readonly object _originalValue;
         private object _value;
         private readonly bool _useParameters;
+        private readonly bool _sensitiveLoggingEnabled;
+        private List<ColumnModification> _sharedColumnModifications;
 
         /// <summary>
         ///     Creates a new <see cref="ColumnModification" /> instance.
@@ -38,6 +44,7 @@ namespace Microsoft.EntityFrameworkCore.Update
         /// <param name="isKey"> Indicates whether or not the column part of a primary or alternate key.</param>
         /// <param name="isCondition"> Indicates whether or not the column is used in the <c>WHERE</c> clause when updating. </param>
         /// <param name="isConcurrencyToken"> Indicates whether or not the column is acting as an optimistic concurrency token. </param>
+        /// <param name="sensitiveLoggingEnabled"> Indicates whether or not potentially sensitive data (e.g. database values) can be logged. </param>
         public ColumnModification(
             [NotNull] IUpdateEntry entry,
             [NotNull] IProperty property,
@@ -47,7 +54,8 @@ namespace Microsoft.EntityFrameworkCore.Update
             bool isWrite,
             bool isKey,
             bool isCondition,
-            bool isConcurrencyToken)
+            bool isConcurrencyToken,
+            bool sensitiveLoggingEnabled)
             : this(
                 Check.NotNull(propertyAnnotations, nameof(propertyAnnotations)).ColumnName,
                 originalValue: null,
@@ -56,7 +64,8 @@ namespace Microsoft.EntityFrameworkCore.Update
                 isRead: isRead,
                 isWrite: isWrite,
                 isKey: isKey,
-                isCondition: isCondition)
+                isCondition: isCondition,
+                sensitiveLoggingEnabled: sensitiveLoggingEnabled)
         {
             Check.NotNull(entry, nameof(entry));
             Check.NotNull(property, nameof(property));
@@ -79,6 +88,7 @@ namespace Microsoft.EntityFrameworkCore.Update
         /// <param name="isWrite"> Indicates whether or not a value must be written to the database for the column. </param>
         /// <param name="isKey"> Indicates whether or not the column part of a primary or alternate key.</param>
         /// <param name="isCondition"> Indicates whether or not the column is used in the <c>WHERE</c> clause when updating. </param>
+        /// <param name="sensitiveLoggingEnabled"> Indicates whether or not potentially sensitive data (e.g. database values) can be logged. </param>
         public ColumnModification(
             [NotNull] string columnName,
             [CanBeNull] object originalValue,
@@ -87,7 +97,8 @@ namespace Microsoft.EntityFrameworkCore.Update
             bool isRead,
             bool isWrite,
             bool isKey,
-            bool isCondition)
+            bool isCondition,
+            bool sensitiveLoggingEnabled)
         {
             Check.NotNull(columnName, nameof(columnName));
 
@@ -99,6 +110,7 @@ namespace Microsoft.EntityFrameworkCore.Update
             IsWrite = isWrite;
             IsKey = isKey;
             IsCondition = isCondition;
+            _sensitiveLoggingEnabled = sensitiveLoggingEnabled;
         }
 
         /// <summary>
@@ -166,7 +178,11 @@ namespace Microsoft.EntityFrameworkCore.Update
         /// <summary>
         ///     The original value of the property mapped to this column.
         /// </summary>
-        public virtual object OriginalValue => Entry == null ? _originalValue : Entry.GetOriginalValue(Property);
+        public virtual object OriginalValue => Entry == null
+            ? _originalValue
+            : Entry.SharedIdentityEntry == null
+                ? Entry.GetOriginalValue(Property)
+                : Entry.SharedIdentityEntry.GetOriginalValue(Property);
 
         /// <summary>
         ///     Gets or sets the current value of the property mapped to this column.
@@ -184,8 +200,76 @@ namespace Microsoft.EntityFrameworkCore.Update
                 else
                 {
                     Entry.SetStoreGeneratedValue(Property, value);
+                    if(_sharedColumnModifications != null)
+                    {
+                        foreach(var sharedModification in _sharedColumnModifications)
+                        {
+                            sharedModification.Value = value;
+                        }
+                    }
                 }
             }
+        }
+
+        /// <summary>
+        ///     Adds a modification affecting the same database value.
+        /// </summary>
+        /// <param name="modification"> The modification for the shared column. </param>
+        public virtual void AddSharedColumnModification(ColumnModification modification)
+        {
+            if (_sharedColumnModifications == null)
+            {
+                _sharedColumnModifications = new List<ColumnModification>();
+            }
+
+            if (UseCurrentValueParameter
+                && !StructuralComparisons.StructuralEqualityComparer.Equals(Value, modification.Value))
+            {
+                if (_sensitiveLoggingEnabled)
+                {
+                    throw new InvalidOperationException(
+                        RelationalStrings.ConflictingRowValuesSensitive(
+                            Entry.EntityType.DisplayName(),
+                            modification.Entry.EntityType.DisplayName(),
+                            Entry.BuildCurrentValuesString(Entry.EntityType.FindPrimaryKey().Properties),
+                            Entry.BuildCurrentValuesString(new[] { Property }),
+                            modification.Entry.BuildCurrentValuesString(new[] { modification.Property }),
+                            new[] { Property }.FormatColumns()));
+                }
+
+                throw new InvalidOperationException(
+                    RelationalStrings.ConflictingRowValues(
+                        Entry.EntityType.DisplayName(),
+                        modification.Entry.EntityType.DisplayName(),
+                        new[] { Property }.Format(),
+                        new[] { modification.Property }.Format(),
+                        new[] { Property }.FormatColumns()));
+            }
+            else if (UseOriginalValueParameter
+                     && !StructuralComparisons.StructuralEqualityComparer.Equals(OriginalValue, modification.OriginalValue))
+            {
+                if (_sensitiveLoggingEnabled)
+                {
+                    throw new InvalidOperationException(
+                        RelationalStrings.ConflictingOriginalRowValuesSensitive(
+                            Entry.EntityType.DisplayName(),
+                            modification.Entry.EntityType.DisplayName(),
+                            Entry.BuildCurrentValuesString(Entry.EntityType.FindPrimaryKey().Properties),
+                            Entry.BuildOriginalValuesString(new[] { Property }),
+                            modification.Entry.BuildOriginalValuesString(new[] { modification.Property }),
+                            new[] { Property }.FormatColumns()));
+                }
+
+                throw new InvalidOperationException(
+                    RelationalStrings.ConflictingOriginalRowValues(
+                        Entry.EntityType.DisplayName(),
+                        modification.Entry.EntityType.DisplayName(),
+                        new[] { Property }.Format(),
+                        new[] { modification.Property }.Format(),
+                        new[] { Property }.FormatColumns()));
+            }
+
+            _sharedColumnModifications.Add(modification);
         }
     }
 }

--- a/src/EFCore.Relational/Update/ICommandBatchPreparer.cs
+++ b/src/EFCore.Relational/Update/ICommandBatchPreparer.cs
@@ -30,6 +30,6 @@ namespace Microsoft.EntityFrameworkCore.Update
         /// </summary>
         /// <param name="entries"> The entries that represent the entities to be modified. </param>
         /// <returns> The list of batches to execute. </returns>
-        IEnumerable<ModificationCommandBatch> BatchCommands([NotNull] IReadOnlyList<IUpdateEntry> entries);
+        IEnumerable<ModificationCommandBatch> BatchCommands([NotNull] IList<IUpdateEntry> entries);
     }
 }

--- a/src/EFCore.Relational/Update/ModificationCommand.cs
+++ b/src/EFCore.Relational/Update/ModificationCommand.cs
@@ -5,11 +5,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
-using Microsoft.EntityFrameworkCore.Update.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Update
@@ -48,13 +48,13 @@ namespace Microsoft.EntityFrameworkCore.Update
             : this(
                 Check.NotEmpty(name, nameof(name)),
                 schema,
-                null)
+                null,
+                sensitiveLoggingEnabled)
         {
             Check.NotNull(generateParameterName, nameof(generateParameterName));
 
             _generateParameterName = generateParameterName;
             _comparer = comparer;
-            _sensitiveLoggingEnabled = sensitiveLoggingEnabled;
         }
 
         /// <summary>
@@ -63,16 +63,19 @@ namespace Microsoft.EntityFrameworkCore.Update
         /// <param name="name"> The name of the table containing the data to be modified. </param>
         /// <param name="schema"> The schema containing the table, or <c>null</c> to use the default schema. </param>
         /// <param name="columnModifications"> The list of <see cref="ColumnModification" />s needed to perform the insert, update, or delete. </param>
+        /// <param name="sensitiveLoggingEnabled"> Indicates whether or not potentially sensitive data (e.g. database values) can be logged. </param>
         public ModificationCommand(
             [NotNull] string name,
             [CanBeNull] string schema,
-            [CanBeNull] IReadOnlyList<ColumnModification> columnModifications)
+            [CanBeNull] IReadOnlyList<ColumnModification> columnModifications,
+            bool sensitiveLoggingEnabled)
         {
             Check.NotNull(name, nameof(name));
 
             TableName = name;
             Schema = schema;
             _columnModifications = columnModifications;
+            _sensitiveLoggingEnabled = sensitiveLoggingEnabled;
         }
 
         /// <summary>
@@ -101,11 +104,21 @@ namespace Microsoft.EntityFrameworkCore.Update
         {
             get
             {
-                foreach (var e in _entries)
+                if (_entries.Count > 0)
                 {
-                    if (e.SharedIdentityEntry == null)
+                    for (var i = 0; i < _entries.Count; i++)
                     {
-                        return e.EntityState;
+                        var entry = _entries[0];
+                        if (entry.SharedIdentityEntry != null)
+                        {
+                            return EntityState.Modified;
+                        }
+
+                        var state = entry.EntityState;
+                        if (state != EntityState.Unchanged)
+                        {
+                            return state;
+                        }
                     }
                 }
 
@@ -154,14 +167,12 @@ namespace Microsoft.EntityFrameworkCore.Update
 
             if (_entries.Count > 0)
             {
-                var lastEntry = _entries[_entries.Count - 1];
-                var lastEntryState = lastEntry.SharedIdentityEntry == null
-                    ? lastEntry.EntityState
-                    : EntityState.Modified;
+                var currentState = EntityState;
                 var entryState = entry.SharedIdentityEntry == null
                     ? entry.EntityState
                     : EntityState.Modified;
-                if (lastEntryState != entryState)
+                if (currentState != entryState
+                    && entryState != EntityState.Unchanged)
                 {
                     if (_sensitiveLoggingEnabled)
                     {
@@ -170,17 +181,17 @@ namespace Microsoft.EntityFrameworkCore.Update
                                 entry.EntityType.DisplayName(),
                                 entry.BuildCurrentValuesString(entry.EntityType.FindPrimaryKey().Properties),
                                 entryState,
-                                lastEntry.EntityType.DisplayName(),
-                                lastEntry.BuildCurrentValuesString(lastEntry.EntityType.FindPrimaryKey().Properties),
-                                lastEntryState));
+                                _entries[0].EntityType.DisplayName(),
+                                _entries[0].BuildCurrentValuesString(_entries[0].EntityType.FindPrimaryKey().Properties),
+                                currentState));
                     }
 
                     throw new InvalidOperationException(
                         RelationalStrings.ConflictingRowUpdateTypes(
                             entry.EntityType.DisplayName(),
                             entryState,
-                            lastEntry.EntityType.DisplayName(),
-                            lastEntryState));
+                            _entries[0].EntityType.DisplayName(),
+                            currentState));
                 }
             }
 
@@ -190,39 +201,35 @@ namespace Microsoft.EntityFrameworkCore.Update
 
         private IReadOnlyList<ColumnModification> GenerateColumnModifications()
         {
-            var adding = EntityState == EntityState.Added;
+            var state = EntityState;
+            var adding = state == EntityState.Added;
+            var updating = state == EntityState.Modified;
             var columnModifications = new List<ColumnModification>();
+            Dictionary<string, ColumnValuePropagator> sharedColumnMap = null;
 
-            if (_comparer != null)
+            if (_entries.Count > 1
+                || (_entries.Count == 1 && _entries[0].SharedIdentityEntry != null))
             {
-                _entries.Sort(_comparer);
+                sharedColumnMap = new Dictionary<string, ColumnValuePropagator>();
+
+                if (_comparer != null)
+                {
+                    _entries.Sort(_comparer);
+                }
+
+                foreach (var entry in _entries)
+                {
+                    if (entry.SharedIdentityEntry != null)
+                    {
+                        InitializeSharedColumns(entry.SharedIdentityEntry, updating, sharedColumnMap);
+                    }
+
+                    InitializeSharedColumns(entry, updating, sharedColumnMap);
+                }
             }
-
-            var columnMap = _entries.Count == 1
-                ? null
-                : new Dictionary<string, ColumnModification>();
-
-            Dictionary<IUpdateEntry, List<ColumnModification>> conflictingColumnValues = null;
-            Dictionary<IUpdateEntry, List<ColumnModification>> conflictingOriginalColumnValues = null;
 
             foreach (var entry in _entries)
             {
-                Dictionary<string, IProperty> sharedIdentityEntryProperties = null;
-                if (entry.SharedIdentityEntry != null)
-                {
-                    if (entry.EntityState == EntityState.Deleted)
-                    {
-                        continue;
-                    }
-
-                    sharedIdentityEntryProperties = new Dictionary<string, IProperty>();
-
-                    foreach (var property in entry.SharedIdentityEntry.EntityType.GetProperties())
-                    {
-                        sharedIdentityEntryProperties[property.Relational().ColumnName] = property;
-                    }
-                }
-
                 foreach (var property in entry.EntityType.GetProperties())
                 {
                     var propertyAnnotations = property.Relational();
@@ -230,6 +237,8 @@ namespace Microsoft.EntityFrameworkCore.Update
                     var isConcurrencyToken = property.IsConcurrencyToken;
                     var isCondition = !adding && (isKey || isConcurrencyToken);
                     var readValue = entry.IsStoreGenerated(property);
+                    var columnName = propertyAnnotations.ColumnName;
+                    var columnPropagator = sharedColumnMap?[columnName];
 
                     var writeValue = false;
                     if (!readValue)
@@ -238,20 +247,11 @@ namespace Microsoft.EntityFrameworkCore.Update
                         {
                             writeValue = property.BeforeSaveBehavior == PropertySaveBehavior.Save;
                         }
-                        else
+                        else if (updating && property.AfterSaveBehavior == PropertySaveBehavior.Save)
                         {
-                            if (property.AfterSaveBehavior == PropertySaveBehavior.Save
-                                && entry.IsModified(property))
-                            {
-                                writeValue = true;
-                            }
-                            else if (sharedIdentityEntryProperties != null
-                                     && (property.BeforeSaveBehavior == PropertySaveBehavior.Save
-                                         || property.AfterSaveBehavior == PropertySaveBehavior.Save))
-                            {
-                                writeValue = !sharedIdentityEntryProperties.TryGetValue(propertyAnnotations.ColumnName, out var originalProperty)
-                                             || !Equals(entry.SharedIdentityEntry.GetOriginalValue(originalProperty), entry.GetCurrentValue(property));
-                            }
+                            writeValue = columnPropagator == null
+                                ? entry.IsModified(property)
+                                : columnPropagator.TryPropagate(property, (InternalEntityEntry)entry);
                         }
                     }
 
@@ -273,29 +273,19 @@ namespace Microsoft.EntityFrameworkCore.Update
                             writeValue,
                             isKey,
                             isCondition,
-                            isConcurrencyToken);
+                            isConcurrencyToken,
+                            _sensitiveLoggingEnabled);
 
-                        if (columnMap != null)
+                        if (columnPropagator != null)
                         {
-                            if (columnMap.TryGetValue(columnModification.ColumnName, out var existingColumnModification))
+                            if (columnPropagator.ColumnModification != null)
                             {
-                                if (columnModification.UseCurrentValueParameter
-                                    && !Equals(columnModification.Value, existingColumnModification.Value))
-                                {
-                                    conflictingColumnValues = AddConflictingColumnValues(
-                                        conflictingColumnValues, columnModification, existingColumnModification);
-                                }
-                                else if (columnModification.UseOriginalValueParameter
-                                         && !Equals(columnModification.OriginalValue, existingColumnModification.OriginalValue))
-                                {
-                                    conflictingOriginalColumnValues = AddConflictingColumnValues(
-                                        conflictingOriginalColumnValues, columnModification, existingColumnModification);
-                                }
+                                columnPropagator.ColumnModification.AddSharedColumnModification(columnModification);
 
                                 continue;
                             }
 
-                            columnMap.Add(columnModification.ColumnName, columnModification);
+                            columnPropagator.ColumnModification = columnModification;
                         }
 
                         columnModifications.Add(columnModification);
@@ -303,96 +293,25 @@ namespace Microsoft.EntityFrameworkCore.Update
                 }
             }
 
-            if (conflictingColumnValues != null)
-            {
-                var firstPair = conflictingColumnValues.First();
-                var firstEntry = firstPair.Key;
-                var firstProperties = firstPair.Value.Select(c => c.Property).ToList();
-                var lastPair = conflictingColumnValues.Last();
-                var lastEntry = lastPair.Key;
-                var lastProperties = lastPair.Value.Select(c => c.Property);
-
-                if (_sensitiveLoggingEnabled)
-                {
-                    throw new InvalidOperationException(
-                        RelationalStrings.ConflictingRowValuesSensitive(
-                            firstEntry.EntityType.DisplayName(),
-                            lastEntry.EntityType.DisplayName(),
-                            firstEntry.BuildCurrentValuesString(firstEntry.EntityType.FindPrimaryKey().Properties),
-                            firstEntry.BuildCurrentValuesString(firstProperties),
-                            lastEntry.BuildCurrentValuesString(lastProperties),
-                            firstProperties.FormatColumns()));
-                }
-
-                throw new InvalidOperationException(
-                    RelationalStrings.ConflictingRowValues(
-                        firstEntry.EntityType.DisplayName(),
-                        lastEntry.EntityType.DisplayName(),
-                        firstProperties.Format(),
-                        lastProperties.Format(),
-                        firstProperties.FormatColumns()));
-            }
-
-            if (conflictingOriginalColumnValues != null)
-            {
-                var firstPair = conflictingOriginalColumnValues.First();
-                var firstEntry = firstPair.Key;
-                var firstProperties = firstPair.Value.Select(c => c.Property).ToList();
-                var lastPair = conflictingOriginalColumnValues.Last();
-                var lastEntry = lastPair.Key;
-                var lastProperties = lastPair.Value.Select(c => c.Property);
-
-                if (_sensitiveLoggingEnabled)
-                {
-                    throw new InvalidOperationException(
-                        RelationalStrings.ConflictingOriginalRowValuesSensitive(
-                            firstEntry.EntityType.DisplayName(),
-                            lastEntry.EntityType.DisplayName(),
-                            firstEntry.BuildCurrentValuesString(firstEntry.EntityType.FindPrimaryKey().Properties),
-                            firstEntry.BuildOriginalValuesString(firstProperties),
-                            lastEntry.BuildOriginalValuesString(lastProperties),
-                            firstProperties.FormatColumns()));
-                }
-
-                throw new InvalidOperationException(
-                    RelationalStrings.ConflictingOriginalRowValues(
-                        firstEntry.EntityType.DisplayName(),
-                        lastEntry.EntityType.DisplayName(),
-                        firstProperties.Format(),
-                        lastProperties.Format(),
-                        firstProperties.FormatColumns()));
-            }
-
             return columnModifications;
         }
 
-        private static Dictionary<IUpdateEntry, List<ColumnModification>> AddConflictingColumnValues(
-            Dictionary<IUpdateEntry, List<ColumnModification>> conflictingColumnValues,
-            ColumnModification columnModification,
-            ColumnModification existingColumn)
+        private static void InitializeSharedColumns(IUpdateEntry entry, bool updating, Dictionary<string, ColumnValuePropagator> columnMap)
         {
-            if (conflictingColumnValues == null)
+            foreach (var property in entry.EntityType.GetProperties())
             {
-                conflictingColumnValues = new Dictionary<IUpdateEntry, List<ColumnModification>>();
+                var columnName = property.Relational().ColumnName;
+                if (!columnMap.TryGetValue(columnName, out var columnPropagator))
+                {
+                    columnPropagator = new ColumnValuePropagator();
+                    columnMap.Add(columnName, columnPropagator);
+                }
+
+                if (updating)
+                {
+                    columnPropagator.RecordValue(property, entry);
+                }
             }
-
-            if (!conflictingColumnValues.TryGetValue(columnModification.Entry, out var conflictList))
-            {
-                conflictList = new List<ColumnModification>();
-                conflictingColumnValues.Add(columnModification.Entry, conflictList);
-            }
-
-            conflictList.Add(columnModification);
-
-            if (!conflictingColumnValues.TryGetValue(existingColumn.Entry, out var otherConflictList))
-            {
-                otherConflictList = new List<ColumnModification>();
-                conflictingColumnValues.Add(existingColumn.Entry, otherConflictList);
-            }
-
-            otherConflictList.Add(existingColumn);
-
-            return conflictingColumnValues;
         }
 
         /// <summary>
@@ -411,6 +330,54 @@ namespace Microsoft.EntityFrameworkCore.Update
             foreach (var modification in ColumnModifications.Where(o => o.IsRead))
             {
                 modification.Value = valueBuffer[index++];
+            }
+        }
+
+        private class ColumnValuePropagator
+        {
+            private bool _write;
+            private object _originalValue;
+            private object _currentValue;
+
+            public ColumnModification ColumnModification { get; set; }
+
+            public void RecordValue(IProperty property, IUpdateEntry entry)
+            {
+                switch (entry.EntityState)
+                {
+                    case EntityState.Modified:
+                        if (!_write && entry.IsModified(property))
+                        {
+                            _write = true;
+                            _currentValue = entry.GetCurrentValue(property);
+                        }
+                        break;
+                    case EntityState.Added:
+                        if (!_write)
+                        {
+                            _currentValue = entry.GetCurrentValue(property);
+                            _write = !Equals(_originalValue, _currentValue);
+                        }
+                        break;
+                    case EntityState.Deleted:
+                        _originalValue = entry.GetOriginalValue(property);
+                        break;
+                }
+            }
+
+            public bool TryPropagate(IProperty property, InternalEntityEntry entry)
+            {
+                if (_write
+                    && (entry.EntityState == EntityState.Unchanged
+                       || (entry.EntityState == EntityState.Modified && !entry.IsModified(property))
+                       || (entry.EntityState == EntityState.Added && Equals(_originalValue, entry.GetCurrentValue(property)))))
+                {
+                    entry[property] = _currentValue;
+
+                    return false;
+                }
+
+                return _write;
             }
         }
     }

--- a/src/EFCore/ChangeTracking/Internal/IStateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/IStateManager.cs
@@ -241,7 +241,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        IReadOnlyList<IUpdateEntry> GetEntriesToSave();
+        IList<IUpdateEntry> GetEntriesToSave();
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
@@ -593,9 +593,12 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                         var dependentEntry = dependents.FirstOrDefault();
                         if (dependentEntry != null)
                         {
-                            if (!foreignKey.IsOwnership
-                                || (dependentEntry.EntityState != EntityState.Deleted
-                                 && dependentEntry.EntityState != EntityState.Detached))
+                            if ((!foreignKey.IsOwnership
+                                    || (dependentEntry.EntityState != EntityState.Deleted
+                                     && dependentEntry.EntityState != EntityState.Detached))
+                                 && (foreignKey.PrincipalToDependent == null
+                                    || entry[foreignKey.PrincipalToDependent] == null
+                                    || entry[foreignKey.PrincipalToDependent] == dependentEntry.Entity))
                             {
                                 // Set navigations to and from principal entity that is indicated by FK
                                 SetNavigation(entry, foreignKey.PrincipalToDependent, dependentEntry);

--- a/src/EFCore/ChangeTracking/Internal/StateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/StateManager.cs
@@ -818,7 +818,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 return 0;
             }
 
-            var entriesToSave = GetInternalEntriesToSave();
+            var entriesToSave = GetEntriesToSave();
             if (entriesToSave.Count == 0)
             {
                 return 0;
@@ -830,7 +830,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
                 if (acceptAllChangesOnSuccess)
                 {
-                    AcceptAllChanges(entriesToSave);
+                    AcceptAllChanges((IReadOnlyList<IUpdateEntry>)entriesToSave);
                 }
 
                 return result;
@@ -839,7 +839,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             {
                 foreach (var entry in entriesToSave)
                 {
-                    entry.DiscardStoreGeneratedValues();
+                    ((InternalEntityEntry)entry).DiscardStoreGeneratedValues();
                 }
 
                 throw;
@@ -850,18 +850,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual IReadOnlyList<IUpdateEntry> GetEntriesToSave()
-            => GetInternalEntriesToSave();
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public virtual IReadOnlyList<InternalEntityEntry> GetInternalEntriesToSave()
+        public virtual IList<IUpdateEntry> GetEntriesToSave()
         {
             CascadeChanges(force: false);
 
-            var toSave = new List<InternalEntityEntry>(GetCountForState(added: true, modified: true, deleted: true));
+            var toSave = new List<IUpdateEntry>(GetCountForState(added: true, modified: true, deleted: true));
 
             // Perf sensitive
 
@@ -995,7 +988,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 return 0;
             }
 
-            var entriesToSave = GetInternalEntriesToSave();
+            var entriesToSave = GetEntriesToSave();
             if (entriesToSave.Count == 0)
             {
                 return 0;
@@ -1007,7 +1000,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
                 if (acceptAllChangesOnSuccess)
                 {
-                    AcceptAllChanges(entriesToSave);
+                    AcceptAllChanges((IReadOnlyList<IUpdateEntry>)entriesToSave);
                 }
 
                 return result;
@@ -1016,7 +1009,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             {
                 foreach (var entry in entriesToSave)
                 {
-                    entry.DiscardStoreGeneratedValues();
+                    ((InternalEntityEntry)entry).DiscardStoreGeneratedValues();
                 }
 
                 throw;
@@ -1028,7 +1021,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected virtual int SaveChanges(
-            [NotNull] IReadOnlyList<InternalEntityEntry> entriesToSave)
+            [NotNull] IList<IUpdateEntry> entriesToSave)
         {
             using (_concurrencyDetector.EnterCriticalSection())
             {
@@ -1041,7 +1034,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected virtual async Task<int> SaveChangesAsync(
-            [NotNull] IReadOnlyList<InternalEntityEntry> entriesToSave,
+            [NotNull] IList<IUpdateEntry> entriesToSave,
             CancellationToken cancellationToken = default)
         {
             using (_concurrencyDetector.EnterCriticalSection())
@@ -1057,12 +1050,12 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         public virtual void AcceptAllChanges()
             => AcceptAllChanges(this.ToListForState(added: true, modified: true, deleted: true));
 
-        private static void AcceptAllChanges(IReadOnlyList<InternalEntityEntry> changedEntries)
+        private static void AcceptAllChanges(IReadOnlyList<IUpdateEntry> changedEntries)
         {
             // ReSharper disable once ForCanBeConvertedToForeach
             for (var entryIndex = 0; entryIndex < changedEntries.Count; entryIndex++)
             {
-                changedEntries[entryIndex].AcceptChanges();
+                ((InternalEntityEntry)changedEntries[entryIndex]).AcceptChanges();
             }
         }
 

--- a/src/EFCore/DbUpdateException.cs
+++ b/src/EFCore/DbUpdateException.cs
@@ -56,7 +56,8 @@ namespace Microsoft.EntityFrameworkCore
         {
             Check.NotEmpty(entries, nameof(entries));
 
-            _entries = new LazyRef<IReadOnlyList<EntityEntry>>(() => entries.Select(e => e.ToEntityEntry()).ToList());
+            _entries = new LazyRef<IReadOnlyList<EntityEntry>>(() => entries.Where(e => e.EntityState != EntityState.Unchanged)
+                .Select(e => e.ToEntityEntry()).ToList());
         }
 
         /// <summary>

--- a/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
+++ b/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
@@ -236,7 +236,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
 
                 owner = ownership.PrincipalEntityType;
-                if (owner.ClrType == targetType)
+                if (owner.ClrType.IsAssignableFrom(targetType))
                 {
                     return owner;
                 }
@@ -247,14 +247,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public static bool IsInOwnershipPath([NotNull] this EntityType entityType, [NotNull] Type targetType)
+        public static bool IsInOwnershipPath([NotNull] this IEntityType entityType, [NotNull] Type targetType)
             => entityType.FindInOwnershipPath(targetType) != null;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public static bool IsInOwnershipPath([NotNull] this EntityType entityType, [NotNull] EntityType targetType)
+        public static bool IsInOwnershipPath([NotNull] this IEntityType entityType, [NotNull] IEntityType targetType)
         {
             var owner = entityType;
             while (true)
@@ -266,7 +266,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
 
                 owner = ownOwnership.PrincipalEntityType;
-                if (owner == targetType)
+                if (owner.IsAssignableFrom(targetType))
                 {
                     return true;
                 }

--- a/src/EFCore/Storage/Database.cs
+++ b/src/EFCore/Storage/Database.cs
@@ -54,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="entries"> Entries representing the changes to be persisted. </param>
         /// <returns> The number of state entries persisted to the database. </returns>
-        public abstract int SaveChanges(IReadOnlyList<IUpdateEntry> entries);
+        public abstract int SaveChanges(IList<IUpdateEntry> entries);
 
         /// <summary>
         ///     Asynchronously persists changes from the supplied entries to the database.
@@ -66,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     number of entries persisted to the database.
         /// </returns>
         public abstract Task<int> SaveChangesAsync(
-            IReadOnlyList<IUpdateEntry> entries,
+            IList<IUpdateEntry> entries,
             CancellationToken cancellationToken = default);
 
         /// <summary>

--- a/src/EFCore/Storage/IDatabase.cs
+++ b/src/EFCore/Storage/IDatabase.cs
@@ -37,7 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="entries"> Entries representing the changes to be persisted. </param>
         /// <returns> The number of state entries persisted to the database. </returns>
-        int SaveChanges([NotNull] IReadOnlyList<IUpdateEntry> entries);
+        int SaveChanges([NotNull] IList<IUpdateEntry> entries);
 
         /// <summary>
         ///     Asynchronously persists changes from the supplied entries to the database.
@@ -49,7 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     number of entries persisted to the database.
         /// </returns>
         Task<int> SaveChangesAsync(
-            [NotNull] IReadOnlyList<IUpdateEntry> entries,
+            [NotNull] IList<IUpdateEntry> entries,
             CancellationToken cancellationToken = default);
 
         /// <summary>

--- a/test/EFCore.Relational.Specification.Tests/F1RelationalFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/F1RelationalFixture.cs
@@ -13,8 +13,7 @@ namespace Microsoft.EntityFrameworkCore
 
         public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
             => base.AddOptions(builder).ConfigureWarnings(
-                w =>
-                    w.Ignore(RelationalEventId.BatchSmallerThanMinBatchSize));
+                w => w.Ignore(RelationalEventId.BatchSmallerThanMinBatchSize));
 
         protected override void BuildModelExternal(ModelBuilder modelBuilder)
         {

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -1045,16 +1045,16 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                             v => Assert.Equal(42, v));
                         AssertMultidimensionalArray(
                             m.Values,
-                            v => Assert.Equal("London", v),
-                            v => Assert.Equal("Abbey Road", v),
                             v => Assert.Equal("San Francisco", v),
-                            v => Assert.Equal("Lombard", v));
+                            v => Assert.Equal("Lombard", v),
+                            v => Assert.Equal("London", v),
+                            v => Assert.Equal("Abbey Road", v));
                         Assert.Collection(
                             m.Columns,
-                            v => Assert.Equal("BillingAddress_City", v),
-                            v => Assert.Equal("BillingAddress_Street", v),
                             v => Assert.Equal("ShippingAddress_City", v),
-                            v => Assert.Equal("ShippingAddress_Street", v));
+                            v => Assert.Equal("ShippingAddress_Street", v),
+                            v => Assert.Equal("BillingAddress_City", v),
+                            v => Assert.Equal("BillingAddress_Street", v));
                     }),
                 downOps => Assert.Collection(
                     downOps,
@@ -5011,57 +5011,27 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     upOps,
                     o =>
                     {
-                        var operation = Assert.IsType<DeleteDataOperation>(o);
-                        Assert.Equal("Animal", operation.Table);
-                        Assert.Collection(
-                            operation.KeyColumns,
-                            v => Assert.Equal("Id", v));
-                        AssertMultidimensionalArray(
-                            operation.KeyValues,
-                            v => Assert.Equal(43, v));
-                    },
-                    o =>
-                    {
-                        var operation = Assert.IsType<InsertDataOperation>(o);
+                        var operation = Assert.IsType<UpdateDataOperation>(o);
                         Assert.Equal("Animal", operation.Table);
                         Assert.Collection(
                             operation.Columns,
-                            v => Assert.Equal("Id", v),
-                            v => Assert.Equal("Discriminator", v),
-                            v => Assert.Equal("Name", v));
+                            v => Assert.Equal("Discriminator", v));
                         AssertMultidimensionalArray(
                             operation.Values,
-                            v => Assert.Equal(43, v),
-                            v => Assert.Equal("Shark", v),
-                            v => Assert.Equal("Bob", v));
+                            v => Assert.Equal("Shark", v));
                     }),
                 downOps => Assert.Collection(
                     downOps,
                     o =>
                     {
-                        var operation = Assert.IsType<DeleteDataOperation>(o);
-                        Assert.Equal("Animal", operation.Table);
-                        Assert.Collection(
-                            operation.KeyColumns,
-                            v => Assert.Equal("Id", v));
-                        AssertMultidimensionalArray(
-                            operation.KeyValues,
-                            v => Assert.Equal(43, v));
-                    },
-                    o =>
-                    {
-                        var operation = Assert.IsType<InsertDataOperation>(o);
+                        var operation = Assert.IsType<UpdateDataOperation>(o);
                         Assert.Equal("Animal", operation.Table);
                         Assert.Collection(
                             operation.Columns,
-                            v => Assert.Equal("Id", v),
-                            v => Assert.Equal("Discriminator", v),
-                            v => Assert.Equal("Name", v));
+                            v => Assert.Equal("Discriminator", v));
                         AssertMultidimensionalArray(
                             operation.Values,
-                            v => Assert.Equal(43, v),
-                            v => Assert.Equal("Animal", v),
-                            v => Assert.Equal("Bob", v));
+                            v => Assert.Equal("Animal", v));
                     }));
         }
 

--- a/test/EFCore.Relational.Tests/Update/CommandBatchPreparerTest.cs
+++ b/test/EFCore.Relational.Tests/Update/CommandBatchPreparerTest.cs
@@ -76,7 +76,6 @@ namespace Microsoft.EntityFrameworkCore.Update
                 });
 
             entry.SetEntityState(EntityState.Modified);
-            entry.SetPropertyModified(entry.EntityType.FindPrimaryKey().Properties.Single(), isModified: false);
 
             var commandBatches = CreateCommandBatchPreparer().BatchCommands(new[] { entry }).ToArray();
             Assert.Equal(1, commandBatches.Length);
@@ -188,7 +187,6 @@ namespace Microsoft.EntityFrameworkCore.Update
                     Id = 42
                 });
             relatedEntry.SetEntityState(EntityState.Modified);
-            relatedEntry.SetPropertyModified(relatedEntry.EntityType.FindProperty(nameof(RelatedFakeEntity.RelatedId)));
 
             var commandBatches = CreateCommandBatchPreparer().BatchCommands(new[] { relatedEntry, entry }).ToArray();
 
@@ -255,7 +253,6 @@ namespace Microsoft.EntityFrameworkCore.Update
                 });
             relatedEntry.SetEntityState(EntityState.Modified);
             relatedEntry.SetOriginalValue(relatedEntry.EntityType.FindProperty("RelatedId"), 42);
-            relatedEntry.SetPropertyModified(relatedEntry.EntityType.FindPrimaryKey().Properties.Single(), isModified: false);
 
             var commandBatches = CreateCommandBatchPreparer().BatchCommands(new[] { relatedEntry, previousParent, newParent }).ToArray();
 
@@ -428,7 +425,6 @@ namespace Microsoft.EntityFrameworkCore.Update
                 });
             fakeEntry2.SetEntityState(EntityState.Modified);
             fakeEntry2.SetOriginalValue(fakeEntry2.EntityType.FindProperty(nameof(FakeEntity.Value)), "Test");
-            fakeEntry2.SetPropertyModified(fakeEntry2.EntityType.FindPrimaryKey().Properties.Single(), isModified: false);
 
             var sortedEntities = CreateCommandBatchPreparer()
                 .BatchCommands(new[] { fakeEntry, fakeEntry2, relatedFakeEntry })
@@ -529,7 +525,6 @@ namespace Microsoft.EntityFrameworkCore.Update
                 });
             fakeEntry2.SetEntityState(EntityState.Modified);
             fakeEntry2.SetOriginalValue(fakeEntry2.EntityType.FindProperty(nameof(FakeEntity.UniqueValue)), "Test");
-            fakeEntry2.SetPropertyModified(fakeEntry2.EntityType.FindPrimaryKey().Properties.Single(), isModified: false);
 
             var expectedCycle = sensitiveLogging
                 ? "FakeEntity { 'Id': 42 } [Added] <- ForeignKey { 'RelatedId': 42 } RelatedFakeEntity { 'Id': 1 } [Added] <- ForeignKey { 'RelatedId': 1 } FakeEntity { 'Id': 2 } [Modified] <- Index { 'UniqueValue': Test } FakeEntity { 'Id': 42 } [Added]"
@@ -610,7 +605,6 @@ namespace Microsoft.EntityFrameworkCore.Update
                 });
             fakeEntry2.SetEntityState(EntityState.Modified);
             fakeEntry2.SetOriginalValue(fakeEntry.EntityType.FindProperty(nameof(FakeEntity.UniqueValue)), "Test");
-            fakeEntry2.SetPropertyModified(fakeEntry.EntityType.FindPrimaryKey().Properties.Single(), isModified: false);
 
             var batches = CreateCommandBatchPreparer(stateManager: stateManager)
                 .BatchCommands(new[] { fakeEntry, fakeEntry2 }).ToArray();
@@ -692,7 +686,6 @@ namespace Microsoft.EntityFrameworkCore.Update
             var entry = stateManager.GetOrCreateEntry(entity);
 
             entry.SetEntityState(EntityState.Modified);
-            entry.SetPropertyModified(entry.EntityType.FindPrimaryKey().Properties.Single(), isModified: false);
 
             var commandBatches = CreateCommandBatchPreparer(stateManager: stateManager).BatchCommands(new[] { entry }).ToArray();
             Assert.Equal(1, commandBatches.Length);
@@ -845,14 +838,12 @@ namespace Microsoft.EntityFrameworkCore.Update
             };
             var firstEntry = stateManager.GetOrCreateEntry(first);
             firstEntry.SetEntityState(EntityState.Modified);
-            firstEntry.SetPropertyModified(firstEntry.EntityType.FindPrimaryKey().Properties.Single(), isModified: false);
             var second = new RelatedFakeEntity
             {
                 Id = 42
             };
             var secondEntry = stateManager.GetOrCreateEntry(second);
             secondEntry.SetEntityState(EntityState.Modified);
-            secondEntry.SetPropertyModified(secondEntry.EntityType.FindPrimaryKey().Properties.Single(), isModified: false);
 
             if (useCurrentValues)
             {
@@ -871,8 +862,8 @@ namespace Microsoft.EntityFrameworkCore.Update
                 {
                     Assert.Equal(
                         RelationalStrings.ConflictingRowValuesSensitive(
-                            nameof(RelatedFakeEntity), nameof(FakeEntity), "{Id: 42}",
-                            "{RelatedId: 2}", "{RelatedId: 1}", "{'RelatedId'}"),
+                             nameof(FakeEntity), nameof(RelatedFakeEntity),
+                             "{Id: 42}", "{RelatedId: 1}", "{RelatedId: 2}", "{'RelatedId'}"),
                         Assert.Throws<InvalidOperationException>(
                             () => CreateCommandBatchPreparer(stateManager: stateManager, sensitiveLogging: true)
                                 .BatchCommands(new[] { firstEntry, secondEntry }).ToArray()).Message);
@@ -881,7 +872,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                 {
                     Assert.Equal(
                         RelationalStrings.ConflictingRowValues(
-                            nameof(RelatedFakeEntity), nameof(FakeEntity),
+                            nameof(FakeEntity), nameof(RelatedFakeEntity),
                             "{'RelatedId'}", "{'RelatedId'}", "{'RelatedId'}"),
                         Assert.Throws<InvalidOperationException>(
                             () => CreateCommandBatchPreparer(stateManager: stateManager, sensitiveLogging: false)
@@ -894,8 +885,8 @@ namespace Microsoft.EntityFrameworkCore.Update
                 {
                     Assert.Equal(
                         RelationalStrings.ConflictingOriginalRowValuesSensitive(
-                            nameof(RelatedFakeEntity), nameof(FakeEntity), "{Id: 42}",
-                            "{RelatedId: 2}", "{RelatedId: 1}", "{'RelatedId'}"),
+                            nameof(FakeEntity), nameof(RelatedFakeEntity),
+                            "{Id: 42}", "{RelatedId: 1}", "{RelatedId: 2}", "{'RelatedId'}"),
                         Assert.Throws<InvalidOperationException>(
                             () => CreateCommandBatchPreparer(stateManager: stateManager, sensitiveLogging: true)
                                 .BatchCommands(new[] { firstEntry, secondEntry }).ToArray()).Message);
@@ -904,7 +895,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                 {
                     Assert.Equal(
                         RelationalStrings.ConflictingOriginalRowValues(
-                            nameof(RelatedFakeEntity), nameof(FakeEntity),
+                             nameof(FakeEntity), nameof(RelatedFakeEntity),
                             "{'RelatedId'}", "{'RelatedId'}", "{'RelatedId'}"),
                         Assert.Throws<InvalidOperationException>(
                             () => CreateCommandBatchPreparer(stateManager: stateManager, sensitiveLogging: false)

--- a/test/EFCore.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
+++ b/test/EFCore.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
@@ -341,7 +341,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                             property,
                             property.TestProvider(),
                             parameterNameGenerator.GenerateNext,
-                            false, true, false, false, false)
+                            false, true, false, false, false, true)
                     }));
 
             batch.AddCommand(
@@ -357,7 +357,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                             property,
                             property.TestProvider(),
                             parameterNameGenerator.GenerateNext,
-                            false, true, false, false, false)
+                            false, true, false, false, false, true)
                     }));
 
             var storeCommand = batch.CreateStoreCommandBase();
@@ -393,7 +393,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                             property,
                             property.TestProvider(),
                             parameterNameGenerator.GenerateNext,
-                            false, true, false, false, false)
+                            false, true, false, false, false, true)
                     }));
 
             var storeCommand = batch.CreateStoreCommandBase();
@@ -427,7 +427,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                             property,
                             property.TestProvider(),
                             parameterNameGenerator.GenerateNext,
-                            false, false, false, true, false)
+                            false, false, false, true, false, true)
                     }));
 
             var storeCommand = batch.CreateStoreCommandBase();
@@ -461,7 +461,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                             property,
                             property.TestProvider(),
                             parameterNameGenerator.GenerateNext,
-                            false, true, false, true, false)
+                            false, true, false, true, false, true)
                     }));
 
             var storeCommand = batch.CreateStoreCommandBase();
@@ -495,7 +495,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                             property,
                             property.TestProvider(),
                             parameterNameGenerator.GenerateNext,
-                            true, false, false, false, false)
+                            true, false, false, false, false, true)
                     }));
 
             var storeCommand = batch.CreateStoreCommandBase();
@@ -554,11 +554,11 @@ namespace Microsoft.EntityFrameworkCore.Update
 
         private static FakeDbDataReader CreateFakeDataReader(string[] columnNames = null, IList<object[]> results = null)
         {
-            results = results ?? new List<object[]>
+            results ??= new List<object[]>
             {
                 new object[] { 1 }
             };
-            columnNames = columnNames ?? new[] { "RowsAffected" };
+            columnNames ??= new[] { "RowsAffected" };
 
             return new FakeDbDataReader(columnNames, results);
         }
@@ -611,7 +611,7 @@ namespace Microsoft.EntityFrameworkCore.Update
 
             protected override void UpdateCachedCommandText(int commandIndex)
             {
-                CachedCommandText = CachedCommandText ?? new StringBuilder();
+                CachedCommandText ??= new StringBuilder();
                 CachedCommandText.Append(".");
             }
 

--- a/test/EFCore.Relational.Tests/Update/UpdateSqlGeneratorTestBase.cs
+++ b/test/EFCore.Relational.Tests/Update/UpdateSqlGeneratorTestBase.cs
@@ -330,17 +330,17 @@ namespace Microsoft.EntityFrameworkCore.Update
             var columnModifications = new[]
             {
                 new ColumnModification(
-                    entry, idProperty, idProperty.TestProvider(), generator.GenerateNext, identityKey, !identityKey, true, false, false),
+                    entry, idProperty, idProperty.TestProvider(), generator.GenerateNext, identityKey, !identityKey, true, false, false, true),
                 new ColumnModification(
-                    entry, nameProperty, nameProperty.TestProvider(), generator.GenerateNext, false, true, false, false, false),
+                    entry, nameProperty, nameProperty.TestProvider(), generator.GenerateNext, false, true, false, false, false, true),
                 new ColumnModification(
-                    entry, quacksProperty, quacksProperty.TestProvider(), generator.GenerateNext, false, true, false, false, false),
+                    entry, quacksProperty, quacksProperty.TestProvider(), generator.GenerateNext, false, true, false, false, false, true),
                 new ColumnModification(
                     entry, computedProperty, computedProperty.TestProvider(), generator.GenerateNext, isComputed, false, false, false,
-                    true),
+                    true, true),
                 new ColumnModification(
                     entry, concurrencyProperty, concurrencyProperty.TestProvider(), generator.GenerateNext, false, true, false, false,
-                    false)
+                    false, true)
             };
 
             if (defaultsOnly)
@@ -367,17 +367,17 @@ namespace Microsoft.EntityFrameworkCore.Update
             var columnModifications = new[]
             {
                 new ColumnModification(
-                    entry, idProperty, idProperty.TestProvider(), generator.GenerateNext, false, false, true, true, false),
+                    entry, idProperty, idProperty.TestProvider(), generator.GenerateNext, false, false, true, true, false, true),
                 new ColumnModification(
-                    entry, nameProperty, nameProperty.TestProvider(), generator.GenerateNext, false, true, false, false, false),
+                    entry, nameProperty, nameProperty.TestProvider(), generator.GenerateNext, false, true, false, false, false, true),
                 new ColumnModification(
-                    entry, quacksProperty, quacksProperty.TestProvider(), generator.GenerateNext, false, true, false, false, false),
+                    entry, quacksProperty, quacksProperty.TestProvider(), generator.GenerateNext, false, true, false, false, false, true),
                 new ColumnModification(
                     entry, computedProperty, computedProperty.TestProvider(), generator.GenerateNext, isComputed, false, false, false,
-                    false),
+                    false, true),
                 new ColumnModification(
                     entry, concurrencyProperty, concurrencyProperty.TestProvider(), generator.GenerateNext, false, true, false,
-                    concurrencyToken, concurrencyToken)
+                    concurrencyToken, concurrencyToken, true)
             };
 
             return new FakeModificationCommand(
@@ -396,10 +396,10 @@ namespace Microsoft.EntityFrameworkCore.Update
             var columnModifications = new[]
             {
                 new ColumnModification(
-                    entry, idProperty, idProperty.TestProvider(), generator.GenerateNext, false, false, true, true, concurrencyToken),
+                    entry, idProperty, idProperty.TestProvider(), generator.GenerateNext, false, false, true, true, concurrencyToken, true),
                 new ColumnModification(
                     entry, concurrencyProperty, concurrencyProperty.TestProvider(), generator.GenerateNext, false, false, false,
-                    concurrencyToken, concurrencyToken)
+                    concurrencyToken, concurrencyToken, true)
             };
 
             return new FakeModificationCommand(

--- a/test/EFCore.Specification.Tests/OptimisticConcurrencyTestBase.cs
+++ b/test/EFCore.Specification.Tests/OptimisticConcurrencyTestBase.cs
@@ -240,7 +240,7 @@ namespace Microsoft.EntityFrameworkCore
                     c.EngineSuppliers.Single(s => s.Name == "Renault"),
                 (c, ex) =>
                 {
-                    var entry = ex.Entries.Single();
+                    var entry = ex.Entries.Single(e => e.Metadata.ClrType == typeof(Engine));
                     Assert.IsAssignableFrom<Engine>(entry.Entity);
                     entry.Reload();
                 },

--- a/test/EFCore.SqlServer.FunctionalTests/F1SqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/F1SqlServerFixture.cs
@@ -25,9 +25,18 @@ namespace Microsoft.EntityFrameworkCore
                 .ValueGeneratedOnAddOrUpdate()
                 .IsConcurrencyToken();
 
+            modelBuilder.Entity<Sponsor>(eb =>
+            {
+                eb.Property<byte[]>("Version").IsRowVersion().HasColumnName("Version");
+                eb.Property<int?>(Sponsor.ClientTokenPropertyName).HasColumnName(Sponsor.ClientTokenPropertyName);
+            });
             modelBuilder.Entity<TitleSponsor>()
-                .OwnsOne(s => s.Details)
-                .Property(d => d.Space).HasColumnType("decimal(18,2)");
+                .OwnsOne(s => s.Details, eb =>
+                {
+                    eb.Property(d => d.Space).HasColumnType("decimal(18,2)");
+                    eb.Property<byte[]>("Version").IsRowVersion().HasColumnName("Version");
+                    eb.Property<int?>(Sponsor.ClientTokenPropertyName).IsConcurrencyToken().HasColumnName(Sponsor.ClientTokenPropertyName);
+                });
         }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/OptimisticConcurrencySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/OptimisticConcurrencySqlServerTest.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel;
 using Xunit;
 
 // ReSharper disable InconsistentNaming
@@ -88,6 +89,87 @@ namespace Microsoft.EntityFrameworkCore
                     ResolveConcurrencyTokens(secondDriverEntry);
                 },
                 c => Assert.Equal(ClientPodiums, c.Drivers.Single(d => d.CarNumber == 2).Podiums));
+        }
+
+        [Fact]
+        public async Task Database_concurrency_token_value_is_updated_for_all_sharing_entities()
+        {
+            using (var c = CreateF1Context())
+            {
+                await c.Database.CreateExecutionStrategy().ExecuteAsync(
+                    c, async context =>
+                    {
+                        using (var transaction = context.Database.BeginTransaction())
+                        {
+                            var sponsor = context.Set<TitleSponsor>().Single();
+                            var sponsorEntry = c.Entry(sponsor);
+                            var detailsEntry = sponsorEntry.Reference(s => s.Details).TargetEntry;
+                            var sponsorVersion = sponsorEntry.Property<byte[]>("Version").CurrentValue;
+                            var detailsVersion = detailsEntry.Property<byte[]>("Version").CurrentValue;
+
+                            Assert.Null(sponsorEntry.Property<int?>(Sponsor.ClientTokenPropertyName).CurrentValue);
+                            sponsorEntry.Property<int?>(Sponsor.ClientTokenPropertyName).CurrentValue = 1;
+
+                            sponsor.Name = "Telecom";
+
+                            Assert.Equal(sponsorVersion, detailsVersion);
+
+                            await context.SaveChangesAsync();
+
+                            var newSponsorVersion = sponsorEntry.Property<byte[]>("Version").CurrentValue;
+                            var newDetailsVersion = detailsEntry.Property<byte[]>("Version").CurrentValue;
+
+                            Assert.Equal(newSponsorVersion, newDetailsVersion);
+                            Assert.NotEqual(sponsorVersion, newSponsorVersion);
+
+                            Assert.Equal(1, sponsorEntry.Property<int?>(Sponsor.ClientTokenPropertyName).CurrentValue);
+                            Assert.Equal(1, detailsEntry.Property<int?>(Sponsor.ClientTokenPropertyName).CurrentValue);
+                        }
+                    });
+            }
+        }
+
+        [Fact]
+        public async Task Original_concurrency_token_value_is_used_when_replacing_owned_instance()
+        {
+            using (var c = CreateF1Context())
+            {
+                await c.Database.CreateExecutionStrategy().ExecuteAsync(
+                    c, async context =>
+                    {
+                        using (var transaction = context.Database.BeginTransaction())
+                        {
+                            var sponsor = context.Set<TitleSponsor>().Single();
+                            var sponsorEntry = c.Entry(sponsor);
+                            var sponsorVersion = sponsorEntry.Property<byte[]>("Version").CurrentValue;
+
+                            Assert.Null(sponsorEntry.Property<int?>(Sponsor.ClientTokenPropertyName).CurrentValue);
+                            sponsorEntry.Property<int?>(Sponsor.ClientTokenPropertyName).CurrentValue = 1;
+
+                            sponsor.Details = new SponsorDetails
+                            {
+                                Days = 11,
+                                Space = 51m
+                            };
+
+                            context.ChangeTracker.DetectChanges();
+
+                            var detailsEntry = sponsorEntry.Reference(s => s.Details).TargetEntry;
+                            detailsEntry.Property<int?>(Sponsor.ClientTokenPropertyName).CurrentValue = 1;
+
+                            await context.SaveChangesAsync();
+
+                            var newSponsorVersion = sponsorEntry.Property<byte[]>("Version").CurrentValue;
+                            var newDetailsVersion = detailsEntry.Property<byte[]>("Version").CurrentValue;
+
+                            Assert.Equal(newSponsorVersion, newDetailsVersion);
+                            Assert.NotEqual(sponsorVersion, newSponsorVersion);
+
+                            Assert.Equal(1, sponsorEntry.Property<int?>(Sponsor.ClientTokenPropertyName).CurrentValue);
+                            Assert.Equal(1, detailsEntry.Property<int?>(Sponsor.ClientTokenPropertyName).CurrentValue);
+                        }
+                    });
+            }
         }
 
         protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)

--- a/test/EFCore.SqlServer.FunctionalTests/PropertyEntrySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/PropertyEntrySqlServerTest.cs
@@ -27,10 +27,12 @@ ORDER BY [e].[Id]",
 @p2='1'
 @p0='FO 108X' (Size = 4000)
 @p3='ChangedEngine' (Size = 4000)
+@p4='47.64491'
+@p5='-122.128101'
 
 SET NOCOUNT ON;
 UPDATE [Engines] SET [Name] = @p0
-WHERE [Id] = @p1 AND [EngineSupplierId] = @p2 AND [Name] = @p3;
+WHERE [Id] = @p1 AND [EngineSupplierId] = @p2 AND [Name] = @p3 AND [StorageLocation_Latitude] = @p4 AND [StorageLocation_Longitude] = @p5;
 SELECT @@ROWCOUNT;");
         }
 

--- a/test/EFCore.Sqlite.FunctionalTests/PropertyEntrySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/PropertyEntrySqliteTest.cs
@@ -25,9 +25,11 @@ LIMIT 1",
 @p2='1' (DbType = String)
 @p0='FO 108X' (Size = 7)
 @p3='ChangedEngine' (Size = 13)
+@p4='47.64491' (DbType = String)
+@p5='-122.128101' (DbType = String)
 
 UPDATE ""Engines"" SET ""Name"" = @p0
-WHERE ""Id"" = @p1 AND ""EngineSupplierId"" = @p2 AND ""Name"" = @p3;
+WHERE ""Id"" = @p1 AND ""EngineSupplierId"" = @p2 AND ""Name"" = @p3 AND ""StorageLocation_Latitude"" = @p4 AND ""StorageLocation_Longitude"" = @p5;
 SELECT changes();");
         }
 

--- a/test/EFCore.Tests/TestUtilities/FakeStateManager.cs
+++ b/test/EFCore.Tests/TestUtilities/FakeStateManager.cs
@@ -87,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         public IEnumerable<InternalEntityEntry> GetDependentsFromNavigation(InternalEntityEntry principalEntry, IForeignKey foreignKey) =>
             throw new NotImplementedException();
 
-        public IReadOnlyList<IUpdateEntry> GetEntriesToSave() => Enumerable.Empty<IUpdateEntry>().ToList();
+        public IList<IUpdateEntry> GetEntriesToSave() => Enumerable.Empty<IUpdateEntry>().ToList();
         public virtual void AcceptAllChanges() => throw new NotImplementedException();
         public InternalEntityEntry GetOrCreateEntry(object entity) => throw new NotImplementedException();
         public InternalEntityEntry GetOrCreateEntry(object entity, IEntityType entityType) => throw new NotImplementedException();


### PR DESCRIPTION
Propagate modified values to all properties sharing a column.
Validate that the store generated concurrency token is mapped to all entity types sharing the table.
Set owned type table name using the default value provider instead of a convention
Don't mark the discriminator as read-only

Fixes #14154
Fixes #12758
Fixes #12865
Fixes #14539