### PR TITLE
Fix to #15720 - Query: Subquery Member pushdown

### DIFF
--- a/src/EFCore.Relational/Query/Pipeline/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Pipeline/QuerySqlGenerator.cs
@@ -638,11 +638,12 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 
         protected override Expression VisitSubSelect(SubSelectExpression subSelectExpression)
         {
-            _relationalCommandBuilder.Append("(");
-			using (_relationalCommandBuilder.Indent())
-			{
-				Visit(subSelectExpression.Subquery);
-			}
+            _relationalCommandBuilder.AppendLine("(");
+            using (_relationalCommandBuilder.Indent())
+            {
+                Visit(subSelectExpression.Subquery);
+            }
+
             _relationalCommandBuilder.Append(")");
 
             return subSelectExpression;

--- a/src/EFCore/Query/NavigationExpansion/NavigationExpansionExpression.cs
+++ b/src/EFCore/Query/NavigationExpansion/NavigationExpansionExpression.cs
@@ -95,13 +95,17 @@ namespace Microsoft.EntityFrameworkCore.Query.NavigationExpansion
             if (State.ApplyPendingSelector)
             {
                 expressionPrinter.StringBuilder.Append(".PendingSelect(");
-                expressionPrinter.Visit(State.PendingSelector);
+                using (expressionPrinter.StringBuilder.Indent())
+                {
+                    expressionPrinter.Visit(State.PendingSelector);
+                }
+
                 expressionPrinter.StringBuilder.Append(")");
             }
 
             if (State.PendingCardinalityReducingOperator != null)
             {
-                expressionPrinter.StringBuilder.Append(".Pending" + State.PendingCardinalityReducingOperator.Name);
+                expressionPrinter.StringBuilder.Append(".Pending" + State.PendingCardinalityReducingOperator.Name + "()");
             }
         }
     }

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
@@ -979,7 +979,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     () => c.Orders.OrderBy(o => o.OrderID).FirstOrDefault().OrderDetails.OrderBy(od => od.ProductID).FirstOrDefault())));
         }
 
-        [ConditionalTheory(Skip = "Issue#15720")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multiple_collection_navigation_with_FirstOrDefault_chained_projecting_scalar(bool isAsync)
         {

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -3511,7 +3511,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "Issue#15720")]
+        [ConditionalFact]
         public virtual void Select_Where_Subquery_Deep_First()
         {
             using (var context = CreateContext())
@@ -4966,7 +4966,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) => Assert.Equal(e.Property, a.Property));
         }
 
-        [ConditionalTheory(Skip = "Issue#15720")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task DTO_subquery_orderby(bool isAsync)
         {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -615,17 +615,15 @@ WHERE @_outer_CustomerID1 = [c2].[CustomerID]");
             AssertSql(
                 @"@__p_0='2'
 
-SELECT TOP(@__p_0) [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice]
-FROM [Order Details] AS [od]
+SELECT TOP(@__p_0) [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
+FROM [Order Details] AS [o]
 WHERE (
     SELECT TOP(1) (
         SELECT TOP(1) [c].[City]
         FROM [Customers] AS [c]
-        WHERE [o].[CustomerID] = [c].[CustomerID]
-    )
-    FROM [Orders] AS [o]
-    WHERE [od].[OrderID] = [o].[OrderID]
-) = N'Seattle'");
+        WHERE [o0].[CustomerID] = [c].[CustomerID])
+    FROM [Orders] AS [o0]
+    WHERE [o].[OrderID] = [o0].[OrderID]) = N'Seattle'");
         }
 
         public override void Select_Where_Subquery_Equality()


### PR DESCRIPTION
Problem was we were not handling a scenario with nested FirstOrDefault, e.g. customers.Select(c => orders.Select(orderDetails.FirstOrDefault()).FirstOrDefault().DetailName)
In this case we need to recursively pushdown the property until we don't encounter cardinality reducing operator.

Also resolves #15363 - Consecutive calls to FirstOrDefault() in a projection not translatable
This was already working but adding a test.