### PR TITLE
[Query] Remove QueryExpression from ProjectionBindingExpression

### DIFF
--- a/src/EFCore.InMemory/Query/PipeLine/InMemoryProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/PipeLine/InMemoryProjectionBindingExpressionVisitor.cs
@@ -77,7 +77,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Pipeline
 
                 _projectionMapping[_projectionMembers.Peek()] = translation;
 
-                return new ProjectionBindingExpression(_queryExpression, _projectionMembers.Peek(), expression.Type);
+                return new ProjectionBindingExpression(_projectionMembers.Peek(), expression.Type);
             }
 
             return base.Visit(expression);
@@ -92,7 +92,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Pipeline
                         entityShaperExpression.ValueBufferExpression.ProjectionMember);
 
                 return entityShaperExpression.Update(
-                    new ProjectionBindingExpression(_queryExpression, _projectionMembers.Peek(), typeof(ValueBuffer)));
+                    new ProjectionBindingExpression(_projectionMembers.Peek(), typeof(ValueBuffer)));
             }
 
             throw new InvalidOperationException();

--- a/src/EFCore.InMemory/Query/PipeLine/InMemoryQueryExpression.cs
+++ b/src/EFCore.InMemory/Query/PipeLine/InMemoryQueryExpression.cs
@@ -90,7 +90,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Pipeline
             _projectionMapping.Clear();
             _projectionMapping[new ProjectionMember()] = _valueBufferSlots[0];
 
-            return new ProjectionBindingExpression(this, new ProjectionMember(), ServerQueryExpression.Type);
+            return new ProjectionBindingExpression(new ProjectionMember(), ServerQueryExpression.Type);
         }
 
         public Expression BindProperty(Expression projectionExpression, IProperty property)

--- a/src/EFCore.InMemory/Query/PipeLine/InMemoryShapedQueryExpression.cs
+++ b/src/EFCore.InMemory/Query/PipeLine/InMemoryShapedQueryExpression.cs
@@ -12,13 +12,9 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Pipeline
         public InMemoryShapedQueryExpression(IEntityType entityType)
         {
             QueryExpression = new InMemoryQueryExpression(entityType);
-            var resultParameter = Parameter(typeof(InMemoryQueryExpression), "result");
             ShaperExpression = new EntityShaperExpression(
                 entityType,
-                new ProjectionBindingExpression(
-                    QueryExpression,
-                    new ProjectionMember(),
-                    typeof(ValueBuffer)),
+                new ProjectionBindingExpression(new ProjectionMember(), typeof(ValueBuffer)),
                 false);
         }
     }

--- a/src/EFCore.Relational/Query/PipeLine/RelationalProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/PipeLine/RelationalProjectionBindingExpressionVisitor.cs
@@ -87,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 
                 _projectionMapping[_projectionMembers.Peek()] = translation ?? throw new InvalidOperationException();
 
-                return new ProjectionBindingExpression(_selectExpression, _projectionMembers.Peek(), expression.Type);
+                return new ProjectionBindingExpression(_projectionMembers.Peek(), expression.Type);
             }
 
             return base.Visit(expression);
@@ -102,7 +102,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                         entityShaperExpression.ValueBufferExpression.ProjectionMember);
 
                 return entityShaperExpression.Update(
-                    new ProjectionBindingExpression(_selectExpression, _projectionMembers.Peek(), typeof(ValueBuffer)));
+                    new ProjectionBindingExpression(_projectionMembers.Peek(), typeof(ValueBuffer)));
             }
 
             throw new InvalidOperationException();

--- a/src/EFCore.Relational/Query/PipeLine/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/PipeLine/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -65,7 +65,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                     new List<ProjectionExpression>(),
                     new List<TableExpressionBase>());
 
-                source.ShaperExpression = new ProjectionBindingExpression(source.QueryExpression, new ProjectionMember(), typeof(bool));
+                source.ShaperExpression = new ProjectionBindingExpression(new ProjectionMember(), typeof(bool));
 
                 return source;
             }
@@ -99,7 +99,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                 projectionMapping,
                 new List<ProjectionExpression>(),
                 new List<TableExpressionBase>());
-            source.ShaperExpression = new ProjectionBindingExpression(source.QueryExpression, new ProjectionMember(), typeof(bool));
+            source.ShaperExpression = new ProjectionBindingExpression(new ProjectionMember(), typeof(bool));
 
             return source;
         }
