### PR TITLE
[Query] Make ShapedQueryExpression.ShaperExpression lambda body only

### DIFF
--- a/src/EFCore.InMemory/Query/PipeLine/InMemoryProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/PipeLine/InMemoryProjectionBindingExpressionVisitor.cs
@@ -77,7 +77,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Pipeline
 
                 _projectionMapping[_projectionMembers.Peek()] = translation;
 
-                return new ProjectionBindingExpression(_queryExpression, _projectionMembers.Peek(), expression.Type);
+                return new ProjectionBindingExpression(_projectionMembers.Peek(), expression.Type);
             }
 
             return base.Visit(expression);
@@ -92,7 +92,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Pipeline
                         entityShaperExpression.ValueBufferExpression.ProjectionMember);
 
                 return entityShaperExpression.Update(
-                    new ProjectionBindingExpression(_queryExpression, _projectionMembers.Peek(), typeof(ValueBuffer)));
+                    new ProjectionBindingExpression(_projectionMembers.Peek(), typeof(ValueBuffer)));
             }
 
             throw new InvalidOperationException();

--- a/src/EFCore.InMemory/Query/PipeLine/InMemoryQueryExpression.cs
+++ b/src/EFCore.InMemory/Query/PipeLine/InMemoryQueryExpression.cs
@@ -90,7 +90,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Pipeline
             _projectionMapping.Clear();
             _projectionMapping[new ProjectionMember()] = _valueBufferSlots[0];
 
-            return new ProjectionBindingExpression(this, new ProjectionMember(), ServerQueryExpression.Type);
+            return new ProjectionBindingExpression(new ProjectionMember(), ServerQueryExpression.Type);
         }
 
         public Expression BindProperty(Expression projectionExpression, IProperty property)

--- a/src/EFCore.InMemory/Query/PipeLine/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/PipeLine/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
@@ -32,10 +32,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Pipeline
                     inMemoryQueryExpression.ServerQueryExpression,
                     TranslateLambdaExpression(source, predicate));
 
-            source.ShaperExpression
-                = Expression.Lambda(
-                    inMemoryQueryExpression.GetSingleScalarProjection(),
-                    source.ShaperExpression.Parameters);
+            source.ShaperExpression = inMemoryQueryExpression.GetSingleScalarProjection();
 
             return source;
         }
@@ -53,10 +50,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Pipeline
                     inMemoryQueryExpression.ServerQueryExpression,
                     TranslateLambdaExpression(source, predicate));
 
-            source.ShaperExpression
-                = Expression.Lambda(
-                    inMemoryQueryExpression.GetSingleScalarProjection(),
-                    source.ShaperExpression.Parameters);
+            source.ShaperExpression = inMemoryQueryExpression.GetSingleScalarProjection();
 
             return source;
         }
@@ -83,10 +77,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Pipeline
                         inMemoryQueryExpression.GetScalarProjectionLambda()),
                     item);
 
-            source.ShaperExpression
-                = Expression.Lambda(
-                    inMemoryQueryExpression.GetSingleScalarProjection(),
-                    source.ShaperExpression.Parameters);
+            source.ShaperExpression = inMemoryQueryExpression.GetSingleScalarProjection();
 
             return source;
         }
@@ -111,10 +102,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Pipeline
                         TranslateLambdaExpression(source, predicate));
             }
 
-            source.ShaperExpression
-                = Expression.Lambda(
-                    inMemoryQueryExpression.GetSingleScalarProjection(),
-                    source.ShaperExpression.Parameters);
+            source.ShaperExpression = inMemoryQueryExpression.GetSingleScalarProjection();
 
             return source;
         }
@@ -214,10 +202,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Pipeline
                         TranslateLambdaExpression(source, predicate));
             }
 
-            source.ShaperExpression
-                = Expression.Lambda(
-                    inMemoryQueryExpression.GetSingleScalarProjection(),
-                    source.ShaperExpression.Parameters);
+            source.ShaperExpression = inMemoryQueryExpression.GetSingleScalarProjection();
 
             return source;
         }
