### PR TITLE
Basic FromSql() support in new pipeline

### DIFF
--- a/src/EFCore.Relational/Query/Pipeline/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Pipeline/QuerySqlGenerator.cs
@@ -216,6 +216,22 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
             return tableExpression;
         }
 
+        protected override Expression VisitFromSql(FromSqlExpression fromSqlExpression)
+        {
+            _relationalCommandBuilder.AppendLine("(");
+
+            using (_relationalCommandBuilder.Indent())
+            {
+                _relationalCommandBuilder.AppendLines(fromSqlExpression.Sql);
+                // TODO: Generate parameters
+            }
+
+            _relationalCommandBuilder.Append(") AS ")
+                .Append(_sqlGenerationHelper.DelimitIdentifier(fromSqlExpression.Alias));
+
+            return fromSqlExpression;
+        }
+
         protected override Expression VisitSqlBinary(SqlBinaryExpression sqlBinaryExpression)
         {
             if (sqlBinaryExpression.OperatorType == ExpressionType.Coalesce)

--- a/src/EFCore.Relational/Query/Pipeline/RelationalEntityQueryableExpressionVisitor2.cs
+++ b/src/EFCore.Relational/Query/Pipeline/RelationalEntityQueryableExpressionVisitor2.cs
@@ -2,23 +2,42 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query.Pipeline;
+using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 {
     public class RelationalEntityQueryableExpressionVisitor2 : EntityQueryableExpressionVisitor2
     {
-        private IModel _model;
+        private readonly IModel _model;
 
         public RelationalEntityQueryableExpressionVisitor2(IModel model)
         {
             _model = model;
         }
 
-        protected override ShapedQueryExpression CreateShapedQueryExpression(Type elementType)
+        protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
         {
-            return new RelationalShapedQueryExpression(_model.FindEntityType(elementType));
+            if (methodCallExpression.Method.DeclaringType == typeof(RelationalQueryableExtensions)
+                && methodCallExpression.Method.Name == nameof(RelationalQueryableExtensions.FromSqlOnQueryable))
+            {
+                // TODO: Implement parameters
+                var sql = (string)((ConstantExpression)methodCallExpression.Arguments[1]).Value;
+                var queryable = (IQueryable)((ConstantExpression)methodCallExpression.Arguments[0]).Value;
+                return CreateShapedQueryExpression(queryable.ElementType, sql);
+            }
+
+            return base.VisitMethodCall(methodCallExpression);
         }
+
+        protected override ShapedQueryExpression CreateShapedQueryExpression(Type elementType)
+            => new RelationalShapedQueryExpression(_model.FindEntityType(elementType));
+
+        protected virtual ShapedQueryExpression CreateShapedQueryExpression(Type elementType, string sql)
+            => new RelationalShapedQueryExpression(_model.FindEntityType(elementType), sql);
     }
 }

--- a/src/EFCore.Relational/Query/Pipeline/RelationalShapedQueryExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/RelationalShapedQueryExpression.cs
@@ -21,5 +21,17 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                     typeof(ValueBuffer)),
                 false);
         }
+
+        public RelationalShapedQueryExpression(IEntityType entityType, string sql)
+        {
+            QueryExpression = new SelectExpression(entityType, sql);
+            ShaperExpression = new EntityShaperExpression(
+                entityType,
+                new ProjectionBindingExpression(
+                    QueryExpression,
+                    new ProjectionMember(),
+                    typeof(ValueBuffer)),
+                false);
+        }
     }
 }

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressionVisitor.cs
@@ -24,6 +24,9 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                 case ExistsExpression existsExpression:
                     return VisitExists(existsExpression);
 
+                case FromSqlExpression fromSqlExpression:
+                    return VisitFromSql(fromSqlExpression);
+
                 case InExpression inExpression:
                     return VisitIn(inExpression);
 
@@ -76,6 +79,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
         protected abstract Expression VisitExists(ExistsExpression existsExpression);
         protected abstract Expression VisitIn(InExpression inExpression);
         protected abstract Expression VisitCrossJoin(CrossJoinExpression crossJoinExpression);
+        protected abstract Expression VisitFromSql(FromSqlExpression fromSqlExpression);
         protected abstract Expression VisitInnerJoin(InnerJoinExpression innerJoinExpression);
         protected abstract Expression VisitLeftJoin(LeftJoinExpression leftJoinExpression);
         protected abstract Expression VisitProjection(ProjectionExpression projectionExpression);

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/FromSqlExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/FromSqlExpression.cs
@@ -1,0 +1,69 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
+{
+    public class FromSqlExpression : TableExpressionBase
+    {
+        #region Fields & Constructors
+        public FromSqlExpression(
+            [NotNull] string sql,
+            [NotNull] string alias)
+            : base(alias)
+        {
+            Sql = sql;
+        }
+        #endregion
+
+        #region Public Properties
+
+        /// <summary>
+        ///     Gets the SQL.
+        /// </summary>
+        /// <value>
+        ///     The SQL.
+        /// </value>
+        public string Sql { get; }
+
+        #endregion
+
+        #region Expression-based methods
+
+        protected override Expression VisitChildren(ExpressionVisitor visitor)
+            => this;
+
+        public override void Print(ExpressionPrinter expressionPrinter)
+            => expressionPrinter.StringBuilder.Append(Sql);
+
+        #endregion
+
+        #region Equality & HashCode
+
+        public override bool Equals(object obj)
+            => obj != null
+               && (ReferenceEquals(this, obj)
+                   || obj is FromSqlExpression fromSqlExpression
+                   && Equals(fromSqlExpression));
+
+        private bool Equals(FromSqlExpression fromSqlExpression)
+            => base.Equals(fromSqlExpression)
+               && string.Equals(Sql, fromSqlExpression.Sql);
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = base.GetHashCode();
+                hashCode = (hashCode * 397) ^ Sql.GetHashCode();
+
+                return hashCode;
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SelectExpression.cs
@@ -56,6 +56,18 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             _projectionMapping[new ProjectionMember()] = new EntityProjectionExpression(entityType, tableExpression, false);
         }
 
+        public SelectExpression(IEntityType entityType, string sql)
+            : base("")
+        {
+            var fromSqlExpression = new FromSqlExpression(
+                sql,
+                entityType.GetTableName().ToLower().Substring(0, 1));
+
+            _tables.Add(fromSqlExpression);
+
+            _projectionMapping[new ProjectionMember()] = new EntityProjectionExpression(entityType, fromSqlExpression, false);
+        }
+
         public SqlExpression BindProperty(Expression projectionExpression, IProperty property)
         {
             var member = (projectionExpression as ProjectionBindingExpression).ProjectionMember;

--- a/src/EFCore.Relational/Query/ResultOperators/Internal/FromSqlExpressionNode.cs
+++ b/src/EFCore.Relational/Query/ResultOperators/Internal/FromSqlExpressionNode.cs
@@ -24,7 +24,10 @@ namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static readonly IReadOnlyCollection<MethodInfo> SupportedMethods = new[] { RelationalQueryableExtensions.FromSqlMethodInfo };
+        public static readonly IReadOnlyCollection<MethodInfo> SupportedMethods = new List<MethodInfo>
+        {
+            // RelationalQueryableExtensions.FromSqlMethodInfo
+        };
 
         private readonly string _sql;
         private readonly Expression _arguments;

--- a/src/EFCore.SqlServer/Query/Pipeline/SearchConditionConvertingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Pipeline/SearchConditionConvertingExpressionVisitor.cs
@@ -91,6 +91,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Pipeline
             return ApplyConversion(existsExpression.Update(subquery), condition: true);
         }
 
+        protected override Expression VisitFromSql(FromSqlExpression fromSqlExpression)
+            => fromSqlExpression;
+
         protected override Expression VisitIn(InExpression inExpression)
         {
             var parentSearchCondition = _isSearchCondition;

--- a/test/EFCore.Relational.Specification.Tests/Query/AsyncFromSqlQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/AsyncFromSqlQueryTestBase.cs
@@ -81,7 +81,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact]
+        [Fact(Skip = "#15763")]
         public virtual async Task FromSqlRaw_queryable_multiple_composed()
         {
             using (var context = CreateContext())
@@ -101,7 +101,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact]
+        [Fact(Skip = "#15750")]
         public virtual async Task FromSqlRaw_queryable_multiple_composed_with_closure_parameters()
         {
             var startDate = new DateTime(1997, 1, 1);
@@ -125,7 +125,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact]
+        [Fact(Skip = "#15750")]
         public virtual async Task FromSqlRaw_queryable_multiple_composed_with_parameters_and_closure_parameters()
         {
             var city = "London";
@@ -185,7 +185,7 @@ FROM [Customers]"))
             }
         }
 
