### PR TITLE
[For preview 5] Force database providers to register a LoggingDefintions

### DIFF
--- a/src/EFCore.Cosmos/Diagnostics/Internal/CosmosLoggingDefinitions.cs
+++ b/src/EFCore.Cosmos/Diagnostics/Internal/CosmosLoggingDefinitions.cs
@@ -1,16 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.EntityFrameworkCore.Scaffolding;
-using Microsoft.EntityFrameworkCore.Sqlite.Diagnostics.Internal;
-using Microsoft.EntityFrameworkCore.Sqlite.Scaffolding.Internal;
-using Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal;
-using Microsoft.EntityFrameworkCore.Storage;
-using Microsoft.Extensions.DependencyInjection;
 
-namespace Microsoft.EntityFrameworkCore.Sqlite.Design.Internal
+namespace Microsoft.EntityFrameworkCore.Cosmos.Diagnostics.Internal
 {
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -18,7 +11,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Design.Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public class SqliteDesignTimeServices : IDesignTimeServices
+    public class CosmosLoggingDefinitions : LoggingDefinitions
     {
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -26,12 +19,14 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Design.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual void ConfigureDesignTimeServices(IServiceCollection serviceCollection)
-            => serviceCollection
-                .AddSingleton<LoggingDefinitions, SqliteLoggingDefinitions>()
-                .AddSingleton<IRelationalTypeMappingSource, SqliteTypeMappingSource>()
-                .AddSingleton<IDatabaseModelFactory, SqliteDatabaseModelFactory>()
-                .AddSingleton<IProviderConfigurationCodeGenerator, SqliteCodeGenerator>()
-                .AddSingleton<IAnnotationCodeGenerator, AnnotationCodeGenerator>();
+        public EventDefinitionBase LogSavedChanges;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public EventDefinitionBase LogTransactionsNotSupported;
     }
 }

--- a/src/EFCore.Cosmos/Extensions/CosmosServiceCollectionExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Cosmos.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Cosmos.Infrastructure;
 using Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal;
 using Microsoft.EntityFrameworkCore.Cosmos.Metadata.Conventions.Internal;
@@ -10,9 +11,9 @@ using Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 using Microsoft.EntityFrameworkCore.Cosmos.Query.Sql;
 using Microsoft.EntityFrameworkCore.Cosmos.Query.Sql.Internal;
 using Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal;
@@ -28,6 +29,7 @@ namespace Microsoft.Extensions.DependencyInjection
             Check.NotNull(serviceCollection, nameof(serviceCollection));
 
             var builder = new EntityFrameworkServicesBuilder(serviceCollection)
+                .TryAdd<LoggingDefinitions, CosmosLoggingDefinitions>()
                 .TryAdd<IDatabaseProvider, DatabaseProvider<CosmosDbOptionsExtension>>()
                 .TryAdd<IDatabase, CosmosDatabaseWrapper>()
                 .TryAdd<IExecutionStrategyFactory, CosmosExecutionStrategyFactory>()

--- a/src/EFCore.Design/Design/DesignTimeServiceCollectionExtensions.cs
+++ b/src/EFCore.Design/Design/DesignTimeServiceCollectionExtensions.cs
@@ -67,7 +67,6 @@ namespace Microsoft.EntityFrameworkCore.Design
                 .AddSingleton(typeof(IDiagnosticsLogger<>), typeof(DiagnosticsLogger<>))
                 .AddSingleton<DiagnosticSource>(new DiagnosticListener(DbLoggerCategory.Name))
                 .AddSingleton<ILoggingOptions, LoggingOptions>()
-                .AddSingleton<LoggingDefinitions, RelationalLoggingDefinitions>()
                 .AddSingleton<IMigrationsCodeGenerator, CSharpMigrationsGenerator>()
                 .AddSingleton<IMigrationsCodeGeneratorSelector, MigrationsCodeGeneratorSelector>()
                 .AddSingleton<IModelCodeGenerator, CSharpModelGenerator>()

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
@@ -34,6 +34,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         private readonly ICSharpHelper _code;
         private readonly IProviderConfigurationCodeGenerator _providerConfigurationCodeGenerator;
         private readonly IAnnotationCodeGenerator _annotationCodeGenerator;
+        private readonly LoggingDefinitions _loggingDefinitions;
         private IndentedStringBuilder _sb;
         private bool _entityTypeBuilderInitialized;
 
@@ -46,15 +47,18 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         public CSharpDbContextGenerator(
             [NotNull] IProviderConfigurationCodeGenerator providerConfigurationCodeGenerator,
             [NotNull] IAnnotationCodeGenerator annotationCodeGenerator,
-            [NotNull] ICSharpHelper cSharpHelper)
+            [NotNull] ICSharpHelper cSharpHelper,
+            [NotNull] LoggingDefinitions loggingDefinitions)
         {
             Check.NotNull(providerConfigurationCodeGenerator, nameof(providerConfigurationCodeGenerator));
             Check.NotNull(annotationCodeGenerator, nameof(annotationCodeGenerator));
             Check.NotNull(cSharpHelper, nameof(cSharpHelper));
+            Check.NotNull(loggingDefinitions, nameof(loggingDefinitions));
 
             _providerConfigurationCodeGenerator = providerConfigurationCodeGenerator;
             _annotationCodeGenerator = annotationCodeGenerator;
             _code = cSharpHelper;
+            _loggingDefinitions = loggingDefinitions;
         }
 
         /// <summary>
@@ -658,7 +662,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 new ScopedLoggerFactory(new LoggerFactory(), dispose: true),
                 new LoggingOptions(),
                 new DiagnosticListener(""),
-                new LoggingDefinitions());
+                _loggingDefinitions);
 
             var valueGenerated = property.ValueGenerated;
             var isRowVersion = false;

--- a/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
@@ -46,6 +46,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         private readonly IPluralizer _pluralizer;
         private readonly ICSharpUtilities _cSharpUtilities;
         private readonly IScaffoldingTypeMapper _scaffoldingTypeMapper;
+        private readonly LoggingDefinitions _loggingDefinitions;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -58,19 +59,22 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             [NotNull] ICandidateNamingService candidateNamingService,
             [NotNull] IPluralizer pluralizer,
             [NotNull] ICSharpUtilities cSharpUtilities,
-            [NotNull] IScaffoldingTypeMapper scaffoldingTypeMapper)
+            [NotNull] IScaffoldingTypeMapper scaffoldingTypeMapper,
+            [NotNull] LoggingDefinitions loggingDefinitions)
         {
             Check.NotNull(reporter, nameof(reporter));
             Check.NotNull(candidateNamingService, nameof(candidateNamingService));
             Check.NotNull(pluralizer, nameof(pluralizer));
             Check.NotNull(cSharpUtilities, nameof(cSharpUtilities));
             Check.NotNull(scaffoldingTypeMapper, nameof(scaffoldingTypeMapper));
+            Check.NotNull(loggingDefinitions, nameof(loggingDefinitions));
 
             _reporter = reporter;
             _candidateNamingService = candidateNamingService;
             _pluralizer = pluralizer;
             _cSharpUtilities = cSharpUtilities;
             _scaffoldingTypeMapper = scaffoldingTypeMapper;
+            _loggingDefinitions = loggingDefinitions;
         }
 
         /// <summary>
@@ -518,7 +522,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                         new ScopedLoggerFactory(new LoggerFactory(), dispose: true),
                         new LoggingOptions(),
                         new DiagnosticListener(""),
-                        new LoggingDefinitions());
+                        _loggingDefinitions);
 
                     var conventionalValueGenerated = new RelationalValueGeneratorConvention(dummyLogger).GetValueGenerated(property);
                     if (conventionalValueGenerated == ValueGenerated.OnAdd)

--- a/src/EFCore.Relational/Diagnostics/RelationalLoggingDefinitions.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalLoggingDefinitions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     ///         to add caching for their events. It should not be used for any other purpose.
     ///     </para>
     /// </summary>
