### PR TITLE
Support separation of query and update mapping with views

### DIFF
--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeBuilderExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeBuilderExtensions.cs
@@ -319,7 +319,7 @@ namespace Microsoft.EntityFrameworkCore
             Check.NullButNotEmpty(schema, nameof(schema));
 
             entityTypeBuilder.Metadata.SetViewName(name);
-            entityTypeBuilder.Metadata.SetViewSchema(schema);
+            entityTypeBuilder.Metadata.SetViewSchemaName(schema);
 
             return entityTypeBuilder;
         }

--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeBuilderExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeBuilderExtensions.cs
@@ -319,8 +319,7 @@ namespace Microsoft.EntityFrameworkCore
             Check.NullButNotEmpty(schema, nameof(schema));
 
             entityTypeBuilder.Metadata.SetViewName(name);
-            // TODO:
-            //entityTypeBuilder.Metadata.SetViewSchema(schema);
+            entityTypeBuilder.Metadata.SetViewSchema(schema);
 
             return entityTypeBuilder;
         }

--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeBuilderExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeBuilderExtensions.cs
@@ -272,12 +272,11 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         /// <summary>
-        ///     Configures the view or table that the view maps to when targeting a relational database.
+        ///     Configures the view that the entity type maps to when targeting a relational database.
         /// </summary>
-        /// <param name="entityTypeBuilder"> The builder for the query type being configured. </param>
-        /// <param name="name"> The name of the view or table. </param>
+        /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
+        /// <param name="name"> The name of the view. </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
-        [Obsolete("Use ToTable() instead")]
         public static EntityTypeBuilder ToView(
             [NotNull] this EntityTypeBuilder entityTypeBuilder,
             [CanBeNull] string name)
@@ -285,19 +284,18 @@ namespace Microsoft.EntityFrameworkCore
             Check.NotNull(entityTypeBuilder, nameof(entityTypeBuilder));
             Check.NullButNotEmpty(name, nameof(name));
 
-            entityTypeBuilder.Metadata.SetTableName(name);
+            entityTypeBuilder.Metadata.SetViewName(name);
 
             return entityTypeBuilder;
         }
 
         /// <summary>
-        ///     Configures the view or table that the view maps to when targeting a relational database.
+        ///     Configures the view that the entity type maps to when targeting a relational database.
         /// </summary>
-        /// <typeparam name="TEntity"> The query type being configured. </typeparam>
-        /// <param name="entityTypeBuilder"> The builder for the query type being configured. </param>
-        /// <param name="name"> The name of the view or table. </param>
+        /// <typeparam name="TEntity"> The entity type being configured. </typeparam>
+        /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
+        /// <param name="name"> The name of the view. </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
-        [Obsolete("Use ToTable() instead")]
         public static EntityTypeBuilder<TEntity> ToView<TEntity>(
             [NotNull] this EntityTypeBuilder<TEntity> entityTypeBuilder,
             [CanBeNull] string name)
@@ -305,13 +303,12 @@ namespace Microsoft.EntityFrameworkCore
             => (EntityTypeBuilder<TEntity>)ToView((EntityTypeBuilder)entityTypeBuilder, name);
 
         /// <summary>
-        ///     Configures the view or table that the view maps to when targeting a relational database.
+        ///     Configures the view that the entity type maps to when targeting a relational database.
         /// </summary>
         /// <param name="entityTypeBuilder"> The builder for the query type being configured. </param>
-        /// <param name="name"> The name of the view or table. </param>
-        /// <param name="schema"> The schema of the view or table. </param>
+        /// <param name="name"> The name of the view. </param>
+        /// <param name="schema"> The schema of the view. </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
-        [Obsolete("Use ToTable() instead")]
         public static EntityTypeBuilder ToView(
             [NotNull] this EntityTypeBuilder entityTypeBuilder,
             [CanBeNull] string name,
@@ -321,21 +318,21 @@ namespace Microsoft.EntityFrameworkCore
             Check.NullButNotEmpty(name, nameof(name));
             Check.NullButNotEmpty(schema, nameof(schema));
 
-            entityTypeBuilder.Metadata.SetTableName(name);
-            entityTypeBuilder.Metadata.SetSchema(schema);
+            entityTypeBuilder.Metadata.SetViewName(name);
+            // TODO:
+            //entityTypeBuilder.Metadata.SetViewSchema(schema);
 
             return entityTypeBuilder;
         }
 
         /// <summary>
-        ///     Configures the view or table that the view maps to when targeting a relational database.
+        ///     Configures the view that the entity type maps to when targeting a relational database.
         /// </summary>
         /// <typeparam name="TEntity"> The query type being configured. </typeparam>
         /// <param name="entityTypeBuilder"> The builder for the query type being configured. </param>
-        /// <param name="name"> The name of the view or table. </param>
-        /// <param name="schema"> The schema of the view or table. </param>
+        /// <param name="name"> The name of the view. </param>
+        /// <param name="schema"> The schema of the view. </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
-        [Obsolete("Use ToTable() instead")]
         public static EntityTypeBuilder<TEntity> ToView<TEntity>(
             [NotNull] this EntityTypeBuilder<TEntity> entityTypeBuilder,
             [CanBeNull] string name,

--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
@@ -48,6 +48,16 @@ namespace Microsoft.EntityFrameworkCore
                     : entityType.ShortName(),
                 entityType.Model.GetMaxIdentifierLength());
         }
+        /// <summary>
+        ///     Returns the name of the view to which the entity type is mapped.
+        /// </summary>
+        /// <param name="entityType"> The entity type to get the view name for. </param>
+        /// <returns> The name of the view to which the entity type is mapped. </returns>
+        public static string GetViewName([NotNull] this IEntityType entityType) =>
+            entityType.BaseType != null
+                ? entityType.RootType().GetViewName()
+                : (string)entityType[RelationalAnnotationNames.TableName]
+                  ?? GetDefaultTableName(entityType);
 
         /// <summary>
         ///     Sets the name of the table to which the entity type is mapped.
@@ -57,6 +67,16 @@ namespace Microsoft.EntityFrameworkCore
         public static void SetTableName([NotNull] this IMutableEntityType entityType, [CanBeNull] string name)
             => entityType.SetOrRemoveAnnotation(
                 RelationalAnnotationNames.TableName,
+                Check.NullButNotEmpty(name, nameof(name)));
+
+        /// <summary>
+        ///     Sets the name of the view to which the entity type is mapped.
+        /// </summary>
+        /// <param name="entityType"> The entity type to set the view name for. </param>
+        /// <param name="name"> The name to set. </param>
+        public static void SetViewName([NotNull] this IMutableEntityType entityType, [CanBeNull] string name)
+            => entityType.SetOrRemoveAnnotation(
+                RelationalAnnotationNames.ViewName,
                 Check.NullButNotEmpty(name, nameof(name)));
 
         /// <summary>

