### PR TITLE
Always use a MemberInfo for navigations if there is one matching the name

### DIFF
--- a/src/EFCore.Relational/Metadata/Internal/ConstraintNamer.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ConstraintNamer.cs
@@ -58,7 +58,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var sharedTablePrincipalPrimaryKeyProperty = key.Properties[0].FindSharedTableRootPrimaryKeyProperty();
             if (sharedTablePrincipalPrimaryKeyProperty != null)
             {
-                return sharedTablePrincipalPrimaryKeyProperty.GetContainingPrimaryKey().Relational().Name;
+                return sharedTablePrincipalPrimaryKeyProperty.FindContainingPrimaryKey().Relational().Name;
             }
 
             var builder = new StringBuilder();

--- a/src/EFCore.Relational/Metadata/Internal/RelationalPropertyExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalPropertyExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public static IForeignKey FindSharedTableLink([NotNull] this IProperty property)
         {
-            var pk = property.GetContainingPrimaryKey();
+            var pk = property.FindContainingPrimaryKey();
             if (pk == null)
             {
                 return null;

--- a/src/EFCore.SqlServer/Metadata/SqlServerKeyAnnotations.cs
+++ b/src/EFCore.SqlServer/Metadata/SqlServerKeyAnnotations.cs
@@ -51,7 +51,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                 var sharedTablePrincipalPrimaryKeyProperty = Key.Properties[0].FindSharedTableRootPrimaryKeyProperty();
                 if (sharedTablePrincipalPrimaryKeyProperty != null)
                 {
-                    return sharedTablePrincipalPrimaryKeyProperty.GetContainingPrimaryKey().SqlServer().IsClustered;
+                    return sharedTablePrincipalPrimaryKeyProperty.FindContainingPrimaryKey().SqlServer().IsClustered;
                 }
 
                 return null;

--- a/src/EFCore/Extensions/ConventionPropertyExtensions.cs
+++ b/src/EFCore/Extensions/ConventionPropertyExtensions.cs
@@ -133,8 +133,8 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns>
         ///     The primary that use this property, or null if it is not part of the primary key.
         /// </returns>
-        public static IConventionKey GetContainingPrimaryKey([NotNull] this IConventionProperty property)
-            => (IConventionKey)((IProperty)property).GetContainingPrimaryKey();
+        public static IConventionKey FindContainingPrimaryKey([NotNull] this IConventionProperty property)
+            => (IConventionKey)((IProperty)property).FindContainingPrimaryKey();
 
         /// <summary>
         ///     Gets all primary or alternate keys that use this property (including composite keys in which this property

--- a/src/EFCore/Extensions/MutablePropertyExtensions.cs
+++ b/src/EFCore/Extensions/MutablePropertyExtensions.cs
@@ -103,10 +103,22 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="property"> The property to get primary key for. </param>
         /// <returns>
-        ///     The primary that use this property, or null if it is not part of the primary key.
+        ///     The primary that use this property, or <c>null</c> if it is not part of the primary key.
         /// </returns>
+        [Obsolete("Use FindContainingPrimaryKey()")]
         public static IMutableKey GetContainingPrimaryKey([NotNull] this IMutableProperty property)
-            => (IMutableKey)((IProperty)property).GetContainingPrimaryKey();
+            => property.FindContainingPrimaryKey();
+
+        /// <summary>
+        ///     Gets the primary key that uses this property (including a composite primary key in which this property
+        ///     is included).
+        /// </summary>
+        /// <param name="property"> The property to get primary key for. </param>
+        /// <returns>
+        ///     The primary that use this property, or <c>null</c> if it is not part of the primary key.
+        /// </returns>
+        public static IMutableKey FindContainingPrimaryKey([NotNull] this IMutableProperty property)
+            => (IMutableKey)((IProperty)property).FindContainingPrimaryKey();
 
         /// <summary>
         ///     Gets all primary or alternate keys that use this property (including composite keys in which this property

--- a/src/EFCore/Extensions/PropertyExtensions.cs
+++ b/src/EFCore/Extensions/PropertyExtensions.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Internal;
@@ -140,7 +139,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     <c>true</c> if the property is used as the primary key, otherwise <c>false</c>.
         /// </returns>
         public static bool IsPrimaryKey([NotNull] this IProperty property)
-            => GetContainingPrimaryKey(property) != null;
+            => FindContainingPrimaryKey(property) != null;
 
         /// <summary>
         ///     Gets a value indicating whether this property is used as part of a primary or alternate key
@@ -185,7 +184,19 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns>
         ///     The primary that use this property, or <c>null</c> if it is not part of the primary key.
         /// </returns>
+        [Obsolete("Use FindContainingPrimaryKey()")]
         public static IKey GetContainingPrimaryKey([NotNull] this IProperty property)
+            => property.FindContainingPrimaryKey();
+
+        /// <summary>
+        ///     Gets the primary key that uses this property (including a composite primary key in which this property
+        ///     is included).
+        /// </summary>
+        /// <param name="property"> The property to get primary key for. </param>
+        /// <returns>
+        ///     The primary that use this property, or <c>null</c> if it is not part of the primary key.
+        /// </returns>
+        public static IKey FindContainingPrimaryKey([NotNull] this IProperty property)
             => Check.NotNull(property, nameof(property)).AsProperty().PrimaryKey;
 
         /// <summary>

--- a/src/EFCore/Metadata/Builders/CollectionNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/CollectionNavigationBuilder.cs
@@ -164,12 +164,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
 
             return referenceName != null
                    && RelatedEntityType != foreignKey.DeclaringEntityType
-                ? reference.Property == null && CollectionProperty == null
+                ? reference.MemberInfo == null && CollectionProperty == null
                     ? Builder.Navigations(reference.Name, CollectionName, DeclaringEntityType, RelatedEntityType, ConfigurationSource.Explicit)
-                    : Builder.Navigations(reference.Property, CollectionProperty, DeclaringEntityType, RelatedEntityType, ConfigurationSource.Explicit)
-                : reference.Property == null
+                    : Builder.Navigations(reference.MemberInfo, CollectionProperty, DeclaringEntityType, RelatedEntityType, ConfigurationSource.Explicit)
+                : reference.MemberInfo == null
                     ? Builder.DependentToPrincipal(reference.Name, ConfigurationSource.Explicit)
-                    : Builder.DependentToPrincipal(reference.Property, ConfigurationSource.Explicit);
+                    : Builder.DependentToPrincipal(reference.MemberInfo, ConfigurationSource.Explicit);
         }
 
         #region Hidden System.Object members

--- a/src/EFCore/Metadata/Builders/EntityTypeBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/EntityTypeBuilder`.cs
@@ -327,9 +327,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             InternalRelationshipBuilder relationship;
             using (var batch = Builder.Metadata.Model.ConventionDispatcher.StartBatch())
             {
-                relationship = navigation.Property == null
+                relationship = navigation.MemberInfo == null
                     ? Builder.Owns(typeof(TRelatedEntity), navigation.Name, ConfigurationSource.Explicit)
-                    : Builder.Owns(typeof(TRelatedEntity), (PropertyInfo)navigation.Property, ConfigurationSource.Explicit);
+                    : Builder.Owns(typeof(TRelatedEntity), (PropertyInfo)navigation.MemberInfo, ConfigurationSource.Explicit);
                 relationship.IsUnique(true, ConfigurationSource.Explicit);
                 relationship = batch.Run(relationship.Metadata).Builder;
             }
@@ -473,9 +473,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             InternalRelationshipBuilder relationship;
             using (var batch = Builder.Metadata.Model.ConventionDispatcher.StartBatch())
             {
-                relationship = navigation.Property == null
+                relationship = navigation.MemberInfo == null
                     ? Builder.Owns(typeof(TRelatedEntity), navigation.Name, ConfigurationSource.Explicit)
-                    : Builder.Owns(typeof(TRelatedEntity), (PropertyInfo)navigation.Property, ConfigurationSource.Explicit);
+                    : Builder.Owns(typeof(TRelatedEntity), (PropertyInfo)navigation.MemberInfo, ConfigurationSource.Explicit);
                 relationship.IsUnique(false, ConfigurationSource.Explicit);
                 relationship = batch.Run(relationship.Metadata).Builder;
             }

--- a/src/EFCore/Metadata/Builders/OwnedNavigationBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/OwnedNavigationBuilder`.cs
@@ -316,9 +316,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             InternalRelationshipBuilder relationship;
             using (var batch = DependentEntityType.Model.ConventionDispatcher.StartBatch())
             {
-                relationship = navigation.Property == null
+                relationship = navigation.MemberInfo == null
                     ? DependentEntityType.Builder.Owns(typeof(TNewDependentEntity), navigation.Name, ConfigurationSource.Explicit)
-                    : DependentEntityType.Builder.Owns(typeof(TNewDependentEntity), (PropertyInfo)navigation.Property, ConfigurationSource.Explicit);
+                    : DependentEntityType.Builder.Owns(typeof(TNewDependentEntity), (PropertyInfo)navigation.MemberInfo, ConfigurationSource.Explicit);
                 relationship.IsUnique(true, ConfigurationSource.Explicit);
                 relationship = batch.Run(relationship.Metadata).Builder;
             }
@@ -468,9 +468,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             InternalRelationshipBuilder relationship;
             using (var batch = DependentEntityType.Model.ConventionDispatcher.StartBatch())
             {
-                relationship = navigation.Property == null
+                relationship = navigation.MemberInfo == null
                     ? DependentEntityType.Builder.Owns(typeof(TNewRelatedEntity), navigation.Name, ConfigurationSource.Explicit)
-                    : DependentEntityType.Builder.Owns(typeof(TNewRelatedEntity), (PropertyInfo)navigation.Property, ConfigurationSource.Explicit);
+                    : DependentEntityType.Builder.Owns(typeof(TNewRelatedEntity), (PropertyInfo)navigation.MemberInfo, ConfigurationSource.Explicit);
                 relationship.IsUnique(false, ConfigurationSource.Explicit);
                 relationship = batch.Run(relationship.Metadata).Builder;
             }

--- a/src/EFCore/Metadata/Builders/ReferenceNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/ReferenceNavigationBuilder.cs
@@ -162,11 +162,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             }
 
             return RelatedEntityType != foreignKey.PrincipalEntityType