-    public class RelationalLoggingDefinitions : LoggingDefinitions
+    public abstract class RelationalLoggingDefinitions : LoggingDefinitions
     {
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
+++ b/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
@@ -130,7 +130,6 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <returns> This builder, such that further calls can be chained. </returns>
         public override EntityFrameworkServicesBuilder TryAddCoreServices()
         {
-            TryAdd<LoggingDefinitions, RelationalLoggingDefinitions>();
             TryAdd<IParameterNameGeneratorFactory, ParameterNameGeneratorFactory>();
             TryAdd<IComparer<ModificationCommand>, ModificationCommandComparer>();
             TryAdd<IMigrationsIdGenerator, MigrationsIdGenerator>();

--- a/src/EFCore.SqlServer/Design/Internal/SqlServerDesignTimeServices.cs
+++ b/src/EFCore.SqlServer/Design/Internal/SqlServerDesignTimeServices.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Scaffolding;
+using Microsoft.EntityFrameworkCore.SqlServer.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Scaffolding.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -26,6 +28,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Design.Internal
         /// </summary>
         public virtual void ConfigureDesignTimeServices(IServiceCollection serviceCollection)
             => serviceCollection
+                .AddSingleton<LoggingDefinitions, SqlServerLoggingDefinitions>()
                 .AddSingleton<IRelationalTypeMappingSource, SqlServerTypeMappingSource>()
                 .AddSingleton<IDatabaseModelFactory, SqlServerDatabaseModelFactory>()
                 .AddSingleton<IProviderConfigurationCodeGenerator, SqlServerCodeGenerator>()

--- a/src/EFCore/Diagnostics/LoggingDefinitions.cs
+++ b/src/EFCore/Diagnostics/LoggingDefinitions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     ///         to add caching for their events. It should not be used for any other purpose.
     ///     </para>
     /// </summary>
-    public class LoggingDefinitions
+    public abstract class LoggingDefinitions
     {
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
+++ b/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
@@ -217,7 +217,6 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <returns> This builder, such that further calls can be chained. </returns>
         public virtual EntityFrameworkServicesBuilder TryAddCoreServices()
         {
-            TryAdd<LoggingDefinitions, LoggingDefinitions>();
             TryAdd<IDbSetFinder, DbSetFinder>();
             TryAdd<IDbSetInitializer, DbSetInitializer>();
             TryAdd<IDbSetSource, DbSetSource>();

--- a/src/EFCore/Internal/ServiceProviderCache.cs
+++ b/src/EFCore/Internal/ServiceProviderCache.cs
@@ -109,27 +109,32 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 {
                     var scopedProvider = scope.ServiceProvider;
 
-                    // Because IDbContextOptions cannot yet be resolved from the internal provider
-                    var logger = new DiagnosticsLogger<DbLoggerCategory.Infrastructure>(
-                        ScopedLoggerFactory.Create(scopedProvider, options),
-                        scopedProvider.GetService<ILoggingOptions>(),
-                        scopedProvider.GetService<DiagnosticSource>(),
-                        scopedProvider.GetService<LoggingDefinitions>());
-
-                    if (_configurations.Count == 0)
+                    // If loggingDefinitions is null, then there is no provider yet
+                    var loggingDefinitions = scopedProvider.GetService<LoggingDefinitions>();
+                    if (loggingDefinitions != null)
                     {
-                        logger.ServiceProviderCreated(serviceProvider);
-                    }
-                    else
-                    {
-                        logger.ServiceProviderDebugInfo(
-                            debugInfo,
-                            _configurations.Values.Select(v => v.DebugInfo).ToList());
+                        // Because IDbContextOptions cannot yet be resolved from the internal provider
+                        var logger = new DiagnosticsLogger<DbLoggerCategory.Infrastructure>(
+                            ScopedLoggerFactory.Create(scopedProvider, options),
+                            scopedProvider.GetService<ILoggingOptions>(),
+                            scopedProvider.GetService<DiagnosticSource>(),
+                            loggingDefinitions);
 
-                        if (_configurations.Count >= 20)
+                        if (_configurations.Count == 0)
                         {
-                            logger.ManyServiceProvidersCreatedWarning(
-                                _configurations.Values.Select(e => e.ServiceProvider).ToList());
+                            logger.ServiceProviderCreated(serviceProvider);
+                        }
+                        else
+                        {
+                            logger.ServiceProviderDebugInfo(
+                                debugInfo,
+                                _configurations.Values.Select(v => v.DebugInfo).ToList());
+
+                            if (_configurations.Count >= 20)
+                            {
+                                logger.ManyServiceProvidersCreatedWarning(
+                                    _configurations.Values.Select(e => e.ServiceProvider).ToList());
+                            }
                         }
                     }
                 }

--- a/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilderDependencies.cs
+++ b/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilderDependencies.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Diagnostics;
-using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
@@ -11,7 +8,6 @@ using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
 {
@@ -74,51 +70,26 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
         /// <param name="context"> The current context instance. </param>
         public ProviderConventionSetBuilderDependencies(
             [NotNull] ITypeMappingSource typeMappingSource,
-            [CanBeNull] IConstructorBindingFactory constructorBindingFactory,
-            [CanBeNull] IParameterBindingFactories parameterBindingFactories,
-            [CanBeNull] IMemberClassifier memberClassifier,
-            [CanBeNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger,
-            [CanBeNull] IDbSetFinder setFinder,
-            [CanBeNull] ICurrentDbContext context)
+            [NotNull] IConstructorBindingFactory constructorBindingFactory,
+            [NotNull] IParameterBindingFactories parameterBindingFactories,
+            [NotNull] IMemberClassifier memberClassifier,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger,
+            [NotNull] IDbSetFinder setFinder,
+            [NotNull] ICurrentDbContext context)
         {
             Check.NotNull(typeMappingSource, nameof(typeMappingSource));
+            Check.NotNull(constructorBindingFactory, nameof(constructorBindingFactory));
+            Check.NotNull(parameterBindingFactories, nameof(parameterBindingFactories));
+            Check.NotNull(memberClassifier, nameof(memberClassifier));
+            Check.NotNull(logger, nameof(logger));
+            Check.NotNull(setFinder, nameof(setFinder));
+            Check.NotNull(context, nameof(context));
 
             TypeMappingSource = typeMappingSource;
-
-            if (parameterBindingFactories == null)
-            {
-                parameterBindingFactories = new ParameterBindingFactories(
-                    null,
-                    new RegisteredServices(Enumerable.Empty<Type>()));
-            }
-
             ParameterBindingFactories = parameterBindingFactories;
-
-            if (memberClassifier == null)
-            {
-                memberClassifier = new MemberClassifier(
-                    typeMappingSource,
-                    parameterBindingFactories);
-            }
-
             MemberClassifier = memberClassifier;
-
-            if (constructorBindingFactory == null)
-            {
-                ConstructorBindingFactory = new ConstructorBindingFactory(
-                    new PropertyParameterBindingFactory(),
-                    parameterBindingFactories);
-            }
-
             ConstructorBindingFactory = constructorBindingFactory;
-
-            Logger = logger
-                     ?? new DiagnosticsLogger<DbLoggerCategory.Model>(
-                         new ScopedLoggerFactory(new LoggerFactory(), dispose: true),
-                         new LoggingOptions(),
-                         new DiagnosticListener(""),
-                         new LoggingDefinitions());
-
+            Logger = logger;
             SetFinder = setFinder;
             Context = context;
         }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosSqlTest.ResultOperators.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosSqlTest.ResultOperators.cs
@@ -1098,7 +1098,7 @@ WHERE ((c[""Discriminator""] = ""OrderDetail"") AND ((c[""OrderID""] = 10248) AN
             base.Paging_operation_on_string_doesnt_issue_warning();
 
             Assert.DoesNotContain(
-                CoreResources.LogFirstWithoutOrderByAndFilter(new TestLogger<LoggingDefinitions>()).GenerateMessage(
+                CoreResources.LogFirstWithoutOrderByAndFilter(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
                     "(from char <generated>_1 in [c].CustomerID select [<generated>_1]).FirstOrDefault()"),
                 Fixture.TestSqlLoggerFactory.Log.Select(l => l.Message));
         }

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/ReverseEngineerScaffolderTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/ReverseEngineerScaffolderTest.cs
@@ -4,6 +4,7 @@
 using System.Globalization;
 using System.IO;
 using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -172,6 +173,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         private static IReverseEngineerScaffolder CreateScaffolder()
             => new ServiceCollection()
                 .AddEntityFrameworkDesignTimeServices()
+                .AddSingleton<LoggingDefinitions, TestRelationalLoggingDefinitions>()
                 .AddSingleton<IRelationalTypeMappingSource, TestRelationalTypeMappingSource>()
                 .AddSingleton<IAnnotationCodeGenerator, AnnotationCodeGenerator>()
                 .AddSingleton<IDatabaseModelFactory, FakeDatabaseModelFactory>()

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/ReverseEngineeringConfigurationTests.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/ReverseEngineeringConfigurationTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -26,6 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         {
             var reverseEngineer = new ServiceCollection()
                 .AddEntityFrameworkDesignTimeServices()
+                .AddSingleton<LoggingDefinitions, TestRelationalLoggingDefinitions>()
                 .AddSingleton<IRelationalTypeMappingSource, TestRelationalTypeMappingSource>()
                 .AddSingleton<IAnnotationCodeGenerator, AnnotationCodeGenerator>()
                 .AddSingleton<IDatabaseModelFactory, FakeDatabaseModelFactory>()

--- a/test/EFCore.Design.Tests/TestUtilities/FakeScaffoldingModelFactory.cs
+++ b/test/EFCore.Design.Tests/TestUtilities/FakeScaffoldingModelFactory.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Design.Internal;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
 using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
@@ -16,8 +17,9 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             ICandidateNamingService candidateNamingService,
             IPluralizer pluralizer,
             ICSharpUtilities cSharpUtilities,
-            IScaffoldingTypeMapper scaffoldingTypeMapper)
-            : base(reporter, candidateNamingService, pluralizer, cSharpUtilities, scaffoldingTypeMapper)
+            IScaffoldingTypeMapper scaffoldingTypeMapper,
+            LoggingDefinitions loggingDefinitions)
+            : base(reporter, candidateNamingService, pluralizer, cSharpUtilities, scaffoldingTypeMapper, loggingDefinitions)
         {
         }
 

--- a/test/EFCore.Proxies.Tests/LazyLoadingProxyTests.cs
+++ b/test/EFCore.Proxies.Tests/LazyLoadingProxyTests.cs
@@ -297,7 +297,7 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(
                 CoreStrings.WarningAsErrorTemplate(
                     CoreEventId.LazyLoadOnDisposedContextWarning.ToString(),
-                    CoreResources.LogLazyLoadOnDisposedContext(new TestLogger<LoggingDefinitions>()).GenerateMessage("Texts", "PhoneProxy"),
+                    CoreResources.LogLazyLoadOnDisposedContext(new TestLogger<TestLoggingDefinitions>()).GenerateMessage("Texts", "PhoneProxy"),
                     "CoreEventId.LazyLoadOnDisposedContextWarning"),
                 Assert.Throws<InvalidOperationException>(
                     () => phone.Texts).Message);

--- a/test/EFCore.Relational.Specification.Tests/Query/QueryNoClientEvalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/QueryNoClientEvalTestBase.cs
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Assert.Equal(
                     CoreStrings.WarningAsErrorTemplate(
                         RelationalEventId.QueryClientEvaluationWarning,
-                        RelationalResources.LogClientEvalWarning(new TestLogger<RelationalLoggingDefinitions>()).GenerateMessage("where [c].IsLondon"),
+                        RelationalResources.LogClientEvalWarning(new TestLogger<TestRelationalLoggingDefinitions>()).GenerateMessage("where [c].IsLondon"),
                         "RelationalEventId.QueryClientEvaluationWarning"),
                     Assert.Throws<InvalidOperationException>(
                             () => context.Customers.Where(c => c.IsLondon).ToList())
@@ -44,7 +44,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Assert.Equal(
                     CoreStrings.WarningAsErrorTemplate(
                         RelationalEventId.QueryClientEvaluationWarning,
-                        RelationalResources.LogClientEvalWarning(new TestLogger<RelationalLoggingDefinitions>()).GenerateMessage("orderby [c].IsLondon asc"),
+                        RelationalResources.LogClientEvalWarning(new TestLogger<TestRelationalLoggingDefinitions>()).GenerateMessage("orderby [c].IsLondon asc"),
                         "RelationalEventId.QueryClientEvaluationWarning"),
                     Assert.Throws<InvalidOperationException>(
                         () => context.Customers.OrderBy(c => c.IsLondon).ToList()).Message);
@@ -59,7 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Assert.Equal(
                     CoreStrings.WarningAsErrorTemplate(
                         RelationalEventId.QueryClientEvaluationWarning,
-                        RelationalResources.LogClientEvalWarning(new TestLogger<RelationalLoggingDefinitions>()).GenerateMessage("orderby [c].IsLondon asc, ClientMethod([c]) asc"),
+                        RelationalResources.LogClientEvalWarning(new TestLogger<TestRelationalLoggingDefinitions>()).GenerateMessage("orderby [c].IsLondon asc, ClientMethod([c]) asc"),
                         "RelationalEventId.QueryClientEvaluationWarning"),
                     Assert.Throws<InvalidOperationException>(
                         () => context.Customers
@@ -79,7 +79,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Assert.Equal(
                     CoreStrings.WarningAsErrorTemplate(
                         RelationalEventId.QueryClientEvaluationWarning,
-                        RelationalResources.LogClientEvalWarning(new TestLogger<RelationalLoggingDefinitions>()).GenerateMessage(
+                        RelationalResources.LogClientEvalWarning(new TestLogger<TestRelationalLoggingDefinitions>()).GenerateMessage(
                             "where {from Customer c2 in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) where (([c1].CustomerID == [c2].CustomerID) AndAlso [c2].IsLondon) select [c2] => Any()}"),
                         "RelationalEventId.QueryClientEvaluationWarning"),
                     Assert.Throws<InvalidOperationException>(
@@ -99,7 +99,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Assert.Equal(
                     CoreStrings.WarningAsErrorTemplate(
                         RelationalEventId.QueryClientEvaluationWarning,
-                        RelationalResources.LogClientEvalWarning(new TestLogger<RelationalLoggingDefinitions>()).GenerateMessage("All([c].IsLondon)"),
+                        RelationalResources.LogClientEvalWarning(new TestLogger<TestRelationalLoggingDefinitions>()).GenerateMessage("All([c].IsLondon)"),
                         "RelationalEventId.QueryClientEvaluationWarning"),
                     Assert.Throws<InvalidOperationException>(
                         () => context.Customers.All(c => c.IsLondon)).Message);
@@ -114,7 +114,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Assert.Equal(
                     CoreStrings.WarningAsErrorTemplate(
                         RelationalEventId.QueryClientEvaluationWarning,
-                        RelationalResources.LogClientEvalWarning(new TestLogger<RelationalLoggingDefinitions>()).GenerateMessage("where [c].IsLondon"),
+                        RelationalResources.LogClientEvalWarning(new TestLogger<TestRelationalLoggingDefinitions>()).GenerateMessage("where [c].IsLondon"),
                         "RelationalEventId.QueryClientEvaluationWarning"),
                     Assert.Throws<InvalidOperationException>(
                         () => context.Customers
@@ -146,7 +146,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Assert.Equal(
                     CoreStrings.WarningAsErrorTemplate(
                         RelationalEventId.QueryClientEvaluationWarning,
-                        RelationalResources.LogClientEvalWarning(new TestLogger<RelationalLoggingDefinitions>()).GenerateMessage("where [c].IsLondon"),
+                        RelationalResources.LogClientEvalWarning(new TestLogger<TestRelationalLoggingDefinitions>()).GenerateMessage("where [c].IsLondon"),
                         "RelationalEventId.QueryClientEvaluationWarning"),
                     Assert.Throws<InvalidOperationException>(
                         () =>
@@ -167,7 +167,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Assert.Equal(
                     CoreStrings.WarningAsErrorTemplate(
                         RelationalEventId.QueryClientEvaluationWarning,
-                        RelationalResources.LogClientEvalWarning(new TestLogger<RelationalLoggingDefinitions>()).GenerateMessage("from Int32 i in value(System.Int32[])"),
+                        RelationalResources.LogClientEvalWarning(new TestLogger<TestRelationalLoggingDefinitions>()).GenerateMessage("from Int32 i in value(System.Int32[])"),
                         "RelationalEventId.QueryClientEvaluationWarning"),
                     Assert.Throws<InvalidOperationException>(
                         () =>
@@ -186,7 +186,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Assert.Equal(
                     CoreStrings.WarningAsErrorTemplate(
                         RelationalEventId.QueryClientEvaluationWarning,
-                        RelationalResources.LogClientEvalWarning(new TestLogger<RelationalLoggingDefinitions>()).GenerateMessage(
+                        RelationalResources.LogClientEvalWarning(new TestLogger<TestRelationalLoggingDefinitions>()).GenerateMessage(
                             "join UInt32 i in __p_0 on [e1].EmployeeID equals [i]"
                         ),
                         "RelationalEventId.QueryClientEvaluationWarning"),
@@ -207,7 +207,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Assert.Equal(
                     CoreStrings.WarningAsErrorTemplate(
                         RelationalEventId.QueryClientEvaluationWarning,
-                        RelationalResources.LogClientEvalWarning(new TestLogger<RelationalLoggingDefinitions>()).GenerateMessage(
+                        RelationalResources.LogClientEvalWarning(new TestLogger<TestRelationalLoggingDefinitions>()).GenerateMessage(
                             "join UInt32 i in __p_0 on [e1].EmployeeID equals [i]"
                         ),
                         "RelationalEventId.QueryClientEvaluationWarning"),
@@ -228,7 +228,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Assert.Equal(
                     CoreStrings.WarningAsErrorTemplate(
                         RelationalEventId.QueryClientEvaluationWarning,
-                        RelationalResources.LogClientEvalWarning(new TestLogger<RelationalLoggingDefinitions>()).GenerateMessage("GroupBy([c].CustomerID, [c])"),
+                        RelationalResources.LogClientEvalWarning(new TestLogger<TestRelationalLoggingDefinitions>()).GenerateMessage("GroupBy([c].CustomerID, [c])"),
                         "RelationalEventId.QueryClientEvaluationWarning"),
                     Assert.Throws<InvalidOperationException>(
                         () => context.Customers
@@ -245,7 +245,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Assert.Equal(
                     CoreStrings.WarningAsErrorTemplate(
                         RelationalEventId.QueryClientEvaluationWarning,
-                        RelationalResources.LogClientEvalWarning(new TestLogger<RelationalLoggingDefinitions>()).GenerateMessage("where [c].IsLondon"),
+                        RelationalResources.LogClientEvalWarning(new TestLogger<TestRelationalLoggingDefinitions>()).GenerateMessage("where [c].IsLondon"),
                         "RelationalEventId.QueryClientEvaluationWarning"),
                     Assert.Throws<InvalidOperationException>(
                         () => context.Customers.First(c => c.IsLondon)).Message);
@@ -260,7 +260,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Assert.Equal(
                     CoreStrings.WarningAsErrorTemplate(
                         RelationalEventId.QueryClientEvaluationWarning,
-                        RelationalResources.LogClientEvalWarning(new TestLogger<RelationalLoggingDefinitions>()).GenerateMessage("where [c].IsLondon"),
+                        RelationalResources.LogClientEvalWarning(new TestLogger<TestRelationalLoggingDefinitions>()).GenerateMessage("where [c].IsLondon"),
                         "RelationalEventId.QueryClientEvaluationWarning"),
                     Assert.Throws<InvalidOperationException>(
                         () => context.Customers.Single(c => c.IsLondon)).Message);
@@ -275,7 +275,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Assert.Equal(
                     CoreStrings.WarningAsErrorTemplate(
                         RelationalEventId.QueryClientEvaluationWarning,
-                        RelationalResources.LogClientEvalWarning(new TestLogger<RelationalLoggingDefinitions>()).GenerateMessage("where [c].IsLondon"),
+                        RelationalResources.LogClientEvalWarning(new TestLogger<TestRelationalLoggingDefinitions>()).GenerateMessage("where [c].IsLondon"),
                         "RelationalEventId.QueryClientEvaluationWarning"),
                     Assert.Throws<InvalidOperationException>(
                         () => context.Customers.FirstOrDefault(c => c.IsLondon)).Message);
@@ -290,7 +290,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Assert.Equal(
                     CoreStrings.WarningAsErrorTemplate(
                         RelationalEventId.QueryClientEvaluationWarning,
-                        RelationalResources.LogClientEvalWarning(new TestLogger<RelationalLoggingDefinitions>()).GenerateMessage("where [c].IsLondon"),
+                        RelationalResources.LogClientEvalWarning(new TestLogger<TestRelationalLoggingDefinitions>()).GenerateMessage("where [c].IsLondon"),
                         "RelationalEventId.QueryClientEvaluationWarning"),
                     Assert.Throws<InvalidOperationException>(
                         () => context.Customers.SingleOrDefault(c => c.IsLondon)).Message);

--- a/test/EFCore.Relational.Specification.Tests/Query/WarningsTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/WarningsTestBase.cs
@@ -36,7 +36,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Assert.Equal(
                     CoreStrings.WarningAsErrorTemplate(
                         RelationalEventId.QueryClientEvaluationWarning,
-                        RelationalResources.LogClientEvalWarning(new TestLogger<RelationalLoggingDefinitions>()).GenerateMessage("where [c].IsLondon"),
+                        RelationalResources.LogClientEvalWarning(new TestLogger<TestRelationalLoggingDefinitions>()).GenerateMessage("where [c].IsLondon"),
                         "RelationalEventId.QueryClientEvaluationWarning"),
                     Assert.Throws<InvalidOperationException>(
                         () => context.Customers.Where(c => c.IsLondon).ToList()).Message);
@@ -150,7 +150,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Assert.Equal(
                     CoreStrings.WarningAsErrorTemplate(
                         RelationalEventId.QueryClientEvaluationWarning,
-                        RelationalResources.LogClientEvalWarning(new TestLogger<RelationalLoggingDefinitions>()).GenerateMessage("Last()"),
+                        RelationalResources.LogClientEvalWarning(new TestLogger<TestRelationalLoggingDefinitions>()).GenerateMessage("Last()"),
                         "RelationalEventId.QueryClientEvaluationWarning"),
                     Assert.Throws<InvalidOperationException>(
                         () => context.Customers.Last()).Message);
@@ -165,7 +165,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Assert.Equal(
                     CoreStrings.WarningAsErrorTemplate(
                         RelationalEventId.QueryClientEvaluationWarning,
-                        RelationalResources.LogClientEvalWarning(new TestLogger<RelationalLoggingDefinitions>()).GenerateMessage("Last()"),
+                        RelationalResources.LogClientEvalWarning(new TestLogger<TestRelationalLoggingDefinitions>()).GenerateMessage("Last()"),
                         "RelationalEventId.QueryClientEvaluationWarning"),
                     Assert.Throws<InvalidOperationException>(
                         () => context.Customers
@@ -183,7 +183,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Assert.Equal(
                     CoreStrings.WarningAsErrorTemplate(
                         RelationalEventId.QueryClientEvaluationWarning,
-                        RelationalResources.LogClientEvalWarning(new TestLogger<RelationalLoggingDefinitions>()).GenerateMessage("LastOrDefault()"),
+                        RelationalResources.LogClientEvalWarning(new TestLogger<TestRelationalLoggingDefinitions>()).GenerateMessage("LastOrDefault()"),
                         "RelationalEventId.QueryClientEvaluationWarning"),
                     Assert.Throws<InvalidOperationException>(
                         () => context.Customers.LastOrDefault()).Message);

--- a/test/EFCore.Relational.Specification.Tests/TestUtilities/TestRelationalLoggingDefinitions.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestUtilities/TestRelationalLoggingDefinitions.cs
@@ -1,0 +1,11 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities
+{
+    public class TestRelationalLoggingDefinitions : RelationalLoggingDefinitions
+    {
+    }
+}

--- a/test/EFCore.Relational.Specification.Tests/TransactionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/TransactionTestBase.cs
@@ -50,7 +50,7 @@ namespace Microsoft.EntityFrameworkCore
                         Name = "Bobble"
                     });
 
-                
+
                 // Issue #14935. Cannot eval 'Last()'
                 // Added AsEnumerable()
                 context.Entry(context.Set<TransactionCustomer>().AsEnumerable().Last()).State = EntityState.Added;
@@ -86,7 +86,7 @@ namespace Microsoft.EntityFrameworkCore
                         Id = 77,
                         Name = "Bobble"
                     });
-                
+
                 // Issue #14935. Cannot eval 'Last()'
                 // Added AsEnumerable()
                 context.Entry(context.Set<TransactionCustomer>().OrderBy(c => c.Id).AsEnumerable().Last()).State = EntityState.Added;
@@ -122,7 +122,7 @@ namespace Microsoft.EntityFrameworkCore
                         Id = 77,
                         Name = "Bobble"
                     });
-                
+
                 // Issue #14935. Cannot eval 'Last()'
                 // Added AsEnumerable()
                 context.Entry(context.Set<TransactionCustomer>().OrderBy(c => c.Id).AsEnumerable().Last()).State = EntityState.Added;
@@ -146,7 +146,7 @@ namespace Microsoft.EntityFrameworkCore
                         Id = 77,
                         Name = "Bobble"
                     });
-                
+
                 // Issue #14935. Cannot eval 'Last()'
                 // Added AsEnumerable()
                 context.Entry(context.Set<TransactionCustomer>().OrderBy(c => c.Id).AsEnumerable().Last()).State = EntityState.Added;
@@ -206,7 +206,7 @@ namespace Microsoft.EntityFrameworkCore
                 }
 
                 Assert.Equal(
-                    RelationalResources.LogExplicitTransactionEnlisted(new TestLogger<RelationalLoggingDefinitions>()).GenerateMessage("Serializable"),
+                    RelationalResources.LogExplicitTransactionEnlisted(new TestLogger<TestRelationalLoggingDefinitions>()).GenerateMessage("Serializable"),
                     Fixture.ListLoggerFactory.Log.First().Message);
             }
 
@@ -370,7 +370,7 @@ namespace Microsoft.EntityFrameworkCore
                 }
 
                 Assert.Equal(
-                    RelationalResources.LogAmbientTransactionEnlisted(new TestLogger<RelationalLoggingDefinitions>()).GenerateMessage("Serializable"),
+                    RelationalResources.LogAmbientTransactionEnlisted(new TestLogger<TestRelationalLoggingDefinitions>()).GenerateMessage("Serializable"),
                     Fixture.ListLoggerFactory.Log.First().Message);
             }
 

--- a/test/EFCore.Relational.Tests/Metadata/Conventions/Internal/DiscriminatorConventionTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/Conventions/Internal/DiscriminatorConventionTest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         public void Sets_discriminator_for_two_level_hierarchy()
         {
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<Entity>();
-            var logger = new TestLogger<DbLoggerCategory.Model, RelationalLoggingDefinitions>();
+            var logger = new TestLogger<DbLoggerCategory.Model, TestRelationalLoggingDefinitions>();
 
             Assert.True(new DiscriminatorConvention(logger).Apply(entityTypeBuilder, oldBaseType: null));
 
@@ -47,7 +47,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         [Fact]
         public void Sets_discriminator_for_three_level_hierarchy()
         {
-            var logger = new TestLogger<DbLoggerCategory.Model, RelationalLoggingDefinitions>();
+            var logger = new TestLogger<DbLoggerCategory.Model, TestRelationalLoggingDefinitions>();
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<Entity>();
 
             Assert.True(new DiscriminatorConvention(logger).Apply(entityTypeBuilder, oldBaseType: null));
@@ -91,7 +91,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         public void Uses_explicit_discriminator_if_compatible()
         {
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<Entity>();
-            var logger = new TestLogger<DbLoggerCategory.Model, RelationalLoggingDefinitions>();
+            var logger = new TestLogger<DbLoggerCategory.Model, TestRelationalLoggingDefinitions>();
 
             var baseTypeBuilder = entityTypeBuilder.ModelBuilder.Entity(typeof(EntityBase), ConfigurationSource.DataAnnotation);
             entityTypeBuilder.HasBaseType(baseTypeBuilder.Metadata, ConfigurationSource.DataAnnotation);
@@ -112,7 +112,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         public void Does_nothing_if_explicit_discriminator_is_not_compatible()
         {
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<Entity>();
-            var logger = new TestLogger<DbLoggerCategory.Model, RelationalLoggingDefinitions>();
+            var logger = new TestLogger<DbLoggerCategory.Model, TestRelationalLoggingDefinitions>();
 
             var baseTypeBuilder = entityTypeBuilder.ModelBuilder.Entity(typeof(EntityBase), ConfigurationSource.DataAnnotation);
             entityTypeBuilder.HasBaseType(baseTypeBuilder.Metadata, ConfigurationSource.DataAnnotation);
@@ -133,7 +133,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         public void Does_nothing_if_explicit_discriminator_set_on_derived_type()
         {
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<Entity>();
-            var logger = new TestLogger<DbLoggerCategory.Model, RelationalLoggingDefinitions>();
+            var logger = new TestLogger<DbLoggerCategory.Model, TestRelationalLoggingDefinitions>();
 
             entityTypeBuilder.Relational(ConfigurationSource.Explicit).HasDiscriminator("T", typeof(string));
 

--- a/test/EFCore.Relational.Tests/Metadata/Conventions/Internal/RelationalPropertyMappingValidationConventionTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/Conventions/Internal/RelationalPropertyMappingValidationConventionTest.cs
@@ -54,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 typeMappingSource,
                 TestServiceFactory.Instance.Create<IMemberClassifier>(
                     (typeof(ITypeMappingSource), typeMappingSource)),
-                new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>());
+                new TestLogger<DbLoggerCategory.Model, TestRelationalLoggingDefinitions>());
         }
     }
 }

--- a/test/EFCore.Relational.Tests/Metadata/DbFunctionMetadataTests.cs
+++ b/test/EFCore.Relational.Tests/Metadata/DbFunctionMetadataTests.cs
@@ -491,7 +491,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             var conventionset = new ConventionSet();
 
             conventionset.ModelAnnotationChangedConventions.Add(
-                new RelationalDbFunctionConvention(new TestLogger<DbLoggerCategory.Model, RelationalLoggingDefinitions>()));
+                new RelationalDbFunctionConvention(new TestLogger<DbLoggerCategory.Model, TestRelationalLoggingDefinitions>()));
 
             return new ModelBuilder(conventionset);
         }

--- a/test/EFCore.Relational.Tests/Metadata/RelationalEntityTypeAttributeConventionTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/RelationalEntityTypeAttributeConventionTest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             entityBuilder.HasAnnotation(RelationalAnnotationNames.TableName, "ConventionalName", ConfigurationSource.Convention);
             entityBuilder.HasAnnotation(RelationalAnnotationNames.Schema, "ConventionalSchema", ConfigurationSource.Convention);
 
-            new RelationalTableAttributeConvention(new TestLogger<DbLoggerCategory.Model, RelationalLoggingDefinitions>()).Apply(entityBuilder);
+            new RelationalTableAttributeConvention(new TestLogger<DbLoggerCategory.Model, TestRelationalLoggingDefinitions>()).Apply(entityBuilder);
 
             Assert.Equal("MyTable", entityBuilder.Metadata.Relational().TableName);
             Assert.Equal("MySchema", entityBuilder.Metadata.Relational().Schema);
@@ -48,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             entityBuilder.HasAnnotation(RelationalAnnotationNames.TableName, "ExplicitName", ConfigurationSource.Explicit);
             entityBuilder.HasAnnotation(RelationalAnnotationNames.Schema, "ExplicitName", ConfigurationSource.Explicit);
 
-            new RelationalTableAttributeConvention(new TestLogger<DbLoggerCategory.Model, RelationalLoggingDefinitions>()).Apply(entityBuilder);
+            new RelationalTableAttributeConvention(new TestLogger<DbLoggerCategory.Model, TestRelationalLoggingDefinitions>()).Apply(entityBuilder);
 
             Assert.Equal("ExplicitName", entityBuilder.Metadata.Relational().TableName);
             Assert.Equal("ExplicitName", entityBuilder.Metadata.Relational().Schema);
@@ -62,7 +62,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                     new TestRelationalTypeMappingSource(
                         TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
                         TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>()),
-                    new TestLogger<DbLoggerCategory.Model, RelationalLoggingDefinitions>()));
+                    new TestLogger<DbLoggerCategory.Model, TestRelationalLoggingDefinitions>()));
 
             var modelBuilder = new InternalModelBuilder(new Model(conventionSet));
 

--- a/test/EFCore.Relational.Tests/Metadata/RelationalPropertyAttributeConventionTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/RelationalPropertyAttributeConventionTest.cs
@@ -48,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             propertyBuilder.HasAnnotation(RelationalAnnotationNames.ColumnName, "ConventionalName", ConfigurationSource.Convention);
             propertyBuilder.HasAnnotation(RelationalAnnotationNames.ColumnType, "BYTE", ConfigurationSource.Convention);
 
-            new RelationalColumnAttributeConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(propertyBuilder);
+            new RelationalColumnAttributeConvention(new TestLogger<DbLoggerCategory.Model, TestRelationalLoggingDefinitions>()).Apply(propertyBuilder);
 
             Assert.Equal("Post Name", propertyBuilder.Metadata.Relational().ColumnName);
             Assert.Equal("DECIMAL", propertyBuilder.Metadata.Relational().ColumnType);
@@ -64,7 +64,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             propertyBuilder.HasAnnotation(RelationalAnnotationNames.ColumnName, "ExplicitName", ConfigurationSource.Explicit);
             propertyBuilder.HasAnnotation(RelationalAnnotationNames.ColumnType, "BYTE", ConfigurationSource.Explicit);
 
-            new RelationalColumnAttributeConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(propertyBuilder);
+            new RelationalColumnAttributeConvention(new TestLogger<DbLoggerCategory.Model, TestRelationalLoggingDefinitions>()).Apply(propertyBuilder);
 
             Assert.Equal("ExplicitName", propertyBuilder.Metadata.Relational().ColumnName);
             Assert.Equal("BYTE", propertyBuilder.Metadata.Relational().ColumnType);
@@ -78,7 +78,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                     new TestRelationalTypeMappingSource(
                         TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
                         TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>()),
-                    new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()));
+                    new TestLogger<DbLoggerCategory.Model, TestRelationalLoggingDefinitions>()));
 
             var modelBuilder = new InternalModelBuilder(new Model(conventionSet));
 

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsAssemblyTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsAssemblyTest.cs
@@ -43,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         [Fact]
         public void Migrations_ignores_the_unattributed()
         {
-            var logger = new TestLogger<DbLoggerCategory.Migrations, RelationalLoggingDefinitions>
+            var logger = new TestLogger<DbLoggerCategory.Migrations, TestRelationalLoggingDefinitions>
             {
                 EnabledFor = LogLevel.Warning
             };

--- a/test/EFCore.Relational.Tests/RelationalEventIdTest.cs
+++ b/test/EFCore.Relational.Tests/RelationalEventIdTest.cs
@@ -68,7 +68,7 @@ namespace Microsoft.EntityFrameworkCore
                     }
                 },
                 { typeof(IRelationalConnection), () => new FakeRelationalConnection() },
-                { typeof(LoggingDefinitions), () => new RelationalLoggingDefinitions() },
+                { typeof(LoggingDefinitions), () => new TestRelationalLoggingDefinitions() },
                 { typeof(DbCommand), () => new FakeDbCommand() },
                 { typeof(DbTransaction), () => new FakeDbTransaction() },
                 { typeof(DbDataReader), () => new FakeDbDataReader() },
@@ -88,7 +88,7 @@ namespace Microsoft.EntityFrameworkCore
             TestEventLogging(
                 typeof(RelationalEventId),
                 typeof(RelationalLoggerExtensions),
-                typeof(RelationalLoggingDefinitions),
+                typeof(TestRelationalLoggingDefinitions),
                 fakeFactories);
         }
 

--- a/test/EFCore.Relational.Tests/RelationalModelValidatorTest.cs
+++ b/test/EFCore.Relational.Tests/RelationalModelValidatorTest.cs
@@ -51,7 +51,7 @@ namespace Microsoft.EntityFrameworkCore
             property.Relational().DefaultValue = true;
             property.ValueGenerated = ValueGenerated.OnAdd;
 
-            VerifyWarning(RelationalResources.LogBoolWithDefaultWarning(new TestLogger<RelationalLoggingDefinitions>()).GenerateMessage("ImBool", "E"), model);
+            VerifyWarning(RelationalResources.LogBoolWithDefaultWarning(new TestLogger<TestRelationalLoggingDefinitions>()).GenerateMessage("ImBool", "E"), model);
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace Microsoft.EntityFrameworkCore
             property.Relational().DefaultValueSql = "TRUE";
             property.ValueGenerated = ValueGenerated.OnAddOrUpdate;
 
-            VerifyWarning(RelationalResources.LogBoolWithDefaultWarning(new TestLogger<RelationalLoggingDefinitions>()).GenerateMessage("ImBool", "E"), model);
+            VerifyWarning(RelationalResources.LogBoolWithDefaultWarning(new TestLogger<TestRelationalLoggingDefinitions>()).GenerateMessage("ImBool", "E"), model);
         }
 
         [Fact]
@@ -78,7 +78,7 @@ namespace Microsoft.EntityFrameworkCore
             SetPrimaryKey(entityA);
             entityA.FindProperty("Id").Relational().DefaultValue = 1;
 
-            VerifyWarning(RelationalResources.LogKeyHasDefaultValue(new TestLogger<RelationalLoggingDefinitions>()).GenerateMessage("Id", "A"), model);
+            VerifyWarning(RelationalResources.LogKeyHasDefaultValue(new TestLogger<TestRelationalLoggingDefinitions>()).GenerateMessage("Id", "A"), model);
         }
 
         [Fact]
