### PR TITLE
Add TimeSpan overloads to SqlServer DateDiff function

### DIFF
--- a/src/EFCore.SqlServer/Extensions/SqlServerDbFunctionsExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerDbFunctionsExtensions.cs
@@ -346,6 +346,41 @@ namespace Microsoft.EntityFrameworkCore
                 : null;
 
         /// <summary>
+        ///     Counts the number of hour boundaries crossed between the startTimeSpan and endTimeSpan.
+        ///     Corresponds to SQL Server's DATEDIFF(HOUR,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startTimeSpan">Starting timespan for the calculation.</param>
+        /// <param name="endTimeSpan">Ending timespan for the calculation.</param>
+        /// <returns>Number of hour boundaries crossed between the timespans.</returns>
+        public static int DateDiffHour(
+            [CanBeNull] this DbFunctions _,
+            TimeSpan startTimeSpan,
+            TimeSpan endTimeSpan)
+        {
+            checked
+            {
+                return endTimeSpan.Hours - startTimeSpan.Hours;
+            }
+        }
+
+        /// <summary>
+        ///     Counts the number of hour boundaries crossed between the startTimeSpan and endTimeSpan.
+        ///     Corresponds to SQL Server's DATEDIFF(HOUR,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startTimeSpan">Starting timespan for the calculation.</param>
+        /// <param name="endTimeSpan">Ending timespan for the calculation.</param>
+        /// <returns>Number of hour boundaries crossed between the timespans.</returns>
+        public static int? DateDiffHour(
+            [CanBeNull] this DbFunctions _,
+            TimeSpan? startTimeSpan,
+            TimeSpan? endTimeSpan)
+            => (startTimeSpan.HasValue && endTimeSpan.HasValue)
+                ? (int?)DateDiffHour(_, startTimeSpan.Value, endTimeSpan.Value)
+                : null;
+
+        /// <summary>
         ///     Counts the number of minute boundaries crossed between the startDate and endDate.
         ///     Corresponds to SQL Server's DATEDIFF(MINUTE,startDate,endDate).
         /// </summary>
@@ -408,6 +443,41 @@ namespace Microsoft.EntityFrameworkCore
             DateTimeOffset? endDate)
             => (startDate.HasValue && endDate.HasValue)
                 ? (int?)DateDiffMinute(_, startDate.Value, endDate.Value)
+                : null;
+
+        /// <summary>
+        ///     Counts the number of minute boundaries crossed between the startTimeSpan and endTimeSpan.
+        ///     Corresponds to SQL Server's DATEDIFF(MINUTE,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startTimeSpan">Starting timespan for the calculation.</param>
+        /// <param name="endTimeSpan">Ending timespan for the calculation.</param>
+        /// <returns>Number of minute boundaries crossed between the timepsans.</returns>
+        public static int DateDiffMinute(
+            [CanBeNull] this DbFunctions _,
+            TimeSpan startTimeSpan,
+            TimeSpan endTimeSpan)
+        {
+            checked
+            {
+                return DateDiffHour(_, startTimeSpan, endTimeSpan) * 60 + endTimeSpan.Minutes - startTimeSpan.Minutes;
+            }
+        }
+
+        /// <summary>
+        ///     Counts the number of minute boundaries crossed between the startTimeSpan and endTimeSpan.
+        ///     Corresponds to SQL Server's DATEDIFF(MINUTE,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startTimeSpan">Starting timespan for the calculation.</param>
+        /// <param name="endTimeSpan">Ending timespan for the calculation.</param>
+        /// <returns>Number of minute boundaries crossed between the timespans.</returns>
+        public static int? DateDiffMinute(
+            [CanBeNull] this DbFunctions _,
+            TimeSpan? startTimeSpan,
+            TimeSpan? endTimeSpan)
+            => (startTimeSpan.HasValue && endTimeSpan.HasValue)
+                ? (int?)DateDiffMinute(_, startTimeSpan.Value, endTimeSpan.Value)
                 : null;
 
         /// <summary>
@@ -476,6 +546,41 @@ namespace Microsoft.EntityFrameworkCore
                 : null;
 
         /// <summary>