@@ -182,7 +182,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                     projectionMapping,
                     new List<ProjectionExpression>(),
                     new List<TableExpressionBase>());
-                source.ShaperExpression = new ProjectionBindingExpression(source.QueryExpression, new ProjectionMember(), typeof(bool));
+                source.ShaperExpression = new ProjectionBindingExpression(new ProjectionMember(), typeof(bool));
 
                 return source;
             }
@@ -216,7 +216,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 
             selectExpression.ClearOrdering();
             selectExpression.ApplyProjection(_projectionMapping);
-            source.ShaperExpression = new ProjectionBindingExpression(selectExpression, new ProjectionMember(), typeof(int));
+            source.ShaperExpression = new ProjectionBindingExpression(new ProjectionMember(), typeof(int));
 
             return source;
         }
@@ -481,7 +481,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 
             selectExpression.ClearOrdering();
             selectExpression.ApplyProjection(_projectionMapping);
-            source.ShaperExpression = new ProjectionBindingExpression(selectExpression, new ProjectionMember(), typeof(long));
+            source.ShaperExpression = new ProjectionBindingExpression(new ProjectionMember(), typeof(long));
 
             return source;
         }
@@ -812,7 +812,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 
             selectExpression.ClearOrdering();
 
-            Expression shaper = new ProjectionBindingExpression(selectExpression, new ProjectionMember(), projection.Type);
+            Expression shaper = new ProjectionBindingExpression(new ProjectionMember(), projection.Type);
 
             if (throwOnNullResult)
             {

--- a/src/EFCore.Relational/Query/PipeLine/RelationalShapedQueryExpression.cs
+++ b/src/EFCore.Relational/Query/PipeLine/RelationalShapedQueryExpression.cs
@@ -13,11 +13,9 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
         public RelationalShapedQueryExpression(IEntityType entityType)
         {
             QueryExpression = new SelectExpression(entityType);
-            var resultParameter = Parameter(typeof(SelectExpression), "result");
             ShaperExpression = new EntityShaperExpression(
                 entityType,
                 new ProjectionBindingExpression(
-                    QueryExpression,
                     new ProjectionMember(),
                     typeof(ValueBuffer)),
                 false);

--- a/src/EFCore.Relational/Query/PipeLine/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/PipeLine/RelationalSqlTranslatingExpressionVisitor.cs
@@ -159,8 +159,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 
             if (extensionExpression is ProjectionBindingExpression projectionBindingExpression)
             {
-                return ((SelectExpression)projectionBindingExpression.QueryExpression)
-                    .GetProjectionExpression(projectionBindingExpression.ProjectionMember);
+                return _selectExpression.GetProjectionExpression(projectionBindingExpression.ProjectionMember);
             }
 
             if (extensionExpression is NullConditionalExpression nullConditionalExpression)

--- a/src/EFCore/Query/PipeLine/ProjectionBindingExpression.cs
+++ b/src/EFCore/Query/PipeLine/ProjectionBindingExpression.cs
@@ -8,14 +8,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
 {
     public class ProjectionBindingExpression : Expression
     {
-        public ProjectionBindingExpression(Expression queryExpression, ProjectionMember projectionMember, Type type)
+        public ProjectionBindingExpression(ProjectionMember projectionMember, Type type)
         {
-            QueryExpression = queryExpression;
             ProjectionMember = projectionMember;
             Type = type;
         }
 
-        public Expression QueryExpression { get; }
         public ProjectionMember ProjectionMember { get; }
         public override Type Type { get; }
         public override ExpressionType NodeType => ExpressionType.Extension;

--- a/src/EFCore/Query/PipeLine/QueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore/Query/PipeLine/QueryableMethodTranslatingExpressionVisitor.cs
@@ -576,7 +576,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
                 if (node is ProjectionBindingExpression projectionBindingExpression)
                 {
                     return new ProjectionBindingExpression(
-                        _queryExpression,
                         projectionBindingExpression.ProjectionMember.ShiftMember(_memberShift),
                         projectionBindingExpression.Type);
                 }


### PR DESCRIPTION
Invariant: ProjectionBindingExpression can only appear in ShapedQueryExpression.ShaperExpression and it would always refer to ShapedQueryExpression.QueryExpression
