### PR TITLE
Close connection even if ambient transaction hasn't completed

### DIFF
--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -614,6 +614,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 GetString("MissingConcurrencyColumn", nameof(entityType), nameof(missingColumn), nameof(table)),
                 entityType, missingColumn, table);
 
+        /// <summary>
+        ///     This connection was used with an ambient transaction. The original ambient transaction needs to be completed before this connection can be used outside of it.
+        /// </summary>
+        public static string PendingAmbientTransaction
+            => GetString("PendingAmbientTransaction");
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -504,4 +504,7 @@
   <data name="MissingConcurrencyColumn" xml:space="preserve">
     <value>Entity type '{entityType}' doesn't contain a property mapped to the store-generated concurrency token column '{missingColumn}' that is used by another entity type sharing the table '{table}'. Add a compatible property, that can be in shadow state, to '{entityType}'.</value>
   </data>
+  <data name="PendingAmbientTransaction" xml:space="preserve">
+    <value>This connection was used with an ambient transaction. The original ambient transaction needs to be completed before this connection can be used outside of it.</value>
+  </data>
 </root>

--- a/test/EFCore.Relational.Specification.Tests/TransactionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/TransactionTestBase.cs
@@ -427,7 +427,7 @@ namespace Microsoft.EntityFrameworkCore
                         Assert.Throws<DbUpdateException>(() => context.SaveChanges());
                     }
 
-                    Assert.Equal(ConnectionState.Open, connection.State);
+                    Assert.Equal(ConnectionState.Closed, connection.State);
 
                     context.Database.AutoTransactionsEnabled = true;
                 }
@@ -465,7 +465,8 @@ namespace Microsoft.EntityFrameworkCore
 
                     using (new TransactionScope(TransactionScopeOption.Suppress))
                     {
-                        Assert.Throws<InvalidOperationException>(() => context.SaveChanges());
+                        Assert.Equal(RelationalStrings.PendingAmbientTransaction,
+                            Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                     }
                 }
             }


### PR DESCRIPTION
On SQL Server if a connection was enlisted in a transaction, closed, then enlisted in a different transaction before the first one was completed results in a deadlock. We maintained the connection opened to allow the database to throw in this case, but this was unexpected behavior.

Now we close the database connection, but keep the reference to the original transaction to perform the above check explicitly.

This change also allowed to remove the semaphore as the opened count shouldn't be mutated on different threads anymore.

Fixes #14218