### PR TITLE
Minor query cleanup

### DIFF
--- a/src/EFCore/Query/NavigationExpansion/Visitors/NavigationExpandingVisitor.cs
+++ b/src/EFCore/Query/NavigationExpansion/Visitors/NavigationExpandingVisitor.cs
@@ -214,13 +214,11 @@ namespace Microsoft.EntityFrameworkCore.Query.NavigationExpansion.Visitors
         protected override Expression VisitMember(MemberExpression memberExpression)
         {
             var newExpression = Visit(memberExpression.Expression);
-            if (newExpression is NavigationExpansionExpression navigationExpansionExpression
-                && navigationExpansionExpression.State.PendingCardinalityReducingOperator != null)
-            {
-                return ProcessMemberPushdown(newExpression, navigationExpansionExpression, efProperty: false, memberExpression.Member, propertyName: null, memberExpression.Type);
-            }
 
-            return base.VisitMember(memberExpression);
+            return newExpression is NavigationExpansionExpression navigationExpansionExpression
+                && navigationExpansionExpression.State.PendingCardinalityReducingOperator != null
+                ? ProcessMemberPushdown(newExpression, navigationExpansionExpression, efProperty: false, memberExpression.Member, propertyName: null, memberExpression.Type)
+                : memberExpression.Update(newExpression);
         }
 
         protected override Expression VisitBinary(BinaryExpression binaryExpression)

--- a/src/EFCore/Query/NavigationExpansion/Visitors/NavigationExpandingVisitor_MethodCall.cs
+++ b/src/EFCore/Query/NavigationExpansion/Visitors/NavigationExpandingVisitor_MethodCall.cs
@@ -20,19 +20,17 @@ namespace Microsoft.EntityFrameworkCore.Query.NavigationExpansion.Visitors
             if (methodCallExpression.Method.IsEFPropertyMethod())
             {
                 var newSource = Visit(methodCallExpression.Arguments[0]);
-                if (newSource is NavigationExpansionExpression navigationExpansionExpression
-                    && navigationExpansionExpression.State.PendingCardinalityReducingOperator != null)
-                {
-                    return ProcessMemberPushdown(
+
+                return newSource is NavigationExpansionExpression navigationExpansionExpression
+                    && navigationExpansionExpression.State.PendingCardinalityReducingOperator != null
+                    ? ProcessMemberPushdown(
                         newSource,
                         navigationExpansionExpression,
                         efProperty: true,
                         memberInfo: null,
                         (string)((ConstantExpression)methodCallExpression.Arguments[1]).Value,
-                        methodCallExpression.Type);
-                }
-
-                return methodCallExpression.Update(methodCallExpression.Object, new[] { newSource, methodCallExpression.Arguments[1] });
+                        methodCallExpression.Type)
+                    : methodCallExpression.Update(methodCallExpression.Object, new[] { newSource, methodCallExpression.Arguments[1] });
             }
 
             switch (methodCallExpression.Method.Name)

--- a/src/EFCore/Storage/Database.cs
+++ b/src/EFCore/Storage/Database.cs
@@ -94,21 +94,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
         public virtual Func<QueryContext, TResult> CompileQuery2<TResult>(Expression query, bool async)
         {
-            try
-            {
-                return Dependencies.QueryCompilationContextFactory2
-                    .Create(async)
-                    .CreateQueryExecutor<TResult>(query);
-            }
-            catch (Exception e)
-            {
-                if (e is NotImplementedException)
-                {
-                    return qc => default;
-                }
-
-                throw;
-            }
+            return Dependencies.QueryCompilationContextFactory2
+                .Create(async)
+                .CreateQueryExecutor<TResult>(query);
         }
     }
 }

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -348,7 +348,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory(Skip = "Issue #15041")]
+        [ConditionalTheory(Skip = "Issue #15834")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_navigation_key_access_optional(bool isAsync)
         {
@@ -375,7 +375,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Id1 + " " + e.Id2);
         }
 
-        [ConditionalTheory(Skip = "Issue #15041")]
+        [ConditionalTheory(Skip = "Issue #15834")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_navigation_key_access_required(bool isAsync)
         {
@@ -759,7 +759,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Id1 + " " + e.Id3);
         }
 
-        [ConditionalTheory(Skip = "Issue #15041")]
+        [ConditionalTheory(Skip = "Issue #15834")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_navigation_in_inner_selector_translated_to_subquery(bool isAsync)
         {
@@ -784,7 +784,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Id2 + " " + e.Id1);
         }
 
