### PR TITLE
Query: Enable parameter & sproc support for FromSql

### DIFF
--- a/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
+++ b/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
@@ -94,7 +94,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 { typeof(IRelationalTypeMappingSourcePlugin), new ServiceCharacteristics(ServiceLifetime.Singleton, multipleRegistrations: true) },
 
                 // New Query Pipeline
-                { typeof(IQuerySqlGeneratorFactory2), new ServiceCharacteristics(ServiceLifetime.Scoped) },
+                { typeof(IQuerySqlGeneratorFactory2), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(IRelationalSqlTranslatingExpressionVisitorFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(IMethodCallTranslatorProvider), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(IMemberTranslatorProvider), new ServiceCharacteristics(ServiceLifetime.Singleton) },

--- a/src/EFCore.Relational/Query/Pipeline/FromSqlParameterApplyingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Pipeline/FromSqlParameterApplyingExpressionVisitor.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
+{
+    public partial class RelationalShapedQueryCompilingExpressionVisitor
+    {
+        private class FromSqlParameterApplyingExpressionVisitor : ExpressionVisitor
+        {
+            private readonly IDictionary<FromSqlExpression, Expression> _visitedFromSqlExpressions
+                = new Dictionary<FromSqlExpression, Expression>(ReferenceEqualityComparer.Instance);
+
+            private readonly ISqlExpressionFactory _SqlExpressionFactory;
+            private readonly ParameterNameGenerator _parameterNameGenerator;
+            private IReadOnlyDictionary<string, object> _parametersValues;
+
+            public FromSqlParameterApplyingExpressionVisitor(
+                ISqlExpressionFactory _sqlExpressionFactory,
+                ParameterNameGenerator parameterNameGenerator,
+                IReadOnlyDictionary<string, object> parametersValues)
+            {
+                _SqlExpressionFactory = _sqlExpressionFactory;
+                _parameterNameGenerator = parameterNameGenerator;
+                _parametersValues = parametersValues;
+            }
+
+            public override Expression Visit(Expression expression)
+            {
+                if (expression is FromSqlExpression fromSql)
+                {
+                    if (!_visitedFromSqlExpressions.TryGetValue(fromSql, out var updatedFromSql))
+                    {
+                        switch (fromSql.Arguments)
+                        {
+                            case ParameterExpression parameterExpression:
+                                var parameterValues = (object[])_parametersValues[parameterExpression.Name];
+
+                                var subParameters = new List<IRelationalParameter>(parameterValues.Length);
+                                for (var i = 0; i < parameterValues.Length; i++)
+                                {
+                                    var parameterName = _parameterNameGenerator.GenerateNext();
+                                    if (parameterValues[i] is DbParameter dbParameter)
+                                    {
+                                        if (string.IsNullOrEmpty(dbParameter.ParameterName))
+                                        {
+                                            dbParameter.ParameterName = parameterName;
+                                        }
+                                        else
+                                        {
+                                            parameterName = dbParameter.ParameterName;
+                                        }
+
+                                        subParameters.Add(new RawRelationalParameter(parameterName, dbParameter));
+                                    }
+                                    else
+                                    {
+                                        subParameters.Add(
+                                            new TypeMappedRelationalParameter(
+                                                parameterName,
+                                                parameterName,
+                                                _SqlExpressionFactory.GetTypeMappingForValue(parameterValues[i]),
+                                                parameterValues[i]?.GetType().IsNullableType()));
+                                    }
+                                }
+
+                                updatedFromSql = new FromSqlExpression(
+                                    fromSql.Sql,
+                                    Expression.Constant(
+                                        new CompositeRelationalParameter(
+                                            parameterExpression.Name,
+                                            subParameters)),
+                                    fromSql.Alias);
+
+                                _visitedFromSqlExpressions[fromSql] = updatedFromSql;
+                                break;
+                        }
+                    }
+
+                    return updatedFromSql;
+                }
+
+                return base.Visit(expression);
+            }
+        }
+    }
+}

--- a/src/EFCore.Relational/Query/Pipeline/ISqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/Pipeline/ISqlExpressionFactory.cs
@@ -15,6 +15,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
         #region TypeMapping
         SqlExpression ApplyTypeMapping(SqlExpression sqlExpression, RelationalTypeMapping typeMapping);
         SqlExpression ApplyDefaultTypeMapping(SqlExpression sqlExpression);
+        RelationalTypeMapping GetTypeMappingForValue(object value);
         #endregion
 
         #region Binary

--- a/src/EFCore.Relational/Query/Pipeline/InExpressionValuesExpandingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Pipeline/InExpressionValuesExpandingExpressionVisitor.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
+{
+    public partial class RelationalShapedQueryCompilingExpressionVisitor
+    {
+        private class InExpressionValuesExpandingExpressionVisitor : ExpressionVisitor
+        {
+            private readonly ISqlExpressionFactory _sqlExpressionFactory;
+            private IReadOnlyDictionary<string, object> _parametersValues;
+
+            public InExpressionValuesExpandingExpressionVisitor(
+                ISqlExpressionFactory sqlExpressionFactory, IReadOnlyDictionary<string, object> parametersValues)
+            {
+                _sqlExpressionFactory = sqlExpressionFactory;
+                _parametersValues = parametersValues;
+            }
+
+            public override Expression Visit(Expression expression)
+            {
+                if (expression is InExpression inExpression
+                    && inExpression.Values != null)
+                {
+                    var inValues = new List<object>();
+                    var hasNullValue = false;
+                    RelationalTypeMapping typeMapping = null;
+
+                    switch (inExpression.Values)
+                    {
+                        case SqlConstantExpression sqlConstant:
+                            {
+                                typeMapping = sqlConstant.TypeMapping;
+                                var values = (IEnumerable)sqlConstant.Value;
+                                foreach (var value in values)
+                                {
+                                    if (value == null)
+                                    {
+                                        hasNullValue = true;
+                                        continue;
+                                    }
+
+                                    inValues.Add(value);
+                                }
+                            }
+                            break;
+
+                        case SqlParameterExpression sqlParameter:
+                            {
+                                typeMapping = sqlParameter.TypeMapping;
+                                var values = (IEnumerable)_parametersValues[sqlParameter.Name];
+                                foreach (var value in values)
+                                {
+                                    if (value == null)
+                                    {
+                                        hasNullValue = true;
+                                        continue;
+                                    }
+
+                                    inValues.Add(value);
+                                }
+                            }
+                            break;
+                    }
+
+                    var updatedInExpression = inValues.Count > 0
+                        ? _sqlExpressionFactory.In(
+                            (SqlExpression)Visit(inExpression.Item),
+                            _sqlExpressionFactory.Constant(inValues, typeMapping),
+                            inExpression.Negated)
+                        : null;
+
+                    var nullCheckExpression = hasNullValue
+                        ? _sqlExpressionFactory.IsNull(inExpression.Item)
+                        : null;
+
+                    if (updatedInExpression != null && nullCheckExpression != null)
+                    {
+                        return _sqlExpressionFactory.OrElse(updatedInExpression, nullCheckExpression);
+                    }
+
+                    if (updatedInExpression == null && nullCheckExpression == null)
+                    {
+                        return _sqlExpressionFactory.Equal(_sqlExpressionFactory.Constant(true), _sqlExpressionFactory.Constant(false));
+                    }
+
+                    return (SqlExpression)updatedInExpression ?? nullCheckExpression;
+                }
+
+                return base.Visit(expression);
+            }
+        }
+    }
+}

--- a/src/EFCore.Relational/Query/Pipeline/ParameterValueBasedSelectExpressionOptimizer.cs
+++ b/src/EFCore.Relational/Query/Pipeline/ParameterValueBasedSelectExpressionOptimizer.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
+{
+    public partial class RelationalShapedQueryCompilingExpressionVisitor
+    {
+        private class ParameterValueBasedSelectExpressionOptimizer
+        {
+            private readonly ISqlExpressionFactory _sqlExpressionFactory;
+            private readonly IParameterNameGeneratorFactory _parameterNameGeneratorFactory;
+
+            public ParameterValueBasedSelectExpressionOptimizer(
+                ISqlExpressionFactory sqlExpressionFactory,
+                IParameterNameGeneratorFactory parameterNameGeneratorFactory)
+            {
+                _sqlExpressionFactory = sqlExpressionFactory;
+                _parameterNameGeneratorFactory = parameterNameGeneratorFactory;
+            }
+
+            public SelectExpression Optimize(SelectExpression selectExpression, IReadOnlyDictionary<string, object> parametersValues)
+            {
+                var query = new InExpressionValuesExpandingExpressionVisitor(
+                    _sqlExpressionFactory, parametersValues).Visit(selectExpression);
+
+                query = new FromSqlParameterApplyingExpressionVisitor(
+                    _sqlExpressionFactory,
+                    _parameterNameGeneratorFactory.Create(),
+                    parametersValues).Visit(query);
+
+
+                return (SelectExpression)query;
+            }
+        }
+    }
+}

--- a/src/EFCore.Relational/Query/Pipeline/RelationalShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Pipeline/RelationalShapedQueryCompilingExpressionVisitor.cs
@@ -2,20 +2,26 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
+using System.Data.Common;
 using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.Pipeline;
 using Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions;
+using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 {
     public partial class RelationalShapedQueryCompilingExpressionVisitor : ShapedQueryCompilingExpressionVisitor
     {
         private readonly IQuerySqlGeneratorFactory2 _querySqlGeneratorFactory;
+        private readonly ISqlExpressionFactory _sqlExpressionFactory;
+        private readonly IParameterNameGeneratorFactory _parameterNameGeneratorFactory;
         private readonly Type _contextType;
         private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
         private static ParameterExpression _resultCoordinatorParameter
@@ -24,6 +30,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
         public RelationalShapedQueryCompilingExpressionVisitor(
             IEntityMaterializerSource entityMaterializerSource,
             IQuerySqlGeneratorFactory2 querySqlGeneratorFactory,
+            ISqlExpressionFactory sqlExpressionFactory,
+            IParameterNameGeneratorFactory parameterNameGeneratorFactory,
             Type contextType,
             IDiagnosticsLogger<DbLoggerCategory.Query> logger,
             bool trackQueryResults,
@@ -31,6 +39,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
             : base(entityMaterializerSource, trackQueryResults, async)
         {
             _querySqlGeneratorFactory = querySqlGeneratorFactory;
+            _sqlExpressionFactory = sqlExpressionFactory;
+            _parameterNameGeneratorFactory = parameterNameGeneratorFactory;
             _contextType = contextType;
             _logger = logger;
         }
@@ -45,6 +55,31 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 
             shaperBody = new IncludeCompilingExpressionVisitor(TrackQueryResults).Visit(shaperBody);
 
+            if (selectExpression.IsNonComposedFromSql())
+            {
+                var indexMapParameter = Expression.Parameter(typeof(int[]), "indexMap");
+                shaperBody = new IndexMapInjectingExpressionVisitor(indexMapParameter).Visit(shaperBody);
+                var remappedShaperLambda =
+                    Expression.Lambda(
+                        shaperBody,
+                        QueryCompilationContext2.QueryContextParameter,
+                        RelationalProjectionBindingRemovingExpressionVisitor.DataReaderParameter,
+                        indexMapParameter);
+
+                return Expression.New(
+                    Async
+                        ? typeof(FromSqlNonComposedAsyncQueryingEnumerable<>).MakeGenericType(remappedShaperLambda.ReturnType.GetGenericArguments().Single()).GetConstructors()[0]
+                        : typeof(FromSqlNonComposedQueryingEnumerable<>).MakeGenericType(remappedShaperLambda.ReturnType).GetConstructors()[0],
+                    Expression.Convert(QueryCompilationContext2.QueryContextParameter, typeof(RelationalQueryContext)),
+                    Expression.Constant(_querySqlGeneratorFactory),
+                    Expression.Constant(_sqlExpressionFactory),
+                    Expression.Constant(_parameterNameGeneratorFactory),
+                    Expression.Constant(selectExpression),
+                    Expression.Constant(remappedShaperLambda.Compile()),
+                    Expression.Constant(_contextType),
+                    Expression.Constant(_logger));
+            }
+
             var shaperLambda = Expression.Lambda(
                 shaperBody,
                 QueryCompilationContext2.QueryContextParameter,
@@ -57,6 +92,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                     typeof(AsyncQueryingEnumerable<>).MakeGenericType(shaperLambda.ReturnType.GetGenericArguments().Single()).GetConstructors()[0],
                     Expression.Convert(QueryCompilationContext2.QueryContextParameter, typeof(RelationalQueryContext)),
                     Expression.Constant(_querySqlGeneratorFactory),
+                    Expression.Constant(_sqlExpressionFactory),
+                    Expression.Constant(_parameterNameGeneratorFactory),
                     Expression.Constant(selectExpression),
                     Expression.Constant(shaperLambda.Compile()),
                     Expression.Constant(_contextType),
@@ -67,10 +104,39 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                 typeof(QueryingEnumerable<>).MakeGenericType(shaperLambda.ReturnType).GetConstructors()[0],
                 Expression.Convert(QueryCompilationContext2.QueryContextParameter, typeof(RelationalQueryContext)),
                 Expression.Constant(_querySqlGeneratorFactory),
+                Expression.Constant(_sqlExpressionFactory),
+                Expression.Constant(_parameterNameGeneratorFactory),
                 Expression.Constant(selectExpression),
                 Expression.Constant(shaperLambda.Compile()),
                 Expression.Constant(_contextType),
                 Expression.Constant(_logger));
+        }
+
+        private class IndexMapInjectingExpressionVisitor : ExpressionVisitor
+        {
+            private ParameterExpression _indexMapParameter;
+
+            public IndexMapInjectingExpressionVisitor(ParameterExpression indexMapParameter)
+            {
+                _indexMapParameter = indexMapParameter;
+            }
+
+            protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
+            {
+                if (methodCallExpression.Object != null
+                    && typeof(DbDataReader).IsAssignableFrom(methodCallExpression.Object.Type))
+                {
+                    var indexArgument = methodCallExpression.Arguments[0];
+                    return methodCallExpression.Update(
+                        methodCallExpression.Object,
+                        new[]
+                        {
+                            Expression.ArrayIndex(_indexMapParameter, indexArgument),
+                        });
+                }
+
+                return base.VisitMethodCall(methodCallExpression);
+            }
         }
 
         private class ResultCoordinator

--- a/src/EFCore.Relational/Query/Pipeline/RelationalShapedQueryExpressionVisitorFactory.cs
+++ b/src/EFCore.Relational/Query/Pipeline/RelationalShapedQueryExpressionVisitorFactory.cs
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.EntityFrameworkCore.Metadata;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Query.Pipeline;
+using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 {
@@ -11,12 +11,19 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
     {
         private readonly IEntityMaterializerSource _entityMaterializerSource;
         private readonly IQuerySqlGeneratorFactory2 _querySqlGeneratorFactory;
+        private readonly ISqlExpressionFactory _sqlExpressionFactory;
+        private readonly IParameterNameGeneratorFactory _parameterNameGeneratorFactory;
 
-        public RelationalShapedQueryCompilingExpressionVisitorFactory(IEntityMaterializerSource entityMaterializerSource,
-            IQuerySqlGeneratorFactory2 querySqlGeneratorFactory)
+        public RelationalShapedQueryCompilingExpressionVisitorFactory(
+            IEntityMaterializerSource entityMaterializerSource,
+            IQuerySqlGeneratorFactory2 querySqlGeneratorFactory,
+            ISqlExpressionFactory sqlExpressionFactory,
+            IParameterNameGeneratorFactory parameterNameGeneratorFactory)
         {
             _entityMaterializerSource = entityMaterializerSource;
             _querySqlGeneratorFactory = querySqlGeneratorFactory;
+            _sqlExpressionFactory = sqlExpressionFactory;
+            _parameterNameGeneratorFactory = parameterNameGeneratorFactory;
         }
 
         public ShapedQueryCompilingExpressionVisitor Create(QueryCompilationContext2 queryCompilationContext)
@@ -24,6 +31,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
             return new RelationalShapedQueryCompilingExpressionVisitor(
                 _entityMaterializerSource,
                 _querySqlGeneratorFactory,
+                _sqlExpressionFactory,
+                _parameterNameGeneratorFactory,
                 queryCompilationContext.ContextType,
                 queryCompilationContext.Logger,
                 queryCompilationContext.TrackQueryResults,

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressionFactory.cs
@@ -200,6 +200,11 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                 resultType,
                 resultTypeMapping);
         }
+
+        public virtual RelationalTypeMapping GetTypeMappingForValue(object value)
+        {
+            return _typeMappingSource.GetMappingForValue(value);
+        }
         #endregion
 
         #region Binary

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SelectExpression.cs
@@ -84,6 +84,18 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             _projectionMapping[new ProjectionMember()] = new EntityProjectionExpression(entityType, fromSqlExpression, false);
         }
 
+        public bool IsNonComposedFromSql()
+        {
+            return Limit == null
+                && Offset == null
+                && !IsDistinct
+                && Predicate == null
+                && Orderings.Count == 0
+                && Tables.Count == 1
+                && Tables[0] is FromSqlExpression fromSql
+                && Projection.All(pe => pe.Expression is ColumnExpression column ? ReferenceEquals(column.Table, fromSql) : false);
+        }
+
         public SqlExpression BindProperty(Expression projectionExpression, IProperty property)
         {
             var member = (projectionExpression as ProjectionBindingExpression).ProjectionMember;

--- a/src/EFCore.Relational/Storage/RelationalCommand.cs
+++ b/src/EFCore.Relational/Storage/RelationalCommand.cs
@@ -419,7 +419,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             var command = connection.DbConnection.CreateCommand();
 
             command.CommandText = CommandText;
-            
+
             if (connection.CurrentTransaction != null)
             {
                 command.Transaction = connection.CurrentTransaction.GetDbTransaction();

--- a/src/EFCore.Relational/Storage/RelationalCommandBuilderExtensions.cs
+++ b/src/EFCore.Relational/Storage/RelationalCommandBuilderExtensions.cs
@@ -280,7 +280,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                     property.FindRelationalMapping(),
                     property));
         }
-        
+
         private sealed class Indenter : IDisposable
         {
             private readonly IRelationalCommandBuilder _builder;

--- a/src/EFCore.Relational/Storage/RelationalSqlGenerationHelper.cs
+++ b/src/EFCore.Relational/Storage/RelationalSqlGenerationHelper.cs
@@ -51,7 +51,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     A valid name based on the candidate name.
         /// </returns>
         public virtual string GenerateParameterName(string name)
-            => "@" + name;
+            => name.StartsWith("@")
+                ? name
+                : "@" + name;
 
         /// <summary>
         ///     Writes a valid parameter name for the given candidate name.

--- a/test/EFCore.Relational.Specification.Tests/Query/AsyncFromSqlQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/AsyncFromSqlQueryTestBase.cs
@@ -101,7 +101,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact(Skip = "#15750")]
+        [Fact(Skip = "Issue#15763")]
         public virtual async Task FromSqlRaw_queryable_multiple_composed_with_closure_parameters()
         {
             var startDate = new DateTime(1997, 1, 1);
@@ -125,7 +125,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact(Skip = "#15750")]
+        [Fact(Skip = "Issue#15763")]
         public virtual async Task FromSqlRaw_queryable_multiple_composed_with_parameters_and_closure_parameters()
         {
             var city = "London";
@@ -185,7 +185,7 @@ FROM [Customers]"))
             }
         }
 
-        [Fact(Skip = "#15750")]
+        [Fact]
         public virtual async Task FromSqlRaw_queryable_with_parameters()
         {
             var city = "London";
@@ -203,7 +203,7 @@ FROM [Customers]"))
             }
         }
 