+        ///     Counts the number of second boundaries crossed between the startTimeSpan and endTimeSpan.
+        ///     Corresponds to SQL Server's DATEDIFF(SECOND,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startTimeSpan">Starting timespan for the calculation.</param>
+        /// <param name="endTimeSpan">Ending timespan for the calculation.</param>
+        /// <returns>Number of second boundaries crossed between the timespans.</returns>
+        public static int DateDiffSecond(
+            [CanBeNull] this DbFunctions _,
+            TimeSpan startTimeSpan,
+            TimeSpan endTimeSpan)
+        {
+            checked
+            {
+                return DateDiffMinute(_, startTimeSpan, endTimeSpan) * 60 + endTimeSpan.Seconds - startTimeSpan.Seconds;
+            }
+        }
+
+        /// <summary>
+        ///     Counts the number of second boundaries crossed between the startTimeSpan and endTimeSpan.
+        ///     Corresponds to SQL Server's DATEDIFF(SECOND,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startTimeSpan">Starting timespan for the calculation.</param>
+        /// <param name="endTimeSpan">Ending timespan for the calculation.</param>
+        /// <returns>Number of second boundaries crossed between the timespans.</returns>
+        public static int? DateDiffSecond(
+            [CanBeNull] this DbFunctions _,
+            TimeSpan? startTimeSpan,
+            TimeSpan? endTimeSpan)
+            => (startTimeSpan.HasValue && endTimeSpan.HasValue)
+                ? (int?)DateDiffSecond(_, startTimeSpan.Value, endTimeSpan.Value)
+                : null;
+
+        /// <summary>
         ///     Counts the number of millisecond boundaries crossed between the startDate and endDate.
         ///     Corresponds to SQL Server's DATEDIFF(MILLISECOND,startDate,endDate).
         /// </summary>
@@ -538,6 +643,41 @@ namespace Microsoft.EntityFrameworkCore
             DateTimeOffset? endDate)
             => (startDate.HasValue && endDate.HasValue)
                 ? (int?)DateDiffMillisecond(_, startDate.Value, endDate.Value)
+                : null;
+
+        /// <summary>
+        ///     Counts the number of millisecond boundaries crossed between the startTimeSpan and endTimeSpan.
+        ///     Corresponds to SQL Server's DATEDIFF(MILLISECOND,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startTimeSpan">Starting timespan for the calculation.</param>
+        /// <param name="endTimeSpan">Ending timespan for the calculation.</param>
+        /// <returns>Number of millisecond boundaries crossed between the timespans.</returns>
+        public static int DateDiffMillisecond(
+            [CanBeNull] this DbFunctions _,
+            TimeSpan startTimeSpan,
+            TimeSpan endTimeSpan)
+        {
+            checked
+            {
+                return DateDiffSecond(_, startTimeSpan, endTimeSpan) * 1000 + endTimeSpan.Milliseconds - startTimeSpan.Milliseconds;
+            }
+        }
+
+        /// <summary>
+        ///     Counts the number of millisecond boundaries crossed between the startTimeSpan and endTimeSpan.
+        ///     Corresponds to SQL Server's DATEDIFF(MILLISECOND,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startTimeSpan">Starting timespan for the calculation.</param>
+        /// <param name="endTimeSpan">Ending timespan for the calculation.</param>
+        /// <returns>Number of millisecond boundaries crossed between the timespans.</returns>
+        public static int? DateDiffMillisecond(
+            [CanBeNull] this DbFunctions _,
+            TimeSpan? startTimeSpan,
+            TimeSpan? endTimeSpan)
+            => (startTimeSpan.HasValue && endTimeSpan.HasValue)
+                ? (int?)DateDiffMillisecond(_, startTimeSpan.Value, endTimeSpan.Value)
                 : null;
 
         /// <summary>
@@ -606,6 +746,41 @@ namespace Microsoft.EntityFrameworkCore
                 : null;
 
         /// <summary>