--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
@@ -57,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore
             entityType.BaseType != null
                 ? entityType.RootType().GetViewName()
                 : (string)entityType[RelationalAnnotationNames.TableName]
-                  ?? GetDefaultTableName(entityType);
+                  ?? GetTableName(entityType);
 
         /// <summary>
         ///     Sets the name of the table to which the entity type is mapped.

--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
@@ -48,6 +48,7 @@ namespace Microsoft.EntityFrameworkCore
                     : entityType.ShortName(),
                 entityType.Model.GetMaxIdentifierLength());
         }
+
         /// <summary>
         ///     Returns the name of the view to which the entity type is mapped.
         /// </summary>
@@ -132,6 +133,17 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         /// <summary>
+        ///     Returns the database schema that contains the mapped view.
+        /// </summary>
+        /// <param name="entityType"> The entity type to get the schema for. </param>
+        /// <returns> The database schema that contains the mapped view. </returns>
+        public static string GetViewSchemaName([NotNull] this IEntityType entityType) =>
+            entityType.BaseType != null
+                ? entityType.RootType().GetViewSchemaName()
+                : (string)entityType[RelationalAnnotationNames.Schema]
+                  ?? GetSchema(entityType);
+
+        /// <summary>
         ///     Sets the database schema that contains the mapped table.
         /// </summary>
         /// <param name="entityType"> The entity type to set the schema for. </param>
@@ -151,6 +163,29 @@ namespace Microsoft.EntityFrameworkCore
             [NotNull] this IConventionEntityType entityType, [CanBeNull] string value, bool fromDataAnnotation = false)
             => entityType.SetOrRemoveAnnotation(
                 RelationalAnnotationNames.Schema,
+                Check.NullButNotEmpty(value, nameof(value)),
+                fromDataAnnotation);
+
+        /// <summary>
+        ///     Sets the database schema that contains the mapped view.
+        /// </summary>
+        /// <param name="entityType"> The entity type to set the schema for. </param>
+        /// <param name="value"> The value to set. </param>
+        public static void SetViewSchema([NotNull] this IMutableEntityType entityType, [CanBeNull] string value)
+            => entityType.SetOrRemoveAnnotation(
+                RelationalAnnotationNames.ViewSchemaName,
+                Check.NullButNotEmpty(value, nameof(value)));
+
+        /// <summary>
+        ///     Sets the database schema that contains the mapped view.
+        /// </summary>
+        /// <param name="entityType"> The entity type to set the schema for. </param>
+        /// <param name="value"> The value to set. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        public static void SetViewSchema(
+            [NotNull] this IConventionEntityType entityType, [CanBeNull] string value, bool fromDataAnnotation = false)
+            => entityType.SetOrRemoveAnnotation(
+                RelationalAnnotationNames.ViewSchemaName,
                 Check.NullButNotEmpty(value, nameof(value)),
                 fromDataAnnotation);
 

--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
@@ -57,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore
         public static string GetViewName([NotNull] this IEntityType entityType) =>
             entityType.BaseType != null
                 ? entityType.RootType().GetViewName()
-                : (string)entityType[RelationalAnnotationNames.TableName]
+                : (string)entityType[RelationalAnnotationNames.ViewName]
                   ?? GetTableName(entityType);
 
         /// <summary>
@@ -140,7 +140,7 @@ namespace Microsoft.EntityFrameworkCore
         public static string GetViewSchemaName([NotNull] this IEntityType entityType) =>
             entityType.BaseType != null
                 ? entityType.RootType().GetViewSchemaName()
-                : (string)entityType[RelationalAnnotationNames.Schema]
+                : (string)entityType[RelationalAnnotationNames.ViewSchemaName]
                   ?? GetSchema(entityType);
 
         /// <summary>
@@ -171,7 +171,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entityType"> The entity type to set the schema for. </param>
         /// <param name="value"> The value to set. </param>
-        public static void SetViewSchema([NotNull] this IMutableEntityType entityType, [CanBeNull] string value)
+        public static void SetViewSchemaName([NotNull] this IMutableEntityType entityType, [CanBeNull] string value)
             => entityType.SetOrRemoveAnnotation(
                 RelationalAnnotationNames.ViewSchemaName,
                 Check.NullButNotEmpty(value, nameof(value)));
@@ -182,7 +182,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type to set the schema for. </param>
         /// <param name="value"> The value to set. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