-        [Fact(Skip = "#15750")]
+        [Fact]
         public virtual async Task FromSqlRaw_queryable_with_parameters_and_closure()
         {
             var city = "London";
@@ -241,7 +241,7 @@ FROM [Customers]"))
             }
         }
 
-        [Fact(Skip = "#15750")]
+        [Fact]
         public virtual async Task FromSqlRaw_queryable_with_parameters_cache_key_includes_parameters()
         {
             var city = "London";

--- a/test/EFCore.Relational.Specification.Tests/Query/FromSqlQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/FromSqlQueryTestBase.cs
@@ -325,7 +325,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact(Skip = "#15750")]
+        [Fact(Skip = "Issue#15763")]
         public virtual void FromSqlRaw_queryable_multiple_composed_with_closure_parameters()
         {
             var startDate = new DateTime(1997, 1, 1);
@@ -351,7 +351,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact(Skip = "#15750")]
+        [Fact(Skip = "Issue#15763")]
         public virtual void FromSqlRaw_queryable_multiple_composed_with_parameters_and_closure_parameters()
         {
             var city = "London";
@@ -434,7 +434,7 @@ FROM [Customers]"))
             }
         }
 
-        [Fact(Skip = "#15750")]
+        [Fact]
         public virtual void FromSqlRaw_queryable_with_parameters()
         {
             var city = "London";
@@ -452,7 +452,7 @@ FROM [Customers]"))
             }
         }
 