@@ -256,12 +241,10 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Pipeline
             }
 
             var newSelectorBody = ReplacingExpressionVisitor.Replace(
-                selector.Parameters.Single(), source.ShaperExpression.Body, selector.Body);
+                selector.Parameters.Single(), source.ShaperExpression, selector.Body);
 
-            newSelectorBody = _projectionBindingExpressionVisitor
+            source.ShaperExpression = _projectionBindingExpressionVisitor
                     .Translate((InMemoryQueryExpression)source.QueryExpression, newSelectorBody);
-
-            source.ShaperExpression = Expression.Lambda(newSelectorBody, source.ShaperExpression.Parameters);
 
             return source;
         }
@@ -357,7 +340,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Pipeline
             ShapedQueryExpression shapedQueryExpression, LambdaExpression lambdaExpression)
         {
             var lambdaBody = ReplacingExpressionVisitor.Replace(
-                lambdaExpression.Parameters.Single(), shapedQueryExpression.ShaperExpression.Body, lambdaExpression.Body);
+                lambdaExpression.Parameters.Single(), shapedQueryExpression.ShaperExpression, lambdaExpression.Body);
 
             return Expression.Lambda(
                 TranslateExpression((InMemoryQueryExpression)shapedQueryExpression.QueryExpression, lambdaBody),
@@ -381,10 +364,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Pipeline
                         inMemoryQueryExpression.ServerQueryExpression,
                         selector);
 
-            source.ShaperExpression
-                = Expression.Lambda(
-                    inMemoryQueryExpression.GetSingleScalarProjection(),
-                    source.ShaperExpression.Parameters);
+            source.ShaperExpression = inMemoryQueryExpression.GetSingleScalarProjection();
 
             return source;
         }
@@ -404,11 +384,9 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Pipeline
                     inMemoryQueryExpression.ServerQueryExpression,
                     predicate);
 
-            if (source.ShaperExpression.ReturnType != returnType)
+            if (source.ShaperExpression.Type != returnType)
             {
-                source.ShaperExpression = Expression.Lambda(
-                    Expression.Convert(source.ShaperExpression.Body, returnType),
-                    source.ShaperExpression.Parameters);
+                source.ShaperExpression = Expression.Convert(source.ShaperExpression, returnType);
             }
 
             return source;

--- a/src/EFCore.InMemory/Query/PipeLine/InMemoryShapedQueryExpression.cs
+++ b/src/EFCore.InMemory/Query/PipeLine/InMemoryShapedQueryExpression.cs
@@ -12,13 +12,9 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Pipeline
         public InMemoryShapedQueryExpression(IEntityType entityType)
         {
             QueryExpression = new InMemoryQueryExpression(entityType);
-            var resultParameter = Parameter(typeof(InMemoryQueryExpression), "result");
             ShaperExpression = new EntityShaperExpression(
                 entityType,
-                new ProjectionBindingExpression(
-                    QueryExpression,
-                    new ProjectionMember(),
-                    typeof(ValueBuffer)),
+                new ProjectionBindingExpression(new ProjectionMember(), typeof(ValueBuffer)),
                 false);
         }
     }

--- a/src/EFCore.InMemory/Query/PipeLine/InMemoryShapedQueryExpression.cs
+++ b/src/EFCore.InMemory/Query/PipeLine/InMemoryShapedQueryExpression.cs
@@ -13,14 +13,13 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Pipeline
         {
             QueryExpression = new InMemoryQueryExpression(entityType);
             var resultParameter = Parameter(typeof(InMemoryQueryExpression), "result");
-            ShaperExpression = Lambda(new EntityShaperExpression(
+            ShaperExpression = new EntityShaperExpression(
                 entityType,
                 new ProjectionBindingExpression(
                     QueryExpression,
                     new ProjectionMember(),
                     typeof(ValueBuffer)),
-                false),
-                resultParameter);
+                false);
         }
     }
 