-        public static void SetViewSchema(
+        public static void SetViewSchemaName(
             [NotNull] this IConventionEntityType entityType, [CanBeNull] string value, bool fromDataAnnotation = false)
             => entityType.SetOrRemoveAnnotation(
                 RelationalAnnotationNames.ViewSchemaName,

--- a/src/EFCore.Relational/Metadata/Internal/TableMapping.cs
+++ b/src/EFCore.Relational/Metadata/Internal/TableMapping.cs
@@ -26,10 +26,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public TableMapping(
             [CanBeNull] string schema,
             [NotNull] string name,
+            [NotNull] string viewName,
             [NotNull] IReadOnlyList<IEntityType> entityTypes)
         {
             Schema = schema;
             Name = name;
+            ViewName = viewName;
             EntityTypes = entityTypes;
         }
 
@@ -48,6 +50,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual string Name { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual string ViewName { get; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -144,10 +154,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public static IReadOnlyList<TableMapping> GetTableMappings([NotNull] IModel model)
         {
-            var tables = new Dictionary<(string Schema, string TableName), List<IEntityType>>();
+            var tables = new Dictionary<(string Schema, string TableName, string ViewName), List<IEntityType>>();
             foreach (var entityType in model.GetEntityTypes().Where(et => et.FindPrimaryKey() != null))
             {
-                var fullName = (entityType.GetSchema(), entityType.GetTableName());
+                var fullName = (entityType.GetSchema(), entityType.GetTableName(), entityType.GetViewName());
                 if (!tables.TryGetValue(fullName, out var mappedEntityTypes))
                 {
                     mappedEntityTypes = new List<IEntityType>();
@@ -158,7 +168,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 mappedEntityTypes.Add(entityType);
             }
 
-            return tables.Select(kv => new TableMapping(kv.Key.Schema, kv.Key.TableName, kv.Value))
+            return tables.Select(kv => new TableMapping(kv.Key.Schema, kv.Key.TableName, kv.Key.ViewName, kv.Value))
                 .OrderBy(t => t.Schema).ThenBy(t => t.Name).ToList();
         }
 
@@ -168,12 +178,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static TableMapping GetTableMapping([NotNull] IModel model, [NotNull] string table, [CanBeNull] string schema)
+        public static TableMapping GetTableMapping([NotNull] IModel model, [NotNull] string table, [NotNull] string view, [CanBeNull] string schema)
         {
             var mappedEntities = new List<IEntityType>();
             foreach (var entityType in model.GetEntityTypes().Where(et => et.FindPrimaryKey() != null))
             {
                 if (table == entityType.GetTableName()
+                    && view == entityType.GetViewName()
                     && schema == entityType.GetSchema())
                 {
                     mappedEntities.Add(entityType);
@@ -181,7 +192,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             return mappedEntities.Count > 0
-                ? new TableMapping(schema, table, mappedEntities)
+                ? new TableMapping(schema, table, view, mappedEntities)
                 : null;
         }
     }

--- a/src/EFCore.Relational/Metadata/Internal/TableMapping.cs
+++ b/src/EFCore.Relational/Metadata/Internal/TableMapping.cs
@@ -59,7 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual string ViewName { get; }
+        public virtual string ViewSchemaName { get; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -67,7 +67,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual string ViewSchemaName { get; }
+        public virtual string ViewName { get; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Metadata/RelationalAnnotationNames.cs
+++ b/src/EFCore.Relational/Metadata/RelationalAnnotationNames.cs
@@ -45,6 +45,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         public const string TableName = Prefix + "TableName";
 
         /// <summary>
+        ///     The name for schema name annotations.
+        /// </summary>
+        public const string Schema = Prefix + "Schema";
+
+        /// <summary>
         ///     The name for view name annotations.
         /// </summary>
         public const string ViewName = Prefix + "ViewName";
@@ -52,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     The name for schema name annotations.
         /// </summary>
-        public const string Schema = Prefix + "Schema";
+        public const string ViewSchemaName = Prefix + "ViewSchemaName";
 
         /// <summary>
         ///     The name for default schema annotations.

--- a/src/EFCore.Relational/Metadata/RelationalAnnotationNames.cs
+++ b/src/EFCore.Relational/Metadata/RelationalAnnotationNames.cs
@@ -45,6 +45,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         public const string TableName = Prefix + "TableName";
 
         /// <summary>
+        ///     The name for view name annotations.
+        /// </summary>
+        public const string ViewName = Prefix + "ViewName";
+
+        /// <summary>
         ///     The name for schema name annotations.
         /// </summary>
         public const string Schema = Prefix + "Schema";

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -1633,9 +1633,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     target.EntityTypes,
                     _targetUpdateAdapter,
                     target.Name,
+                    target.Schema,
                     target.ViewName,
-                    target.Schema)
-                ((t, v, s, c) => new List<IUpdateEntry>());
+                    target.ViewSchemaName)
+                ((t, s, v, vs, c) => new List<IUpdateEntry>());
 
             foreach (var targetEntityType in target.EntityTypes)
             {
@@ -1694,9 +1695,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     source.EntityTypes,
                     _sourceUpdateAdapter,
                     source.Name,
-                    source.ViewName,
-                    source.Schema)
-                ((t, v, s, c) => new EntryMapping());
+                    source.Schema,
+                    source.ViewSchemaName,
+                    source.ViewName)
+                ((t, s, v, vs, c) => new EntryMapping());
 
             foreach (var sourceEntityType in source.EntityTypes)
             {

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -1633,8 +1633,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     target.EntityTypes,
                     _targetUpdateAdapter,
                     target.Name,
+                    target.ViewName,
                     target.Schema)
-                ((t, s, c) => new List<IUpdateEntry>());
+                ((t, v, s, c) => new List<IUpdateEntry>());
 
             foreach (var targetEntityType in target.EntityTypes)
             {
@@ -1693,8 +1694,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     source.EntityTypes,
                     _sourceUpdateAdapter,
                     source.Name,
+                    source.ViewName,
                     source.Schema)
-                ((t, s, c) => new EntryMapping());
+                ((t, v, s, c) => new EntryMapping());
 
             foreach (var sourceEntityType in source.EntityTypes)
             {

--- a/src/EFCore.Relational/Migrations/Operations/DeleteDataOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/DeleteDataOperation.cs
@@ -58,8 +58,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
                 KeyColumns.Length == KeyValues.GetLength(1),
                 $"The number of key values doesn't match the number of keys (${KeyColumns.Length})");
 
+            var viewName = ViewName ?? Table;
+            var viewSchemaName = ViewSchemaName ?? Schema;
+
             var properties = model != null
-                ? TableMapping.GetTableMapping(model, Table, Schema, ViewName, ViewSchemaName)?.GetPropertyMap()
+                ? TableMapping.GetTableMapping(model, Table, Schema, viewName, viewSchemaName)?.GetPropertyMap()
                 : null;
 
             for (var i = 0; i < KeyValues.GetLength(0); i++)
@@ -72,7 +75,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
                         isRead: false, isWrite: true, isKey: true, isCondition: true, sensitiveLoggingEnabled: true);
                 }
 
-                yield return new ModificationCommand(Table, Schema, ViewName, ViewSchemaName, modifications, sensitiveLoggingEnabled: true);
+                yield return new ModificationCommand(Table, Schema, viewName, viewSchemaName, modifications, sensitiveLoggingEnabled: true);
             }
         }
     }

--- a/src/EFCore.Relational/Migrations/Operations/DeleteDataOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/DeleteDataOperation.cs
@@ -22,6 +22,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
         public virtual string Table { get; [param: NotNull] set; }
 
         /// <summary>
+        ///     The view from which data will be deleted.
+        /// </summary>
+        public virtual string View { get; [param: NotNull] set; }
+
+        /// <summary>
         ///     The schema that contains the table, or <c>null</c> if the default schema should be used.
         /// </summary>
         public virtual string Schema { get; [param: CanBeNull] set; }
@@ -49,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
                 $"The number of key values doesn't match the number of keys (${KeyColumns.Length})");
 
             var properties = model != null
-                ? TableMapping.GetTableMapping(model, Table, Schema)?.GetPropertyMap()
+                ? TableMapping.GetTableMapping(model, Table, View, Schema)?.GetPropertyMap()
                 : null;
 
             for (var i = 0; i < KeyValues.GetLength(0); i++)
