### PR TITLE
Query: Apply unique projection names in the subquery

### DIFF
--- a/src/EFCore.Relational/Query/Pipeline/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Pipeline/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -254,44 +254,45 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 
         protected override ShapedQueryExpression TranslateGroupJoin(ShapedQueryExpression outer, ShapedQueryExpression inner, LambdaExpression outerKeySelector, LambdaExpression innerKeySelector, LambdaExpression resultSelector)
         {
-            var outerSelectExpression = (SelectExpression)outer.QueryExpression;
-            if (outerSelectExpression.Limit != null
-                || outerSelectExpression.Offset != null
-                || outerSelectExpression.IsDistinct)
-            {
-                outerSelectExpression.PushdownIntoSubQuery();
-            }
+            //var outerSelectExpression = (SelectExpression)outer.QueryExpression;
+            //if (outerSelectExpression.Limit != null
+            //    || outerSelectExpression.Offset != null
+            //    || outerSelectExpression.IsDistinct)
+            //{
+            //    outerSelectExpression.PushdownIntoSubQuery();
+            //}
 
-            var innerSelectExpression = (SelectExpression)inner.QueryExpression;
-            if (innerSelectExpression.Orderings.Any()
-                || innerSelectExpression.Limit != null
-                || innerSelectExpression.Offset != null
-                || innerSelectExpression.IsDistinct
-                || innerSelectExpression.Predicate != null)
-            {
-                innerSelectExpression.PushdownIntoSubQuery();
-            }
+            //var innerSelectExpression = (SelectExpression)inner.QueryExpression;
+            //if (innerSelectExpression.Orderings.Any()
+            //    || innerSelectExpression.Limit != null
+            //    || innerSelectExpression.Offset != null
+            //    || innerSelectExpression.IsDistinct
+            //    || innerSelectExpression.Predicate != null
+            //    || innerSelectExpression.Tables.Count > 1)
+            //{
+            //    innerSelectExpression.PushdownIntoSubQuery();
+            //}
 
-            var joinPredicate = CreateJoinPredicate(outer, outerKeySelector, inner, innerKeySelector);
-            if (joinPredicate != null)
-            {
-                outer = TranslateThenBy(outer, outerKeySelector, true);
+            //var joinPredicate = CreateJoinPredicate(outer, outerKeySelector, inner, innerKeySelector);
+            //if (joinPredicate != null)
+            //{
+            //    outer = TranslateThenBy(outer, outerKeySelector, true);
 
-                var innerTransparentIdentifierType = CreateTransparentIdentifierType(
-                    resultSelector.Parameters[0].Type,
-                    resultSelector.Parameters[1].Type.TryGetSequenceType());
+            //    var innerTransparentIdentifierType = CreateTransparentIdentifierType(
+            //        resultSelector.Parameters[0].Type,
+            //        resultSelector.Parameters[1].Type.TryGetSequenceType());
 
-                outerSelectExpression.AddLeftJoin(
-                    innerSelectExpression, joinPredicate, innerTransparentIdentifierType);
+            //    outerSelectExpression.AddLeftJoin(
+            //        innerSelectExpression, joinPredicate, innerTransparentIdentifierType);
 
-                return TranslateResultSelectorForGroupJoin(
-                    outer,
-                    inner.ShaperExpression,
-                    outerKeySelector,
-                    innerKeySelector,
-                    resultSelector,
-                    innerTransparentIdentifierType);
-            }
+            //    return TranslateResultSelectorForGroupJoin(
+            //        outer,
+            //        inner.ShaperExpression,
+            //        outerKeySelector,
+            //        innerKeySelector,
+            //        resultSelector,
+            //        innerTransparentIdentifierType);
+            //}
 
             throw new NotImplementedException();
         }
@@ -305,6 +306,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
             LambdaExpression innerKeySelector,
             LambdaExpression resultSelector)
         {
+            // TODO: write a test which has distinct on outer so that we can verify pushdown
             var innerSelectExpression = (SelectExpression)inner.QueryExpression;
             if (innerSelectExpression.Orderings.Any()
                 || innerSelectExpression.Limit != null
@@ -353,7 +355,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                 || innerSelectExpression.Limit != null
                 || innerSelectExpression.Offset != null
                 || innerSelectExpression.IsDistinct
-                || innerSelectExpression.Predicate != null)
+                || innerSelectExpression.Predicate != null
+                || innerSelectExpression.Tables.Count > 1)
             {
                 innerSelectExpression.PushdownIntoSubQuery();
             }

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -348,7 +348,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory(Skip = "Issue #15833")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_navigation_key_access_optional(bool isAsync)
         {
@@ -375,7 +375,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Id1 + " " + e.Id2);
         }
 
-        [ConditionalTheory(Skip = "Issue #15833")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_navigation_key_access_required(bool isAsync)
         {
@@ -759,7 +759,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Id1 + " " + e.Id3);
         }
 
-        [ConditionalTheory(Skip = "Issue #15833")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_navigation_in_inner_selector_translated_to_subquery(bool isAsync)
         {
@@ -784,7 +784,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Id2 + " " + e.Id1);
         }
 
-        [ConditionalTheory(Skip = "Issue #15833")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_navigations_in_inner_selector_translated_to_multiple_subquery_without_collision(bool isAsync)
         {
@@ -814,7 +814,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Id2 + " " + e.Id1 + " " + e.Id3);
         }
 
-        [ConditionalTheory(Skip = "issue #15833")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_navigation_translated_to_subquery_non_key_join(bool isAsync)
         {
@@ -874,7 +874,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Id2 + " " + e.Name2 + " " + e.Id1 + " " + e.Name1);
         }
 