-                ? collection.Property == null && ReferenceProperty == null
+                ? collection.MemberInfo == null && ReferenceProperty == null
                     ? builder.Navigations(ReferenceName, collection.Name, RelatedEntityType, DeclaringEntityType, ConfigurationSource.Explicit)
-                    : builder.Navigations(ReferenceProperty, collection.Property, RelatedEntityType, DeclaringEntityType, ConfigurationSource.Explicit)
-                : collection.Property != null
-                    ? builder.PrincipalToDependent(collection.Property, ConfigurationSource.Explicit)
+                    : builder.Navigations(ReferenceProperty, collection.MemberInfo, RelatedEntityType, DeclaringEntityType, ConfigurationSource.Explicit)
+                : collection.MemberInfo != null
+                    ? builder.PrincipalToDependent(collection.MemberInfo, ConfigurationSource.Explicit)
                     : builder.PrincipalToDependent(collection.Name, ConfigurationSource.Explicit);
         }
 
@@ -252,7 +252,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                     ThrowForConflictingNavigation(foreignKey, referenceName, pointsToPrincipal);
                 }
 
-                var referenceProperty = reference.Property;
+                var referenceProperty = reference.MemberInfo;
                 if (referenceName != null
                     && pointsToPrincipal
                     && RelatedEntityType != foreignKey.DeclaringEntityType)

