### PR TITLE
Add forgotten delimiter in raw SQL test

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/Query/FromSqlQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/FromSqlQueryTestBase.cs
@@ -943,7 +943,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
                 var tableName = "Orders";
                 var max = 10250;
                 var query = context.Orders.FromSqlRaw(
-                        NormalizeDelimetersInRawString($"SELECT * FROM {tableName} WHERE [OrderID] < {{0}}"), max)
+                        NormalizeDelimetersInRawString($"SELECT * FROM [{tableName}] WHERE [OrderID] < {{0}}"), max)
                     .ToList();
 
                 Assert.Equal(2, query.Count);


### PR DESCRIPTION
Necessary for PostgreSQL, which folds unquoted identifiers to lowercase...