-        [Fact]
+        [Fact(Skip = "#15750")]
         public virtual async Task FromSqlRaw_queryable_with_parameters()
         {
             var city = "London";
@@ -203,7 +203,7 @@ FROM [Customers]"))
             }
         }
 
-        [Fact]
+        [Fact(Skip = "#15750")]
         public virtual async Task FromSqlRaw_queryable_with_parameters_and_closure()
         {
             var city = "London";
@@ -241,7 +241,7 @@ FROM [Customers]"))
             }
         }
 
-        [Fact]
+        [Fact(Skip = "#15750")]
         public virtual async Task FromSqlRaw_queryable_with_parameters_cache_key_includes_parameters()
         {
             var city = "London";
@@ -410,345 +410,6 @@ FROM [Customers]"))
                 Assert.Equal(ConnectionState.Closed, connection.State);
             }
         }
-
-#pragma warning disable CS0618 // Type or member is obsolete
-        [Fact]
-        public virtual async Task From_sql_queryable_simple()
-        {
-            using (var context = CreateContext())
-            {
-                var actual = await context.Set<Customer>()
-                    .FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [ContactName] LIKE '%z%'"))
-                    .ToArrayAsync();
-
-                Assert.Equal(14, actual.Length);
-                Assert.Equal(14, context.ChangeTracker.Entries().Count());
-            }
-        }
-
-        [Fact]
-        public virtual async Task From_sql_queryable_simple_columns_out_of_order()
-        {
-            using (var context = CreateContext())
-            {
-                var actual = await context.Set<Customer>().FromSql(
-                        NormalizeDelimetersInRawString(
-                            "SELECT [Region], [PostalCode], [Phone], [Fax], [CustomerID], [Country], [ContactTitle], [ContactName], [CompanyName], [City], [Address] FROM [Customers]"))
-                    .ToArrayAsync();
-
-                Assert.Equal(91, actual.Length);
-                Assert.Equal(91, context.ChangeTracker.Entries().Count());
-            }
-        }
-
-        [Fact]
-        public virtual async Task From_sql_queryable_simple_columns_out_of_order_and_extra_columns()
-        {
-            using (var context = CreateContext())
-            {
-                var actual = await context.Set<Customer>().FromSql(
-                        NormalizeDelimetersInRawString(
-                            "SELECT [Region], [PostalCode], [PostalCode] AS [Foo], [Phone], [Fax], [CustomerID], [Country], [ContactTitle], [ContactName], [CompanyName], [City], [Address] FROM [Customers]"))
-                    .ToArrayAsync();
-
-                Assert.Equal(91, actual.Length);
-                Assert.Equal(91, context.ChangeTracker.Entries().Count());
-            }
-        }
-
-        [Fact]
-        public virtual async Task From_sql_queryable_composed()
-        {
-            using (var context = CreateContext())
-            {
-                var actual = await context.Set<Customer>().FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Customers]"))
-                    .Where(c => c.ContactName.Contains("z"))
-                    .ToArrayAsync();
-
-                Assert.Equal(14, actual.Length);
-            }
-        }
-
-        [Fact]
-        public virtual async Task From_sql_queryable_multiple_composed()
-        {
-            using (var context = CreateContext())
-            {
-                var actual
-                    = await (from c in context.Set<Customer>().FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Customers]"))
-                             from o in context.Set<Order>().FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Orders]"))
-                             where c.CustomerID == o.CustomerID
-                             select new
-                             {
-                                 c,
-                                 o
-                             })
-                        .ToArrayAsync();
-
-                Assert.Equal(830, actual.Length);
-            }
-        }
-
-        [Fact]
-        public virtual async Task From_sql_queryable_multiple_composed_with_closure_parameters()
-        {
-            var startDate = new DateTime(1997, 1, 1);
-            var endDate = new DateTime(1998, 1, 1);
-
-            using (var context = CreateContext())
-            {
-                var actual
-                    = await (from c in context.Set<Customer>().FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Customers]"))
-                             from o in context.Set<Order>().FromSql(
-                                 NormalizeDelimetersInRawString("SELECT * FROM [Orders] WHERE [OrderDate] BETWEEN {0} AND {1}"), startDate, endDate)
-                             where c.CustomerID == o.CustomerID
-                             select new
-                             {
-                                 c,
-                                 o
-                             })
-                        .ToArrayAsync();
-
-                Assert.Equal(411, actual.Length);
-            }
-        }
-
-        [Fact]
-        public virtual async Task From_sql_queryable_multiple_composed_with_parameters_and_closure_parameters()
-        {
-            var city = "London";
-            var startDate = new DateTime(1997, 1, 1);
-            var endDate = new DateTime(1998, 1, 1);
-
-            using (var context = CreateContext())
-            {
-                var actual
-                    = await (from c in context.Set<Customer>().FromSql(
-                                 NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [City] = {0}"), city)
-                             from o in context.Set<Order>().FromSql(
-                                 NormalizeDelimetersInRawString("SELECT * FROM [Orders] WHERE [OrderDate] BETWEEN {0} AND {1}"), startDate, endDate)
-                             where c.CustomerID == o.CustomerID
-                             select new
-                             {
-                                 c,
-                                 o
-                             })
-                        .ToArrayAsync();
-
-                Assert.Equal(25, actual.Length);
-            }
-        }
-
-        [Fact]
-        public virtual async Task From_sql_queryable_multiple_line_query()
-        {
-            using (var context = CreateContext())
-            {
-                var actual = await context.Set<Customer>().FromSql(
-                        NormalizeDelimetersInRawString(
-                            @"SELECT *
-FROM [Customers]
-WHERE [City] = 'London'"))
-                    .ToArrayAsync();
-
-                Assert.Equal(6, actual.Length);
-                Assert.True(actual.All(c => c.City == "London"));
-            }
-        }
-
-        [Fact]
-        public virtual async Task From_sql_queryable_composed_multiple_line_query()
-        {
-            using (var context = CreateContext())
-            {
-                var actual = await context.Set<Customer>().FromSql(
-                        NormalizeDelimetersInRawString(
-                            @"SELECT *
-FROM [Customers]"))
-                    .Where(c => c.City == "London")
-                    .ToArrayAsync();
-
-                Assert.Equal(6, actual.Length);
-                Assert.True(actual.All(c => c.City == "London"));
-            }
-        }
-
-        [Fact]
-        public virtual async Task From_sql_queryable_with_parameters()
-        {
-            var city = "London";
-            var contactTitle = "Sales Representative";
-
-            using (var context = CreateContext())
-            {
-                var actual = await context.Set<Customer>().FromSql(
-                        NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [City] = {0} AND [ContactTitle] = {1}"), city, contactTitle)
-                    .ToArrayAsync();
-
-                Assert.Equal(3, actual.Length);
-                Assert.True(actual.All(c => c.City == "London"));
-                Assert.True(actual.All(c => c.ContactTitle == "Sales Representative"));
-            }
-        }
-
-        [Fact]
-        public virtual async Task From_sql_queryable_with_parameters_and_closure()
-        {
-            var city = "London";
-            var contactTitle = "Sales Representative";
-
-            using (var context = CreateContext())
-            {
-                var actual = await context.Set<Customer>().FromSql(
-                        NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [City] = {0}"), city)
-                    .Where(c => c.ContactTitle == contactTitle)
-                    .ToArrayAsync();
-
-                Assert.Equal(3, actual.Length);
-                Assert.True(actual.All(c => c.City == "London"));
-                Assert.True(actual.All(c => c.ContactTitle == "Sales Representative"));
-            }
-        }
-
-        [Fact]
-        public virtual async Task From_sql_queryable_simple_cache_key_includes_query_string()
-        {
-            using (var context = CreateContext())
-            {
-                var actual = await context.Set<Customer>().FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [City] = 'London'"))
-                    .ToArrayAsync();
-
-                Assert.Equal(6, actual.Length);
-                Assert.True(actual.All(c => c.City == "London"));
-
-                actual = await context.Set<Customer>().FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [City] = 'Seattle'"))
-                    .ToArrayAsync();
-
-                Assert.Equal(1, actual.Length);
-                Assert.True(actual.All(c => c.City == "Seattle"));
-            }
-        }
-
-        [Fact]
-        public virtual async Task From_sql_queryable_with_parameters_cache_key_includes_parameters()
-        {
-            var city = "London";
-            var contactTitle = "Sales Representative";
-            var sql = "SELECT * FROM [Customers] WHERE [City] = {0} AND [ContactTitle] = {1}";
-
-            using (var context = CreateContext())
-            {
-                var actual = await context.Set<Customer>().FromSql(NormalizeDelimetersInRawString(sql), city, contactTitle)
-                    .ToArrayAsync();
-
-                Assert.Equal(3, actual.Length);
-                Assert.True(actual.All(c => c.City == "London"));
-                Assert.True(actual.All(c => c.ContactTitle == "Sales Representative"));
-
-                city = "Madrid";
-                contactTitle = "Accounting Manager";
-
-                actual = await context.Set<Customer>().FromSql(NormalizeDelimetersInRawString(sql), city, contactTitle)
-                    .ToArrayAsync();
-
-                Assert.Equal(2, actual.Length);
-                Assert.True(actual.All(c => c.City == "Madrid"));
-                Assert.True(actual.All(c => c.ContactTitle == "Accounting Manager"));
-            }
-        }
-
-        [Fact]
-        public virtual async Task From_sql_queryable_simple_as_no_tracking_not_composed()
-        {
-            using (var context = CreateContext())
-            {
-                var actual = await context.Set<Customer>().FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Customers]"))
-                    .AsNoTracking()
-                    .ToArrayAsync();
-
-                Assert.Equal(91, actual.Length);
-                Assert.Equal(0, context.ChangeTracker.Entries().Count());
-            }
-        }
-
-        [Fact]
-        public virtual async Task From_sql_queryable_simple_projection_not_composed()
-        {
-            using (var context = CreateContext())
-            {
-                var actual = await context.Set<Customer>().FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Customers]"))
-                    .Select(
-                        c => new
-                        {
-                            c.CustomerID,
-                            c.City
-                        })
-                    .AsNoTracking()
-                    .ToArrayAsync();
-
-                Assert.Equal(91, actual.Length);
-                Assert.Equal(0, context.ChangeTracker.Entries().Count());
-            }
-        }
-
-        [Fact(Skip = "issue #15611")]
-        public virtual async Task From_sql_queryable_simple_include()
-        {
-            using (var context = CreateContext())
-            {
-                var actual = await context.Set<Customer>().FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Customers]"))
-                    .Include(c => c.Orders)
-                    .ToArrayAsync();
-
-                Assert.Equal(830, actual.SelectMany(c => c.Orders).Count());
-            }
-        }
-
-        [Fact(Skip = "issue #15611")]
-        public virtual async Task From_sql_queryable_simple_composed_include()
-        {
-            using (var context = CreateContext())
-            {
-                var actual = await context.Set<Customer>().FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Customers]"))
-                    .Where(c => c.City == "London")
-                    .Include(c => c.Orders)
-                    .ToArrayAsync();
-
-                Assert.Equal(46, actual.SelectMany(c => c.Orders).Count());
-            }
-        }
-
-        [Fact]
-        public virtual async Task From_sql_annotations_do_not_affect_successive_calls()
-        {
-            using (var context = CreateContext())
-            {
-                var actual = await context.Customers
-                    .FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [ContactName] LIKE '%z%'"))
-                    .ToArrayAsync();
-
-                Assert.Equal(14, actual.Length);
-
-                actual = await context.Customers
-                    .ToArrayAsync();
-
-                Assert.Equal(91, actual.Length);
-            }
-        }
-
-        [Fact]
-        public virtual async Task From_sql_composed_with_nullable_predicate()
-        {
-            using (var context = CreateContext())
-            {
-                var actual = await context.Set<Customer>().FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Customers]"))
-                    .Where(c => c.ContactName == c.CompanyName)
-                    .ToArrayAsync();
-
-                Assert.Equal(0, actual.Length);
-            }
-        }
-#pragma warning restore CS0618 // Type or member is obsolete
 
         private string NormalizeDelimetersInRawString(string sql)
             => Fixture.TestStore.NormalizeDelimetersInRawString(sql);

--- a/test/EFCore.Relational.Specification.Tests/Query/FromSqlQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/FromSqlQueryTestBase.cs
@@ -33,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         protected TFixture Fixture { get; }
 
-        [Fact]
+        [Fact(Skip = "#15751")]
         public virtual void Bad_data_error_handling_invalid_cast_key()
         {
             using (var context = CreateContext())
@@ -50,7 +50,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact]
+        [Fact(Skip = "#15751")]
         public virtual void Bad_data_error_handling_invalid_cast()
         {
             using (var context = CreateContext())
@@ -67,7 +67,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact]
+        [Fact(Skip = "#15751")]
         public virtual void Bad_data_error_handling_invalid_cast_projection()
         {
             using (var context = CreateContext())
@@ -85,7 +85,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact]
+        [Fact(Skip = "#15751")]
         public virtual void Bad_data_error_handling_invalid_cast_no_tracking()
         {
             using (var context = CreateContext())
@@ -95,19 +95,24 @@ namespace Microsoft.EntityFrameworkCore.Query
                     Assert.Throws<InvalidOperationException>(
                         () =>
                             context.Set<Product>()
-                                .AsNoTracking().FromSqlRaw(
+                                .FromSqlRaw(
                                     NormalizeDelimetersInRawString(
                                         @"SELECT [ProductID] AS [ProductName], [ProductName] AS [ProductID], [SupplierID], [UnitPrice], [UnitsInStock], [Discontinued]
-                               FROM [Products]"))
+                               FROM [Products]")).AsNoTracking()
                                 .ToList()).Message);
             }
         }
 
-        [Fact]
+        [Fact(Skip = "#15751")]
         public virtual void Bad_data_error_handling_null()
         {
             using (var context = CreateContext())
             {
+                context.Set<Product>().FromSqlRaw(
+                        NormalizeDelimetersInRawString(
+                            @"SELECT [ProductID], [ProductName], [SupplierID], [UnitPrice], [UnitsInStock], NULL AS [Discontinued]
+                               FROM [Products]"))
+                    .ToList();
                 Assert.Equal(
                     CoreStrings.ErrorMaterializingPropertyNullReference("Product", "Discontinued", typeof(bool)),
                     Assert.Throws<InvalidOperationException>(
@@ -120,7 +125,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact]
+        [Fact(Skip = "#15751")]
         public virtual void Bad_data_error_handling_null_projection()
         {
             using (var context = CreateContext())
@@ -138,7 +143,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact]
+        [Fact(Skip = "#15751")]
         public virtual void Bad_data_error_handling_null_no_tracking()
         {
             using (var context = CreateContext())
@@ -148,10 +153,10 @@ namespace Microsoft.EntityFrameworkCore.Query
                     Assert.Throws<InvalidOperationException>(
                         () =>
                             context.Set<Product>()
-                                .AsNoTracking().FromSqlRaw(
+                                .FromSqlRaw(
                                     NormalizeDelimetersInRawString(
                                         @"SELECT [ProductID], [ProductName], [SupplierID], [UnitPrice], [UnitsInStock], NULL AS [Discontinued]
-                               FROM [Products]"))
+                               FROM [Products]")).AsNoTracking()
                                 .ToList()).Message);
             }
         }
@@ -200,7 +205,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact]
+        [Fact(Skip = "#15751")]
         public virtual void FromSqlRaw_queryable_simple_columns_out_of_order_and_not_enough_columns_throws()
         {
             using (var context = CreateContext())
@@ -249,7 +254,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Compiled queries not yet supported, #14551")]
         public virtual void FromSqlRaw_queryable_composed_compiled()
         {
             var query = EF.CompileQuery(
@@ -300,7 +305,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact]
+        [Fact(Skip = "#15763")]
         public virtual void FromSqlRaw_queryable_multiple_composed()
         {
             using (var context = CreateContext())
@@ -320,7 +325,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact]
+        [Fact(Skip = "#15750")]
         public virtual void FromSqlRaw_queryable_multiple_composed_with_closure_parameters()
         {
             var startDate = new DateTime(1997, 1, 1);
@@ -346,7 +351,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact]
+        [Fact(Skip = "#15750")]
         public virtual void FromSqlRaw_queryable_multiple_composed_with_parameters_and_closure_parameters()
         {
             var city = "London";
@@ -429,7 +434,7 @@ FROM [Customers]"))
             }
         }
 
-        [Fact]
+        [Fact(Skip = "#15750")]
         public virtual void FromSqlRaw_queryable_with_parameters()
         {
             var city = "London";
@@ -447,7 +452,7 @@ FROM [Customers]"))
             }
         }
 
-        [Fact]
+        [Fact(Skip = "#15750")]
         public virtual void FromSqlRaw_queryable_with_parameters_inline()
         {
             using (var context = CreateContext())
@@ -463,7 +468,7 @@ FROM [Customers]"))
             }
         }
 
-        [Fact]
+        [Fact(Skip = "#15750")]
         public virtual void FromSqlInterpolated_queryable_with_parameters_interpolated()
         {
             var city = "London";
@@ -482,7 +487,7 @@ FROM [Customers]"))
             }
         }
 
-        [Fact]
+        [Fact(Skip = "#15750")]
         public virtual void FromSqlInterpolated_queryable_with_parameters_inline_interpolated()
         {
             using (var context = CreateContext())
@@ -498,7 +503,7 @@ FROM [Customers]"))
             }
         }
 
-        [Fact]
+        [Fact(Skip = "#15750")]
         public virtual void FromSqlInterpolated_queryable_multiple_composed_with_parameters_and_closure_parameters_interpolated()
         {
             var city = "London";
@@ -541,7 +546,7 @@ FROM [Customers]"))
             }
         }
 
-        [Fact]
+        [Fact(Skip = "#15750")]
         public virtual void FromSqlRaw_queryable_with_null_parameter()
         {
             uint? reportsTo = null;
@@ -558,7 +563,7 @@ FROM [Customers]"))
             }
         }
 
-        [Fact]
+        [Fact(Skip = "#15750")]
         public virtual void FromSqlRaw_queryable_with_parameters_and_closure()
         {
             var city = "London";
@@ -595,7 +600,7 @@ FROM [Customers]"))
             }
         }
 
-        [Fact]
+        [Fact(Skip = "#15750")]
         public virtual void FromSqlRaw_queryable_with_parameters_cache_key_includes_parameters()
         {
             var city = "London";
@@ -713,7 +718,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
             }
         }
 
-        [Fact]
+        [Fact(Skip = "#15750")]
         public virtual void FromSqlRaw_with_dbParameter()
         {
             using (var context = CreateContext())
@@ -728,7 +733,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
             }
         }
 
