### PR TITLE
Use Microsoft.NET.Compilers 

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,11 +1,12 @@
 <Project>
-  <PropertyGroup>
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-  </PropertyGroup>
-  <PropertyGroup>
+  <PropertyGroup Label="Version settings">
     <VersionPrefix>3.0.0</VersionPrefix>
     <PreReleaseVersionLabel>preview6</PreReleaseVersionLabel>
     <IncludeSourceRevisionInInformationalVersion>False</IncludeSourceRevisionInInformationalVersion>
+  </PropertyGroup>
+  <PropertyGroup Label="Arcade settings">
+    <!-- Opt-in to using the version of the Roslyn compiler bundled with Arcade. -->
+    <UsingToolMicrosoftNetCompilers>true</UsingToolMicrosoftNetCompilers>
     <UsingToolNetFrameworkReferenceAssemblies>True</UsingToolNetFrameworkReferenceAssemblies>
     <UsingToolXliff>False</UsingToolXliff>
   </PropertyGroup>


### PR DESCRIPTION
This upgrades the compiler to the version bundled in Arcade, which is 3.2.0-beta1-19253-08 right now. This allows this repo to consume a compiler that is newer than what is bundled in the .NET Core SDK. This is valuable during previews to get the latest C# 8 features and test them against EF's expression tree -> SQL code. 

This should workaround aspnet/AspNetCore-Internal#2476.