--- a/src/EFCore/Metadata/Conventions/Internal/BackingFieldConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/BackingFieldConvention.cs
@@ -8,7 +8,6 @@ using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
@@ -69,7 +68,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 {
                     var fieldInfo = TryMatchFieldName(
                         propertyBase.DeclaringType.Model, type, propertyBase.ClrType, propertyBase.Name);
-                    if (fieldInfo != null)
+                    if (fieldInfo != null
+                        && (propertyBase.PropertyInfo != null || propertyBase.Name == fieldInfo.GetSimpleMemberName()))
                     {
                         propertyBase.SetField(fieldInfo, ConfigurationSource.Convention);
                         return;

--- a/src/EFCore/Metadata/Conventions/Internal/ServicePropertyDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ServicePropertyDiscoveryConvention.cs
@@ -151,10 +151,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 }
 
                 var otherMember = duplicateServiceProperties.First();
-                var factory = _parameterBindingFactories.FindFactory(type, otherMember.GetSimpleMemberName());
+                var otherName = otherMember.GetSimpleMemberName();
+                var factory = _parameterBindingFactories.FindFactory(type, otherName);
                 entityType.Builder.ServiceProperty(otherMember, ConfigurationSource.Convention)?.SetParameterBinding(
-                    (ServiceParameterBinding)factory.Bind(entityType, type, otherMember.GetSimpleMemberName()),
-                    ConfigurationSource.Convention);
+                    (ServiceParameterBinding)factory.Bind(entityType, type, otherName), ConfigurationSource.Convention);
                 duplicateMap.Remove(type);
                 if (duplicateMap.Count == 0)
                 {

--- a/src/EFCore/Metadata/Internal/EntityMaterializerSource.cs
+++ b/src/EFCore/Metadata/Internal/EntityMaterializerSource.cs
@@ -137,7 +137,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         constructorExpression)
                 };
 