--- a/src/EFCore.InMemory/Query/PipeLine/InMemoryShapedQueryExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/PipeLine/InMemoryShapedQueryExpressionVisitor.cs
@@ -47,7 +47,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Pipeline
 
         protected override Expression VisitShapedQueryExpression(ShapedQueryExpression shapedQueryExpression)
         {
-            var shaperLambda = InjectEntityMaterializer(shapedQueryExpression.ShaperExpression);
+            var shaperBody = InjectEntityMaterializer(shapedQueryExpression.ShaperExpression);
 
             var innerEnumerable = Visit(shapedQueryExpression.QueryExpression);
 
@@ -55,14 +55,14 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Pipeline
 
             var newBody = new InMemoryProjectionBindingRemovingExpressionVisitor(
                 (InMemoryQueryExpression)shapedQueryExpression.QueryExpression)
-                .Visit(shaperLambda.Body);
+                .Visit(shaperBody);
 
             newBody = ReplacingExpressionVisitor.Replace(
                 InMemoryQueryExpression.ValueBufferParameter,
                 Expression.MakeMemberAccess(enumeratorParameter, _enumeratorCurrent),
                 newBody);
 
-            shaperLambda = Expression.Lambda(
+            var shaperLambda = Expression.Lambda(
                 newBody,
                 QueryCompilationContext2.QueryContextParameter,
                 enumeratorParameter);

--- a/src/EFCore.Relational/Query/PipeLine/RelationalProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/PipeLine/RelationalProjectionBindingExpressionVisitor.cs
@@ -87,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 
                 _projectionMapping[_projectionMembers.Peek()] = translation ?? throw new InvalidOperationException();
 
-                return new ProjectionBindingExpression(_selectExpression, _projectionMembers.Peek(), expression.Type);
+                return new ProjectionBindingExpression(_projectionMembers.Peek(), expression.Type);
             }
 
             return base.Visit(expression);
@@ -102,7 +102,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                         entityShaperExpression.ValueBufferExpression.ProjectionMember);
 
                 return entityShaperExpression.Update(
-                    new ProjectionBindingExpression(_selectExpression, _projectionMembers.Peek(), typeof(ValueBuffer)));
+                    new ProjectionBindingExpression(_projectionMembers.Peek(), typeof(ValueBuffer)));
             }
 
             throw new InvalidOperationException();

--- a/src/EFCore.Relational/Query/PipeLine/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/PipeLine/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -65,10 +65,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                     new List<ProjectionExpression>(),
                     new List<TableExpressionBase>());
 
-                source.ShaperExpression
-                    = Expression.Lambda(
-                        new ProjectionBindingExpression(source.QueryExpression, new ProjectionMember(), typeof(bool)),
-                        source.ShaperExpression.Parameters);
+                source.ShaperExpression = new ProjectionBindingExpression(source.QueryExpression, new ProjectionMember(), typeof(bool));
 
                 return source;
             }
@@ -102,10 +99,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                 projectionMapping,
                 new List<ProjectionExpression>(),
                 new List<TableExpressionBase>());
-            source.ShaperExpression
-                = Expression.Lambda(
-                    new ProjectionBindingExpression(source.QueryExpression, new ProjectionMember(), typeof(bool)),
-                    source.ShaperExpression.Parameters);
+            source.ShaperExpression = new ProjectionBindingExpression(source.QueryExpression, new ProjectionMember(), typeof(bool));
 
             return source;
         }
@@ -153,7 +147,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 
         protected override ShapedQueryExpression TranslateCast(ShapedQueryExpression source, Type resultType)
         {
-            if (source.ShaperExpression.ReturnType == resultType)
+            if (source.ShaperExpression.Type == resultType)
             {
                 return source;
             }
@@ -188,10 +182,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                     projectionMapping,
                     new List<ProjectionExpression>(),
                     new List<TableExpressionBase>());
-                source.ShaperExpression
-                    = Expression.Lambda(
-                        new ProjectionBindingExpression(source.QueryExpression, new ProjectionMember(), typeof(bool)),
-                        source.ShaperExpression.Parameters);
+                source.ShaperExpression = new ProjectionBindingExpression(source.QueryExpression, new ProjectionMember(), typeof(bool));
 
                 return source;
             }
@@ -225,10 +216,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 
             selectExpression.ClearOrdering();
             selectExpression.ApplyProjection(_projectionMapping);