@@ -62,7 +67,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
                         isRead: false, isWrite: true, isKey: true, isCondition: true, sensitiveLoggingEnabled: true);
                 }
 
-                yield return new ModificationCommand(Table, Schema, modifications, sensitiveLoggingEnabled: true);
+                yield return new ModificationCommand(Table, View, Schema, modifications, sensitiveLoggingEnabled: true);
             }
         }
     }

--- a/src/EFCore.Relational/Migrations/Operations/DeleteDataOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/DeleteDataOperation.cs
@@ -22,14 +22,19 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
         public virtual string Table { get; [param: NotNull] set; }
 
         /// <summary>
+        ///     The schema that contains the table, or <c>null</c> if the default schema should be used.
+        /// </summary>
+        public virtual string Schema { get; [param: CanBeNull] set; }
+
+        /// <summary>
         ///     The view from which data will be deleted.
         /// </summary>
-        public virtual string View { get; [param: NotNull] set; }
+        public virtual string ViewName { get; [param: NotNull] set; }
 
         /// <summary>
         ///     The schema that contains the table, or <c>null</c> if the default schema should be used.
         /// </summary>
-        public virtual string Schema { get; [param: CanBeNull] set; }
+        public virtual string ViewSchemaName { get; [param: CanBeNull] set; }
 
         /// <summary>
         ///     A list of column names that represent the columns that will be used to identify
@@ -54,7 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
                 $"The number of key values doesn't match the number of keys (${KeyColumns.Length})");
 
             var properties = model != null
-                ? TableMapping.GetTableMapping(model, Table, View, Schema)?.GetPropertyMap()
+                ? TableMapping.GetTableMapping(model, Table, Schema, ViewName, ViewSchemaName)?.GetPropertyMap()
                 : null;
 
             for (var i = 0; i < KeyValues.GetLength(0); i++)
@@ -67,7 +72,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
                         isRead: false, isWrite: true, isKey: true, isCondition: true, sensitiveLoggingEnabled: true);
                 }
 
-                yield return new ModificationCommand(Table, View, Schema, modifications, sensitiveLoggingEnabled: true);
+                yield return new ModificationCommand(Table, Schema, ViewName, ViewSchemaName, modifications, sensitiveLoggingEnabled: true);
             }
         }
     }

--- a/src/EFCore.Relational/Migrations/Operations/InsertDataOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/InsertDataOperation.cs
@@ -57,8 +57,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
                 Columns.Length == Values.GetLength(1),
                 $"The number of values doesn't match the number of keys (${Columns.Length})");
 
+            var viewName = ViewName ?? Table;
+            var viewSchemaName = ViewSchemaName ?? Schema;
+
             var properties = model != null
-                ? TableMapping.GetTableMapping(model, Table, Schema, ViewName, ViewSchemaName)?.GetPropertyMap()
+                ? TableMapping.GetTableMapping(model, Table, Schema, viewName, viewSchemaName)?.GetPropertyMap()
                 : null;
 
             for (var i = 0; i < Values.GetLength(0); i++)
@@ -71,7 +74,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
                         isRead: false, isWrite: true, isKey: true, isCondition: false, sensitiveLoggingEnabled: true);
                 }
 
-                yield return new ModificationCommand(Table, Schema, ViewName, ViewSchemaName, modifications, sensitiveLoggingEnabled: true);
+                yield return new ModificationCommand(Table, Schema, viewName, viewSchemaName, modifications, sensitiveLoggingEnabled: true);
             }
         }
     }

--- a/src/EFCore.Relational/Migrations/Operations/InsertDataOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/InsertDataOperation.cs
@@ -22,14 +22,19 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
         public virtual string Table { get; [param: NotNull] set; }
 
         /// <summary>
-        ///     The name of the view into which data will be inserted.
-        /// </summary>
-        public virtual string View { get; [param: NotNull] set; }
-
-        /// <summary>
         ///     The schema that contains the table, or <c>null</c> if the default schema should be used.
         /// </summary>
         public virtual string Schema { get; [param: CanBeNull] set; }
+
+        /// <summary>
+        ///     The name of the view into which data will be inserted.
+        /// </summary>
+        public virtual string ViewName { get; [param: NotNull] set; }
+
+        /// <summary>
+        ///     The schema that contains the view, or <c>null</c> if the default schema should be used.
+        /// </summary>
+        public virtual string ViewSchemaName { get; [param: CanBeNull] set; }
 
         /// <summary>
         ///     A list of column names that represent the columns into which data will be inserted.
@@ -53,7 +58,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
                 $"The number of values doesn't match the number of keys (${Columns.Length})");
 
             var properties = model != null
-                ? TableMapping.GetTableMapping(model, Table, View, Schema)?.GetPropertyMap()
+                ? TableMapping.GetTableMapping(model, Table, Schema, ViewName, ViewSchemaName)?.GetPropertyMap()
                 : null;
 
             for (var i = 0; i < Values.GetLength(0); i++)
@@ -66,7 +71,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
                         isRead: false, isWrite: true, isKey: true, isCondition: false, sensitiveLoggingEnabled: true);
                 }
 
-                yield return new ModificationCommand(Table, View, Schema, modifications, sensitiveLoggingEnabled: true);
+                yield return new ModificationCommand(Table, Schema, ViewName, ViewSchemaName, modifications, sensitiveLoggingEnabled: true);
             }
         }
     }

--- a/src/EFCore.Relational/Migrations/Operations/InsertDataOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/InsertDataOperation.cs
@@ -22,6 +22,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
         public virtual string Table { get; [param: NotNull] set; }
 
         /// <summary>
+        ///     The name of the view into which data will be inserted.
+        /// </summary>
+        public virtual string View { get; [param: NotNull] set; }
+
+        /// <summary>
         ///     The schema that contains the table, or <c>null</c> if the default schema should be used.
         /// </summary>
         public virtual string Schema { get; [param: CanBeNull] set; }
@@ -48,7 +53,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
                 $"The number of values doesn't match the number of keys (${Columns.Length})");
 
             var properties = model != null
-                ? TableMapping.GetTableMapping(model, Table, Schema)?.GetPropertyMap()
+                ? TableMapping.GetTableMapping(model, Table, View, Schema)?.GetPropertyMap()
                 : null;
 
             for (var i = 0; i < Values.GetLength(0); i++)
@@ -61,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
                         isRead: false, isWrite: true, isKey: true, isCondition: false, sensitiveLoggingEnabled: true);
                 }
 
-                yield return new ModificationCommand(Table, Schema, modifications, sensitiveLoggingEnabled: true);
+                yield return new ModificationCommand(Table, View, Schema, modifications, sensitiveLoggingEnabled: true);
             }
         }
     }