-            var indexerPropertyInfo = entityType.EFIndexerProperty();
+            var indexerPropertyInfo = entityType.FindIndexerProperty();
 
             foreach (var property in properties)
             {

--- a/src/EFCore/Metadata/Internal/ForeignKey.cs
+++ b/src/EFCore/Metadata/Internal/ForeignKey.cs
@@ -314,7 +314,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             Navigation navigation = null;
-            var property = propertyIdentity?.Property;
+            var property = propertyIdentity?.MemberInfo;
             if (property != null)
             {
                 navigation = pointsToPrincipal

--- a/src/EFCore/Metadata/Internal/IndexedPropertyGetterFactory.cs
+++ b/src/EFCore/Metadata/Internal/IndexedPropertyGetterFactory.cs
@@ -30,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (!propertyInfo.IsEFIndexerProperty())
             {
                 throw new InvalidOperationException(
-                    CoreStrings.NoIndexer(propertyBase.Name, propertyBase.DeclaringType.DisplayName()));
+                    CoreStrings.NoIndexer(propertyBase.DeclaringType.DisplayName()));
             }
 
             var entityParameter = Expression.Parameter(typeof(TEntity), "entity");

--- a/src/EFCore/Metadata/Internal/IndexedPropertySetterFactory.cs
+++ b/src/EFCore/Metadata/Internal/IndexedPropertySetterFactory.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (!propertyInfo.IsEFIndexerProperty())
             {
                 throw new InvalidOperationException(
-                    CoreStrings.NoIndexer(propertyBase.Name, propertyBase.DeclaringType.DisplayName()));
+                    CoreStrings.NoIndexer(propertyBase.DeclaringType.DisplayName()));
             }
 
             var entityParameter = Expression.Parameter(typeof(TEntity), "entity");

--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -1879,7 +1879,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 navigationToTarget != null
                 || inverseNavigation != null);
 
-            var navigationProperty = navigationToTarget?.Property;
+            var navigationProperty = navigationToTarget?.MemberInfo;
             if (inverseNavigation == null
                 && navigationProperty?.GetMemberType().GetTypeInfo().IsAssignableFrom(
                     targetEntityTypeBuilder.Metadata.ClrType.GetTypeInfo()) == false)
@@ -2022,7 +2022,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         navigationToTarget = inverseNavigation;
                         inverseNavigation = navigation;
 
-                        navigationProperty = navigationToTarget?.Property;
+                        navigationProperty = navigationToTarget?.MemberInfo;
 
                         newRelationship = targetEntityTypeBuilder.CreateForeignKey(
                             this,
@@ -2047,7 +2047,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     }
                 }
 
