### PR TITLE
fix condition in CSharpDbContextGenerator.GenerateSequence

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
@@ -855,7 +855,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
             var parameters = _code.Literal(sequence.Name);
 
-            if (string.IsNullOrEmpty(sequence.Schema)
+            if (!string.IsNullOrEmpty(sequence.Schema)
                 && sequence.Model.Relational().DefaultSchema != sequence.Schema)
             {
                 parameters += $", {_code.Literal(sequence.Schema)}";


### PR DESCRIPTION
Summary of the change

- Fix the condition in `CSharpDbContextGenerator.GenerateSequence` to correctly append schema parameter to sequence creation code when sequence's schema is provided.

Fixes #15513 