@@ -93,7 +93,7 @@ namespace Microsoft.EntityFrameworkCore
             entityA.AddKey(new[] { property });
             property.Relational().DefaultValue = 1;
 
-            VerifyWarning(RelationalResources.LogKeyHasDefaultValue(new TestLogger<RelationalLoggingDefinitions>()).GenerateMessage("P0", "A"), model);
+            VerifyWarning(RelationalResources.LogKeyHasDefaultValue(new TestLogger<TestRelationalLoggingDefinitions>()).GenerateMessage("P0", "A"), model);
         }
 
         [Fact]

--- a/test/EFCore.Relational.Tests/Storage/RelationalCommandTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalCommandTest.cs
@@ -921,7 +921,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 logFactory,
                 new FakeLoggingOptions(false),
                 new DiagnosticListener("Fake"),
-                new RelationalLoggingDefinitions());
+                new TestRelationalLoggingDefinitions());
 
             var relationalCommand = CreateRelationalCommand(
                 commandText: "Logged Command",
@@ -977,7 +977,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 logFactory,
                 new FakeLoggingOptions(true),
                 new DiagnosticListener("Fake"),
-                new RelationalLoggingDefinitions());
+                new TestRelationalLoggingDefinitions());
 
             var relationalCommand = CreateRelationalCommand(
                 commandText: "Logged Command",
@@ -1002,7 +1002,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
             Assert.Equal(3, logFactory.Log.Count);
             Assert.Equal(LogLevel.Warning, logFactory.Log[0].Level);
-            Assert.Equal(CoreResources.LogSensitiveDataLoggingEnabled(new TestLogger<RelationalLoggingDefinitions>()).GenerateMessage(), logFactory.Log[0].Message);
+            Assert.Equal(CoreResources.LogSensitiveDataLoggingEnabled(new TestLogger<TestRelationalLoggingDefinitions>()).GenerateMessage(), logFactory.Log[0].Message);
 
             Assert.Equal(LogLevel.Debug, logFactory.Log[1].Level);
             Assert.Equal(LogLevel.Debug, logFactory.Log[2].Level);
@@ -1033,7 +1033,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 new ListLoggerFactory(),
                 new FakeLoggingOptions(false),
                 new ListDiagnosticSource(diagnostic),
-                new RelationalLoggingDefinitions());
+                new TestRelationalLoggingDefinitions());
 
             var relationalCommand = CreateRelationalCommand(
                 parameters: new[]
@@ -1103,7 +1103,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 new ListLoggerFactory(),
                 new FakeLoggingOptions(false),
                 new ListDiagnosticSource(diagnostic),
-                new RelationalLoggingDefinitions());
+                new TestRelationalLoggingDefinitions());
 
             var relationalCommand = CreateRelationalCommand(
                 parameters: new[]

--- a/test/EFCore.Relational.Tests/Storage/RelationalTransactionExtensionsTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalTransactionExtensionsTest.cs
@@ -33,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                     loggerFactory,
                     new LoggingOptions(),
                     new DiagnosticListener("Fake"),
-                    new RelationalLoggingDefinitions()),
+                    new TestRelationalLoggingDefinitions()),
                 false);
 
             Assert.Equal(dbTransaction, transaction.GetDbTransaction());

