### PR TITLE
Make shared table dependents optional.

### DIFF
--- a/src/EFCore.Relational/Metadata/RelationalPropertyExtensions.cs
+++ b/src/EFCore.Relational/Metadata/RelationalPropertyExtensions.cs
@@ -39,20 +39,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="property"> The <see cref="IProperty" />. </param>
         /// <returns> <c>True</c> if the mapped column is nullable; <c>false</c> otherwise. </returns>
         public static bool IsColumnNullable([NotNull] this IProperty property)
-            => property.DeclaringEntityType.BaseType != null
-               || property.IsNullable ||
-               !property.IsPrimaryKey()
-               && IsOwnedByDerivedType(property.DeclaringEntityType);
+            => !property.IsPrimaryKey()
+                   && (property.DeclaringEntityType.BaseType != null
+                       || property.IsNullable
+                       || IsTableSplitting(property.DeclaringEntityType));
 
-        private static bool IsOwnedByDerivedType(IEntityType entityType)
-        {
-            var ownerEntityType = entityType.FindPrimaryKey()?.Properties.First()
-                ?.FindSharedTableLink()?.PrincipalEntityType;
-
-            return ownerEntityType?.BaseType != null ||
-                   ownerEntityType != null
-                   && IsOwnedByDerivedType(ownerEntityType);
-        }
+        private static bool IsTableSplitting(IEntityType entityType)
+            => entityType.FindPrimaryKey()?.Properties[0].FindSharedTableLink() != null;
 
         /// <summary>
         ///     <para>

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -607,7 +607,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => GetString("SqlFunctionUnexpectedInstanceMapping");
 
         /// <summary>
-        ///     Entity type '{entityType}' doesn't contain a property mapped to the store-generated concurrency token column '{missingColumn}' that is used by another entity type sharing the table '{table}'. Add a compatible property, that can be in shadow state, to '{entityType}'.
+        ///     Entity type '{entityType}' doesn't contain a property mapped to the store-generated concurrency token column '{missingColumn}' that is used by another entity type sharing the table '{table}'. Add a store-generated property mapped to the same column to '{entityType}'. It can be in shadow state.
         /// </summary>
         public static string MissingConcurrencyColumn([CanBeNull] object entityType, [CanBeNull] object missingColumn, [CanBeNull] object table)
             => string.Format(

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -492,7 +492,7 @@
     <value>An instance type mapping was specified without an instance expression.</value>
   </data>
   <data name="MissingConcurrencyColumn" xml:space="preserve">
-    <value>Entity type '{entityType}' doesn't contain a property mapped to the store-generated concurrency token column '{missingColumn}' that is used by another entity type sharing the table '{table}'. Add a compatible property, that can be in shadow state, to '{entityType}'.</value>
+    <value>Entity type '{entityType}' doesn't contain a property mapped to the store-generated concurrency token column '{missingColumn}' that is used by another entity type sharing the table '{table}'. Add a store-generated property mapped to the same column to '{entityType}'. It can be in shadow state.</value>
   </data>
   <data name="PendingAmbientTransaction" xml:space="preserve">
     <value>This connection was used with an ambient transaction. The original ambient transaction needs to be completed before this connection can be used outside of it.</value>

--- a/src/EFCore.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
@@ -311,14 +311,14 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                     typeIndexMap);
 
         private static void FindPaths(
-            IEntityType entityType, ICollection<IEntityType> sharedTypes,
+            IEntityType entityType, ICollection<IEntityType> sharingTypes,
             Stack<IEntityType> currentPath, ICollection<List<IEntityType>> result)
         {
             var identifyingFks = entityType.FindForeignKeys(entityType.FindPrimaryKey().Properties)
                 .Where(
                     fk => fk.PrincipalKey.IsPrimaryKey()
                           && fk.PrincipalEntityType != entityType
-                          && sharedTypes.Contains(fk.PrincipalEntityType))
+                          && sharingTypes.Contains(fk.PrincipalEntityType))
                 .ToList();
 
             if (identifyingFks.Count == 0)
@@ -330,7 +330,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
             foreach (var fk in identifyingFks)
             {
                 currentPath.Push(fk.PrincipalEntityType);
-                FindPaths(fk.PrincipalEntityType.RootType(), sharedTypes, currentPath, result);
+                FindPaths(fk.PrincipalEntityType.RootType(), sharingTypes, currentPath, result);
                 currentPath.Pop();
             }
         }
@@ -380,6 +380,72 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
             return discriminatorPredicate;
         }
 
+        private static Expression GenerateSharedTableExpression(
+            IEntityType entityType, HashSet<IEntityType> sharingTypes, SelectExpression selectExpression, IQuerySource querySource)
+        {
+            if (sharingTypes.Count == 1
+                || !entityType.FindForeignKeys(entityType.FindPrimaryKey().Properties)
+                    .Any(fk => fk.PrincipalKey.IsPrimaryKey()
+                               && fk.PrincipalEntityType != entityType
+                               && sharingTypes.Contains(fk.PrincipalEntityType)))
+            {
+                return null;
+            }
+
+            var requiredNonPkProperties = entityType.GetProperties().Where(p => !p.IsNullable && !p.IsPrimaryKey()).ToList();
+            if (requiredNonPkProperties.Count > 0)
+            {
+                var discriminatorPredicate
+                    = IsNotNull(requiredNonPkProperties[0], selectExpression, querySource);
+
+                if (requiredNonPkProperties.Count > 1)
+                {
+                    discriminatorPredicate
+                        = requiredNonPkProperties
+                            .Skip(1)
+                            .Aggregate(
+                                discriminatorPredicate, (current, property) =>
+                                    Expression.AndAlso(
+                                        IsNotNull(property, selectExpression, querySource),
+                                        current));
+                }
+
+                return discriminatorPredicate;
+            }
+            else
+            {
+                var allNonPkProperties = entityType.GetProperties().Where(p => !p.IsPrimaryKey()).ToList();
+                if (allNonPkProperties.Count == 0)
+                {
+                    return null;
+                }
+
+                var discriminatorPredicate
+                    = IsNotNull(allNonPkProperties[0], selectExpression, querySource);
+
+                if (allNonPkProperties.Count > 1)
+                {
+                    discriminatorPredicate
+                        = allNonPkProperties
+                            .Skip(1)
+                            .Aggregate(
+                                discriminatorPredicate, (current, property) =>
+                                    Expression.OrElse(
+                                        IsNotNull(property, selectExpression, querySource),
+                                        current));
+                }
+
+                return discriminatorPredicate;
+            }
+        }
+
+        private static Expression IsNotNull(IProperty property, SelectExpression selectExpression, IQuerySource querySource)
+        {
+            var column = selectExpression.BindProperty(property, querySource);            
+            var nullableColumn = column.Type.IsNullableType() ? column : new NullableExpression(column);
+            return Expression.Not(new IsNullExpression(nullableColumn));
+        }
+
         private void DiscriminateProjectionQuery(
             IEntityType entityType, SelectExpression selectExpression, IQuerySource querySource)
         {
@@ -391,7 +457,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
             }
             else
             {
-                var sharedTypes = new HashSet<IEntityType>(
+                var sharingTypes = new HashSet<IEntityType>(
                     _model.GetEntityTypes()
                         .Where(et => et.FindPrimaryKey() != null
                                   && et.Relational().TableName == entityType.Relational().TableName
@@ -401,12 +467,13 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                 currentPath.Push(entityType);
 
                 var allPaths = new List<List<IEntityType>>();
-                FindPaths(entityType.RootType(), sharedTypes, currentPath, allPaths);
+                FindPaths(entityType.RootType(), sharingTypes, currentPath, allPaths);
 
                 discriminatorPredicate = allPaths
                     .Select(
                         p => p.Select(
-                                et => GenerateDiscriminatorExpression(et, selectExpression, querySource))
+                                et => GenerateDiscriminatorExpression(et, selectExpression, querySource)
+                                   ?? GenerateSharedTableExpression(et, sharingTypes, selectExpression, querySource))
                             .Aggregate(
                                 (Expression)null,
                                 (result, current) => result != null

--- a/src/EFCore.Relational/Query/Expressions/NullableExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/NullableExpression.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query.Internal;
+using Microsoft.EntityFrameworkCore.Query.Sql;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Query.Expressions
@@ -56,6 +57,18 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             return newExpression != _operand
                 ? new NullableExpression(newExpression)
                 : this;
+        }
+
+        /// <summary>
+        ///     Dispatches to the specific visit method for this node type.
+        /// </summary>
+        protected override Expression Accept(ExpressionVisitor visitor)
+        {
+            Check.NotNull(visitor, nameof(visitor));
+
+            return visitor is ISqlExpressionVisitor specificVisitor
+                ? specificVisitor.VisitNullable(this)
+                : base.Accept(visitor);
         }
 
         /// <summary>

--- a/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -1395,6 +1395,20 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         }
 
         /// <summary>
+        ///     Visit a NullableExpression.
+        /// </summary>
+        /// <param name="nullableExpression"> The nullable expression. </param>
+        /// <returns>
+        ///     An Expression.
+        /// </returns>
+        public virtual Expression VisitNullable(NullableExpression nullableExpression)
+        {
+            Visit(nullableExpression.Operand);
+
+            return nullableExpression;
+        }
+
+        /// <summary>
         ///     Visits an IsNotNullExpression.
         /// </summary>
         /// <param name="isNotNullExpression"> The is not null expression. </param>
@@ -1822,8 +1836,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
                         if (parameterValue == null)
                         {
-                            return
-                                expression.NodeType == ExpressionType.Equal
+                            return expression.NodeType == ExpressionType.Equal
                                     ? (Expression)new IsNullExpression(nonParameterExpression)
                                     : Expression.Not(new IsNullExpression(nonParameterExpression));
                         }

--- a/src/EFCore.Relational/Query/Sql/ISqlExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Sql/ISqlExpressionVisitor.cs
@@ -40,6 +40,15 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         Expression VisitIsNull([NotNull] IsNullExpression isNullExpression);
 
         /// <summary>
+        ///     Visit a NullableExpression.
+        /// </summary>
+        /// <param name="nullableExpression"> The nullable expression. </param>
+        /// <returns>
+        ///     An Expression.
+        /// </returns>
+        Expression VisitNullable([NotNull] NullableExpression nullableExpression);
+
+        /// <summary>
         ///     Visit a LikeExpression.
         /// </summary>
         /// <param name="likeExpression"> The like expression. </param>

--- a/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
+++ b/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
@@ -275,50 +275,6 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                                     principalEntityType.DisplayName(),
                                     command.EntityState));
                         }
