### PR TITLE
Fix ASP.NET templates test break

### DIFF
--- a/src/EFCore.Relational/Extensions/RelationalIndexBuilderExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalIndexBuilderExtensions.cs
@@ -130,6 +130,6 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns> <c>true</c> if the given name can be set for the index. </returns>
         public static bool CanSetFilter(
             [NotNull] this IConventionIndexBuilder indexBuilder, [CanBeNull] string sql, bool fromDataAnnotation = false)
-            => indexBuilder.CanSetAnnotation(RelationalAnnotationNames.Name, sql, fromDataAnnotation);
+            => indexBuilder.CanSetAnnotation(RelationalAnnotationNames.Filter, sql, fromDataAnnotation);
     }
 }


### PR DESCRIPTION
The issue here was that the SQL Server convention was not correctly setting the index filter. This resulted in differences between the actual and expected initial migrations.

Will add tests later, but wanted to get this into the build ASAP.
