### PR TITLE
[Query] Always pass in Members when creating NewExpression

### DIFF
--- a/src/EFCore/Query/NavigationExpansion/NavigationExpansionHelpers.cs
+++ b/src/EFCore/Query/NavigationExpansion/NavigationExpansionHelpers.cs
@@ -143,8 +143,14 @@ namespace Microsoft.EntityFrameworkCore.Query.NavigationExpansion
                     var groupJoinResultTransparentIdentifierCtorInfo
                         = groupJoinResultType.GetTypeInfo().GetConstructors().Single();
 
+                    var groupJoinResultTransparentIdentifierOuterMemberInfo = groupJoinResultType.GetTypeInfo().GetDeclaredField("Outer");
+                    var groupJoinResultTransparentIdentifierInnerMemberInfo = groupJoinResultType.GetTypeInfo().GetDeclaredField("Inner");
+
                     var groupJoinResultSelector = Expression.Lambda(
-                        Expression.New(groupJoinResultTransparentIdentifierCtorInfo, resultSelectorOuterParameter, resultSelectorInnerParameter),
+                        Expression.New(
+                            groupJoinResultTransparentIdentifierCtorInfo,
+                            new[] { resultSelectorOuterParameter, resultSelectorInnerParameter },
+                            new[] { groupJoinResultTransparentIdentifierOuterMemberInfo, groupJoinResultTransparentIdentifierInnerMemberInfo }),
                         resultSelectorOuterParameter,
                         resultSelectorInnerParameter);
 
@@ -180,9 +186,15 @@ namespace Microsoft.EntityFrameworkCore.Query.NavigationExpansion
                     var selectManyResultTransparentIdentifierCtorInfo
                         = selectManyResultType.GetTypeInfo().GetConstructors().Single();
 
+                    var selectManyResultTransparentIdentifierOuterMemberInfo = selectManyResultType.GetTypeInfo().GetDeclaredField("Outer");
+                    var selectManyResultTransparentIdentifierInnerMemberInfo = selectManyResultType.GetTypeInfo().GetDeclaredField("Inner");
+
                     // TODO: dont reuse parameters here?
                     var selectManyResultSelector = Expression.Lambda(
-                        Expression.New(selectManyResultTransparentIdentifierCtorInfo, selectManyCollectionSelectorParameter, innerKeySelectorParameter),
+                        Expression.New(
+                            selectManyResultTransparentIdentifierCtorInfo,
+                            new[] { selectManyCollectionSelectorParameter, innerKeySelectorParameter },
+                            new[] { selectManyResultTransparentIdentifierOuterMemberInfo, selectManyResultTransparentIdentifierInnerMemberInfo }),
                         selectManyCollectionSelectorParameter,
                         innerKeySelectorParameter);
 
@@ -220,8 +232,14 @@ namespace Microsoft.EntityFrameworkCore.Query.NavigationExpansion
                     var transparentIdentifierCtorInfo
                         = resultType.GetTypeInfo().GetConstructors().Single();
 
+                    var transparentIdentifierOuterMemberInfo = resultType.GetTypeInfo().GetDeclaredField("Outer");
+                    var transparentIdentifierInnerMemberInfo = resultType.GetTypeInfo().GetDeclaredField("Inner");
+
                     var resultSelector = Expression.Lambda(
-                        Expression.New(transparentIdentifierCtorInfo, resultSelectorOuterParameter, resultSelectorInnerParameter),
+                        Expression.New(
+                            transparentIdentifierCtorInfo,
+                            new[] { resultSelectorOuterParameter, resultSelectorInnerParameter },
+                            new[] { transparentIdentifierOuterMemberInfo, transparentIdentifierInnerMemberInfo }),
                         resultSelectorOuterParameter,
                         resultSelectorInnerParameter);
 

--- a/src/EFCore/Query/NavigationExpansion/Visitors/NavigationExpandingVisitor_MethodCall.cs
+++ b/src/EFCore/Query/NavigationExpansion/Visitors/NavigationExpandingVisitor_MethodCall.cs
@@ -632,8 +632,14 @@ namespace Microsoft.EntityFrameworkCore.Query.NavigationExpansion.Visitors
                 outerApplyOrderingsResult.state.CustomRootMappings.Concat(new[] { groupingMapping }).ToList(),
                 materializeCollectionNavigation: null);
 
+            var transparentIdentifierOuterMemberInfo = resultType.GetTypeInfo().GetDeclaredField("Outer");
+            var transparentIdentifierInnerMemberInfo = resultType.GetTypeInfo().GetDeclaredField("Inner");
+
             var lambda = Expression.Lambda(
-                Expression.New(transparentIdentifierCtorInfo, outerApplyOrderingsResult.state.CurrentParameter, newGroupingParameter),
+                Expression.New(
+                    transparentIdentifierCtorInfo,
+                    new[] { outerApplyOrderingsResult.state.CurrentParameter, newGroupingParameter },
+                    new[] { transparentIdentifierOuterMemberInfo, transparentIdentifierInnerMemberInfo }),
                 outerApplyOrderingsResult.state.CurrentParameter,
                 newGroupingParameter);
 
@@ -1354,8 +1360,14 @@ namespace Microsoft.EntityFrameworkCore.Query.NavigationExpansion.Visitors
                 outerState.CustomRootMappings.Concat(innerState.CustomRootMappings).ToList(),
                 materializeCollectionNavigation: null);
 
+            var transparentIdentifierOuterMemberInfo = resultType.GetTypeInfo().GetDeclaredField("Outer");
+            var transparentIdentifierInnerMemberInfo = resultType.GetTypeInfo().GetDeclaredField("Inner");
+
             var lambda = Expression.Lambda(
-                Expression.New(transparentIdentifierCtorInfo, outerState.CurrentParameter, innerState.CurrentParameter),
+                Expression.New(
+                    transparentIdentifierCtorInfo,
+                    new[] { outerState.CurrentParameter, innerState.CurrentParameter },
+                    new[] { transparentIdentifierOuterMemberInfo, transparentIdentifierInnerMemberInfo }),
                 outerState.CurrentParameter,
                 innerState.CurrentParameter);
 


### PR DESCRIPTION
They are required for binding in projection
 Blocking issue for #14455 