-
-                        var dependents = modificationCommandIdentityMap.GetDependents(entry.EntityType);
-                        // ReSharper disable once ForCanBeConvertedToForeach
-                        for (var dependentIndex = 0; dependentIndex < dependents.Count; dependentIndex++)
-                        {
-                            var dependentEntityType = dependents[dependentIndex];
-                            var dependentFound = false;
-                            // ReSharper disable once ForCanBeConvertedToForeach
-                            for (var otherEntryIndex = 0; otherEntryIndex < command.Entries.Count; otherEntryIndex++)
-                            {
-                                var dependentEntry = command.Entries[otherEntryIndex];
-                                if (dependentEntry != entry
-                                    && dependentEntityType.IsAssignableFrom(dependentEntry.EntityType))
-                                {
-                                    dependentFound = true;
-                                    break;
-                                }
-                            }
-
-                            if (dependentFound)
-                            {
-                                continue;
-                            }
-
-                            var tableName = (string.IsNullOrEmpty(command.Schema) ? "" : command.Schema + ".") +
-                                            command.TableName;
-                            if (_sensitiveLoggingEnabled)
-                            {
-                                throw new InvalidOperationException(
-                                    RelationalStrings.SharedRowEntryCountMismatchSensitive(
-                                        entry.EntityType.DisplayName(),
-                                        tableName,
-                                        dependentEntityType.DisplayName(),
-                                        entry.BuildCurrentValuesString(entry.EntityType.FindPrimaryKey().Properties),
-                                        command.EntityState));
-                            }
-
-                            throw new InvalidOperationException(
-                                RelationalStrings.SharedRowEntryCountMismatch(
-                                    entry.EntityType.DisplayName(),
-                                    tableName,
-                                    dependentEntityType.DisplayName(),
-                                    command.EntityState));
-                        }
                     }
                 }
             }

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -4921,7 +4921,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     Assert.Equal(2, createTableOperation.Columns.Count);
                     var timeColumn = createTableOperation.Columns[1];
                     Assert.Equal("Time", timeColumn.Name);
-                    Assert.False(timeColumn.IsNullable);
+                    Assert.True(timeColumn.IsNullable);
                 });
         }
 

--- a/test/EFCore.Specification.Tests/TestModels/TransportationModel/FuelTank.cs
+++ b/test/EFCore.Specification.Tests/TestModels/TransportationModel/FuelTank.cs
@@ -7,7 +7,6 @@ namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
     {
         public string VehicleName { get; set; }
         public string FuelType { get; set; }
-
         public string Capacity { get; set; }
 
         public PoweredVehicle Vehicle { get; set; }

--- a/test/EFCore.Specification.Tests/TestModels/TransportationModel/TransportationContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/TransportationModel/TransportationContext.cs
@@ -52,12 +52,9 @@ namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
                     eb.HasOne(e => e.Engine)
                         .WithOne(e => e.FuelTank)
                         .HasForeignKey<FuelTank>(e => e.VehicleName);
-                    // Make dependent optional
-                    // #9005
-                    //eb.HasOne(e => e.Vehicle)
-                    //    .WithOne()
-                    //    .HasForeignKey<FuelTank>(e => e.VehicleName);
-                    eb.Ignore(e => e.Vehicle);
+                    eb.HasOne(e => e.Vehicle)
+                        .WithOne()
+                        .HasForeignKey<FuelTank>(e => e.VehicleName);
                 });
 
             modelBuilder.Entity<SolidFuelTank>(
@@ -99,9 +96,7 @@ namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
                         VehicleName = "Trek Pro Fit Madone 6 Series"
                     }
                 },
-                // This should be a PoweredVehicle when Engine is made optional
-                // #9005
-                new Vehicle
+                new PoweredVehicle
                 {
                     Name = "1984 California Car",
                     SeatingCapacity = 34,
@@ -163,13 +158,6 @@ namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
                             GrainGeometry = "Cylindrical",
                             VehicleName = "AIM-9M Sidewinder"
                         },
-                        VehicleName = "AIM-9M Sidewinder"
-                    },
-                    // This should be null
-                    // #9005
-                    Operator = new Operator
-                    {
-                        Name = "Infrared homing guidance",
                         VehicleName = "AIM-9M Sidewinder"
                     }
                 }

--- a/test/EFCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
@@ -149,12 +149,32 @@ namespace Microsoft.EntityFrameworkCore
             base.ConcurrencyCheckAttribute_throws_if_value_in_database_changed();
 
             Assert.Equal(
-                @"SELECT TOP(1) [r].[UniqueNo], [r].[MaxLengthProperty], [r].[Name], [r].[RowVersion], [r].[UniqueNo], [r].[Details_Name], [r].[UniqueNo], [r].[AdditionalDetails_Name]
+                @"SELECT TOP(1) [r].[UniqueNo], [r].[MaxLengthProperty], [r].[Name], [r].[RowVersion], [t].[UniqueNo], [t].[Details_Name], [t0].[UniqueNo], [t0].[AdditionalDetails_Name]
 FROM [Sample] AS [r]
+LEFT JOIN (
+    SELECT [r.Details].*
+    FROM [Sample] AS [r.Details]
+    WHERE [r.Details].[Details_Name] IS NOT NULL
+) AS [t] ON [r].[UniqueNo] = [t].[UniqueNo]
+LEFT JOIN (
+    SELECT [r.AdditionalDetails].*
+    FROM [Sample] AS [r.AdditionalDetails]
+    WHERE [r.AdditionalDetails].[AdditionalDetails_Name] IS NOT NULL
+) AS [t0] ON [r].[UniqueNo] = [t0].[UniqueNo]
 WHERE [r].[UniqueNo] = 1
 
-SELECT TOP(1) [r].[UniqueNo], [r].[MaxLengthProperty], [r].[Name], [r].[RowVersion], [r].[UniqueNo], [r].[Details_Name], [r].[UniqueNo], [r].[AdditionalDetails_Name]
+SELECT TOP(1) [r].[UniqueNo], [r].[MaxLengthProperty], [r].[Name], [r].[RowVersion], [t].[UniqueNo], [t].[Details_Name], [t0].[UniqueNo], [t0].[AdditionalDetails_Name]
 FROM [Sample] AS [r]
+LEFT JOIN (
+    SELECT [r.Details].*
+    FROM [Sample] AS [r.Details]
+    WHERE [r.Details].[Details_Name] IS NOT NULL
+) AS [t] ON [r].[UniqueNo] = [t].[UniqueNo]
+LEFT JOIN (
+    SELECT [r.AdditionalDetails].*
+    FROM [Sample] AS [r.AdditionalDetails]
+    WHERE [r.AdditionalDetails].[AdditionalDetails_Name] IS NOT NULL
+) AS [t0] ON [r].[UniqueNo] = [t0].[UniqueNo]
 WHERE [r].[UniqueNo] = 1
 
 @p2='1'

--- a/test/EFCore.SqlServer.FunctionalTests/PropertyEntrySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/PropertyEntrySqlServerTest.cs
@@ -18,9 +18,14 @@ namespace Microsoft.EntityFrameworkCore
         {
             base.Property_entry_original_value_is_set();
 
-            AssertContainsSql(
-                @"SELECT TOP(1) [e].[Id], [e].[EngineSupplierId], [e].[Name], [e].[Id], [e].[StorageLocation_Latitude], [e].[StorageLocation_Longitude]
+             AssertContainsSql(
+                @"SELECT TOP(1) [e].[Id], [e].[EngineSupplierId], [e].[Name], [t].[Id], [t].[StorageLocation_Latitude], [t].[StorageLocation_Longitude]
 FROM [Engines] AS [e]
+LEFT JOIN (
+    SELECT [e.StorageLocation].*
+    FROM [Engines] AS [e.StorageLocation]
+    WHERE [e.StorageLocation].[StorageLocation_Longitude] IS NOT NULL AND [e.StorageLocation].[StorageLocation_Latitude] IS NOT NULL
+) AS [t] ON [e].[Id] = [t].[Id]
 ORDER BY [e].[Id]",
                 //
                 @"@p1='1'

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsWeakQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsWeakQuerySqlServerTest.cs
@@ -21,8 +21,13 @@ namespace Microsoft.EntityFrameworkCore.Query
             await base.Simple_level1_include(isAsync);
 
             AssertSql(
-                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[Id], [l1].[OneToOne_Required_PK_Date], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[Level2_Name], [l1].[OneToMany_Optional_Inverse2Id], [l1].[OneToMany_Required_Inverse2Id], [l1].[OneToOne_Optional_PK_Inverse2Id]
-FROM [Level1] AS [l1]");
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [t].[Id], [t].[OneToOne_Required_PK_Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Level2_Name], [t].[OneToMany_Optional_Inverse2Id], [t].[OneToMany_Required_Inverse2Id], [t].[OneToOne_Optional_PK_Inverse2Id]
+FROM [Level1] AS [l1]
+LEFT JOIN (
+    SELECT [l1.OneToOne_Required_PK1].*
+    FROM [Level1] AS [l1.OneToOne_Required_PK1]
+    WHERE [l1.OneToOne_Required_PK1].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l1.OneToOne_Required_PK1].[Level1_Required_Id] IS NOT NULL AND [l1.OneToOne_Required_PK1].[OneToOne_Required_PK_Date] IS NOT NULL)
+) AS [t] ON [l1].[Id] = [t].[Id]");
         }
 
         public override async Task Simple_level1(bool isAsync)
@@ -39,8 +44,18 @@ FROM [Level1] AS [l]");
             await base.Simple_level1_level2_include(isAsync);
 
             AssertSql(
-                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[Id], [l1].[OneToOne_Required_PK_Date], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[Level2_Name], [l1].[OneToMany_Optional_Inverse2Id], [l1].[OneToMany_Required_Inverse2Id], [l1].[OneToOne_Optional_PK_Inverse2Id], [l1].[Id], [l1].[Level2_Optional_Id], [l1].[Level2_Required_Id], [l1].[Level3_Name], [l1].[OneToMany_Optional_Inverse3Id], [l1].[OneToMany_Required_Inverse3Id], [l1].[OneToOne_Optional_PK_Inverse3Id]
-FROM [Level1] AS [l1]");
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [t].[Id], [t].[OneToOne_Required_PK_Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Level2_Name], [t].[OneToMany_Optional_Inverse2Id], [t].[OneToMany_Required_Inverse2Id], [t].[OneToOne_Optional_PK_Inverse2Id], [t0].[Id], [t0].[Level2_Optional_Id], [t0].[Level2_Required_Id], [t0].[Level3_Name], [t0].[OneToMany_Optional_Inverse3Id], [t0].[OneToMany_Required_Inverse3Id], [t0].[OneToOne_Optional_PK_Inverse3Id]
+FROM [Level1] AS [l1]
+LEFT JOIN (
+    SELECT [l1.OneToOne_Required_PK1].*
+    FROM [Level1] AS [l1.OneToOne_Required_PK1]
+    WHERE [l1.OneToOne_Required_PK1].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l1.OneToOne_Required_PK1].[Level1_Required_Id] IS NOT NULL AND [l1.OneToOne_Required_PK1].[OneToOne_Required_PK_Date] IS NOT NULL)
+) AS [t] ON [l1].[Id] = [t].[Id]
+LEFT JOIN (
+    SELECT [l1.OneToOne_Required_PK1.OneToOne_Required_PK2].*
+    FROM [Level1] AS [l1.OneToOne_Required_PK1.OneToOne_Required_PK2]
+    WHERE ([l1.OneToOne_Required_PK1.OneToOne_Required_PK2].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l1.OneToOne_Required_PK1.OneToOne_Required_PK2].[Level1_Required_Id] IS NOT NULL AND [l1.OneToOne_Required_PK1.OneToOne_Required_PK2].[OneToOne_Required_PK_Date] IS NOT NULL)) AND ([l1.OneToOne_Required_PK1.OneToOne_Required_PK2].[OneToMany_Required_Inverse3Id] IS NOT NULL AND [l1.OneToOne_Required_PK1.OneToOne_Required_PK2].[Level2_Required_Id] IS NOT NULL)
+) AS [t0] ON [t].[Id] = [t0].[Id]");
         }
 
         public override async Task Simple_level1_level2_GroupBy_Count(bool isAsync)