--- a/test/EFCore.Relational.Tests/TestUtilities/FakeDiagnosticsLogger.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/FakeDiagnosticsLogger.cs
@@ -35,6 +35,6 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
         public IDisposable BeginScope<TState>(TState state) => null;
 
-        public virtual LoggingDefinitions Definitions { get; } = new RelationalLoggingDefinitions();
+        public virtual LoggingDefinitions Definitions { get; } = new TestRelationalLoggingDefinitions();
     }
 }

--- a/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalConnection.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalConnection.cs
@@ -27,12 +27,12 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider
                         new LoggerFactory(),
                         new LoggingOptions(),
                         new DiagnosticListener("FakeDiagnosticListener"),
-                        new RelationalLoggingDefinitions()),
+                        new TestRelationalLoggingDefinitions()),
                     new DiagnosticsLogger<DbLoggerCategory.Database.Connection>(
                         new LoggerFactory(),
                         new LoggingOptions(),
                         new DiagnosticListener("FakeDiagnosticListener"),
-                        new RelationalLoggingDefinitions()),
+                        new TestRelationalLoggingDefinitions()),
                     new NamedConnectionStringResolver(options ?? CreateOptions()),
                     new RelationalTransactionFactory(new RelationalTransactionFactoryDependencies())))
         {

--- a/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalOptionsExtension.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalOptionsExtension.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
@@ -42,6 +43,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider
         public static IServiceCollection AddEntityFrameworkRelationalDatabase(IServiceCollection serviceCollection)
         {
             var builder = new EntityFrameworkRelationalServicesBuilder(serviceCollection)
+                .TryAdd<LoggingDefinitions, TestRelationalLoggingDefinitions>()
                 .TryAdd<IDatabaseProvider, DatabaseProvider<FakeRelationalOptionsExtension>>()
                 .TryAdd<ISqlGenerationHelper, RelationalSqlGenerationHelper>()
                 .TryAdd<IRelationalTypeMappingSource, TestRelationalTypeMappingSource>()

--- a/test/EFCore.Relational.Tests/TestUtilities/RelationalTestHelpers.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/RelationalTestHelpers.cs
@@ -38,6 +38,6 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                         TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
                         TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>())));
 
-        public override LoggingDefinitions LoggingDefinitions { get; } = new RelationalLoggingDefinitions();
+        public override LoggingDefinitions LoggingDefinitions { get; } = new TestRelationalLoggingDefinitions();
     }
 }