-        [ConditionalTheory(Skip = "Issue# 15833")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_navigation_translated_to_subquery_self_ref(bool isAsync)
         {
@@ -900,7 +900,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Id1 + " " + e.Id2);
         }
 
-        [ConditionalTheory(Skip = "Issue #15833")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_navigation_translated_to_subquery_nested(bool isAsync)
         {
@@ -959,7 +959,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Id3 + " " + e.Id1);
         }
 
-        [ConditionalTheory(Skip = "Issue #15833")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_navigation_translated_to_subquery_deeply_nested_non_key_join(bool isAsync)
         {
@@ -994,7 +994,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Id4 + " " + e.Name4 + " " + e.Id1 + " " + e.Name1);
         }
 
-        [ConditionalTheory(Skip = "Issue #15833")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_navigation_translated_to_subquery_deeply_nested_required(bool isAsync)
         {
@@ -2407,7 +2407,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 (e, a) => Assert.Equal(e.Id, a.Id));
         }
 
-        [ConditionalTheory(Skip = "issue #15833")]
+        [ConditionalTheory(Skip = "Issue#15872")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Null_protection_logic_work_for_inner_key_access_of_manually_created_GroupJoin2(bool isAsync)
         {
@@ -3680,7 +3680,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.Id1);
         }
 
-        [ConditionalTheory(Skip = "issue #15833")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Optional_navigation_propagates_nullability_to_manually_created_left_join2(bool isAsync)
         {
@@ -3708,7 +3708,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.Name1 + e.Name2);
         }
 
-        [ConditionalTheory(Skip = "issue #15833")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Null_reference_protection_complex(bool isAsync)
         {
@@ -3736,7 +3736,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select Maybe(l2_outer, () => l2_outer.Name));
         }
 
-        [ConditionalTheory(Skip = "issue #15833")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Null_reference_protection_complex_materialization(bool isAsync)
         {
@@ -3783,7 +3783,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return element;
         }
 
-        [ConditionalTheory(Skip = "issue #15833")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Null_reference_protection_complex_client_eval(bool isAsync)
         {
@@ -3811,7 +3811,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select ClientMethodReturnSelf(Maybe(l2_outer, () => l2_outer.Name)));
         }
 
-        [ConditionalTheory(Skip = "issue #15833")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_with_complex_subquery_with_joins_does_not_get_flattened(bool isAsync)
         {
@@ -3841,7 +3841,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select MaybeScalar<int>(subquery, () => subquery.Id));
         }
 
-        [ConditionalTheory(Skip = "issue #15833")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_with_complex_subquery_with_joins_does_not_get_flattened2(bool isAsync)
         {
@@ -3871,7 +3871,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select MaybeScalar<int>(subquery, () => subquery.Id));
         }
 
-        [ConditionalTheory(Skip = "issue #15833")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_with_complex_subquery_with_joins_does_not_get_flattened3(bool isAsync)
         {
@@ -5851,7 +5851,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15833")]
+        [ConditionalFact]
         public virtual void Include17()
         {
             using (var ctx = CreateContext())
@@ -5909,7 +5909,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 expectedIncludes);
         }
 
-        [ConditionalFact(Skip = "issue #15833")]
+        [ConditionalFact]
         public virtual void Include18_3()
         {
             using (var ctx = CreateContext())
@@ -5920,7 +5920,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15833")]
+        [ConditionalFact]
         public virtual void Include18_3_1()
         {
             using (var ctx = CreateContext())
@@ -5931,7 +5931,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15833")]
+        [ConditionalFact]
         public virtual void Include18_3_2()
         {
             using (var ctx = CreateContext())
@@ -5957,7 +5957,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 expectedIncludes);
         }
 
-        [ConditionalFact(Skip = "issue #15833")]
+        [ConditionalFact]
         public virtual void Include18_4()
         {
             using (var ctx = CreateContext())
@@ -5968,7 +5968,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15833")]
+        [ConditionalFact]
         public virtual void Include18()
         {
             using (var ctx = CreateContext())
@@ -5979,7 +5979,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15833")]
+        [ConditionalFact]
         public virtual void Include19()
         {
             using (var ctx = CreateContext())

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -1954,7 +1954,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select g);
         }
 
-        [ConditionalTheory(Skip = "Issue #15833")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_navigation_translated_to_subquery_composite_key(bool isAsync)
         {
@@ -6137,7 +6137,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.Name1 + " " + e.Name2);
         }
 
-        [ConditionalTheory(Skip = "Issue #15833")]
+        [ConditionalTheory(Skip = "Issue#15588")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_on_entity_qsre_keys_inner_key_is_navigation(bool isAsync)
         {
@@ -6188,7 +6188,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.SquadName + " " + e.WeaponName);
         }
 
-        [ConditionalTheory(Skip = "Issue #15833")]
+        [ConditionalTheory(Skip = "Issue#15588")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_on_entity_qsre_keys_inner_key_is_nested_navigation(bool isAsync)
         {

--- a/test/EFCore.Specification.Tests/Query/QueryNavigationsTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/QueryNavigationsTestBase.cs
@@ -1318,7 +1318,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.OrderID);
         }
 
-        [ConditionalTheory(Skip = "issue #15833")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_with_complex_subquery_and_LOJ_gets_flattened(bool isAsync)
         {
@@ -1339,7 +1339,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 91);
         }
 
-        [ConditionalTheory(Skip = "issue #15833")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_with_complex_subquery_and_LOJ_gets_flattened2(bool isAsync)
         {


### PR DESCRIPTION
Fixes #15833