@@ -50,7 +65,17 @@ FROM [Level1] AS [l1]");
             AssertSql(
                 @"SELECT COUNT(*)
 FROM [Level1] AS [l1]
-GROUP BY [l1].[Level3_Name]");
+LEFT JOIN (
+    SELECT [l1.OneToOne_Required_PK1].*
+    FROM [Level1] AS [l1.OneToOne_Required_PK1]
+    WHERE [l1.OneToOne_Required_PK1].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l1.OneToOne_Required_PK1].[Level1_Required_Id] IS NOT NULL AND [l1.OneToOne_Required_PK1].[OneToOne_Required_PK_Date] IS NOT NULL)
+) AS [t] ON [l1].[Id] = [t].[Id]
+LEFT JOIN (
+    SELECT [l1.OneToOne_Required_PK1.OneToOne_Required_PK2].*
+    FROM [Level1] AS [l1.OneToOne_Required_PK1.OneToOne_Required_PK2]
+    WHERE ([l1.OneToOne_Required_PK1.OneToOne_Required_PK2].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l1.OneToOne_Required_PK1.OneToOne_Required_PK2].[Level1_Required_Id] IS NOT NULL AND [l1.OneToOne_Required_PK1.OneToOne_Required_PK2].[OneToOne_Required_PK_Date] IS NOT NULL)) AND ([l1.OneToOne_Required_PK1.OneToOne_Required_PK2].[OneToMany_Required_Inverse3Id] IS NOT NULL AND [l1.OneToOne_Required_PK1.OneToOne_Required_PK2].[Level2_Required_Id] IS NOT NULL)
+) AS [t0] ON [t].[Id] = [t0].[Id]
+GROUP BY [t0].[Level3_Name]");
         }
 
         public override async Task Simple_level1_level2_GroupBy_Having_Count(bool isAsync)
@@ -60,8 +85,18 @@ GROUP BY [l1].[Level3_Name]");
             AssertSql(
                 @"SELECT COUNT(*)
 FROM [Level1] AS [l1]
-GROUP BY [l1].[Level3_Name]
-HAVING MIN(COALESCE([l1].[Id], 0)) > 0");
+LEFT JOIN (
+    SELECT [l1.OneToOne_Required_PK1].*
+    FROM [Level1] AS [l1.OneToOne_Required_PK1]
+    WHERE [l1.OneToOne_Required_PK1].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l1.OneToOne_Required_PK1].[Level1_Required_Id] IS NOT NULL AND [l1.OneToOne_Required_PK1].[OneToOne_Required_PK_Date] IS NOT NULL)
+) AS [t] ON [l1].[Id] = [t].[Id]
+LEFT JOIN (
+    SELECT [l1.OneToOne_Required_PK1.OneToOne_Required_PK2].*
+    FROM [Level1] AS [l1.OneToOne_Required_PK1.OneToOne_Required_PK2]
+    WHERE ([l1.OneToOne_Required_PK1.OneToOne_Required_PK2].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l1.OneToOne_Required_PK1.OneToOne_Required_PK2].[Level1_Required_Id] IS NOT NULL AND [l1.OneToOne_Required_PK1.OneToOne_Required_PK2].[OneToOne_Required_PK_Date] IS NOT NULL)) AND ([l1.OneToOne_Required_PK1.OneToOne_Required_PK2].[OneToMany_Required_Inverse3Id] IS NOT NULL AND [l1.OneToOne_Required_PK1.OneToOne_Required_PK2].[Level2_Required_Id] IS NOT NULL)
+) AS [t0] ON [t].[Id] = [t0].[Id]
+GROUP BY [t0].[Level3_Name]
+HAVING MIN(COALESCE([t].[Id], 0)) > 0");
         }
 
         public override async Task Simple_level1_level2_level3_include(bool isAsync)
@@ -69,8 +104,23 @@ HAVING MIN(COALESCE([l1].[Id], 0)) > 0");
             await base.Simple_level1_level2_level3_include(isAsync);
 
             AssertSql(
-                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[Id], [l1].[OneToOne_Required_PK_Date], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[Level2_Name], [l1].[OneToMany_Optional_Inverse2Id], [l1].[OneToMany_Required_Inverse2Id], [l1].[OneToOne_Optional_PK_Inverse2Id], [l1].[Id], [l1].[Level2_Optional_Id], [l1].[Level2_Required_Id], [l1].[Level3_Name], [l1].[OneToMany_Optional_Inverse3Id], [l1].[OneToMany_Required_Inverse3Id], [l1].[OneToOne_Optional_PK_Inverse3Id], [l1].[Id], [l1].[Level3_Optional_Id], [l1].[Level3_Required_Id], [l1].[Level4_Name], [l1].[OneToMany_Optional_Inverse4Id], [l1].[OneToMany_Required_Inverse4Id], [l1].[OneToOne_Optional_PK_Inverse4Id]
-FROM [Level1] AS [l1]");
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [t].[Id], [t].[OneToOne_Required_PK_Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Level2_Name], [t].[OneToMany_Optional_Inverse2Id], [t].[OneToMany_Required_Inverse2Id], [t].[OneToOne_Optional_PK_Inverse2Id], [t0].[Id], [t0].[Level2_Optional_Id], [t0].[Level2_Required_Id], [t0].[Level3_Name], [t0].[OneToMany_Optional_Inverse3Id], [t0].[OneToMany_Required_Inverse3Id], [t0].[OneToOne_Optional_PK_Inverse3Id], [t1].[Id], [t1].[Level3_Optional_Id], [t1].[Level3_Required_Id], [t1].[Level4_Name], [t1].[OneToMany_Optional_Inverse4Id], [t1].[OneToMany_Required_Inverse4Id], [t1].[OneToOne_Optional_PK_Inverse4Id]
+FROM [Level1] AS [l1]
+LEFT JOIN (
+    SELECT [l1.OneToOne_Required_PK1].*
+    FROM [Level1] AS [l1.OneToOne_Required_PK1]
+    WHERE [l1.OneToOne_Required_PK1].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l1.OneToOne_Required_PK1].[Level1_Required_Id] IS NOT NULL AND [l1.OneToOne_Required_PK1].[OneToOne_Required_PK_Date] IS NOT NULL)
+) AS [t] ON [l1].[Id] = [t].[Id]
+LEFT JOIN (
+    SELECT [l1.OneToOne_Required_PK1.OneToOne_Required_PK2].*
+    FROM [Level1] AS [l1.OneToOne_Required_PK1.OneToOne_Required_PK2]
+    WHERE ([l1.OneToOne_Required_PK1.OneToOne_Required_PK2].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l1.OneToOne_Required_PK1.OneToOne_Required_PK2].[Level1_Required_Id] IS NOT NULL AND [l1.OneToOne_Required_PK1.OneToOne_Required_PK2].[OneToOne_Required_PK_Date] IS NOT NULL)) AND ([l1.OneToOne_Required_PK1.OneToOne_Required_PK2].[OneToMany_Required_Inverse3Id] IS NOT NULL AND [l1.OneToOne_Required_PK1.OneToOne_Required_PK2].[Level2_Required_Id] IS NOT NULL)
+) AS [t0] ON [t].[Id] = [t0].[Id]
+LEFT JOIN (
+    SELECT [l1.OneToOne_Required_PK1.OneToOne_Required_PK2.OneToOne_Required_PK3].*
+    FROM [Level1] AS [l1.OneToOne_Required_PK1.OneToOne_Required_PK2.OneToOne_Required_PK3]
+    WHERE (([l1.OneToOne_Required_PK1.OneToOne_Required_PK2.OneToOne_Required_PK3].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l1.OneToOne_Required_PK1.OneToOne_Required_PK2.OneToOne_Required_PK3].[Level1_Required_Id] IS NOT NULL AND [l1.OneToOne_Required_PK1.OneToOne_Required_PK2.OneToOne_Required_PK3].[OneToOne_Required_PK_Date] IS NOT NULL)) AND ([l1.OneToOne_Required_PK1.OneToOne_Required_PK2.OneToOne_Required_PK3].[OneToMany_Required_Inverse3Id] IS NOT NULL AND [l1.OneToOne_Required_PK1.OneToOne_Required_PK2.OneToOne_Required_PK3].[Level2_Required_Id] IS NOT NULL)) AND ([l1.OneToOne_Required_PK1.OneToOne_Required_PK2.OneToOne_Required_PK3].[OneToMany_Required_Inverse4Id] IS NOT NULL AND [l1.OneToOne_Required_PK1.OneToOne_Required_PK2.OneToOne_Required_PK3].[Level3_Required_Id] IS NOT NULL)
+) AS [t1] ON [t0].[Id] = [t1].[Id]");
         }
 
         public override async Task Nested_group_join_with_take(bool isAsync)
@@ -80,22 +130,32 @@ FROM [Level1] AS [l1]");
             AssertSql(
                 @"@__p_0='2'
 
-SELECT [t3].[Level2_Name]
+SELECT [t5].[Level2_Name]
 FROM (
-    SELECT TOP(@__p_0) [t0].*
+    SELECT TOP(@__p_0) [t1].*
     FROM [Level1] AS [l1_inner]
     LEFT JOIN (
-        SELECT [t].[Id], [t].[OneToOne_Required_PK_Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Level2_Name], [t].[OneToMany_Optional_Inverse2Id], [t].[OneToMany_Required_Inverse2Id], [t].[OneToOne_Optional_PK_Inverse2Id]
+        SELECT [t0].[Id], [t0].[OneToOne_Required_PK_Date], [t0].[Level1_Optional_Id], [t0].[Level1_Required_Id], [t0].[Level2_Name], [t0].[OneToMany_Optional_Inverse2Id], [t0].[OneToMany_Required_Inverse2Id], [t0].[OneToOne_Optional_PK_Inverse2Id]
         FROM [Level1] AS [t]
-        WHERE [t].[Id] IS NOT NULL
-    ) AS [t0] ON [l1_inner].[Id] = [t0].[Level1_Optional_Id]
+        LEFT JOIN (
+            SELECT [t.OneToOne_Required_PK1].*
+            FROM [Level1] AS [t.OneToOne_Required_PK1]
+            WHERE [t.OneToOne_Required_PK1].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([t.OneToOne_Required_PK1].[Level1_Required_Id] IS NOT NULL AND [t.OneToOne_Required_PK1].[OneToOne_Required_PK_Date] IS NOT NULL)
+        ) AS [t0] ON [t].[Id] = [t0].[Id]
+        WHERE [t0].[Id] IS NOT NULL
+    ) AS [t1] ON [l1_inner].[Id] = [t1].[Level1_Optional_Id]
     ORDER BY [l1_inner].[Id]
-) AS [t1]
+) AS [t2]
 LEFT JOIN (
-    SELECT [t2].*
-    FROM [Level1] AS [t2]
-    WHERE [t2].[Id] IS NOT NULL
-) AS [t3] ON [t1].[Id] = [t3].[Level1_Optional_Id]");
+    SELECT [t4].*
+    FROM [Level1] AS [t3]
+    LEFT JOIN (
+        SELECT [t.OneToOne_Required_PK10].*
+        FROM [Level1] AS [t.OneToOne_Required_PK10]
+        WHERE [t.OneToOne_Required_PK10].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([t.OneToOne_Required_PK10].[Level1_Required_Id] IS NOT NULL AND [t.OneToOne_Required_PK10].[OneToOne_Required_PK_Date] IS NOT NULL)
+    ) AS [t4] ON [t3].[Id] = [t4].[Id]
+    WHERE [t4].[Id] IS NOT NULL
+) AS [t5] ON [t2].[Id] = [t5].[Level1_Optional_Id]");
         }
 
         public override async Task Explicit_GroupJoin_in_subquery_with_unrelated_projection2(bool isAsync)