--- a/test/EFCore.Specification.Tests/DataAnnotationTestBase.cs
+++ b/test/EFCore.Specification.Tests/DataAnnotationTestBase.cs
@@ -1838,7 +1838,7 @@ namespace Microsoft.EntityFrameworkCore
             var logEntry = Fixture.ListLoggerFactory.Log.Single();
             Assert.Equal(LogLevel.Warning, logEntry.Level);
             Assert.Equal(
-                CoreResources.LogForeignKeyAttributesOnBothProperties(new TestLogger<LoggingDefinitions>()).GenerateMessage(
+                CoreResources.LogForeignKeyAttributesOnBothProperties(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
                     nameof(PostDetails), nameof(PostDetails.Post),
                     nameof(Post), nameof(Post.PostDetails),
                     nameof(PostDetails.PostId),
@@ -1864,7 +1864,7 @@ namespace Microsoft.EntityFrameworkCore
             var logEntry = Fixture.ListLoggerFactory.Log.Single();
             Assert.Equal(LogLevel.Warning, logEntry.Level);
             Assert.Equal(
-                CoreResources.LogForeignKeyAttributesOnBothNavigations(new TestLogger<LoggingDefinitions>()).GenerateMessage(
+                CoreResources.LogForeignKeyAttributesOnBothNavigations(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
                     nameof(Post), nameof(Post.Author), nameof(Author), nameof(Author.Post)), logEntry.Message);
         }
 
@@ -1894,7 +1894,7 @@ namespace Microsoft.EntityFrameworkCore
             var logEntry = Fixture.ListLoggerFactory.Log.Single();
             Assert.Equal(LogLevel.Warning, logEntry.Level);
             Assert.Equal(
-                CoreResources.LogConflictingForeignKeyAttributesOnNavigationAndProperty(new TestLogger<LoggingDefinitions>()).GenerateMessage(
+                CoreResources.LogConflictingForeignKeyAttributesOnNavigationAndProperty(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
                     nameof(Author), nameof(Author.AuthorDetails), nameof(AuthorDetails), nameof(AuthorDetails.AuthorId)),
                 logEntry.Message);
         }

--- a/test/EFCore.Specification.Tests/LazyLoadProxyTestBase.cs
+++ b/test/EFCore.Specification.Tests/LazyLoadProxyTestBase.cs
@@ -61,7 +61,7 @@ namespace Microsoft.EntityFrameworkCore
                     Assert.Equal(
                         CoreStrings.WarningAsErrorTemplate(
                             CoreEventId.LazyLoadOnDisposedContextWarning.ToString(),
-                            CoreResources.LogLazyLoadOnDisposedContext(new TestLogger<LoggingDefinitions>()).GenerateMessage("Children", "ParentProxy"),
+                            CoreResources.LogLazyLoadOnDisposedContext(new TestLogger<TestLoggingDefinitions>()).GenerateMessage("Children", "ParentProxy"),
                             "CoreEventId.LazyLoadOnDisposedContextWarning"),
                         Assert.Throws<InvalidOperationException>(
                             () => parent.Children).Message);
@@ -135,7 +135,7 @@ namespace Microsoft.EntityFrameworkCore
                     Assert.Equal(
                         CoreStrings.WarningAsErrorTemplate(
                             CoreEventId.LazyLoadOnDisposedContextWarning.ToString(),
-                            CoreResources.LogLazyLoadOnDisposedContext(new TestLogger<LoggingDefinitions>()).GenerateMessage("Parent", "ChildProxy"),
+                            CoreResources.LogLazyLoadOnDisposedContext(new TestLogger<TestLoggingDefinitions>()).GenerateMessage("Parent", "ChildProxy"),
                             "CoreEventId.LazyLoadOnDisposedContextWarning"),
                         Assert.Throws<InvalidOperationException>(
                             () => child.Parent).Message);
@@ -211,7 +211,7 @@ namespace Microsoft.EntityFrameworkCore
                     Assert.Equal(
                         CoreStrings.WarningAsErrorTemplate(
                             CoreEventId.LazyLoadOnDisposedContextWarning.ToString(),
-                            CoreResources.LogLazyLoadOnDisposedContext(new TestLogger<LoggingDefinitions>()).GenerateMessage("Parent", "SingleProxy"),
+                            CoreResources.LogLazyLoadOnDisposedContext(new TestLogger<TestLoggingDefinitions>()).GenerateMessage("Parent", "SingleProxy"),
                             "CoreEventId.LazyLoadOnDisposedContextWarning"),
                         Assert.Throws<InvalidOperationException>(
                             () => single.Parent).Message);
@@ -287,7 +287,7 @@ namespace Microsoft.EntityFrameworkCore
                     Assert.Equal(
                         CoreStrings.WarningAsErrorTemplate(
                             CoreEventId.LazyLoadOnDisposedContextWarning.ToString(),
-                            CoreResources.LogLazyLoadOnDisposedContext(new TestLogger<LoggingDefinitions>()).GenerateMessage("Single", "ParentProxy"),
+                            CoreResources.LogLazyLoadOnDisposedContext(new TestLogger<TestLoggingDefinitions>()).GenerateMessage("Single", "ParentProxy"),
                             "CoreEventId.LazyLoadOnDisposedContextWarning"),
                         Assert.Throws<InvalidOperationException>(
                             () => parent.Single).Message);
@@ -1657,7 +1657,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.Equal(
                     CoreStrings.WarningAsErrorTemplate(
                         CoreEventId.DetachedLazyLoadingWarning.ToString(),
-                        CoreResources.LogDetachedLazyLoading(new TestLogger<LoggingDefinitions>()).GenerateMessage(nameof(Parent.Children), "ParentProxy"),
+                        CoreResources.LogDetachedLazyLoading(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(nameof(Parent.Children), "ParentProxy"),
                         "CoreEventId.DetachedLazyLoadingWarning"),
                     Assert.Throws<InvalidOperationException>(
                         () => parent.Children).Message);
@@ -1674,7 +1674,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.Equal(
                     CoreStrings.WarningAsErrorTemplate(
                         CoreEventId.DetachedLazyLoadingWarning.ToString(),
-                        CoreResources.LogDetachedLazyLoading(new TestLogger<LoggingDefinitions>()).GenerateMessage(nameof(Child.Parent), "ChildProxy"),
+                        CoreResources.LogDetachedLazyLoading(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(nameof(Child.Parent), "ChildProxy"),
                         "CoreEventId.DetachedLazyLoadingWarning"),
                     Assert.Throws<InvalidOperationException>(
                         () => child.Parent).Message);
@@ -1691,7 +1691,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.Equal(
                     CoreStrings.WarningAsErrorTemplate(
                         CoreEventId.DetachedLazyLoadingWarning.ToString(),
-                        CoreResources.LogDetachedLazyLoading(new TestLogger<LoggingDefinitions>()).GenerateMessage(nameof(Parent.Single), "ParentProxy"),
+                        CoreResources.LogDetachedLazyLoading(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(nameof(Parent.Single), "ParentProxy"),
                         "CoreEventId.DetachedLazyLoadingWarning"),
                     Assert.Throws<InvalidOperationException>(
                         () => parent.Single).Message);

--- a/test/EFCore.Specification.Tests/LoadTestBase.cs
+++ b/test/EFCore.Specification.Tests/LoadTestBase.cs
@@ -1376,7 +1376,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.Equal(
                     CoreStrings.WarningAsErrorTemplate(
                         CoreEventId.DetachedLazyLoadingWarning.ToString(),
-                        CoreResources.LogDetachedLazyLoading(new TestLogger<LoggingDefinitions>()).GenerateMessage(nameof(Parent.Children), "Parent"),
+                        CoreResources.LogDetachedLazyLoading(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(nameof(Parent.Children), "Parent"),
                         "CoreEventId.DetachedLazyLoadingWarning"),
                     Assert.Throws<InvalidOperationException>(
                         () => parent.Children).Message);
@@ -1400,7 +1400,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.Equal(
                     CoreStrings.WarningAsErrorTemplate(
                         CoreEventId.DetachedLazyLoadingWarning.ToString(),
-                        CoreResources.LogDetachedLazyLoading(new TestLogger<LoggingDefinitions>()).GenerateMessage(nameof(Child.Parent), "Child"),
+                        CoreResources.LogDetachedLazyLoading(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(nameof(Child.Parent), "Child"),
                         "CoreEventId.DetachedLazyLoadingWarning"),
                     Assert.Throws<InvalidOperationException>(
                         () => child.Parent).Message);
@@ -1424,7 +1424,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.Equal(
                     CoreStrings.WarningAsErrorTemplate(
                         CoreEventId.DetachedLazyLoadingWarning.ToString(),
-                        CoreResources.LogDetachedLazyLoading(new TestLogger<LoggingDefinitions>()).GenerateMessage(nameof(Parent.Single), "Parent"),
+                        CoreResources.LogDetachedLazyLoading(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(nameof(Parent.Single), "Parent"),
                         "CoreEventId.DetachedLazyLoadingWarning"),
                     Assert.Throws<InvalidOperationException>(
                         () => parent.Single).Message);

--- a/test/EFCore.Specification.Tests/LoggingTestBase.cs
+++ b/test/EFCore.Specification.Tests/LoggingTestBase.cs
@@ -39,7 +39,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         protected virtual string ExpectedMessage(string optionsFragment)
-            => CoreResources.LogContextInitialized(new TestLogger<LoggingDefinitions>()).GenerateMessage(
+            => CoreResources.LogContextInitialized(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
                 ProductInfo.GetVersion(),
                 nameof(LoggingContext),
                 ProviderName,

--- a/test/EFCore.Specification.Tests/TestUtilities/TestHelpers.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/TestHelpers.cs
@@ -247,7 +247,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         public virtual IModelValidator CreateModelValidator()
             => new ModelValidator(new ModelValidatorDependencies());
 
-        public virtual LoggingDefinitions LoggingDefinitions { get; } = new LoggingDefinitions();
+        public virtual LoggingDefinitions LoggingDefinitions { get; } = new TestLoggingDefinitions();
 
         public InternalEntityEntry CreateInternalEntry<TEntity>(
             IModel model, EntityState entityState = EntityState.Detached, TEntity entity = null)

--- a/test/EFCore.Specification.Tests/TestUtilities/TestLoggingDefinitions.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/TestLoggingDefinitions.cs
@@ -1,0 +1,11 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities
+{
+    public class TestLoggingDefinitions : LoggingDefinitions
+    {
+    }
+}

--- a/test/EFCore.Specification.Tests/TestUtilities/TestServiceFactory.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/TestServiceFactory.cs
@@ -31,9 +31,9 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             {
                 (typeof(IRegisteredServices), new RegisteredServices(Enumerable.Empty<Type>())),
                 (typeof(ServiceParameterBindingFactory), new ServiceParameterBindingFactory(typeof(IStateManager))),
-                (typeof(IDiagnosticsLogger<DbLoggerCategory.Model>), new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()),
-                (typeof(IDiagnosticsLogger<DbLoggerCategory.Model.Validation>), new TestLogger<DbLoggerCategory.Model.Validation, LoggingDefinitions>()),
-                (typeof(IDiagnosticsLogger<DbLoggerCategory.Query>), new TestLogger<DbLoggerCategory.Query, LoggingDefinitions>())
+                (typeof(IDiagnosticsLogger<DbLoggerCategory.Model>), new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()),
+                (typeof(IDiagnosticsLogger<DbLoggerCategory.Model.Validation>), new TestLogger<DbLoggerCategory.Model.Validation, TestLoggingDefinitions>()),
+                (typeof(IDiagnosticsLogger<DbLoggerCategory.Query>), new TestLogger<DbLoggerCategory.Query, TestLoggingDefinitions>())
             };
 
         public TService Create<TService>(params (Type Type, object Implementation)[] specialCases)

--- a/test/EFCore.Tests/ChangeTracking/ChangeTrackerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/ChangeTrackerTest.cs
@@ -39,11 +39,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
                 var (level, _, message, _, _) = _loggerFactory.Log.Single(e => e.Id.Id == CoreEventId.DetectChangesStarting.Id);
                 Assert.Equal(LogLevel.Debug, level);
-                Assert.Equal(CoreResources.LogDetectChangesStarting(new TestLogger<LoggingDefinitions>()).GenerateMessage(nameof(LikeAZooContext)), message);
+                Assert.Equal(CoreResources.LogDetectChangesStarting(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(nameof(LikeAZooContext)), message);
 
                 (level, _, message, _, _) = _loggerFactory.Log.Single(e => e.Id.Id == CoreEventId.DetectChangesCompleted.Id);
                 Assert.Equal(LogLevel.Debug, level);
-                Assert.Equal(CoreResources.LogDetectChangesCompleted(new TestLogger<LoggingDefinitions>()).GenerateMessage(nameof(LikeAZooContext)), message);
+                Assert.Equal(CoreResources.LogDetectChangesCompleted(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(nameof(LikeAZooContext)), message);
             }
         }
 
@@ -67,9 +67,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                 Assert.Equal(LogLevel.Debug, level);
                 Assert.Equal(
                     sensitive
-                        ? CoreResources.LogPropertyChangeDetectedSensitive(new TestLogger<LoggingDefinitions>()).GenerateMessage(
+                        ? CoreResources.LogPropertyChangeDetectedSensitive(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
                             nameof(Cat), nameof(Cat.Name), "Smokey", "Smoke-a-doke", "{Id: 1}")
-                        : CoreResources.LogPropertyChangeDetected(new TestLogger<LoggingDefinitions>()).GenerateMessage(nameof(Cat), nameof(Cat.Name)),
+                        : CoreResources.LogPropertyChangeDetected(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(nameof(Cat), nameof(Cat.Name)),
                     message);
 
                 _loggerFactory.Log.Clear();
@@ -102,8 +102,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                 Assert.Equal(LogLevel.Debug, level);
                 Assert.Equal(
                     sensitive
-                        ? CoreResources.LogForeignKeyChangeDetectedSensitive(new TestLogger<LoggingDefinitions>()).GenerateMessage(nameof(Hat), nameof(Hat.CatId), 1, 2, "{Id: 77}")
-                        : CoreResources.LogForeignKeyChangeDetected(new TestLogger<LoggingDefinitions>()).GenerateMessage(nameof(Hat), nameof(Hat.CatId)),
+                        ? CoreResources.LogForeignKeyChangeDetectedSensitive(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(nameof(Hat), nameof(Hat.CatId), 1, 2, "{Id: 77}")
+                        : CoreResources.LogForeignKeyChangeDetected(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(nameof(Hat), nameof(Hat.CatId)),
                     message);
 
                 _loggerFactory.Log.Clear();
@@ -115,8 +115,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                 Assert.Equal(LogLevel.Debug, level);
                 Assert.Equal(
                     sensitive
-                        ? CoreResources.LogForeignKeyChangeDetectedSensitive(new TestLogger<LoggingDefinitions>()).GenerateMessage(nameof(Hat), nameof(Hat.CatId), 2, 1, "{Id: 77}")
-                        : CoreResources.LogForeignKeyChangeDetected(new TestLogger<LoggingDefinitions>()).GenerateMessage(nameof(Hat), nameof(Hat.CatId)),
+                        ? CoreResources.LogForeignKeyChangeDetectedSensitive(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(nameof(Hat), nameof(Hat.CatId), 2, 1, "{Id: 77}")
+                        : CoreResources.LogForeignKeyChangeDetected(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(nameof(Hat), nameof(Hat.CatId)),
                     message);
             }
         }
@@ -142,8 +142,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                 Assert.Equal(LogLevel.Debug, level);
                 Assert.Equal(
                     sensitive
-                        ? CoreResources.LogCollectionChangeDetectedSensitive(new TestLogger<LoggingDefinitions>()).GenerateMessage(0, 1, nameof(Cat), nameof(Cat.Hats), "{Id: 1}")
-                        : CoreResources.LogCollectionChangeDetected(new TestLogger<LoggingDefinitions>()).GenerateMessage(0, 1, nameof(Cat), nameof(Cat.Hats)),
+                        ? CoreResources.LogCollectionChangeDetectedSensitive(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(0, 1, nameof(Cat), nameof(Cat.Hats), "{Id: 1}")
+                        : CoreResources.LogCollectionChangeDetected(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(0, 1, nameof(Cat), nameof(Cat.Hats)),
                     message);
 
                 _loggerFactory.Log.Clear();
@@ -155,8 +155,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                 Assert.Equal(LogLevel.Debug, level);
                 Assert.Equal(
                     sensitive
-                        ? CoreResources.LogCollectionChangeDetectedSensitive(new TestLogger<LoggingDefinitions>()).GenerateMessage(1, 0, nameof(Cat), nameof(Cat.Hats), "{Id: 1}")
-                        : CoreResources.LogCollectionChangeDetected(new TestLogger<LoggingDefinitions>()).GenerateMessage(1, 0, nameof(Cat), nameof(Cat.Hats)),
+                        ? CoreResources.LogCollectionChangeDetectedSensitive(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(1, 0, nameof(Cat), nameof(Cat.Hats), "{Id: 1}")
+                        : CoreResources.LogCollectionChangeDetected(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(1, 0, nameof(Cat), nameof(Cat.Hats)),
                     message);
             }
         }
@@ -182,8 +182,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                 Assert.Equal(LogLevel.Debug, level);
                 Assert.Equal(
                     sensitive
-                        ? CoreResources.LogReferenceChangeDetectedSensitive(new TestLogger<LoggingDefinitions>()).GenerateMessage(nameof(Hat), nameof(Hat.Cat), "{Id: 77}")
-                        : CoreResources.LogReferenceChangeDetected(new TestLogger<LoggingDefinitions>()).GenerateMessage(nameof(Hat), nameof(Hat.Cat)),
+                        ? CoreResources.LogReferenceChangeDetectedSensitive(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(nameof(Hat), nameof(Hat.Cat), "{Id: 77}")
+                        : CoreResources.LogReferenceChangeDetected(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(nameof(Hat), nameof(Hat.Cat)),
                     message);
 
                 _loggerFactory.Log.Clear();
@@ -195,8 +195,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                 Assert.Equal(LogLevel.Debug, level);
                 Assert.Equal(
                     sensitive
-                        ? CoreResources.LogReferenceChangeDetectedSensitive(new TestLogger<LoggingDefinitions>()).GenerateMessage(nameof(Hat), nameof(Hat.Cat), "{Id: 77}")
-                        : CoreResources.LogReferenceChangeDetected(new TestLogger<LoggingDefinitions>()).GenerateMessage(nameof(Hat), nameof(Hat.Cat)),
+                        ? CoreResources.LogReferenceChangeDetectedSensitive(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(nameof(Hat), nameof(Hat.Cat), "{Id: 77}")
+                        : CoreResources.LogReferenceChangeDetected(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(nameof(Hat), nameof(Hat.Cat)),
                     message);
             }
         }
@@ -217,8 +217,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                 Assert.Equal(LogLevel.Debug, level);
                 Assert.Equal(
                     sensitive
-                        ? CoreResources.LogStartedTrackingSensitive(new TestLogger<LoggingDefinitions>()).GenerateMessage(nameof(LikeAZooContextSensitive), nameof(Cat), "{Id: 1}")
-                        : CoreResources.LogStartedTracking(new TestLogger<LoggingDefinitions>()).GenerateMessage(nameof(LikeAZooContext), nameof(Cat)),
+                        ? CoreResources.LogStartedTrackingSensitive(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(nameof(LikeAZooContextSensitive), nameof(Cat), "{Id: 1}")
+                        : CoreResources.LogStartedTracking(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(nameof(LikeAZooContext), nameof(Cat)),
                     message);
             }
         }
@@ -237,8 +237,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                 Assert.Equal(LogLevel.Debug, level);
                 Assert.Equal(
                     sensitive
-                        ? CoreResources.LogStartedTrackingSensitive(new TestLogger<LoggingDefinitions>()).GenerateMessage(nameof(LikeAZooContextSensitive), nameof(Hat), "{Id: 88}")
-                        : CoreResources.LogStartedTracking(new TestLogger<LoggingDefinitions>()).GenerateMessage(nameof(LikeAZooContext), nameof(Hat)),
+                        ? CoreResources.LogStartedTrackingSensitive(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(nameof(LikeAZooContextSensitive), nameof(Hat), "{Id: 88}")
+                        : CoreResources.LogStartedTracking(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(nameof(LikeAZooContext), nameof(Hat)),
                     message);
             }
         }
@@ -262,9 +262,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                 Assert.Equal(LogLevel.Debug, level);
                 Assert.Equal(
                     sensitive
-                        ? CoreResources.LogStateChangedSensitive(new TestLogger<LoggingDefinitions>()).GenerateMessage(
+                        ? CoreResources.LogStateChangedSensitive(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
                             nameof(Cat), "{Id: 1}", nameof(LikeAZooContextSensitive), EntityState.Unchanged, EntityState.Deleted)
-                        : CoreResources.LogStateChanged(new TestLogger<LoggingDefinitions>()).GenerateMessage(
+                        : CoreResources.LogStateChanged(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
                             nameof(Cat), nameof(LikeAZooContext), EntityState.Unchanged, EntityState.Deleted),
                     message);
             }
@@ -306,18 +306,18 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                 {
                     Assert.Equal(
                         sensitive
-                            ? CoreResources.LogTempValueGeneratedSensitive(new TestLogger<LoggingDefinitions>()).GenerateMessage(
+                            ? CoreResources.LogTempValueGeneratedSensitive(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
                                 nameof(LikeAZooContextSensitive), 1, nameof(Hat.Id), nameof(Hat))
-                            : CoreResources.LogTempValueGenerated(new TestLogger<LoggingDefinitions>()).GenerateMessage(nameof(LikeAZooContext), nameof(Hat.Id), nameof(Hat)),
+                            : CoreResources.LogTempValueGenerated(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(nameof(LikeAZooContext), nameof(Hat.Id), nameof(Hat)),
                         message);
                 }
                 else
                 {
                     Assert.Equal(
                         sensitive
-                            ? CoreResources.LogValueGeneratedSensitive(new TestLogger<LoggingDefinitions>()).GenerateMessage(
+                            ? CoreResources.LogValueGeneratedSensitive(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
                                 nameof(LikeAZooContextSensitive), 1, nameof(Hat.Id), nameof(Hat))
-                            : CoreResources.LogValueGenerated(new TestLogger<LoggingDefinitions>()).GenerateMessage(nameof(LikeAZooContext), nameof(Hat.Id), nameof(Hat)),
+                            : CoreResources.LogValueGenerated(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(nameof(LikeAZooContext), nameof(Hat.Id), nameof(Hat)),
                         message);
                 }
             }
@@ -464,8 +464,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                     Assert.Equal(LogLevel.Debug, cascadeDeleteLevel);
                     Assert.Equal(
                         sensitive
-                            ? CoreResources.LogCascadeDeleteSensitive(new TestLogger<LoggingDefinitions>()).GenerateMessage(nameof(Hat), "{Id: 77}", EntityState.Deleted, nameof(Cat), "{Id: 1}")
-                            : CoreResources.LogCascadeDelete(new TestLogger<LoggingDefinitions>()).GenerateMessage(nameof(Hat), EntityState.Deleted, nameof(Cat)),
+                            ? CoreResources.LogCascadeDeleteSensitive(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(nameof(Hat), "{Id: 77}", EntityState.Deleted, nameof(Cat), "{Id: 1}")
+                            : CoreResources.LogCascadeDelete(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(nameof(Hat), EntityState.Deleted, nameof(Cat)),
                         cascadeDeleteMessage);
                 }
             }
@@ -586,8 +586,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                     Assert.Equal(LogLevel.Debug, deleteOrphansLevel);
                     Assert.Equal(
                         sensitive
-                            ? CoreResources.LogCascadeDeleteOrphanSensitive(new TestLogger<LoggingDefinitions>()).GenerateMessage(nameof(Hat), "{Id: 77}", EntityState.Deleted, nameof(Cat))
-                            : CoreResources.LogCascadeDeleteOrphan(new TestLogger<LoggingDefinitions>()).GenerateMessage(nameof(Hat), EntityState.Deleted, nameof(Cat)),
+                            ? CoreResources.LogCascadeDeleteOrphanSensitive(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(nameof(Hat), "{Id: 77}", EntityState.Deleted, nameof(Cat))
+                            : CoreResources.LogCascadeDeleteOrphan(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(nameof(Hat), EntityState.Deleted, nameof(Cat)),
                         deleteOrphansMessage);
                 }
             }
@@ -619,11 +619,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
                 var (level, _, message, _, _) = _loggerFactory.Log.Single(e => e.Id.Id == CoreEventId.SaveChangesStarting.Id);
                 Assert.Equal(LogLevel.Debug, level);
-                Assert.Equal(CoreResources.LogSaveChangesStarting(new TestLogger<LoggingDefinitions>()).GenerateMessage(nameof(LikeAZooContext)), message);
+                Assert.Equal(CoreResources.LogSaveChangesStarting(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(nameof(LikeAZooContext)), message);
 
                 (level, _, message, _, _) = _loggerFactory.Log.Single(e => e.Id.Id == CoreEventId.SaveChangesCompleted.Id);
                 Assert.Equal(LogLevel.Debug, level);
-                Assert.Equal(CoreResources.LogSaveChangesCompleted(new TestLogger<LoggingDefinitions>()).GenerateMessage(nameof(LikeAZooContext), 1), message);
+                Assert.Equal(CoreResources.LogSaveChangesCompleted(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(nameof(LikeAZooContext), 1), message);
             }
         }
 
@@ -639,7 +639,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
             var (level, _, message, _, _) = _loggerFactory.Log.Single(e => e.Id.Id == CoreEventId.ContextDisposed.Id);
             Assert.Equal(LogLevel.Debug, level);
-            Assert.Equal(CoreResources.LogContextDisposed(new TestLogger<LoggingDefinitions>()).GenerateMessage(nameof(LikeAZooContext)), message);
+            Assert.Equal(CoreResources.LogContextDisposed(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(nameof(LikeAZooContext)), message);
         }
 
         [Fact]

--- a/test/EFCore.Tests/ChangeTracking/Internal/OwnedFixupTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/OwnedFixupTest.cs
@@ -83,7 +83,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 Assert.Equal(
                     CoreStrings.WarningAsErrorTemplate(
                         CoreEventId.DuplicateDependentEntityTypeInstanceWarning.ToString(),
-                        CoreResources.LogDuplicateDependentEntityTypeInstance(new TestLogger<LoggingDefinitions>()).GenerateMessage(
+                        CoreResources.LogDuplicateDependentEntityTypeInstance(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
                             typeof(ParentPN).ShortDisplayName() + "." + nameof(ParentPN.Child2) + "#" + typeof(ChildPN).ShortDisplayName(),
                             typeof(ParentPN).ShortDisplayName() + "." + nameof(ParentPN.Child1) + "#" + typeof(ChildPN).ShortDisplayName()),
                         "CoreEventId.DuplicateDependentEntityTypeInstanceWarning"),
@@ -1355,7 +1355,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 Assert.Equal(
                     entityState == EntityState.Added ? null : (EntityState?)EntityState.Deleted,
                     dependent2Entry.GetInfrastructure().SharedIdentityEntry?.EntityState);
-                
+
                 Assert.Same(subDependent1, dependent1.SubChild);
                 var subDependentEntry1 = dependent1Entry.Reference(p => p.SubChild).TargetEntry;
                 Assert.Equal(principal.Id, subDependentEntry1.Property("ParentId").CurrentValue);

--- a/test/EFCore.Tests/Infrastructure/CoreEventIdTest.cs
+++ b/test/EFCore.Tests/Infrastructure/CoreEventIdTest.cs
@@ -74,7 +74,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             TestEventLogging(
                 typeof(CoreEventId),
                 typeof(CoreLoggerExtensions),
-                typeof(LoggingDefinitions),
+                typeof(TestLoggingDefinitions),
                 fakeFactories);
         }
 

--- a/test/EFCore.Tests/Infrastructure/DiagnosticsLoggerTest.cs
+++ b/test/EFCore.Tests/Infrastructure/DiagnosticsLoggerTest.cs
@@ -46,11 +46,11 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             var loggerFactory = new ListLoggerFactory(filter);
 
             var dbLogger = new DiagnosticsLogger<DbLoggerCategory.Database>(
-                loggerFactory, new LoggingOptions(), new DiagnosticListener("Fake"), new LoggingDefinitions());
+                loggerFactory, new LoggingOptions(), new DiagnosticListener("Fake"), new TestLoggingDefinitions());
             var sqlLogger = new DiagnosticsLogger<DbLoggerCategory.Database.Command>(
-                loggerFactory, new LoggingOptions(), new DiagnosticListener("Fake"), new LoggingDefinitions());
+                loggerFactory, new LoggingOptions(), new DiagnosticListener("Fake"), new TestLoggingDefinitions());
             var queryLogger = new DiagnosticsLogger<DbLoggerCategory.Query>(
-                loggerFactory, new LoggingOptions(), new DiagnosticListener("Fake"), new LoggingDefinitions());
+                loggerFactory, new LoggingOptions(), new DiagnosticListener("Fake"), new TestLoggingDefinitions());
             var randomLogger = loggerFactory.CreateLogger("Random");
 
             dbLogger.Logger.LogInformation(1, "DB1");

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
@@ -52,7 +52,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             var keyProperty = entityType.AddProperty("Key", typeof(int));
             entityType.AddKey(keyProperty);
 
-            VerifyWarning(CoreResources.LogShadowPropertyCreated(new TestLogger<LoggingDefinitions>()).GenerateMessage("Key", "A"), model, LogLevel.Debug);
+            VerifyWarning(CoreResources.LogShadowPropertyCreated(new TestLogger<TestLoggingDefinitions>()).GenerateMessage("Key", "A"), model, LogLevel.Debug);
         }
 
         [Fact]
@@ -63,7 +63,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             var keyProperty = entityType.AddProperty("Key", typeof(int));
             entityType.SetPrimaryKey(keyProperty);
 
-            VerifyWarning(CoreResources.LogShadowPropertyCreated(new TestLogger<LoggingDefinitions>()).GenerateMessage("Key", "A"), model, LogLevel.Debug);
+            VerifyWarning(CoreResources.LogShadowPropertyCreated(new TestLogger<TestLoggingDefinitions>()).GenerateMessage("Key", "A"), model, LogLevel.Debug);
         }
 
         [Fact]
@@ -161,7 +161,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
             modelBuilder.Entity<A>().HasOne<A>().WithOne().IsRequired().HasForeignKey<A>(a => a.Id).HasPrincipalKey<A>(b => b.Id);
 
-            VerifyWarning(CoreResources.LogRedundantForeignKey(new TestLogger<LoggingDefinitions>()).GenerateMessage("{'Id'}", "A"), modelBuilder.Model, LogLevel.Warning);
+            VerifyWarning(CoreResources.LogRedundantForeignKey(new TestLogger<TestLoggingDefinitions>()).GenerateMessage("{'Id'}", "A"), modelBuilder.Model, LogLevel.Warning);
         }
 
         [Fact]

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/BackingFieldConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/BackingFieldConventionTest.cs
@@ -71,7 +71,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         {
             var entityType = CreateModel().AddEntityType(typeof(TheDarkSideOfTheMoon));
             var property = entityType.AddProperty("SpeakToMe", typeof(int));
-            new BackingFieldConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(((Property)property).Builder);
+            new BackingFieldConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(((Property)property).Builder);
 
             Assert.Null(property.GetFieldName());
         }
@@ -121,7 +121,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         {
             var entityType = CreateModel().AddEntityType(typeof(TheDarkerSideOfTheMoon));
             var property = entityType.AddProperty("SpeakToMe", typeof(int));
-            new BackingFieldConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(((Property)property).Builder);
+            new BackingFieldConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(((Property)property).Builder);
 
             Assert.Null(property.GetFieldName());
         }
@@ -131,7 +131,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var entityType = CreateModel().AddEntityType(typeof(TEntity));
             var property = entityType.AddProperty(propertyName, typeof(int));
 
-            new BackingFieldConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(((Property)property).Builder);
+            new BackingFieldConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(((Property)property).Builder);
 
             Assert.Equal(fieldName, property.GetFieldName());
         }
@@ -142,7 +142,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var entityType = CreateModel().AddEntityType(typeof(TheDarkSide));
             var property = entityType.AddProperty(OfTheMoon.TheGreatGigInTheSkyProperty);
 
-            new BackingFieldConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(((Property)property).Builder);
+            new BackingFieldConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(((Property)property).Builder);
 
             Assert.Equal("_theGreatGigInTheSky", property.GetFieldName());
         }
@@ -153,7 +153,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var entityType = CreateModel().AddEntityType(typeof(TheDarkSide));
             var property = entityType.AddProperty(TheDarkSide.OnBaseProperty);
 
-            new BackingFieldConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(((Property)property).Builder);
+            new BackingFieldConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(((Property)property).Builder);
 
             Assert.Equal("_onBase", property.GetFieldName());
         }
@@ -164,7 +164,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var entityType = CreateModel().AddEntityType(typeof(AlwaysLookOnTheBrightSideOfLife));
             var property = entityType.AddProperty("OnTheRun", typeof(int));
 
-            var convention = new BackingFieldConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>());
+            var convention = new BackingFieldConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>());
 
             Assert.Equal(
                 CoreStrings.ConflictingBackingFields(
@@ -179,7 +179,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var entityType = CreateModel().AddEntityType(typeof(HesNotTheMessiah));
             var property = entityType.AddProperty("OnTheRun", typeof(int));
 
-            var convention = new BackingFieldConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>());
+            var convention = new BackingFieldConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>());
 
             Assert.Equal(
                 CoreStrings.ConflictingBackingFields(
@@ -194,7 +194,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var entityType = CreateModel().AddEntityType(typeof(HesAVeryNaughtyBoy));
             var property = entityType.AddProperty("OnTheRun", typeof(object));
 
-            var convention = new BackingFieldConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>());
+            var convention = new BackingFieldConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>());
 
             Assert.Equal(
                 CoreStrings.ConflictingBackingFields(
@@ -210,7 +210,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var property = entityType.AddProperty("OnTheRun", typeof(int));
             property.SetField("m_onTheRun");
 
-            new BackingFieldConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(((Property)property).Builder);
+            new BackingFieldConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(((Property)property).Builder);
 
             Assert.Equal("m_onTheRun", property.GetFieldName());
         }
@@ -222,7 +222,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var property = entityType.AddProperty("OnTheRun", typeof(int));
             property.SetField("m_onTheRun", fromDataAnnotation: true);
 
-            new BackingFieldConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(((Property)property).Builder);
+            new BackingFieldConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(((Property)property).Builder);
 
             Assert.Equal("m_onTheRun", property.GetFieldName());
         }

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/BaseTypeDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/BaseTypeDiscoveryConventionTest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var entityBuilderC = entityBuilderA.ModelBuilder.Entity(typeof(C), ConfigurationSource.Explicit);
             Assert.Null(entityBuilderC.Metadata.BaseType);
 
-            new BaseTypeDiscoveryConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(entityBuilderC);
+            new BaseTypeDiscoveryConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(entityBuilderC);
 
             Assert.Same(entityBuilderB.Metadata, entityBuilderC.Metadata.BaseType);
         }
@@ -31,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var entityBuilderC = entityBuilderA.ModelBuilder.Entity(typeof(C), ConfigurationSource.Explicit);
             Assert.Null(entityBuilderC.Metadata.BaseType);
 
-            new BaseTypeDiscoveryConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(entityBuilderC);
+            new BaseTypeDiscoveryConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(entityBuilderC);
 
             Assert.Same(entityBuilderA.Metadata, entityBuilderC.Metadata.BaseType);
         }
@@ -44,7 +44,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var entityBuilderC = entityBuilderA.ModelBuilder.Entity(typeof(C), ConfigurationSource.Explicit);
             entityBuilderC.HasBaseType(entityBuilderA.Metadata, ConfigurationSource.Convention);
 
-            new BaseTypeDiscoveryConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(entityBuilderC);
+            new BaseTypeDiscoveryConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(entityBuilderC);
 
             Assert.Same(entityBuilderB.Metadata, entityBuilderC.Metadata.BaseType);
         }

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/DerivedTypeDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/DerivedTypeDiscoveryConventionTest.cs
@@ -19,12 +19,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Null(entityBuilderB.Metadata.BaseType);
             Assert.Null(entityBuilderC.Metadata.BaseType);
 
-            new DerivedTypeDiscoveryConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(entityBuilderA);
+            new DerivedTypeDiscoveryConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(entityBuilderA);
 
             Assert.Same(entityBuilderA.Metadata, entityBuilderB.Metadata.BaseType);
             Assert.Same(entityBuilderA.Metadata, entityBuilderC.Metadata.BaseType);
 
-            new DerivedTypeDiscoveryConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(entityBuilderB);
+            new DerivedTypeDiscoveryConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(entityBuilderB);
 
             Assert.Same(entityBuilderA.Metadata, entityBuilderB.Metadata.BaseType);
             Assert.Same(entityBuilderB.Metadata, entityBuilderC.Metadata.BaseType);
@@ -38,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var entityBuilderC = entityBuilderA.ModelBuilder.Entity(typeof(C), ConfigurationSource.Explicit);
             entityBuilderC.HasBaseType(entityBuilderB.Metadata, ConfigurationSource.DataAnnotation);
 
-            new DerivedTypeDiscoveryConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(entityBuilderA);
+            new DerivedTypeDiscoveryConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(entityBuilderA);
 
             Assert.Same(entityBuilderA.Metadata, entityBuilderB.Metadata.BaseType);
             Assert.Same(entityBuilderB.Metadata, entityBuilderC.Metadata.BaseType);
@@ -53,7 +53,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var entityBuilderC = entityBuilderA.ModelBuilder.Entity(typeof(C), ConfigurationSource.Explicit);
             entityBuilderC.HasBaseType(entityBuilderA.Metadata, ConfigurationSource.Convention);
 
-            new DerivedTypeDiscoveryConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(entityBuilderB);
+            new DerivedTypeDiscoveryConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(entityBuilderB);
 
             Assert.Same(entityBuilderB.Metadata, entityBuilderC.Metadata.BaseType);
         }

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/EntityTypeAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/EntityTypeAttributeConventionTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             var entityBuilder = modelBuilder.Entity(typeof(A), ConfigurationSource.Convention);
 
-            new NotMappedEntityTypeAttributeConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(entityBuilder);
+            new NotMappedEntityTypeAttributeConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(entityBuilder);
 
             Assert.Equal(0, modelBuilder.Metadata.GetEntityTypes().Count());
         }
@@ -35,7 +35,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             var entityBuilder = modelBuilder.Entity(typeof(A), ConfigurationSource.Explicit);
 
-            new NotMappedEntityTypeAttributeConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(entityBuilder);
+            new NotMappedEntityTypeAttributeConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(entityBuilder);
 
             Assert.Equal(1, modelBuilder.Metadata.GetEntityTypes().Count());
         }

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConventionTest.cs
@@ -438,7 +438,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var logEntry = ListLoggerFactory.Log.Single();
             Assert.Equal(LogLevel.Debug, logEntry.Level);
             Assert.Equal(
-                CoreResources.LogIncompatibleMatchingForeignKeyProperties(new TestLogger<LoggingDefinitions>()).GenerateMessage(
+                CoreResources.LogIncompatibleMatchingForeignKeyProperties(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
                     "{'PrincipalEntityPeeKay' : string}", "{'PeeKay' : int}"), logEntry.Message);
 
             convention.Apply(relationshipBuilder.Metadata.DeclaringEntityType.Model.Builder);
@@ -754,7 +754,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var logEntry = ListLoggerFactory.Log.Single();
             Assert.Equal(LogLevel.Warning, logEntry.Level);
             Assert.Equal(
-                CoreResources.LogConflictingShadowForeignKeys(new TestLogger<LoggingDefinitions>()).GenerateMessage(
+                CoreResources.LogConflictingShadowForeignKeys(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
                     nameof(DependentEntity), nameof(PrincipalEntity), nameof(DependentEntity)), logEntry.Message);
         }
 
@@ -1039,7 +1039,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     ListLoggerFactory,
                     options,
                     new DiagnosticListener("Fake"),
-                    new LoggingDefinitions()));
+                    new TestLoggingDefinitions()));
         }
 
         public ListLoggerFactory ListLoggerFactory { get; }

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/KeyDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/KeyDiscoveryConventionTest.cs
@@ -129,7 +129,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var logEntry = ListLoggerFactory.Log.Single();
             Assert.Equal(LogLevel.Debug, logEntry.Level);
             Assert.Equal(
-                CoreResources.LogMultiplePrimaryKeyCandidates(new TestLogger<LoggingDefinitions>()).GenerateMessage(
+                CoreResources.LogMultiplePrimaryKeyCandidates(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
                     nameof(EntityWithMultipleIds.ID), nameof(EntityWithMultipleIds.Id), nameof(EntityWithMultipleIds)), logEntry.Message);
         }
 
@@ -147,7 +147,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 ListLoggerFactory,
                 options,
                 new DiagnosticListener("Fake"),
-                new LoggingDefinitions());
+                new TestLoggingDefinitions());
             return modelLogger;
         }
 