+        ///     Counts the number of microsecond boundaries crossed between the startTimeSpan and endTimeSpan.
+        ///     Corresponds to SQL Server's DATEDIFF(MICROSECOND,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startTimeSpan">Starting timespan for the calculation.</param>
+        /// <param name="endTimeSpan">Ending timespan for the calculation.</param>
+        /// <returns>Number of microsecond boundaries crossed between the timespans.</returns>
+        public static int DateDiffMicrosecond(
+            [CanBeNull] this DbFunctions _,
+            TimeSpan startTimeSpan,
+            TimeSpan endTimeSpan)
+        {
+            checked
+            {
+                return (int)((endTimeSpan.Ticks - startTimeSpan.Ticks) / 10);
+            }
+        }
+
+        /// <summary>
+        ///     Counts the number of microsecond boundaries crossed between the startTimeSpan and endTimeSpan.
+        ///     Corresponds to SQL Server's DATEDIFF(MICROSECOND,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startTimeSpan">Starting timespan for the calculation.</param>
+        /// <param name="endTimeSpan">Ending timespan for the calculation.</param>
+        /// <returns>Number of microsecond boundaries crossed between the timespans.</returns>
+        public static int? DateDiffMicrosecond(
+            [CanBeNull] this DbFunctions _,
+            TimeSpan? startTimeSpan,
+            TimeSpan? endTimeSpan)
+            => (startTimeSpan.HasValue && endTimeSpan.HasValue)
+                ? (int?)DateDiffMicrosecond(_, startTimeSpan.Value, endTimeSpan.Value)
+                : null;
+
+        /// <summary>
         ///     Counts the number of nanosecond boundaries crossed between the startDate and endDate.
         ///     Corresponds to SQL Server's DATEDIFF(NANOSECOND,startDate,endDate).
         /// </summary>
@@ -668,6 +843,41 @@ namespace Microsoft.EntityFrameworkCore
             DateTimeOffset? endDate)
             => (startDate.HasValue && endDate.HasValue)
                 ? (int?)DateDiffNanosecond(_, startDate.Value, endDate.Value)
+                : null;
+
+        /// <summary>
+        ///     Counts the number of nanosecond boundaries crossed between the startTimeSpan and endTimeSpan.
+        ///     Corresponds to SQL Server's DATEDIFF(NANOSECOND,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startTimeSpan">Starting timespan for the calculation.</param>
+        /// <param name="endTimeSpan">Ending timespan for the calculation.</param>
+        /// <returns>Number of nanosecond boundaries crossed between the dates.</returns>
+        public static int DateDiffNanosecond(
+            [CanBeNull] this DbFunctions _,
+            TimeSpan startTimeSpan,
+            TimeSpan endTimeSpan)
+        {
+            checked
+            {
+                return (int)((endTimeSpan.Ticks - startTimeSpan.Ticks) * 100);
+            }
+        }
+
+        /// <summary>
+        ///     Counts the number of nanosecond boundaries crossed between the startTimeSpan and endTimeSpan.
+        ///     Corresponds to SQL Server's DATEDIFF(NANOSECOND,startDate,endDate).
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="startTimeSpan">Starting timespan for the calculation.</param>
+        /// <param name="endTimeSpan">Ending timespan for the calculation.</param>
+        /// <returns>Number of nanosecond boundaries crossed between the dates.</returns>
+        public static int? DateDiffNanosecond(
+            [CanBeNull] this DbFunctions _,
+            TimeSpan? startTimeSpan,
+            TimeSpan? endTimeSpan)
+            => (startTimeSpan.HasValue && endTimeSpan.HasValue)
+                ? (int?)DateDiffNanosecond(_, startTimeSpan.Value, endTimeSpan.Value)
                 : null;
     }
 }