-        [Fact(Skip = "#15750")]
+        [Fact]
         public virtual void FromSqlRaw_queryable_with_parameters_inline()
         {
             using (var context = CreateContext())
@@ -468,7 +468,7 @@ FROM [Customers]"))
             }
         }
 
-        [Fact(Skip = "#15750")]
+        [Fact]
         public virtual void FromSqlInterpolated_queryable_with_parameters_interpolated()
         {
             var city = "London";
@@ -487,7 +487,7 @@ FROM [Customers]"))
             }
         }
 
-        [Fact(Skip = "#15750")]
+        [Fact]
         public virtual void FromSqlInterpolated_queryable_with_parameters_inline_interpolated()
         {
             using (var context = CreateContext())
@@ -503,7 +503,7 @@ FROM [Customers]"))
             }
         }
 
-        [Fact(Skip = "#15750")]
+        [Fact(Skip = "Issue#15763")]
         public virtual void FromSqlInterpolated_queryable_multiple_composed_with_parameters_and_closure_parameters_interpolated()
         {
             var city = "London";
@@ -546,7 +546,7 @@ FROM [Customers]"))
             }
         }
 
-        [Fact(Skip = "#15750")]
+        [Fact]
         public virtual void FromSqlRaw_queryable_with_null_parameter()
         {
             uint? reportsTo = null;
@@ -556,14 +556,14 @@ FROM [Customers]"))
                 var actual = context.Set<Employee>().FromSqlRaw(
                         NormalizeDelimetersInRawString(
                             // ReSharper disable once ExpressionIsAlwaysNull
-                            "SELECT * FROM [Employees] WHERE [ReportsTo] = {0} OR (]ReportsTo] IS NULL AND {0} IS NULL)"), reportsTo)
+                            "SELECT * FROM [Employees] WHERE [ReportsTo] = {0} OR ([ReportsTo] IS NULL AND {0} IS NULL)"), reportsTo)
                     .ToArray();
 
                 Assert.Equal(1, actual.Length);
             }
         }
 
