### PR TITLE
Enable nullable backing field pattern for store-generated defaults

### DIFF
--- a/src/EFCore.InMemory/Query/Pipeline/InMemoryQueryExpression.cs
+++ b/src/EFCore.InMemory/Query/Pipeline/InMemoryQueryExpression.cs
@@ -142,7 +142,16 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Pipeline
             var readValueExpression = (MethodCallExpression)projection;
             var index = (int)((ConstantExpression)readValueExpression.Arguments[1]).Value;
 
-            return _valueBufferSlots[index];
+            var valueBufferSlotExpression = _valueBufferSlots[index];
+
+            var memberType = member.MemberType;
+            if (memberType != null
+                && memberType != valueBufferSlotExpression.Type)
+            {
+                valueBufferSlotExpression = Convert(valueBufferSlotExpression, memberType);
+            }
+
+            return valueBufferSlotExpression;
         }
 
         public LambdaExpression GetScalarProjectionLambda()

--- a/src/EFCore.InMemory/Query/Pipeline/Translator.cs
+++ b/src/EFCore.InMemory/Query/Pipeline/Translator.cs
@@ -54,7 +54,15 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Pipeline
                     var entityType = entityShaper.EntityType;
                     var property = entityType.FindProperty((string)((ConstantExpression)methodCallExpression.Arguments[1]).Value);
 
-                    return _inMemoryQueryExpression.BindProperty(entityShaper.ValueBufferExpression, property);
+                    var boundPropertyExpression = _inMemoryQueryExpression.BindProperty(entityShaper.ValueBufferExpression, property);
+
+                    if (boundPropertyExpression.Type
+                        != methodCallExpression.Type)
+                    {
+                        boundPropertyExpression = Expression.Convert(boundPropertyExpression, methodCallExpression.Type);
+                    }
+
+                    return boundPropertyExpression;
                 }
             }
 

