### PR TITLE
Remove C# 8 nullability annotations

### DIFF
--- a/src/EFCore.Abstractions/DbFunctionAttribute.cs
+++ b/src/EFCore.Abstractions/DbFunctionAttribute.cs
@@ -17,8 +17,8 @@ namespace Microsoft.EntityFrameworkCore
     public class DbFunctionAttribute : Attribute
 #pragma warning restore CA1813 // Avoid unsealed attributes
     {
-        private string? _functionName;
-        private string? _schema;
+        private string _functionName;
+        private string _schema;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="DbFunctionAttribute" /> class.
@@ -32,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="functionName">The name of the function in the database.</param>
         /// <param name="schema">The schema of the function in the database.</param>
-        public DbFunctionAttribute([NotNull] string functionName, [CanBeNull] string? schema = null)
+        public DbFunctionAttribute([NotNull] string functionName, [CanBeNull] string schema = null)
         {
             Check.NotEmpty(functionName, nameof(functionName));
 
@@ -43,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <summary>
         ///     The name of the function in the database.
         /// </summary>
-        public virtual string? FunctionName
+        public virtual string FunctionName
         {
             get => _functionName;
             [param: NotNull]
@@ -58,7 +58,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <summary>
         ///     The schema of the function in the database.
         /// </summary>
-        public virtual string? Schema
+        public virtual string Schema
         {
             get => _schema;
             [param: CanBeNull] set => _schema = value;

--- a/src/EFCore.Abstractions/EFCore.Abstractions.csproj
+++ b/src/EFCore.Abstractions/EFCore.Abstractions.csproj
@@ -8,9 +8,6 @@
     <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>..\..\EFCore.ruleset</CodeAnalysisRuleSet>
-    <LangVersion>8.0</LangVersion>
-    <NullableContextOptions>enable</NullableContextOptions>
-    <NullableReferenceTypes>true</NullableReferenceTypes>  <!-- Older SDK -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EFCore.Abstractions/Infrastructure/LazyLoaderExtensions.cs
+++ b/src/EFCore.Abstractions/Infrastructure/LazyLoaderExtensions.cs
@@ -23,10 +23,10 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <returns>
         ///     The loaded navigation property value, or the navigation property value unchanged if the loader is <c>null</c>.
         /// </returns>
-        public static TRelated? Load<TRelated>(
-            [CanBeNull] this ILazyLoader? loader,
+        public static TRelated Load<TRelated>(
+            [CanBeNull] this ILazyLoader loader,
             [NotNull] object entity,
-            [CanBeNull] ref TRelated? navigationField,
+            [CanBeNull] ref TRelated navigationField,
             // ReSharper disable once AssignNullToNotNullAttribute
             [NotNull] [CallerMemberName] string navigationName = "")
             where TRelated : class

--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -20,8 +20,6 @@ using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore
 {
     /// <summary>
@@ -54,16 +52,16 @@ namespace Microsoft.EntityFrameworkCore
         IDbSetCache,
         IDbContextPoolable
     {
-        private IDictionary<Type, object>? _sets;
+        private IDictionary<Type, object> _sets;
         private readonly DbContextOptions _options;
 
-        private IDbContextServices? _contextServices;
-        private IDbContextDependencies? _dbContextDependencies;
-        private DatabaseFacade? _database;
-        private ChangeTracker? _changeTracker;
+        private IDbContextServices _contextServices;
+        private IDbContextDependencies _dbContextDependencies;
+        private DatabaseFacade _database;
+        private ChangeTracker _changeTracker;
 
-        private IServiceScope? _serviceScope;
-        private IDbContextPool? _dbContextPool;
+        private IServiceScope _serviceScope;
+        private IDbContextPool _dbContextPool;
         private bool _initializing;
         private bool _disposed;
 
@@ -579,7 +577,7 @@ namespace Microsoft.EntityFrameworkCore
             }
             else
             {
-                ((IResettableService?)_changeTracker)?.ResetState();
+                ((IResettableService)_changeTracker)?.ResetState();
             }
 
             if (_database != null)
@@ -1369,7 +1367,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The type of entity to find. </param>
         /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
         /// <returns>The entity found, or null.</returns>
-        public virtual object? Find([NotNull] Type entityType, [CanBeNull] params object[]? keyValues)
+        public virtual object Find([NotNull] Type entityType, [CanBeNull] params object[] keyValues)
         {
             CheckDisposed();
 
@@ -1386,7 +1384,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The type of entity to find. </param>
         /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
         /// <returns>The entity found, or null.</returns>
-        public virtual Task<object?> FindAsync([NotNull] Type entityType, [CanBeNull] params object[]? keyValues)
+        public virtual Task<object> FindAsync([NotNull] Type entityType, [CanBeNull] params object[] keyValues)
         {
             CheckDisposed();
 
@@ -1404,7 +1402,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns>The entity found, or null.</returns>
-        public virtual Task<object?> FindAsync([NotNull] Type entityType, [CanBeNull] object[]? keyValues, CancellationToken cancellationToken)
+        public virtual Task<object> FindAsync([NotNull] Type entityType, [CanBeNull] object[] keyValues, CancellationToken cancellationToken)
         {
             CheckDisposed();
 
@@ -1421,7 +1419,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <typeparam name="TEntity"> The type of entity to find. </typeparam>
         /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
         /// <returns>The entity found, or null.</returns>
-        public virtual TEntity? Find<TEntity>([CanBeNull] params object[]? keyValues)
+        public virtual TEntity Find<TEntity>([CanBeNull] params object[] keyValues)
             where TEntity : class
         {
             CheckDisposed();
@@ -1439,7 +1437,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <typeparam name="TEntity"> The type of entity to find. </typeparam>
         /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
         /// <returns>The entity found, or null.</returns>
-        public virtual Task<TEntity?> FindAsync<TEntity>([CanBeNull] params object[]? keyValues)
+        public virtual Task<TEntity> FindAsync<TEntity>([CanBeNull] params object[] keyValues)
             where TEntity : class
         {
             CheckDisposed();
@@ -1458,7 +1456,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns>The entity found, or null.</returns>
-        public virtual Task<TEntity?> FindAsync<TEntity>([CanBeNull] object[]? keyValues, CancellationToken cancellationToken)
+        public virtual Task<TEntity> FindAsync<TEntity>([CanBeNull] object[] keyValues, CancellationToken cancellationToken)
             where TEntity : class
         {
             CheckDisposed();

--- a/src/EFCore/DbSet.cs
+++ b/src/EFCore/DbSet.cs
@@ -15,8 +15,6 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore
 {
     /// <summary>
@@ -74,7 +72,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
         /// <returns>The entity found, or null.</returns>
-        public virtual TEntity? Find([CanBeNull] params object[]? keyValues) => throw new NotImplementedException();
+        public virtual TEntity Find([CanBeNull] params object[] keyValues) => throw new NotImplementedException();
 
         /// <summary>
         ///     Finds an entity with the given primary key values. If an entity with the given primary key values
@@ -85,7 +83,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
         /// <returns>The entity found, or null.</returns>
-        public virtual Task<TEntity?> FindAsync([CanBeNull] params object[]? keyValues) => throw new NotImplementedException();
+        public virtual Task<TEntity> FindAsync([CanBeNull] params object[] keyValues) => throw new NotImplementedException();
 
         /// <summary>
         ///     Finds an entity with the given primary key values. If an entity with the given primary key values
@@ -97,7 +95,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns>The entity found, or null.</returns>
-        public virtual Task<TEntity?> FindAsync([CanBeNull] object[]? keyValues, CancellationToken cancellationToken)
+        public virtual Task<TEntity> FindAsync([CanBeNull] object[] keyValues, CancellationToken cancellationToken)
             => throw new NotImplementedException();
 
         /// <summary>

--- a/src/EFCore/Diagnostics/EventDefinition.cs
+++ b/src/EFCore/Diagnostics/EventDefinition.cs
@@ -6,8 +6,6 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.Logging;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Diagnostics
 {
     /// <summary>
@@ -16,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     /// </summary>
     public class EventDefinition : EventDefinitionBase
     {
-        private readonly Action<ILogger, Exception?> _logAction;
+        private readonly Action<ILogger, Exception> _logAction;
 
         /// <summary>
         ///     Creates an event definition instance.
@@ -31,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             EventId eventId,
             LogLevel level,
             [NotNull] string eventIdCode,
-            [NotNull] Func<LogLevel, Action<ILogger, Exception?>> logActionFunc)
+            [NotNull] Func<LogLevel, Action<ILogger, Exception>> logActionFunc)
             : base(loggingOptions, eventId, level, eventIdCode)
         {
             Check.NotNull(logActionFunc, nameof(logActionFunc));
@@ -61,7 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public virtual void Log<TLoggerCategory>(
             [NotNull] IDiagnosticsLogger<TLoggerCategory> logger,
             WarningBehavior warningBehavior,
-            [CanBeNull] Exception? exception = null)
+            [CanBeNull] Exception exception = null)
             where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
         {
             switch (warningBehavior)

--- a/src/EFCore/Diagnostics/EventDefinitionBase.cs
+++ b/src/EFCore/Diagnostics/EventDefinitionBase.cs
@@ -8,8 +8,6 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.Logging;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Diagnostics
 {
     /// <summary>
@@ -111,7 +109,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         protected sealed class MessageExtractingLogger : ILogger
         {
-            private string? _message;
+            private string _message;
 
             /// <summary>
             ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Diagnostics/EventDefinition`.cs
+++ b/src/EFCore/Diagnostics/EventDefinition`.cs
@@ -6,8 +6,6 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.Logging;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Diagnostics
 {
     /// <summary>
@@ -16,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     /// </summary>
     public class EventDefinition<TParam> : EventDefinitionBase
     {
-        private readonly Action<ILogger, TParam, Exception?> _logAction;
+        private readonly Action<ILogger, TParam, Exception> _logAction;
 
         /// <summary>
         ///     Creates an event definition instance.
@@ -31,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             EventId eventId,
             LogLevel level,
             [NotNull] string eventIdCode,
-            [NotNull] Func<LogLevel, Action<ILogger, TParam, Exception?>> logActionFunc)
+            [NotNull] Func<LogLevel, Action<ILogger, TParam, Exception>> logActionFunc)
             : base(loggingOptions, eventId, level, eventIdCode)
         {
             Check.NotNull(logActionFunc, nameof(logActionFunc));

--- a/src/EFCore/Diagnostics/EventDefinition``.cs
+++ b/src/EFCore/Diagnostics/EventDefinition``.cs
@@ -6,8 +6,6 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.Logging;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Diagnostics
 {
     /// <summary>
@@ -16,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     /// </summary>
     public class EventDefinition<TParam1, TParam2> : EventDefinitionBase
     {
-        private readonly Action<ILogger, TParam1, TParam2, Exception?> _logAction;
+        private readonly Action<ILogger, TParam1, TParam2, Exception> _logAction;
 
         /// <summary>
         ///     Creates an event definition instance.
@@ -31,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             EventId eventId,
             LogLevel level,
             [NotNull] string eventIdCode,
-            [NotNull] Func<LogLevel, Action<ILogger, TParam1, TParam2, Exception?>> logActionFunc)
+            [NotNull] Func<LogLevel, Action<ILogger, TParam1, TParam2, Exception>> logActionFunc)
             : base(loggingOptions, eventId, level, eventIdCode)
         {
             Check.NotNull(logActionFunc, nameof(logActionFunc));

--- a/src/EFCore/Diagnostics/EventDefinition```.cs
+++ b/src/EFCore/Diagnostics/EventDefinition```.cs
@@ -6,8 +6,6 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.Logging;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Diagnostics
 {
     /// <summary>
@@ -16,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     /// </summary>
     public class EventDefinition<TParam1, TParam2, TParam3> : EventDefinitionBase
     {
-        private readonly Action<ILogger, TParam1, TParam2, TParam3, Exception?> _logAction;
+        private readonly Action<ILogger, TParam1, TParam2, TParam3, Exception> _logAction;
 
         /// <summary>
         ///     Creates an event definition instance.
@@ -31,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             EventId eventId,
             LogLevel level,
             [NotNull] string eventIdCode,
-            [NotNull] Func<LogLevel, Action<ILogger, TParam1, TParam2, TParam3, Exception?>> logActionFunc)
+            [NotNull] Func<LogLevel, Action<ILogger, TParam1, TParam2, TParam3, Exception>> logActionFunc)
             : base(loggingOptions, eventId, level, eventIdCode)
         {
             Check.NotNull(logActionFunc, nameof(logActionFunc));
@@ -52,7 +50,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             [CanBeNull] TParam1 arg1,
             [CanBeNull] TParam2 arg2,
             [CanBeNull] TParam3 arg3,
-            [CanBeNull] Exception? exception = null)
+            [CanBeNull] Exception exception = null)
         {
             var extractor = new MessageExtractingLogger();
             _logAction(extractor, arg1, arg2, arg3, exception);
@@ -75,7 +73,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             [CanBeNull] TParam1 arg1,
             [CanBeNull] TParam2 arg2,
             [CanBeNull] TParam3 arg3,
-            [CanBeNull] Exception? exception = null)
+            [CanBeNull] Exception exception = null)
             where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
         {
             switch (warningBehavior)

--- a/src/EFCore/Diagnostics/EventDefinition````.cs
+++ b/src/EFCore/Diagnostics/EventDefinition````.cs
@@ -6,8 +6,6 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.Logging;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Diagnostics
 {
     /// <summary>
@@ -16,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     /// </summary>
     public class EventDefinition<TParam1, TParam2, TParam3, TParam4> : EventDefinitionBase
     {
-        private readonly Action<ILogger, TParam1, TParam2, TParam3, TParam4, Exception?> _logAction;
+        private readonly Action<ILogger, TParam1, TParam2, TParam3, TParam4, Exception> _logAction;
 
         /// <summary>
         ///     Creates an event definition instance.
@@ -31,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             EventId eventId,
             LogLevel level,
             [NotNull] string eventIdCode,
-            [NotNull] Func<LogLevel, Action<ILogger, TParam1, TParam2, TParam3, TParam4, Exception?>> logActionFunc)
+            [NotNull] Func<LogLevel, Action<ILogger, TParam1, TParam2, TParam3, TParam4, Exception>> logActionFunc)
             : base(loggingOptions, eventId, level, eventIdCode)
         {
             Check.NotNull(logActionFunc, nameof(logActionFunc));

--- a/src/EFCore/Diagnostics/EventDefinition`````.cs
+++ b/src/EFCore/Diagnostics/EventDefinition`````.cs
@@ -6,8 +6,6 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.Logging;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Diagnostics
 {
     /// <summary>
@@ -16,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     /// </summary>
     public class EventDefinition<TParam1, TParam2, TParam3, TParam4, TParam5> : EventDefinitionBase
     {
-        private readonly Action<ILogger, TParam1, TParam2, TParam3, TParam4, TParam5, Exception?> _logAction;
+        private readonly Action<ILogger, TParam1, TParam2, TParam3, TParam4, TParam5, Exception> _logAction;
 
         /// <summary>
         ///     Creates an event definition instance.
@@ -31,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             EventId eventId,
             LogLevel level,
             [NotNull] string eventIdCode,
-            [NotNull] Func<LogLevel, Action<ILogger, TParam1, TParam2, TParam3, TParam4, TParam5, Exception?>> logActionFunc)
+            [NotNull] Func<LogLevel, Action<ILogger, TParam1, TParam2, TParam3, TParam4, TParam5, Exception>> logActionFunc)
             : base(loggingOptions, eventId, level, eventIdCode)
         {
             Check.NotNull(logActionFunc, nameof(logActionFunc));

--- a/src/EFCore/Diagnostics/EventDefinition``````.cs
+++ b/src/EFCore/Diagnostics/EventDefinition``````.cs
@@ -6,8 +6,6 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.Logging;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Diagnostics
 {
     /// <summary>
@@ -16,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     /// </summary>
     public class EventDefinition<TParam1, TParam2, TParam3, TParam4, TParam5, TParam6> : EventDefinitionBase
     {
-        private readonly Action<ILogger, TParam1, TParam2, TParam3, TParam4, TParam5, TParam6, Exception?> _logAction;
+        private readonly Action<ILogger, TParam1, TParam2, TParam3, TParam4, TParam5, TParam6, Exception> _logAction;
 
         /// <summary>
         ///     Creates an event definition instance.
@@ -31,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             EventId eventId,
             LogLevel level,
             [NotNull] string eventIdCode,
-            [NotNull] Func<LogLevel, Action<ILogger, TParam1, TParam2, TParam3, TParam4, TParam5, TParam6, Exception?>> logActionFunc)
+            [NotNull] Func<LogLevel, Action<ILogger, TParam1, TParam2, TParam3, TParam4, TParam5, TParam6, Exception>> logActionFunc)
             : base(loggingOptions, eventId, level, eventIdCode)
         {
             Check.NotNull(logActionFunc, nameof(logActionFunc));

--- a/src/EFCore/Diagnostics/FallbackEventDefinition.cs
+++ b/src/EFCore/Diagnostics/FallbackEventDefinition.cs
@@ -6,8 +6,6 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.Logging;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Diagnostics
 {
     /// <summary>

--- a/src/EFCore/EntityFrameworkQueryableExtensions.cs
+++ b/src/EFCore/EntityFrameworkQueryableExtensions.cs
@@ -17,8 +17,6 @@ using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
-#nullable enable
-
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
@@ -3138,7 +3136,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         private static MethodInfo GetMethod<TResult>(
-            string name, int parameterCount = 0, Func<MethodInfo, bool>? predicate = null)
+            string name, int parameterCount = 0, Func<MethodInfo, bool> predicate = null)
             => GetMethod(
                 name,
                 parameterCount,
@@ -3146,7 +3144,7 @@ namespace Microsoft.EntityFrameworkCore
                       && (predicate == null || predicate(mi)));
 
         private static MethodInfo GetMethod(
-            string name, int parameterCount = 0, Func<MethodInfo, bool>? predicate = null)
+            string name, int parameterCount = 0, Func<MethodInfo, bool> predicate = null)
             => typeof(Queryable).GetTypeInfo().GetDeclaredMethods(name)
                 .Single(
                     mi => mi.GetParameters().Length == parameterCount + 1

--- a/src/EFCore/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/EFCore/EntityFrameworkServiceCollectionExtensions.cs
@@ -13,8 +13,6 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
-#nullable enable
-
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -63,7 +61,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </returns>
         public static IServiceCollection AddDbContext<TContext>(
             [NotNull] this IServiceCollection serviceCollection,
-            [CanBeNull] Action<DbContextOptionsBuilder>? optionsAction = null,
+            [CanBeNull] Action<DbContextOptionsBuilder> optionsAction = null,
             ServiceLifetime contextLifetime = ServiceLifetime.Scoped,
             ServiceLifetime optionsLifetime = ServiceLifetime.Scoped)
             where TContext : DbContext
@@ -110,14 +108,14 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </returns>
         public static IServiceCollection AddDbContext<TContextService, TContextImplementation>(
             [NotNull] this IServiceCollection serviceCollection,
-            [CanBeNull] Action<DbContextOptionsBuilder>? optionsAction = null,
+            [CanBeNull] Action<DbContextOptionsBuilder> optionsAction = null,
             ServiceLifetime contextLifetime = ServiceLifetime.Scoped,
             ServiceLifetime optionsLifetime = ServiceLifetime.Scoped)
             where TContextImplementation : DbContext, TContextService
             => AddDbContext<TContextService, TContextImplementation>(
                 serviceCollection,
                 optionsAction == null
-                    ? (Action<IServiceProvider, DbContextOptionsBuilder>?)null
+                    ? (Action<IServiceProvider, DbContextOptionsBuilder>)null
                     : (p, b) => optionsAction?.Invoke(b), contextLifetime, optionsLifetime);
 
         /// <summary>
@@ -358,7 +356,7 @@ namespace Microsoft.Extensions.DependencyInjection
             where TContextService : class
             => AddDbContext<TContextService, TContextImplementation>(
                 serviceCollection,
-                (Action<IServiceProvider, DbContextOptionsBuilder>?)null,
+                (Action<IServiceProvider, DbContextOptionsBuilder>)null,
                 contextLifetime,
                 optionsLifetime);
 
@@ -477,7 +475,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </returns>
         public static IServiceCollection AddDbContext<TContextService, TContextImplementation>(
             [NotNull] this IServiceCollection serviceCollection,
-            [CanBeNull] Action<IServiceProvider, DbContextOptionsBuilder>? optionsAction,
+            [CanBeNull] Action<IServiceProvider, DbContextOptionsBuilder> optionsAction,
             ServiceLifetime contextLifetime = ServiceLifetime.Scoped,
             ServiceLifetime optionsLifetime = ServiceLifetime.Scoped)
             where TContextImplementation : DbContext, TContextService
@@ -503,7 +501,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         private static void AddCoreServices<TContextImplementation>(
             IServiceCollection serviceCollection,
-            Action<IServiceProvider, DbContextOptionsBuilder>? optionsAction,
+            Action<IServiceProvider, DbContextOptionsBuilder> optionsAction,
             ServiceLifetime optionsLifetime)
             where TContextImplementation : DbContext
         {
@@ -522,7 +520,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         private static DbContextOptions<TContext> DbContextOptionsFactory<TContext>(
             [NotNull] IServiceProvider applicationServiceProvider,
-            [CanBeNull] Action<IServiceProvider, DbContextOptionsBuilder>? optionsAction)
+            [CanBeNull] Action<IServiceProvider, DbContextOptionsBuilder> optionsAction)
             where TContext : DbContext
         {
             var builder = new DbContextOptionsBuilder<TContext>(

--- a/src/EFCore/Internal/EntityFinder.cs
+++ b/src/EFCore/Internal/EntityFinder.cs
@@ -15,8 +15,6 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Internal
 {
     /// <summary>
@@ -53,7 +51,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual TEntity? Find(object[]? keyValues)
+        public virtual TEntity Find(object[] keyValues)
         {
             return keyValues == null || keyValues.Any(v => v == null)
                 ? null
@@ -65,46 +63,42 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        object? IEntityFinder.Find(object[]? keyValues)
+        object IEntityFinder.Find(object[] keyValues)
             => Find(keyValues);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Task<TEntity?> FindAsync(object[]? keyValues, CancellationToken cancellationToken = default)
+        public virtual Task<TEntity> FindAsync(object[] keyValues, CancellationToken cancellationToken = default)
         {
             if (keyValues == null || keyValues.Any(v => v == null))
             {
-                return Task.FromResult<TEntity?>(null);
+                return Task.FromResult<TEntity>(null);
             }
 
             var tracked = FindTracked(keyValues, out var keyProperties);
-#nullable disable // https://github.com/dotnet/roslyn/issues/33010
             return tracked != null
                 ? Task.FromResult(tracked)
                 : _queryRoot.FirstOrDefaultAsync(BuildLambda(keyProperties, new ValueBuffer(keyValues)), cancellationToken);
-#nullable enable
         }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        Task<object?> IEntityFinder.FindAsync(object[]? keyValues, CancellationToken cancellationToken)
+        Task<object> IEntityFinder.FindAsync(object[] keyValues, CancellationToken cancellationToken)
         {
             if (keyValues == null || keyValues.Any(v => v == null))
             {
-                return Task.FromResult<object?>(null);
+                return Task.FromResult<object>(null);
             }
 
             var tracked = FindTracked(keyValues, out var keyProperties);
-#nullable disable // https://github.com/dotnet/roslyn/issues/33010
             return tracked != null
                 ? Task.FromResult((object)tracked)
                 : _queryRoot.FirstOrDefaultAsync(
                     BuildObjectLambda(keyProperties, new ValueBuffer(keyValues)), cancellationToken);
-#nullable enable
         }
 
         /// <summary>
@@ -179,22 +173,18 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual object[]? GetDatabaseValues(InternalEntityEntry entry)
+        public virtual object[] GetDatabaseValues(InternalEntityEntry entry)
             => GetDatabaseValuesQuery(entry)?.FirstOrDefault();
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-#pragma warning disable RCS1210 // Return Task.FromResult instead of returning null.
-#nullable disable // https://github.com/dotnet/roslyn/issues/33010
         public virtual Task<object[]> GetDatabaseValuesAsync(
             InternalEntityEntry entry, CancellationToken cancellationToken = default)
             => GetDatabaseValuesQuery(entry)?.FirstOrDefaultAsync(cancellationToken);
-#nullable enable
-#pragma warning restore RCS1210 // Return Task.FromResult instead of returning null.
 
-        private IQueryable<object[]>? GetDatabaseValuesQuery(InternalEntityEntry entry)
+        private IQueryable<object[]> GetDatabaseValuesQuery(InternalEntityEntry entry)
         {
             var entityType = entry.EntityType;
             var properties = entityType.FindPrimaryKey().Properties;
@@ -225,7 +215,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         IQueryable IEntityFinder.Query(INavigation navigation, InternalEntityEntry entry)
             => Query(navigation, entry);
 
-        private static object[]? GetLoadValues(INavigation navigation, InternalEntityEntry entry)
+        private static object[] GetLoadValues(INavigation navigation, InternalEntityEntry entry)
         {
             var properties = navigation.IsDependentToPrincipal()
                 ? navigation.ForeignKey.Properties
@@ -251,7 +241,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 ? navigation.ForeignKey.PrincipalKey.Properties
                 : navigation.ForeignKey.Properties;
 
-        private TEntity? FindTracked(object[] keyValues, out IReadOnlyList<IProperty> keyProperties)
+        private TEntity FindTracked(object[] keyValues, out IReadOnlyList<IProperty> keyProperties)
         {
             var key = _model.FindEntityType(typeof(TEntity)).FindPrimaryKey();
             keyProperties = key.Properties;

--- a/src/EFCore/Internal/IEntityFinder.cs
+++ b/src/EFCore/Internal/IEntityFinder.cs
@@ -8,8 +8,6 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Internal
 {
     /// <summary>
@@ -22,13 +20,13 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        object? Find([CanBeNull] object[]? keyValues);
+        object Find([CanBeNull] object[] keyValues);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        Task<object?> FindAsync([CanBeNull] object[]? keyValues, CancellationToken cancellationToken = default);
+        Task<object> FindAsync([CanBeNull] object[] keyValues, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -55,13 +53,13 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        object[]? GetDatabaseValues([NotNull] InternalEntityEntry entry);
+        object[] GetDatabaseValues([NotNull] InternalEntityEntry entry);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        Task<object[]?> GetDatabaseValuesAsync(
+        Task<object[]> GetDatabaseValuesAsync(
             [NotNull] InternalEntityEntry entry, CancellationToken cancellationToken = default);
     }
 }

--- a/src/EFCore/Internal/IEntityFinder`.cs
+++ b/src/EFCore/Internal/IEntityFinder`.cs
@@ -8,8 +8,6 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Internal
 {
     /// <summary>
@@ -23,13 +21,13 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        new TEntity? Find([CanBeNull] object[]? keyValues);
+        new TEntity Find([CanBeNull] object[] keyValues);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        new Task<TEntity?> FindAsync([CanBeNull] object[]? keyValues, CancellationToken cancellationToken = default);
+        new Task<TEntity> FindAsync([CanBeNull] object[] keyValues, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Internal/InternalDbSet.cs
+++ b/src/EFCore/Internal/InternalDbSet.cs
@@ -16,8 +16,6 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Internal
 {
     /// <summary>
@@ -31,9 +29,9 @@ namespace Microsoft.EntityFrameworkCore.Internal
         where TEntity : class
     {
         private readonly DbContext _context;
-        private IEntityType? _entityType;
-        private EntityQueryable<TEntity>? _entityQueryable;
-        private LocalView<TEntity>? _localView;
+        private IEntityType _entityType;
+        private EntityQueryable<TEntity> _entityQueryable;
+        private LocalView<TEntity> _localView;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -128,21 +126,21 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public override TEntity? Find(params object[]? keyValues)
+        public override TEntity Find(params object[] keyValues)
             => Finder.Find(keyValues);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public override Task<TEntity?> FindAsync(params object[]? keyValues)
+        public override Task<TEntity> FindAsync(params object[] keyValues)
             => Finder.FindAsync(keyValues);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public override Task<TEntity?> FindAsync(object[]? keyValues, CancellationToken cancellationToken)
+        public override Task<TEntity> FindAsync(object[] keyValues, CancellationToken cancellationToken)
             => Finder.FindAsync(keyValues, cancellationToken);
 
         /// <summary>

--- a/src/EFCore/Internal/LazyLoader.cs
+++ b/src/EFCore/Internal/LazyLoader.cs
@@ -14,8 +14,6 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Internal
 {
     /// <summary>
@@ -33,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
     public class LazyLoader : ILazyLoader
     {
         private bool _disposed;
-        private IDictionary<string, bool>? _loadedStates;
+        private IDictionary<string, bool> _loadedStates;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -114,7 +112,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         private bool ShouldLoad(object entity, string navigationName,
-            [NotNullWhenTrue] out NavigationEntry? navigationEntry)
+            [NotNullWhenTrue] out NavigationEntry navigationEntry)
         {
             if (_loadedStates != null
                 && _loadedStates.TryGetValue(navigationName, out var loaded)

--- a/src/EFCore/Internal/NonCapturingLazyInitializer.cs
+++ b/src/EFCore/Internal/NonCapturingLazyInitializer.cs
@@ -5,8 +5,6 @@ using System;
 using System.Threading;
 using JetBrains.Annotations;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Internal
 {
     /// <summary>
@@ -20,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static TValue EnsureInitialized<TParam, TValue>(
-            [CanBeNull] ref TValue? target,
+            [CanBeNull] ref TValue target,
             [CanBeNull] TParam param,
             [NotNull] Func<TParam, TValue> valueFactory)
             where TValue : class
@@ -41,7 +39,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static TValue EnsureInitialized<TParam1, TParam2, TValue>(
-            [CanBeNull] ref TValue? target,
+            [CanBeNull] ref TValue target,
             [CanBeNull] TParam1 param1,
             [CanBeNull] TParam2 param2,
             [NotNull] Func<TParam1, TParam2, TValue> valueFactory)
@@ -63,7 +61,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static TValue EnsureInitialized<TValue>(
-            [CanBeNull] ref TValue? target,
+            [CanBeNull] ref TValue target,
             [NotNull] TValue value)
             where TValue : class
         {
@@ -83,7 +81,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static TValue EnsureInitialized<TParam, TValue>(
-            [CanBeNull] ref TValue? target,
+            [CanBeNull] ref TValue target,
             [CanBeNull] TParam param,
             [NotNull] Action<TParam> valueFactory)
             where TValue : class

--- a/src/EFCore/Internal/TypeExtensions.cs
+++ b/src/EFCore/Internal/TypeExtensions.cs
@@ -8,8 +8,6 @@ using System.Reflection;
 using System.Text;
 using JetBrains.Annotations;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Internal
 {
     /// <summary>
@@ -42,7 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public static bool IsDefaultValue([NotNull] this Type type, [CanBeNull] object? value)
+        public static bool IsDefaultValue([NotNull] this Type type, [CanBeNull] object value)
             => (value?.Equals(type.GetDefaultValue()) != false);
 
         /// <summary>

--- a/src/EFCore/ModelBuilder.cs
+++ b/src/EFCore/ModelBuilder.cs
@@ -14,8 +14,6 @@ using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore
 {
     /// <summary>
@@ -361,7 +359,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns>
         ///     The same <see cref="ModelBuilder" /> instance so that additional configuration calls can be chained.
         /// </returns>
-        public virtual ModelBuilder ApplyConfigurationsFromAssembly(Assembly assembly, Func<Type, bool>? predicate = null)
+        public virtual ModelBuilder ApplyConfigurationsFromAssembly(Assembly assembly, Func<Type, bool> predicate = null)
         {
             var applyEntityConfigurationMethod = typeof(ModelBuilder)
                 .GetMethods()

--- a/src/EFCore/Storage/CoreTypeMapping.cs
+++ b/src/EFCore/Storage/CoreTypeMapping.cs
@@ -13,8 +13,6 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>
@@ -43,10 +41,10 @@ namespace Microsoft.EntityFrameworkCore.Storage
             /// <param name="valueGeneratorFactory"> An optional factory for creating a specific <see cref="ValueGenerator" />. </param>
             public CoreTypeMappingParameters(
                 [NotNull] Type clrType,
-                [CanBeNull] ValueConverter? converter = null,
-                [CanBeNull] ValueComparer? comparer = null,
-                [CanBeNull] ValueComparer? keyComparer = null,
-                [CanBeNull] Func<IProperty, IEntityType, ValueGenerator>? valueGeneratorFactory = null)
+                [CanBeNull] ValueConverter converter = null,
+                [CanBeNull] ValueComparer comparer = null,
+                [CanBeNull] ValueComparer keyComparer = null,
+                [CanBeNull] Func<IProperty, IEntityType, ValueGenerator> valueGeneratorFactory = null)
                 : this(clrType, converter, comparer, keyComparer, null, valueGeneratorFactory)
             {
             }
@@ -62,11 +60,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
             /// <param name="valueGeneratorFactory"> An optional factory for creating a specific <see cref="ValueGenerator" />. </param>
             public CoreTypeMappingParameters(
                 [NotNull] Type clrType,
-                [CanBeNull] ValueConverter? converter,
-                [CanBeNull] ValueComparer? comparer,
-                [CanBeNull] ValueComparer? keyComparer,
-                [CanBeNull] ValueComparer? structuralComparer,
-                [CanBeNull] Func<IProperty, IEntityType, ValueGenerator>? valueGeneratorFactory)
+                [CanBeNull] ValueConverter converter,
+                [CanBeNull] ValueComparer comparer,
+                [CanBeNull] ValueComparer keyComparer,
+                [CanBeNull] ValueComparer structuralComparer,
+                [CanBeNull] Func<IProperty, IEntityType, ValueGenerator> valueGeneratorFactory)
             {
                 Check.NotNull(clrType, nameof(clrType));
 
@@ -86,28 +84,28 @@ namespace Microsoft.EntityFrameworkCore.Storage
             /// <summary>
             ///     The mapping converter.
             /// </summary>
-            public ValueConverter? Converter { get; }
+            public ValueConverter Converter { get; }
 
             /// <summary>
             ///     The mapping comparer.
             /// </summary>
-            public ValueComparer? Comparer { get; }
+            public ValueComparer Comparer { get; }
 
             /// <summary>
             ///     The mapping key comparer.
             /// </summary>
-            public ValueComparer? KeyComparer { get; }
+            public ValueComparer KeyComparer { get; }
 
             /// <summary>
             ///     The mapping structural comparer.
             /// </summary>
-            public ValueComparer? StructuralComparer { get; }
+            public ValueComparer StructuralComparer { get; }
 
             /// <summary>
             ///     An optional factory for creating a specific <see cref="ValueGenerator" /> to use with
             ///     this mapping.
             /// </summary>
-            public Func<IProperty, IEntityType, ValueGenerator>? ValueGeneratorFactory { get; }
+            public Func<IProperty, IEntityType, ValueGenerator> ValueGeneratorFactory { get; }
 
             /// <summary>
             ///     Creates a new <see cref="CoreTypeMappingParameters" /> parameter object with the given
@@ -125,9 +123,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
                     ValueGeneratorFactory);
         }
 
-        private ValueComparer? _comparer;
-        private ValueComparer? _keyComparer;
-        private readonly ValueComparer? _structuralComparer;
+        private ValueComparer _comparer;
+        private ValueComparer _keyComparer;
+        private readonly ValueComparer _structuralComparer;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="CoreTypeMapping" /> class.
@@ -175,13 +173,13 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Converts types to and from the store whenever this mapping is used.
         ///     May be null if no conversion is needed.
         /// </summary>
-        public virtual ValueConverter? Converter => Parameters.Converter;
+        public virtual ValueConverter Converter => Parameters.Converter;
 
         /// <summary>
         ///     An optional factory for creating a specific <see cref="ValueGenerator" /> to use with
         ///     this mapping.
         /// </summary>
-        public virtual Func<IProperty, IEntityType, ValueGenerator>? ValueGeneratorFactory { get; }
+        public virtual Func<IProperty, IEntityType, ValueGenerator> ValueGeneratorFactory { get; }
 
         /// <summary>
         ///     A <see cref="ValueComparer" /> adds custom value snapshotting and comparison for

--- a/src/EFCore/Storage/Database.cs
+++ b/src/EFCore/Storage/Database.cs
@@ -12,8 +12,6 @@ using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 using Remotion.Linq;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/DatabaseDependencies.cs
+++ b/src/EFCore/Storage/DatabaseDependencies.cs
@@ -6,8 +6,6 @@ using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/DatabaseProvider.cs
+++ b/src/EFCore/Storage/DatabaseProvider.cs
@@ -8,8 +8,6 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/DatabaseProviderDependencies.cs
+++ b/src/EFCore/Storage/DatabaseProviderDependencies.cs
@@ -3,8 +3,6 @@
 
 using Microsoft.Extensions.DependencyInjection;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/ExecutionResult.cs
+++ b/src/EFCore/Storage/ExecutionResult.cs
@@ -3,8 +3,6 @@
 
 using JetBrains.Annotations;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/ExecutionStrategy.cs
+++ b/src/EFCore/Storage/ExecutionStrategy.cs
@@ -12,8 +12,6 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>
@@ -164,7 +162,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
         private TResult ExecuteImplementation<TState, TResult>(
             Func<DbContext, TState, TResult> operation,
-            Func<DbContext, TState, ExecutionResult<TResult>>? verifySucceeded,
+            Func<DbContext, TState, ExecutionResult<TResult>> verifySucceeded,
             TState state)
         {
             while (true)
@@ -256,7 +254,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
         private async Task<TResult> ExecuteImplementationAsync<TState, TResult>(
             Func<DbContext, TState, CancellationToken, Task<TResult>> operation,
-            Func<DbContext, TState, CancellationToken, Task<ExecutionResult<TResult>>>? verifySucceeded,
+            Func<DbContext, TState, CancellationToken, Task<ExecutionResult<TResult>>> verifySucceeded,
             TState state,
             CancellationToken cancellationToken)
         {

--- a/src/EFCore/Storage/ExecutionStrategyDependencies.cs
+++ b/src/EFCore/Storage/ExecutionStrategyDependencies.cs
@@ -8,8 +8,6 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/IDatabase.cs
+++ b/src/EFCore/Storage/IDatabase.cs
@@ -11,8 +11,6 @@ using Microsoft.EntityFrameworkCore.Update;
 using Microsoft.Extensions.DependencyInjection;
 using Remotion.Linq;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/IDatabaseCreator.cs
+++ b/src/EFCore/Storage/IDatabaseCreator.cs
@@ -4,8 +4,6 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/IDatabaseProvider.cs
+++ b/src/EFCore/Storage/IDatabaseProvider.cs
@@ -5,8 +5,6 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/IDbContextTransaction.cs
+++ b/src/EFCore/Storage/IDbContextTransaction.cs
@@ -4,8 +4,6 @@
 using System;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/IDbContextTransactionManager.cs
+++ b/src/EFCore/Storage/IDbContextTransactionManager.cs
@@ -6,8 +6,6 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/IExecutionStrategy.cs
+++ b/src/EFCore/Storage/IExecutionStrategy.cs
@@ -6,8 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/IExecutionStrategyFactory.cs
+++ b/src/EFCore/Storage/IExecutionStrategyFactory.cs
@@ -3,8 +3,6 @@
 
 using Microsoft.Extensions.DependencyInjection;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/ITransactionEnlistmentManager.cs
+++ b/src/EFCore/Storage/ITransactionEnlistmentManager.cs
@@ -4,8 +4,6 @@
 using System.Transactions;
 using JetBrains.Annotations;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/ITypeMappingSource.cs
+++ b/src/EFCore/Storage/ITypeMappingSource.cs
@@ -7,8 +7,6 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.Extensions.DependencyInjection;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>
@@ -37,7 +35,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="property"> The property. </param>
         /// <returns> The type mapping, or <c>null</c> if none was found. </returns>
-        CoreTypeMapping? FindMapping([NotNull] IProperty property);
+        CoreTypeMapping FindMapping([NotNull] IProperty property);
 
         /// <summary>
         ///     <para>
@@ -51,7 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="member"> The field or property. </param>
         /// <returns> The type mapping, or <c>null</c> if none was found. </returns>
-        CoreTypeMapping? FindMapping([NotNull] MemberInfo member);
+        CoreTypeMapping FindMapping([NotNull] MemberInfo member);
 
         /// <summary>
         ///     <para>
@@ -65,6 +63,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="type"> The CLR type. </param>
         /// <returns> The type mapping, or <c>null</c> if none was found. </returns>
-        CoreTypeMapping? FindMapping([NotNull] Type type);
+        CoreTypeMapping FindMapping([NotNull] Type type);
     }
 }

--- a/src/EFCore/Storage/ITypeMappingSourcePlugin.cs
+++ b/src/EFCore/Storage/ITypeMappingSourcePlugin.cs
@@ -3,8 +3,6 @@
 
 using Microsoft.Extensions.DependencyInjection;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/Internal/ExecutionStrategyFactory.cs
+++ b/src/EFCore/Storage/Internal/ExecutionStrategyFactory.cs
@@ -5,8 +5,6 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.Internal
 {
     /// <summary>

--- a/src/EFCore/Storage/Internal/NoopExecutionStrategy.cs
+++ b/src/EFCore/Storage/Internal/NoopExecutionStrategy.cs
@@ -6,8 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.Internal
 {
     /// <summary>

--- a/src/EFCore/Storage/MaterializationContext.cs
+++ b/src/EFCore/Storage/MaterializationContext.cs
@@ -6,8 +6,6 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/RetryLimitExceededException.cs
+++ b/src/EFCore/Storage/RetryLimitExceededException.cs
@@ -4,8 +4,6 @@
 using System;
 using JetBrains.Annotations;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/TypeMappingInfo.cs
+++ b/src/EFCore/Storage/TypeMappingInfo.cs
@@ -10,8 +10,6 @@ using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.EntityFrameworkCore.Utilities;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>
@@ -45,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         {
             Check.NotNull(principals, nameof(principals));
 
-            ValueConverter? customConverter = null;
+            ValueConverter customConverter = null;
             int? size = null;
             bool? isUnicode = null;
             for (var i = 0; i < principals.Count; i++)
@@ -124,7 +122,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="precision"> Specifies a precision for the mapping, or <c>null</c> for default. </param>
         /// <param name="scale"> Specifies a scale for the mapping, or <c>null</c> for default. </param>
         public TypeMappingInfo(
-            [CanBeNull] Type? type = null,
+            [CanBeNull] Type type = null,
             bool keyOrIndex = false,
             bool? unicode = null,
             int? size = null,
@@ -216,7 +214,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     The CLR type in the model. May be null if type information is conveyed via other means
         ///     (e.g. the store name in a relational type mapping info)
         /// </summary>
-        public Type? ClrType { get; }
+        public Type ClrType { get; }
 
         /// <summary>
         ///     Compares this <see cref="TypeMappingInfo" /> to another to check if they represent the same mapping.

--- a/src/EFCore/Storage/TypeMappingSource.cs
+++ b/src/EFCore/Storage/TypeMappingSource.cs
@@ -11,8 +11,6 @@ using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.Extensions.DependencyInjection;
 
-#nullable enable
-
 #pragma warning disable 1574, CS0419 // Ambiguous reference in cref attribute
 namespace Microsoft.EntityFrameworkCore.Storage
 {
@@ -33,8 +31,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
     /// </summary>
     public abstract class TypeMappingSource : TypeMappingSourceBase
     {
-        private readonly ConcurrentDictionary<(TypeMappingInfo, Type?, ValueConverter?), CoreTypeMapping?> _explicitMappings
-            = new ConcurrentDictionary<(TypeMappingInfo, Type?, ValueConverter?), CoreTypeMapping?>();
+        private readonly ConcurrentDictionary<(TypeMappingInfo, Type, ValueConverter), CoreTypeMapping> _explicitMappings
+            = new ConcurrentDictionary<(TypeMappingInfo, Type, ValueConverter), CoreTypeMapping>();
 
         /// <summary>
         ///     Initializes a new instance of the this class.
@@ -45,12 +43,12 @@ namespace Microsoft.EntityFrameworkCore.Storage
         {
         }
 
-        private CoreTypeMapping? FindMappingWithConversion(
+        private CoreTypeMapping FindMappingWithConversion(
             in TypeMappingInfo mappingInfo,
-            [CanBeNull] IReadOnlyList<IProperty>? principals)
+            [CanBeNull] IReadOnlyList<IProperty> principals)
         {
-            Type? providerClrType = null;
-            ValueConverter? customConverter = null;
+            Type providerClrType = null;
+            ValueConverter customConverter = null;
             if (principals != null)
             {
                 for (var i = 0; i < principals.Count; i++)
@@ -149,7 +147,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="property"> The property. </param>
         /// <returns> The type mapping, or <c>null</c> if none was found. </returns>
-        public override CoreTypeMapping? FindMapping(IProperty property)
+        public override CoreTypeMapping FindMapping(IProperty property)
         {
             var mapping = property.FindMapping();
             if (mapping != null)
@@ -176,7 +174,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="type"> The CLR type. </param>
         /// <returns> The type mapping, or <c>null</c> if none was found. </returns>
-        public override CoreTypeMapping? FindMapping(Type type)
+        public override CoreTypeMapping FindMapping(Type type)
             => FindMappingWithConversion(new TypeMappingInfo(type), null);
 
         /// <summary>
@@ -194,7 +192,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="member"> The field or property. </param>
         /// <returns> The type mapping, or <c>null</c> if none was found. </returns>
-        public override CoreTypeMapping? FindMapping(MemberInfo member)
+        public override CoreTypeMapping FindMapping(MemberInfo member)
             => FindMappingWithConversion(new TypeMappingInfo(member), null);
     }
 }

--- a/src/EFCore/Storage/TypeMappingSourceBase.cs
+++ b/src/EFCore/Storage/TypeMappingSourceBase.cs
@@ -8,8 +8,6 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
-#nullable enable
-
 #pragma warning disable 1574, CS0419 // Ambiguous reference in cref attribute
 namespace Microsoft.EntityFrameworkCore.Storage
 {
@@ -58,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="mappingInfo"> The mapping info to use to create the mapping. </param>
         /// <returns> The type mapping, or <c>null</c> if none could be found. </returns>
-        protected virtual CoreTypeMapping? FindMapping(in TypeMappingInfo mappingInfo)
+        protected virtual CoreTypeMapping FindMapping(in TypeMappingInfo mappingInfo)
         {
             foreach (var plugin in Dependencies.Plugins)
             {
@@ -78,8 +76,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="mapping"> The mapping, if any. </param>
         /// <param name="property"> The property, if any. </param>
         protected virtual void ValidateMapping(
-            [CanBeNull] CoreTypeMapping? mapping,
-            [CanBeNull] IProperty? property)
+            [CanBeNull] CoreTypeMapping mapping,
+            [CanBeNull] IProperty property)
         {
         }
 
@@ -93,7 +91,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="property"> The property. </param>
         /// <returns> The type mapping, or <c>null</c> if none was found. </returns>
-        public abstract CoreTypeMapping? FindMapping(IProperty property);
+        public abstract CoreTypeMapping FindMapping(IProperty property);
 
         /// <summary>
         ///     <para>
@@ -110,7 +108,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="type"> The CLR type. </param>
         /// <returns> The type mapping, or <c>null</c> if none was found. </returns>
-        public abstract CoreTypeMapping? FindMapping(Type type);
+        public abstract CoreTypeMapping FindMapping(Type type);
 
         /// <summary>
         ///     <para>
@@ -127,6 +125,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="member"> The field or property. </param>
         /// <returns> The type mapping, or <c>null</c> if none was found. </returns>
-        public abstract CoreTypeMapping? FindMapping(MemberInfo member);
+        public abstract CoreTypeMapping FindMapping(MemberInfo member);
     }
 }

--- a/src/EFCore/Storage/TypeMappingSourceDependencies.cs
+++ b/src/EFCore/Storage/TypeMappingSourceDependencies.cs
@@ -7,8 +7,6 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/ValueBuffer.cs
+++ b/src/EFCore/Storage/ValueBuffer.cs
@@ -7,8 +7,6 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>

--- a/src/EFCore/Storage/ValueConversion/BoolToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/BoolToStringConverter.cs
@@ -6,8 +6,6 @@ using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -28,7 +26,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         public BoolToStringConverter(
             [NotNull] string falseValue,
             [NotNull] string trueValue,
-            [CanBeNull] ConverterMappingHints? mappingHints = null)
+            [CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
                 Check.NotEmpty(falseValue, nameof(falseValue)),
                 Check.NotEmpty(trueValue, nameof(trueValue)),

--- a/src/EFCore/Storage/ValueConversion/BoolToTwoValuesConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/BoolToTwoValuesConverter.cs
@@ -5,8 +5,6 @@ using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -33,8 +31,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         public BoolToTwoValuesConverter(
             [CanBeNull] TProvider falseValue,
             [CanBeNull] TProvider trueValue,
-            [CanBeNull] Expression<Func<TProvider, bool>>? fromProvider = null,
-            [CanBeNull] ConverterMappingHints? mappingHints = null)
+            [CanBeNull] Expression<Func<TProvider, bool>> fromProvider = null,
+            [CanBeNull] ConverterMappingHints mappingHints = null)
             : base(ToProvider(falseValue, trueValue), fromProvider ?? ToBool(trueValue), mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/BoolToZeroOneConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/BoolToZeroOneConverter.cs
@@ -4,8 +4,6 @@
 using System;
 using JetBrains.Annotations;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -20,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public BoolToZeroOneConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
+        public BoolToZeroOneConverter([CanBeNull] ConverterMappingHints mappingHints = null)
             : base(Zero(), One(), null, mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/BytesToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/BytesToStringConverter.cs
@@ -4,8 +4,6 @@
 using System;
 using JetBrains.Annotations;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -21,12 +19,10 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     facets for the converted data.
         /// </param>
         public BytesToStringConverter(
-            [CanBeNull] ConverterMappingHints? mappingHints = null)
+            [CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
-#nullable disable // https://github.com/dotnet/roslyn/issues/30953
                 v => v == null ? null : Convert.ToBase64String(v),
                 v => v == null ? null : Convert.FromBase64String(v),
-#nullable enable
                 mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/CastingConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/CastingConverter.cs
@@ -5,8 +5,6 @@ using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -16,9 +14,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
     public class CastingConverter<TModel, TProvider> : ValueConverter<TModel, TProvider>
     {
         // ReSharper disable once StaticMemberInGenericType
-        private static readonly ConverterMappingHints? _defaultHints = CreateDefaultHints();
+        private static readonly ConverterMappingHints _defaultHints = CreateDefaultHints();
 
-        private static ConverterMappingHints? CreateDefaultHints()
+        private static ConverterMappingHints CreateDefaultHints()
         {
             if (typeof(TProvider).UnwrapNullableType() == typeof(decimal))
             {
@@ -43,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// <summary>
         ///     Creates a new instance of this converter.
         /// </summary>
-        public CastingConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
+        public CastingConverter([CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
                 Convert<TModel, TProvider>(),
                 Convert<TProvider, TModel>(),

--- a/src/EFCore/Storage/ValueConversion/CharToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/CharToStringConverter.cs
@@ -4,8 +4,6 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -23,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public CharToStringConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
+        public CharToStringConverter([CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
                 ToString(),
                 ToChar(),

--- a/src/EFCore/Storage/ValueConversion/ConverterMappingHints.cs
+++ b/src/EFCore/Storage/ValueConversion/ConverterMappingHints.cs
@@ -6,8 +6,6 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -29,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
             int? precision = null,
             int? scale = null,
             bool? unicode = null,
-            [CanBeNull] Func<IProperty, IEntityType, ValueGenerator>? valueGeneratorFactory = null)
+            [CanBeNull] Func<IProperty, IEntityType, ValueGenerator> valueGeneratorFactory = null)
         {
             Size = size;
             Precision = precision;
@@ -44,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// </summary>
         /// <param name="hints"> The hints to add. </param>
         /// <returns> The combined hints. </returns>
-        public virtual ConverterMappingHints With([CanBeNull] ConverterMappingHints? hints)
+        public virtual ConverterMappingHints With([CanBeNull] ConverterMappingHints hints)
             => hints == null
                 ? this
                 : new ConverterMappingHints(
@@ -78,6 +76,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     An optional factory for creating a specific <see cref="ValueGenerator" /> to use for model
         ///     values when this converter is being used.
         /// </summary>
-        public virtual Func<IProperty, IEntityType, ValueGenerator>? ValueGeneratorFactory { get; }
+        public virtual Func<IProperty, IEntityType, ValueGenerator> ValueGeneratorFactory { get; }
     }
 }

--- a/src/EFCore/Storage/ValueConversion/DateTimeOffsetToBinaryConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/DateTimeOffsetToBinaryConverter.cs
@@ -4,8 +4,6 @@
 using System;
 using JetBrains.Annotations;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -21,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public DateTimeOffsetToBinaryConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
+        public DateTimeOffsetToBinaryConverter([CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
                 v => ((v.Ticks / 1000) << 11) | ((long)v.Offset.TotalMinutes & 0x7FF),
                 v => new DateTimeOffset(

--- a/src/EFCore/Storage/ValueConversion/DateTimeOffsetToBytesConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/DateTimeOffsetToBytesConverter.cs
@@ -5,8 +5,6 @@ using System;
 using System.Linq;
 using JetBrains.Annotations;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -30,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public DateTimeOffsetToBytesConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
+        public DateTimeOffsetToBytesConverter([CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
                 v => ToBytes(v),
                 v => v == null ? default : FromBytes(v),

--- a/src/EFCore/Storage/ValueConversion/DateTimeOffsetToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/DateTimeOffsetToStringConverter.cs
@@ -5,8 +5,6 @@ using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -21,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public DateTimeOffsetToStringConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
+        public DateTimeOffsetToStringConverter([CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
                 ToString(),
                 ToDateTimeOffset(),

--- a/src/EFCore/Storage/ValueConversion/DateTimeToBinaryConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/DateTimeToBinaryConverter.cs
@@ -4,8 +4,6 @@
 using System;
 using JetBrains.Annotations;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -21,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public DateTimeToBinaryConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
+        public DateTimeToBinaryConverter([CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
                 v => v.ToBinary(),
                 v => DateTime.FromBinary(v),

--- a/src/EFCore/Storage/ValueConversion/DateTimeToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/DateTimeToStringConverter.cs
@@ -5,8 +5,6 @@ using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -21,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public DateTimeToStringConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
+        public DateTimeToStringConverter([CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
                 ToString(),
                 ToDateTime(),

--- a/src/EFCore/Storage/ValueConversion/DateTimeToTicksConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/DateTimeToTicksConverter.cs
@@ -4,8 +4,6 @@
 using System;
 using JetBrains.Annotations;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -20,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public DateTimeToTicksConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
+        public DateTimeToTicksConverter([CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
                 v => v.Ticks,
                 v => new DateTime(v),

--- a/src/EFCore/Storage/ValueConversion/DefaultValueConverterRegistryDependencies.cs
+++ b/src/EFCore/Storage/ValueConversion/DefaultValueConverterRegistryDependencies.cs
@@ -3,8 +3,6 @@
 
 using Microsoft.Extensions.DependencyInjection;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>

--- a/src/EFCore/Storage/ValueConversion/EnumToNumberConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/EnumToNumberConverter.cs
@@ -7,8 +7,6 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -19,9 +17,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         where TNumber : struct
     {
         // ReSharper disable once StaticMemberInGenericType
-        private static readonly ConverterMappingHints? _defaultHints = CreateDefaultHints();
+        private static readonly ConverterMappingHints _defaultHints = CreateDefaultHints();
 
-        private static ConverterMappingHints? CreateDefaultHints()
+        private static ConverterMappingHints CreateDefaultHints()
         {
             var underlyingModelType = typeof(TEnum).UnwrapEnumType();
 
@@ -38,12 +36,10 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public EnumToNumberConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
+        public EnumToNumberConverter([CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
-#nullable disable // https://github.com/dotnet/roslyn/issues/30953
                 ToNumber(),
                 ToEnum(),
-#nullable enable
                 _defaultHints?.With(mappingHints) ?? mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/EnumToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/EnumToStringConverter.cs
@@ -4,8 +4,6 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -21,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public EnumToStringConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
+        public EnumToStringConverter([CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
                 ToString(),
                 ToEnum(),

--- a/src/EFCore/Storage/ValueConversion/GuidToBytesConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/GuidToBytesConverter.cs
@@ -5,8 +5,6 @@ using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -33,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public GuidToBytesConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
+        public GuidToBytesConverter([CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
                 v => v.ToByteArray(),
                 v => v == null ? Guid.Empty : new Guid(v),

--- a/src/EFCore/Storage/ValueConversion/GuidToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/GuidToStringConverter.cs
@@ -5,8 +5,6 @@ using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -22,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public GuidToStringConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
+        public GuidToStringConverter([CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
                 ToString(),
                 ToGuid(),

--- a/src/EFCore/Storage/ValueConversion/IValueConverterSelector.cs
+++ b/src/EFCore/Storage/ValueConversion/IValueConverterSelector.cs
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -34,6 +32,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// <returns> The converters available. </returns>
         IEnumerable<ValueConverterInfo> Select(
             [NotNull] Type modelClrType,
-            [CanBeNull] Type? providerClrType = null);
+            [CanBeNull] Type providerClrType = null);
     }
 }

--- a/src/EFCore/Storage/ValueConversion/Internal/CompositeValueConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/CompositeValueConverter.cs
@@ -7,8 +7,6 @@ using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Remotion.Linq.Parsing.ExpressionVisitors;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
 {
     /// <summary>
@@ -24,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
         public CompositeValueConverter(
             [NotNull] ValueConverter converter1,
             [NotNull] ValueConverter converter2,
-            [CanBeNull] ConverterMappingHints? mappingHints = null)
+            [CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
                 Compose(
                     (Expression<Func<TModel, TMiddle>>)converter1.ConvertToProviderExpression,

--- a/src/EFCore/Storage/ValueConversion/Internal/StringCharConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/StringCharConverter.cs
@@ -6,8 +6,6 @@ using System.Globalization;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
 {
     /// <summary>
@@ -23,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
         public StringCharConverter(
             [NotNull] Expression<Func<TModel, TProvider>> convertToProviderExpression,
             [NotNull] Expression<Func<TProvider, TModel>> convertFromProviderExpression,
-            [CanBeNull] ConverterMappingHints? mappingHints = null)
+            [CanBeNull] ConverterMappingHints mappingHints = null)
             : base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/Internal/StringDateTimeConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/StringDateTimeConverter.cs
@@ -6,8 +6,6 @@ using System.Globalization;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
 {
     /// <summary>
@@ -31,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
         public StringDateTimeConverter(
             [NotNull] Expression<Func<TModel, TProvider>> convertToProviderExpression,
             [NotNull] Expression<Func<TProvider, TModel>> convertFromProviderExpression,
-            [CanBeNull] ConverterMappingHints? mappingHints = null)
+            [CanBeNull] ConverterMappingHints mappingHints = null)
             : base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/Internal/StringDateTimeOffsetConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/StringDateTimeOffsetConverter.cs
@@ -6,8 +6,6 @@ using System.Globalization;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
 {
     /// <summary>
@@ -31,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
         public StringDateTimeOffsetConverter(
             [NotNull] Expression<Func<TModel, TProvider>> convertToProviderExpression,
             [NotNull] Expression<Func<TProvider, TModel>> convertFromProviderExpression,
-            [CanBeNull] ConverterMappingHints? mappingHints = null)
+            [CanBeNull] ConverterMappingHints mappingHints = null)
             : base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/Internal/StringEnumConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/StringEnumConverter.cs
@@ -7,8 +7,6 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
 {
     /// <summary>
@@ -25,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
         public StringEnumConverter(
             [NotNull] Expression<Func<TModel, TProvider>> convertToProviderExpression,
             [NotNull] Expression<Func<TProvider, TModel>> convertFromProviderExpression,
-            [CanBeNull] ConverterMappingHints? mappingHints = null)
+            [CanBeNull] ConverterMappingHints mappingHints = null)
             : base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/Internal/StringGuidConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/StringGuidConverter.cs
@@ -6,8 +6,6 @@ using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
 {
     /// <summary>
@@ -33,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
         public StringGuidConverter(
             [NotNull] Expression<Func<TModel, TProvider>> convertToProviderExpression,
             [NotNull] Expression<Func<TProvider, TModel>> convertFromProviderExpression,
-            [CanBeNull] ConverterMappingHints? mappingHints = null)
+            [CanBeNull] ConverterMappingHints mappingHints = null)
             : base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/Internal/StringNumberConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/StringNumberConverter.cs
@@ -6,8 +6,6 @@ using System.Globalization;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
 {
     /// <summary>
@@ -31,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
         public StringNumberConverter(
             [NotNull] Expression<Func<TModel, TProvider>> convertToProviderExpression,
             [NotNull] Expression<Func<TProvider, TModel>> convertFromProviderExpression,
-            [CanBeNull] ConverterMappingHints? mappingHints = null)
+            [CanBeNull] ConverterMappingHints mappingHints = null)
             : base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
         {
         }
@@ -72,9 +70,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
                         typeof(TNumber).IsNullableType()
                             ? (Expression)Expression.Convert(parsedVariable, typeof(TNumber))
                             : parsedVariable,
-#nullable disable // https://github.com/dotnet/roslyn/issues/30953
                         Expression.Constant(default(TNumber), typeof(TNumber)))),
-#nullable enable
                 param);
         }
 
@@ -82,7 +78,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected static new Expression<Func<TNumber, string?>> ToString()
+        protected static new Expression<Func<TNumber, string>> ToString()
         {
             var type = typeof(TNumber).UnwrapNullableType();
 

--- a/src/EFCore/Storage/ValueConversion/Internal/StringTimeSpanConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/StringTimeSpanConverter.cs
@@ -6,8 +6,6 @@ using System.Globalization;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
 {
     /// <summary>
@@ -31,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
         public StringTimeSpanConverter(
             [NotNull] Expression<Func<TModel, TProvider>> convertToProviderExpression,
             [NotNull] Expression<Func<TProvider, TModel>> convertFromProviderExpression,
-            [CanBeNull] ConverterMappingHints? mappingHints = null)
+            [CanBeNull] ConverterMappingHints mappingHints = null)
             : base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/NumberToBytesConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/NumberToBytesConverter.cs
@@ -6,8 +6,6 @@ using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -34,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public NumberToBytesConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
+        public NumberToBytesConverter([CanBeNull] ConverterMappingHints mappingHints = null)
             : base(ToBytes(), ToNumber(), _defaultHints.With(mappingHints))
         {
         }
@@ -124,9 +122,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
             return Expression.Lambda<Func<byte[], TNumber>>(
                 Expression.Condition(
                     Expression.ReferenceEqual(param, Expression.Constant(null)),
-#nullable disable // https://github.com/dotnet/roslyn/issues/30953
                     Expression.Constant(default(TNumber), typeof(TNumber)),
-#nullable enable
                     output),
                 param);
         }

--- a/src/EFCore/Storage/ValueConversion/NumberToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/NumberToStringConverter.cs
@@ -4,8 +4,6 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -21,12 +19,10 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     facets for the converted data.
         /// </param>
         public NumberToStringConverter(
-            [CanBeNull] ConverterMappingHints? mappingHints = null)
+            [CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
-#nullable disable
                 ToString(),
                 ToNumber(),
-#nullable enable
                 _defaultHints.With(mappingHints))
         {
         }

--- a/src/EFCore/Storage/ValueConversion/StringToBoolConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToBoolConverter.cs
@@ -4,8 +4,6 @@
 using System;
 using JetBrains.Annotations;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -21,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     facets for the converted data.
         /// </param>
         public StringToBoolConverter(
-            [CanBeNull] ConverterMappingHints? mappingHints = null)
+            [CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
                 v => Convert.ToBoolean(v),
                 v => Convert.ToString(v),

--- a/src/EFCore/Storage/ValueConversion/StringToBytesConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToBytesConverter.cs
@@ -4,8 +4,6 @@
 using System.Text;
 using JetBrains.Annotations;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -23,12 +21,10 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// </param>
         public StringToBytesConverter(
             [NotNull] Encoding encoding,
-            [CanBeNull] ConverterMappingHints? mappingHints = null)
+            [CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
-#nullable disable
                 v => v == null ? null : encoding.GetBytes(v),
                 v => v == null ? null : encoding.GetString(v),
-#nullable enable
                 mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/StringToCharConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToCharConverter.cs
@@ -4,8 +4,6 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -23,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public StringToCharConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
+        public StringToCharConverter([CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
                 ToChar(),
                 ToString(),

--- a/src/EFCore/Storage/ValueConversion/StringToDateTimeConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToDateTimeConverter.cs
@@ -5,8 +5,6 @@ using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -21,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public StringToDateTimeConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
+        public StringToDateTimeConverter([CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
                 ToDateTime(),
                 ToString(),

--- a/src/EFCore/Storage/ValueConversion/StringToDateTimeOffsetConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToDateTimeOffsetConverter.cs
@@ -5,8 +5,6 @@ using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -22,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     facets for the converted data.
         /// </param>
         public StringToDateTimeOffsetConverter(
-            [CanBeNull] ConverterMappingHints? mappingHints = null)
+            [CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
                 ToDateTimeOffset(),
                 ToString(),

--- a/src/EFCore/Storage/ValueConversion/StringToEnumConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToEnumConverter.cs
@@ -4,8 +4,6 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -21,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public StringToEnumConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
+        public StringToEnumConverter([CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
                 ToEnum(),
                 ToString(),

--- a/src/EFCore/Storage/ValueConversion/StringToGuidConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToGuidConverter.cs
@@ -5,8 +5,6 @@ using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -22,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public StringToGuidConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
+        public StringToGuidConverter([CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
                 ToGuid(),
                 ToString(),

--- a/src/EFCore/Storage/ValueConversion/StringToNumberConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToNumberConverter.cs
@@ -4,8 +4,6 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -21,12 +19,10 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     facets for the converted data.
         /// </param>
         public StringToNumberConverter(
-            [CanBeNull] ConverterMappingHints? mappingHints = null)
+            [CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
-#nullable disable // https://github.com/dotnet/roslyn/issues/30953
                 ToNumber(),
                 ToString(),
-#nullable enable
                 _defaultHints.With(mappingHints))
         {
         }

--- a/src/EFCore/Storage/ValueConversion/StringToTimeSpanConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToTimeSpanConverter.cs
@@ -5,8 +5,6 @@ using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -21,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public StringToTimeSpanConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
+        public StringToTimeSpanConverter([CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
                 ToTimeSpan(),
                 ToString(),

--- a/src/EFCore/Storage/ValueConversion/TimeSpanToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/TimeSpanToStringConverter.cs
@@ -5,8 +5,6 @@ using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -21,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public TimeSpanToStringConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
+        public TimeSpanToStringConverter([CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
                 ToString(),
                 ToTimeSpan(),

--- a/src/EFCore/Storage/ValueConversion/TimeSpanToTicksConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/TimeSpanToTicksConverter.cs
@@ -4,8 +4,6 @@
 using System;
 using JetBrains.Annotations;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -20,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
-        public TimeSpanToTicksConverter([CanBeNull] ConverterMappingHints? mappingHints = null)
+        public TimeSpanToTicksConverter([CanBeNull] ConverterMappingHints mappingHints = null)
             : base(v => v.Ticks, v => new TimeSpan(v), mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/ValueConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/ValueConverter.cs
@@ -10,8 +10,6 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -40,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         protected ValueConverter(
             [NotNull] LambdaExpression convertToProviderExpression,
             [NotNull] LambdaExpression convertFromProviderExpression,
-            [CanBeNull] ConverterMappingHints? mappingHints = null)
+            [CanBeNull] ConverterMappingHints mappingHints = null)
         {
             Check.NotNull(convertToProviderExpression, nameof(convertToProviderExpression));
             Check.NotNull(convertFromProviderExpression, nameof(convertFromProviderExpression));
@@ -54,13 +52,13 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Gets the function to convert objects when writing data to the store,
         ///     setup to handle nulls, boxing, and non-exact matches of simple types.
         /// </summary>
-        public abstract Func<object?, object?> ConvertToProvider { get; }
+        public abstract Func<object, object> ConvertToProvider { get; }
 
         /// <summary>
         ///     Gets the function to convert objects when reading data from the store,
         ///     setup to handle nulls, boxing, and non-exact matches of simple types.
         /// </summary>
-        public abstract Func<object?, object?> ConvertFromProvider { get; }
+        public abstract Func<object, object> ConvertFromProvider { get; }
 
         /// <summary>
         ///     Gets the expression to convert objects when writing data to the store,
@@ -90,7 +88,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </summary>
-        public virtual ConverterMappingHints? MappingHints { get; }
+        public virtual ConverterMappingHints MappingHints { get; }
 
         /// <summary>
         ///     Checks that the type used with a value converter is supported by that converter and throws if not.
@@ -127,7 +125,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// <param name="secondConverter"> The second converter. </param>
         /// <returns> The composed converter. </returns>
         public virtual ValueConverter ComposeWith(
-            [CanBeNull] ValueConverter? secondConverter)
+            [CanBeNull] ValueConverter secondConverter)
         {
             if (secondConverter == null)
             {

--- a/src/EFCore/Storage/ValueConversion/ValueConverterInfo.cs
+++ b/src/EFCore/Storage/ValueConversion/ValueConverterInfo.cs
@@ -5,8 +5,6 @@ using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -31,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
             [NotNull] Type modelClrType,
             [NotNull] Type providerClrType,
             [NotNull] Func<ValueConverterInfo, ValueConverter> factory,
-            [CanBeNull] ConverterMappingHints? mappingHints = null)
+            [CanBeNull] ConverterMappingHints mappingHints = null)
         {
             _factory = factory;
             Check.NotNull(modelClrType, nameof(modelClrType));
@@ -57,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </summary>
-        public ConverterMappingHints? MappingHints { get; }
+        public ConverterMappingHints MappingHints { get; }
 
         /// <summary>
         ///     Creates an instance of the <see cref="ValueConverter" />.

--- a/src/EFCore/Storage/ValueConversion/ValueConverterSelector.cs
+++ b/src/EFCore/Storage/ValueConversion/ValueConverterSelector.cs
@@ -10,8 +10,6 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -67,7 +65,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// <returns> The converters available. </returns>
         public virtual IEnumerable<ValueConverterInfo> Select(
             Type modelClrType,
-            Type? providerClrType = null)
+            Type providerClrType = null)
         {
             Check.NotNull(modelClrType, nameof(modelClrType));
 
@@ -282,7 +280,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         }
 
         private IEnumerable<ValueConverterInfo> ForChar(
-            Type underlyingModelType, Type? underlyingProviderType)
+            Type underlyingModelType, Type underlyingProviderType)
         {
             if (underlyingProviderType == null
                 || underlyingProviderType == typeof(string))
@@ -303,7 +301,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         }
 
         private IEnumerable<ValueConverterInfo> CharToBytes(
-            Type underlyingModelType, Type? underlyingProviderType)
+            Type underlyingModelType, Type underlyingProviderType)
         {
             if (underlyingProviderType == null
                 || underlyingProviderType == typeof(byte[]))
@@ -315,7 +313,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         }
 
         private IEnumerable<ValueConverterInfo> EnumToStringOrBytes(
-            Type underlyingModelType, Type? underlyingProviderType)
+            Type underlyingModelType, Type underlyingProviderType)
         {
             if (underlyingProviderType == null
                 || underlyingProviderType == typeof(string))
@@ -355,7 +353,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         }
 
         private IEnumerable<ValueConverterInfo> NumberToStringOrBytes(
-            Type underlyingModelType, Type? underlyingProviderType)
+            Type underlyingModelType, Type underlyingProviderType)
         {
             if (underlyingProviderType == null
                 || underlyingProviderType == typeof(string))
@@ -382,9 +380,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 
         private IEnumerable<ValueConverterInfo> FindNumericConventions(
             Type modelType,
-            Type? providerType,
+            Type providerType,
             Type converterType,
-            Func<Type, Type?, IEnumerable<ValueConverterInfo>>? afterPreferred)
+            Func<Type, Type, IEnumerable<ValueConverterInfo>> afterPreferred)
         {
             var usedTypes = new List<Type>
             {
@@ -484,7 +482,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         private IEnumerable<ValueConverterInfo> FindPreferredConversions(
             Type[] candidateTypes,
             Type modelType,
-            Type? providerType,
+            Type providerType,
             Type converterType)
         {
             var underlyingModelType = modelType.UnwrapEnumType();

--- a/src/EFCore/Storage/ValueConversion/ValueConverter`.cs
+++ b/src/EFCore/Storage/ValueConversion/ValueConverter`.cs
@@ -6,8 +6,6 @@ using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -16,8 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
     /// </summary>
     public class ValueConverter<TModel, TProvider> : ValueConverter
     {
-        private Func<object?, object?>? _convertToProvider;
-        private Func<object?, object?>? _convertFromProvider;
+        private Func<object, object> _convertToProvider;
+        private Func<object, object> _convertFromProvider;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="ValueConverter{TModel,TProvider}" /> class.
@@ -31,19 +29,19 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         public ValueConverter(
             [NotNull] Expression<Func<TModel, TProvider>> convertToProviderExpression,
             [NotNull] Expression<Func<TProvider, TModel>> convertFromProviderExpression,
-            [CanBeNull] ConverterMappingHints? mappingHints = null)
+            [CanBeNull] ConverterMappingHints mappingHints = null)
             : base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
         {
             _convertToProvider = SanitizeConverter(convertToProviderExpression);
             _convertFromProvider = SanitizeConverter(convertFromProviderExpression);
         }
 
-        private static Func<object?, object?> SanitizeConverter<TIn, TOut>(Expression<Func<TIn, TOut>> convertExpression)
+        private static Func<object, object> SanitizeConverter<TIn, TOut>(Expression<Func<TIn, TOut>> convertExpression)
         {
             var compiled = convertExpression.Compile();
 
             return v => v == null
-                ? (object?)null
+                ? (object)null
                 : compiled(Sanitize<TIn>(v));
         }
 
@@ -60,7 +58,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Gets the function to convert objects when writing data to the store,
         ///     setup to handle nulls, boxing, and non-exact matches of simple types.
         /// </summary>
-        public override Func<object?, object?> ConvertToProvider
+        public override Func<object, object> ConvertToProvider
             => NonCapturingLazyInitializer.EnsureInitialized(
                 ref _convertToProvider, this, c => SanitizeConverter(c.ConvertToProviderExpression));
 
@@ -68,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Gets the function to convert objects when reading data from the store,
         ///     setup to handle nulls, boxing, and non-exact matches of simple types.
         /// </summary>
-        public override Func<object?, object?> ConvertFromProvider
+        public override Func<object, object> ConvertFromProvider
             => NonCapturingLazyInitializer.EnsureInitialized(
                 ref _convertFromProvider, this, c => SanitizeConverter(c.ConvertFromProviderExpression));
 

--- a/src/Shared/Check.cs
+++ b/src/Shared/Check.cs
@@ -8,10 +8,6 @@ using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
-// Disable nullability checks until all projects using this file are converted to perform nullability checks
-// themselves
-#nullable disable
-
 namespace Microsoft.EntityFrameworkCore.Utilities
 {
     [DebuggerStepThrough]

--- a/src/Shared/SharedTypeExtensions.cs
+++ b/src/Shared/SharedTypeExtensions.cs
@@ -7,8 +7,6 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-#nullable enable
-
 // ReSharper disable once CheckNamespace
 namespace System
 {
@@ -149,11 +147,11 @@ namespace System
             return sequenceType;
         }
 
-        public static Type? TryGetSequenceType(this Type type)
+        public static Type TryGetSequenceType(this Type type)
             => type.TryGetElementType(typeof(IEnumerable<>))
                ?? type.TryGetElementType(typeof(IAsyncEnumerable<>));
 
-        public static Type? TryGetElementType(this Type type, Type interfaceOrBaseType)
+        public static Type TryGetElementType(this Type type, Type interfaceOrBaseType)
         {
             if (type.GetTypeInfo().IsGenericTypeDefinition)
             {
@@ -162,7 +160,7 @@ namespace System
 
             var types = GetGenericTypeImplementations(type, interfaceOrBaseType);
 
-            Type? singleImplementation = null;
+            Type singleImplementation = null;
             foreach (var impelementation in types)
             {
                 if (singleImplementation == null)
@@ -299,7 +297,7 @@ namespace System
 #pragma warning restore IDE0034 // Simplify 'default' expression
         };
 
-        public static object? GetDefaultValue(this Type type)
+        public static object GetDefaultValue(this Type type)
         {
             if (!type.GetTypeInfo().IsValueType)
             {


### PR DESCRIPTION
Reverts #14569, which added C# 8 null awareness to some part of the codebase.

Fun fact: it is much quicker to go from a null-annotated codebase to a null-oblivious than the other way around. Bye bye [NullableAttribute], we hardly knew ya.