-        [Fact]
+        [Fact(Skip = "#15750")]
         public virtual void FromSqlRaw_with_dbParameter_mixed()
         {
             using (var context = CreateContext())
@@ -760,7 +765,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Uses Include()")]
         public virtual void Include_does_not_close_user_opened_connection_for_empty_result()
         {
             Fixture.TestStore.CloseConnection();
@@ -790,7 +795,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
             Fixture.TestStore.OpenConnection();
         }
 
-        [Fact]
+        [Fact(Skip = "#15750")]
         public virtual void FromSqlRaw_with_db_parameters_called_multiple_times()
         {
             using (var context = CreateContext())
@@ -872,7 +877,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Uses Include()")]
         public virtual void Include_closed_connection_opened_by_it_when_buffering()
         {
             Fixture.TestStore.CloseConnection();
@@ -892,7 +897,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
             }
         }
 
-        [Fact]
+        [Fact(Skip = "#15750")]
         public virtual void FromSqlInterpolated_with_inlined_db_parameter()
         {
             using (var context = CreateContext())
@@ -905,7 +910,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
             }
         }
 
-        [Fact]
+        [Fact(Skip = "#15750")]
         public virtual void FromSqlInterpolated_parameterization_issue_12213()
         {
             using (var context = CreateContext())
@@ -935,7 +940,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
             }
         }
 