--- a/src/EFCore.Relational/Migrations/Operations/UpdateDataOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/UpdateDataOperation.cs
@@ -23,6 +23,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
         public virtual string Table { get; [param: NotNull] set; }
 
         /// <summary>
+        ///     The name of the view in which data will be updated.
+        /// </summary>
+        public virtual string View { get; [param: NotNull] set; }
+
+        /// <summary>
         ///     The schema that contains the table, or <c>null</c> if the default schema should be used.
         /// </summary>
         public virtual string Schema { get; [param: CanBeNull] set; }
@@ -67,7 +72,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
                 $"The number of key values doesn't match the number of values (${KeyValues.GetLength(0)})");
 
             var properties = model != null
-                ? TableMapping.GetTableMapping(model, Table, Schema)?.GetPropertyMap()
+                ? TableMapping.GetTableMapping(model, Table, View, Schema)?.GetPropertyMap()
                 : null;
 
             for (var i = 0; i < KeyValues.GetLength(0); i++)
@@ -88,7 +93,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
                         isRead: false, isWrite: true, isKey: true, isCondition: false, sensitiveLoggingEnabled: true);
                 }
 
-                yield return new ModificationCommand(Table, Schema, keys.Concat(modifications).ToArray(), sensitiveLoggingEnabled: true);
+                yield return new ModificationCommand(Table, View, Schema, keys.Concat(modifications).ToArray(), sensitiveLoggingEnabled: true);
             }
         }
     }

--- a/src/EFCore.Relational/Migrations/Operations/UpdateDataOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/UpdateDataOperation.cs
@@ -76,8 +76,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
                 KeyValues.GetLength(0) == Values.GetLength(0),
                 $"The number of key values doesn't match the number of values (${KeyValues.GetLength(0)})");
 
+            var viewName = ViewName ?? Table;
+            var viewSchemaName = ViewSchemaName ?? Schema;
+
             var properties = model != null
-                ? TableMapping.GetTableMapping(model, Table, Schema, ViewName, ViewSchemaName)?.GetPropertyMap()
+                ? TableMapping.GetTableMapping(model, Table, Schema, viewName, viewSchemaName)?.GetPropertyMap()
                 : null;
 
             for (var i = 0; i < KeyValues.GetLength(0); i++)
@@ -98,7 +101,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
                         isRead: false, isWrite: true, isKey: true, isCondition: false, sensitiveLoggingEnabled: true);
                 }
 
-                yield return new ModificationCommand(Table, Schema, ViewName, ViewSchemaName, keys.Concat(modifications).ToArray(), sensitiveLoggingEnabled: true);
+                yield return new ModificationCommand(Table, Schema, viewName, viewSchemaName, keys.Concat(modifications).ToArray(), sensitiveLoggingEnabled: true);
             }
         }
     }

--- a/src/EFCore.Relational/Migrations/Operations/UpdateDataOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/UpdateDataOperation.cs
@@ -23,14 +23,19 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
         public virtual string Table { get; [param: NotNull] set; }
 
         /// <summary>
+        ///     The schema that contains the table, or <c>null</c> if the default schema should be used.
+        /// </summary>
+        public virtual string Schema { get; [param: CanBeNull] set; }
+
+        /// <summary>
         ///     The name of the view in which data will be updated.
         /// </summary>
-        public virtual string View { get; [param: NotNull] set; }
+        public virtual string ViewName { get; [param: NotNull] set; }
 
         /// <summary>
         ///     The schema that contains the table, or <c>null</c> if the default schema should be used.
         /// </summary>
-        public virtual string Schema { get; [param: CanBeNull] set; }
+        public virtual string ViewSchemaName { get; [param: CanBeNull] set; }
 
         /// <summary>
         ///     A list of column names that represent the columns that will be used to identify
@@ -72,7 +77,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
                 $"The number of key values doesn't match the number of values (${KeyValues.GetLength(0)})");
 
             var properties = model != null
-                ? TableMapping.GetTableMapping(model, Table, View, Schema)?.GetPropertyMap()
+                ? TableMapping.GetTableMapping(model, Table, Schema, ViewName, ViewSchemaName)?.GetPropertyMap()
                 : null;
 
             for (var i = 0; i < KeyValues.GetLength(0); i++)
@@ -93,7 +98,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
                         isRead: false, isWrite: true, isKey: true, isCondition: false, sensitiveLoggingEnabled: true);
                 }
 
-                yield return new ModificationCommand(Table, View, Schema, keys.Concat(modifications).ToArray(), sensitiveLoggingEnabled: true);
+                yield return new ModificationCommand(Table, Schema, ViewName, ViewSchemaName, keys.Concat(modifications).ToArray(), sensitiveLoggingEnabled: true);
             }
         }
     }

--- a/src/EFCore.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
@@ -151,7 +151,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
 
             QueryModelVisitor.AddQuery(_querySource, selectExpression);
 
-            var tableName = entityType.GetTableName();
+            var tableName = entityType.GetViewName();
 
             var tableAlias
                 = relationalQueryCompilationContext.CreateUniqueTableAlias(

--- a/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
+++ b/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
@@ -40,7 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
         private readonly int _minBatchSize;
         private readonly bool _sensitiveLoggingEnabled;
 
-        private IReadOnlyDictionary<(string Schema, string Name, string ViewName), SharedTableEntryMapFactory<ModificationCommand>> _sharedTableEntryMapFactories;
+        private IReadOnlyDictionary<(string Schema, string Name, string ViewSchemaName, string ViewName), SharedTableEntryMapFactory<ModificationCommand>> _sharedTableEntryMapFactories;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -166,7 +166,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                     .CreateSharedTableEntryMapFactories(modelData.Model, modelData);
             }
 