--- a/src/EFCore.Relational/Query/Pipeline/ExpressionExtensions.cs
+++ b/src/EFCore.Relational/Query/Pipeline/ExpressionExtensions.cs
@@ -1,22 +1,57 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 {
     public static class ExpressionExtensions
     {
-        public static RelationalTypeMapping InferTypeMapping(params Expression[] expressions)
+        public static RelationalTypeMapping InferTypeMapping(
+            IValueConverterSelector valueConverterSelector,
+            params Expression[] expressions)
         {
             for (var i = 0; i < expressions.Length; i++)
             {
-                if (expressions[i] is SqlExpression sql
-                    && sql.TypeMapping != null)
+                if (expressions[i] is SqlExpression sqlExpression)
                 {
-                    return sql.TypeMapping;
+                    var mapping = sqlExpression.TypeMapping;
+                    if (mapping != null)
+                    {
+                        return mapping;
+                    }
+
+                    // This is to cover the cases of enums and char values being erased when using
+                    // literals in the expression tree. It adds a new converter onto the type mapper
+                    // that takes the literal and converts it back to the type that the type mapping
+                    // is expecting.
+                    // This code is temporary until more complete type inference is completed.
+                    if (sqlExpression is SqlUnaryExpression sqlUnaryExpression
+                        && sqlUnaryExpression.OperatorType == ExpressionType.Convert)
+                    {
+                        var operandType = sqlUnaryExpression.Operand.Type.UnwrapNullableType();
+                        mapping = InferTypeMapping(valueConverterSelector, sqlUnaryExpression.Operand);
+
+                        if (mapping != null
+                            && (operandType.IsEnum
+                            || operandType == typeof(char)
+                            || mapping.Converter?.ProviderClrType == typeof(byte[])))
+                        {
+                            if (mapping.ClrType != sqlUnaryExpression.Type)
+                            {
+                                var converter = valueConverterSelector.Select(sqlUnaryExpression.Type, mapping.ClrType).ToList();
+
+                                mapping = (RelationalTypeMapping)mapping.Clone(converter.First().Create());
+                            }
+
+                            return mapping;
+                        }
+                    }
                 }
             }
 

--- a/src/EFCore.Relational/Storage/RelationalTypeMappingInfo.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMappingInfo.cs
@@ -214,9 +214,17 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public bool? IsRowVersion => _coreTypeMappingInfo.IsRowVersion;
 
         /// <summary>
-        ///     The CLR type in the model.
+        ///     The CLR type used to store the property in the model. This may be the backing field type.
+        ///     May be null if type information is conveyed via other means (e.g. the store name in a relational type mapping info)
         /// </summary>
         public Type ClrType => _coreTypeMappingInfo.ClrType;
+
+        /// <summary>
+        ///     The CLR type of the property, which may be different from <see cref="ClrType"/> if a backing field of
+        ///     a different type is used.
+        ///     May be null if type information is conveyed via other means (e.g. the store name in a relational type mapping info)
+        /// </summary>
+        public Type DeclaredClrType => _coreTypeMappingInfo.DeclaredClrType;
 
         /// <summary>
         ///     Returns a new <see cref="TypeMappingInfo" /> with the given converter applied.

--- a/src/EFCore.Relational/Storage/RelationalTypeMappingSource.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMappingSource.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -126,54 +127,79 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 k =>
                 {
                     var (info, providerType, converter) = k;
+
+                    var sourceType = info.ClrType;
+                    var sourceDeclaredType = info.DeclaredClrType;
+
+                    var needsConvertFromObject
+                        = sourceType == typeof(object)
+                          && sourceDeclaredType != typeof(object);
+
+                    var effectiveSourceType = needsConvertFromObject ? sourceDeclaredType : sourceType;
+
+                    ValueConverterInfo fromObjectConverter = default;
+                    var fromObjectMappingInfo = info;
+
+                    if (needsConvertFromObject)
+                    {
+                        fromObjectConverter = Dependencies.ValueConverterSelector
+                            .Select(typeof(object), sourceDeclaredType)
+                            .Single();
+
+                        fromObjectMappingInfo = info.WithConverter(fromObjectConverter);
+                    }
+
                     var mapping = providerType == null
-                                  || providerType == info.ClrType
-                        ? FindMapping(info)
+                              || providerType == effectiveSourceType
+                        ? FindMapping(fromObjectMappingInfo)
                         : null;
 
-                    if (mapping == null)
+                    if (mapping == null
+                        && effectiveSourceType != null)
                     {
-                        var sourceType = info.ClrType;
-
-                        if (sourceType != null)
+                        foreach (var converterInfo in Dependencies
+                            .ValueConverterSelector
+                            .Select(effectiveSourceType, providerType))
                         {
-                            foreach (var converterInfo in Dependencies
-                                .ValueConverterSelector
-                                .Select(sourceType, providerType))
+                            var mappingInfoUsed = info.WithConverter(converterInfo);
+                            mapping = FindMapping(mappingInfoUsed);
+
+                            if (mapping == null
+                                && providerType != null)
                             {
-                                var mappingInfoUsed = info.WithConverter(converterInfo);
-                                mapping = FindMapping(mappingInfoUsed);
-
-                                if (mapping == null
-                                    && providerType != null)
+                                foreach (var secondConverterInfo in Dependencies
+                                    .ValueConverterSelector
+                                    .Select(providerType))
                                 {
-                                    foreach (var secondConverterInfo in Dependencies
-                                        .ValueConverterSelector
-                                        .Select(providerType))
-                                    {
-                                        mapping = FindMapping(mappingInfoUsed.WithConverter(secondConverterInfo));
+                                    mapping = FindMapping(mappingInfoUsed.WithConverter(secondConverterInfo));
 
-                                        if (mapping != null)
-                                        {
-                                            mapping = (RelationalTypeMapping)mapping.Clone(secondConverterInfo.Create());
-                                            break;
-                                        }
+                                    if (mapping != null)
+                                    {
+                                        mapping = (RelationalTypeMapping)mapping.Clone(secondConverterInfo.Create());
+                                        break;
                                     }
                                 }
+                            }
 
-                                if (mapping != null)
-                                {
-                                    mapping = (RelationalTypeMapping)mapping.Clone(converterInfo.Create());
-                                    break;
-                                }
+                            if (mapping != null)
+                            {
+                                mapping = (RelationalTypeMapping)mapping.Clone(converterInfo.Create());
+                                break;
                             }
                         }
                     }
 
-                    if (mapping != null
-                        && converter != null)
+                    if (mapping != null)
                     {
-                        mapping = (RelationalTypeMapping)mapping.Clone(converter);
+                        if (needsConvertFromObject)
+                        {
+                            mapping = (RelationalTypeMapping)mapping.Clone(fromObjectConverter.Create());
+                        }
+
+                        if (converter != null)
+                        {
+                            mapping = (RelationalTypeMapping)mapping.Clone(converter);
+                        }
                     }
 
                     return mapping;

--- a/src/EFCore.SqlServer.NTS/Query/Pipeline/SqlServerNetTopologySuiteMethodCallTranslatorPlugin.cs
+++ b/src/EFCore.SqlServer.NTS/Query/Pipeline/SqlServerNetTopologySuiteMethodCallTranslatorPlugin.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Relational.Query.Pipeline;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Pipeline
@@ -30,12 +31,14 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Pipeline
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public SqlServerNetTopologySuiteMethodCallTranslatorPlugin(IRelationalTypeMappingSource typeMappingSource,
-            ISqlExpressionFactory sqlExpressionFactory)
+        public SqlServerNetTopologySuiteMethodCallTranslatorPlugin(
+            IRelationalTypeMappingSource typeMappingSource,
+            ISqlExpressionFactory sqlExpressionFactory,
+            IValueConverterSelector valueConverterSelector)
         {
             Translators = new IMethodCallTranslator[]
             {
-                new SqlServerGeometryMethodTranslator(typeMappingSource, sqlExpressionFactory),
+                new SqlServerGeometryMethodTranslator(typeMappingSource, sqlExpressionFactory, valueConverterSelector),
                 new SqlServerGeometryCollectionMethodTranslator(typeMappingSource, sqlExpressionFactory),
                 new SqlServerLineStringMethodTranslator(typeMappingSource, sqlExpressionFactory),
                 new SqlServerPolygonMethodTranslator(typeMappingSource, sqlExpressionFactory)

--- a/src/EFCore.SqlServer/Query/Pipeline/SqlServerDateDiffFunctionsTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Pipeline/SqlServerDateDiffFunctionsTranslator.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Relational.Query.Pipeline;
 using Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Pipeline
 {
@@ -232,11 +233,14 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Pipeline
                 }
             };
         private readonly ISqlExpressionFactory _sqlExpressionFactory;
+        private readonly IValueConverterSelector _valueConverterSelector;
 
         public SqlServerDateDiffFunctionsTranslator(
-            ISqlExpressionFactory sqlExpressionFactory)
+            ISqlExpressionFactory sqlExpressionFactory,
+            IValueConverterSelector valueConverterSelector)
         {
             _sqlExpressionFactory = sqlExpressionFactory;
+            _valueConverterSelector = valueConverterSelector;
         }
 
         public SqlExpression Translate(SqlExpression instance, MethodInfo method, IList<SqlExpression> arguments)
@@ -245,7 +249,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Pipeline
             {
                 var startDate = arguments[1];
                 var endDate = arguments[2];
-                var typeMapping = ExpressionExtensions.InferTypeMapping(startDate, endDate);
+                var typeMapping = ExpressionExtensions.InferTypeMapping(_valueConverterSelector, startDate, endDate);
 
                 startDate = _sqlExpressionFactory.ApplyTypeMapping(startDate, typeMapping);
                 endDate = _sqlExpressionFactory.ApplyTypeMapping(endDate, typeMapping);

--- a/src/EFCore.SqlServer/Query/Pipeline/SqlServerMethodCallTranslatorProvider.cs
+++ b/src/EFCore.SqlServer/Query/Pipeline/SqlServerMethodCallTranslatorProvider.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Relational.Query.Pipeline;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Pipeline
 {
@@ -10,16 +11,17 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Pipeline
     {
         public SqlServerMethodCallTranslatorProvider(
             ISqlExpressionFactory sqlExpressionFactory,
+            IValueConverterSelector valueConverterSelector,
             IEnumerable<IMethodCallTranslatorPlugin> plugins)
             : base(sqlExpressionFactory, plugins)
         {
             AddTranslators(new IMethodCallTranslator[]
             {
-                new SqlServerMathTranslator(sqlExpressionFactory),
+                new SqlServerMathTranslator(sqlExpressionFactory, valueConverterSelector),
                 new SqlServerNewGuidTranslator(sqlExpressionFactory),
-                new SqlServerStringMethodTranslator(sqlExpressionFactory),
+                new SqlServerStringMethodTranslator(sqlExpressionFactory, valueConverterSelector),
                 new SqlServerDateTimeMethodTranslator(sqlExpressionFactory),
-                new SqlServerDateDiffFunctionsTranslator(sqlExpressionFactory),
+                new SqlServerDateDiffFunctionsTranslator(sqlExpressionFactory, valueConverterSelector),
                 new SqlServerConvertTranslator(sqlExpressionFactory),
                 new SqlServerObjectToStringTranslator(sqlExpressionFactory),
                 new SqlServerFullTextSearchFunctionsTranslator(sqlExpressionFactory),

--- a/src/EFCore.Sqlite.Core/Query/Pipeline/SqliteMathTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Pipeline/SqliteMathTranslator.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using Microsoft.EntityFrameworkCore.Relational.Query.Pipeline;
 using Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Pipeline
 {
@@ -43,10 +44,14 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Pipeline
         };
 
         private readonly ISqlExpressionFactory _sqlExpressionFactory;
+        private readonly IValueConverterSelector _valueConverterSelector;
 
-        public SqliteMathTranslator(ISqlExpressionFactory sqlExpressionFactory)
+        public SqliteMathTranslator(
+            ISqlExpressionFactory sqlExpressionFactory,
+            IValueConverterSelector valueConverterSelector)
         {
             _sqlExpressionFactory = sqlExpressionFactory;
+            _valueConverterSelector = valueConverterSelector;
         }
 
         public SqlExpression Translate(SqlExpression instance, MethodInfo method, IList<SqlExpression> arguments)
@@ -58,7 +63,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Pipeline
                 if (string.Equals(sqlFunctionName, "max")
                     || string.Equals(sqlFunctionName, "max"))
                 {
-                    typeMapping = ExpressionExtensions.InferTypeMapping(arguments[0], arguments[1]);
+                    typeMapping = ExpressionExtensions.InferTypeMapping(_valueConverterSelector, arguments[0], arguments[1]);
                     newArguments = new List<SqlExpression>
                     {
                         _sqlExpressionFactory.ApplyTypeMapping(arguments[0], typeMapping),

--- a/src/EFCore.Sqlite.Core/Query/Pipeline/SqliteMethodCallTranslatorProvider.cs
+++ b/src/EFCore.Sqlite.Core/Query/Pipeline/SqliteMethodCallTranslatorProvider.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Relational.Query.Pipeline;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Pipeline
 {
@@ -10,15 +11,16 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Pipeline
     {
         public SqliteMethodCallTranslatorProvider(
             ISqlExpressionFactory sqlExpressionFactory,
+            IValueConverterSelector valueConverterSelector,
             IEnumerable<IMethodCallTranslatorPlugin> plugins)
             : base(sqlExpressionFactory, plugins)
         {
             AddTranslators(
                 new IMethodCallTranslator[]
                 {
-                    new SqliteMathTranslator(sqlExpressionFactory),
+                    new SqliteMathTranslator(sqlExpressionFactory, valueConverterSelector),
                     new SqliteDateTimeAddTranslator(sqlExpressionFactory),
-                    new SqliteStringMethodTranslator(sqlExpressionFactory),
+                    new SqliteStringMethodTranslator(sqlExpressionFactory, valueConverterSelector),
                 });
         }
     }

--- a/src/EFCore/ChangeTracking/CollectionEntry`.cs
+++ b/src/EFCore/ChangeTracking/CollectionEntry`.cs
@@ -64,7 +64,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         /// </summary>
         public new virtual IEnumerable<TProperty> CurrentValue
         {
-            get => this.GetInfrastructure().GetCurrentValue<IEnumerable<TProperty>>(Metadata);
+            get => this.GetInfrastructure().GetDeclaredCurrentValue<IEnumerable<TProperty>>(Metadata);
             [param: CanBeNull] set => base.CurrentValue = value;
         }
 

--- a/src/EFCore/ChangeTracking/Internal/CurrentPropertyValues.cs
+++ b/src/EFCore/ChangeTracking/Internal/CurrentPropertyValues.cs
@@ -33,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public override TValue GetValue<TValue>(string propertyName)
-            => InternalEntry.GetCurrentValue<TValue>(InternalEntry.EntityType.GetProperty(propertyName));
+            => InternalEntry.GetDeclaredCurrentValue<TValue>(InternalEntry.EntityType.GetProperty(propertyName));
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -42,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public override TValue GetValue<TValue>(IProperty property)
-            => InternalEntry.GetCurrentValue<TValue>(InternalEntry.EntityType.CheckPropertyBelongsToType(property));
+            => InternalEntry.GetDeclaredCurrentValue<TValue>(InternalEntry.EntityType.CheckPropertyBelongsToType(property));
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -694,6 +694,15 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public virtual TProperty GetDeclaredCurrentValue<TProperty>(IPropertyBase propertyBase)
+            => ((Func<InternalEntityEntry, TProperty>)propertyBase.GetPropertyAccessors().DeclaredCurrentValueGetter)(this);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public virtual TProperty GetOriginalValue<TProperty>(IProperty property)
             => ((Func<InternalEntityEntry, TProperty>)property.GetPropertyAccessors().OriginalValueGetter)(this);
 
@@ -703,9 +712,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual TProperty GetRelationshipSnapshotValue<TProperty>([NotNull] IPropertyBase propertyBase)
-            => ((Func<InternalEntityEntry, TProperty>)propertyBase.GetPropertyAccessors().RelationshipSnapshotGetter)(
-                    this);
+        public virtual TProperty GetDeclaredOriginalValue<TProperty>(IProperty property)
+            => ((Func<InternalEntityEntry, TProperty>)property.GetPropertyAccessors().DeclaredOriginalValueGetter)(this);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/ChangeTracking/Internal/OriginalPropertyValues.cs
+++ b/src/EFCore/ChangeTracking/Internal/OriginalPropertyValues.cs
@@ -33,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public override TValue GetValue<TValue>(string propertyName)
-            => InternalEntry.GetOriginalValue<TValue>(InternalEntry.EntityType.GetProperty(propertyName));
+            => InternalEntry.GetDeclaredOriginalValue<TValue>(InternalEntry.EntityType.GetProperty(propertyName));
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -42,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public override TValue GetValue<TValue>(IProperty property)
-            => InternalEntry.GetOriginalValue<TValue>(InternalEntry.EntityType.CheckPropertyBelongsToType(property));
+            => InternalEntry.GetDeclaredOriginalValue<TValue>(InternalEntry.EntityType.CheckPropertyBelongsToType(property));
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/ChangeTracking/PropertyEntry`.cs
+++ b/src/EFCore/ChangeTracking/PropertyEntry`.cs
@@ -59,7 +59,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         /// </summary>
         public new virtual TProperty CurrentValue
         {
-            get => InternalEntry.GetCurrentValue<TProperty>(Metadata);
+            get => InternalEntry.GetDeclaredCurrentValue<TProperty>(Metadata);
             [param: CanBeNull] set => base.CurrentValue = value;
         }
 
@@ -71,7 +71,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         /// </summary>
         public new virtual TProperty OriginalValue
         {
-            get => InternalEntry.GetOriginalValue<TProperty>(Metadata);
+            get => InternalEntry.GetDeclaredOriginalValue<TProperty>(Metadata);
             [param: CanBeNull] set => base.OriginalValue = value;
         }
     }

--- a/src/EFCore/ChangeTracking/ReferenceEntry`.cs
+++ b/src/EFCore/ChangeTracking/ReferenceEntry`.cs
@@ -75,7 +75,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         /// </summary>
         public new virtual TProperty CurrentValue
         {
-            get => this.GetInfrastructure().GetCurrentValue<TProperty>(Metadata);
+            get => this.GetInfrastructure().GetDeclaredCurrentValue<TProperty>(Metadata);
             [param: CanBeNull] set => base.CurrentValue = value;
         }
 

--- a/src/EFCore/ChangeTracking/ValueComparer`.cs
+++ b/src/EFCore/ChangeTracking/ValueComparer`.cs
@@ -113,9 +113,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                 || unwrappedType == typeof(bool)
                 || unwrappedType == typeof(decimal)
                 || unwrappedType == typeof(double)
-                || unwrappedType == typeof(float)
-                || unwrappedType == typeof(object)
-            )
+                || unwrappedType == typeof(float))
             {
                 return Expression.Lambda<Func<T, T, bool>>(
                     Expression.Equal(param1, param2),

--- a/src/EFCore/Metadata/IPropertyBase.cs
+++ b/src/EFCore/Metadata/IPropertyBase.cs
@@ -23,9 +23,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ITypeBase DeclaringType { get; }
 
         /// <summary>
-        ///     Gets the type of value that this property holds.
+        ///     Gets the type of value that this property holds, which will be the type of the
+        ///     field for properties that are known to be backed by fields.
         /// </summary>
         Type ClrType { get; }
+
+        /// <summary>
+        ///     Gets the type that this property is declared as.
+        /// </summary>
+        Type DeclaredClrType { get; }
 
         /// <summary>
         ///     Gets the <see cref="PropertyInfo" /> for the underlying CLR property that this

--- a/src/EFCore/Metadata/Internal/Navigation.cs
+++ b/src/EFCore/Metadata/Internal/Navigation.cs
@@ -49,7 +49,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public override Type ClrType => this.GetIdentifyingMemberInfo()?.GetMemberType() ?? typeof(object);
+        public override Type ClrType => (FieldInfo ?? (MemberInfo)PropertyInfo)?.GetMemberType() ?? typeof(object);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public override Type DeclaredClrType => (PropertyInfo ?? (MemberInfo)FieldInfo)?.GetMemberType() ?? typeof(object);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/Property.cs
+++ b/src/EFCore/Metadata/Internal/Property.cs
@@ -55,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Check.NotNull(declaringEntityType, nameof(declaringEntityType));
 
             DeclaringEntityType = declaringEntityType;
-            ClrType = clrType;
+            DeclaredClrType = clrType;
             _configurationSource = configurationSource;
             _typeConfigurationSource = typeConfigurationSource;
 
@@ -95,7 +95,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public override Type ClrType { [DebuggerStepThrough] get; }
+        public override Type ClrType
+        {
+            [DebuggerStepThrough] get => FieldInfo?.FieldType ?? DeclaredClrType;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public override Type DeclaredClrType
+        {
+            [DebuggerStepThrough] get;
+        }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/PropertyAccessors.cs
+++ b/src/EFCore/Metadata/Internal/PropertyAccessors.cs
@@ -23,14 +23,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public PropertyAccessors(
             [NotNull] Delegate currentValueGetter,
+            [NotNull] Delegate declaredCurrentValueGetter,
             [NotNull] Delegate preStoreGeneratedCurrentValueGetter,
             [CanBeNull] Delegate originalValueGetter,
+            [CanBeNull] Delegate declaredOriginalValueGetter,
             [NotNull] Delegate relationshipSnapshotGetter,
             [CanBeNull] Func<ValueBuffer, object> valueBufferGetter)
         {
             CurrentValueGetter = currentValueGetter;
+            DeclaredCurrentValueGetter = declaredCurrentValueGetter;
             PreStoreGeneratedCurrentValueGetter = preStoreGeneratedCurrentValueGetter;
             OriginalValueGetter = originalValueGetter;
+            DeclaredOriginalValueGetter = declaredOriginalValueGetter;
             RelationshipSnapshotGetter = relationshipSnapshotGetter;
             ValueBufferGetter = valueBufferGetter;
         }
@@ -49,6 +53,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public Delegate DeclaredCurrentValueGetter { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public Delegate PreStoreGeneratedCurrentValueGetter { get; }
 
         /// <summary>
@@ -58,6 +70,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public Delegate OriginalValueGetter { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public Delegate DeclaredOriginalValueGetter { get; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/PropertyBase.cs
+++ b/src/EFCore/Metadata/Internal/PropertyBase.cs
@@ -298,6 +298,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public abstract Type DeclaredClrType { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public virtual IClrPropertyGetter Getter =>
             NonCapturingLazyInitializer.EnsureInitialized(
                 ref _getter, this,

--- a/src/EFCore/Metadata/Internal/ServiceProperty.cs
+++ b/src/EFCore/Metadata/Internal/ServiceProperty.cs
@@ -40,7 +40,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Check.NotNull(declaringEntityType, nameof(declaringEntityType));
 
             DeclaringEntityType = declaringEntityType;
-            ClrType = propertyInfo?.PropertyType ?? fieldInfo?.FieldType;
+            DeclaredClrType = (propertyInfo ?? (MemberInfo)fieldInfo).GetMemberType();
+            ClrType = (fieldInfo ?? (MemberInfo)propertyInfo).GetMemberType();
             _configurationSource = configurationSource;
 
             Builder = new InternalServicePropertyBuilder(this, declaringEntityType.Model.Builder);
@@ -80,6 +81,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public override Type ClrType { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public override Type DeclaredClrType { get; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Query/Pipeline/ProjectionMember.cs
+++ b/src/EFCore/Query/Pipeline/ProjectionMember.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Reflection;
@@ -38,6 +39,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
 
             return new ProjectionMember(existingChain);
         }
+
+        public Type MemberType => _memberChain.LastOrDefault()?.GetMemberType();
 
         public override int GetHashCode()
         {

--- a/src/EFCore/Storage/CoreTypeMapping.cs
+++ b/src/EFCore/Storage/CoreTypeMapping.cs
@@ -38,33 +38,15 @@ namespace Microsoft.EntityFrameworkCore.Storage
             /// <param name="converter"> Converts types to and from the store whenever this mapping is used. </param>
             /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
             /// <param name="keyComparer"> Supports custom comparisons between keys--e.g. PK to FK comparison. </param>
+            /// <param name="structuralComparer"> Supports structural snapshotting needed for mutable reference types. </param>
             /// <param name="valueGeneratorFactory"> An optional factory for creating a specific <see cref="ValueGenerator" />. </param>
             public CoreTypeMappingParameters(
                 [NotNull] Type clrType,
                 [CanBeNull] ValueConverter converter = null,
                 [CanBeNull] ValueComparer comparer = null,
                 [CanBeNull] ValueComparer keyComparer = null,
+                [CanBeNull] ValueComparer structuralComparer = null,
                 [CanBeNull] Func<IProperty, IEntityType, ValueGenerator> valueGeneratorFactory = null)
-                : this(clrType, converter, comparer, keyComparer, null, valueGeneratorFactory)
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new <see cref="CoreTypeMappingParameters" /> parameter object.
-            /// </summary>
-            /// <param name="clrType"> The .NET type used in the EF model. </param>
-            /// <param name="converter"> Converts types to and from the store whenever this mapping is used. </param>
-            /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
-            /// <param name="keyComparer"> Supports custom comparisons between keys--e.g. PK to FK comparison. </param>
-            /// <param name="structuralComparer"> Supports structural snapshotting needed for mutable reference types. </param>
-            /// <param name="valueGeneratorFactory"> An optional factory for creating a specific <see cref="ValueGenerator" />. </param>
-            public CoreTypeMappingParameters(
-                [NotNull] Type clrType,
-                [CanBeNull] ValueConverter converter,
-                [CanBeNull] ValueComparer comparer,
-                [CanBeNull] ValueComparer keyComparer,
-                [CanBeNull] ValueComparer structuralComparer,
-                [CanBeNull] Func<IProperty, IEntityType, ValueGenerator> valueGeneratorFactory)
             {
                 Check.NotNull(clrType, nameof(clrType));
 

--- a/src/EFCore/Storage/ValueConversion/BoolToZeroOneConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/BoolToZeroOneConverter.cs
@@ -36,7 +36,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
                 typeof(BoolToZeroOneConverter<TProvider>),
                 typeof(int), typeof(short), typeof(long), typeof(sbyte),
                 typeof(uint), typeof(ushort), typeof(ulong), typeof(byte),
-                typeof(decimal), typeof(double), typeof(float));
+                typeof(decimal), typeof(double), typeof(float), typeof(char));
 
             return Activator.CreateInstance<TProvider>();
         }
@@ -67,7 +67,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
                                                     ? (double)1
                                                     : type == typeof(float)
                                                         ? (float)1
-                                                        : (object)1);
+                                                        : type == typeof(char)
+                                                            ? (char)1
+                                                            : (object)1);
         }
     }
 }

--- a/src/EFCore/Storage/ValueConversion/EnumToNumberConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/EnumToNumberConverter.cs
@@ -66,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
                 typeof(EnumToNumberConverter<TEnum, TNumber>),
                 typeof(int), typeof(long), typeof(short), typeof(byte),
                 typeof(uint), typeof(ulong), typeof(ushort), typeof(sbyte),
-                typeof(double), typeof(float), typeof(decimal));
+                typeof(double), typeof(float), typeof(decimal), typeof(char));
 
             var param = Expression.Parameter(typeof(TEnum), "value");
 

--- a/test/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
+++ b/test/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -53,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Theory(Skip = "QueryIssue")]
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public virtual async Task Can_filter_projection_with_inline_enum_variable(bool async)
@@ -203,7 +204,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual void Can_query_using_any_data_type()
         {
             using (var context = CreateContext())
@@ -216,7 +217,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual void Can_query_using_any_data_type_shadow()
         {
             using (var context = CreateContext())
@@ -549,7 +550,7 @@ namespace Microsoft.EntityFrameworkCore
             return entityEntry;
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual void Can_query_using_any_nullable_data_type()
         {
             using (var context = CreateContext())
@@ -562,7 +563,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual void Can_query_using_any_data_type_nullable_shadow()
         {
             using (var context = CreateContext())
@@ -925,7 +926,7 @@ namespace Microsoft.EntityFrameworkCore
             return entityEntry;
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual void Can_query_using_any_nullable_data_type_as_literal()
         {
             using (var context = CreateContext())
@@ -1135,7 +1136,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "Tasklist#8")]
+        [Fact]
         public virtual void Can_query_with_null_parameters_using_any_nullable_data_type()
         {
             using (var context = CreateContext())
@@ -1670,6 +1671,220 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
+        [Fact]
+        public virtual void Can_insert_and_read_back_object_backed_data_types()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<ObjectBackedDataTypes>().Add(
+                    new ObjectBackedDataTypes
+                    {
+                        Id = 101,
+                        PartitionId = 101,
+                        String = "TestString",
+                        Bytes = new byte[] { 10, 9, 8, 7, 6 },
+                        Int16 = -1234,
+                        Int32 = -123456789,
+                        Int64 = -1234567890123456789L,
+                        Double = -1.23456789,
+                        Decimal = -1234567890.01M,
+                        DateTime = DateTime.Parse("01/01/2000 12:34:56"),
+                        DateTimeOffset = new DateTimeOffset(DateTime.Parse("01/01/2000 12:34:56"), TimeSpan.FromHours(-8.0)),
+                        TimeSpan = new TimeSpan(0, 10, 9, 8, 7),
+                        Single = -1.234F,
+                        Boolean = false,
+                        Byte = 255,
+                        UnsignedInt16 = 1234,
+                        UnsignedInt32 = 1234565789U,
+                        UnsignedInt64 = 1234567890123456789UL,
+                        Character = 'a',
+                        SignedByte = -128,
+                        Enum64 = Enum64.SomeValue,
+                        Enum32 = Enum32.SomeValue,
+                        Enum16 = Enum16.SomeValue,
+                        Enum8 = Enum8.SomeValue,
+                        EnumU64 = EnumU64.SomeValue,
+                        EnumU32 = EnumU32.SomeValue,
+                        EnumU16 = EnumU16.SomeValue,
+                        EnumS8 = EnumS8.SomeValue
+                    });
+
+                Assert.Equal(1, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                var dt = context.Set<ObjectBackedDataTypes>().Where(ndt => ndt.Id == 101).ToList().Single();
+
+                Assert.Equal("TestString", dt.String);
+                Assert.Equal(new byte[] { 10, 9, 8, 7, 6 }, dt.Bytes);
+                Assert.Equal((short)-1234, dt.Int16);
+                Assert.Equal(-123456789, dt.Int32);
+                Assert.Equal(-1234567890123456789L, dt.Int64);
+                Assert.Equal(-1.23456789, dt.Double);
+                Assert.Equal(-1234567890.01M, dt.Decimal);
+                Assert.Equal(DateTime.Parse("01/01/2000 12:34:56"), dt.DateTime);
+                Assert.Equal(new DateTimeOffset(DateTime.Parse("01/01/2000 12:34:56"), TimeSpan.FromHours(-8.0)), dt.DateTimeOffset);
+                Assert.Equal(new TimeSpan(0, 10, 9, 8, 7), dt.TimeSpan);
+                Assert.Equal(-1.234F, dt.Single);
+                Assert.Equal(false, dt.Boolean);
+                Assert.Equal((byte)255, dt.Byte);
+                Assert.Equal(Enum64.SomeValue, dt.Enum64);
+                Assert.Equal(Enum32.SomeValue, dt.Enum32);
+                Assert.Equal(Enum16.SomeValue, dt.Enum16);
+                Assert.Equal(Enum8.SomeValue, dt.Enum8);
+                Assert.Equal((ushort)1234, dt.UnsignedInt16);
+                Assert.Equal(1234565789U, dt.UnsignedInt32);
+                Assert.Equal(1234567890123456789UL, dt.UnsignedInt64);
+                Assert.Equal('a', dt.Character);
+                Assert.Equal((sbyte)-128, dt.SignedByte);
+                Assert.Equal(EnumU64.SomeValue, dt.EnumU64);
+                Assert.Equal(EnumU32.SomeValue, dt.EnumU32);
+                Assert.Equal(EnumU16.SomeValue, dt.EnumU16);
+                Assert.Equal(EnumS8.SomeValue, dt.EnumS8);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_nullable_backed_data_types()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<NullableBackedDataTypes>().Add(
+                    new NullableBackedDataTypes
+                    {
+                        Id = 101,
+                        PartitionId = 101,
+                        Int16 = -1234,
+                        Int32 = -123456789,
+                        Int64 = -1234567890123456789L,
+                        Double = -1.23456789,
+                        Decimal = -1234567890.01M,
+                        DateTime = DateTime.Parse("01/01/2000 12:34:56"),
+                        DateTimeOffset = new DateTimeOffset(DateTime.Parse("01/01/2000 12:34:56"), TimeSpan.FromHours(-8.0)),
+                        TimeSpan = new TimeSpan(0, 10, 9, 8, 7),
+                        Single = -1.234F,
+                        Boolean = false,
+                        Byte = 255,
+                        UnsignedInt16 = 1234,
+                        UnsignedInt32 = 1234565789U,
+                        UnsignedInt64 = 1234567890123456789UL,
+                        Character = 'a',
+                        SignedByte = -128,
+                        Enum64 = Enum64.SomeValue,
+                        Enum32 = Enum32.SomeValue,
+                        Enum16 = Enum16.SomeValue,
+                        Enum8 = Enum8.SomeValue,
+                        EnumU64 = EnumU64.SomeValue,
+                        EnumU32 = EnumU32.SomeValue,
+                        EnumU16 = EnumU16.SomeValue,
+                        EnumS8 = EnumS8.SomeValue
+                    });
+
+                Assert.Equal(1, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                var dt = context.Set<NullableBackedDataTypes>().Where(ndt => ndt.Id == 101).ToList().Single();
+
+                Assert.Equal((short)-1234, dt.Int16);
+                Assert.Equal(-123456789, dt.Int32);
+                Assert.Equal(-1234567890123456789L, dt.Int64);
+                Assert.Equal(-1.23456789, dt.Double);
+                Assert.Equal(-1234567890.01M, dt.Decimal);
+                Assert.Equal(DateTime.Parse("01/01/2000 12:34:56"), dt.DateTime);
+                Assert.Equal(new DateTimeOffset(DateTime.Parse("01/01/2000 12:34:56"), TimeSpan.FromHours(-8.0)), dt.DateTimeOffset);
+                Assert.Equal(new TimeSpan(0, 10, 9, 8, 7), dt.TimeSpan);
+                Assert.Equal(-1.234F, dt.Single);
+                Assert.Equal(false, dt.Boolean);
+                Assert.Equal((byte)255, dt.Byte);
+                Assert.Equal(Enum64.SomeValue, dt.Enum64);
+                Assert.Equal(Enum32.SomeValue, dt.Enum32);
+                Assert.Equal(Enum16.SomeValue, dt.Enum16);
+                Assert.Equal(Enum8.SomeValue, dt.Enum8);
+                Assert.Equal((ushort)1234, dt.UnsignedInt16);
+                Assert.Equal(1234565789U, dt.UnsignedInt32);
+                Assert.Equal(1234567890123456789UL, dt.UnsignedInt64);
+                Assert.Equal('a', dt.Character);
+                Assert.Equal((sbyte)-128, dt.SignedByte);
+                Assert.Equal(EnumU64.SomeValue, dt.EnumU64);
+                Assert.Equal(EnumU32.SomeValue, dt.EnumU32);
+                Assert.Equal(EnumU16.SomeValue, dt.EnumU16);
+                Assert.Equal(EnumS8.SomeValue, dt.EnumS8);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_non_nullable_backed_data_types()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<NonNullableBackedDataTypes>().Add(
+                    new NonNullableBackedDataTypes
+                    {
+                        Id = 101,
+                        PartitionId = 101,
+                        Int16 = -1234,
+                        Int32 = -123456789,
+                        Int64 = -1234567890123456789L,
+                        Double = -1.23456789,
+                        Decimal = -1234567890.01M,
+                        DateTime = DateTime.Parse("01/01/2000 12:34:56"),
+                        DateTimeOffset = new DateTimeOffset(DateTime.Parse("01/01/2000 12:34:56"), TimeSpan.FromHours(-8.0)),
+                        TimeSpan = new TimeSpan(0, 10, 9, 8, 7),
+                        Single = -1.234F,
+                        Boolean = false,
+                        Byte = 255,
+                        UnsignedInt16 = 1234,
+                        UnsignedInt32 = 1234565789U,
+                        UnsignedInt64 = 1234567890123456789UL,
+                        Character = 'a',
+                        SignedByte = -128,
+                        Enum64 = Enum64.SomeValue,
+                        Enum32 = Enum32.SomeValue,
+                        Enum16 = Enum16.SomeValue,
+                        Enum8 = Enum8.SomeValue,
+                        EnumU64 = EnumU64.SomeValue,
+                        EnumU32 = EnumU32.SomeValue,
+                        EnumU16 = EnumU16.SomeValue,
+                        EnumS8 = EnumS8.SomeValue
+                    });
+
+                Assert.Equal(1, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                var dt = context.Set<NonNullableBackedDataTypes>().Where(ndt => ndt.Id == 101).ToList().Single();
+
+                Assert.Equal((short)-1234, dt.Int16);
+                Assert.Equal(-123456789, dt.Int32);
+                Assert.Equal(-1234567890123456789L, dt.Int64);
+                Assert.Equal(-1.23456789, dt.Double);
+                Assert.Equal(-1234567890.01M, dt.Decimal);
+                Assert.Equal(DateTime.Parse("01/01/2000 12:34:56"), dt.DateTime);
+                Assert.Equal(new DateTimeOffset(DateTime.Parse("01/01/2000 12:34:56"), TimeSpan.FromHours(-8.0)), dt.DateTimeOffset);
+                Assert.Equal(new TimeSpan(0, 10, 9, 8, 7), dt.TimeSpan);
+                Assert.Equal(-1.234F, dt.Single);
+                Assert.Equal(false, dt.Boolean);
+                Assert.Equal((byte)255, dt.Byte);
+                Assert.Equal(Enum64.SomeValue, dt.Enum64);
+                Assert.Equal(Enum32.SomeValue, dt.Enum32);
+                Assert.Equal(Enum16.SomeValue, dt.Enum16);
+                Assert.Equal(Enum8.SomeValue, dt.Enum8);
+                Assert.Equal((ushort)1234, dt.UnsignedInt16);
+                Assert.Equal(1234565789U, dt.UnsignedInt32);
+                Assert.Equal(1234567890123456789UL, dt.UnsignedInt64);
+                Assert.Equal('a', dt.Character);
+                Assert.Equal((sbyte)-128, dt.SignedByte);
+                Assert.Equal(EnumU64.SomeValue, dt.EnumU64);
+                Assert.Equal(EnumU32.SomeValue, dt.EnumU32);
+                Assert.Equal(EnumU16.SomeValue, dt.EnumU16);
+                Assert.Equal(EnumS8.SomeValue, dt.EnumS8);
+            }
+        }
+
         public abstract class BuiltInDataTypesFixtureBase : SharedStoreFixtureBase<PoolableDbContext>
         {
             protected override string StoreName { get; } = "BuiltInDataTypes";
@@ -1805,6 +2020,101 @@ namespace Microsoft.EntityFrameworkCore
                                 Id = Guid.Parse("3C56082A-005A-4FFB-A9CF-F5EBD641E07D"),
                                 TemplateType = EmailTemplateType.PasswordResetRequest
                             });
+                    });
+
+                modelBuilder.Entity<ObjectBackedDataTypes>()
+                    .HasData(new ObjectBackedDataTypes
+                    {
+                        Id = 13,
+                        PartitionId = 1,
+                        String = "string",
+                        Bytes = new byte[] { 4, 20 },
+                        Int16 = -1234,
+                        Int32 = -123456789,
+                        Int64 = -1234567890123456789L,
+                        Double = -1.23456789,
+                        Decimal = -1234567890.01M,
+                        DateTime = new DateTime(1973, 9,3),
+                        DateTimeOffset = new DateTimeOffset(new DateTime(), TimeSpan.FromHours(-8.0)),
+                        TimeSpan = new TimeSpan(0, 10, 9, 8, 7),
+                        Single = -1.234F,
+                        Boolean = true,
+                        Byte = 255,
+                        UnsignedInt16 = 1234,
+                        UnsignedInt32 = 1234565789U,
+                        UnsignedInt64 = 1234567890123456789UL,
+                        Character = 'a',
+                        SignedByte = -128,
+                        Enum64 = Enum64.SomeValue,
+                        Enum32 = Enum32.SomeValue,
+                        Enum16 = Enum16.SomeValue,
+                        Enum8 = Enum8.SomeValue,
+                        EnumU64 = EnumU64.SomeValue,
+                        EnumU32 = EnumU32.SomeValue,
+                        EnumU16 = EnumU16.SomeValue,
+                        EnumS8 = EnumS8.SomeValue
+                    });
+
+                modelBuilder.Entity<NullableBackedDataTypes>()
+                    .HasData(new NullableBackedDataTypes
+                    {
+                        Id = 13,
+                        PartitionId = 1,
+                        Int16 = -1234,
+                        Int32 = -123456789,
+                        Int64 = -1234567890123456789L,
+                        Double = -1.23456789,
+                        Decimal = -1234567890.01M,
+                        DateTime = new DateTime(1973, 9,3),
+                        DateTimeOffset = new DateTimeOffset(new DateTime(), TimeSpan.FromHours(-8.0)),
+                        TimeSpan = new TimeSpan(0, 10, 9, 8, 7),
+                        Single = -1.234F,
+                        Boolean = true,
+                        Byte = 255,
+                        UnsignedInt16 = 1234,
+                        UnsignedInt32 = 1234565789U,
+                        UnsignedInt64 = 1234567890123456789UL,
+                        Character = 'a',
+                        SignedByte = -128,
+                        Enum64 = Enum64.SomeValue,
+                        Enum32 = Enum32.SomeValue,
+                        Enum16 = Enum16.SomeValue,
+                        Enum8 = Enum8.SomeValue,
+                        EnumU64 = EnumU64.SomeValue,
+                        EnumU32 = EnumU32.SomeValue,
+                        EnumU16 = EnumU16.SomeValue,
+                        EnumS8 = EnumS8.SomeValue
+                    });
+
+                modelBuilder.Entity<NonNullableBackedDataTypes>()
+                    .HasData(new NonNullableBackedDataTypes
+                    {
+                        Id = 13,
+                        PartitionId = 1,
+                        Int16 = -1234,
+                        Int32 = -123456789,
+                        Int64 = -1234567890123456789L,
+                        Double = -1.23456789,
+                        Decimal = -1234567890.01M,
+                        DateTime = new DateTime(1973, 9,3),
+                        DateTimeOffset = new DateTimeOffset(new DateTime(), TimeSpan.FromHours(-8.0)),
+                        TimeSpan = new TimeSpan(0, 10, 9, 8, 7),
+                        Single = -1.234F,
+                        Boolean = true,
+                        Byte = 255,
+                        UnsignedInt16 = 1234,
+                        UnsignedInt32 = 1234565789U,
+                        UnsignedInt64 = 1234567890123456789UL,
+                        Character = 'a',
+                        SignedByte = -128,
+                        Enum64 = Enum64.SomeValue,
+                        Enum32 = Enum32.SomeValue,
+                        Enum16 = Enum16.SomeValue,
+                        Enum8 = Enum8.SomeValue,
+                        EnumU64 = EnumU64.SomeValue,
+                        EnumU32 = EnumU32.SomeValue,
+                        EnumU16 = EnumU16.SomeValue,
+                        EnumS8 = EnumS8.SomeValue
                     });
             }
 
@@ -2023,6 +2333,548 @@ namespace Microsoft.EntityFrameworkCore
         {
             PasswordResetRequest = 0,
             EmailConfirmation = 1
+        }
+
+        protected class ObjectBackedDataTypes
+        {
+            private object _string;
+            private object _bytes;
+            private object _int16;
+            private object _int32;
+            private object _int64;
+            private object _double;
+            private object _decimal;
+            private object _dateTime;
+            private object _dateTimeOffset;
+            private object _timeSpan;
+            private object _single;
+            private object _boolean;
+            private object _byte;
+            private object _unsignedInt16;
+            private object _unsignedInt32;
+            private object _unsignedInt64;
+            private object _character;
+            private object _signedByte;
+            private object _enum64;
+            private object _enum32;
+            private object _enum16;
+            private object _enum8;
+            private object _enumU64;
+            private object _enumU32;
+            private object _enumU16;
+            private object _enumS8;
+
+            [DatabaseGenerated(DatabaseGeneratedOption.None)]
+            public int Id { get; set; }
+            public int PartitionId { get; set; }
+
+            public string String
+            {
+                get => (string)_string;
+                set => _string = value;
+            }
+
+            public byte[] Bytes
+            {
+                get => (byte[])_bytes;
+                set => _bytes = value;
+            }
+
+            public short Int16
+            {
+                get => (short)_int16;
+                set => _int16 = value;
+            }
+
+            public int Int32
+            {
+                get => (int)_int32;
+                set => _int32 = value;
+            }
+
+            public long Int64
+            {
+                get => (long)_int64;
+                set => _int64 = value;
+            }
+
+            public double Double
+            {
+                get => (double)_double;
+                set => _double = value;
+            }
+
+            public decimal Decimal
+            {
+                get => (decimal)_decimal;
+                set => _decimal = value;
+            }
+
+            public DateTime DateTime
+            {
+                get => (DateTime)_dateTime;
+                set => _dateTime = value;
+            }
+
+            public DateTimeOffset DateTimeOffset
+            {
+                get => (DateTimeOffset)_dateTimeOffset;
+                set => _dateTimeOffset = value;
+            }
+
+            public TimeSpan TimeSpan
+            {
+                get => (TimeSpan)_timeSpan;
+                set => _timeSpan = value;
+            }
+
+            public float Single
+            {
+                get => (float)_single;
+                set => _single = value;
+            }
+
+            public bool Boolean
+            {
+                get => (bool)_boolean;
+                set => _boolean = value;
+            }
+
+            public byte Byte
+            {
+                get => (byte)_byte;
+                set => _byte = value;
+            }
+
+            public ushort UnsignedInt16
+            {
+                get => (ushort)_unsignedInt16;
+                set => _unsignedInt16 = value;
+            }
+
+            public uint UnsignedInt32
+            {
+                get => (uint)_unsignedInt32;
+                set => _unsignedInt32 = value;
+            }
+
+            public ulong UnsignedInt64
+            {
+                get => (ulong)_unsignedInt64;
+                set => _unsignedInt64 = value;
+            }
+
+            public char Character
+            {
+                get => (char)_character;
+                set => _character = value;
+            }
+
+            public sbyte SignedByte
+            {
+                get => (sbyte)_signedByte;
+                set => _signedByte = value;
+            }
+
+            public Enum64 Enum64
+            {
+                get => (Enum64)_enum64;
+                set => _enum64 = value;
+            }
+
+            public Enum32 Enum32
+            {
+                get => (Enum32)_enum32;
+                set => _enum32 = value;
+            }
+
+            public Enum16 Enum16
+            {
+                get => (Enum16)_enum16;
+                set => _enum16 = value;
+            }
+
+            public Enum8 Enum8
+            {
+                get => (Enum8)_enum8;
+                set => _enum8 = value;
+            }
+
+            public EnumU64 EnumU64
+            {
+                get => (EnumU64)_enumU64;
+                set => _enumU64 = value;
+            }
+
+            public EnumU32 EnumU32
+            {
+                get => (EnumU32)_enumU32;
+                set => _enumU32 = value;
+            }
+
+            public EnumU16 EnumU16
+            {
+                get => (EnumU16)_enumU16;
+                set => _enumU16 = value;
+            }
+
+            public EnumS8 EnumS8
+            {
+                get => (EnumS8)_enumS8;
+                set => _enumS8 = value;
+            }
+        }
+
+        protected class NullableBackedDataTypes
+        {
+            private short? _int16;
+            private int? _int32;
+            private long? _int64;
+            private double? _double;
+            private decimal? _decimal;
+            private DateTime? _dateTime;
+            private DateTimeOffset? _dateTimeOffset;
+            private TimeSpan? _timeSpan;
+            private float? _single;
+            private bool? _boolean;
+            private byte? _byte;
+            private ushort? _unsignedInt16;
+            private uint? _unsignedInt32;
+            private ulong? _unsignedInt64;
+            private char? _character;
+            private sbyte? _signedByte;
+            private Enum64? _enum64;
+            private Enum32? _enum32;
+            private Enum16? _enum16;
+            private Enum8? _enum8;
+            private EnumU64? _enumU64;
+            private EnumU32? _enumU32;
+            private EnumU16? _enumU16;
+            private EnumS8? _enumS8;
+
+            [DatabaseGenerated(DatabaseGeneratedOption.None)]
+            public int Id { get; set; }
+            public int PartitionId { get; set; }
+
+            public short Int16
+            {
+                get => (short)_int16;
+                set => _int16 = value;
+            }
+
+            public int Int32
+            {
+                get => (int)_int32;
+                set => _int32 = value;
+            }
+
+            public long Int64
+            {
+                get => (long)_int64;
+                set => _int64 = value;
+            }
+
+            public double Double
+            {
+                get => (double)_double;
+                set => _double = value;
+            }
+
+            public decimal Decimal
+            {
+                get => (decimal)_decimal;
+                set => _decimal = value;
+            }
+
+            public DateTime DateTime
+            {
+                get => (DateTime)_dateTime;
+                set => _dateTime = value;
+            }
+
+            public DateTimeOffset DateTimeOffset
+            {
+                get => (DateTimeOffset)_dateTimeOffset;
+                set => _dateTimeOffset = value;
+            }
+
+            public TimeSpan TimeSpan
+            {
+                get => (TimeSpan)_timeSpan;
+                set => _timeSpan = value;
+            }
+
+            public float Single
+            {
+                get => (float)_single;
+                set => _single = value;
+            }
+
+            public bool Boolean
+            {
+                get => (bool)_boolean;
+                set => _boolean = value;
+            }
+
+            public byte Byte
+            {
+                get => (byte)_byte;
+                set => _byte = value;
+            }
+
+            public ushort UnsignedInt16
+            {
+                get => (ushort)_unsignedInt16;
+                set => _unsignedInt16 = value;
+            }
+
+            public uint UnsignedInt32
+            {
+                get => (uint)_unsignedInt32;
+                set => _unsignedInt32 = value;
+            }
+
+            public ulong UnsignedInt64
+            {
+                get => (ulong)_unsignedInt64;
+                set => _unsignedInt64 = value;
+            }
+
+            public char Character
+            {
+                get => (char)_character;
+                set => _character = value;
+            }
+
+            public sbyte SignedByte
+            {
+                get => (sbyte)_signedByte;
+                set => _signedByte = value;
+            }
+
+            public Enum64 Enum64
+            {
+                get => (Enum64)_enum64;
+                set => _enum64 = value;
+            }
+
+            public Enum32 Enum32
+            {
+                get => (Enum32)_enum32;
+                set => _enum32 = value;
+            }
+
+            public Enum16 Enum16
+            {
+                get => (Enum16)_enum16;
+                set => _enum16 = value;
+            }
+
+            public Enum8 Enum8
+            {
+                get => (Enum8)_enum8;
+                set => _enum8 = value;
+            }
+
+            public EnumU64 EnumU64
+            {
+                get => (EnumU64)_enumU64;
+                set => _enumU64 = value;
+            }
+
+            public EnumU32 EnumU32
+            {
+                get => (EnumU32)_enumU32;
+                set => _enumU32 = value;
+            }
+
+            public EnumU16 EnumU16
+            {
+                get => (EnumU16)_enumU16;
+                set => _enumU16 = value;
+            }
+
+            public EnumS8 EnumS8
+            {
+                get => (EnumS8)_enumS8;
+                set => _enumS8 = value;
+            }
+        }
+
+        protected class NonNullableBackedDataTypes
+        {
+            private short _int16;
+            private int _int32;
+            private long _int64;
+            private double _double;
+            private decimal _decimal;
+            private DateTime _dateTime;
+            private DateTimeOffset _dateTimeOffset;
+            private TimeSpan _timeSpan;
+            private float _single;
+            private bool _boolean;
+            private byte _byte;
+            private ushort _unsignedInt16;
+            private uint _unsignedInt32;
+            private ulong _unsignedInt64;
+            private char _character;
+            private sbyte _signedByte;
+            private Enum64 _enum64;
+            private Enum32 _enum32;
+            private Enum16 _enum16;
+            private Enum8 _enum8;
+            private EnumU64 _enumU64;
+            private EnumU32 _enumU32;
+            private EnumU16 _enumU16;
+            private EnumS8 _enumS8;
+
+            [DatabaseGenerated(DatabaseGeneratedOption.None)]
+            public int Id { get; set; }
+            public int PartitionId { get; set; }
+
+            public short? Int16
+            {
+                get => _int16;
+                set => _int16 = (short)value;
+            }
+
+            public int? Int32
+            {
+                get => _int32;
+                set => _int32 = (int)value;
+            }
+
+            public long? Int64
+            {
+                get => _int64;
+                set => _int64 = (long)value;
+            }
+
+            public double? Double
+            {
+                get => _double;
+                set => _double = (double)value;
+            }
+
+            public decimal? Decimal
+            {
+                get => _decimal;
+                set => _decimal = (decimal)value;
+            }
+
+            public DateTime? DateTime
+            {
+                get => _dateTime;
+                set => _dateTime = (DateTime)value;
+            }
+
+            public DateTimeOffset? DateTimeOffset
+            {
+                get => _dateTimeOffset;
+                set => _dateTimeOffset = (DateTimeOffset)value;
+            }
+
+            public TimeSpan? TimeSpan
+            {
+                get => _timeSpan;
+                set => _timeSpan = (TimeSpan)value;
+            }
+
+            public float? Single
+            {
+                get => _single;
+                set => _single = (float)value;
+            }
+
+            public bool? Boolean
+            {
+                get => _boolean;
+                set => _boolean = (bool)value;
+            }
+
+            public byte? Byte
+            {
+                get => _byte;
+                set => _byte = (byte)value;
+            }
+
+            public ushort? UnsignedInt16
+            {
+                get => _unsignedInt16;
+                set => _unsignedInt16 = (ushort)value;
+            }
+
+            public uint? UnsignedInt32
+            {
+                get => _unsignedInt32;
+                set => _unsignedInt32 = (uint)value;
+            }
+
+            public ulong? UnsignedInt64
+            {
+                get => _unsignedInt64;
+                set => _unsignedInt64 = (ulong)value;
+            }
+
+            public char? Character
+            {
+                get => _character;
+                set => _character = (char)value;
+            }
+
+            public sbyte? SignedByte
+            {
+                get => _signedByte;
+                set => _signedByte = (sbyte)value;
+            }
+
+            public Enum64? Enum64
+            {
+                get => _enum64;
+                set => _enum64 = (Enum64)value;
+            }
+
+            public Enum32? Enum32
+            {
+                get => _enum32;
+                set => _enum32 = (Enum32)value;
+            }
+
+            public Enum16? Enum16
+            {
+                get => _enum16;
+                set => _enum16 = (Enum16)value;
+            }
+
+            public Enum8? Enum8
+            {
+                get => _enum8;
+                set => _enum8 = (Enum8)value;
+            }
+
+            public EnumU64? EnumU64
+            {
+                get => _enumU64;
+                set => _enumU64 = (EnumU64)value;
+            }
+
+            public EnumU32? EnumU32
+            {
+                get => _enumU32;
+                set => _enumU32 = (EnumU32)value;
+            }
+
+            public EnumU16? EnumU16
+            {
+                get => _enumU16;
+                set => _enumU16 = (EnumU16)value;
+            }
+
+            public EnumS8? EnumS8
+            {
+                get => _enumS8;
+                set => _enumS8 = (EnumS8)value;
+            }
         }
     }
 }

--- a/test/EFCore.Specification.Tests/ConvertToProviderTypesTestBase.cs
+++ b/test/EFCore.Specification.Tests/ConvertToProviderTypesTestBase.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Xunit;
+
 namespace Microsoft.EntityFrameworkCore
 {
     public abstract class ConvertToProviderTypesTestBase<TFixture> : BuiltInDataTypesTestBase<TFixture>
@@ -9,6 +11,36 @@ namespace Microsoft.EntityFrameworkCore
         protected ConvertToProviderTypesTestBase(TFixture fixture)
             : base(fixture)
         {
+        }
+
+        [Fact(Skip = "QueryIssue")]
+        public override void Can_query_using_any_data_type()
+        {
+            base.Can_query_using_any_data_type();
+        }
+
+        [Fact(Skip = "QueryIssue")]
+        public override void Can_query_using_any_data_type_shadow()
+        {
+            base.Can_query_using_any_data_type();
+        }
+
+        [Fact(Skip = "QueryIssue")]
+        public override void Can_query_using_any_data_type_nullable_shadow()
+        {
+            base.Can_query_using_any_data_type();
+        }
+
+        [Fact(Skip = "QueryIssue")]
+        public override void Can_query_using_any_nullable_data_type()
+        {
+            base.Can_query_using_any_data_type();
+        }
+
+        [Fact(Skip = "QueryIssue")]
+        public override void Can_query_using_any_nullable_data_type_as_literal()
+        {
+            base.Can_query_using_any_data_type();
         }
 
         public abstract class ConvertToProviderTypesFixtureBase : BuiltInDataTypesFixtureBase

--- a/test/EFCore.Specification.Tests/CustomConvertersTestBase.cs
+++ b/test/EFCore.Specification.Tests/CustomConvertersTestBase.cs
@@ -19,6 +19,42 @@ namespace Microsoft.EntityFrameworkCore
         {
         }
 
+        [Fact(Skip = "QueryIssue")]
+        public override void Can_query_using_any_data_type()
+        {
+            base.Can_query_using_any_data_type();
+        }
+
+        [Fact(Skip = "QueryIssue")]
+        public override void Can_query_using_any_data_type_shadow()
+        {
+            base.Can_query_using_any_data_type();
+        }
+
+        [Fact(Skip = "QueryIssue")]
+        public override void Can_query_using_any_data_type_nullable_shadow()
+        {
+            base.Can_query_using_any_data_type();
+        }
+
+        [Fact(Skip = "QueryIssue")]
+        public override void Can_query_using_any_nullable_data_type()
+        {
+            base.Can_query_using_any_data_type();
+        }
+
+        [Fact(Skip = "QueryIssue")]
+        public override void Can_query_using_any_nullable_data_type_as_literal()
+        {
+            base.Can_query_using_any_data_type();
+        }
+
+        [Fact(Skip = "QueryIssue")]
+        public override void Can_query_with_null_parameters_using_any_nullable_data_type()
+        {
+            base.Can_query_using_any_data_type();
+        }
+
         [Fact]
         public virtual void Can_query_and_update_with_nullable_converter_on_unique_index()
         {

--- a/test/EFCore.Specification.Tests/FieldMappingTestBase.cs
+++ b/test/EFCore.Specification.Tests/FieldMappingTestBase.cs
@@ -27,7 +27,22 @@ namespace Microsoft.EntityFrameworkCore
 
         protected class User2 : IUser2
         {
+            private object _loginSessionId;
+            private object _loginSessionId2;
+
             public int Id { get; set; }
+
+            public int? LoginSessionId
+            {
+                get => (int?)_loginSessionId;
+                set => _loginSessionId = value;
+            }
+
+            public int? LoginSessionId2
+            {
+                get => (int?)_loginSessionId2;
+                set => _loginSessionId2 = value;
+            }
         }
 
         protected class LoginSession
@@ -1883,7 +1898,14 @@ namespace Microsoft.EntityFrameworkCore
                 modelBuilder.Entity<PostFullExplicit>().Metadata.FindNavigation("Blog").SetField("_myblog");
                 modelBuilder.Entity<BlogFullExplicit>().Metadata.FindNavigation("Posts").SetField("_myposts");
 
-                modelBuilder.Entity<LoginSession>().UsePropertyAccessMode(PropertyAccessMode.Field);
+                modelBuilder.Entity<LoginSession>(
+                    b =>
+                    {
+                        b.UsePropertyAccessMode(PropertyAccessMode.Field);
+
+                        b.HasOne(e => e.User).WithOne().HasForeignKey<User2>(e => e.LoginSessionId);
+                        b.HasMany(e => e.Users).WithOne().HasForeignKey(e => e.LoginSessionId2);
+                    });
 
                 if (modelBuilder.Model.GetPropertyAccessMode() != PropertyAccessMode.Property)
                 {

--- a/test/EFCore.Specification.Tests/StoreGeneratedTestBase.cs
+++ b/test/EFCore.Specification.Tests/StoreGeneratedTestBase.cs
@@ -1068,6 +1068,80 @@ namespace Microsoft.EntityFrameworkCore
                 });
         }
 
+        [Fact]
+        public virtual void Nullable_fields_get_defaults_when_not_set()
+        {
+            ExecuteWithStrategyInTransaction(
+                context =>
+                {
+                    var entity = context.Add(new WithNullableBackingFields()).Entity;
+
+                    context.SaveChanges();
+
+                    Assert.NotEqual(0, entity.Id);
+                    Assert.True(entity.NullableBackedBool);
+                    Assert.Equal(-1, entity.NullableBackedInt);
+                },
+                context =>
+                {
+                    var entity = context.Set<WithNullableBackingFields>().Single();
+                    Assert.True(entity.NullableBackedBool);
+                    Assert.Equal(-1, entity.NullableBackedInt);
+                });
+        }
+
+        [Fact]
+        public virtual void Nullable_fields_store_non_defaults_when_set()
+        {
+            ExecuteWithStrategyInTransaction(
+                context =>
+                {
+                    var entity = context.Add(new WithNullableBackingFields
+                    {
+                        NullableBackedBool = false,
+                        NullableBackedInt = 0
+                    }).Entity;
+
+                    context.SaveChanges();
+
+                    Assert.NotEqual(0, entity.Id);
+                    Assert.False(entity.NullableBackedBool);
+                    Assert.Equal(0, entity.NullableBackedInt);
+                },
+                context =>
+                {
+                    var entity = context.Set<WithNullableBackingFields>().Single();
+                    Assert.False(entity.NullableBackedBool);
+                    Assert.Equal(0, entity.NullableBackedInt);
+                });
+        }
+
+        [Fact]
+        public virtual void Nullable_fields_store_any_value_when_set()
+        {
+            ExecuteWithStrategyInTransaction(
+                context =>
+                {
+                    var entity = context.Add(new WithNullableBackingFields
+                    {
+                        NullableBackedBool = true,
+                        NullableBackedInt = 3
+                    }).Entity;
+
+                    context.SaveChanges();
+
+                    Assert.NotEqual(0, entity.Id);
+                    Assert.True(entity.NullableBackedBool);
+                    Assert.Equal(3, entity.NullableBackedInt);
+                },
+                context =>
+                {
+                    var entity = context.Set<WithNullableBackingFields>().Single();
+                    Assert.True(entity.NullableBackedBool);
+                    Assert.Equal(3, entity.NullableBackedInt);
+                });
+        }
+
         protected class Darwin
         {
             public int Id { get; set; }
@@ -1148,13 +1222,12 @@ namespace Microsoft.EntityFrameworkCore
         {
             private int _id;
 
-#pragma warning disable RCS1085 // Use auto-implemented property.
+            // ReSharper disable once ConvertToAutoProperty
             public int Id
             {
                 get => _id;
                 set => _id = value;
             }
-#pragma warning restore RCS1085 // Use auto-implemented property.
 
             private int? _nullableAsNonNullable = 0;
 
@@ -1170,6 +1243,31 @@ namespace Microsoft.EntityFrameworkCore
             {
                 get => _nonNullableAsNullable;
                 set => _nonNullableAsNullable = (int)value;
+            }
+        }
+
+        protected class WithNullableBackingFields
+        {
+            private int? _id;
+
+            public int Id
+            {
+                get => _id ?? 0;
+                set => _id = value;
+            }
+
+            private bool? _nullableBackedBool;
+            public bool NullableBackedBool
+            {
+                get => _nullableBackedBool ?? false;
+                set => _nullableBackedBool = value;
+            }
+
+            private int? _nullableBackedInt;
+            public int NullableBackedInt
+            {
+                get => _nullableBackedInt ?? 0;
+                set => _nullableBackedInt = value;
             }
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
@@ -2368,7 +2368,9 @@ WHERE (([m].[TimeSpanAsTime] = @__timeSpan_0) AND ([m].[TimeSpanAsTime] IS NOT N
         [ConditionalFact]
         public virtual void Columns_have_expected_data_types()
         {
-            var actual = QueryForColumnTypes(CreateContext());
+            var actual = QueryForColumnTypes(
+                CreateContext(),
+                nameof(ObjectBackedDataTypes), nameof(NullableBackedDataTypes), nameof(NonNullableBackedDataTypes));
 
             const string expected = @"BinaryForeignKeyDataType.BinaryKeyDataTypeId ---> [nullable varbinary] [MaxLength = 900]
 BinaryForeignKeyDataType.Id ---> [int] [Precision = 10 Scale = 0]
@@ -2805,7 +2807,7 @@ UnicodeDataTypes.StringUnicode ---> [nullable nvarchar] [MaxLength = -1]
             }
         }
 
-        public static string QueryForColumnTypes(DbContext context)
+        public static string QueryForColumnTypes(DbContext context, params string[] tablesToIgnore)
         {
             const string query
                 = @"SELECT
@@ -2844,7 +2846,10 @@ UnicodeDataTypes.StringUnicode ---> [nullable nvarchar] [MaxLength = -1]
                             DateTimePrecision = reader.IsDBNull(7) ? null : (int?)reader.GetInt16(7)
                         };
 
-                        columns.Add(columnInfo);
+                        if (!tablesToIgnore.Contains(columnInfo.TableName))
+                        {
+                            columns.Add(columnInfo);
+                        }
                     }
                 }
             }

--- a/test/EFCore.SqlServer.FunctionalTests/ConvertToProviderTypesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ConvertToProviderTypesSqlServerTest.cs
@@ -42,7 +42,9 @@ namespace Microsoft.EntityFrameworkCore
         [ConditionalFact]
         public virtual void Columns_have_expected_data_types()
         {
-            var actual = BuiltInDataTypesSqlServerTest.QueryForColumnTypes(CreateContext());
+            var actual = BuiltInDataTypesSqlServerTest.QueryForColumnTypes(
+                CreateContext(),
+                nameof(ObjectBackedDataTypes), nameof(NullableBackedDataTypes), nameof(NonNullableBackedDataTypes));
 
             const string expected = @"BinaryForeignKeyDataType.BinaryKeyDataTypeId ---> [nullable nvarchar] [MaxLength = 450]
 BinaryForeignKeyDataType.Id ---> [int] [Precision = 10 Scale = 0]

--- a/test/EFCore.SqlServer.FunctionalTests/CustomConvertersSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/CustomConvertersSqlServerTest.cs
@@ -21,7 +21,9 @@ namespace Microsoft.EntityFrameworkCore
         [ConditionalFact]
         public virtual void Columns_have_expected_data_types()
         {
-            var actual = BuiltInDataTypesSqlServerTest.QueryForColumnTypes(CreateContext());
+            var actual = BuiltInDataTypesSqlServerTest.QueryForColumnTypes(
+                CreateContext(),
+                nameof(ObjectBackedDataTypes), nameof(NullableBackedDataTypes), nameof(NonNullableBackedDataTypes));
 
             const string expected = @"BinaryForeignKeyDataType.BinaryKeyDataTypeId ---> [nullable varbinary] [MaxLength = 900]
 BinaryForeignKeyDataType.Id ---> [int] [Precision = 10 Scale = 0]

--- a/test/EFCore.SqlServer.FunctionalTests/EverythingIsBytesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/EverythingIsBytesSqlServerTest.cs
@@ -25,7 +25,9 @@ namespace Microsoft.EntityFrameworkCore
         [ConditionalFact]
         public virtual void Columns_have_expected_data_types()
         {
-            var actual = BuiltInDataTypesSqlServerTest.QueryForColumnTypes(CreateContext());
+            var actual = BuiltInDataTypesSqlServerTest.QueryForColumnTypes(
+                CreateContext(),
+                nameof(ObjectBackedDataTypes), nameof(NullableBackedDataTypes), nameof(NonNullableBackedDataTypes));
 
             const string expected = @"BinaryForeignKeyDataType.BinaryKeyDataTypeId ---> [nullable varbinary] [MaxLength = 900]
 BinaryForeignKeyDataType.Id ---> [varbinary] [MaxLength = 4]
@@ -243,29 +245,26 @@ UnicodeDataTypes.StringUnicode ---> [nullable varbinary] [MaxLength = -1]
                     }
                 }
 
-                if (clrType != null)
+                if (clrType == typeof(byte[]))
                 {
-                    if (clrType == typeof(byte[]))
+                    if (mappingInfo.IsRowVersion == true)
                     {
-                        if (mappingInfo.IsRowVersion == true)
-                        {
-                            return _rowversion;
-                        }
-
-                        var isFixedLength = mappingInfo.IsFixedLength == true;
-
-                        var size = mappingInfo.Size ?? (mappingInfo.IsKeyOrIndex ? (int?)900 : null);
-                        if (size > 8000)
-                        {
-                            size = isFixedLength ? 8000 : (int?)null;
-                        }
-
-                        return new SqlServerByteArrayTypeMapping(
-                            "varbinary(" + (size == null ? "max" : size.ToString()) + ")",
-                            size,
-                            isFixedLength,
-                            storeTypePostfix: size == null ? StoreTypePostfix.None : (StoreTypePostfix?)null);
+                        return _rowversion;
                     }
+
+                    var isFixedLength = mappingInfo.IsFixedLength == true;
+
+                    var size = mappingInfo.Size ?? (mappingInfo.IsKeyOrIndex ? (int?)900 : null);
+                    if (size > 8000)
+                    {
+                        size = isFixedLength ? 8000 : (int?)null;
+                    }
+
+                    return new SqlServerByteArrayTypeMapping(
+                        "varbinary(" + (size == null ? "max" : size.ToString()) + ")",
+                        size,
+                        isFixedLength,
+                        storeTypePostfix: size == null ? StoreTypePostfix.None : (StoreTypePostfix?)null);
                 }
 
                 return null;

--- a/test/EFCore.SqlServer.FunctionalTests/EverythingIsStringsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/EverythingIsStringsSqlServerTest.cs
@@ -26,7 +26,9 @@ namespace Microsoft.EntityFrameworkCore
         [ConditionalFact]
         public virtual void Columns_have_expected_data_types()
         {
-            var actual = BuiltInDataTypesSqlServerTest.QueryForColumnTypes(CreateContext());
+            var actual = BuiltInDataTypesSqlServerTest.QueryForColumnTypes(
+                CreateContext(),
+                nameof(ObjectBackedDataTypes), nameof(NullableBackedDataTypes), nameof(NonNullableBackedDataTypes));
 
             const string expected = @"BinaryForeignKeyDataType.BinaryKeyDataTypeId ---> [nullable nvarchar] [MaxLength = 450]
 BinaryForeignKeyDataType.Id ---> [nvarchar] [MaxLength = 64]

--- a/test/EFCore.SqlServer.FunctionalTests/StoreGeneratedSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/StoreGeneratedSqlServerTest.cs
@@ -163,6 +163,13 @@ namespace Microsoft.EntityFrameworkCore
                         b.Property(e => e.NonNullableAsNullable).HasComputedColumnSql("1");
                     });
 
+                modelBuilder.Entity<WithNullableBackingFields>(
+                    b =>
+                    {
+                        b.Property(e => e.NullableBackedBool).HasDefaultValue(true);
+                        b.Property(e => e.NullableBackedInt).HasDefaultValue(-1);
+                    });
+
                 base.OnModelCreating(modelBuilder, context);
             }
         }

--- a/test/EFCore.Sqlite.FunctionalTests/StoreGeneratedSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/StoreGeneratedSqliteTest.cs
@@ -82,6 +82,13 @@ namespace Microsoft.EntityFrameworkCore
                         b.Property(e => e.OnUpdateThrowBeforeThrowAfter).HasDefaultValue("Rabbit");
                     });
 
+                modelBuilder.Entity<WithNullableBackingFields>(
+                    b =>
+                    {
+                        b.Property(e => e.NullableBackedBool).HasDefaultValue(true);
+                        b.Property(e => e.NullableBackedInt).HasDefaultValue(-1);
+                    });
+
                 base.OnModelCreating(modelBuilder, context);
             }
         }

--- a/test/EFCore.Tests/ChangeTracking/PropertyEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/PropertyEntryTest.cs
@@ -6,7 +6,6 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
@@ -195,12 +194,19 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
         [Fact]
         public void Can_get_name()
+            => Can_get_name<Wotty>();
+
+        [Fact]
+        public void Can_get_name_with_object_field()
+            => Can_get_name<ObjectWotty>();
+
+        private void Can_get_name<TWotty>() where TWotty : IWotty, new()
         {
             using (var context = new PrimateContext())
             {
                 var entry = context
                     .Entry(
-                        new Wotty
+                        new TWotty
                         {
                             Id = 1,
                             Primate = "Monkey",
@@ -216,12 +222,19 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
         [Fact]
         public void Can_get_current_value()
+            => Can_get_current_value<Wotty>();
+
+        [Fact]
+        public void Can_get_current_value_with_object_field()
+            => Can_get_current_value<ObjectWotty>();
+
+        private void Can_get_current_value<TWotty>() where TWotty : IWotty, new()
         {
             using (var context = new PrimateContext())
             {
                 var entry = context
                     .Entry(
-                        new Wotty
+                        new TWotty
                         {
                             Id = 1,
                             Primate = "Monkey",
@@ -238,10 +251,17 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
         [Fact]
         public void Can_set_current_value()
+            => Can_set_current_value<Wotty>();
+
+        [Fact]
+        public void Can_set_current_value_with_object_field()
+            => Can_set_current_value<ObjectWotty>();
+
+        private void Can_set_current_value<TWotty>() where TWotty : IWotty, new()
         {
             using (var context = new PrimateContext())
             {
-                var entity = new Wotty
+                var entity = new TWotty
                 {
                     Id = 1,
                     Primate = "Monkey",
@@ -265,10 +285,17 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
         [Fact]
         public void Can_set_current_value_to_null()
+            => Can_set_current_value_to_null<Wotty>();
+
+        [Fact]
+        public void Can_set_current_value_to_null_with_object_field()
+            => Can_set_current_value_to_null<ObjectWotty>();
+
+        private void Can_set_current_value_to_null<TWotty>() where TWotty : IWotty, new()
         {
             using (var context = new PrimateContext())
             {
-                var entity = new Wotty
+                var entity = new TWotty
                 {
                     Id = 1,
                     Primate = "Monkey",
@@ -292,10 +319,17 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
         [Fact]
         public void Can_set_and_get_original_value()
+            => Can_set_and_get_original_value<Wotty>();
+
+        [Fact]
+        public void Can_set_and_get_original_value_with_object_field()
+            => Can_set_and_get_original_value<ObjectWotty>();
+
+        private void Can_set_and_get_original_value<TWotty>() where TWotty : IWotty, new()
         {
             using (var context = new PrimateContext())
             {
-                var entity = new Wotty
+                var entity = new TWotty
                 {
                     Id = 1,
                     Primate = "Monkey",
@@ -328,10 +362,17 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
         [Fact]
         public void Can_set_and_get_original_value_starting_null()
+            => Can_set_and_get_original_value_starting_null<Wotty>();
+
+        [Fact]
+        public void Can_set_and_get_original_value_starting_null_with_object_field()
+            => Can_set_and_get_original_value_starting_null<ObjectWotty>();
+
+        private void Can_set_and_get_original_value_starting_null<TWotty>() where TWotty : IWotty, new()
         {
             using (var context = new PrimateContext())
             {
-                var entity = new Wotty
+                var entity = new TWotty
                 {
                     Id = 1
                 };
@@ -362,10 +403,17 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
         [Fact]
         public void Can_set_original_value_to_null()
+            => Can_set_original_value_to_null<Wotty>();
+
+        [Fact]
+        public void Can_set_original_value_to_null_with_object_field()
+            => Can_set_original_value_to_null<ObjectWotty>();
+
+        private void Can_set_original_value_to_null<TWotty>() where TWotty : IWotty, new()
         {
             using (var context = new PrimateContext())
             {
-                var entity = new Wotty
+                var entity = new TWotty
                 {
                     Id = 1,
                     Primate = "Monkey",
@@ -389,10 +437,17 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
         [Fact]
         public void Can_set_and_clear_modified_on_Modified_entity()
+            => Can_set_and_clear_modified_on_Modified_entity<Wotty>();
+
+        [Fact]
+        public void Can_set_and_clear_modified_on_Modified_entity_with_object_field()
+            => Can_set_and_clear_modified_on_Modified_entity<ObjectWotty>();
+
+        private void Can_set_and_clear_modified_on_Modified_entity<TWotty>() where TWotty : IWotty, new()
         {
             using (var context = new PrimateContext())
             {
-                var entity = new Wotty
+                var entity = new TWotty
                 {
                     Id = 1
                 };
@@ -435,10 +490,19 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         [InlineData(EntityState.Added)]
         [InlineData(EntityState.Deleted)]
         public void Can_set_and_clear_modified_on_Added_or_Deleted_entity(EntityState initialState)
+            => Can_set_and_clear_modified_on_Added_or_Deleted_entity<Wotty>(initialState);
+
+        [Theory]
+        [InlineData(EntityState.Added)]
+        [InlineData(EntityState.Deleted)]
+        public void Can_set_and_clear_modified_on_Added_or_Deleted_entity_with_object_field(EntityState initialState)
+            => Can_set_and_clear_modified_on_Added_or_Deleted_entity<ObjectWotty>(initialState);
+
+        private void Can_set_and_clear_modified_on_Added_or_Deleted_entity<TWotty>(EntityState initialState) where TWotty : IWotty, new()
         {
             using (var context = new PrimateContext())
             {
-                var entity = new Wotty
+                var entity = new TWotty
                 {
                     Id = 1
                 };
@@ -472,10 +536,19 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         [InlineData(EntityState.Detached)]
         [InlineData(EntityState.Unchanged)]
         public void Can_set_and_clear_modified_on_Unchanged_or_Detached_entity(EntityState initialState)
+            => Can_set_and_clear_modified_on_Unchanged_or_Detached_entity<Wotty>(initialState);
+
+        [Theory]
+        [InlineData(EntityState.Detached)]
+        [InlineData(EntityState.Unchanged)]
+        public void Can_set_and_clear_modified_on_Unchanged_or_Detached_entity_with_object_field(EntityState initialState)
+            => Can_set_and_clear_modified_on_Unchanged_or_Detached_entity<ObjectWotty>(initialState);
+
+        private void Can_set_and_clear_modified_on_Unchanged_or_Detached_entity<TWotty>(EntityState initialState) where TWotty : IWotty, new()
         {
             using (var context = new PrimateContext())
             {
-                var entity = new Wotty
+                var entity = new TWotty
                 {
                     Id = 1
                 };
@@ -507,10 +580,17 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
         [Fact]
         public void Can_reject_changes_when_clearing_modified_flag()
+            => Can_reject_changes_when_clearing_modified_flag<Wotty>();
+
+        [Fact]
+        public void Can_reject_changes_when_clearing_modified_flag_with_object_field()
+            => Can_reject_changes_when_clearing_modified_flag<ObjectWotty>();
+
+        private void Can_reject_changes_when_clearing_modified_flag<TWotty>() where TWotty : IWotty, new()
         {
             using (var context = new PrimateContext())
             {
-                var entity = new Wotty
+                var entity = new TWotty
                 {
                     Id = 1,
                     Primate = "Monkey",
@@ -592,11 +672,18 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
         [Fact]
         public void Can_get_name_generic()
+            => Can_get_name_generic<Wotty>();
+
+        [Fact]
+        public void Can_get_name_generic_with_object_field()
+            => Can_get_name_generic<ObjectWotty>();
+
+        private void Can_get_name_generic<TWotty>() where TWotty : class, IWotty, new()
         {
             var entry = InMemoryTestHelpers.Instance.CreateInternalEntry(
                 BuildModel(),
                 EntityState.Unchanged,
-                new Wotty
+                new TWotty
                 {
                     Id = 1,
                     Primate = "Monkey"
@@ -607,11 +694,18 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
         [Fact]
         public void Can_get_current_value_generic()
+            => Can_get_current_value_generic<Wotty>();
+
+        [Fact]
+        public void Can_get_current_value_generic_with_object_field()
+            => Can_get_current_value_generic<ObjectWotty>();
+
+        private void Can_get_current_value_generic<TWotty>() where TWotty : class, IWotty, new()
         {
             var entry = InMemoryTestHelpers.Instance.CreateInternalEntry(
                 BuildModel(),
                 EntityState.Unchanged,
-                new Wotty
+                new TWotty
                 {
                     Id = 1,
                     Primate = "Monkey"
@@ -622,8 +716,15 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
         [Fact]
         public void Can_set_current_value_generic()
+            => Can_set_current_value_generic<Wotty>();
+
+        [Fact]
+        public void Can_set_current_value_generic_with_object_field()
+            => Can_set_current_value_generic<ObjectWotty>();
+
+        private void Can_set_current_value_generic<TWotty>() where TWotty : class, IWotty, new()
         {
-            var entity = new Wotty
+            var entity = new TWotty
             {
                 Id = 1,
                 Primate = "Monkey"
@@ -641,8 +742,15 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
         [Fact]
         public void Can_set_current_value_to_null_generic()
+            => Can_set_current_value_to_null_generic<Wotty>();
+
+        [Fact]
+        public void Can_set_current_value_to_null_generic_with_object_field()
+            => Can_set_current_value_to_null_generic<ObjectWotty>();
+
+        private void Can_set_current_value_to_null_generic<TWotty>() where TWotty : class, IWotty, new()
         {
-            var entity = new Wotty
+            var entity = new TWotty
             {
                 Id = 1,
                 Primate = "Monkey"
@@ -660,8 +768,15 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
         [Fact]
         public void Can_set_and_get_original_value_generic()
+            => Can_set_and_get_original_value_generic<Wotty>();
+
+        [Fact]
+        public void Can_set_and_get_original_value_generic_with_object_field()
+            => Can_set_and_get_original_value_generic<ObjectWotty>();
+
+        private void Can_set_and_get_original_value_generic<TWotty>() where TWotty : class, IWotty, new()
         {
-            var entity = new Wotty
+            var entity = new TWotty
             {
                 Id = 1,
                 Primate = "Monkey"
@@ -682,11 +797,18 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
         [Fact]
         public void Can_set_original_value_to_null_generic()
+            => Can_set_original_value_to_null_generic<Wotty>();
+
+        [Fact]
+        public void Can_set_original_value_to_null_generic_with_object_field()
+            => Can_set_original_value_to_null_generic<ObjectWotty>();
+
+        private void Can_set_original_value_to_null_generic<TWotty>() where TWotty : class, IWotty, new()
         {
             var entry = InMemoryTestHelpers.Instance.CreateInternalEntry(
                 BuildModel(),
                 EntityState.Unchanged,
-                new Wotty
+                new TWotty
                 {
                     Id = 1,
                     Primate = "Monkey"
@@ -699,8 +821,15 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
         [Fact]
         public void Can_set_and_clear_modified_generic()
+            => Can_set_and_clear_modified_generic<Wotty>();
+
+        [Fact]
+        public void Can_set_and_clear_modified_generic_with_object_field()
+            => Can_set_and_clear_modified_generic<ObjectWotty>();
+
+        private void Can_set_and_clear_modified_generic<TWotty>() where TWotty : class, IWotty, new()
         {
-            var entity = new Wotty
+            var entity = new TWotty
             {
                 Id = 1,
                 Primate = "Monkey"
@@ -972,7 +1101,47 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
             Assert.Equal("Monkey", entity.Primate);
         }
 
-        private class Wotty
+        private interface IWotty
+        {
+            int Id { get; set; }
+            string Primate { get; set; }
+            string RequiredPrimate { get; set; }
+            string Marmate { get; set; }
+        }
+
+        private class ObjectWotty : IWotty
+        {
+            private object _id;
+            private object _primate;
+            private object _requiredPrimate;
+            private object _marmate;
+
+            public int Id
+            {
+                get => (int)_id;
+                set => _id = value;
+            }
+
+            public string Primate
+            {
+                get => (string)_primate;
+                set => _primate = value;
+            }
+
+            public string RequiredPrimate
+            {
+                get => (string)_requiredPrimate;
+                set => _requiredPrimate = value;
+            }
+
+            public string Marmate
+            {
+                get => (string)_marmate;
+                set => _marmate = value;
+            }
+        }
+
+        private class Wotty : IWotty
         {
             public int Id { get; set; }
             public string Primate { get; set; }
@@ -1090,6 +1259,13 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
             builder.HasChangeTrackingStrategy(fullNotificationStrategy);
 
             builder.Entity<Wotty>(
+                b =>
+                {
+                    b.Property(e => e.RequiredPrimate).IsRequired();
+                    b.HasChangeTrackingStrategy(ChangeTrackingStrategy.Snapshot);
+                });
+
+            builder.Entity<ObjectWotty>(
                 b =>
                 {
                     b.Property(e => e.RequiredPrimate).IsRequired();

--- a/test/EFCore.Tests/Metadata/Internal/ClrCollectionAccessorFactoryTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/ClrCollectionAccessorFactoryTest.cs
@@ -43,6 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             public string Name { get; }
             public ITypeBase DeclaringType { get; }
             public Type ClrType { get; }
+            public Type DeclaredClrType { get; }
             public PropertyInfo PropertyInfo { get; }
             public FieldInfo FieldInfo { get; }
             public IEntityType DeclaringEntityType { get; }

--- a/test/EFCore.Tests/Metadata/Internal/ClrPropertyGetterFactoryTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/ClrPropertyGetterFactoryTest.cs
@@ -30,9 +30,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             public string Name { get; }
             public ITypeBase DeclaringType { get; }
             public Type ClrType { get; }
+            public Type DeclaredClrType { get; }
             public IEntityType DeclaringEntityType { get; }
             public bool IsNullable { get; }
-            public bool IsStoreGeneratedAlways { get; }
             public ValueGenerated ValueGenerated { get; }
             public bool IsConcurrencyToken { get; }
             public PropertyInfo PropertyInfo { get; }

--- a/test/EFCore.Tests/Metadata/Internal/ClrPropertySetterFactoryTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/ClrPropertySetterFactoryTest.cs
@@ -31,11 +31,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             public string Name { get; }
             public ITypeBase DeclaringType { get; }
             public Type ClrType { get; }
+            public Type DeclaredClrType { get; }
             public IEntityType DeclaringEntityType { get; }
             public bool IsNullable { get; }
-            public bool IsReadOnlyBeforeSave { get; }
-            public bool IsReadOnlyAfterSave { get; }
-            public bool IsStoreGeneratedAlways { get; }
             public ValueGenerated ValueGenerated { get; }
             public bool IsConcurrencyToken { get; }
             public PropertyInfo PropertyInfo { get; }

--- a/test/EFCore.Tests/Metadata/Internal/NavigationTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/NavigationTest.cs
@@ -30,6 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             public string Name { get; }
             public ITypeBase DeclaringType { get; }
             public Type ClrType { get; }
+            public Type DeclaredClrType { get; }
             public PropertyInfo PropertyInfo { get; }
             public FieldInfo FieldInfo { get; }
             public IEntityType DeclaringEntityType { get; }

--- a/test/EFCore.Tests/Metadata/Internal/PropertyTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/PropertyTest.cs
@@ -46,9 +46,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             public string Name { get; }
             public ITypeBase DeclaringType { get; }
             public Type ClrType { get; }
+            public Type DeclaredClrType { get; }
             public IEntityType DeclaringEntityType { get; }
             public bool IsNullable { get; }
-            public bool IsStoreGeneratedAlways { get; }
             public ValueGenerated ValueGenerated { get; }
             public bool IsConcurrencyToken { get; }
             public PropertyInfo PropertyInfo { get; }

--- a/test/EFCore.Tests/Storage/EnumToNumberConverterTest.cs
+++ b/test/EFCore.Tests/Storage/EnumToNumberConverterTest.cs
@@ -289,7 +289,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 CoreStrings.ConverterBadType(
                     typeof(EnumToNumberConverter<Beatles, Guid>).ShortDisplayName(),
                     "Guid",
-                    "int, long, short, byte, uint, ulong, ushort, sbyte, double, float, decimal"),
+                    "int, long, short, byte, uint, ulong, ushort, sbyte, double, float, decimal, char"),
                 Assert.Throws<InvalidOperationException>(
                     () => new EnumToNumberConverter<Beatles, Guid>()).Message);
         }

--- a/test/EFCore.Tests/Storage/ValueConverterSelectorTest.cs
+++ b/test/EFCore.Tests/Storage/ValueConverterSelectorTest.cs
@@ -32,7 +32,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 (typeof(EnumToNumberConverter<Queen, ushort>), default),
                 (typeof(EnumToNumberConverter<Queen, sbyte>), default),
                 (typeof(EnumToNumberConverter<Queen, double>), default),
-                (typeof(EnumToNumberConverter<Queen, float>), default));
+                (typeof(EnumToNumberConverter<Queen, float>), default),
+                (typeof(EnumToNumberConverter<Queen, char>), default));
         }
 
         [Fact]
@@ -52,7 +53,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 (typeof(EnumToNumberConverter<Gnr, ushort>), default),
                 (typeof(EnumToNumberConverter<Gnr, sbyte>), default),
                 (typeof(EnumToNumberConverter<Gnr, double>), default),
-                (typeof(EnumToNumberConverter<Gnr, float>), default));
+                (typeof(EnumToNumberConverter<Gnr, float>), default),
+                (typeof(EnumToNumberConverter<Gnr, char>), default));
         }
 
         [Fact]
@@ -72,7 +74,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 (typeof(EnumToNumberConverter<Velvets, ushort>), default),
                 (typeof(EnumToNumberConverter<Velvets, sbyte>), default),
                 (typeof(EnumToNumberConverter<Velvets, double>), default),
-                (typeof(EnumToNumberConverter<Velvets, float>), default));
+                (typeof(EnumToNumberConverter<Velvets, float>), default),
+                (typeof(EnumToNumberConverter<Velvets, char>), default));
         }
 
         [Fact]
@@ -92,7 +95,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 (typeof(CompositeValueConverter<Nwa, byte, byte[]>), new ConverterMappingHints(size: 1)),
                 (typeof(EnumToNumberConverter<Nwa, sbyte>), default),
                 (typeof(EnumToNumberConverter<Nwa, double>), default),
-                (typeof(EnumToNumberConverter<Nwa, float>), default));
+                (typeof(EnumToNumberConverter<Nwa, float>), default),
+                (typeof(EnumToNumberConverter<Nwa, char>), default));
         }
 
         [Fact]
@@ -143,7 +147,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 (typeof(CastingConverter<int, ushort>), default),
                 (typeof(CastingConverter<int, sbyte>), default),
                 (typeof(CastingConverter<int, double>), default),
-                (typeof(CastingConverter<int, float>), default));
+                (typeof(CastingConverter<int, float>), default),
+                (typeof(CastingConverter<int, char>), default));
         }
 
         [Fact]
@@ -162,7 +167,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 (typeof(CastingConverter<uint, ushort>), default),
                 (typeof(CastingConverter<uint, sbyte>), default),
                 (typeof(CastingConverter<uint, double>), default),
-                (typeof(CastingConverter<uint, float>), default));
+                (typeof(CastingConverter<uint, float>), default),
+                (typeof(CastingConverter<uint, char>), default));
         }
 
         [Fact]
@@ -181,7 +187,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 (typeof(CastingConverter<sbyte, uint>), default),
                 (typeof(CastingConverter<sbyte, ushort>), default),
                 (typeof(CastingConverter<sbyte, double>), default),
-                (typeof(CastingConverter<sbyte, float>), default));
+                (typeof(CastingConverter<sbyte, float>), default),
+                (typeof(CastingConverter<sbyte, char>), default));
         }
 
         [Fact]
@@ -200,7 +207,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 (typeof(NumberToBytesConverter<byte>), new ConverterMappingHints(size: 1)),
                 (typeof(CastingConverter<byte, sbyte>), default),
                 (typeof(CastingConverter<byte, double>), default),
-                (typeof(CastingConverter<byte, float>), default));
+                (typeof(CastingConverter<byte, float>), default),
+                (typeof(CastingConverter<byte, char>), default));
         }
 
         [Fact]
@@ -219,7 +227,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 (typeof(CastingConverter<double, uint>), default),
                 (typeof(CastingConverter<double, ushort>), default),
                 (typeof(CastingConverter<double, sbyte>), default),
-                (typeof(CastingConverter<double, float>), default));
+                (typeof(CastingConverter<double, float>), default),
+                (typeof(CastingConverter<double, char>), default));
         }
 
         [Fact]
@@ -238,7 +247,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 (typeof(CastingConverter<float, ulong>), default),
                 (typeof(CastingConverter<float, uint>), default),
                 (typeof(CastingConverter<float, ushort>), default),
-                (typeof(CastingConverter<float, sbyte>), default));
+                (typeof(CastingConverter<float, sbyte>), default),
+                (typeof(CastingConverter<float, char>), default));
         }
 
         [Fact]
@@ -257,7 +267,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 (typeof(CastingConverter<decimal, ushort>), default),
                 (typeof(CastingConverter<decimal, sbyte>), default),
                 (typeof(CastingConverter<decimal, double>), default),
-                (typeof(CastingConverter<decimal, float>), default));
+                (typeof(CastingConverter<decimal, float>), default),
+                (typeof(CastingConverter<decimal, char>), default));
         }
 
         [Fact]
@@ -366,6 +377,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 (typeof(BoolToZeroOneConverter<decimal>), default),
                 (typeof(BoolToZeroOneConverter<double>), default),
                 (typeof(BoolToZeroOneConverter<float>), default),
+                (typeof(BoolToZeroOneConverter<char>), default),
                 (typeof(BoolToStringConverter), new ConverterMappingHints(size: 1)),
                 (typeof(CompositeValueConverter<bool, byte, byte[]>), new ConverterMappingHints(size: 1)));
         }


### PR DESCRIPTION
Fixes #15182

There is quite a fundamental change included here: the CLR type reported for a mapped property is now the backing field type, if it is known, not the property type. This is what allows a three states to be saved for a non-nullable property with a nullable backing field.

Perceptive readers will realize that this means that the CLR type of an `IProperty` can now change if the backing field is changed.

The most difficult case to handle seems to be properties backed by `object` fields. This likely isn't very common, but we had tests for it because of previous issues reported. One scenario is not working here--creating a shadow property FK by convention for a PK that is backed by an object field. I will file a bug for this.

Query changes are just what I needed to do to re-enable some tests to get coverage for this change. In particular, the type inference is not a universal solution, but unblocks important tests.