-            source.ShaperExpression
-                = Expression.Lambda(
-                    new ProjectionBindingExpression(selectExpression, new ProjectionMember(), typeof(int)),
-                    source.ShaperExpression.Parameters);
+            source.ShaperExpression = new ProjectionBindingExpression(selectExpression, new ProjectionMember(), typeof(int));
 
             return source;
         }
@@ -256,11 +244,9 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
             var selectExpression = (SelectExpression)source.QueryExpression;
             selectExpression.ApplyLimit(TranslateExpression(selectExpression, Expression.Constant(1)));
 
-            if (source.ShaperExpression.ReturnType != returnType)
+            if (source.ShaperExpression.Type != returnType)
             {
-                source.ShaperExpression = Expression.Lambda(
-                    Expression.Convert(source.ShaperExpression.Body, returnType),
-                    source.ShaperExpression.Parameters);
+                source.ShaperExpression = Expression.Convert(source.ShaperExpression, returnType);
             }
 
             return source;
@@ -403,8 +389,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
             var outerSelectExpression = (SelectExpression)outer.QueryExpression;
             var innerSelectExpression = (SelectExpression)inner.QueryExpression;
 
-            var outerKey = RemapLambdaBody(outer.ShaperExpression.Body, outerKeySelector);
-            var innerKey = RemapLambdaBody(inner.ShaperExpression.Body, innerKeySelector);
+            var outerKey = RemapLambdaBody(outer.ShaperExpression, outerKeySelector);
+            var innerKey = RemapLambdaBody(inner.ShaperExpression, innerKeySelector);
 
             if (outerKey is NewExpression outerNew)
             {
@@ -462,11 +448,9 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
             selectExpression.ReverseOrderings();
             selectExpression.ApplyLimit(TranslateExpression(selectExpression, Expression.Constant(1)));
 
-            if (source.ShaperExpression.ReturnType != returnType)
+            if (source.ShaperExpression.Type != returnType)
             {
-                source.ShaperExpression = Expression.Lambda(
-                    Expression.Convert(source.ShaperExpression.Body, returnType),
-                    source.ShaperExpression.Parameters);
+                source.ShaperExpression = Expression.Convert(source.ShaperExpression, returnType);
             }
 
             return source;
@@ -497,10 +481,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 
             selectExpression.ClearOrdering();
             selectExpression.ApplyProjection(_projectionMapping);
-            source.ShaperExpression
-                = Expression.Lambda(
-                    new ProjectionBindingExpression(selectExpression, new ProjectionMember(), typeof(long)),
-                    source.ShaperExpression.Parameters);
+            source.ShaperExpression = new ProjectionBindingExpression(selectExpression, new ProjectionMember(), typeof(long));
 
             return source;
         }
@@ -578,12 +559,10 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                 return source;
             }
 
-            var newSelectorBody = ReplacingExpressionVisitor.Replace(selector.Parameters.Single(), source.ShaperExpression.Body, selector.Body);
+            var newSelectorBody = ReplacingExpressionVisitor.Replace(selector.Parameters.Single(), source.ShaperExpression, selector.Body);
 
-            newSelectorBody = _projectionBindingExpressionVisitor
+            source.ShaperExpression = _projectionBindingExpressionVisitor
                 .Translate((SelectExpression)source.QueryExpression, newSelectorBody);
-
-            source.ShaperExpression = Expression.Lambda(newSelectorBody, source.ShaperExpression.Parameters);
 
             return source;
         }
@@ -692,11 +671,9 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
             var selectExpression = (SelectExpression)source.QueryExpression;
             selectExpression.ApplyLimit(TranslateExpression(selectExpression, Expression.Constant(1)));
 
-            if (source.ShaperExpression.ReturnType != returnType)
+            if (source.ShaperExpression.Type != returnType)
             {
-                source.ShaperExpression = Expression.Lambda(
-                    Expression.Convert(source.ShaperExpression.Body, returnType),
-                    source.ShaperExpression.Parameters);
+                source.ShaperExpression = Expression.Convert(source.ShaperExpression, returnType);
             }
 
             return source;