-        [ConditionalTheory(Skip = "Issue #15041")]
+        [ConditionalTheory(Skip = "Issue #15834")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_navigations_in_inner_selector_translated_to_multiple_subquery_without_collision(bool isAsync)
         {
@@ -814,7 +814,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Id2 + " " + e.Id1 + " " + e.Id3);
         }
 
-        [ConditionalTheory(Skip = "issue #15041")]
+        [ConditionalTheory(Skip = "issue #15834")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_navigation_translated_to_subquery_non_key_join(bool isAsync)
         {
@@ -874,7 +874,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Id2 + " " + e.Name2 + " " + e.Id1 + " " + e.Name1);
         }
 
-        [ConditionalTheory(Skip = "Issue# 15041")]
+        [ConditionalTheory(Skip = "Issue# 15834")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_navigation_translated_to_subquery_self_ref(bool isAsync)
         {
@@ -900,7 +900,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Id1 + " " + e.Id2);
         }
 
-        [ConditionalTheory(Skip = "Issue #15041")]
+        [ConditionalTheory(Skip = "Issue #15834")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_navigation_translated_to_subquery_nested(bool isAsync)
         {
@@ -959,7 +959,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Id3 + " " + e.Id1);
         }
 
-        [ConditionalTheory(Skip = "Issue #15041")]
+        [ConditionalTheory(Skip = "Issue #15834")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_navigation_translated_to_subquery_deeply_nested_non_key_join(bool isAsync)
         {
@@ -994,7 +994,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Id4 + " " + e.Name4 + " " + e.Id1 + " " + e.Name1);
         }
 
-        [ConditionalTheory(Skip = "Issue #15041")]
+        [ConditionalTheory(Skip = "Issue #15834")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_navigation_translated_to_subquery_deeply_nested_required(bool isAsync)
         {
@@ -2106,7 +2106,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 (e, a) => Assert.Equal(e.Id, a.Id));
         }
 
-        [ConditionalTheory(Skip = "issue #15041")]
+        [ConditionalTheory(Skip = "issue #15081")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task SelectMany_navigation_property_with_another_navigation_in_subquery(bool isAsync)
         {
@@ -2407,7 +2407,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 (e, a) => Assert.Equal(e.Id, a.Id));
         }
 
-        [ConditionalTheory(Skip = "issue #15041")]
+        [ConditionalTheory(Skip = "issue #15834")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Null_protection_logic_work_for_inner_key_access_of_manually_created_GroupJoin2(bool isAsync)
         {
@@ -3680,7 +3680,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.Id1);
         }
 
-        [ConditionalTheory(Skip = "issue #15041")]
+        [ConditionalTheory(Skip = "issue #15834")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Optional_navigation_propagates_nullability_to_manually_created_left_join2(bool isAsync)
         {
@@ -3708,7 +3708,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.Name1 + e.Name2);
         }
 
-        [ConditionalTheory(Skip = "issue #15041")]
+        [ConditionalTheory(Skip = "issue #15834")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Null_reference_protection_complex(bool isAsync)
         {
@@ -3736,7 +3736,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select Maybe(l2_outer, () => l2_outer.Name));
         }
 