@@ -158,7 +158,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             new PropertyDiscoveryConvention(
                     TestServiceFactory.Instance.Create<InMemoryTypeMappingSource>(),
-                    new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>())
+                    new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>())
                 .Apply(entityBuilder);
 
             return entityBuilder;

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/ModelCleanupConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/ModelCleanupConventionTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             dependentEntityBuilder.Relationship(
                 principalEntityBuilder, nameof(OneToOneDependent.OneToOnePrincipal), null, ConfigurationSource.Convention);
 
-            new ModelCleanupConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(modelBuilder);
+            new ModelCleanupConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(modelBuilder);
 
             Assert.Equal(nameof(OneToOnePrincipal), modelBuilder.Metadata.GetEntityTypes().Single().DisplayName());
         }
@@ -37,7 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             dependentEntityBuilder.Relationship(
                 principalEntityBuilder, null, nameof(OneToOnePrincipal.OneToOneDependent), ConfigurationSource.Convention);
 
-            new ModelCleanupConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(modelBuilder);
+            new ModelCleanupConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(modelBuilder);
 
             Assert.Equal(2, modelBuilder.Metadata.GetEntityTypes().Count());
         }
@@ -59,7 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             baseEntityBuilder.Relationship(baseEntityBuilder, ConfigurationSource.Convention);
             baseEntityBuilder.Relationship(baseEntityBuilder, ConfigurationSource.Convention);
 
-            new ModelCleanupConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(modelBuilder);
+            new ModelCleanupConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(modelBuilder);
 
             Assert.True(modelBuilder.Metadata.GetEntityTypes().All(e => !e.GetDeclaredForeignKeys().Any()));
         }

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/NavigationAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/NavigationAttributeConventionTest.cs
@@ -46,7 +46,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Contains(principalEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(Blog.BlogDetails));
             Assert.Contains(dependentEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(BlogDetails.Blog));
 
-            new NotMappedMemberAttributeConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(principalEntityTypeBuilder);
+            new NotMappedMemberAttributeConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(principalEntityTypeBuilder);
 
             Assert.DoesNotContain(principalEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(Blog.BlogDetails));
             Assert.DoesNotContain(dependentEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(BlogDetails.Blog));
@@ -74,7 +74,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Contains(principalEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(Blog.BlogDetails));
             Assert.Contains(dependentEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(BlogDetails.Blog));
 
-            new NotMappedMemberAttributeConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(principalEntityTypeBuilder);
+            new NotMappedMemberAttributeConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(principalEntityTypeBuilder);
 
             Assert.Contains(principalEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(Blog.BlogDetails));
             Assert.Contains(dependentEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(BlogDetails.Blog));
@@ -217,7 +217,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var logEntry = ListLoggerFactory.Log.Single();
             Assert.Equal(LogLevel.Debug, logEntry.Level);
             Assert.Equal(
-                CoreResources.LogRequiredAttributeOnDependent(new TestLogger<LoggingDefinitions>()).GenerateMessage(
+                CoreResources.LogRequiredAttributeOnDependent(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
                     nameof(Principal.Dependent), nameof(Principal)), logEntry.Message);
         }
 
@@ -247,7 +247,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var logEntry = ListLoggerFactory.Log.Single();
             Assert.Equal(LogLevel.Debug, logEntry.Level);
             Assert.Equal(
-                CoreResources.LogRequiredAttributeOnBothNavigations(new TestLogger<LoggingDefinitions>()).GenerateMessage(
+                CoreResources.LogRequiredAttributeOnBothNavigations(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
                     nameof(Blog), nameof(Blog.BlogDetails), nameof(BlogDetails), nameof(BlogDetails.Blog)), logEntry.Message);
         }
 
@@ -355,7 +355,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var logEntry = ListLoggerFactory.Log.Single();
             Assert.Equal(LogLevel.Warning, logEntry.Level);
             Assert.Equal(
-                CoreResources.LogMultipleInversePropertiesSameTarget(new TestLogger<LoggingDefinitions>()).GenerateMessage(
+                CoreResources.LogMultipleInversePropertiesSameTarget(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
                     "AmbiguousDependent.AmbiguousPrincipal, AmbiguousDependent.AnotherAmbiguousPrincipal",
                     nameof(AmbiguousPrincipal.Dependent)), logEntry.Message);
         }