--- a/src/EFCore.SqlServer/Query/Pipeline/SqlServerDateDiffFunctionsTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Pipeline/SqlServerDateDiffFunctionsTranslator.cs
@@ -112,6 +112,18 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Pipeline
                 },
                 {
                     typeof(SqlServerDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(SqlServerDbFunctionsExtensions.DateDiffHour),
+                        new[] { typeof(DbFunctions), typeof(TimeSpan), typeof(TimeSpan) }),
+                    "HOUR"
+                },
+                {
+                    typeof(SqlServerDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(SqlServerDbFunctionsExtensions.DateDiffHour),
+                        new[] { typeof(DbFunctions), typeof(TimeSpan?), typeof(TimeSpan?) }),
+                    "HOUR"
+                },
+                {
+                    typeof(SqlServerDbFunctionsExtensions).GetRuntimeMethod(
                         nameof(SqlServerDbFunctionsExtensions.DateDiffMinute),
                         new[] { typeof(DbFunctions), typeof(DateTime), typeof(DateTime) }),
                     "MINUTE"
@@ -136,6 +148,18 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Pipeline
                 },
                 {
                     typeof(SqlServerDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(SqlServerDbFunctionsExtensions.DateDiffMinute),
+                        new[] { typeof(DbFunctions), typeof(TimeSpan), typeof(TimeSpan) }),
+                    "MINUTE"
+                },
+                {
+                    typeof(SqlServerDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(SqlServerDbFunctionsExtensions.DateDiffMinute),
+                        new[] { typeof(DbFunctions), typeof(TimeSpan?), typeof(TimeSpan?) }),
+                    "MINUTE"
+                },
+                {
+                    typeof(SqlServerDbFunctionsExtensions).GetRuntimeMethod(
                         nameof(SqlServerDbFunctionsExtensions.DateDiffSecond),
                         new[] { typeof(DbFunctions), typeof(DateTime), typeof(DateTime) }),
                     "SECOND"
@@ -160,6 +184,18 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Pipeline
                 },
                 {
                     typeof(SqlServerDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(SqlServerDbFunctionsExtensions.DateDiffSecond),
+                        new[] { typeof(DbFunctions), typeof(TimeSpan), typeof(TimeSpan) }),
+                    "SECOND"
+                },
+                {
+                    typeof(SqlServerDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(SqlServerDbFunctionsExtensions.DateDiffSecond),
+                        new[] { typeof(DbFunctions), typeof(TimeSpan?), typeof(TimeSpan?) }),
+                    "SECOND"
+                },
+                {
+                    typeof(SqlServerDbFunctionsExtensions).GetRuntimeMethod(
                         nameof(SqlServerDbFunctionsExtensions.DateDiffMillisecond),
                         new[] { typeof(DbFunctions), typeof(DateTime), typeof(DateTime) }),
                     "MILLISECOND"
@@ -180,6 +216,18 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Pipeline
                     typeof(SqlServerDbFunctionsExtensions).GetRuntimeMethod(
                         nameof(SqlServerDbFunctionsExtensions.DateDiffMillisecond),
                         new[] { typeof(DbFunctions), typeof(DateTimeOffset?), typeof(DateTimeOffset?) }),
+                    "MILLISECOND"
+                },
+                {
+                    typeof(SqlServerDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(SqlServerDbFunctionsExtensions.DateDiffMillisecond),
+                        new[] { typeof(DbFunctions), typeof(TimeSpan), typeof(TimeSpan) }),
+                    "MILLISECOND"
+                },
+                {
+                    typeof(SqlServerDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(SqlServerDbFunctionsExtensions.DateDiffMillisecond),
+                        new[] { typeof(DbFunctions), typeof(TimeSpan?), typeof(TimeSpan?) }),
                     "MILLISECOND"
                 },
                 {
@@ -204,6 +252,18 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Pipeline
                     typeof(SqlServerDbFunctionsExtensions).GetRuntimeMethod(
                         nameof(SqlServerDbFunctionsExtensions.DateDiffMicrosecond),
                         new[] { typeof(DbFunctions), typeof(DateTimeOffset?), typeof(DateTimeOffset?) }),
+                    "MICROSECOND"
+                },
+                {
+                    typeof(SqlServerDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(SqlServerDbFunctionsExtensions.DateDiffMicrosecond),
+                        new[] { typeof(DbFunctions), typeof(TimeSpan), typeof(TimeSpan) }),
+                    "MICROSECOND"
+                },
+                {
+                    typeof(SqlServerDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(SqlServerDbFunctionsExtensions.DateDiffMicrosecond),
+                        new[] { typeof(DbFunctions), typeof(TimeSpan?), typeof(TimeSpan?) }),
                     "MICROSECOND"
                 },
                 {
@@ -228,6 +288,18 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Pipeline
                     typeof(SqlServerDbFunctionsExtensions).GetRuntimeMethod(
                         nameof(SqlServerDbFunctionsExtensions.DateDiffNanosecond),
                         new[] { typeof(DbFunctions), typeof(DateTimeOffset?), typeof(DateTimeOffset?) }),
+                    "NANOSECOND"
+                },
+                {
+                    typeof(SqlServerDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(SqlServerDbFunctionsExtensions.DateDiffNanosecond),
+                        new[] { typeof(DbFunctions), typeof(TimeSpan), typeof(TimeSpan) }),
+                    "NANOSECOND"
+                },
+                {
+                    typeof(SqlServerDbFunctionsExtensions).GetRuntimeMethod(
+                        nameof(SqlServerDbFunctionsExtensions.DateDiffNanosecond),
+                        new[] { typeof(DbFunctions), typeof(TimeSpan?), typeof(TimeSpan?) }),
                     "NANOSECOND"
                 }
             };

