### PR TITLE
Better access to EF.Property and indexer properties

### DIFF
--- a/src/EFCore.Cosmos/Query/ExpressionVisitors/Internal/CosmosMemberAccessBindingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/ExpressionVisitors/Internal/CosmosMemberAccessBindingExpressionVisitor.cs
@@ -83,9 +83,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.ExpressionVisitors.Internal
         {
             if (_queryModelVisitor.CurrentParameter?.Type == typeof(JObject))
             {
-                if (methodCallExpression.Method.IsEFPropertyMethod())
+                if (methodCallExpression.TryGetEFPropertyArguments(out var source, out _))
                 {
-                    var source = methodCallExpression.Arguments[0];
                     var newSource = Visit(source);
 
                     if (source != newSource

--- a/src/EFCore.InMemory/Query/Pipeline/InMemoryProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Pipeline/InMemoryProjectionBindingExpressionVisitor.cs
@@ -63,8 +63,8 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Pipeline
                     && unaryExpression.NodeType == ExpressionType.Convert
                     && unaryExpression.Type == typeof(object)
                     && unaryExpression.Operand is MethodCallExpression methodCall
-                    && methodCall.Method.IsEFPropertyMethod()
-                    && methodCall.Arguments[0] is EntityShaperExpression entityShaperExpression
+                    && methodCall.TryGetEFPropertyArguments(out var source, out _)
+                    && source is EntityShaperExpression entityShaperExpression
                     && entityShaperExpression.EntityType.GetProperties().Count() == newArrayExpression.Expressions.Count)
                 {
                     VerifyQueryExpression(entityShaperExpression.ValueBufferExpression);

--- a/src/EFCore.InMemory/Query/Pipeline/Translator.cs
+++ b/src/EFCore.InMemory/Query/Pipeline/Translator.cs
@@ -46,13 +46,12 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Pipeline
 
         protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
         {
-            if (methodCallExpression.Method.IsEFPropertyMethod())
+            if (methodCallExpression.TryGetEFPropertyArguments(out var source, out var propertyName))
             {
-                var firstArgument = Visit(methodCallExpression.Arguments[0]);
-                if (firstArgument is EntityShaperExpression entityShaper)
+                if (source is EntityShaperExpression entityShaper)
                 {
                     var entityType = entityShaper.EntityType;
-                    var property = entityType.FindProperty((string)((ConstantExpression)methodCallExpression.Arguments[1]).Value);
+                    var property = entityType.FindProperty(propertyName);
 
                     return _inMemoryQueryExpression.BindProperty(entityShaper.ValueBufferExpression, property);
                 }

--- a/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -411,11 +411,10 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
 
             protected override Expression VisitMethodCall(MethodCallExpression node)
             {
-                if (node.Method.IsEFPropertyMethod())
+                if (node.TryGetEFPropertyArguments(out var source, out var propertyName))
                 {
-                    if (node.Arguments[0].RemoveConvert() is QuerySourceReferenceExpression querySource
-                        && node.Arguments[1] is ConstantExpression propertyNameExpression
-                        && (string)propertyNameExpression.Value == _propertyName)
+                    if (source.RemoveConvert() is QuerySourceReferenceExpression querySource
+                        && propertyName == _propertyName)
                     {
                         _canRemoveNullCheck = querySource.ReferencedQuerySource == _querySource;
                     }

--- a/src/EFCore.Relational/Query/Pipeline/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Pipeline/RelationalSqlTranslatingExpressionVisitor.cs
@@ -97,21 +97,19 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 
         protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
         {
-            if (methodCallExpression.Method.IsEFPropertyMethod())
+            if (methodCallExpression.TryGetEFPropertyArguments(out var source, out var propertyName))
             {
-                var firstArgument = methodCallExpression.Arguments[0];
-
                 // In certain cases EF.Property would have convert node around the source.
-                if (firstArgument is UnaryExpression unaryExpression
+                if (source is UnaryExpression unaryExpression
                     && unaryExpression.NodeType == ExpressionType.Convert
                     && unaryExpression.Type == typeof(object))
                 {
-                    firstArgument = unaryExpression.Operand;
+                    source = unaryExpression.Operand;
                 }
 
-                if (firstArgument is EntityShaperExpression entityShaper)
+                if (source is EntityShaperExpression entityShaper)
                 {
-                    return BindProperty(entityShaper, (string)((ConstantExpression)methodCallExpression.Arguments[1]).Value);
+                    return BindProperty(entityShaper, propertyName);
                 }
                 else
                 {

--- a/src/EFCore/Extensions/Internal/EFPropertyExtensions.cs
+++ b/src/EFCore/Extensions/Internal/EFPropertyExtensions.cs
@@ -29,6 +29,29 @@ namespace Microsoft.EntityFrameworkCore.Extensions.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public static bool TryGetEFPropertyArguments(
+            [NotNull] this MethodCallExpression methodCallExpression,
+            out Expression entityExpression,
+            out string propertyName)
+        {
+            if (IsEFProperty(methodCallExpression)
+                && methodCallExpression.Arguments[1] is ConstantExpression propertyNameExpression)
+            {
+                entityExpression = methodCallExpression.Arguments[0];
+                propertyName = (string)propertyNameExpression.Value;
+                return true;
+            }
+
+            (entityExpression, propertyName) = (null, null);
+            return false;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public static bool IsEFProperty([NotNull] this MethodCallExpression methodCallExpression)
             => IsEFPropertyMethod(methodCallExpression.Method);
 
@@ -45,6 +68,38 @@ namespace Microsoft.EntityFrameworkCore.Extensions.Internal
                || methodInfo?.IsGenericMethod == true
                && methodInfo.Name == nameof(EF.Property)
                && methodInfo.DeclaringType?.FullName == _efTypeName;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public static bool TryGetEFIndexerArguments(
+            [NotNull] this MethodCallExpression methodCallExpression,
+            out Expression entityExpression,
+            out string propertyName)
+        {
+            if (IsEFIndexer(methodCallExpression)
+                && methodCallExpression.Arguments[0] is ConstantExpression propertyNameExpression)
+            {
+                entityExpression = methodCallExpression.Object;
+                propertyName = (string)propertyNameExpression.Value;
+                return true;
+            }
+
+            (entityExpression, propertyName) = (null, null);
+            return false;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public static bool IsEFIndexer([NotNull] this MethodCallExpression methodCallExpression)
+            => IsEFIndexer(methodCallExpression.Method);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Query/Expressions/Internal/NullConditionalExpression.cs
+++ b/src/EFCore/Query/Expressions/Internal/NullConditionalExpression.cs
@@ -149,14 +149,14 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions.Internal
                     return;
                 }
 
-                if (methodCallExpression.Method.IsEFPropertyMethod())
+                if (methodCallExpression.TryGetEFPropertyArguments(out _, out var propertyName))
                 {
                     var method = methodCallExpression.Method;
 
                     expressionPrinter.StringBuilder.Append(method.DeclaringType?.Name + "." + method.Name + "(?");
                     expressionPrinter.Visit(Caller);
                     expressionPrinter.StringBuilder.Append("?, ");
-                    expressionPrinter.Visit(methodCallExpression.Arguments[1]);
+                    expressionPrinter.Visit(Constant(propertyName));
                     expressionPrinter.StringBuilder.Append(")");
 
                     return;
@@ -201,11 +201,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions.Internal
                            + "(" + string.Join(",", methodCallExpression.Arguments) + ")";
                 }
 
-                var method = methodCallExpression.Method;
-                if (method.IsEFPropertyMethod())
+                if (methodCallExpression.TryGetEFPropertyArguments(out _, out var propertyName))
                 {
+                    var method = methodCallExpression.Method;
                     return method.DeclaringType?.Name + "." + method.Name
-                           + "(?" + Caller + "?, " + methodCallExpression.Arguments[1] + ")";
+                           + "(?" + Caller + "?, " + propertyName + ")";
                 }
             }
 

--- a/src/EFCore/Query/Internal/ExpressionPrinter.cs
+++ b/src/EFCore/Query/Internal/ExpressionPrinter.cs
@@ -735,7 +735,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         /// </summary>
         protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
         {
-            if (!methodCallExpression.Method.IsEFPropertyMethod())
+            if (!methodCallExpression.IsEFProperty())
             {
                 _stringBuilder.Append(methodCallExpression.Method.ReturnType.ShortDisplayName() + " ");
             }
@@ -760,7 +760,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             var isSimpleMethodOrProperty = _simpleMethods.Contains(methodCallExpression.Method.Name)
                                            || methodCallExpression.Arguments.Count < 2
-                                           || methodCallExpression.Method.IsEFPropertyMethod();
+                                           || methodCallExpression.IsEFProperty();
 
             var appendAction = isSimpleMethodOrProperty ? (Action<string>)Append : AppendLine;
 

--- a/src/EFCore/Query/NavigationExpansion/Visitors/IncludeApplyingVisitor.cs
+++ b/src/EFCore/Query/NavigationExpansion/Visitors/IncludeApplyingVisitor.cs
@@ -15,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore.Query.NavigationExpansion.Visitors
         protected override Expression VisitTypeBinary(TypeBinaryExpression typeBinaryExpression) => typeBinaryExpression;
 
         protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
-            => methodCallExpression.Method.IsEFPropertyMethod()
+            => methodCallExpression.IsEFProperty()
             ? methodCallExpression
             : base.VisitMethodCall(methodCallExpression);
 

--- a/src/EFCore/Query/NavigationExpansion/Visitors/NavigationPropertyBindingVisitor.cs
+++ b/src/EFCore/Query/NavigationExpansion/Visitors/NavigationPropertyBindingVisitor.cs
@@ -76,7 +76,7 @@ namespace Microsoft.EntityFrameworkCore.Query.NavigationExpansion.Visitors
 
         protected override Expression VisitUnary(UnaryExpression unaryExpression)
         {
-            if ((unaryExpression.NodeType == ExpressionType.Convert || unaryExpression.NodeType == ExpressionType.TypeAs) 
+            if ((unaryExpression.NodeType == ExpressionType.Convert || unaryExpression.NodeType == ExpressionType.TypeAs)
                 && unaryExpression.Type != typeof(object))
             {
                 if (unaryExpression.Type == unaryExpression.Operand.Type)
@@ -132,10 +132,9 @@ namespace Microsoft.EntityFrameworkCore.Query.NavigationExpansion.Visitors
 
         protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
         {
-            if (methodCallExpression.Method.IsEFPropertyMethod())
+            if (methodCallExpression.TryGetEFPropertyArguments(out var source, out var propertyName))
             {
-                var newCaller = Visit(methodCallExpression.Arguments[0]);
-                var propertyName = (string)((ConstantExpression)methodCallExpression.Arguments[1]).Value;
+                var newCaller = Visit(source);
                 var boundProperty = TryBindProperty(methodCallExpression, newCaller, propertyName);
 
                 return boundProperty ?? methodCallExpression.Update(methodCallExpression.Object, new[] { newCaller, methodCallExpression.Arguments[1] });

--- a/src/EFCore/Query/NavigationExpansion/Visitors/PendingIncludeFindingVisitor.cs
+++ b/src/EFCore/Query/NavigationExpansion/Visitors/PendingIncludeFindingVisitor.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Query.NavigationExpansion.Visitors
         protected override Expression VisitTypeBinary(TypeBinaryExpression typeBinaryExpression) => typeBinaryExpression;
 
         protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
-            => methodCallExpression.Method.IsEFPropertyMethod()
+            => methodCallExpression.IsEFProperty()
             ? methodCallExpression
             : base.VisitMethodCall(methodCallExpression);
 

--- a/test/EFCore.Specification.Tests/TestModels/Northwind/NorthwindData.cs
+++ b/test/EFCore.Specification.Tests/TestModels/Northwind/NorthwindData.cs
@@ -190,7 +190,7 @@ namespace Microsoft.EntityFrameworkCore.TestModels.Northwind
             private class ShadowStateAccessRewriter : ExpressionVisitorBase
             {
                 protected override Expression VisitMethodCall(MethodCallExpression expression)
-                    => expression.Method.IsEFPropertyMethod()
+                    => expression.IsEFProperty()
                         ? Expression.Property(
                             expression.Arguments[0].RemoveConvert(),
                             Expression.Lambda<Func<string>>(expression.Arguments[1]).Compile().Invoke())


### PR DESCRIPTION
Replace `IsEFProperty()` calls with new `TryGetEFPropertyArgument()`, which extracts the source and property name. Simplifies code repeated everywhere and is friendlier to nullability static analysis etc.