### PR TITLE
Fix to #15634 - Query: Nav Expansion should generate flattened LeftJoin

### DIFF
--- a/src/EFCore/Query/NavigationExpansion/LinqMethodHelpers.cs
+++ b/src/EFCore/Query/NavigationExpansion/LinqMethodHelpers.cs
@@ -10,6 +10,8 @@ namespace Microsoft.EntityFrameworkCore.Query.NavigationExpansion
 {
     public static class LinqMethodHelpers
     {
+        public static MethodInfo AsQueryable { get; private set; }
+
         public static MethodInfo QueryableWhereMethodInfo { get; private set; }
         public static MethodInfo QueryableSelectMethodInfo { get; private set; }
         public static MethodInfo QueryableOrderByMethodInfo { get; private set; }
@@ -91,6 +93,9 @@ namespace Microsoft.EntityFrameworkCore.Query.NavigationExpansion
         static LinqMethodHelpers()
         {
             var queryableMethods = typeof(Queryable).GetMethods().ToList();
+            var enumerableMethods = typeof(Enumerable).GetMethods().ToList();
+
+            AsQueryable = queryableMethods.Where(m => m.Name == nameof(Queryable.AsQueryable) && m.IsGenericMethod).Single();
 
             QueryableWhereMethodInfo = queryableMethods.Where(m => m.Name == nameof(Queryable.Where) && IsExpressionOfFunc(m.GetParameters()[1].ParameterType, 1)).Single();
             QueryableSelectMethodInfo = queryableMethods.Where(m => m.Name == nameof(Queryable.Select) && IsExpressionOfFunc(m.GetParameters()[1].ParameterType, 1)).Single();
@@ -137,8 +142,6 @@ namespace Microsoft.EntityFrameworkCore.Query.NavigationExpansion
 
             QueryableDefaultIfEmpty = queryableMethods.Where(m => m.Name == nameof(Queryable.DefaultIfEmpty) && m.GetParameters().Count() == 1).Single();
             QueryableDefaultIfEmptyWithDefaultValue = queryableMethods.Where(m => m.Name == nameof(Queryable.DefaultIfEmpty) && m.GetParameters().Count() == 2).Single();
-
-            var enumerableMethods = typeof(Enumerable).GetMethods().ToList();
 
             EnumerableWhereMethodInfo = enumerableMethods.Where(m => m.Name == nameof(Enumerable.Where) && IsFunc(m.GetParameters()[1].ParameterType, 1)).Single();
             EnumerableSelectMethodInfo = enumerableMethods.Where(m => m.Name == nameof(Enumerable.Select) && IsFunc(m.GetParameters()[1].ParameterType, 1)).Single();

--- a/src/EFCore/Query/Pipeline/QueryOptimizingExpressionVisitor.cs
+++ b/src/EFCore/Query/Pipeline/QueryOptimizingExpressionVisitor.cs
@@ -24,7 +24,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
             query = new NavigationExpander(_queryCompilationContext.Model).ExpandNavigations(query);
             query = new EnumerableToQueryableReMappingExpressionVisitor().Visit(query);
             query = new QueryMetadataExtractingExpressionVisitor(_queryCompilationContext).Visit(query);
-            query = new GroupJoinFlatteningExpressionVisitor().Visit(query);
             query = new NullCheckRemovingExpressionVisitor().Visit(query);
             query = new FunctionPreprocessingVisitor().Visit(query);
             new EnumerableVerifyingExpressionVisitor().Visit(query);


### PR DESCRIPTION
Generating LeftJoin calls in nav expansion. In case source is Enumerable we apply AsQueryable. Removing second pass of GroupJoin flattening visitor, it also makes queries simpler: we do longer produce double TransparentIdentifiers when translating GroupJoin-SelectMany-DefaultIfEmpty, because we no longer project the inner groupings.