@@ -813,7 +790,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
         private SqlExpression TranslateLambdaExpression(
             ShapedQueryExpression shapedQueryExpression, LambdaExpression lambdaExpression)
         {
-            var lambdaBody = RemapLambdaBody(shapedQueryExpression.ShaperExpression.Body, lambdaExpression);
+            var lambdaBody = RemapLambdaBody(shapedQueryExpression.ShaperExpression, lambdaExpression);
 
             return TranslateExpression((SelectExpression)shapedQueryExpression.QueryExpression, lambdaBody);
         }
@@ -861,10 +838,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                 shaper = Expression.Convert(shaper, resultType);
             }
 
-            source.ShaperExpression
-                = Expression.Lambda(
-                    shaper,
-                    source.ShaperExpression.Parameters);
+            source.ShaperExpression = shaper;
 
             return source;
         }

--- a/src/EFCore.Relational/Query/PipeLine/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/PipeLine/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -65,7 +65,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                     new List<ProjectionExpression>(),
                     new List<TableExpressionBase>());
 
-                source.ShaperExpression = new ProjectionBindingExpression(source.QueryExpression, new ProjectionMember(), typeof(bool));
+                source.ShaperExpression = new ProjectionBindingExpression(new ProjectionMember(), typeof(bool));
 
                 return source;
             }
@@ -99,7 +99,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                 projectionMapping,
                 new List<ProjectionExpression>(),
                 new List<TableExpressionBase>());
-            source.ShaperExpression = new ProjectionBindingExpression(source.QueryExpression, new ProjectionMember(), typeof(bool));
+            source.ShaperExpression = new ProjectionBindingExpression(new ProjectionMember(), typeof(bool));
 
             return source;
         }
@@ -182,7 +182,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                     projectionMapping,
                     new List<ProjectionExpression>(),
                     new List<TableExpressionBase>());
-                source.ShaperExpression = new ProjectionBindingExpression(source.QueryExpression, new ProjectionMember(), typeof(bool));
+                source.ShaperExpression = new ProjectionBindingExpression(new ProjectionMember(), typeof(bool));
 
                 return source;
             }
@@ -216,7 +216,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 
             selectExpression.ClearOrdering();
             selectExpression.ApplyProjection(_projectionMapping);
-            source.ShaperExpression = new ProjectionBindingExpression(selectExpression, new ProjectionMember(), typeof(int));
+            source.ShaperExpression = new ProjectionBindingExpression(new ProjectionMember(), typeof(int));
 
             return source;
         }
@@ -481,7 +481,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 
             selectExpression.ClearOrdering();
             selectExpression.ApplyProjection(_projectionMapping);
-            source.ShaperExpression = new ProjectionBindingExpression(selectExpression, new ProjectionMember(), typeof(long));
+            source.ShaperExpression = new ProjectionBindingExpression(new ProjectionMember(), typeof(long));
 
             return source;
         }
@@ -812,7 +812,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 
             selectExpression.ClearOrdering();
 
-            Expression shaper = new ProjectionBindingExpression(selectExpression, new ProjectionMember(), projection.Type);
+            Expression shaper = new ProjectionBindingExpression(new ProjectionMember(), projection.Type);
 
             if (throwOnNullResult)
             {

--- a/src/EFCore.Relational/Query/PipeLine/RelationalShapedQueryExpression.cs
+++ b/src/EFCore.Relational/Query/PipeLine/RelationalShapedQueryExpression.cs
@@ -13,11 +13,9 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
         public RelationalShapedQueryExpression(IEntityType entityType)
         {
             QueryExpression = new SelectExpression(entityType);
-            var resultParameter = Parameter(typeof(SelectExpression), "result");
             ShaperExpression = new EntityShaperExpression(
                 entityType,
                 new ProjectionBindingExpression(
-                    QueryExpression,
                     new ProjectionMember(),
                     typeof(ValueBuffer)),
                 false);

--- a/src/EFCore.Relational/Query/PipeLine/RelationalShapedQueryExpression.cs
+++ b/src/EFCore.Relational/Query/PipeLine/RelationalShapedQueryExpression.cs
@@ -14,14 +14,13 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
         {
             QueryExpression = new SelectExpression(entityType);
             var resultParameter = Parameter(typeof(SelectExpression), "result");
-            ShaperExpression = Lambda(new EntityShaperExpression(
+            ShaperExpression = new EntityShaperExpression(
                 entityType,
                 new ProjectionBindingExpression(
                     QueryExpression,
                     new ProjectionMember(),
                     typeof(ValueBuffer)),
-                false),
-                resultParameter);
+                false);
         }
     }
 }