-            Dictionary<(string Schema, string Name, string ViewName), SharedTableEntryMap<ModificationCommand>> sharedTablesCommandsMap =
+            Dictionary<(string Schema, string Name, string ViewSchemaName, string ViewName), SharedTableEntryMap<ModificationCommand>> sharedTablesCommandsMap =
                 null;
             foreach (var entry in entries)
             {
@@ -180,7 +180,8 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                 var table = entityType.GetTableName();
                 var schema = entityType.GetSchema();
                 var viewName = entityType.GetViewName();
-                var tableKey = (schema, table, viewName);
+                var viewSchemaName = entityType.GetViewSchemaName();
+                var tableKey = (schema, table, viewSchemaName, viewName);
 
                 ModificationCommand command;
                 if (_sharedTableEntryMapFactories.TryGetValue(tableKey, out var commandIdentityMapFactory))
@@ -188,15 +189,15 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                     if (sharedTablesCommandsMap == null)
                     {
                         sharedTablesCommandsMap =
-                            new Dictionary<(string Schema, string Name, string ViewName), SharedTableEntryMap<ModificationCommand>>();
+                            new Dictionary<(string Schema, string Name, string ViewSchemaName, string ViewName), SharedTableEntryMap<ModificationCommand>>();
                     }
 
                     if (!sharedTablesCommandsMap.TryGetValue(tableKey, out var sharedCommandsMap))
                     {
                         sharedCommandsMap = commandIdentityMapFactory(
-                            (t, v, s, c) => new ModificationCommand(
-                                t, v, s, generateParameterName, _sensitiveLoggingEnabled, c));
-                        sharedTablesCommandsMap.Add((schema, table, viewName), sharedCommandsMap);
+                            (t, s, v, vs, c) => new ModificationCommand(
+                                t, s, v, vs, generateParameterName, _sensitiveLoggingEnabled, c));
+                        sharedTablesCommandsMap.Add((schema, table, viewSchemaName, viewName), sharedCommandsMap);
                     }
 
                     command = sharedCommandsMap.GetOrAddValue(entry);
@@ -204,7 +205,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                 else
                 {
                     command = new ModificationCommand(
-                        table, viewName, schema, generateParameterName, _sensitiveLoggingEnabled, comparer: null);
+                        table, schema, viewName, viewSchemaName, generateParameterName, _sensitiveLoggingEnabled, comparer: null);
                 }
 
                 command.AddEntry(entry);
@@ -223,7 +224,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
         }
 
         private void Validate(
-            Dictionary<(string Schema, string Name, string ViewName),
+            Dictionary<(string Schema, string Name, string ViewSchemaName, string ViewName),
                 SharedTableEntryMap<ModificationCommand>> sharedTablesCommandsMap)
         {
             foreach (var modificationCommandIdentityMap in sharedTablesCommandsMap.Values)
@@ -289,7 +290,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
         }
 
         private void AddUnchangedSharingEntries(
-            Dictionary<(string Schema, string Name, string ViewName), SharedTableEntryMap<ModificationCommand>> sharedTablesCommandsMap,
+            Dictionary<(string Schema, string Name, string ViewSchemaName, string ViewName), SharedTableEntryMap<ModificationCommand>> sharedTablesCommandsMap,
             IList<IUpdateEntry> entries)
         {
             foreach (var modificationCommandIdentityMap in sharedTablesCommandsMap.Values)

--- a/src/EFCore.Relational/Update/Internal/SharedTableEntryMap.cs
+++ b/src/EFCore.Relational/Update/Internal/SharedTableEntryMap.cs
@@ -90,7 +90,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                     continue;
                 }
 
-                var factory = CreateSharedTableEntryMapFactory(tableMapping.Value, updateAdapter, tableMapping.Key.TableName, tableMapping.Key.Schema, tableMapping.Key.ViewSchemaName, tableMapping.Key.ViewName);
+                var factory = CreateSharedTableEntryMapFactory(tableMapping.Value, updateAdapter, tableMapping.Key.TableName, tableMapping.Key.Schema, tableMapping.Key.ViewName, tableMapping.Key.ViewSchemaName);
 
                 sharedTablesMap.Add(tableMapping.Key, factory);
             }

--- a/src/EFCore.Relational/Update/Internal/SharedTableEntryValueFactory.cs
+++ b/src/EFCore.Relational/Update/Internal/SharedTableEntryValueFactory.cs
@@ -11,5 +11,5 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public delegate TValue SharedTableEntryValueFactory<out TValue>(string tableName, string schema, IComparer<IUpdateEntry> comparer);
+    public delegate TValue SharedTableEntryValueFactory<out TValue>(string tableName, string viewName, string schema, IComparer<IUpdateEntry> comparer);
 }

--- a/src/EFCore.Relational/Update/Internal/SharedTableEntryValueFactory.cs
+++ b/src/EFCore.Relational/Update/Internal/SharedTableEntryValueFactory.cs
@@ -11,5 +11,5 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public delegate TValue SharedTableEntryValueFactory<out TValue>(string tableName, string viewName, string schema, IComparer<IUpdateEntry> comparer);
+    public delegate TValue SharedTableEntryValueFactory<out TValue>(string tableName, string schema, string viewName, string viewSchemaName, IComparer<IUpdateEntry> comparer);
 }

--- a/src/EFCore.Relational/Update/ModificationCommand.cs
+++ b/src/EFCore.Relational/Update/ModificationCommand.cs
@@ -35,18 +35,21 @@ namespace Microsoft.EntityFrameworkCore.Update
         ///     Initializes a new <see cref="ModificationCommand" /> instance.
         /// </summary>
         /// <param name="name"> The name of the table containing the data to be modified. </param>
+        /// <param name="viewName"> The name of the view containing the data to be modified. </param>
         /// <param name="schema"> The schema containing the table, or <c>null</c> to use the default schema. </param>
         /// <param name="generateParameterName"> A delegate to generate parameter names. </param>
         /// <param name="sensitiveLoggingEnabled"> Indicates whether or not potentially sensitive data (e.g. database values) can be logged. </param>
         /// <param name="comparer"> A <see cref="IComparer{T}" /> for <see cref="IUpdateEntry" />s. </param>
         public ModificationCommand(
             [NotNull] string name,
+            [NotNull] string viewName,
             [CanBeNull] string schema,
             [NotNull] Func<string> generateParameterName,
             bool sensitiveLoggingEnabled,
             [CanBeNull] IComparer<IUpdateEntry> comparer)
             : this(
                 Check.NotEmpty(name, nameof(name)),
+                Check.NotEmpty(viewName, nameof(viewName)),
                 schema,
                 null,
                 sensitiveLoggingEnabled)
@@ -61,18 +64,22 @@ namespace Microsoft.EntityFrameworkCore.Update
         ///     Initializes a new <see cref="ModificationCommand" /> instance.
         /// </summary>
         /// <param name="name"> The name of the table containing the data to be modified. </param>
