### PR TITLE
Migrations: Throw not implemented in MigrationSqlGenerator for computed columns

### DIFF
--- a/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
+++ b/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
@@ -1232,6 +1232,13 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             Check.NotNull(operation, nameof(operation));
             Check.NotNull(builder, nameof(builder));
 
+            if (operation.ComputedColumnSql != null)
+            {
+                ComputedColumnDefinition(schema, table, name, operation, model, builder);
+
+                return;
+            }
+
             builder
                 .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(name))
                 .Append(" ")
@@ -1240,6 +1247,26 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             builder.Append(operation.IsNullable ? " NULL" : " NOT NULL");
 
             DefaultValue(operation.DefaultValue, operation.DefaultValueSql, builder);
+        }
+
+        /// <summary>
+        ///     Generates a SQL fragment for a computed column definition for the given column metadata.
+        /// </summary>
+        /// <param name="schema"> The schema that contains the table, or <c>null</c> to use the default schema. </param>
+        /// <param name="table"> The table that contains the column. </param>
+        /// <param name="name"> The column name. </param>
+        /// <param name="operation"> The column metadata. </param>
+        /// <param name="model"> The target model which may be <c>null</c> if the operations exist without a model. </param>
+        /// <param name="builder"> The command builder to use to add the SQL fragment. </param>
+        protected virtual void ComputedColumnDefinition(
+            [CanBeNull] string schema,
+            [NotNull] string table,
+            [NotNull] string name,
+            [NotNull] ColumnOperation operation,
+            [CanBeNull] IModel model,
+            [NotNull] MigrationCommandListBuilder builder)
+        {
+            throw new NotImplementedException();
         }
 
         /// <summary>

--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -1253,16 +1253,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             Check.NotNull(operation, nameof(operation));
             Check.NotNull(builder, nameof(builder));
 
-            if (operation.ComputedColumnSql != null)
-            {
-                builder
-                    .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(name))
-                    .Append(" AS ")
-                    .Append(operation.ComputedColumnSql);
-
-                return;
-            }
-
             base.ColumnDefinition(
                 schema,
                 table,
@@ -1278,6 +1268,33 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             {
                 builder.Append(" IDENTITY");
             }
+        }
+
+        /// <summary>
+        ///     Generates a SQL fragment for a computed column definition for the given column metadata.
+        /// </summary>
+        /// <param name="schema"> The schema that contains the table, or <c>null</c> to use the default schema. </param>
+        /// <param name="table"> The table that contains the column. </param>
+        /// <param name="name"> The column name. </param>
+        /// <param name="operation"> The column metadata. </param>
+        /// <param name="model"> The target model which may be <c>null</c> if the operations exist without a model. </param>
+        /// <param name="builder"> The command builder to use to add the SQL fragment. </param>
+        protected override void ComputedColumnDefinition(
+            string schema,
+            string table,
+            string name,
+            ColumnOperation operation,
+            IModel model,
+            MigrationCommandListBuilder builder)
+        {
+            Check.NotEmpty(name, nameof(name));
+            Check.NotNull(operation, nameof(operation));
+            Check.NotNull(builder, nameof(builder));
+
+            builder
+                .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(name))
+                .Append(" AS ")
+                .Append(operation.ComputedColumnSql);
         }
 
         /// <summary>

--- a/src/EFCore.Sqlite.Core/Migrations/SqliteMigrationsSqlGenerator.cs
+++ b/src/EFCore.Sqlite.Core/Migrations/SqliteMigrationsSqlGenerator.cs
@@ -476,6 +476,15 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             => throw new NotSupportedException(
                 SqliteStrings.InvalidMigrationOperation(operation.GetType().ShortDisplayName()));
 
+        protected override void ComputedColumnDefinition(
+            string schema,
+            string table,
+            string name,
+            ColumnOperation operation,
+            IModel model,
+            MigrationCommandListBuilder builder)
+            => throw new NotSupportedException(SqliteStrings.ComputedColumnsNotSupported);
+
         #endregion
 
         #region Ignored schema operations

