### PR TITLE
Automate dependency updates to NETStandard 2.1 ref pack

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -13,6 +13,9 @@
       <DefaultRuntimeFrameworkVersion Condition="'%(TargetFramework)' == 'netcoreapp3.0'">$(MicrosoftNETCoreAppPackageVersion)</DefaultRuntimeFrameworkVersion>
       <TargetingPackVersion Condition="'%(TargetFramework)' == 'netcoreapp3.0'">$(MicrosoftNETCoreAppPackageVersion)</TargetingPackVersion>
     </KnownFrameworkReference>
+    <KnownFrameworkReference Update="NETStandard.Library">
+      <TargetingPackVersion Condition="'%(TargetFramework)' == 'netstandard2.1'">$(NETStandardLibraryRefPackageVersion)</TargetingPackVersion>
+    </KnownFrameworkReference>
   </ItemGroup>
 
   <!-- This is required to workaround overlap between System.Collections.Generic.IAsyncEnumerable in System.Runtime and System.Interactive.Async. -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -49,6 +49,10 @@
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>c3145b06ba5151d5eafcf177a2e380f7acb61189</Sha>
     </Dependency>
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview6-27720-09" CoherentParentDependency="Microsoft.Extensions.Logging">
+      <Uri>https://github.com/dotnet/core-setup</Uri>
+      <Sha>c3145b06ba5151d5eafcf177a2e380f7acb61189</Sha>
+    </Dependency>
     <Dependency Name="System.Collections.Immutable" Version="1.6.0-preview6.19270.12" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>ef1a5aa730098b6c3350977a991232c1ff11cfe3</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -49,5 +49,6 @@
     <MicrosoftDotNetPlatformAbstractionsPackageVersion>3.0.0-preview6-27720-09</MicrosoftDotNetPlatformAbstractionsPackageVersion>
     <MicrosoftExtensionsDependencyModelPackageVersion>3.0.0-preview6-27720-09</MicrosoftExtensionsDependencyModelPackageVersion>
     <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27720-09</MicrosoftNETCoreAppPackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview6-27720-09</NETStandardLibraryRefPackageVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This ensures the version of .NET Standard 2.1 we are using matches with the .NET Core runtime. This caused some problems in AspNetCore. Adding to this repo now as a defensive measure.