-        [ConditionalTheory(Skip = "issue #15041")]
+        [ConditionalTheory(Skip = "issue #15834")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Null_reference_protection_complex_materialization(bool isAsync)
         {
@@ -3783,7 +3783,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return element;
         }
 
-        [ConditionalTheory(Skip = "issue #15041")]
+        [ConditionalTheory(Skip = "issue #15834")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Null_reference_protection_complex_client_eval(bool isAsync)
         {
@@ -3811,7 +3811,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select ClientMethodReturnSelf(Maybe(l2_outer, () => l2_outer.Name)));
         }
 
-        [ConditionalTheory(Skip = "issue #15041")]
+        [ConditionalTheory(Skip = "issue #15834")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_with_complex_subquery_with_joins_does_not_get_flattened(bool isAsync)
         {
@@ -3841,7 +3841,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select MaybeScalar<int>(subquery, () => subquery.Id));
         }
 
-        [ConditionalTheory(Skip = "issue #15041")]
+        [ConditionalTheory(Skip = "issue #15834")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_with_complex_subquery_with_joins_does_not_get_flattened2(bool isAsync)
         {
@@ -3871,7 +3871,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select MaybeScalar<int>(subquery, () => subquery.Id));
         }
 
-        [ConditionalTheory(Skip = "issue #15041")]
+        [ConditionalTheory(Skip = "issue #15834")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_with_complex_subquery_with_joins_does_not_get_flattened3(bool isAsync)
         {
@@ -5851,7 +5851,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15041")]
+        [ConditionalFact(Skip = "issue #15833")]
         public virtual void Include17()
         {
             using (var ctx = CreateContext())
@@ -5909,7 +5909,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 expectedIncludes);
         }
 
-        [ConditionalFact(Skip = "issue #15041")]
+        [ConditionalFact(Skip = "issue #15833")]
         public virtual void Include18_3()
         {
             using (var ctx = CreateContext())
@@ -5920,7 +5920,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15041")]
+        [ConditionalFact(Skip = "issue #15833")]
         public virtual void Include18_3_1()
         {
             using (var ctx = CreateContext())
@@ -5931,7 +5931,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15041")]
+        [ConditionalFact(Skip = "issue #15833")]
         public virtual void Include18_3_2()
         {
             using (var ctx = CreateContext())
@@ -5957,7 +5957,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 expectedIncludes);
         }
 
-        [ConditionalFact(Skip = "issue #15041")]
+        [ConditionalFact(Skip = "issue #15833")]
         public virtual void Include18_4()
         {
             using (var ctx = CreateContext())
@@ -5968,7 +5968,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15041")]
+        [ConditionalFact(Skip = "issue #15833")]
         public virtual void Include18()
         {
             using (var ctx = CreateContext())
@@ -5979,7 +5979,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15041")]
+        [ConditionalFact(Skip = "issue #15833")]
         public virtual void Include19()
         {
             using (var ctx = CreateContext())

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -1948,7 +1948,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select g);
         }
 
-        [ConditionalTheory(Skip = "Issue #15041")]
+        [ConditionalTheory(Skip = "Issue #15834")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_navigation_translated_to_subquery_composite_key(bool isAsync)
         {
@@ -2533,7 +2533,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: GroupingAsserter<int, CogTag>(t => t.Id, (e, a) => Assert.Equal(e.Id, a.Id)));
         }
 
-        [ConditionalTheory(Skip = "Issue #15041")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Optional_navigation_type_compensation_works_with_all(bool isAsync)
         {
@@ -3072,7 +3072,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       select s.Name);
         }
 
-        [ConditionalTheory(Skip = "Issue #15041")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task All_with_optional_navigation_is_translated_to_sql(bool isAsync)
         {
@@ -6128,7 +6128,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.Name1 + " " + e.Name2);
         }
 
-        [ConditionalTheory(Skip = "Issue #15041")]
+        [ConditionalTheory(Skip = "Issue #15834")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_on_entity_qsre_keys_inner_key_is_navigation(bool isAsync)
         {
@@ -6179,7 +6179,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.SquadName + " " + e.WeaponName);
         }
 
-        [ConditionalTheory(Skip = "Issue #15041")]
+        [ConditionalTheory(Skip = "Issue #15834")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_on_entity_qsre_keys_inner_key_is_nested_navigation(bool isAsync)
         {

--- a/test/EFCore.Specification.Tests/Query/QueryNavigationsTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/QueryNavigationsTestBase.cs
@@ -1318,7 +1318,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.OrderID);
         }
 
-        [ConditionalTheory(Skip = "issue #15041")]
+        [ConditionalTheory(Skip = "issue #15833")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_with_complex_subquery_and_LOJ_gets_flattened(bool isAsync)
         {
@@ -1339,7 +1339,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 91);
         }
 
-        [ConditionalTheory(Skip = "issue #15041")]
+        [ConditionalTheory(Skip = "issue #15833")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_with_complex_subquery_and_LOJ_gets_flattened2(bool isAsync)
         {

--- a/test/EFCore.Tests/QueryProviderTest.cs
+++ b/test/EFCore.Tests/QueryProviderTest.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(0, (int)q.Provider.Execute(expr));
         }
 
-        [Fact]
+        [Fact(Skip = "issue #15835")]
         public void Non_generic_ExecuteQuery_does_not_throw_incorrect_pattern()
         {
             var context = new TestContext();


### PR DESCRIPTION
- fixed bug where we would visit member expression twice in some cases during nav rewrite
- removed code that would swallow NotImplementedExceptions, which was making debugging more difficult
- enabled some tests for now fixed issue - 15041, tests that are still failing due to other issues have been properly re-assigned