+        /// <param name="viewName"> The name of the view containing the data to be modified. </param>
         /// <param name="schema"> The schema containing the table, or <c>null</c> to use the default schema. </param>
         /// <param name="columnModifications"> The list of <see cref="ColumnModification" />s needed to perform the insert, update, or delete. </param>
         /// <param name="sensitiveLoggingEnabled"> Indicates whether or not potentially sensitive data (e.g. database values) can be logged. </param>
         public ModificationCommand(
             [NotNull] string name,
+            [NotNull] string viewName,
             [CanBeNull] string schema,
             [CanBeNull] IReadOnlyList<ColumnModification> columnModifications,
             bool sensitiveLoggingEnabled)
         {
             Check.NotNull(name, nameof(name));
+            Check.NotNull(viewName, nameof(viewName));
 
             TableName = name;
+            ViewName = viewName;
             Schema = schema;
             _columnModifications = columnModifications;
             _sensitiveLoggingEnabled = sensitiveLoggingEnabled;
@@ -82,6 +89,11 @@ namespace Microsoft.EntityFrameworkCore.Update
         ///     The name of the table containing the data to be modified.
         /// </summary>
         public virtual string TableName { get; }
+
+        /// <summary>
+        ///     The name of the view containing the data to be modified.
+        /// </summary>
+        public virtual string ViewName { get; }
 
         /// <summary>
         ///     The schema containing the table, or <c>null</c> to use the default schema.

--- a/src/EFCore.Relational/Update/ModificationCommand.cs
+++ b/src/EFCore.Relational/Update/ModificationCommand.cs
@@ -85,6 +85,52 @@ namespace Microsoft.EntityFrameworkCore.Update
             _sensitiveLoggingEnabled = sensitiveLoggingEnabled;
         }
 
+
+        /// <summary>
+        ///     Initializes a new <see cref="ModificationCommand" /> instance.
+        /// </summary>
+        /// <param name="name"> The name of the table containing the data to be modified. </param>
+        /// <param name="schema"> The schema containing the table, or <c>null</c> to use the default schema. </param>
+        /// <param name="generateParameterName"> A delegate to generate parameter names. </param>
+        /// <param name="sensitiveLoggingEnabled"> Indicates whether or not potentially sensitive data (e.g. database values) can be logged. </param>
+        /// <param name="comparer"> A <see cref="IComparer{T}" /> for <see cref="IUpdateEntry" />s. </param>
+        public ModificationCommand(
+            [NotNull] string name,
+            [CanBeNull] string schema,
+            [NotNull] Func<string> generateParameterName,
+            bool sensitiveLoggingEnabled,
+            [CanBeNull] IComparer<IUpdateEntry> comparer)
+            : this(
+                Check.NotEmpty(name, nameof(name)),
+                Check.NotEmpty(name, nameof(name)),
+                schema,
+                null,
+                sensitiveLoggingEnabled,
+                comparer)
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new <see cref="ModificationCommand" /> instance.
+        /// </summary>
+        /// <param name="name"> The name of the table containing the data to be modified. </param>
+        /// <param name="schema"> The schema containing the table, or <c>null</c> to use the default schema. </param>
+        /// <param name="columnModifications"> The list of <see cref="ColumnModification" />s needed to perform the insert, update, or delete. </param>
+        /// <param name="sensitiveLoggingEnabled"> Indicates whether or not potentially sensitive data (e.g. database values) can be logged. </param>
+        public ModificationCommand(
+            [NotNull] string name,
+            [CanBeNull] string schema,
+            [CanBeNull] IReadOnlyList<ColumnModification> columnModifications,
+            bool sensitiveLoggingEnabled)
+            : this(
+                Check.NotEmpty(name, nameof(name)),
+                Check.NotEmpty(name, nameof(name)),
+                schema,
+                null,
+                sensitiveLoggingEnabled)
+        {
+        }
+
         /// <summary>
         ///     The name of the table containing the data to be modified.
         /// </summary>

--- a/src/EFCore.Relational/Update/ModificationCommand.cs
+++ b/src/EFCore.Relational/Update/ModificationCommand.cs
@@ -35,22 +35,25 @@ namespace Microsoft.EntityFrameworkCore.Update
         ///     Initializes a new <see cref="ModificationCommand" /> instance.
         /// </summary>
         /// <param name="name"> The name of the table containing the data to be modified. </param>
-        /// <param name="viewName"> The name of the view containing the data to be modified. </param>
         /// <param name="schema"> The schema containing the table, or <c>null</c> to use the default schema. </param>
+        /// <param name="viewName"> The name of the view containing the data to be modified. </param>
+        /// <param name="viewSchemaName"> The schema containing the view, or <c>null</c> to use the default schema. </param>
         /// <param name="generateParameterName"> A delegate to generate parameter names. </param>
         /// <param name="sensitiveLoggingEnabled"> Indicates whether or not potentially sensitive data (e.g. database values) can be logged. </param>
         /// <param name="comparer"> A <see cref="IComparer{T}" /> for <see cref="IUpdateEntry" />s. </param>
         public ModificationCommand(
             [NotNull] string name,
-            [NotNull] string viewName,
             [CanBeNull] string schema,
+            [NotNull] string viewName,
+            [CanBeNull] string viewSchemaName,
             [NotNull] Func<string> generateParameterName,
             bool sensitiveLoggingEnabled,
             [CanBeNull] IComparer<IUpdateEntry> comparer)
             : this(
                 Check.NotEmpty(name, nameof(name)),
-                Check.NotEmpty(viewName, nameof(viewName)),
                 schema,
+                Check.NotEmpty(viewName, nameof(viewName)),
+                viewSchemaName,
                 null,
                 sensitiveLoggingEnabled)
         {
@@ -64,14 +67,16 @@ namespace Microsoft.EntityFrameworkCore.Update
         ///     Initializes a new <see cref="ModificationCommand" /> instance.
         /// </summary>
         /// <param name="name"> The name of the table containing the data to be modified. </param>
-        /// <param name="viewName"> The name of the view containing the data to be modified. </param>
         /// <param name="schema"> The schema containing the table, or <c>null</c> to use the default schema. </param>
+        /// <param name="viewName"> The name of the view containing the data to be modified. </param>
+        /// <param name="viewSchemaName"> The schema containing the view, or <c>null</c> to use the default schema. </param>
         /// <param name="columnModifications"> The list of <see cref="ColumnModification" />s needed to perform the insert, update, or delete. </param>
         /// <param name="sensitiveLoggingEnabled"> Indicates whether or not potentially sensitive data (e.g. database values) can be logged. </param>
         public ModificationCommand(
             [NotNull] string name,
-            [NotNull] string viewName,
             [CanBeNull] string schema,
+            [NotNull] string viewName,
+            [CanBeNull] string viewSchemaName,
             [CanBeNull] IReadOnlyList<ColumnModification> columnModifications,
             bool sensitiveLoggingEnabled)
         {
@@ -79,8 +84,9 @@ namespace Microsoft.EntityFrameworkCore.Update
             Check.NotNull(viewName, nameof(viewName));
 
             TableName = name;
-            ViewName = viewName;
             Schema = schema;
+            ViewName = viewName;
+            ViewSchemaName = viewSchemaName;
             _columnModifications = columnModifications;
             _sensitiveLoggingEnabled = sensitiveLoggingEnabled;
         }
@@ -102,6 +108,7 @@ namespace Microsoft.EntityFrameworkCore.Update
             [CanBeNull] IComparer<IUpdateEntry> comparer)
             : this(
                 Check.NotEmpty(name, nameof(name)),
+                schema,
                 Check.NotEmpty(name, nameof(name)),
                 schema,
                 null,
@@ -124,6 +131,7 @@ namespace Microsoft.EntityFrameworkCore.Update
             bool sensitiveLoggingEnabled)
             : this(
                 Check.NotEmpty(name, nameof(name)),
+                schema,
                 Check.NotEmpty(name, nameof(name)),
                 schema,
                 null,
@@ -137,14 +145,19 @@ namespace Microsoft.EntityFrameworkCore.Update
         public virtual string TableName { get; }
 
         /// <summary>
+        ///     The schema containing the table, or <c>null</c> to use the default schema.
+        /// </summary>
+        public virtual string Schema { get; }
+
+        /// <summary>
         ///     The name of the view containing the data to be modified.
         /// </summary>
         public virtual string ViewName { get; }
 
         /// <summary>
-        ///     The schema containing the table, or <c>null</c> to use the default schema.
+        ///     The schema containing the view, or <c>null</c> to use the default schema.
         /// </summary>
-        public virtual string Schema { get; }
+        public virtual string ViewSchemaName { get; }
 
         /// <summary>
         ///     The <see cref="IUpdateEntry" />s that represent the entities that are mapped to the row

--- a/src/EFCore.Relational/Update/ModificationCommand.cs
+++ b/src/EFCore.Relational/Update/ModificationCommand.cs
@@ -91,7 +91,6 @@ namespace Microsoft.EntityFrameworkCore.Update
             _sensitiveLoggingEnabled = sensitiveLoggingEnabled;
         }
 