@@ -391,7 +391,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var logEntry = ListLoggerFactory.Log.Single();
             Assert.Equal(LogLevel.Warning, logEntry.Level);
             Assert.Equal(
-                CoreResources.LogNonDefiningInverseNavigation(new TestLogger<LoggingDefinitions>()).GenerateMessage(
+                CoreResources.LogNonDefiningInverseNavigation(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
                     nameof(Principal), nameof(Principal.Dependent), "Principal.Dependents#Dependent", nameof(Dependent.Principal),
                     nameof(Principal.Dependents)), logEntry.Message);
         }
@@ -422,7 +422,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var logEntry = ListLoggerFactory.Log.Single();
             Assert.Equal(LogLevel.Warning, logEntry.Level);
             Assert.Equal(
-                CoreResources.LogNonOwnershipInverseNavigation(new TestLogger<LoggingDefinitions>()).GenerateMessage(
+                CoreResources.LogNonOwnershipInverseNavigation(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
                     nameof(Principal), nameof(Principal.Dependent), nameof(Dependent), nameof(Dependent.Principal),
                     nameof(Principal.Dependents)), logEntry.Message);
         }
@@ -834,7 +834,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             conventionSet.EntityTypeAddedConventions.Add(
                 new PropertyDiscoveryConvention(
                     CreateTypeMapper(),
-                    new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()));
+                    new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()));
 
             conventionSet.EntityTypeAddedConventions.Add(new KeyDiscoveryConvention(CreateLogger()));
 
@@ -871,7 +871,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 ListLoggerFactory,
                 options,
                 new DiagnosticListener("Fake"),
-                new LoggingDefinitions());
+                new TestLoggingDefinitions());
             return modelLogger;
         }
 

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/PropertyAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/PropertyAttributeConventionTest.cs
@@ -33,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             propertyBuilder.IsConcurrencyToken(false, ConfigurationSource.Convention);
 
-            new ConcurrencyCheckAttributeConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(propertyBuilder);
+            new ConcurrencyCheckAttributeConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(propertyBuilder);
 
             Assert.True(propertyBuilder.Metadata.IsConcurrencyToken);
         }
@@ -47,7 +47,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             propertyBuilder.IsConcurrencyToken(false, ConfigurationSource.Explicit);
 
-            new ConcurrencyCheckAttributeConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(propertyBuilder);
+            new ConcurrencyCheckAttributeConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(propertyBuilder);
 
             Assert.False(propertyBuilder.Metadata.IsConcurrencyToken);
         }
@@ -83,7 +83,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             propertyBuilder.ValueGenerated(ValueGenerated.OnAdd, ConfigurationSource.Convention);
 
-            new DatabaseGeneratedAttributeConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(propertyBuilder);
+            new DatabaseGeneratedAttributeConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(propertyBuilder);
 
             Assert.Equal(ValueGenerated.OnAddOrUpdate, propertyBuilder.Metadata.ValueGenerated);
         }
@@ -97,7 +97,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             propertyBuilder.ValueGenerated(ValueGenerated.Never, ConfigurationSource.Explicit);
 
-            new DatabaseGeneratedAttributeConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(propertyBuilder);
+            new DatabaseGeneratedAttributeConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(propertyBuilder);
 
             Assert.Equal(ValueGenerated.Never, propertyBuilder.Metadata.ValueGenerated);
         }
@@ -137,7 +137,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     "Id"
                 }, ConfigurationSource.Convention);
 
-            new KeyAttributeConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(propertyBuilder);
+            new KeyAttributeConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(propertyBuilder);
 
             Assert.Equal("MyPrimaryKey", entityTypeBuilder.Metadata.FindPrimaryKey().Properties[0].Name);
         }
@@ -155,7 +155,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     "Id"
                 }, ConfigurationSource.Explicit);
 
-            new KeyAttributeConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(propertyBuilder);
+            new KeyAttributeConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(propertyBuilder);
 
             Assert.Equal("Id", entityTypeBuilder.Metadata.FindPrimaryKey().Properties[0].Name);
         }
@@ -169,7 +169,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             Assert.Null(entityTypeBuilder.Metadata.FindDeclaredPrimaryKey());
 
-            new KeyAttributeConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(propertyBuilder);
+            new KeyAttributeConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(propertyBuilder);
 
             Assert.Equal(1, entityTypeBuilder.Metadata.FindDeclaredPrimaryKey().Properties.Count);
             Assert.Equal("MyPrimaryKey", entityTypeBuilder.Metadata.FindDeclaredPrimaryKey().Properties[0].Name);
@@ -179,7 +179,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         public void KeyAttribute_throws_when_setting_composite_primary_key()
         {
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<B>();
-            var keyAttributeConvention = new KeyAttributeConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>());
+            var keyAttributeConvention = new KeyAttributeConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>());
 
             Assert.Null(entityTypeBuilder.Metadata.FindDeclaredPrimaryKey());
 
@@ -224,7 +224,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Equal(
                 CoreStrings.KeyAttributeOnDerivedEntity(derivedEntityTypeBuilder.Metadata.DisplayName(), propertyBuilder.Metadata.Name),
                 Assert.Throws<InvalidOperationException>(
-                        () => new KeyAttributeConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(derivedEntityTypeBuilder.ModelBuilder))
+                        () => new KeyAttributeConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(derivedEntityTypeBuilder.ModelBuilder))
                     .Message);
         }
 
@@ -242,7 +242,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     "Name"
                 }, ConfigurationSource.Explicit);
 
-            new KeyAttributeConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(derivedEntityTypeBuilder.ModelBuilder);
+            new KeyAttributeConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(derivedEntityTypeBuilder.ModelBuilder);
 
             Assert.Equal(2, baseEntityTypeBuilder.Metadata.FindPrimaryKey().Properties.Count);
         }
@@ -270,7 +270,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             propertyBuilder.HasMaxLength(100, ConfigurationSource.Convention);
 
-            new MaxLengthAttributeConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(propertyBuilder);
+            new MaxLengthAttributeConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(propertyBuilder);
 
             Assert.Equal(10, propertyBuilder.Metadata.GetMaxLength());
         }
@@ -284,7 +284,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             propertyBuilder.HasMaxLength(100, ConfigurationSource.Explicit);
 
-            new MaxLengthAttributeConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(propertyBuilder);
+            new MaxLengthAttributeConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(propertyBuilder);
 
             Assert.Equal(100, propertyBuilder.Metadata.GetMaxLength());
         }
@@ -317,7 +317,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
             entityTypeBuilder.Property("IgnoredProperty", typeof(string), ConfigurationSource.Convention);
 
-            entityTypeBuilder = new NotMappedMemberAttributeConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(entityTypeBuilder);
+            entityTypeBuilder = new NotMappedMemberAttributeConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(entityTypeBuilder);
 
             Assert.False(entityTypeBuilder.Metadata.GetProperties().Any(p => p.Name == "IgnoredProperty"));
         }
@@ -328,7 +328,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
             entityTypeBuilder.Property("IgnoredProperty", typeof(string), ConfigurationSource.Explicit);
 
-            entityTypeBuilder = new NotMappedMemberAttributeConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(entityTypeBuilder);
+            entityTypeBuilder = new NotMappedMemberAttributeConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(entityTypeBuilder);
 
             Assert.True(entityTypeBuilder.Metadata.GetProperties().Any(p => p.Name == "IgnoredProperty"));
         }
@@ -359,7 +359,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<F>();
             entityTypeBuilder.Property("IgnoredProperty", typeof(string), ConfigurationSource.Convention);
 
-            entityTypeBuilder = new NotMappedMemberAttributeConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(entityTypeBuilder);
+            entityTypeBuilder = new NotMappedMemberAttributeConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(entityTypeBuilder);
 
             Assert.False(entityTypeBuilder.Metadata.GetProperties().Any(p => p.Name == "IgnoredProperty"));
         }
@@ -377,7 +377,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             propertyBuilder.IsRequired(false, ConfigurationSource.Convention);
 
-            new RequiredPropertyAttributeConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(propertyBuilder);
+            new RequiredPropertyAttributeConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(propertyBuilder);
 
             Assert.False(propertyBuilder.Metadata.IsNullable);
         }
@@ -391,7 +391,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             propertyBuilder.IsRequired(false, ConfigurationSource.Explicit);
 
-            new RequiredPropertyAttributeConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(propertyBuilder);
+            new RequiredPropertyAttributeConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(propertyBuilder);
 
             Assert.True(propertyBuilder.Metadata.IsNullable);
         }
@@ -427,7 +427,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             propertyBuilder.HasMaxLength(100, ConfigurationSource.Convention);
 
-            new StringLengthAttributeConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(propertyBuilder);
+            new StringLengthAttributeConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(propertyBuilder);
 
             Assert.Equal(20, propertyBuilder.Metadata.GetMaxLength());
         }
@@ -441,7 +441,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             propertyBuilder.HasMaxLength(100, ConfigurationSource.Explicit);
 
-            new StringLengthAttributeConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(propertyBuilder);
+            new StringLengthAttributeConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(propertyBuilder);
 
             Assert.Equal(100, propertyBuilder.Metadata.GetMaxLength());
         }
@@ -478,7 +478,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             propertyBuilder.ValueGenerated(ValueGenerated.Never, ConfigurationSource.Convention);
             propertyBuilder.IsConcurrencyToken(false, ConfigurationSource.Convention);
 
-            new TimestampAttributeConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(propertyBuilder);
+            new TimestampAttributeConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(propertyBuilder);
 
             Assert.Equal(ValueGenerated.OnAddOrUpdate, propertyBuilder.Metadata.ValueGenerated);
             Assert.True(propertyBuilder.Metadata.IsConcurrencyToken);
@@ -494,7 +494,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             propertyBuilder.ValueGenerated(ValueGenerated.Never, ConfigurationSource.Explicit);
             propertyBuilder.IsConcurrencyToken(false, ConfigurationSource.Explicit);
 
-            new TimestampAttributeConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(propertyBuilder);
+            new TimestampAttributeConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(propertyBuilder);
 
             Assert.Equal(ValueGenerated.Never, propertyBuilder.Metadata.ValueGenerated);
             Assert.False(propertyBuilder.Metadata.IsConcurrencyToken);
@@ -537,7 +537,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             conventionSet.EntityTypeAddedConventions.Add(
                 new PropertyDiscoveryConvention(
                     CreateTypeMapper(),
-                    new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()));
+                    new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()));
 
             var modelBuilder = new InternalModelBuilder(new Model(conventionSet));
 

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/PropertyDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/PropertyDiscoveryConventionTest.cs
@@ -154,7 +154,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Same(
                 entityBuilder, new PropertyDiscoveryConvention(
                     TestServiceFactory.Instance.Create<InMemoryTypeMappingSource>(),
-                    new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(entityBuilder));
+                    new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(entityBuilder));
 
             Assert.Empty(entityBuilder.Metadata.GetProperties());
         }
@@ -215,7 +215,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Same(
                 entityBuilder, new PropertyDiscoveryConvention(
                         TestServiceFactory.Instance.Create<InMemoryTypeMappingSource>(),
-                        new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>())
+                        new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>())
                     .Apply(entityBuilder));
 
             Assert.Equal(
@@ -238,7 +238,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Same(
                 entityBuilder, new PropertyDiscoveryConvention(
                         TestServiceFactory.Instance.Create<InMemoryTypeMappingSource>(),
-                        new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>())
+                        new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>())
                     .Apply(entityBuilder));
 
             Assert.Empty(entityBuilder.Metadata.GetProperties());

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/PropertyMappingValidationConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/PropertyMappingValidationConventionTest.cs
@@ -191,7 +191,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 typeMappingSource,
                 TestServiceFactory.Instance.Create<IMemberClassifier>(
                     (typeof(ITypeMappingSource), typeMappingSource)),
-                new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>());
+                new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>());
         }
 
         protected class NonPrimitiveNonNavigationAsPropertyEntity

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/RelationshipDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/RelationshipDiscoveryConventionTest.cs
@@ -246,7 +246,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var entityBuilder = CreateInternalEntityBuilder<ManyToManyFirst>();
 
             Assert.Same(entityBuilder, CreateRelationshipDiscoveryConvention().Apply(entityBuilder));
-            new ModelCleanupConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(entityBuilder.ModelBuilder);
+            new ModelCleanupConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(entityBuilder.ModelBuilder);
 
             Assert.Empty(entityBuilder.Metadata.GetForeignKeys());
             Assert.Empty(entityBuilder.Metadata.GetNavigations());
@@ -343,7 +343,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var logEntry = ListLoggerFactory.Log[0];
             Assert.Equal(LogLevel.Debug, logEntry.Level);
             Assert.Equal(
-                CoreResources.LogMultipleNavigationProperties(new TestLogger<LoggingDefinitions>()).GenerateMessage(
+                CoreResources.LogMultipleNavigationProperties(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
                     nameof(MultipleNavigationsSecond),
                     nameof(MultipleNavigationsFirst),
                     "{'MultipleNavigationsFirst'}",
@@ -533,7 +533,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit);
 
             Assert.Same(entityBuilder, CreateRelationshipDiscoveryConvention().Apply(entityBuilder));
-            new ModelCleanupConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(modelBuilder);
+            new ModelCleanupConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(modelBuilder);
 
             VerifyRelationship(
                 entityBuilder.Metadata.FindNavigation(nameof(NavigationsToBaseAndDerived.Base)),
@@ -907,7 +907,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var logEntry = ListLoggerFactory.Log[0];
             Assert.Equal(LogLevel.Debug, logEntry.Level);
             Assert.Equal(
-                CoreResources.LogMultipleNavigationProperties(new TestLogger<LoggingDefinitions>()).GenerateMessage(
+                CoreResources.LogMultipleNavigationProperties(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
                     nameof(SelfRef), nameof(SelfRef), "{'SelfRef1'}", "{'SelfRef2', 'SelfRef3', 'SelfRef4'}"), logEntry.Message);
         }
 
@@ -990,7 +990,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 ListLoggerFactory,
                 options,
                 new DiagnosticListener("Fake"),
-                new LoggingDefinitions());
+                new TestLoggingDefinitions());
             return modelLogger;
         }
 

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/ValueGeneratorConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/ValueGeneratorConventionTest.cs
@@ -53,7 +53,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             var keyBuilder = entityBuilder.PrimaryKey(properties, ConfigurationSource.Convention);
 
-            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(entityBuilder, (Key)null));
+            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(entityBuilder, (Key)null));
 
             var keyProperties = keyBuilder.Metadata.Properties;
 
@@ -86,7 +86,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             var keyBuilder = referencedEntityBuilder.PrimaryKey(properties, ConfigurationSource.Convention);
 
-            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(referencedEntityBuilder, (Key)null));
+            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(referencedEntityBuilder, (Key)null));
 
             var keyProperties = keyBuilder.Metadata.Properties;
 
@@ -119,7 +119,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             var keyBuilder = referencedEntityBuilder.PrimaryKey(properties, ConfigurationSource.Convention);
 
-            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(referencedEntityBuilder, (Key)null));
+            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(referencedEntityBuilder, (Key)null));
 
             var keyProperties = keyBuilder.Metadata.Properties;
 
@@ -151,7 +151,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             var keyBuilder = referencedEntityBuilder.PrimaryKey(new[] { properties[1] }, ConfigurationSource.Convention);
 
-            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(referencedEntityBuilder, (Key)null));
+            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(referencedEntityBuilder, (Key)null));
 
             var keyProperties = keyBuilder.Metadata.Properties;
 
@@ -175,7 +175,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             var keyBuilder = entityBuilder.PrimaryKey(properties, ConfigurationSource.Convention);
 
-            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(entityBuilder, (Key)null));
+            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(entityBuilder, (Key)null));
 
             var keyProperties = keyBuilder.Metadata.Properties;
 
@@ -199,7 +199,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             var keyBuilder = referencedEntityBuilder.PrimaryKey(properties, ConfigurationSource.Convention);
 
-            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(referencedEntityBuilder, (Key)null));
+            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(referencedEntityBuilder, (Key)null));
 
             var keyProperties = keyBuilder.Metadata.Properties;
 
@@ -210,7 +210,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention),
                 ConfigurationSource.Convention);
 
-            Assert.Same(foreignKeyBuilder, new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(foreignKeyBuilder));
+            Assert.Same(foreignKeyBuilder, new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(foreignKeyBuilder));
 
             Assert.False(keyProperties[0].RequiresValueGenerator());
             Assert.Equal(ValueGenerated.Never, keyProperties[0].ValueGenerated);