--- a/src/EFCore.Sqlite.Core/Properties/SqliteStrings.Designer.cs
+++ b/src/EFCore.Sqlite.Core/Properties/SqliteStrings.Designer.cs
@@ -39,6 +39,12 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
         public static string SequencesNotSupported
             => GetString("SequencesNotSupported");
 
+        /// <summary>
+        ///     SQLite doesn't support computed columns. For more information, see http://go.microsoft.com/fwlink/?LinkId=723262.
+        /// </summary>
+        public static string ComputedColumnsNotSupported
+            => GetString("ComputedColumnsNotSupported");
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore.Sqlite.Core/Properties/SqliteStrings.resx
+++ b/src/EFCore.Sqlite.Core/Properties/SqliteStrings.resx
@@ -174,4 +174,7 @@
     <value>Found unique constraint with name: {uniqueConstraintName}, table: {tableName}.</value>
     <comment>Debug SqliteEventId.UniqueConstraintFound string string</comment>
   </data>
+  <data name="ComputedColumnsNotSupported" xml:space="preserve">
+    <value>SQLite doesn't support computed columns. For more information, see http://go.microsoft.com/fwlink/?LinkId=723262.</value>
+  </data>
 </root>

--- a/test/EFCore.Relational.Specification.Tests/MigrationSqlGeneratorTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/MigrationSqlGeneratorTestBase.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Metadata;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -71,19 +70,6 @@ namespace Microsoft.EntityFrameworkCore
                     ColumnType = "date",
                     IsNullable = true,
                     DefaultValueSql = "CURRENT_TIMESTAMP"
-                });
-
-        [Fact]
-        public virtual void AddColumnOperation_with_computed_column_SQL()
-            => Generate(
-                new AddColumnOperation
-                {
-                    Table = "People",
-                    Name = "Birthday",
-                    ClrType = typeof(DateTime),
-                    ColumnType = "date",
-                    IsNullable = true,
-                    ComputedColumnSql = "CURRENT_TIMESTAMP"
                 });
 
         [Fact]

--- a/test/EFCore.Relational.Tests/Migrations/MigrationSqlGeneratorTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/MigrationSqlGeneratorTest.cs
@@ -27,15 +27,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 Sql);
         }
 
-        public override void AddColumnOperation_with_computed_column_SQL()
-        {
-            base.AddColumnOperation_with_computed_column_SQL();
-
-            Assert.Equal(
-                "ALTER TABLE \"People\" ADD \"Birthday\" date NULL;" + EOL,
-                Sql);
-        }
-
         public override void AddColumnOperation_without_column_type()
         {
             base.AddColumnOperation_without_column_type();

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerMigrationSqlGeneratorTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerMigrationSqlGeneratorTest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.IO;
 using Microsoft.EntityFrameworkCore.Metadata;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.SqlServer.Internal;
@@ -52,9 +51,19 @@ namespace Microsoft.EntityFrameworkCore
                 Sql);
         }
 
-        public override void AddColumnOperation_with_computed_column_SQL()
+        [Fact]
+        public void AddColumnOperation_with_computed_column_SQL()
         {
-            base.AddColumnOperation_with_computed_column_SQL();
+            Generate(
+                new AddColumnOperation
+                {
+                    Table = "People",
+                    Name = "Birthday",
+                    ClrType = typeof(DateTime),
+                    ColumnType = "date",
+                    IsNullable = true,
+                    ComputedColumnSql = "CURRENT_TIMESTAMP"
+                });
 
             Assert.Equal(
                 "ALTER TABLE [People] ADD [Birthday] AS CURRENT_TIMESTAMP;" + EOL,
@@ -266,7 +275,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [Fact]
-        public virtual void AlterColumnOperation_computed()
+        public void AlterColumnOperation_computed()
         {
             Generate(
                 new AlterColumnOperation


### PR DESCRIPTION
Fixes #8764

**Providers** you may need to tweak the way computed columns are implemented.