### PR TITLE
Fix for false-positive publish failures when tests fail

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,7 +74,7 @@ jobs:
               name: Build
             - task: PublishBuildArtifacts@1
               displayName: Upload artifacts
-              condition: eq(variables['system.pullrequest.isfork'], false)
+              condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false))
               inputs:
                 pathtoPublish: 'artifacts/packages/'
                 artifactName: packages


### PR DESCRIPTION
The PublishBuildArtifacts fails when artifacts/packages/ does not exist or is empty. This change will only publish packages if build.cmd succeeds (which means all tests, code signing, and compilation must pass)

Fix https://github.com/aspnet/AspNetCore-Internal/issues/2305