@@ -233,7 +233,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             var keyBuilder = referencedEntityBuilder.PrimaryKey(properties, ConfigurationSource.Convention);
 
-            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(referencedEntityBuilder, (Key)null));
+            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(referencedEntityBuilder, (Key)null));
 
             var keyProperties = keyBuilder.Metadata.Properties;
 
@@ -244,14 +244,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention),
                 ConfigurationSource.Convention);
 
-            Assert.Same(relationshipBuilder, new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(relationshipBuilder));
+            Assert.Same(relationshipBuilder, new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(relationshipBuilder));
 
             Assert.False(keyProperties[0].RequiresValueGenerator());
             Assert.Equal(ValueGenerated.Never, keyProperties[0].ValueGenerated);
 
             referencedEntityBuilder.RemoveForeignKey(relationshipBuilder.Metadata, ConfigurationSource.Convention);
 
-            new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(referencedEntityBuilder, relationshipBuilder.Metadata);
+            new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(referencedEntityBuilder, relationshipBuilder.Metadata);
 
             Assert.True(keyProperties[0].RequiresValueGenerator());
             Assert.Equal(ValueGenerated.OnAdd, keyProperties[0].ValueGenerated);
@@ -273,7 +273,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     "Id"
                 }, ConfigurationSource.Convention);
 
-            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(entityBuilder, (Key)null));
+            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(entityBuilder, (Key)null));
 
             var property = keyBuilder.Metadata.Properties.First();
 
@@ -292,7 +292,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     "Number"
                 }, ConfigurationSource.Convention);
 
-            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(entityBuilder, (Key)null));
+            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(entityBuilder, (Key)null));
 
             var property = keyBuilder.Metadata.Properties.First();
 
@@ -312,7 +312,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     "Number"
                 }, ConfigurationSource.Convention);
 
-            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(entityBuilder, (Key)null));
+            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(entityBuilder, (Key)null));
 
             var keyProperties = keyBuilder.Metadata.Properties;
 
@@ -393,7 +393,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Same(idProperty, entityBuilder.Metadata.FindProperty("Id"));
             Assert.Same(numberProperty, entityBuilder.Metadata.FindProperty("Number"));
 
-            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(entityBuilder, (Key)null));
+            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(entityBuilder, (Key)null));
 
             Assert.Same(idProperty, entityBuilder.Metadata.FindProperty("Id"));
             Assert.Same(numberProperty, entityBuilder.Metadata.FindProperty("Number"));
@@ -417,7 +417,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     "Id"
                 }, ConfigurationSource.Convention);
 
-            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(entityBuilder, (Key)null));
+            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(entityBuilder, (Key)null));
 
             var property = keyBuilder.Metadata.Properties.First();
 
@@ -438,7 +438,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             };
             var keyBuilder = referencedEntityBuilder.PrimaryKey(properties, ConfigurationSource.Convention);
 
-            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(referencedEntityBuilder, (Key)null));
+            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(referencedEntityBuilder, (Key)null));
 
             var property = keyBuilder.Metadata.Properties.First();
 
@@ -449,7 +449,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention),
                 ConfigurationSource.Convention);
 
-            Assert.Same(relationshipBuilder, new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(relationshipBuilder));
+            Assert.Same(relationshipBuilder, new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(relationshipBuilder));
 
             Assert.Equal(ValueGenerated.Never, ((IProperty)property).ValueGenerated);
         }
@@ -468,7 +468,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             };
             var keyBuilder = referencedEntityBuilder.PrimaryKey(properties, ConfigurationSource.Convention);
 
-            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(referencedEntityBuilder, (Key)null));
+            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(referencedEntityBuilder, (Key)null));
 
             var property = keyBuilder.Metadata.Properties.First();
 
@@ -479,13 +479,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention),
                 ConfigurationSource.Convention);
 
-            Assert.Same(relationshipBuilder, new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(relationshipBuilder));
+            Assert.Same(relationshipBuilder, new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(relationshipBuilder));
 
             Assert.Equal(ValueGenerated.Never, ((IProperty)property).ValueGenerated);
 
             referencedEntityBuilder.RemoveForeignKey(relationshipBuilder.Metadata, ConfigurationSource.Convention);
 
-            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(referencedEntityBuilder, (Key)null));
+            Assert.True(new ValueGeneratorConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(referencedEntityBuilder, (Key)null));
 
             Assert.Equal(ValueGenerated.OnAdd, property.ValueGenerated);
         }
@@ -495,7 +495,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         private static InternalModelBuilder CreateInternalModelBuilder()
         {
             var conventions = new ConventionSet();
-            var logger = new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>();
+            var logger = new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>();
 
             conventions.EntityTypeAddedConventions.Add(
                 new PropertyDiscoveryConvention(

--- a/test/EFCore.Tests/Metadata/Internal/ClrCollectionAccessorFactoryTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/ClrCollectionAccessorFactoryTest.cs
@@ -252,7 +252,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     nameof(MyEntity.AsICollectionWithCustomComparer),
                     BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance));
 
-            new BackingFieldConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>())
+            new BackingFieldConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>())
                 .Apply(((ForeignKey)foreignKey).Builder, (Navigation)navigation);
 
             var accessor = new ClrCollectionAccessorFactory().Create(navigation);
@@ -411,7 +411,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var navigation = foreignKey.HasPrincipalToDependent(
                 typeof(MyEntity).GetProperty(navigationName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance));
 
-            new BackingFieldConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>())
+            new BackingFieldConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>())
                 .Apply(((ForeignKey)foreignKey).Builder, (Navigation)navigation);
 
             return navigation;

--- a/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
@@ -1769,7 +1769,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 ConfigureOrdersHierarchy(modelBuilder);
             }
 
-            var logger = new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>();
+            var logger = new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>();
             var validationConvention = new IgnoredMembersValidationConvention(logger);
             if (exceptionExpected)
             {
@@ -1789,7 +1789,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 modelBuilder.Metadata,
                 new DiagnosticsLoggers(
                     logger,
-                    new TestLogger<DbLoggerCategory.Model.Validation, LoggingDefinitions>()));
+                    new TestLogger<DbLoggerCategory.Model.Validation, TestLoggingDefinitions>()));
 
             Assert.Equal(
                 expectedIgnored,

--- a/test/EFCore.Tests/Metadata/Internal/InternalModelBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalModelBuilderTest.cs
@@ -233,7 +233,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             Assert.True(modelBuilder.Ignore(typeof(Customer), ConfigurationSource.Explicit));
 
-            modelBuilder = new ModelCleanupConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(modelBuilder);
+            modelBuilder = new ModelCleanupConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(modelBuilder);
             Assert.Empty(modelBuilder.Metadata.GetEntityTypes());
         }
 
@@ -254,7 +254,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             Assert.True(modelBuilder.Ignore(typeof(Customer), ConfigurationSource.DataAnnotation));
 
-            modelBuilder = new ModelCleanupConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(modelBuilder);
+            modelBuilder = new ModelCleanupConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(modelBuilder);
             Assert.Equal(new[] { typeof(Order), typeof(Product) }, modelBuilder.Metadata.GetEntityTypes().Select(et => et.ClrType));
             Assert.Equal(typeof(Product), orderEntityTypeBuilder.Metadata.GetForeignKeys().Single().PrincipalEntityType.ClrType);
         }
@@ -276,7 +276,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             Assert.True(modelBuilder.Ignore(typeof(Customer), ConfigurationSource.DataAnnotation));
 
-            modelBuilder = new ModelCleanupConvention(new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>()).Apply(modelBuilder);
+            modelBuilder = new ModelCleanupConvention(new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>()).Apply(modelBuilder);
             Assert.Equal(new[] { typeof(Order), typeof(Product) }, modelBuilder.Metadata.GetEntityTypes().Select(et => et.ClrType));
             Assert.Equal(typeof(Product), orderEntityTypeBuilder.Metadata.GetForeignKeys().Single().PrincipalEntityType.ClrType);
         }

--- a/test/EFCore.Tests/Metadata/Internal/PropertyBaseTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/PropertyBaseTest.cs
@@ -753,8 +753,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 InMemoryTestHelpers.Instance.CreateContextServices().GetRequiredService<IModelValidator>()
                     .Validate(propertyBase.DeclaringType.Model,
                         new DiagnosticsLoggers(
-                            new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>(),
-                            new TestLogger<DbLoggerCategory.Model.Validation, LoggingDefinitions>()));
+                            new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>(),
+                            new TestLogger<DbLoggerCategory.Model.Validation, TestLoggingDefinitions>()));
 
                 Assert.Null(failMessage);
             }

--- a/test/EFCore.Tests/ModelBuilding/InheritanceTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/InheritanceTestBase.cs
@@ -541,7 +541,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var (Level, _, Message, _, _) = modelBuilder.ModelLoggerFactory.Log.Single(e => e.Id == CoreEventId.RedundantIndexRemoved);
                 Assert.Equal(LogLevel.Debug, Level);
                 Assert.Equal(
-                    CoreResources.LogRedundantIndexRemoved(new TestLogger<LoggingDefinitions>()).GenerateMessage(
+                    CoreResources.LogRedundantIndexRemoved(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
                         "{'CustomerId'}", nameof(Order), "{'CustomerId', 'AnotherCustomerId'}"), Message);
 
                 fk = dependentEntityType.GetForeignKeys().Single(foreignKey => foreignKey.DependentToPrincipal == null);
@@ -610,7 +610,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 modelBuilder.FinalizeModel();
 
                 var indexRemoveMessage =
-                    CoreResources.LogRedundantIndexRemoved(new TestLogger<LoggingDefinitions>()).GenerateMessage(
+                    CoreResources.LogRedundantIndexRemoved(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
                         "{'CustomerId'}", nameof(Order), "{'CustomerId', 'AnotherCustomerId'}");
                 Assert.Equal(1, modelBuilder.ModelLoggerFactory.Log.Count(l => l.Message == indexRemoveMessage));
 

--- a/test/EFCore.Tests/ModelSourceTest.cs
+++ b/test/EFCore.Tests/ModelSourceTest.cs
@@ -79,8 +79,8 @@ namespace Microsoft.EntityFrameworkCore
         {
             var setFinder = new FakeSetFinder();
             var loggers = new DiagnosticsLoggers(
-                new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>(),
-                new TestLogger<DbLoggerCategory.Model.Validation, LoggingDefinitions>());
+                new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>(),
+                new TestLogger<DbLoggerCategory.Model.Validation, TestLoggingDefinitions>());
 
             var model = CreateDefaultModelSource(setFinder)
                 .GetModel(InMemoryTestHelpers.Instance.CreateContext(), _nullConventionSetBuilder, new FakeModelValidator(), loggers);
@@ -131,8 +131,8 @@ namespace Microsoft.EntityFrameworkCore
         {
             var modelSource = CreateDefaultModelSource(new DbSetFinder());
             var loggers = new DiagnosticsLoggers(
-                new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>(),
-                new TestLogger<DbLoggerCategory.Model.Validation, LoggingDefinitions>());
+                new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>(),
+                new TestLogger<DbLoggerCategory.Model.Validation, TestLoggingDefinitions>());
 
             var model1 = modelSource.GetModel(new Context1(), _nullConventionSetBuilder, _coreModelValidator, loggers);
             var model2 = modelSource.GetModel(new Context2(), _nullConventionSetBuilder, _coreModelValidator, loggers);
@@ -147,8 +147,8 @@ namespace Microsoft.EntityFrameworkCore
         {
             var modelSource = CreateDefaultModelSource(new DbSetFinder());
             var loggers = new DiagnosticsLoggers(
-                new TestLogger<DbLoggerCategory.Model, LoggingDefinitions>(),
-                new TestLogger<DbLoggerCategory.Model.Validation, LoggingDefinitions>());
+                new TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions>(),
+                new TestLogger<DbLoggerCategory.Model.Validation, TestLoggingDefinitions>());
 
             var model = modelSource.GetModel(new Context1(), _nullConventionSetBuilder, _coreModelValidator, loggers);
             var packageVersion = typeof(Context1).Assembly.GetCustomAttributes<AssemblyMetadataAttribute>()

--- a/test/EFCore.Tests/ServiceProviderCacheTest.cs
+++ b/test/EFCore.Tests/ServiceProviderCacheTest.cs
@@ -31,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(1, loggerFactory.Log.Count);
 
             Assert.Equal(
-                CoreResources.LogServiceProviderCreated(new TestLogger<LoggingDefinitions>()).GenerateMessage(),
+                CoreResources.LogServiceProviderCreated(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(),
                 loggerFactory.Log[0].Message);
         }
 
@@ -53,11 +53,11 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(2, loggerFactory.Log.Count);
 
             Assert.Equal(
-                CoreResources.LogServiceProviderCreated(new TestLogger<LoggingDefinitions>()).GenerateMessage(),
+                CoreResources.LogServiceProviderCreated(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(),
                 loggerFactory.Log[0].Message);
 
             Assert.Equal(
-                CoreResources.LogServiceProviderDebugInfo(new TestLogger<LoggingDefinitions>()).GenerateMessage(
+                CoreResources.LogServiceProviderDebugInfo(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
                     string.Join(
                         ", ",
                         CoreStrings.ServiceProviderConfigRemoved("Fake1"),
@@ -87,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(1, loggerFactory.Log.Count);
 
             Assert.Equal(
-                CoreResources.LogServiceProviderCreated(new TestLogger<LoggingDefinitions>()).GenerateMessage(),
+                CoreResources.LogServiceProviderCreated(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(),
                 loggerFactory.Log[0].Message);
         }
 
@@ -116,11 +116,11 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(2, loggerFactory.Log.Count);
 
             Assert.Equal(
-                CoreResources.LogServiceProviderCreated(new TestLogger<LoggingDefinitions>()).GenerateMessage(),
+                CoreResources.LogServiceProviderCreated(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(),
                 loggerFactory.Log[0].Message);
 
             Assert.Equal(
-                CoreResources.LogServiceProviderDebugInfo(new TestLogger<LoggingDefinitions>()).GenerateMessage(
+                CoreResources.LogServiceProviderDebugInfo(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
                     CoreStrings.ServiceProviderConfigChanged("Core:ReplaceService:" + typeof(object).DisplayName())),
                 loggerFactory.Log[1].Message);
         }
@@ -189,21 +189,21 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.Equal(4, loggerFactory.Log.Count);
 
                 Assert.Equal(
-                    CoreResources.LogServiceProviderCreated(new TestLogger<LoggingDefinitions>()).GenerateMessage(),
+                    CoreResources.LogServiceProviderCreated(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(),
                     loggerFactory.Log[0].Message);
 
                 Assert.Equal(
-                    CoreResources.LogServiceProviderDebugInfo(new TestLogger<LoggingDefinitions>()).GenerateMessage(
+                    CoreResources.LogServiceProviderDebugInfo(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
                         CoreStrings.ServiceProviderConfigChanged("Core:ConfigureWarnings")),
                     loggerFactory.Log[1].Message);
 
                 Assert.Equal(
-                    CoreResources.LogServiceProviderDebugInfo(new TestLogger<LoggingDefinitions>()).GenerateMessage(
+                    CoreResources.LogServiceProviderDebugInfo(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
                         CoreStrings.ServiceProviderConfigChanged("Core:EnableSensitiveDataLogging")),
                     loggerFactory.Log[2].Message);
 
                 Assert.Equal(
-                    CoreResources.LogServiceProviderDebugInfo(new TestLogger<LoggingDefinitions>()).GenerateMessage(
+                    CoreResources.LogServiceProviderDebugInfo(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
                         string.Join(
                             ", ",
                             CoreStrings.ServiceProviderConfigChanged("Core:EnableDetailedErrors"),
@@ -218,6 +218,7 @@ namespace Microsoft.EntityFrameworkCore
             var optionsBuilder = new DbContextOptionsBuilder();
             ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(new TExtension());
             optionsBuilder.UseLoggerFactory(loggerFactory);
+            optionsBuilder.UseInMemoryDatabase(Guid.NewGuid().ToString());
 
             return optionsBuilder.Options;
         }


### PR DESCRIPTION
By making the base classes abstract and never registering them as defaults in D.I.

Fixes #15414
