### PR TITLE
[Query] Pull out variables upfront for ShaperExpression

### DIFF
--- a/src/EFCore.Relational/Query/Pipeline/RelationalShapedQueryOptimizingExpressionVisitors.cs
+++ b/src/EFCore.Relational/Query/Pipeline/RelationalShapedQueryOptimizingExpressionVisitors.cs
@@ -3,6 +3,7 @@
 
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Query.Pipeline;
 
 namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
@@ -24,7 +25,6 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
         public override Expression Visit(Expression query)
         {
             query = base.Visit(query);
-            query = new ShaperExpressionDedupingExpressionVisitor().Process(query);
             query = new SelectExpressionProjectionApplyingExpressionVisitor().Visit(query);
             query = new SelectExpressionTableAliasUniquifyingExpressionVisitor().Visit(query);
 
@@ -35,6 +35,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 
             query = new SqlExpressionOptimizingVisitor(SqlExpressionFactory).Visit(query);
             query = new NullComparisonTransformingExpressionVisitor().Visit(query);
+            query = new ShaperExpressionProcessingExpressionVisitor().Process(query);
 
             return query;
         }

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/LikeExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/LikeExpression.cs
@@ -70,7 +70,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
                 var hashCode = base.GetHashCode();
                 hashCode = (hashCode * 397) ^ Match.GetHashCode();
                 hashCode = (hashCode * 397) ^ Pattern.GetHashCode();
-                hashCode = (hashCode * 397) ^ EscapeChar.GetHashCode();
+                hashCode = (hashCode * 397) ^ (EscapeChar?.GetHashCode() ?? 0);
 
                 return hashCode;
             }

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SelectExpression.cs
@@ -550,10 +550,13 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             unchecked
             {
                 var hashCode = base.GetHashCode();
-                foreach (var projectionMapping in _projectionMapping)
+                if (_projectionMapping != null)
                 {
-                    hashCode = (hashCode * 397) ^ projectionMapping.Key.GetHashCode();
-                    hashCode = (hashCode * 397) ^ projectionMapping.Value.GetHashCode();
+                    foreach (var projectionMapping in _projectionMapping)
+                    {
+                        hashCode = (hashCode * 397) ^ projectionMapping.Key.GetHashCode();
+                        hashCode = (hashCode * 397) ^ projectionMapping.Value.GetHashCode();
+                    }
                 }
 
                 hashCode = (hashCode * 397) ^ _tables.Aggregate(

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SqlConstantExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SqlConstantExpression.cs
@@ -51,7 +51,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             unchecked
             {
                 var hashCode = base.GetHashCode();
-                hashCode = (hashCode * 397) ^ Value.GetHashCode();
+                hashCode = (hashCode * 397) ^ (Value?.GetHashCode() ?? 0);
 
                 return hashCode;
             }

--- a/src/EFCore/Query/Pipeline/ProjectionBindingExpression.cs
+++ b/src/EFCore/Query/Pipeline/ProjectionBindingExpression.cs
@@ -35,6 +35,35 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
             return this;
         }
 
+        #region Equality & HashCode
+        public override bool Equals(object obj)
+            => obj != null
+            && (ReferenceEquals(this, obj)
+                || obj is ProjectionBindingExpression projectionBindingExpression
+                    && Equals(projectionBindingExpression));
+
+        private bool Equals(ProjectionBindingExpression projectionBindingExpression)
+            => QueryExpression.Equals(projectionBindingExpression.QueryExpression)
+            && (ProjectionMember == null
+                ? projectionBindingExpression.ProjectionMember == null
+                : ProjectionMember.Equals(projectionBindingExpression.ProjectionMember))
+            && Index == projectionBindingExpression.Index;
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = base.GetHashCode();
+                hashCode = (hashCode * 397) ^ QueryExpression.GetHashCode();
+                hashCode = (hashCode * 397) ^ (ProjectionMember?.GetHashCode() ?? 0);
+                hashCode = (hashCode * 397) ^ Index.GetHashCode();
+
+                return hashCode;
+            }
+        }
+
+        #endregion
+
         public void Print(ExpressionPrinter expressionPrinter)
         {
             expressionPrinter.StringBuilder.Append(nameof(ProjectionBindingExpression) + ": " + ProjectionMember + "/" + Index);

--- a/src/EFCore/Query/Pipeline/ProjectionMember.cs
+++ b/src/EFCore/Query/Pipeline/ProjectionMember.cs
@@ -74,6 +74,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
         }
 
         public override string ToString()
-            => string.Join(".", _memberChain);
+            => string.Join(".", _memberChain.Select(mi => mi.Name));
     }
 }


### PR DESCRIPTION
This phase is our form of projection before we call into client code
