### PR TITLE
Skipping more tests that were missed in previous chekin

### DIFF
--- a/test/EFCore.InMemory.FunctionalTests/GraphUpdatesInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/GraphUpdatesInMemoryTest.cs
@@ -8,7 +8,8 @@ using Microsoft.EntityFrameworkCore.TestUtilities;
 
 namespace Microsoft.EntityFrameworkCore
 {
-    public class GraphUpdatesInMemoryTest
+    // issue #15318
+    internal class GraphUpdatesInMemoryTest
         : GraphUpdatesTestBase<GraphUpdatesInMemoryTest.GraphUpdatesInMemoryFixture>
     {
         public GraphUpdatesInMemoryTest(GraphUpdatesInMemoryFixture fixture)

--- a/test/EFCore.InMemory.FunctionalTests/LoadInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/LoadInMemoryTest.cs
@@ -5,7 +5,8 @@ using Microsoft.EntityFrameworkCore.TestUtilities;
 
 namespace Microsoft.EntityFrameworkCore
 {
-    public class LoadInMemoryTest : LoadTestBase<LoadInMemoryTest.LoadInMemoryFixture>
+    //issue #15318
+    internal class LoadInMemoryTest : LoadTestBase<LoadInMemoryTest.LoadInMemoryFixture>
     {
         public LoadInMemoryTest(LoadInMemoryFixture fixture)
             : base(fixture)

--- a/test/EFCore.InMemory.FunctionalTests/ProxyGraphUpdatesInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/ProxyGraphUpdatesInMemoryTest.cs
@@ -114,7 +114,8 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        public class LazyLoading : ProxyGraphUpdatesInMemoryTestBase<LazyLoading.ProxyGraphUpdatesWithLazyLoadingInMemoryFixture>
+        // issue #15318
+        internal class LazyLoading : ProxyGraphUpdatesInMemoryTestBase<LazyLoading.ProxyGraphUpdatesWithLazyLoadingInMemoryFixture>
         {
             public LazyLoading(ProxyGraphUpdatesWithLazyLoadingInMemoryFixture fixture)
                 : base(fixture)

--- a/test/EFCore.Sqlite.FunctionalTests/GraphUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/GraphUpdatesSqliteTest.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore
-{
+{ 
     public abstract class GraphUpdatesSqliteTest
     {
         public abstract class GraphUpdatesSqliteTestBase<TFixture> : GraphUpdatesTestBase<TFixture>
@@ -37,7 +37,8 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        public class SnapshotNotifications
+        // issue #15318
+        internal class SnapshotNotifications
             : GraphUpdatesSqliteTestBase<SnapshotNotifications.SnapshotNotificationsFixture>
         {
             public SnapshotNotifications(SnapshotNotificationsFixture fixture, ITestOutputHelper testOutputHelper)
@@ -60,7 +61,8 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        public class ChangedNotifications
+        // issue #15318
+        internal class ChangedNotifications
             : GraphUpdatesSqliteTestBase<ChangedNotifications.ChangedNotificationsFixture>
         {
             public ChangedNotifications(ChangedNotificationsFixture fixture)
@@ -81,7 +83,8 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        public class ChangedChangingNotifications
+        // issue #15318
+        internal class ChangedChangingNotifications
             : GraphUpdatesSqliteTestBase<ChangedChangingNotifications.ChangedChangingNotificationsFixture>
         {
             public ChangedChangingNotifications(ChangedChangingNotificationsFixture fixture)
@@ -102,7 +105,8 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        public class FullWithOriginalsNotifications
+        // issue #15318
+        internal class FullWithOriginalsNotifications
             : GraphUpdatesSqliteTestBase<FullWithOriginalsNotifications.FullWithOriginalsNotificationsFixture>
         {
             public FullWithOriginalsNotifications(FullWithOriginalsNotificationsFixture fixture)

--- a/test/EFCore.Sqlite.FunctionalTests/LoadSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/LoadSqliteTest.cs
@@ -5,7 +5,8 @@ using Microsoft.EntityFrameworkCore.TestUtilities;
 
 namespace Microsoft.EntityFrameworkCore
 {
-    public class LoadSqliteTest : LoadTestBase<LoadSqliteTest.LoadSqliteFixture>
+    // issue #15318
+    internal class LoadSqliteTest : LoadTestBase<LoadSqliteTest.LoadSqliteFixture>
     {
         public LoadSqliteTest(LoadSqliteFixture fixture)
             : base(fixture)

--- a/test/EFCore.Sqlite.FunctionalTests/ProxyGraphUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/ProxyGraphUpdatesSqliteTest.cs
@@ -29,7 +29,8 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        public class LazyLoading : ProxyGraphUpdatesSqliteTestBase<LazyLoading.ProxyGraphUpdatesWithLazyLoadingSqliteFixture>
+        // issue #15318
+        internal class LazyLoading : ProxyGraphUpdatesSqliteTestBase<LazyLoading.ProxyGraphUpdatesWithLazyLoadingSqliteFixture>
         {
             public LazyLoading(ProxyGraphUpdatesWithLazyLoadingSqliteFixture fixture)
                 : base(fixture)


### PR DESCRIPTION
GraphsUpdate, ProxyGraphsUpdate & Load tests for InMemory and Sqlite