-        [Fact(Skip = "#15750")]
+        [Fact]
         public virtual void FromSqlRaw_queryable_with_parameters_and_closure()
         {
             var city = "London";
@@ -600,7 +600,7 @@ FROM [Customers]"))
             }
         }
 
-        [Fact(Skip = "#15750")]
+        [Fact]
         public virtual void FromSqlRaw_queryable_with_parameters_cache_key_includes_parameters()
         {
             var city = "London";
@@ -718,7 +718,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
             }
         }
 
-        [Fact(Skip = "#15750")]
+        [Fact]
         public virtual void FromSqlRaw_with_dbParameter()
         {
             using (var context = CreateContext())
@@ -733,7 +733,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
             }
         }
 
-        [Fact(Skip = "#15750")]
+        [Fact]
         public virtual void FromSqlRaw_with_dbParameter_mixed()
         {
             using (var context = CreateContext())
@@ -795,7 +795,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
             Fixture.TestStore.OpenConnection();
         }
 
-        [Fact(Skip = "#15750")]
+        [Fact]
         public virtual void FromSqlRaw_with_db_parameters_called_multiple_times()
         {
             using (var context = CreateContext())
@@ -897,7 +897,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
             }
         }
 
-        [Fact(Skip = "#15750")]
+        [Fact]
         public virtual void FromSqlInterpolated_with_inlined_db_parameter()
         {
             using (var context = CreateContext())
@@ -910,7 +910,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
             }
         }
 