-        [Fact]
+        [Fact(Skip = "#15750")]
         public virtual void FromSqlRaw_does_not_parameterize_interpolated_string()
         {
             using (var context = CreateContext())
@@ -950,741 +955,10 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
             }
         }
 
-#pragma warning disable CS0618 // Type or member is obsolete
-        [Fact]
-        public virtual void From_sql_queryable_simple()
-        {
-            using (var context = CreateContext())
-            {
-                var actual = context.Set<Customer>()
-                    .FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [ContactName] LIKE '%z%'"))
-                    .ToArray();
-
-                Assert.Equal(14, actual.Length);
-                Assert.Equal(14, context.ChangeTracker.Entries().Count());
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_queryable_simple_columns_out_of_order()
-        {
-            using (var context = CreateContext())
-            {
-                var actual = context.Set<Customer>().FromSql(
-                        NormalizeDelimetersInRawString(
-                            "SELECT [Region], [PostalCode], [Phone], [Fax], [CustomerID], [Country], [ContactTitle], [ContactName], [CompanyName], [City], [Address] FROM [Customers]"))
-                    .ToArray();
-
-                Assert.Equal(91, actual.Length);
-                Assert.Equal(91, context.ChangeTracker.Entries().Count());
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_queryable_simple_columns_out_of_order_and_extra_columns()
-        {
-            using (var context = CreateContext())
-            {
-                var actual = context.Set<Customer>().FromSql(
-                        NormalizeDelimetersInRawString(
-                            "SELECT [Region], [PostalCode], [PostalCode] AS [Foo], [Phone], [Fax], [CustomerID], [Country], [ContactTitle], [ContactName], [CompanyName], [City], [Address] FROM [Customers]"))
-                    .ToArray();
-
-                Assert.Equal(91, actual.Length);
-                Assert.Equal(91, context.ChangeTracker.Entries().Count());
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_queryable_simple_columns_out_of_order_and_not_enough_columns_throws()
-        {
-            using (var context = CreateContext())
-            {
-                Assert.Equal(
-                    RelationalStrings.FromSqlMissingColumn("Region"),
-                    Assert.Throws<InvalidOperationException>(
-                        () => context.Set<Customer>().FromSql(
-                                NormalizeDelimetersInRawString(
-                                    "SELECT [PostalCode], [Phone], [Fax], [CustomerID], [Country], [ContactTitle], [ContactName], [CompanyName], [City], [Address] FROM [Customers]"))
-                            .ToArray()
-                    ).Message);
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_queryable_composed()
-        {
-            using (var context = CreateContext())
-            {
-                var actual = context.Set<Customer>().FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Customers]"))
-                    .Where(c => c.ContactName.Contains("z"))
-                    .ToArray();
-
-                Assert.Equal(14, actual.Length);
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_queryable_composed_after_removing_whitespaces()
-        {
-            using (var context = CreateContext())
-            {
-                var actual = context.Set<Customer>().FromSql(
-                        NormalizeDelimetersInRawString(
-                            _eol +
-                            "    " + _eol +
-                            _eol +
-                            _eol +
-                            "SELECT" + _eol +
-                            "* FROM [Customers]"))
-                    .Where(c => c.ContactName.Contains("z"))
-                    .ToArray();
-
-                Assert.Equal(14, actual.Length);
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_queryable_composed_compiled()
-        {
-            var query = EF.CompileQuery(
-                (NorthwindContext context) => context.Set<Customer>().FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Customers]"))
-                    .Where(c => c.ContactName.Contains("z")));
-
-            using (var context = CreateContext())
-            {
-                var actual = query(context).ToArray();
-
-                Assert.Equal(14, actual.Length);
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_composed_contains()
-        {
-            using (var context = CreateContext())
-            {
-                var actual
-                    = (from c in context.Set<Customer>()
-                       where context.Orders.FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Orders]"))
-                           .Select(o => o.CustomerID)
-                           .Contains(c.CustomerID)
-                       select c)
-                    .ToArray();
-
-                Assert.Equal(89, actual.Length);
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_composed_contains2()
-        {
-            using (var context = CreateContext())
-            {
-                var actual
-                    = (from c in context.Set<Customer>()
-                       where
-                           c.CustomerID == "ALFKI"
-                           && context.Orders.FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Orders]"))
-                               .Select(o => o.CustomerID)
-                               .Contains(c.CustomerID)
-                       select c)
-                    .ToArray();
-
-                Assert.Equal(1, actual.Length);
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_queryable_multiple_composed()
-        {
-            using (var context = CreateContext())
-            {
-                var actual
-                    = (from c in context.Set<Customer>().FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Customers]"))
-                       from o in context.Set<Order>().FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Orders]"))
-                       where c.CustomerID == o.CustomerID
-                       select new
-                       {
-                           c,
-                           o
-                       })
-                    .ToArray();
-
-                Assert.Equal(830, actual.Length);
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_queryable_multiple_composed_with_closure_parameters()
-        {
-            var startDate = new DateTime(1997, 1, 1);
-            var endDate = new DateTime(1998, 1, 1);
-
-            using (var context = CreateContext())
-            {
-                var actual
-                    = (from c in context.Set<Customer>().FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Customers]"))
-                       from o in context.Set<Order>().FromSql(
-                           NormalizeDelimetersInRawString("SELECT * FROM [Orders] WHERE [OrderDate] BETWEEN {0} AND {1}"),
-                           startDate,
-                           endDate)
-                       where c.CustomerID == o.CustomerID
-                       select new
-                       {
-                           c,
-                           o
-                       })
-                    .ToArray();
-
-                Assert.Equal(411, actual.Length);
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_queryable_multiple_composed_with_parameters_and_closure_parameters()
-        {
-            var city = "London";
-            var startDate = new DateTime(1997, 1, 1);
-            var endDate = new DateTime(1998, 1, 1);
-
-            using (var context = CreateContext())
-            {
-                var actual
-                    = (from c in context.Set<Customer>().FromSql(
-                           NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [City] = {0}"), city)
-                       from o in context.Set<Order>().FromSql(
-                           NormalizeDelimetersInRawString("SELECT * FROM [Orders] WHERE [OrderDate] BETWEEN {0} AND {1}"),
-                           startDate,
-                           endDate)
-                       where c.CustomerID == o.CustomerID
-                       select new
-                       {
-                           c,
-                           o
-                       })
-                    .ToArray();
-
-                Assert.Equal(25, actual.Length);
-
-                city = "Berlin";
-                startDate = new DateTime(1998, 4, 1);
-                endDate = new DateTime(1998, 5, 1);
-
-                actual
-                    = (from c in context.Set<Customer>().FromSql(
-                           NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [City] = {0}"), city)
-                       from o in context.Set<Order>().FromSql(
-                           NormalizeDelimetersInRawString("SELECT * FROM [Orders] WHERE [OrderDate] BETWEEN {0} AND {1}"),
-                           startDate,
-                           endDate)
-                       where c.CustomerID == o.CustomerID
-                       select new
-                       {
-                           c,
-                           o
-                       })
-                    .ToArray();
-
-                Assert.Equal(1, actual.Length);
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_queryable_multiple_line_query()
-        {
-            using (var context = CreateContext())
-            {
-                var actual = context.Set<Customer>().FromSql(
-                        NormalizeDelimetersInRawString(
-                            @"SELECT *
-FROM [Customers]
-WHERE [City] = 'London'"))
-                    .ToArray();
-
-                Assert.Equal(6, actual.Length);
-                Assert.True(actual.All(c => c.City == "London"));
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_queryable_composed_multiple_line_query()
-        {
-            using (var context = CreateContext())
-            {
-                var actual = context.Set<Customer>().FromSql(
-                        NormalizeDelimetersInRawString(
-                            @"SELECT *
-FROM [Customers]"))
-                    .Where(c => c.City == "London")
-                    .ToArray();
-
-                Assert.Equal(6, actual.Length);
-                Assert.True(actual.All(c => c.City == "London"));
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_queryable_with_parameters()
-        {
-            var city = "London";
-            var contactTitle = "Sales Representative";
-
-            using (var context = CreateContext())
-            {
-                var actual = context.Set<Customer>().FromSql(
-                        NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [City] = {0} AND [ContactTitle] = {1}"), city, contactTitle)
-                    .ToArray();
-
-                Assert.Equal(3, actual.Length);
-                Assert.True(actual.All(c => c.City == "London"));
-                Assert.True(actual.All(c => c.ContactTitle == "Sales Representative"));
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_queryable_with_parameters_inline()
-        {
-            using (var context = CreateContext())
-            {
-                var actual = context.Set<Customer>().FromSql(
-                        NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [City] = {0} AND [ContactTitle] = {1}"), "London",
-                        "Sales Representative")
-                    .ToArray();
-
-                Assert.Equal(3, actual.Length);
-                Assert.True(actual.All(c => c.City == "London"));
-                Assert.True(actual.All(c => c.ContactTitle == "Sales Representative"));
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_queryable_with_parameters_interpolated()
-        {
-            var city = "London";
-            var contactTitle = "Sales Representative";
-
-            using (var context = CreateContext())
-            {
-                var actual = context.Set<Customer>().FromSqlInterpolated(
-                        NormalizeDelimetersInInterpolatedString(
-                            $"SELECT * FROM [Customers] WHERE [City] = {city} AND [ContactTitle] = {contactTitle}"))
-                    .ToArray();
-
-                Assert.Equal(3, actual.Length);
-                Assert.True(actual.All(c => c.City == "London"));
-                Assert.True(actual.All(c => c.ContactTitle == "Sales Representative"));
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_queryable_with_parameters_inline_interpolated()
-        {
-            using (var context = CreateContext())
-            {
-                var actual = context.Set<Customer>().FromSqlInterpolated(
-                        NormalizeDelimetersInInterpolatedString(
-                            $"SELECT * FROM [Customers] WHERE [City] = {"London"} AND [ContactTitle] = {"Sales Representative"}"))
-                    .ToArray();
-
-                Assert.Equal(3, actual.Length);
-                Assert.True(actual.All(c => c.City == "London"));
-                Assert.True(actual.All(c => c.ContactTitle == "Sales Representative"));
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_queryable_multiple_composed_with_parameters_and_closure_parameters_interpolated()
-        {
-            var city = "London";
-            var startDate = new DateTime(1997, 1, 1);
-            var endDate = new DateTime(1998, 1, 1);
-
-            using (var context = CreateContext())
-            {
-                var actual
-                    = (from c in context.Set<Customer>().FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [City] = {0}"), city)
-                       from o in context.Set<Order>().FromSqlInterpolated(
-                           NormalizeDelimetersInInterpolatedString($"SELECT * FROM [Orders] WHERE [OrderDate] BETWEEN {startDate} AND {endDate}"))
-                       where c.CustomerID == o.CustomerID
-                       select new
-                       {
-                           c,
-                           o
-                       })
-                    .ToArray();
-
-                Assert.Equal(25, actual.Length);
-
-                city = "Berlin";
-                startDate = new DateTime(1998, 4, 1);
-                endDate = new DateTime(1998, 5, 1);
-
-                actual
-                    = (from c in context.Set<Customer>().FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [City] = {0}"), city)
-                       from o in context.Set<Order>().FromSqlInterpolated(
-                           NormalizeDelimetersInInterpolatedString($"SELECT * FROM [Orders] WHERE [OrderDate] BETWEEN {startDate} AND {endDate}"))
-                       where c.CustomerID == o.CustomerID
-                       select new
-                       {
-                           c,
-                           o
-                       })
-                    .ToArray();
-
-                Assert.Equal(1, actual.Length);
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_queryable_with_null_parameter()
-        {
-            uint? reportsTo = null;
-
-            using (var context = CreateContext())
-            {
-                var actual = context.Set<Employee>().FromSql(
-                        NormalizeDelimetersInRawString(
-                            // ReSharper disable once ExpressionIsAlwaysNull
-                            "SELECT * FROM [Employees] WHERE [ReportsTo] = {0} OR (]ReportsTo] IS NULL AND {0} IS NULL)"), reportsTo)
-                    .ToArray();
-
-                Assert.Equal(1, actual.Length);
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_queryable_with_parameters_and_closure()
-        {
-            var city = "London";
-            var contactTitle = "Sales Representative";
-
-            using (var context = CreateContext())
-            {
-                var actual = context.Set<Customer>().FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [City] = {0}"), city)
-                    .Where(c => c.ContactTitle == contactTitle)
-                    .ToArray();
-
-                Assert.Equal(3, actual.Length);
-                Assert.True(actual.All(c => c.City == "London"));
-                Assert.True(actual.All(c => c.ContactTitle == "Sales Representative"));
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_queryable_simple_cache_key_includes_query_string()
-        {
-            using (var context = CreateContext())
-            {
-                var actual = context.Set<Customer>().FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [City] = 'London'"))
-                    .ToArray();
-
-                Assert.Equal(6, actual.Length);
-                Assert.True(actual.All(c => c.City == "London"));
-
-                actual = context.Set<Customer>().FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [City] = 'Seattle'"))
-                    .ToArray();
-
-                Assert.Equal(1, actual.Length);
-                Assert.True(actual.All(c => c.City == "Seattle"));
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_queryable_with_parameters_cache_key_includes_parameters()
-        {
-            var city = "London";
-            var contactTitle = "Sales Representative";
-            var sql = "SELECT * FROM [Customers] WHERE [City] = {0} AND [ContactTitle] = {1}";
-
-            using (var context = CreateContext())
-            {
-                var actual = context.Set<Customer>().FromSql(NormalizeDelimetersInRawString(sql), city, contactTitle)
-                    .ToArray();
-
-                Assert.Equal(3, actual.Length);
-                Assert.True(actual.All(c => c.City == "London"));
-                Assert.True(actual.All(c => c.ContactTitle == "Sales Representative"));
-
-                city = "Madrid";
-                contactTitle = "Accounting Manager";
-
-                actual = context.Set<Customer>().FromSql(NormalizeDelimetersInRawString(sql), city, contactTitle)
-                    .ToArray();
-
-                Assert.Equal(2, actual.Length);
-                Assert.True(actual.All(c => c.City == "Madrid"));
-                Assert.True(actual.All(c => c.ContactTitle == "Accounting Manager"));
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_queryable_simple_as_no_tracking_not_composed()
-        {
-            using (var context = CreateContext())
-            {
-                var actual = context.Set<Customer>().FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Customers]"))
-                    .AsNoTracking()
-                    .ToArray();
-
-                Assert.Equal(91, actual.Length);
-                Assert.Equal(0, context.ChangeTracker.Entries().Count());
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_queryable_simple_projection_composed()
-        {
-            using (var context = CreateContext())
-            {
-                var boolMapping = (RelationalTypeMapping)context.GetService<ITypeMappingSource>().FindMapping(typeof(bool));
-                var actual = context.Set<Product>().FromSql(
-                        NormalizeDelimetersInRawString(
-                            @"SELECT *
-FROM [Products]
-WHERE [Discontinued] <> " + boolMapping.GenerateSqlLiteral(true) + @"
-AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
-                    .Select(p => p.ProductName)
-                    .ToArray();
-
-                Assert.Equal(2, actual.Length);
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_queryable_simple_include()
-        {
-            using (var context = CreateContext())
-            {
-                var actual = context.Set<Customer>().FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Customers]"))
-                    .Include(c => c.Orders)
-                    .ToArray();
-
-                Assert.Equal(830, actual.SelectMany(c => c.Orders).Count());
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_queryable_simple_composed_include()
-        {
-            using (var context = CreateContext())
-            {
-                var actual = context.Set<Customer>().FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Customers]"))
-                    .Where(c => c.City == "London")
-                    .Include(c => c.Orders)
-                    .ToArray();
-
-                Assert.Equal(46, actual.SelectMany(c => c.Orders).Count());
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_annotations_do_not_affect_successive_calls()
-        {
-            using (var context = CreateContext())
-            {
-                var actual = context.Customers.FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [ContactName] LIKE '%z%'"))
-                    .ToArray();
-
-                Assert.Equal(14, actual.Length);
-
-                actual = context.Customers
-                    .ToArray();
-
-                Assert.Equal(91, actual.Length);
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_composed_with_nullable_predicate()
-        {
-            using (var context = CreateContext())
-            {
-                var actual = context.Set<Customer>().FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Customers]"))
-                    .Where(c => c.ContactName == c.CompanyName)
-                    .ToArray();
-
-                Assert.Equal(0, actual.Length);
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_with_dbParameter()
-        {
-            using (var context = CreateContext())
-            {
-                var parameter = CreateDbParameter("@city", "London");
-
-                var actual = context.Customers.FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [City] = @city"), parameter)
-                    .ToArray();
-
-                Assert.Equal(6, actual.Length);
-                Assert.True(actual.All(c => c.City == "London"));
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_with_dbParameter_mixed()
-        {
-            using (var context = CreateContext())
-            {
-                var city = "London";
-                var title = "Sales Representative";
-
-                var titleParameter = CreateDbParameter("@title", title);
-
-                var actual = context.Customers.FromSql(
-                        NormalizeDelimetersInRawString(
-                            "SELECT * FROM [Customers] WHERE [City] = {0} AND [ContactTitle] = @title"), city, titleParameter)
-                    .ToArray();
-
-                Assert.Equal(3, actual.Length);
-                Assert.True(actual.All(c => c.City == "London"));
-                Assert.True(actual.All(c => c.ContactTitle == "Sales Representative"));
-
-                var cityParameter = CreateDbParameter("@city", city);
-
-                actual = context.Customers.FromSql(
-                        NormalizeDelimetersInRawString(
-                            "SELECT * FROM [Customers] WHERE [City] = @city AND [ContactTitle] = {1}"), cityParameter, title)
-                    .ToArray();
-
-                Assert.Equal(3, actual.Length);
-                Assert.True(actual.All(c => c.City == "London"));
-                Assert.True(actual.All(c => c.ContactTitle == "Sales Representative"));
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_with_db_parameters_called_multiple_times()
-        {
-            using (var context = CreateContext())
-            {
-                var parameter = CreateDbParameter("@id", "ALFKI");
-
-                var query = context.Customers.FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [CustomerID] = @id"), parameter);
-
-                // ReSharper disable PossibleMultipleEnumeration
-                var result1 = query.ToList();
-
-                Assert.Equal(1, result1.Count);
-
-                var result2 = query.ToList();
-                // ReSharper restore PossibleMultipleEnumeration
-
-                Assert.Equal(1, result2.Count);
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_with_SelectMany_and_include()
-        {
-            using (var context = CreateContext())
-            {
-                var query = from c1 in context.Set<Customer>()
-                                .FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [CustomerID] = 'ALFKI'"))
-                            from c2 in context.Set<Customer>().FromSql(
-                                    NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [CustomerID] = 'AROUT'"))
-                                .Include(c => c.Orders)
-                            select new
-                            {
-                                c1,
-                                c2
-                            };
-
-                var result = query.ToList();
-                Assert.Equal(1, result.Count);
-
-                var customers1 = result.Select(r => r.c1);
-                var customers2 = result.Select(r => r.c2);
-                foreach (var customer1 in customers1)
-                {
-                    Assert.Null(customer1.Orders);
-                }
-
-                foreach (var customer2 in customers2)
-                {
-                    Assert.NotNull(customer2.Orders);
-                }
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_with_join_and_include()
-        {
-            using (var context = CreateContext())
-            {
-                var query = from c in context.Set<Customer>()
-                                .FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [CustomerID] = 'ALFKI'"))
-                            join o in context.Set<Order>().FromSql(NormalizeDelimetersInRawString("SELECT * FROM [Orders] WHERE [OrderID] <> 1"))
-                                    .Include(o => o.OrderDetails)
-                                on c.CustomerID equals o.CustomerID
-                            select new
-                            {
-                                c,
-                                o
-                            };
-
-                var result = query.ToList();
-
-                Assert.Equal(6, result.Count);
-
-                var orders = result.Select(r => r.o);
-                foreach (var order in orders)
-                {
-                    Assert.NotNull(order.OrderDetails);
-                }
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_with_inlined_db_parameter()
-        {
-            using (var context = CreateContext())
-            {
-                var parameter = CreateDbParameter("@somename", "ALFKI");
-
-                var query = context.Customers
-                    .FromSqlInterpolated(NormalizeDelimetersInInterpolatedString($"SELECT * FROM [Customers] WHERE [CustomerID] = {parameter}"))
-                    .ToList();
-            }
-        }
-
-        [Fact]
-        public virtual void From_sql_parameterization_issue_12213()
-        {
-            using (var context = CreateContext())
-            {
-                var min = 10300;
-                var max = 10400;
-
-                var query1 = context.Orders
-                    .FromSqlInterpolated(NormalizeDelimetersInInterpolatedString($"SELECT * FROM [Orders] WHERE [OrderID] >= {min}"))
-                    .Select(i => i.OrderID);
-                query1.ToList();
-
-                var query2 = context.Orders
-                    .Where(o => o.OrderID <= max && query1.Contains(o.OrderID))
-                    .Select(o => o.OrderID);
-                query2.ToList();
-
-                var query3 = context.Orders
-                    .Where(
-                        o => o.OrderID <= max
-                             && context.Orders
-                                 .FromSqlInterpolated(NormalizeDelimetersInInterpolatedString($"SELECT * FROM [Orders] WHERE [OrderID] >= {min}"))
-                                 .Select(i => i.OrderID)
-                                 .Contains(o.OrderID))
-                    .Select(o => o.OrderID);
-                query3.ToList();
-            }
-        }
-#pragma warning restore CS0618 // Type or member is obsolete
-
-        private string NormalizeDelimetersInRawString(string sql)
+        protected string NormalizeDelimetersInRawString(string sql)
             => Fixture.TestStore.NormalizeDelimetersInRawString(sql);
 
-        private FormattableString NormalizeDelimetersInInterpolatedString(FormattableString sql)
+        protected FormattableString NormalizeDelimetersInInterpolatedString(FormattableString sql)
             => Fixture.TestStore.NormalizeDelimetersInInterpolatedString(sql);
 
         protected abstract DbParameter CreateDbParameter(string name, object value);

--- a/test/EFCore.Relational.Specification.Tests/TestModels/Northwind/NorthwindRelationalContext.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/Northwind/NorthwindRelationalContext.cs
@@ -32,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.TestModels.Northwind
                 .Query<OrderQuery>()
                 .ToQuery(
                     () => Orders
-                        .FromSql(@"select * from ""Orders""")
+                        .FromSqlRaw(@"select * from ""Orders""")
                         .Select(
                             o => new OrderQuery
                             {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AsyncFromSqlQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AsyncFromSqlQuerySqlServerTest.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.TestUtilities;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
-    internal class AsyncFromSqlQuerySqlServerTest : AsyncFromSqlQueryTestBase<NorthwindQuerySqlServerFixture<NoopModelCustomizer>>
+    public class AsyncFromSqlQuerySqlServerTest : AsyncFromSqlQueryTestBase<NorthwindQuerySqlServerFixture<NoopModelCustomizer>>
     {
         public AsyncFromSqlQuerySqlServerTest(NorthwindQuerySqlServerFixture<NoopModelCustomizer> fixture)
             : base(fixture)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlQuerySqlServerTest.cs
@@ -10,7 +10,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
-    internal class FromSqlQuerySqlServerTest : FromSqlQueryTestBase<NorthwindQuerySqlServerFixture<NoopModelCustomizer>>
+    public class FromSqlQuerySqlServerTest : FromSqlQueryTestBase<NorthwindQuerySqlServerFixture<NoopModelCustomizer>>
     {
         public FromSqlQuerySqlServerTest(NorthwindQuerySqlServerFixture<NoopModelCustomizer> fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
@@ -525,7 +525,7 @@ ORDER BY [t].[OrderID]");
 SELECT * FROM ""Customers"" WHERE ""CustomerID"" = @somename");
         }
 
-        [Fact]
+        [Fact(Skip = "#15750")]
         public virtual void FromSqlRaw_in_subquery_with_dbParameter()
         {
             using (var context = CreateContext())
@@ -557,7 +557,7 @@ WHERE [o].[CustomerID] IN (
             }
         }
 
-        [Fact]
+        [Fact(Skip = "#15750")]
         public virtual void FromSqlRaw_in_subquery_with_positional_dbParameter_without_name()
         {
             using (var context = CreateContext())
@@ -592,7 +592,7 @@ WHERE [o].[CustomerID] IN (
             }
         }
 
-        [Fact]
+        [Fact(Skip = "#15750")]
         public virtual void FromSqlRaw_in_subquery_with_positional_dbParameter_with_name()
         {
             using (var context = CreateContext())
@@ -624,7 +624,7 @@ WHERE [o].[CustomerID] IN (
             }
         }
 
-        [Fact]
+        [Fact(Skip = "#15750")]
         public virtual void FromSqlRaw_with_dbParameter_mixed_in_subquery()
         {
             using (var context = CreateContext())

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerComplianceTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerComplianceTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore
             typeof(FiltersTestBase<>),                     // issue #15264
             typeof(OwnedQueryTestBase<>),                  // issue #15285
             typeof(QueryFilterFuncletizationTestBase<>),   // issue #15264
-            typeof(RelationalOwnedQueryTestBase<>),         // issue #15285
+            typeof(RelationalOwnedQueryTestBase<>),        // issue #15285
             // Query pipeline
             typeof(ConcurrencyDetectorTestBase<>),
             typeof(CompiledQueryTestBase<>),
@@ -30,9 +30,7 @@ namespace Microsoft.EntityFrameworkCore
             typeof(NullKeysTestBase<>),
             typeof(QueryNavigationsTestBase<>),
             typeof(ConcurrencyDetectorRelationalTestBase<>),
-            typeof(AsyncFromSqlQueryTestBase<>),
             typeof(QueryTaggingTestBase<>),
-            typeof(FromSqlQueryTestBase<>),
             typeof(GearsOfWarFromSqlQueryTestBase<>),
             typeof(InheritanceRelationalTestBase<>),
             typeof(NullSemanticsQueryTestBase<>),

--- a/test/EFCore.Sqlite.FunctionalTests/Query/AsyncFromSqlQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/AsyncFromSqlQuerySqliteTest.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.TestUtilities;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
-    internal class AsyncFromSqlQuerySqliteTest : AsyncFromSqlQueryTestBase<NorthwindQuerySqliteFixture<NoopModelCustomizer>>
+    public class AsyncFromSqlQuerySqliteTest : AsyncFromSqlQueryTestBase<NorthwindQuerySqliteFixture<NoopModelCustomizer>>
     {
         public AsyncFromSqlQuerySqliteTest(NorthwindQuerySqliteFixture<NoopModelCustomizer> fixture)
             : base(fixture)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/FromSqlQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/FromSqlQuerySqliteTest.cs
@@ -4,14 +4,16 @@
 using System.Data.Common;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
-    internal class FromSqlQuerySqliteTest : FromSqlQueryTestBase<NorthwindQuerySqliteFixture<NoopModelCustomizer>>
+    public class FromSqlQuerySqliteTest : FromSqlQueryTestBase<NorthwindQuerySqliteFixture<NoopModelCustomizer>>
     {
-        public FromSqlQuerySqliteTest(NorthwindQuerySqliteFixture<NoopModelCustomizer> fixture)
+        public FromSqlQuerySqliteTest(NorthwindQuerySqliteFixture<NoopModelCustomizer> fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
+            fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
         public override void Bad_data_error_handling_invalid_cast_key()

--- a/test/EFCore.Sqlite.FunctionalTests/SqliteComplianceTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/SqliteComplianceTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore
             typeof(FiltersTestBase<>),                     // issue #15264
             typeof(OwnedQueryTestBase<>),                  // issue #15285
             typeof(QueryFilterFuncletizationTestBase<>),   // issue #15264
-            typeof(RelationalOwnedQueryTestBase<>),         // issue #15285
+            typeof(RelationalOwnedQueryTestBase<>),        // issue #15285
             // Query pipeline
             typeof(ConcurrencyDetectorTestBase<>),
             typeof(CompiledQueryTestBase<>),
@@ -34,9 +34,7 @@ namespace Microsoft.EntityFrameworkCore
             typeof(NullKeysTestBase<>),
             typeof(QueryNavigationsTestBase<>),
             typeof(ConcurrencyDetectorRelationalTestBase<>),
-            typeof(AsyncFromSqlQueryTestBase<>),
             typeof(QueryTaggingTestBase<>),
-            typeof(FromSqlQueryTestBase<>),
             typeof(GearsOfWarFromSqlQueryTestBase<>),
             typeof(InheritanceRelationalTestBase<>),
             typeof(NullSemanticsQueryTestBase<>),


### PR DESCRIPTION
* Parameterization not implemented (see #15750)
* FromSqlRaw() and FromSqlInterpolated() are now defined over DbSet<>,
  not IQueryable<>. FromSql() is still defined over IQueryable<> but
  throws if not directly on a DbSet<>.

Closes #15704 

(rebased and pushed last minute before boarding a plane, it may be somewhat broken :))