### PR TITLE
Add security section to issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,5 @@
+### If you believe you have an issue that affects the security of the platform please do NOT create an issue and instead email your issue details to secure@microsoft.com. Your report may be eligible for our [bug bounty](https://technet.microsoft.com/en-us/mt764065.aspx) but ONLY if it is reported through email.
+
 Describe what is not working as expected.
 
 If you are seeing an exception, include the full exceptions details (message and stack trace).


### PR DESCRIPTION
We had this in the SignalR repo to prevent folks from making public bugs with security issues.