### PR TITLE
Query: Fix potential re-use of QuerySqlGen from multiple threads

### DIFF
--- a/src/EFCore.InMemory/Query/Pipeline/InMemoryShapedQueryExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Pipeline/InMemoryShapedQueryExpressionVisitor.cs
@@ -185,7 +185,6 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Pipeline
                 {
                     try
                     {
-
                         if (_enumerator == null)
                         {
                             _enumerator = _innerEnumerable.GetEnumerator();
@@ -261,7 +260,6 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Pipeline
                 {
                     try
                     {
-
                         if (_enumerator == null)
                         {
                             _enumerator = _innerEnumerable.GetEnumerator();
@@ -274,7 +272,8 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Pipeline
                             : default;
 
                         return hasNext;
-                    } catch (Exception exception)
+                    }
+                    catch (Exception exception)
                     {
                         _logger.QueryIterationFailed(_contextType, exception);
 

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SqlConstantExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SqlConstantExpression.cs
@@ -45,7 +45,9 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
 
         private bool Equals(SqlConstantExpression sqlConstantExpression)
             => base.Equals(sqlConstantExpression)
-            && Value?.Equals(sqlConstantExpression.Value) == true;
+            && (Value == null
+                ? sqlConstantExpression.Value == null
+                : Value.Equals(sqlConstantExpression.Value));
 
         public override int GetHashCode()
         {


### PR DESCRIPTION
Due to internal state, it causes corruption of generated Sql command
The fix is to pass factory and generate SqlGen when we are enumerating.

Also fixed logging when connection opening failed in query
