### PR TITLE
[2.2] Update dotnet-ef.csproj to correct shim generation

### DIFF
--- a/src/dotnet-ef/dotnet-ef.csproj
+++ b/src/dotnet-ef/dotnet-ef.csproj
@@ -1,6 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <!-- workaround for https://github.com/dotnet/sdk/issues/2698 -->
+    <Version>$(PackageVersion)</Version>
+
     <Description>Entity Framework Core Tools for the .NET Command-Line Interface.
 
 Enables these commonly used dotnet-ef commands:


### PR DESCRIPTION
This should fix installations of dotnet-ef as a package which are broken due to https://github.com/dotnet/sdk/issues/2698

#### Description
Fixes https://github.com/aspnet/EntityFrameworkCore/issues/15448.  Due to https://github.com/dotnet/sdk/issues/2698, dotnet-ef does not work when installed as a package.

#### Customer Impact
This fixes a broken experience with dotnet ef typically encountered by .NET Core 3.0 users and anyone using a source-built SDK (like RedHat devs)
		
#### Regression?
No. This package never worked.
		
#### Risk
Low. Does not impact in-the-box version of dotnet-ef.