@@ -103,17 +163,22 @@ LEFT JOIN (
             await base.Explicit_GroupJoin_in_subquery_with_unrelated_projection2(isAsync);
 
             AssertSql(
-                @"SELECT [t1].[Id]
+                @"SELECT [t2].[Id]
 FROM (
     SELECT DISTINCT [l1].*
     FROM [Level1] AS [l1]
     LEFT JOIN (
-        SELECT [t].*
+        SELECT [t0].*
         FROM [Level1] AS [t]
-        WHERE [t].[Id] IS NOT NULL
-    ) AS [t0] ON [l1].[Id] = [t0].[Level1_Optional_Id]
-    WHERE ([t0].[Level2_Name] <> N'Foo') OR [t0].[Level2_Name] IS NULL
-) AS [t1]");
+        LEFT JOIN (
+            SELECT [t.OneToOne_Required_PK1].*
+            FROM [Level1] AS [t.OneToOne_Required_PK1]
+            WHERE [t.OneToOne_Required_PK1].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([t.OneToOne_Required_PK1].[Level1_Required_Id] IS NOT NULL AND [t.OneToOne_Required_PK1].[OneToOne_Required_PK_Date] IS NOT NULL)
+        ) AS [t0] ON [t].[Id] = [t0].[Id]
+        WHERE [t0].[Id] IS NOT NULL
+    ) AS [t1] ON [l1].[Id] = [t1].[Level1_Optional_Id]
+    WHERE ([t1].[Level2_Name] <> N'Foo') OR [t1].[Level2_Name] IS NULL
+) AS [t2]");
         }
 
         public override async Task Result_operator_nav_prop_reference_optional_via_DefaultIfEmpty(bool isAsync)
@@ -122,15 +187,20 @@ FROM (
 
             AssertSql(
                 @"SELECT SUM(CASE
-    WHEN [t0].[Id] IS NULL
-    THEN 0 ELSE [t0].[Level1_Required_Id]
+    WHEN [t1].[Id] IS NULL
+    THEN 0 ELSE [t1].[Level1_Required_Id]
 END)
 FROM [Level1] AS [l1]
 LEFT JOIN (
-    SELECT [t].*
+    SELECT [t0].*
     FROM [Level1] AS [t]
-    WHERE [t].[Id] IS NOT NULL
-) AS [t0] ON [l1].[Id] = [t0].[Level1_Optional_Id]");
+    LEFT JOIN (
+        SELECT [t.OneToOne_Required_PK1].*
+        FROM [Level1] AS [t.OneToOne_Required_PK1]
+        WHERE [t.OneToOne_Required_PK1].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([t.OneToOne_Required_PK1].[Level1_Required_Id] IS NOT NULL AND [t.OneToOne_Required_PK1].[OneToOne_Required_PK_Date] IS NOT NULL)
+    ) AS [t0] ON [t].[Id] = [t0].[Id]
+    WHERE [t0].[Id] IS NOT NULL
+) AS [t1] ON [l1].[Id] = [t1].[Level1_Optional_Id]");
         }
 
         public override async Task SelectMany_with_Include1(bool isAsync)
@@ -141,6 +211,7 @@ LEFT JOIN (
                 @"SELECT [l1.OneToMany_Optional1].[Id], [l1.OneToMany_Optional1].[OneToOne_Required_PK_Date], [l1.OneToMany_Optional1].[Level1_Optional_Id], [l1.OneToMany_Optional1].[Level1_Required_Id], [l1.OneToMany_Optional1].[Level2_Name], [l1.OneToMany_Optional1].[OneToMany_Optional_Inverse2Id], [l1.OneToMany_Optional1].[OneToMany_Required_Inverse2Id], [l1.OneToMany_Optional1].[OneToOne_Optional_PK_Inverse2Id]
 FROM [Level1] AS [l1]
 INNER JOIN [Level1] AS [l1.OneToMany_Optional1] ON [l1].[Id] = [l1.OneToMany_Optional1].[OneToMany_Optional_Inverse2Id]
+WHERE [l1.OneToMany_Optional1].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l1.OneToMany_Optional1].[Level1_Required_Id] IS NOT NULL AND [l1.OneToMany_Optional1].[OneToOne_Required_PK_Date] IS NOT NULL)
 ORDER BY [l1.OneToMany_Optional1].[Id]",
                 //
                 @"SELECT [l1.OneToMany_Optional1.OneToMany_Optional2].[Id], [l1.OneToMany_Optional1.OneToMany_Optional2].[Level2_Optional_Id], [l1.OneToMany_Optional1.OneToMany_Optional2].[Level2_Required_Id], [l1.OneToMany_Optional1.OneToMany_Optional2].[Level3_Name], [l1.OneToMany_Optional1.OneToMany_Optional2].[OneToMany_Optional_Inverse3Id], [l1.OneToMany_Optional1.OneToMany_Optional2].[OneToMany_Required_Inverse3Id], [l1.OneToMany_Optional1.OneToMany_Optional2].[OneToOne_Optional_PK_Inverse3Id]
@@ -149,7 +220,9 @@ INNER JOIN (
     SELECT DISTINCT [l1.OneToMany_Optional10].[Id]
     FROM [Level1] AS [l10]
     INNER JOIN [Level1] AS [l1.OneToMany_Optional10] ON [l10].[Id] = [l1.OneToMany_Optional10].[OneToMany_Optional_Inverse2Id]
+    WHERE [l1.OneToMany_Optional10].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l1.OneToMany_Optional10].[Level1_Required_Id] IS NOT NULL AND [l1.OneToMany_Optional10].[OneToOne_Required_PK_Date] IS NOT NULL)
 ) AS [t] ON [l1.OneToMany_Optional1.OneToMany_Optional2].[OneToMany_Optional_Inverse3Id] = [t].[Id]
