### PR TITLE
Translate LongCount() on SqlServer

### DIFF
--- a/src/EFCore.SqlServer/Extensions/SqlServerServiceCollectionExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerServiceCollectionExtensions.cs
@@ -98,6 +98,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .TryAdd<IMethodCallTranslatorProvider, SqlServerMethodCallTranslatorProvider>()
                 .TryAdd<IMemberTranslatorProvider, SqlServerMemberTranslatorProvider>()
                 .TryAdd<IShapedQueryOptimizerFactory, SqlServerShapedQueryOptimizerFactory>()
+                .TryAdd<IQueryableMethodTranslatingExpressionVisitorFactory, SqlServerQueryableMethodTranslatingExpressionVisitorFactory>()
                 .TryAddProviderSpecificServices(
                     b => b
                         .TryAddSingleton<ISqlServerValueGeneratorCache, SqlServerValueGeneratorCache>()

--- a/src/EFCore.SqlServer/Query/Pipeline/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Pipeline/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Query.Pipeline;
+using Microsoft.EntityFrameworkCore.Relational.Query.Pipeline;
+using Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Pipeline
+{
+    public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQueryableMethodTranslatingExpressionVisitor
+    {
+        public SqlServerQueryableMethodTranslatingExpressionVisitor(
+            IModel model,
+            IQueryableMethodTranslatingExpressionVisitorFactory queryableMethodTranslatingExpressionVisitorFactory,
+            IRelationalSqlTranslatingExpressionVisitorFactory relationalSqlTranslatingExpressionVisitorFactory,
+            ISqlExpressionFactory sqlExpressionFactory)
+            : base(
+                model,
+                queryableMethodTranslatingExpressionVisitorFactory,
+                relationalSqlTranslatingExpressionVisitorFactory,
+                sqlExpressionFactory)
+        {
+        }
+
+        protected override SqlExpression GenerateLongCountExpression()
+            => SqlExpressionFactory.ApplyDefaultTypeMapping(
+                SqlExpressionFactory.Function("COUNT_BIG", new[] { SqlExpressionFactory.Fragment("*") }, typeof(long)));
+    }
+}

--- a/src/EFCore.SqlServer/Query/Pipeline/SqlServerQueryableMethodTranslatingExpressionVisitorFactory.cs
+++ b/src/EFCore.SqlServer/Query/Pipeline/SqlServerQueryableMethodTranslatingExpressionVisitorFactory.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Query.Pipeline;
+using Microsoft.EntityFrameworkCore.Relational.Query.Pipeline;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Pipeline
+{
+    public class SqlServerQueryableMethodTranslatingExpressionVisitorFactory : IQueryableMethodTranslatingExpressionVisitorFactory
+    {
+        private readonly ISqlExpressionFactory _sqlExpressionFactory;
+        private readonly IRelationalSqlTranslatingExpressionVisitorFactory _relationalSqlTranslatingExpressionVisitorFactory;
+
+        public SqlServerQueryableMethodTranslatingExpressionVisitorFactory(
+            IRelationalSqlTranslatingExpressionVisitorFactory relationalSqlTranslatingExpressionVisitorFactory,
+            ISqlExpressionFactory sqlExpressionFactory)
+        {
+            _sqlExpressionFactory = sqlExpressionFactory;
+            _relationalSqlTranslatingExpressionVisitorFactory = relationalSqlTranslatingExpressionVisitorFactory;
+        }
+
+        public QueryableMethodTranslatingExpressionVisitor Create(IModel model)
+        {
+            return new SqlServerQueryableMethodTranslatingExpressionVisitor(
+                model,
+                this,
+                _relationalSqlTranslatingExpressionVisitorFactory,
+                _sqlExpressionFactory);
+        }
+    }
+}

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -2657,7 +2657,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select c.CustomerID);
         }
 
-        [ConditionalTheory(Skip = "Issue#15718")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task SelectMany_LongCount(bool isAsync)
         {
@@ -5103,7 +5103,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 cs => cs.OrderBy(c => c.Country).Take(7));
         }
 
-        [ConditionalTheory(Skip = "Issue#15718")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_take_long_count(bool isAsync)
         {
@@ -5112,7 +5112,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 cs => cs.Take(7));
         }
 
-        [ConditionalTheory(Skip = "Issue#15718")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_orderBy_take_long_count(bool isAsync)
         {
@@ -5175,7 +5175,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 cs => cs.OrderBy(c => c.Country).Skip(7));
         }
 
-        [ConditionalTheory(Skip = "Issue#15718")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_skip_long_count(bool isAsync)
         {
@@ -5184,7 +5184,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 cs => cs.Skip(7));
         }
 
-        [ConditionalTheory(Skip = "Issue#15718")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_orderBy_skip_long_count(bool isAsync)
         {
@@ -5238,7 +5238,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 cs => cs.Distinct());
         }
 
-        [ConditionalTheory(Skip = "Issue#15718")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_distinct_long_count(bool isAsync)
         {


### PR DESCRIPTION
Includes refactoring that makes it easier for providers to override behavior.

Fixes #15718

@smitpatel if the approach is OK I can look into refactoring the other aggregate functions in a similar way (e.g. MAX()).