--- a/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
@@ -99,6 +99,156 @@ WHERE (([m].[TimeSpanAsTime] = @__timeSpan_0) AND ([m].[TimeSpanAsTime] IS NOT N
             }
         }
 
+        [ConditionalFact]
+        public virtual void Can_query_using_DateDiffHour_using_TimeSpan()
+        {
+            using (var context = CreateContext())
+            {
+                var timeSpan = new TimeSpan(2, 1, 0);
+
+                var results
+                    = context.Set<MappedNullableDataTypes>()
+                        .Where(e => EF.Functions.DateDiffHour(e.TimeSpanAsTime, timeSpan) == 0)
+                        .Select(e => e.Int)
+                        .ToList();
+
+                Assert.Equal(0, results.Count);
+                Assert.Equal(
+                    @"@__timeSpan_1='02:01:00' (Nullable = true)
+
+SELECT [m].[Int]
+FROM [MappedNullableDataTypes] AS [m]
+WHERE (DATEDIFF(HOUR, [m].[TimeSpanAsTime], @__timeSpan_1) = 0) AND DATEDIFF(HOUR, [m].[TimeSpanAsTime], @__timeSpan_1) IS NOT NULL",
+                    Sql,
+                    ignoreLineEndingDifferences: true);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Can_query_using_DateDiffMinute_using_TimeSpan()
+        {
+            using (var context = CreateContext())
+            {
+                var timeSpan = new TimeSpan(2, 1, 0);
+
+                var results
+                    = context.Set<MappedNullableDataTypes>()
+                        .Where(e => EF.Functions.DateDiffMinute(e.TimeSpanAsTime, timeSpan) == 0)
+                        .Select(e => e.Int)
+                        .ToList();
+
+                Assert.Equal(0, results.Count);
+                Assert.Equal(
+                    @"@__timeSpan_1='02:01:00' (Nullable = true)
+
+SELECT [m].[Int]
+FROM [MappedNullableDataTypes] AS [m]
+WHERE (DATEDIFF(MINUTE, [m].[TimeSpanAsTime], @__timeSpan_1) = 0) AND DATEDIFF(MINUTE, [m].[TimeSpanAsTime], @__timeSpan_1) IS NOT NULL",
+                    Sql,
+                    ignoreLineEndingDifferences: true);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Can_query_using_DateDiffSecond_using_TimeSpan()
+        {
+            using (var context = CreateContext())
+            {
+                var timeSpan = new TimeSpan(2, 1, 0);
+
+                var results
+                    = context.Set<MappedNullableDataTypes>()
+                        .Where(e => EF.Functions.DateDiffSecond(e.TimeSpanAsTime, timeSpan) == 0)
+                        .Select(e => e.Int)
+                        .ToList();
+
+                Assert.Equal(0, results.Count);
+                Assert.Equal(
+                    @"@__timeSpan_1='02:01:00' (Nullable = true)
+
+SELECT [m].[Int]
+FROM [MappedNullableDataTypes] AS [m]
+WHERE (DATEDIFF(SECOND, [m].[TimeSpanAsTime], @__timeSpan_1) = 0) AND DATEDIFF(SECOND, [m].[TimeSpanAsTime], @__timeSpan_1) IS NOT NULL",
+                    Sql,
+                    ignoreLineEndingDifferences: true);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Can_query_using_DateDiffMillisecond_using_TimeSpan()
+        {
+            using (var context = CreateContext())
+            {
+                var timeSpan = new TimeSpan(2, 1, 0);
+
+                var results
+                    = context.Set<MappedNullableDataTypes>()
+                        .Where(e => EF.Functions.DateDiffMillisecond(e.TimeSpanAsTime, timeSpan) == 0)
+                        .Select(e => e.Int)
+                        .ToList();
+
+                Assert.Equal(0, results.Count);
+                Assert.Equal(
+                    @"@__timeSpan_1='02:01:00' (Nullable = true)
+
+SELECT [m].[Int]
+FROM [MappedNullableDataTypes] AS [m]
+WHERE (DATEDIFF(MILLISECOND, [m].[TimeSpanAsTime], @__timeSpan_1) = 0) AND DATEDIFF(MILLISECOND, [m].[TimeSpanAsTime], @__timeSpan_1) IS NOT NULL",
+                    Sql,
+                    ignoreLineEndingDifferences: true);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Can_query_using_DateDiffMicrosecond_using_TimeSpan()
+        {
+            using (var context = CreateContext())
+            {
+                var timeSpan = new TimeSpan(2, 1, 0);
+
+                var results
+                    = context.Set<MappedNullableDataTypes>()
+                        .Where(e => EF.Functions.DateDiffMicrosecond(e.TimeSpanAsTime, timeSpan) == 0)
+                        .Select(e => e.Int)
+                        .ToList();
+
+                Assert.Equal(0, results.Count);
+                Assert.Equal(
+                    @"@__timeSpan_1='02:01:00' (Nullable = true)
+
+SELECT [m].[Int]
+FROM [MappedNullableDataTypes] AS [m]
+WHERE (DATEDIFF(MICROSECOND, [m].[TimeSpanAsTime], @__timeSpan_1) = 0) AND DATEDIFF(MICROSECOND, [m].[TimeSpanAsTime], @__timeSpan_1) IS NOT NULL",
+                    Sql,
+                    ignoreLineEndingDifferences: true);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Can_query_using_DateDiffNanosecond_using_TimeSpan()
+        {
+            using (var context = CreateContext())
+            {
+                var timeSpan = new TimeSpan(2, 1, 0);
+
+                var results
+                    = context.Set<MappedNullableDataTypes>()
+                        .Where(e => EF.Functions.DateDiffNanosecond(e.TimeSpanAsTime, timeSpan) == 0)
+                        .Select(e => e.Int)
+                        .ToList();
+
+                Assert.Equal(0, results.Count);
+                Assert.Equal(
+                    @"@__timeSpan_1='02:01:00' (Nullable = true)
+
+SELECT [m].[Int]
+FROM [MappedNullableDataTypes] AS [m]
+WHERE (DATEDIFF(NANOSECOND, [m].[TimeSpanAsTime], @__timeSpan_1) = 0) AND DATEDIFF(NANOSECOND, [m].[TimeSpanAsTime], @__timeSpan_1) IS NOT NULL",
+                    Sql,
+                    ignoreLineEndingDifferences: true);
+            }
+        }
+
         [Fact]
         public virtual void Can_query_using_any_mapped_data_type()
         {


### PR DESCRIPTION
Summary of the changes
 - Added TimeSpan overloads to DateDiffHour, DateDiffMinute, DateDiffSecond, DateDiffMillisecond, DateDiffMicrosecond, DateDiffNanosecond
 - Added unit tests to check overloads

Fixes #14685