-                var inverseProperty = inverseNavigation?.Property;
+                var inverseProperty = inverseNavigation?.MemberInfo;
                 if (inverseNavigation == null)
                 {
                     relationship = navigationProperty != null

--- a/src/EFCore/Metadata/Internal/InternalRelationshipBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalRelationshipBuilder.cs
@@ -167,7 +167,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             var navigationToPrincipalName = navigationToPrincipal?.Name;
             if (navigationToPrincipalName != null
-                && navigationToPrincipal.Value.Property == null
+                && navigationToPrincipal.Value.MemberInfo == null
                 && dependentEntityType.HasClrType())
             {
                 var navigationProperty = Navigation.GetClrMember(navigationToPrincipalName, dependentEntityType, principalEntityType, shouldThrow);
@@ -179,7 +179,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             var navigationToDependentName = navigationToDependent?.Name;
             if (navigationToDependentName != null
-                && navigationToDependent.Value.Property == null
+                && navigationToDependent.Value.MemberInfo == null
                 && principalEntityType.HasClrType())
             {
                 var navigationProperty = Navigation.GetClrMember(navigationToDependentName, principalEntityType, dependentEntityType, shouldThrow);
@@ -318,7 +318,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                             Metadata.HasPrincipalToDependent((string)null, configurationSource.Value);
                         }
 
-                        var navigationProperty = navigationToPrincipal.Value.Property;
+                        var navigationProperty = navigationToPrincipal.Value.MemberInfo;
                         if (navigationToPrincipalName != null)
                         {
                             Metadata.DeclaringEntityType.Unignore(navigationToPrincipalName);
@@ -343,7 +343,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
                     if (navigationToDependent != null)
                     {
-                        var navigationProperty = navigationToDependent.Value.Property;
+                        var navigationProperty = navigationToDependent.Value.MemberInfo;
                         if (navigationToDependentName != null)
                         {
                             Metadata.PrincipalEntityType.Unignore(navigationToDependentName);
@@ -594,8 +594,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
             }
 
-            var navigationToPrincipalProperty = navigationToPrincipal?.Property;
-            var navigationToDependentProperty = navigationToDependent?.Property;
+            var navigationToPrincipalProperty = navigationToPrincipal?.MemberInfo;
+            var navigationToDependentProperty = navigationToDependent?.MemberInfo;
 
             // ReSharper disable once InlineOutVariableDeclaration
             bool? invertedShouldBeUnique = null;
@@ -1749,18 +1749,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Check.NotNull(dependentEntityTypeBuilder, nameof(dependentEntityTypeBuilder));
             Debug.Assert(
                 navigationToPrincipal?.Name == null
-                || navigationToPrincipal.Value.Property != null
+                || navigationToPrincipal.Value.MemberInfo != null
                 || !dependentEntityTypeBuilder.Metadata.HasClrType());
             Debug.Assert(
                 navigationToDependent?.Name == null
-                || navigationToDependent.Value.Property != null
+                || navigationToDependent.Value.MemberInfo != null
                 || !principalEntityTypeBuilder.Metadata.HasClrType());
             Debug.Assert(
                 AreCompatible(
                     principalEntityTypeBuilder.Metadata,
                     dependentEntityTypeBuilder.Metadata,
-                    navigationToPrincipal?.Property,
-                    navigationToDependent?.Property,
+                    navigationToPrincipal?.MemberInfo,
+                    navigationToDependent?.MemberInfo,
                     dependentProperties?.Count > 0 ? dependentProperties : null,
                     principalProperties?.Count > 0 ? principalProperties : null,
                     isUnique,

--- a/src/EFCore/Metadata/Internal/PropertyIdentity.cs
+++ b/src/EFCore/Metadata/Internal/PropertyIdentity.cs
@@ -85,14 +85,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public string Name
         {
-            [DebuggerStepThrough] get => Property?.GetSimpleMemberName() ?? (string)_nameOrProperty;
+            [DebuggerStepThrough] get => MemberInfo?.GetSimpleMemberName() ?? (string)_nameOrProperty;
         }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public MemberInfo Property
+        public MemberInfo MemberInfo
         {
             [DebuggerStepThrough] get => _nameOrProperty as MemberInfo;
         }

--- a/src/EFCore/Metadata/Internal/TypeBaseExtensions.cs
+++ b/src/EFCore/Metadata/Internal/TypeBaseExtensions.cs
@@ -1,10 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
@@ -26,14 +28,26 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public static PropertyInfo EFIndexerProperty([NotNull] this ITypeBase type)
-        {
-            var runtimeProperties = type is TypeBase typeBase
-                ? typeBase.GetRuntimeProperties().Values // better perf if we've already computed them once
-                : type.ClrType?.GetRuntimeProperties();
+        public static PropertyInfo FindIndexerProperty([NotNull] this ITypeBase type)
+            => (type is TypeBase typeBase
+                ? typeBase.GetRuntimeProperties().Values
+                : type.ClrType?.GetRuntimeProperties())
+                    ?.FirstOrDefault(p => p.IsEFIndexerProperty());
 
-            // find the indexer with single argument of type string which returns an object
-            return runtimeProperties?.FirstOrDefault(p => p.IsEFIndexerProperty());
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static PropertyInfo GetIndexerProperty([NotNull] this ITypeBase type)
+        {
+            var indexerProperty = type.FindIndexerProperty();
+            if (indexerProperty == null)
+            {
+                throw new InvalidOperationException(CoreStrings.NoIndexer(type.DisplayName()));
+            }
+
+            return indexerProperty;
         }
     }
 }

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -1885,12 +1885,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 navigation, principalType, dependentType);
 
         /// <summary>
-        ///     Property '{property}' on entity type '{entity}' was created as an indexed property. But there is no public indexer on '{entity}' taking a single argument of type 'string' and returning type 'object'.
+        ///     An indexed property was added to entity type '{entity}'. But there is no public indexer on '{entity}' taking a single argument of type 'string' and returning type 'object'.
         /// </summary>
-        public static string NoIndexer([CanBeNull] object property, [CanBeNull] object entity)
+        public static string NoIndexer([CanBeNull] object entity)
             => string.Format(
-                GetString("NoIndexer", nameof(property), nameof(entity)),
-                property, entity);
+                GetString("NoIndexer", nameof(entity)),
+                entity);
 
         /// <summary>
         ///     cannot bind '{failedBinds}' in '{parameters}'
@@ -1995,6 +1995,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => string.Format(
                 GetString("TrackingTypeMismatch", nameof(runtimeEntityType), nameof(entityType)),
                 runtimeEntityType, entityType);
+
+        /// <summary>
+        ///     The specified field '{field}' cannot be used for the property '{entityType}.{property}' because it does not match the property name.
+        /// </summary>
+        public static string FieldNameMismatch([CanBeNull] object field, [CanBeNull] object entityType, [CanBeNull] object property)
+            => string.Format(
+                GetString("FieldNameMismatch", nameof(field), nameof(entityType), nameof(property)),
+                field, entityType, property);
 
         private static string GetString(string name, params string[] formatterNames)
         {

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -1076,7 +1076,7 @@
     <value>The ForeignKeyAttribute for the navigation '{navigation}' cannot be specified on the entity type '{principalType}' since it represents a one-to-many relationship. Move the ForeignKeyAttribute to a property on '{dependentType}'.</value>
   </data>
   <data name="NoIndexer" xml:space="preserve">
-    <value>Property '{property}' on entity type '{entity}' was created as an indexed property. But there is no public indexer on '{entity}' taking a single argument of type 'string' and returning type 'object'.</value>
+    <value>An indexed property was added to entity type '{entity}'. But there is no public indexer on '{entity}' taking a single argument of type 'string' and returning type 'object'.</value>
   </data>
   <data name="ConstructorBindingFailed" xml:space="preserve">
     <value>cannot bind '{failedBinds}' in '{parameters}'</value>
@@ -1120,5 +1120,8 @@
   </data>
   <data name="TrackingTypeMismatch" xml:space="preserve">
     <value>The instance of entity type '{runtimeEntityType}' cannot be tracked as the entity type '{entityType}' because they are not in the same hierarchy.</value>
+  </data>
+  <data name="FieldNameMismatch" xml:space="preserve">
+    <value>The specified field '{field}' cannot be used for the property '{entityType}.{property}' because it does not match the property name.</value>
   </data>
 </root>

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsWeakQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsWeakQueryFixtureBase.cs
@@ -42,9 +42,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var batch = ((Model)modelBuilder.Model).ConventionDispatcher.StartBatch())
             {
                 level2Fk = (ForeignKey)level2.AddForeignKey(level2.FindProperty(nameof(Level2.Id)), level1.FindPrimaryKey(), level1);
+                level2Fk.IsUnique = true;
                 level2Fk.HasPrincipalToDependent(nameof(Level1.OneToOne_Required_PK1));
                 level2Fk.HasDependentToPrincipal(nameof(Level2.OneToOne_Required_PK_Inverse2));
-                level2Fk.IsUnique = true;
                 level2Fk.DeleteBehavior = DeleteBehavior.Restrict;
                 level2Fk = batch.Run(level2Fk);
             }
@@ -135,9 +135,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var batch = ((Model)level2.Model).ConventionDispatcher.StartBatch())
             {
                 level3Fk = (ForeignKey)level3.AddForeignKey(level3.FindProperty(nameof(Level3.Id)), level2.FindPrimaryKey(), level2);
+                level3Fk.IsUnique = true;
                 level3Fk.HasPrincipalToDependent(nameof(Level2.OneToOne_Required_PK2));
                 level3Fk.HasDependentToPrincipal(nameof(Level3.OneToOne_Required_PK_Inverse3));
-                level3Fk.IsUnique = true;
                 level3Fk.DeleteBehavior = DeleteBehavior.Restrict;
                 level3Fk = batch.Run(level3Fk);
             }
@@ -186,9 +186,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var batch = ((Model)level3.Model).ConventionDispatcher.StartBatch())
             {
                 level4Fk = (ForeignKey)level4.AddForeignKey(level4.FindProperty(nameof(Level4.Id)), level3.FindPrimaryKey(), level3);
+                level4Fk.IsUnique = true;
                 level4Fk.HasPrincipalToDependent(nameof(Level3.OneToOne_Required_PK3));
                 level4Fk.HasDependentToPrincipal(nameof(Level4.OneToOne_Required_PK_Inverse4));
-                level4Fk.IsUnique = true;
                 level4Fk.DeleteBehavior = DeleteBehavior.Restrict;
                 level4Fk = batch.Run(level4Fk);
             }

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/BackingFieldConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/BackingFieldConventionTest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
@@ -44,11 +43,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             => FieldMatchTest<TheDarkSideOfTheMoon>("Time", "_time");
 
         [Fact]
-        public void Underscpre_camel_case_matching_field_is_not_used_if_type_is_not_compatible()
+        public void Underscore_camel_case_matching_field_is_not_used_if_type_is_not_compatible()
             => FieldMatchTest<TheDarkSideOfTheMoon>("TheGreatGigInTheSky", "_TheGreatGigInTheSky");
 
         [Fact]
-        public void Underscpre_matching_field_is_used_as_next_preference()
+        public void Underscore_matching_field_is_used_as_next_preference()
             => FieldMatchTest<TheDarkSideOfTheMoon>("Money", "_Money");
 
         [Fact]
@@ -56,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             => FieldMatchTest<TheDarkSideOfTheMoon>("UsAndThem", "m_usAndThem");
 
         [Fact]
-        public void M_underscpre_camel_case_matching_field_is_used_as_next_preference()
+        public void M_Underscore_camel_case_matching_field_is_used_as_next_preference()
             => FieldMatchTest<TheDarkSideOfTheMoon>("AnyColourYouLike", "m_anyColourYouLike");
 
         [Fact]
@@ -82,40 +81,40 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             => FieldMatchTest<TheDarkerSideOfTheMoon>("IsThereAnybodyOutThere", "IsThereAnybodyOutThere");
 
         [Fact]
-        public void Camel_case_matching_field_is_used_as_next_preference_for_field_only()
-            => FieldMatchTest<TheDarkerSideOfTheMoon>("Breathe", "breathe");
+        public void Camel_case_matching_field_is_not_used_as_next_preference_for_field_only()
+            => FieldMatchTest<TheDarkerSideOfTheMoon>("Breathe", null);
 
         [Fact]
         public void Camel_case_matching_field_is_not_used_if_type_is_not_compatible_for_field_only()
-            => FieldMatchTest<TheDarkerSideOfTheMoon>("OnTheRun", "_onTheRun");
+            => FieldMatchTest<TheDarkerSideOfTheMoon>("OnTheRun", null);
 
         [Fact]
-        public void Underscore_camel_case_matching_field_is_used_as_next_preference_for_field_only()
-            => FieldMatchTest<TheDarkerSideOfTheMoon>("Time", "_time");
+        public void Underscore_camel_case_matching_field_is_not_used_as_next_preference_for_field_only()
+            => FieldMatchTest<TheDarkerSideOfTheMoon>("Time", null);
 
         [Fact]
         public void Underscpre_camel_case_matching_field_is_not_used_if_type_is_not_compatible_for_field_only()
-            => FieldMatchTest<TheDarkerSideOfTheMoon>("TheGreatGigInTheSky", "_TheGreatGigInTheSky");
+            => FieldMatchTest<TheDarkerSideOfTheMoon>("TheGreatGigInTheSky", null);
 
         [Fact]
-        public void Underscpre_matching_field_is_used_as_next_preference_for_field_only()
-            => FieldMatchTest<TheDarkerSideOfTheMoon>("Money", "_Money");
+        public void Underscpre_matching_field_is_not_used_as_next_preference_for_field_only()
+            => FieldMatchTest<TheDarkerSideOfTheMoon>("Money", null);
 
         [Fact]
         public void Underscore_matching_field_is_not_used_if_type_is_not_compatible_for_field_only()
-            => FieldMatchTest<TheDarkerSideOfTheMoon>("UsAndThem", "m_usAndThem");
+            => FieldMatchTest<TheDarkerSideOfTheMoon>("UsAndThem", null);
 
         [Fact]
-        public void M_underscpre_camel_case_matching_field_is_used_as_next_preference_for_field_only()
-            => FieldMatchTest<TheDarkerSideOfTheMoon>("AnyColourYouLike", "m_anyColourYouLike");
+        public void M_underscpre_camel_case_matching_field_is_not_used_as_next_preference_for_field_only()
+            => FieldMatchTest<TheDarkerSideOfTheMoon>("AnyColourYouLike", null);
 
         [Fact]
         public void M_underscore_camel_case_matching_field_is_not_used_if_type_is_not_compatible_for_field_only()
-            => FieldMatchTest<TheDarkerSideOfTheMoon>("BrainDamage", "m_BrainDamage");
+            => FieldMatchTest<TheDarkerSideOfTheMoon>("BrainDamage", null);
 
         [Fact]
-        public void M_underscore_matching_field_is_used_as_next_preference_for_field_only()
-            => FieldMatchTest<TheDarkerSideOfTheMoon>("Eclipse", "m_Eclipse");
+        public void M_underscore_matching_field_is_not_used_as_next_preference_for_field_only()
+            => FieldMatchTest<TheDarkerSideOfTheMoon>("Eclipse", null);
 
         [Fact]
         public void M_underscore_matching_field_is_not_used_if_type_is_not_compatible_for_field_only()
@@ -327,7 +326,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 set { m_Eclipse = value; }
             }
         }