--- a/src/EFCore.Relational/Query/PipeLine/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/PipeLine/RelationalSqlTranslatingExpressionVisitor.cs
@@ -159,8 +159,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 
             if (extensionExpression is ProjectionBindingExpression projectionBindingExpression)
             {
-                return ((SelectExpression)projectionBindingExpression.QueryExpression)
-                    .GetProjectionExpression(projectionBindingExpression.ProjectionMember);
+                return _selectExpression.GetProjectionExpression(projectionBindingExpression.ProjectionMember);
             }
 
             if (extensionExpression is NullConditionalExpression nullConditionalExpression)

--- a/src/EFCore.Relational/Query/Pipeline/RelationalShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Pipeline/RelationalShapedQueryCompilingExpressionVisitor.cs
@@ -36,14 +36,14 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 
         protected override Expression VisitShapedQueryExpression(ShapedQueryExpression shapedQueryExpression)
         {
-            var shaperLambda = InjectEntityMaterializer(shapedQueryExpression.ShaperExpression);
+            var shaperBody = InjectEntityMaterializer(shapedQueryExpression.ShaperExpression);
 
             var selectExpression = (SelectExpression)shapedQueryExpression.QueryExpression;
 
             var newBody = new RelationalProjectionBindingRemovingExpressionVisitor(selectExpression)
-                .Visit(shaperLambda.Body);
+                .Visit(shaperBody);
 
-            shaperLambda = Expression.Lambda(
+            var shaperLambda = Expression.Lambda(
                 newBody,
                 QueryCompilationContext2.QueryContextParameter,
                 RelationalProjectionBindingRemovingExpressionVisitor.DataReaderParameter);

--- a/src/EFCore/Query/PipeLine/ProjectionBindingExpression.cs
+++ b/src/EFCore/Query/PipeLine/ProjectionBindingExpression.cs
@@ -8,14 +8,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
 {
     public class ProjectionBindingExpression : Expression
     {
-        public ProjectionBindingExpression(Expression queryExpression, ProjectionMember projectionMember, Type type)
+        public ProjectionBindingExpression(ProjectionMember projectionMember, Type type)
         {
-            QueryExpression = queryExpression;
             ProjectionMember = projectionMember;
             Type = type;
         }
 
-        public Expression QueryExpression { get; }
         public ProjectionMember ProjectionMember { get; }
         public override Type Type { get; }
         public override ExpressionType NodeType => ExpressionType.Extension;

--- a/src/EFCore/Query/PipeLine/QueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore/Query/PipeLine/QueryableMethodTranslatingExpressionVisitor.cs
@@ -576,7 +576,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
                 if (node is ProjectionBindingExpression projectionBindingExpression)
                 {
                     return new ProjectionBindingExpression(
-                        _queryExpression,
                         projectionBindingExpression.ProjectionMember.ShiftMember(_memberShift),
                         projectionBindingExpression.Type);
                 }

--- a/src/EFCore/Query/PipeLine/ShapedQueryExpression.cs
+++ b/src/EFCore/Query/PipeLine/ShapedQueryExpression.cs
@@ -12,9 +12,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
         public Expression QueryExpression { get; set; }
         public ResultType ResultType { get; set; }
 
-        public LambdaExpression ShaperExpression { get; set; }
+        public Expression ShaperExpression { get; set; }
 
-        public override Type Type => typeof(IQueryable<>).MakeGenericType(ShaperExpression.ReturnType);
+        public override Type Type => typeof(IQueryable<>).MakeGenericType(ShaperExpression.Type);
 
         public override ExpressionType NodeType => ExpressionType.Extension;
 


### PR DESCRIPTION
The LambdaExpression.Parameters were not being used anyway