-
         /// <summary>
         ///     Initializes a new <see cref="ModificationCommand" /> instance.
         /// </summary>

--- a/src/EFCore.Relational/Update/ModificationCommand.cs
+++ b/src/EFCore.Relational/Update/ModificationCommand.cs
@@ -110,7 +110,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                 schema,
                 Check.NotEmpty(name, nameof(name)),
                 schema,
-                null,
+                generateParameterName,
                 sensitiveLoggingEnabled,
                 comparer)
         {

--- a/src/EFCore.Relational/Update/UpdateSqlGenerator.cs
+++ b/src/EFCore.Relational/Update/UpdateSqlGenerator.cs
@@ -63,6 +63,7 @@ namespace Microsoft.EntityFrameworkCore.Update
             Check.NotNull(command, nameof(command));
 
             var name = command.TableName;
+            var viewName = command.ViewName;
             var schema = command.Schema;
             var operations = command.ColumnModifications;
 
@@ -75,7 +76,7 @@ namespace Microsoft.EntityFrameworkCore.Update
             {
                 var keyOperations = operations.Where(o => o.IsKey).ToList();
 
-                return AppendSelectAffectedCommand(commandStringBuilder, name, schema, readOperations, keyOperations, commandPosition);
+                return AppendSelectAffectedCommand(commandStringBuilder, viewName, schema, readOperations, keyOperations, commandPosition);
             }
 
             return ResultSetMapping.NoResultSet;
@@ -94,6 +95,7 @@ namespace Microsoft.EntityFrameworkCore.Update
             Check.NotNull(command, nameof(command));
 
             var name = command.TableName;
+            var viewName = command.ViewName;
             var schema = command.Schema;
             var operations = command.ColumnModifications;
 
@@ -107,10 +109,10 @@ namespace Microsoft.EntityFrameworkCore.Update
             {
                 var keyOperations = operations.Where(o => o.IsKey).ToList();
 
-                return AppendSelectAffectedCommand(commandStringBuilder, name, schema, readOperations, keyOperations, commandPosition);
+                return AppendSelectAffectedCommand(commandStringBuilder, viewName, schema, readOperations, keyOperations, commandPosition);
             }
 
-            return AppendSelectAffectedCountCommand(commandStringBuilder, name, schema, commandPosition);
+            return AppendSelectAffectedCountCommand(commandStringBuilder, viewName, schema, commandPosition);
         }
 
         /// <summary>
@@ -126,12 +128,13 @@ namespace Microsoft.EntityFrameworkCore.Update
             Check.NotNull(command, nameof(command));
 
             var name = command.TableName;
+            var viewName = command.ViewName;
             var schema = command.Schema;
             var conditionOperations = command.ColumnModifications.Where(o => o.IsCondition).ToList();
 
             AppendDeleteCommand(commandStringBuilder, name, schema, conditionOperations);
 
-            return AppendSelectAffectedCountCommand(commandStringBuilder, name, schema, commandPosition);
+            return AppendSelectAffectedCountCommand(commandStringBuilder, viewName, schema, commandPosition);
         }
 
         /// <summary>

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
@@ -71,7 +71,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 RelationalAnnotationNames.Filter,
                 RelationalAnnotationNames.DbFunction,
                 RelationalAnnotationNames.MaxIdentifierLength,
-                RelationalAnnotationNames.IsFixedLength
+                RelationalAnnotationNames.IsFixedLength,
+                RelationalAnnotationNames.ViewSchemaName,
+                RelationalAnnotationNames.ViewName,
             };
 
             // Add a line here if the code generator is supposed to handle this annotation
@@ -134,7 +136,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 RelationalAnnotationNames.DiscriminatorValue,
                 RelationalAnnotationNames.Filter,
                 RelationalAnnotationNames.DbFunction,
-                RelationalAnnotationNames.MaxIdentifierLength
+                RelationalAnnotationNames.MaxIdentifierLength,
+                RelationalAnnotationNames.ViewSchemaName,
+                RelationalAnnotationNames.ViewName,
             };
 
             // Add a line here if the code generator is supposed to handle this annotation


### PR DESCRIPTION
Supports separation of query and update mapping on views by allowing the consumer to specify the name of a view different to the name of the table. The table will be used to perform insert, update and delete statements to. The view will be used to perform select statements to. If no view is specified the tablename is taken to perform select statements.

https://github.com/aspnet/EntityFrameworkCore/issues/15671