-
         private class TheDarkerSideOfTheMoon
         {
             private readonly string m_SpeakToMe;

--- a/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
@@ -902,12 +902,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var derivedEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
             derivedEntityBuilder.HasBaseType(entityBuilder.Metadata, ConfigurationSource.Convention);
 
-Assert.Equal(
-                CoreStrings.DerivedEntityTypeKey(typeof(SpecialOrder).Name, typeof(Order).Name),
-                Assert.Throws<InvalidOperationException>(
-                    () =>
-                        derivedEntityBuilder.HasKey(
-                            new[] { Order.IdProperty.Name, Order.CustomerIdProperty.Name }, ConfigurationSource.DataAnnotation)).Message);
+            Assert.Equal(CoreStrings.DerivedEntityTypeKey(typeof(SpecialOrder).Name, typeof(Order).Name),
+                         Assert.Throws<InvalidOperationException>(() =>
+                             derivedEntityBuilder.HasKey(
+                                 new[] { Order.IdProperty.Name, Order.CustomerIdProperty.Name }, ConfigurationSource.DataAnnotation)).Message);
         }
 
         [Fact]

--- a/test/EFCore.Tests/ModelBuilding/OneToOneTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OneToOneTestBase.cs
@@ -3932,11 +3932,11 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 modelBuilder.Ignore<Alpha>();
 
                 modelBuilder.Entity<Quarks>(
-                    b => b.HasOne<Beta>().WithOne().HasForeignKey<Quarks>("ForUp").IsRequired());
+                    b => b.HasOne<Beta>().WithOne().HasForeignKey<Quarks>("_forUp").IsRequired());
 
                 var fkProperty = modelBuilder.Model.FindEntityType(typeof(Quarks)).GetForeignKeys().Single().Properties.Single();
-                Assert.Equal("ForUp", fkProperty.Name);
-                Assert.Equal(typeof(int?), fkProperty.ClrType);
+                Assert.Equal("_forUp", fkProperty.Name);
+                Assert.Equal(typeof(int), fkProperty.ClrType);
                 Assert.Equal("_forUp", fkProperty.FieldInfo.Name);
             }
 


### PR DESCRIPTION
Throw an exception when calling `SetField` would change the shadowness of a property or the name of the identifying `MemberInfo`.
Rename `GetContainingPrimaryKey` to `FindContainingPrimaryKey`
Rename `PropertyIdentity.Property` to `MemberInfo`

Part of #214