+WHERE ([l1.OneToMany_Optional1.OneToMany_Optional2].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l1.OneToMany_Optional1.OneToMany_Optional2].[Level1_Required_Id] IS NOT NULL AND [l1.OneToMany_Optional1.OneToMany_Optional2].[OneToOne_Required_PK_Date] IS NOT NULL)) AND ([l1.OneToMany_Optional1.OneToMany_Optional2].[OneToMany_Required_Inverse3Id] IS NOT NULL AND [l1.OneToMany_Optional1.OneToMany_Optional2].[Level2_Required_Id] IS NOT NULL)
 ORDER BY [t].[Id]");
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
@@ -77,7 +77,7 @@ LEFT JOIN (
 LEFT JOIN (
     SELECT [l.LeafBAddress.Country].*
     FROM [OwnedPerson] AS [l.LeafBAddress.Country]
-    WHERE [l.LeafBAddress.Country].[Discriminator] = N'LeafB'
+    WHERE ([l.LeafBAddress.Country].[Discriminator] = N'LeafB') AND [l.LeafBAddress.Country].[LeafBAddress_Country_PlanetId] IS NOT NULL
 ) AS [t0] ON [t].[Id] = [t0].[Id]
 LEFT JOIN (
     SELECT [l.LeafAAddress].*
@@ -87,7 +87,7 @@ LEFT JOIN (
 LEFT JOIN (
     SELECT [l.LeafAAddress.Country].*
     FROM [OwnedPerson] AS [l.LeafAAddress.Country]
-    WHERE [l.LeafAAddress.Country].[Discriminator] = N'LeafA'
+    WHERE ([l.LeafAAddress.Country].[Discriminator] = N'LeafA') AND [l.LeafAAddress.Country].[LeafAAddress_Country_PlanetId] IS NOT NULL
 ) AS [t2] ON [t1].[Id] = [t2].[Id]
 LEFT JOIN (
     SELECT [b.BranchAddress].*
@@ -97,7 +97,7 @@ LEFT JOIN (
 LEFT JOIN (
     SELECT [b.BranchAddress.Country].*
     FROM [OwnedPerson] AS [b.BranchAddress.Country]
-    WHERE [b.BranchAddress.Country].[Discriminator] IN (N'LeafA', N'Branch')
+    WHERE [b.BranchAddress.Country].[Discriminator] IN (N'LeafA', N'Branch') AND [b.BranchAddress.Country].[BranchAddress_Country_PlanetId] IS NOT NULL
 ) AS [t4] ON [t3].[Id] = [t4].[Id]
 LEFT JOIN (
     SELECT [o.PersonAddress].*
@@ -107,7 +107,7 @@ LEFT JOIN (
 LEFT JOIN (
     SELECT [o.PersonAddress.Country].*
     FROM [OwnedPerson] AS [o.PersonAddress.Country]
-    WHERE [o.PersonAddress.Country].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')
+    WHERE [o.PersonAddress.Country].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson') AND [o.PersonAddress.Country].[PersonAddress_Country_PlanetId] IS NOT NULL
 ) AS [t6] ON [t5].[Id] = [t6].[Id]
 WHERE [o].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')
 ORDER BY [o].[Id]",
@@ -125,7 +125,7 @@ INNER JOIN (
     LEFT JOIN (
         SELECT [l.LeafBAddress.Country0].*
         FROM [OwnedPerson] AS [l.LeafBAddress.Country0]
-        WHERE [l.LeafBAddress.Country0].[Discriminator] = N'LeafB'
+        WHERE ([l.LeafBAddress.Country0].[Discriminator] = N'LeafB') AND [l.LeafBAddress.Country0].[LeafBAddress_Country_PlanetId] IS NOT NULL
     ) AS [t8] ON [t7].[Id] = [t8].[Id]
     LEFT JOIN (
         SELECT [l.LeafAAddress0].*
@@ -135,7 +135,7 @@ INNER JOIN (
     LEFT JOIN (
         SELECT [l.LeafAAddress.Country0].*
         FROM [OwnedPerson] AS [l.LeafAAddress.Country0]
-        WHERE [l.LeafAAddress.Country0].[Discriminator] = N'LeafA'
+        WHERE ([l.LeafAAddress.Country0].[Discriminator] = N'LeafA') AND [l.LeafAAddress.Country0].[LeafAAddress_Country_PlanetId] IS NOT NULL
     ) AS [t10] ON [t9].[Id] = [t10].[Id]
     LEFT JOIN (
         SELECT [b.BranchAddress0].*
@@ -145,7 +145,7 @@ INNER JOIN (
     LEFT JOIN (
         SELECT [b.BranchAddress.Country0].*
         FROM [OwnedPerson] AS [b.BranchAddress.Country0]
-        WHERE [b.BranchAddress.Country0].[Discriminator] IN (N'LeafA', N'Branch')
+        WHERE [b.BranchAddress.Country0].[Discriminator] IN (N'LeafA', N'Branch') AND [b.BranchAddress.Country0].[BranchAddress_Country_PlanetId] IS NOT NULL
     ) AS [t12] ON [t11].[Id] = [t12].[Id]
     LEFT JOIN (
         SELECT [o.PersonAddress0].*
@@ -155,7 +155,7 @@ INNER JOIN (
     LEFT JOIN (
         SELECT [o.PersonAddress.Country0].*
         FROM [OwnedPerson] AS [o.PersonAddress.Country0]
-        WHERE [o.PersonAddress.Country0].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')
+        WHERE [o.PersonAddress.Country0].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson') AND [o.PersonAddress.Country0].[PersonAddress_Country_PlanetId] IS NOT NULL
     ) AS [t14] ON [t13].[Id] = [t14].[Id]
     WHERE [o0].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')
 ) AS [t15] ON [o.Orders].[ClientId] = [t15].[Id]
@@ -187,7 +187,7 @@ LEFT JOIN (
 LEFT JOIN (
     SELECT [l.LeafAAddress.Country].*
     FROM [OwnedPerson] AS [l.LeafAAddress.Country]
-    WHERE [l.LeafAAddress.Country].[Discriminator] = N'LeafA'
+    WHERE ([l.LeafAAddress.Country].[Discriminator] = N'LeafA') AND [l.LeafAAddress.Country].[LeafAAddress_Country_PlanetId] IS NOT NULL
 ) AS [t0] ON [t].[Id] = [t0].[Id]
 LEFT JOIN (
     SELECT [b.BranchAddress].*
@@ -197,7 +197,7 @@ LEFT JOIN (
 LEFT JOIN (
     SELECT [b.BranchAddress.Country].*
     FROM [OwnedPerson] AS [b.BranchAddress.Country]
-    WHERE [b.BranchAddress.Country].[Discriminator] IN (N'LeafA', N'Branch')
+    WHERE [b.BranchAddress.Country].[Discriminator] IN (N'LeafA', N'Branch') AND [b.BranchAddress.Country].[BranchAddress_Country_PlanetId] IS NOT NULL
 ) AS [t2] ON [t1].[Id] = [t2].[Id]
 LEFT JOIN (
     SELECT [o.PersonAddress].*
@@ -207,7 +207,7 @@ LEFT JOIN (
 LEFT JOIN (
     SELECT [o.PersonAddress.Country].*
     FROM [OwnedPerson] AS [o.PersonAddress.Country]
-    WHERE [o.PersonAddress.Country].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')
+    WHERE [o.PersonAddress.Country].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson') AND [o.PersonAddress.Country].[PersonAddress_Country_PlanetId] IS NOT NULL
 ) AS [t4] ON [t3].[Id] = [t4].[Id]
 WHERE [o].[Discriminator] IN (N'LeafA', N'Branch')
 ORDER BY [o].[Id]",
@@ -225,7 +225,7 @@ INNER JOIN (
     LEFT JOIN (
         SELECT [l.LeafAAddress.Country0].*
         FROM [OwnedPerson] AS [l.LeafAAddress.Country0]
-        WHERE [l.LeafAAddress.Country0].[Discriminator] = N'LeafA'
+        WHERE ([l.LeafAAddress.Country0].[Discriminator] = N'LeafA') AND [l.LeafAAddress.Country0].[LeafAAddress_Country_PlanetId] IS NOT NULL
     ) AS [t6] ON [t5].[Id] = [t6].[Id]
     LEFT JOIN (
         SELECT [b.BranchAddress0].*
@@ -235,7 +235,7 @@ INNER JOIN (
     LEFT JOIN (
         SELECT [b.BranchAddress.Country0].*
         FROM [OwnedPerson] AS [b.BranchAddress.Country0]
-        WHERE [b.BranchAddress.Country0].[Discriminator] IN (N'LeafA', N'Branch')
+        WHERE [b.BranchAddress.Country0].[Discriminator] IN (N'LeafA', N'Branch') AND [b.BranchAddress.Country0].[BranchAddress_Country_PlanetId] IS NOT NULL
     ) AS [t8] ON [t7].[Id] = [t8].[Id]
     LEFT JOIN (
         SELECT [o.PersonAddress0].*
@@ -245,7 +245,7 @@ INNER JOIN (
     LEFT JOIN (
         SELECT [o.PersonAddress.Country0].*
         FROM [OwnedPerson] AS [o.PersonAddress.Country0]
-        WHERE [o.PersonAddress.Country0].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')
+        WHERE [o.PersonAddress.Country0].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson') AND [o.PersonAddress.Country0].[PersonAddress_Country_PlanetId] IS NOT NULL
     ) AS [t10] ON [t9].[Id] = [t10].[Id]
     WHERE [o0].[Discriminator] IN (N'LeafA', N'Branch')
 ) AS [t11] ON [o.Orders].[ClientId] = [t11].[Id]
@@ -267,7 +267,7 @@ LEFT JOIN (
 LEFT JOIN (
     SELECT [l.LeafAAddress.Country].*
     FROM [OwnedPerson] AS [l.LeafAAddress.Country]
-    WHERE [l.LeafAAddress.Country].[Discriminator] = N'LeafA'
+    WHERE ([l.LeafAAddress.Country].[Discriminator] = N'LeafA') AND [l.LeafAAddress.Country].[LeafAAddress_Country_PlanetId] IS NOT NULL
 ) AS [t0] ON [t].[Id] = [t0].[Id]
 LEFT JOIN (
     SELECT [b.BranchAddress].*
@@ -277,7 +277,7 @@ LEFT JOIN (
 LEFT JOIN (
     SELECT [b.BranchAddress.Country].*
     FROM [OwnedPerson] AS [b.BranchAddress.Country]
-    WHERE [b.BranchAddress.Country].[Discriminator] IN (N'LeafA', N'Branch')
+    WHERE [b.BranchAddress.Country].[Discriminator] IN (N'LeafA', N'Branch') AND [b.BranchAddress.Country].[BranchAddress_Country_PlanetId] IS NOT NULL
 ) AS [t2] ON [t1].[Id] = [t2].[Id]
 LEFT JOIN (
     SELECT [o.PersonAddress].*
@@ -287,7 +287,7 @@ LEFT JOIN (
 LEFT JOIN (
     SELECT [o.PersonAddress.Country].*
     FROM [OwnedPerson] AS [o.PersonAddress.Country]
-    WHERE [o.PersonAddress.Country].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')
+    WHERE [o.PersonAddress.Country].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson') AND [o.PersonAddress.Country].[PersonAddress_Country_PlanetId] IS NOT NULL
 ) AS [t4] ON [t3].[Id] = [t4].[Id]
 WHERE [o].[Discriminator] = N'LeafA'
 ORDER BY [o].[Id]",
@@ -305,7 +305,7 @@ INNER JOIN (
     LEFT JOIN (
         SELECT [l.LeafAAddress.Country0].*
         FROM [OwnedPerson] AS [l.LeafAAddress.Country0]
-        WHERE [l.LeafAAddress.Country0].[Discriminator] = N'LeafA'
+        WHERE ([l.LeafAAddress.Country0].[Discriminator] = N'LeafA') AND [l.LeafAAddress.Country0].[LeafAAddress_Country_PlanetId] IS NOT NULL
     ) AS [t6] ON [t5].[Id] = [t6].[Id]
     LEFT JOIN (
         SELECT [b.BranchAddress0].*
@@ -315,7 +315,7 @@ INNER JOIN (
     LEFT JOIN (
         SELECT [b.BranchAddress.Country0].*
         FROM [OwnedPerson] AS [b.BranchAddress.Country0]
-        WHERE [b.BranchAddress.Country0].[Discriminator] IN (N'LeafA', N'Branch')
+        WHERE [b.BranchAddress.Country0].[Discriminator] IN (N'LeafA', N'Branch') AND [b.BranchAddress.Country0].[BranchAddress_Country_PlanetId] IS NOT NULL
     ) AS [t8] ON [t7].[Id] = [t8].[Id]
     LEFT JOIN (
         SELECT [o.PersonAddress0].*
@@ -325,7 +325,7 @@ INNER JOIN (
     LEFT JOIN (
         SELECT [o.PersonAddress.Country0].*
         FROM [OwnedPerson] AS [o.PersonAddress.Country0]
-        WHERE [o.PersonAddress.Country0].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')
+        WHERE [o.PersonAddress.Country0].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson') AND [o.PersonAddress.Country0].[PersonAddress_Country_PlanetId] IS NOT NULL
     ) AS [t10] ON [t9].[Id] = [t10].[Id]
     WHERE [o0].[Discriminator] = N'LeafA'
 ) AS [t11] ON [o.Orders].[ClientId] = [t11].[Id]
@@ -453,7 +453,7 @@ LEFT JOIN (
 LEFT JOIN (
     SELECT [p.LeafBAddress.Country].*
     FROM [OwnedPerson] AS [p.LeafBAddress.Country]
-    WHERE [p.LeafBAddress.Country].[Discriminator] = N'LeafB'
+    WHERE ([p.LeafBAddress.Country].[Discriminator] = N'LeafB') AND [p.LeafBAddress.Country].[LeafBAddress_Country_PlanetId] IS NOT NULL
 ) AS [t1] ON [t0].[Id] = [t1].[Id]
 LEFT JOIN (
     SELECT [p.LeafAAddress].*
@@ -463,7 +463,7 @@ LEFT JOIN (
 LEFT JOIN (
     SELECT [p.LeafAAddress.Country].*
     FROM [OwnedPerson] AS [p.LeafAAddress.Country]
-    WHERE [p.LeafAAddress.Country].[Discriminator] = N'LeafA'
+    WHERE ([p.LeafAAddress.Country].[Discriminator] = N'LeafA') AND [p.LeafAAddress.Country].[LeafAAddress_Country_PlanetId] IS NOT NULL
 ) AS [t3] ON [t2].[Id] = [t3].[Id]
 LEFT JOIN (
     SELECT [p.BranchAddress].*
@@ -473,7 +473,7 @@ LEFT JOIN (
 LEFT JOIN (
     SELECT [p.BranchAddress.Country].*
     FROM [OwnedPerson] AS [p.BranchAddress.Country]
-    WHERE [p.BranchAddress.Country].[Discriminator] IN (N'LeafA', N'Branch')
+    WHERE [p.BranchAddress.Country].[Discriminator] IN (N'LeafA', N'Branch') AND [p.BranchAddress.Country].[BranchAddress_Country_PlanetId] IS NOT NULL
 ) AS [t5] ON [t4].[Id] = [t5].[Id]
 LEFT JOIN (
     SELECT [p.PersonAddress].*
@@ -483,7 +483,7 @@ LEFT JOIN (
 LEFT JOIN (
     SELECT [p.PersonAddress.Country].*
     FROM [OwnedPerson] AS [p.PersonAddress.Country]
-    WHERE [p.PersonAddress.Country].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')
+    WHERE [p.PersonAddress.Country].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson') AND [p.PersonAddress.Country].[PersonAddress_Country_PlanetId] IS NOT NULL
 ) AS [t7] ON [t6].[Id] = [t7].[Id]
 ORDER BY [t].[Id]",
                 //
@@ -508,7 +508,7 @@ INNER JOIN (
         LEFT JOIN (
             SELECT [p.LeafBAddress.Country0].*
             FROM [OwnedPerson] AS [p.LeafBAddress.Country0]
-            WHERE [p.LeafBAddress.Country0].[Discriminator] = N'LeafB'
+            WHERE ([p.LeafBAddress.Country0].[Discriminator] = N'LeafB') AND [p.LeafBAddress.Country0].[LeafBAddress_Country_PlanetId] IS NOT NULL
         ) AS [t10] ON [t9].[Id] = [t10].[Id]
         LEFT JOIN (
             SELECT [p.LeafAAddress0].*
@@ -518,7 +518,7 @@ INNER JOIN (
         LEFT JOIN (
             SELECT [p.LeafAAddress.Country0].*
             FROM [OwnedPerson] AS [p.LeafAAddress.Country0]
-            WHERE [p.LeafAAddress.Country0].[Discriminator] = N'LeafA'
+            WHERE ([p.LeafAAddress.Country0].[Discriminator] = N'LeafA') AND [p.LeafAAddress.Country0].[LeafAAddress_Country_PlanetId] IS NOT NULL
         ) AS [t12] ON [t11].[Id] = [t12].[Id]
         LEFT JOIN (
             SELECT [p.BranchAddress0].*
@@ -528,7 +528,7 @@ INNER JOIN (
         LEFT JOIN (
             SELECT [p.BranchAddress.Country0].*
             FROM [OwnedPerson] AS [p.BranchAddress.Country0]
-            WHERE [p.BranchAddress.Country0].[Discriminator] IN (N'LeafA', N'Branch')
+            WHERE [p.BranchAddress.Country0].[Discriminator] IN (N'LeafA', N'Branch') AND [p.BranchAddress.Country0].[BranchAddress_Country_PlanetId] IS NOT NULL
         ) AS [t14] ON [t13].[Id] = [t14].[Id]
         LEFT JOIN (
             SELECT [p.PersonAddress0].*
@@ -538,7 +538,7 @@ INNER JOIN (
         LEFT JOIN (
             SELECT [p.PersonAddress.Country0].*
             FROM [OwnedPerson] AS [p.PersonAddress.Country0]
-            WHERE [p.PersonAddress.Country0].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')
+            WHERE [p.PersonAddress.Country0].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson') AND [p.PersonAddress.Country0].[PersonAddress_Country_PlanetId] IS NOT NULL
         ) AS [t16] ON [t15].[Id] = [t16].[Id]
         ORDER BY [t8].[Id]
     ) AS [t17]
@@ -561,7 +561,7 @@ LEFT JOIN (
 LEFT JOIN (
     SELECT [p.PersonAddress.Country].*
     FROM [OwnedPerson] AS [p.PersonAddress.Country]
-    WHERE [p.PersonAddress.Country].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')
+    WHERE [p.PersonAddress.Country].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson') AND [p.PersonAddress.Country].[PersonAddress_Country_PlanetId] IS NOT NULL
 ) AS [t0] ON [t].[Id] = [t0].[Id]
 WHERE [p].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson') AND ([t0].[PersonAddress_Country_Name] = N'USA')");
         }
@@ -620,7 +620,7 @@ LEFT JOIN (
 LEFT JOIN (
     SELECT [p.PersonAddress.Country].*
     FROM [OwnedPerson] AS [p.PersonAddress.Country]
-    WHERE [p.PersonAddress.Country].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')
+    WHERE [p.PersonAddress.Country].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson') AND [p.PersonAddress.Country].[PersonAddress_Country_PlanetId] IS NOT NULL
 ) AS [t0] ON [t].[Id] = [t0].[Id]
 LEFT JOIN [Planet] AS [p.PersonAddress.Country.Planet] ON [t0].[PersonAddress_Country_PlanetId] = [p.PersonAddress.Country.Planet].[Id]
 WHERE [p].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')");
@@ -641,7 +641,7 @@ LEFT JOIN (
 LEFT JOIN (
     SELECT [p.PersonAddress.Country].*
     FROM [OwnedPerson] AS [p.PersonAddress.Country]
-    WHERE [p.PersonAddress.Country].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')
+    WHERE [p.PersonAddress.Country].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson') AND [p.PersonAddress.Country].[PersonAddress_Country_PlanetId] IS NOT NULL
 ) AS [t0] ON [t].[Id] = [t0].[Id]
 LEFT JOIN [Planet] AS [p.PersonAddress.Country.Planet] ON [t0].[PersonAddress_Country_PlanetId] = [p.PersonAddress.Country.Planet].[Id]
 WHERE [p].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')");
@@ -662,7 +662,7 @@ LEFT JOIN (
 LEFT JOIN (
     SELECT [p.PersonAddress.Country].*
     FROM [OwnedPerson] AS [p.PersonAddress.Country]
-    WHERE [p.PersonAddress.Country].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')
+    WHERE [p.PersonAddress.Country].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson') AND [p.PersonAddress.Country].[PersonAddress_Country_PlanetId] IS NOT NULL
 ) AS [t0] ON [t].[Id] = [t0].[Id]
 LEFT JOIN [Planet] AS [p.PersonAddress.Country.Planet] ON [t0].[PersonAddress_Country_PlanetId] = [p.PersonAddress.Country.Planet].[Id]
 WHERE [p].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')
@@ -681,7 +681,7 @@ INNER JOIN (
     LEFT JOIN (
         SELECT [p.PersonAddress.Country0].*
         FROM [OwnedPerson] AS [p.PersonAddress.Country0]
-        WHERE [p.PersonAddress.Country0].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')
+        WHERE [p.PersonAddress.Country0].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson') AND [p.PersonAddress.Country0].[PersonAddress_Country_PlanetId] IS NOT NULL
     ) AS [t2] ON [t1].[Id] = [t2].[Id]
     LEFT JOIN [Planet] AS [p.PersonAddress.Country.Planet0] ON [t2].[PersonAddress_Country_PlanetId] = [p.PersonAddress.Country.Planet0].[Id]
     WHERE [p0].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')
@@ -700,7 +700,7 @@ INNER JOIN [OwnedPerson] AS [p.PersonAddress] ON [p].[Id] = [p.PersonAddress].[I
 INNER JOIN [OwnedPerson] AS [p.PersonAddress.Country] ON [p.PersonAddress].[Id] = [p.PersonAddress.Country].[Id]
 INNER JOIN [Planet] AS [p.PersonAddress.Country.Planet] ON [p.PersonAddress.Country].[PersonAddress_Country_PlanetId] = [p.PersonAddress.Country.Planet].[Id]
 INNER JOIN [Moon] AS [p.PersonAddress.Country.Planet.Moons] ON [p.PersonAddress.Country.Planet].[Id] = [p.PersonAddress.Country.Planet.Moons].[PlanetId]
-WHERE ([p].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson') AND [p.PersonAddress].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')) AND [p.PersonAddress.Country].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')");
+WHERE ([p].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson') AND [p.PersonAddress].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')) AND ([p.PersonAddress.Country].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson') AND [p.PersonAddress.Country].[PersonAddress_Country_PlanetId] IS NOT NULL)");
         }
 
         public override void SelectMany_on_owned_reference_with_entity_in_between_ending_in_owned_collection()
@@ -715,32 +715,7 @@ INNER JOIN [OwnedPerson] AS [p.PersonAddress.Country] ON [p.PersonAddress].[Id] 
 INNER JOIN [Planet] AS [p.PersonAddress.Country.Planet] ON [p.PersonAddress.Country].[PersonAddress_Country_PlanetId] = [p.PersonAddress.Country.Planet].[Id]
 INNER JOIN [Star] AS [p.PersonAddress.Country.Planet.Star] ON [p.PersonAddress.Country.Planet].[StarId] = [p.PersonAddress.Country.Planet.Star].[Id]
 INNER JOIN [Element] AS [p.PersonAddress.Country.Planet.Star.Composition] ON [p.PersonAddress.Country.Planet.Star].[Id] = [p.PersonAddress.Country.Planet.Star.Composition].[StarId]
-WHERE ([p].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson') AND [p.PersonAddress].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')) AND [p.PersonAddress.Country].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')");
-        }
-
-        public override void Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_collection_count()
-        {
-            base.Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_collection_count();
-
-            AssertSql(
-                @"SELECT (
-    SELECT COUNT(*)
-    FROM [Moon] AS [m]
-    WHERE [p.PersonAddress.Country.Planet].[Id] = [m].[PlanetId]
-)
-FROM [OwnedPerson] AS [p]
-LEFT JOIN (
-    SELECT [p.PersonAddress].*
-    FROM [OwnedPerson] AS [p.PersonAddress]
-    WHERE [p.PersonAddress].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')
-) AS [t] ON [p].[Id] = [t].[Id]
-LEFT JOIN (
-    SELECT [p.PersonAddress.Country].*
-    FROM [OwnedPerson] AS [p.PersonAddress.Country]
-    WHERE [p.PersonAddress.Country].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')
-) AS [t0] ON [t].[Id] = [t0].[Id]
-LEFT JOIN [Planet] AS [p.PersonAddress.Country.Planet] ON [t0].[PersonAddress_Country_PlanetId] = [p.PersonAddress.Country.Planet].[Id]
-WHERE [p].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')");
+WHERE ([p].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson') AND [p.PersonAddress].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')) AND ([p.PersonAddress.Country].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson') AND [p.PersonAddress.Country].[PersonAddress_Country_PlanetId] IS NOT NULL)");
         }
 
         public override void Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_another_reference()
@@ -758,7 +733,7 @@ LEFT JOIN (
 LEFT JOIN (
     SELECT [p.PersonAddress.Country].*
     FROM [OwnedPerson] AS [p.PersonAddress.Country]
-    WHERE [p.PersonAddress.Country].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')
+    WHERE [p.PersonAddress.Country].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson') AND [p.PersonAddress.Country].[PersonAddress_Country_PlanetId] IS NOT NULL
 ) AS [t0] ON [t].[Id] = [t0].[Id]
 LEFT JOIN [Planet] AS [p.PersonAddress.Country.Planet] ON [t0].[PersonAddress_Country_PlanetId] = [p.PersonAddress.Country.Planet].[Id]
 LEFT JOIN [Star] AS [p.PersonAddress.Country.Planet.Star] ON [p.PersonAddress.Country.Planet].[StarId] = [p.PersonAddress.Country.Planet.Star].[Id]
@@ -780,7 +755,7 @@ LEFT JOIN (
 LEFT JOIN (
     SELECT [p.PersonAddress.Country].*
     FROM [OwnedPerson] AS [p.PersonAddress.Country]
-    WHERE [p.PersonAddress.Country].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')
+    WHERE [p.PersonAddress.Country].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson') AND [p.PersonAddress.Country].[PersonAddress_Country_PlanetId] IS NOT NULL
 ) AS [t0] ON [t].[Id] = [t0].[Id]
 LEFT JOIN [Planet] AS [p.PersonAddress.Country.Planet] ON [t0].[PersonAddress_Country_PlanetId] = [p.PersonAddress.Country.Planet].[Id]
 LEFT JOIN [Star] AS [p.PersonAddress.Country.Planet.Star] ON [p.PersonAddress.Country.Planet].[StarId] = [p.PersonAddress.Country.Planet.Star].[Id]
@@ -803,11 +778,12 @@ LEFT JOIN (
 LEFT JOIN (
     SELECT [p.PersonAddress.Country].*
     FROM [OwnedPerson] AS [p.PersonAddress.Country]
-    WHERE [p.PersonAddress.Country].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')
+    WHERE [p.PersonAddress.Country].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson') AND [p.PersonAddress.Country].[PersonAddress_Country_PlanetId] IS NOT NULL
 ) AS [t0] ON [t].[Id] = [t0].[Id]
 LEFT JOIN [Planet] AS [p.PersonAddress.Country.Planet] ON [t0].[PersonAddress_Country_PlanetId] = [p.PersonAddress.Country.Planet].[Id]
 LEFT JOIN [Star] AS [p.PersonAddress.Country.Planet.Star] ON [p.PersonAddress.Country.Planet].[StarId] = [p.PersonAddress.Country.Planet.Star].[Id]
 WHERE [p].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson') AND ([p.PersonAddress.Country.Planet.Star].[Name] = N'Sol')");
+
         }
 
         public override void Query_with_OfType_eagerly_loads_correct_owned_navigations()
@@ -825,7 +801,7 @@ LEFT JOIN (
 LEFT JOIN (
     SELECT [l.LeafAAddress.Country].*
     FROM [OwnedPerson] AS [l.LeafAAddress.Country]
-    WHERE [l.LeafAAddress.Country].[Discriminator] = N'LeafA'
+    WHERE ([l.LeafAAddress.Country].[Discriminator] = N'LeafA') AND [l.LeafAAddress.Country].[LeafAAddress_Country_PlanetId] IS NOT NULL
 ) AS [t0] ON [t].[Id] = [t0].[Id]
 LEFT JOIN (
     SELECT [b.BranchAddress].*
@@ -835,7 +811,7 @@ LEFT JOIN (
 LEFT JOIN (
     SELECT [b.BranchAddress.Country].*
     FROM [OwnedPerson] AS [b.BranchAddress.Country]
-    WHERE [b.BranchAddress.Country].[Discriminator] IN (N'LeafA', N'Branch')
+    WHERE [b.BranchAddress.Country].[Discriminator] IN (N'LeafA', N'Branch') AND [b.BranchAddress.Country].[BranchAddress_Country_PlanetId] IS NOT NULL
 ) AS [t2] ON [t1].[Id] = [t2].[Id]
 LEFT JOIN (
     SELECT [o.PersonAddress].*
@@ -845,7 +821,7 @@ LEFT JOIN (
 LEFT JOIN (
     SELECT [o.PersonAddress.Country].*
     FROM [OwnedPerson] AS [o.PersonAddress.Country]
-    WHERE [o.PersonAddress.Country].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')
+    WHERE [o.PersonAddress.Country].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson') AND [o.PersonAddress.Country].[PersonAddress_Country_PlanetId] IS NOT NULL
 ) AS [t4] ON [t3].[Id] = [t4].[Id]
 WHERE [o].[Discriminator] = N'LeafA'
 ORDER BY [o].[Id]",
@@ -863,7 +839,7 @@ INNER JOIN (
     LEFT JOIN (
         SELECT [l.LeafAAddress.Country0].*
         FROM [OwnedPerson] AS [l.LeafAAddress.Country0]
-        WHERE [l.LeafAAddress.Country0].[Discriminator] = N'LeafA'
+        WHERE ([l.LeafAAddress.Country0].[Discriminator] = N'LeafA') AND [l.LeafAAddress.Country0].[LeafAAddress_Country_PlanetId] IS NOT NULL
     ) AS [t6] ON [t5].[Id] = [t6].[Id]
     LEFT JOIN (
         SELECT [b.BranchAddress0].*
@@ -873,7 +849,7 @@ INNER JOIN (
     LEFT JOIN (
         SELECT [b.BranchAddress.Country0].*
         FROM [OwnedPerson] AS [b.BranchAddress.Country0]
-        WHERE [b.BranchAddress.Country0].[Discriminator] IN (N'LeafA', N'Branch')
+        WHERE [b.BranchAddress.Country0].[Discriminator] IN (N'LeafA', N'Branch') AND [b.BranchAddress.Country0].[BranchAddress_Country_PlanetId] IS NOT NULL
     ) AS [t8] ON [t7].[Id] = [t8].[Id]
     LEFT JOIN (
         SELECT [o.PersonAddress0].*
@@ -883,7 +859,7 @@ INNER JOIN (
     LEFT JOIN (
         SELECT [o.PersonAddress.Country0].*
         FROM [OwnedPerson] AS [o.PersonAddress.Country0]
-        WHERE [o.PersonAddress.Country0].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')
+        WHERE [o.PersonAddress.Country0].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson') AND [o.PersonAddress.Country0].[PersonAddress_Country_PlanetId] IS NOT NULL
     ) AS [t10] ON [t9].[Id] = [t10].[Id]
     WHERE [o0].[Discriminator] = N'LeafA'
 ) AS [t11] ON [o.Orders].[ClientId] = [t11].[Id]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -2433,17 +2433,32 @@ WHERE [c].[Id] IN (
                     Assert.True(result[0].Cast.All(a => a.Details != null));
 
                     AssertSql(
-                        @"SELECT [m].[Id], [m].[Title], [m].[Id], [m].[Details_Info]
+                @"SELECT [m].[Id], [m].[Title], [t].[Id], [t].[Details_Info]
 FROM [Movies] AS [m]
+LEFT JOIN (
+    SELECT [m.Details].*
+    FROM [Movies] AS [m.Details]
+    WHERE [m.Details].[Details_Info] IS NOT NULL
+) AS [t] ON [m].[Id] = [t].[Id]
 ORDER BY [m].[Id]",
-                        //
-                        @"SELECT [m.Cast].[Id], [m.Cast].[Movie9202Id], [m.Cast].[Name], [m.Cast].[Id], [m.Cast].[Details_Info]
+                //
+                @"SELECT [m.Cast].[Id], [m.Cast].[Movie9202Id], [m.Cast].[Name], [t0].[Id], [t0].[Details_Info]
 FROM [Actors] AS [m.Cast]
+LEFT JOIN (
+    SELECT [a.Details].*
+    FROM [Actors] AS [a.Details]
+    WHERE [a.Details].[Details_Info] IS NOT NULL
+) AS [t0] ON [m.Cast].[Id] = [t0].[Id]
 INNER JOIN (
     SELECT DISTINCT [m0].[Id]
     FROM [Movies] AS [m0]
-) AS [t] ON [m.Cast].[Movie9202Id] = [t].[Id]
-ORDER BY [t].[Id]");
+    LEFT JOIN (
+        SELECT [m.Details0].*
+        FROM [Movies] AS [m.Details0]
+        WHERE [m.Details0].[Details_Info] IS NOT NULL
+    ) AS [t1] ON [m0].[Id] = [t1].[Id]
+) AS [t2] ON [m.Cast].[Movie9202Id] = [t2].[Id]
+ORDER BY [t2].[Id]");
                 }
             }
         }
@@ -2464,17 +2479,32 @@ ORDER BY [t].[Id]");
                     Assert.True(result[0].Cast.All(a => a.Details != null));
 
                     AssertSql(
-                        @"SELECT [m].[Id], [m].[Title], [m].[Id], [m].[Details_Info]
+                @"SELECT [m].[Id], [m].[Title], [t].[Id], [t].[Details_Info]
 FROM [Movies] AS [m]
+LEFT JOIN (
+    SELECT [m.Details].*
+    FROM [Movies] AS [m.Details]
+    WHERE [m.Details].[Details_Info] IS NOT NULL
+) AS [t] ON [m].[Id] = [t].[Id]
 ORDER BY [m].[Id]",
-                        //
-                        @"SELECT [m.Cast].[Id], [m.Cast].[Movie9202Id], [m.Cast].[Name], [m.Cast].[Id], [m.Cast].[Details_Info]
+                //
+                @"SELECT [m.Cast].[Id], [m.Cast].[Movie9202Id], [m.Cast].[Name], [t0].[Id], [t0].[Details_Info]
 FROM [Actors] AS [m.Cast]
+LEFT JOIN (
+    SELECT [a.Details].*
+    FROM [Actors] AS [a.Details]
+    WHERE [a.Details].[Details_Info] IS NOT NULL
+) AS [t0] ON [m.Cast].[Id] = [t0].[Id]
 INNER JOIN (
     SELECT DISTINCT [m0].[Id]
     FROM [Movies] AS [m0]
-) AS [t] ON [m.Cast].[Movie9202Id] = [t].[Id]
-ORDER BY [t].[Id]");
+    LEFT JOIN (
+        SELECT [m.Details0].*
+        FROM [Movies] AS [m.Details0]
+        WHERE [m.Details0].[Details_Info] IS NOT NULL
+    ) AS [t1] ON [m0].[Id] = [t1].[Id]
+) AS [t2] ON [m.Cast].[Movie9202Id] = [t2].[Id]
+ORDER BY [t2].[Id]");
                 }
             }
         }
@@ -3490,16 +3520,21 @@ ORDER BY [t].[Id]");
                 Assert.Equal("Full1", result.User.Fullname);
 
                 AssertSql(
-                    @"@__p_0='?' (DbType = Int32)
+                @"@__p_0='?' (DbType = Int32)
 @__p_1='?' (DbType = Int32)
 
-SELECT [t].[Id], [t].[Text], [t].[Id], [t].[User_Email], [t].[User_Fullname]
+SELECT [t0].[Id], [t0].[Text], [t0].[Id0], [t0].[User_Email], [t0].[User_Fullname]
 FROM (
-    SELECT [x].[Id], [x].[Text], [x].[User_Email], [x].[User_Fullname], ROW_NUMBER() OVER(ORDER BY @@RowCount) AS [__RowNumber__]
+    SELECT [x].[Id], [x].[Text], [t].[Id] AS [Id0], [t].[User_Email], [t].[User_Fullname], ROW_NUMBER() OVER(ORDER BY @@RowCount) AS [__RowNumber__]
     FROM [Note] AS [x]
+    LEFT JOIN (
+        SELECT [x.User].*
+        FROM [Note] AS [x.User]
+        WHERE [x.User].[User_Fullname] IS NOT NULL OR [x.User].[User_Email] IS NOT NULL
+    ) AS [t] ON [x].[Id] = [t].[Id]
     WHERE [x].[Text] = N'Foo Bar'
-) AS [t]
-WHERE ([t].[__RowNumber__] > @__p_0) AND ([t].[__RowNumber__] <= (@__p_0 + @__p_1))");
+) AS [t0]
+WHERE ([t0].[__RowNumber__] > @__p_0) AND ([t0].[__RowNumber__] <= (@__p_0 + @__p_1))");
             }
         }
 
@@ -3756,9 +3791,14 @@ WHERE [b].[IsTwo] IN (CAST(1 AS bit), CAST(0 AS bit))");
                         .ToList();
 
                     AssertSql(
-                        @"SELECT [e].[Name] AS [Key], COUNT(*) + 5 AS [cnt]
+                @"SELECT [t].[Name] AS [Key], COUNT(*) + 5 AS [cnt]
 FROM [Table] AS [e]
-GROUP BY [e].[Name]");
+LEFT JOIN (
+    SELECT [a].*
+    FROM [Table] AS [a]
+    WHERE [a].[Name] IS NOT NULL
+) AS [t] ON [e].[Id] = [t].[Id]
+GROUP BY [t].[Name]");
                 }
             }
         }
@@ -3797,9 +3837,19 @@ GROUP BY [e].[Name]");
                         .ToList();
 
                     AssertSql(
-                        @"SELECT [e].[Name] AS [MyKey], COUNT(*) + 5 AS [cnt]
+                @"SELECT [t].[Name] AS [MyKey], COUNT(*) + 5 AS [cnt]
 FROM [Table] AS [e]
-GROUP BY [e].[Name], [e].[MaumarEntity11818_Name]");
+LEFT JOIN (
+    SELECT [a].*
+    FROM [Table] AS [a]
+    WHERE [a].[Name] IS NOT NULL
+) AS [t] ON [e].[Id] = [t].[Id]
+LEFT JOIN (
+    SELECT [m].*
+    FROM [Table] AS [m]
+    WHERE [m].[MaumarEntity11818_Name] IS NOT NULL
+) AS [t0] ON [e].[Id] = [t0].[Id]
+GROUP BY [t].[Name], [t0].[MaumarEntity11818_Name]");
                 }
             }
         }
@@ -5075,20 +5125,25 @@ END IN ('0a47bcb7-a1cb-4345-8944-c58f82d6aac7', '5f221fb9-66f4-442a-92c9-d97ed59
                     Assert.Equal(10, partners[0].Addresses[0].Turnovers.AmountIn);
 
                     AssertSql(
-                        @"SELECT [x].[Id]
+                @"SELECT [x].[Id]
 FROM [Partners] AS [x]
 ORDER BY [x].[Id]",
-                        //
-                        @"SELECT [t].[Id], CASE
-    WHEN [x.Addresses].[Id] IS NULL
+                //
+                @"SELECT [t0].[Id], CASE
+    WHEN [t].[Id] IS NULL
     THEN CAST(1 AS bit) ELSE CAST(0 AS bit)
-END, [x.Addresses].[Turnovers_AmountIn] AS [AmountIn], [x.Addresses].[Partner13157Id]
+END, [t].[Turnovers_AmountIn] AS [AmountIn], [x.Addresses].[Partner13157Id]
 FROM [Address13157] AS [x.Addresses]
+LEFT JOIN (
+    SELECT [y.Turnovers].*
+    FROM [Address13157] AS [y.Turnovers]
+    WHERE [y.Turnovers].[Turnovers_AmountIn] IS NOT NULL
+) AS [t] ON [x.Addresses].[Id] = [t].[Id]
 INNER JOIN (
     SELECT [x0].[Id]
     FROM [Partners] AS [x0]
-) AS [t] ON [x.Addresses].[Partner13157Id] = [t].[Id]
-ORDER BY [t].[Id]");
+) AS [t0] ON [x.Addresses].[Partner13157Id] = [t0].[Id]
+ORDER BY [t0].[Id]");
                 }
             }
         }

--- a/test/EFCore.SqlServer.Tests/Migrations/SqlServerModelDifferTest.cs
+++ b/test/EFCore.SqlServer.Tests/Migrations/SqlServerModelDifferTest.cs
@@ -337,7 +337,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     Assert.Equal(SqlServerValueGenerationStrategy.IdentityColumn, idColumn["SqlServer:ValueGenerationStrategy"]);
                     var timeColumn = createTableOperation.Columns[1];
                     Assert.Equal("Time", timeColumn.Name);
-                    Assert.False(timeColumn.IsNullable);
+                    Assert.True(timeColumn.IsNullable);
                 });
         }
 

--- a/test/EFCore.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
@@ -97,38 +97,53 @@ namespace Microsoft.EntityFrameworkCore
         {
             base.ConcurrencyCheckAttribute_throws_if_value_in_database_changed();
 
-            Assert.Contains(
-                @"SELECT ""r"".""UniqueNo"", ""r"".""MaxLengthProperty"", ""r"".""Name"", ""r"".""RowVersion"", ""r"".""UniqueNo"", ""r"".""Details_Name"", ""r"".""UniqueNo"", ""r"".""AdditionalDetails_Name"""
-                + _eol +
-                @"FROM ""Sample"" AS ""r""" + _eol +
-                @"WHERE ""r"".""UniqueNo"" = 1" + _eol +
-                "LIMIT 1",
-                Sql);
+            Assert.Equal(@"SELECT ""r"".""UniqueNo"", ""r"".""MaxLengthProperty"", ""r"".""Name"", ""r"".""RowVersion"", ""t"".""UniqueNo"", ""t"".""Details_Name"", ""t0"".""UniqueNo"", ""t0"".""AdditionalDetails_Name""
+FROM ""Sample"" AS ""r""
+LEFT JOIN (
+    SELECT ""r.Details"".*
+    FROM ""Sample"" AS ""r.Details""
+    WHERE ""r.Details"".""Details_Name"" IS NOT NULL
+) AS ""t"" ON ""r"".""UniqueNo"" = ""t"".""UniqueNo""
+LEFT JOIN (
+    SELECT ""r.AdditionalDetails"".*
+    FROM ""Sample"" AS ""r.AdditionalDetails""
+    WHERE ""r.AdditionalDetails"".""AdditionalDetails_Name"" IS NOT NULL
+) AS ""t0"" ON ""r"".""UniqueNo"" = ""t0"".""UniqueNo""
+WHERE ""r"".""UniqueNo"" = 1
+LIMIT 1
 
-            Assert.Contains(
-                @"SELECT ""r"".""UniqueNo"", ""r"".""MaxLengthProperty"", ""r"".""Name"", ""r"".""RowVersion"", ""r"".""UniqueNo"", ""r"".""Details_Name"", ""r"".""UniqueNo"", ""r"".""AdditionalDetails_Name"""
-                + _eol +
-                @"FROM ""Sample"" AS ""r""" + _eol +
-                @"WHERE ""r"".""UniqueNo"" = 1" + _eol +
-                "LIMIT 1" + _eol +
-                _eol +
-                "@p2='1' (DbType = String)" + _eol +
-                "@p0='ModifiedData' (Nullable = false) (Size = 12)" + _eol +
-                "@p1='00000000-0000-0000-0003-000000000001' (DbType = String)" + _eol +
-                "@p3='00000001-0000-0000-0000-000000000001' (DbType = String)" + _eol +
-                _eol +
-                @"UPDATE ""Sample"" SET ""Name"" = @p0, ""RowVersion"" = @p1" + _eol +
-                @"WHERE ""UniqueNo"" = @p2 AND ""RowVersion"" = @p3;" + _eol +
-                "SELECT changes();" + _eol +
-                _eol +
-                "@p2='1' (DbType = String)" + _eol +
-                "@p0='ChangedData' (Nullable = false) (Size = 11)" + _eol +
-                "@p1='00000000-0000-0000-0002-000000000001' (DbType = String)" + _eol +
-                "@p3='00000001-0000-0000-0000-000000000001' (DbType = String)" + _eol +
-                _eol +
-                @"UPDATE ""Sample"" SET ""Name"" = @p0, ""RowVersion"" = @p1" + _eol +
-                @"WHERE ""UniqueNo"" = @p2 AND ""RowVersion"" = @p3;" + _eol +
-                "SELECT changes();",
+SELECT ""r"".""UniqueNo"", ""r"".""MaxLengthProperty"", ""r"".""Name"", ""r"".""RowVersion"", ""t"".""UniqueNo"", ""t"".""Details_Name"", ""t0"".""UniqueNo"", ""t0"".""AdditionalDetails_Name""
+FROM ""Sample"" AS ""r""
+LEFT JOIN (
+    SELECT ""r.Details"".*
+    FROM ""Sample"" AS ""r.Details""
+    WHERE ""r.Details"".""Details_Name"" IS NOT NULL
+) AS ""t"" ON ""r"".""UniqueNo"" = ""t"".""UniqueNo""
+LEFT JOIN (
+    SELECT ""r.AdditionalDetails"".*
+    FROM ""Sample"" AS ""r.AdditionalDetails""
+    WHERE ""r.AdditionalDetails"".""AdditionalDetails_Name"" IS NOT NULL
+) AS ""t0"" ON ""r"".""UniqueNo"" = ""t0"".""UniqueNo""
+WHERE ""r"".""UniqueNo"" = 1
+LIMIT 1
+
+@p2='1' (DbType = String)
+@p0='ModifiedData' (Nullable = false) (Size = 12)
+@p1='00000000-0000-0000-0003-000000000001' (DbType = String)
+@p3='00000001-0000-0000-0000-000000000001' (DbType = String)
+
+UPDATE ""Sample"" SET ""Name"" = @p0, ""RowVersion"" = @p1
+WHERE ""UniqueNo"" = @p2 AND ""RowVersion"" = @p3;
+SELECT changes();
+
+@p2='1' (DbType = String)
+@p0='ChangedData' (Nullable = false) (Size = 11)
+@p1='00000000-0000-0000-0002-000000000001' (DbType = String)
+@p3='00000001-0000-0000-0000-000000000001' (DbType = String)
+
+UPDATE ""Sample"" SET ""Name"" = @p0, ""RowVersion"" = @p1
+WHERE ""UniqueNo"" = @p2 AND ""RowVersion"" = @p3;
+SELECT changes();",
                 Sql);
         }
 

--- a/test/EFCore.Sqlite.FunctionalTests/PropertyEntrySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/PropertyEntrySqliteTest.cs
@@ -16,8 +16,13 @@ namespace Microsoft.EntityFrameworkCore
             base.Property_entry_original_value_is_set();
 
             AssertContainsSql(
-                @"SELECT ""e"".""Id"", ""e"".""EngineSupplierId"", ""e"".""Name"", ""e"".""Id"", ""e"".""StorageLocation_Latitude"", ""e"".""StorageLocation_Longitude""
+                @"SELECT ""e"".""Id"", ""e"".""EngineSupplierId"", ""e"".""Name"", ""t"".""Id"", ""t"".""StorageLocation_Latitude"", ""t"".""StorageLocation_Longitude""
 FROM ""Engines"" AS ""e""
+LEFT JOIN (
+    SELECT ""e.StorageLocation"".*
+    FROM ""Engines"" AS ""e.StorageLocation""
+    WHERE ""e.StorageLocation"".""StorageLocation_Longitude"" IS NOT NULL AND ""e.StorageLocation"".""StorageLocation_Latitude"" IS NOT NULL
+) AS ""t"" ON ""e"".""Id"" = ""t"".""Id""
 ORDER BY ""e"".""Id""
 LIMIT 1",
                 //


### PR DESCRIPTION
A dependent is considered missing if any of its required properties is null or if all non-pk properties are optional and all of them are null.

Fixes #9005