### PR TITLE
Query: Add support for join on composite keys generated by Nav rewrite

### DIFF
--- a/src/EFCore.Relational/Query/Pipeline/RelationalShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Pipeline/RelationalShapedQueryCompilingExpressionVisitor.cs
@@ -95,31 +95,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
             {
                 var relatedEntity = innerShaper(queryContext, dbDataReader);
 
-                if (trackingQuery)
-                {
-                    var internalEntityEntry = queryContext.StateManager.TryGetEntry(entity);
-                    Debug.Assert(internalEntityEntry != null);
-
-                    internalEntityEntry.SetIsLoaded(navigation);
-                    if (!ReferenceEquals(relatedEntity, null))
-                    {
-                        internalEntityEntry.SetRelationshipSnapshotValue(navigation, relatedEntity);
-                        if (inverseNavigation != null)
-                        {
-                            var relatedEntry = queryContext.StateManager.TryGetEntry(relatedEntity);
-                            if (inverseNavigation.IsCollection())
-                            {
-                                relatedEntry.AddToCollectionSnapshot(inverseNavigation, entity);
-                            }
-                            else
-                            {
-                                relatedEntry.SetRelationshipSnapshotValue(inverseNavigation, entity);
-                                relatedEntry.SetIsLoaded(inverseNavigation);
-                            }
-                        }
-                    }
-                }
-                else
+                if (!trackingQuery)
                 {
                     SetIsLoadedNoTracking(entity, navigation);
                     if (!ReferenceEquals(relatedEntity, null))


### PR DESCRIPTION
Also remove redundant code from Include in tracking query since all those task are already done by state manager

Couldn't enable GearsOfWar tests since they use TPH.