-        [Fact(Skip = "#15750")]
+        [Fact]
         public virtual void FromSqlInterpolated_parameterization_issue_12213()
         {
             using (var context = CreateContext())
@@ -940,7 +940,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
             }
         }
 
-        [Fact(Skip = "#15750")]
+        [Fact]
         public virtual void FromSqlRaw_does_not_parameterize_interpolated_string()
         {
             using (var context = CreateContext())

--- a/test/EFCore.Relational.Specification.Tests/Query/FromSqlSprocQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/FromSqlSprocQueryTestBase.cs
@@ -56,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Issue#15889")]
         public virtual void From_sql_queryable_stored_procedure_reprojection()
         {
             using (var context = CreateContext())

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AsyncFromSqlSprocQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AsyncFromSqlSprocQuerySqlServerTest.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.TestUtilities;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
-    internal class AsyncFromSqlSprocQuerySqlServerTest : AsyncFromSqlSprocQueryTestBase<NorthwindQuerySqlServerFixture<NoopModelCustomizer>>
+    public class AsyncFromSqlSprocQuerySqlServerTest : AsyncFromSqlSprocQueryTestBase<NorthwindQuerySqlServerFixture<NoopModelCustomizer>>
     {
         public AsyncFromSqlSprocQuerySqlServerTest(NorthwindQuerySqlServerFixture<NoopModelCustomizer> fixture)
             : base(fixture)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlQuerySqlServerTest.cs
@@ -525,7 +525,7 @@ ORDER BY [t].[OrderID]");
 SELECT * FROM ""Customers"" WHERE ""CustomerID"" = @somename");
         }
 
-        [Fact(Skip = "#15750")]
+        [Fact]
         public virtual void FromSqlRaw_in_subquery_with_dbParameter()
         {
             using (var context = CreateContext())
@@ -557,7 +557,7 @@ WHERE [o].[CustomerID] IN (
             }
         }
 
-        [Fact(Skip = "#15750")]
+        [Fact]
         public virtual void FromSqlRaw_in_subquery_with_positional_dbParameter_without_name()
         {
             using (var context = CreateContext())
@@ -592,7 +592,7 @@ WHERE [o].[CustomerID] IN (
             }
         }
 
-        [Fact(Skip = "#15750")]
+        [Fact]
         public virtual void FromSqlRaw_in_subquery_with_positional_dbParameter_with_name()
         {
             using (var context = CreateContext())
@@ -624,7 +624,7 @@ WHERE [o].[CustomerID] IN (
             }
         }
 
-        [Fact(Skip = "#15750")]
+        [Fact]
         public virtual void FromSqlRaw_with_dbParameter_mixed_in_subquery()
         {
             using (var context = CreateContext())

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlSprocQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlSprocQuerySqlServerTest.cs
@@ -8,7 +8,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
-    internal class FromSqlSprocQuerySqlServerTest : FromSqlSprocQueryTestBase<NorthwindQuerySqlServerFixture<NoopModelCustomizer>>
+    public class FromSqlSprocQuerySqlServerTest : FromSqlSprocQueryTestBase<NorthwindQuerySqlServerFixture<NoopModelCustomizer>>
     {
         public FromSqlSprocQuerySqlServerTest(
             NorthwindQuerySqlServerFixture<NoopModelCustomizer> fixture, ITestOutputHelper testOutputHelper)
@@ -40,7 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             base.From_sql_queryable_stored_procedure_with_parameter();
 
             Assert.Equal(
-                @"@p0='ALFKI' (Size = 4000)
+                @"p0='ALFKI' (Size = 4000)
 
 [dbo].[CustOrderHist] @CustomerID = @p0",
                 Sql,

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerComplianceTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerComplianceTest.cs
@@ -31,8 +31,6 @@ namespace Microsoft.EntityFrameworkCore
             typeof(GearsOfWarFromSqlQueryTestBase<>),
             typeof(QueryNoClientEvalTestBase<>),
             typeof(WarningsTestBase<>),
-            typeof(AsyncFromSqlSprocQueryTestBase<>),
-            typeof(FromSqlSprocQueryTestBase<>),
         };
 
         protected override Assembly TargetAssembly { get; } = typeof(SqlServerComplianceTest).Assembly;


### PR DESCRIPTION
Adds optimizer to optimize SelectExpression before printing based on ParameterValues
TODO: Add a factory through service to avoid multiple services here. This also serves point for us to determine second level caching

Lift FromSqlExpression when not composed over to avoid subquery which is necessary for stored procedures
Add additional enumerables which add remapping map to materialize non composed SelectExpression which can have out of order projections

Resolves#15750
