### PR TITLE
Query: Client eval ListInit in sqltranslator

### DIFF
--- a/src/EFCore.Relational/Query/Pipeline/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Pipeline/RelationalSqlTranslatingExpressionVisitor.cs
@@ -243,6 +243,11 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
             return null;
         }
 
+        protected override Expression VisitListInit(ListInitExpression node)
+        {
+            return null;
+        }
+
         protected override Expression VisitConstant(ConstantExpression constantExpression)
             => new SqlConstantExpression(constantExpression, null);
 

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -2493,7 +2493,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.Id);
         }
 
-        [ConditionalTheory(Skip = "issue #15852")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Optional_navigation_type_compensation_works_with_list_initializers(bool isAsync)
         {


### PR DESCRIPTION
Fixes #15852
