### PR TITLE
Query: Enable throwing behavior for Single/SingleOrDefault on top level

### DIFF
--- a/src/EFCore.Relational/Query/Pipeline/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Pipeline/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -728,7 +728,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
             }
 
             var selectExpression = (SelectExpression)source.QueryExpression;
-            selectExpression.ApplyLimit(TranslateExpression(Expression.Constant(1)));
+            selectExpression.ApplyLimit(TranslateExpression(Expression.Constant(2)));
 
             if (source.ShaperExpression.Type != returnType)
             {

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SelectExpression.cs
@@ -221,6 +221,11 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
 
         public void ApplyLimit(SqlExpression sqlExpression)
         {
+            if (Limit != null)
+            {
+                PushdownIntoSubQuery();
+            }
+
             Limit = sqlExpression;
         }
 

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
@@ -416,7 +416,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 selector: o => o.OrderID);
         }
 
-        [ConditionalFact(Skip = "TaskList#24")]
+        [ConditionalFact]
         public virtual void Min_no_data()
         {
             using (var context = CreateContext())
@@ -436,7 +436,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "TaskList#24")]
+        [ConditionalFact]
         public virtual void Max_no_data()
         {
             using (var context = CreateContext())
@@ -456,7 +456,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "TaskList#24")]
+        [ConditionalFact]
         public virtual void Average_no_data()
         {
             using (var context = CreateContext())
@@ -821,10 +821,13 @@ namespace Microsoft.EntityFrameworkCore.Query
                 cs => cs.Select(c => c.City).Select(c => c).Distinct());
         }
 
-        [ConditionalTheory(Skip = "TaskList#24")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Single_Throws(bool isAsync)
         {
+            // TODO: See issue#15535
+            isAsync = false;
+
             return Assert.ThrowsAsync<InvalidOperationException>(
                 async () => await AssertSingle<Customer>(isAsync, cs => cs));
         }
@@ -846,16 +849,20 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             // TODO: See issue#15535
             isAsync = false;
+
             return AssertSingle<Customer>(
                 isAsync,
                 cs => cs.Where(c => c.CustomerID == "ALFKI"),
                 entryCount: 1);
         }
 
-        [ConditionalTheory(Skip = "TaskList#24")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task SingleOrDefault_Throws(bool isAsync)
         {
+            // TODO: See issue#15535
+            isAsync = false;
+
             return Assert.ThrowsAsync<InvalidOperationException>(
                 async () =>
                     await AssertSingleOrDefault<Customer>(isAsync, cs => cs));

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -56,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
         }
 
-        [ConditionalFact(Skip = "TaskList#24")]
+        [ConditionalFact]
         public virtual void Multiple_context_instances()
         {
             using (var context1 = CreateContext())
@@ -74,7 +74,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "TaskList#24")]
+        [ConditionalFact]
         public virtual void Multiple_context_instances_2()
         {
             using (var context1 = CreateContext())
@@ -92,7 +92,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "TaskList#24")]
+        [ConditionalFact]
         public virtual void Multiple_context_instances_set()
         {
             using (var context1 = CreateContext())
@@ -111,7 +111,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "TaskList#24")]
+        [ConditionalFact]
         public virtual void Multiple_context_instances_parameter()
         {
             using (var context1 = CreateContext())
@@ -1208,6 +1208,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             // TODO: Issue#15535
             isAsync = false;
+
             return AssertSingle<Customer>(
                 isAsync,
                 cs => cs.OrderBy(c => c.CustomerID).Take(1),
@@ -4044,7 +4045,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 830);
         }
 
-        [ConditionalFact(Skip = "TaskList#24")]
+        [ConditionalFact]
         public virtual void Parameter_extraction_can_throw_exception_from_user_code()
         {
             using (var context = CreateContext())
@@ -4056,7 +4057,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "TaskList#24")]
+        [ConditionalFact]
         public virtual void Parameter_extraction_can_throw_exception_from_user_code_2()
         {
             using (var context = CreateContext())


### PR DESCRIPTION
In future we need to detect cases when it is used inside subquery to not throw but currently all such tests are disabled because it was doing client eval in previous pipeline

Part of #15559
Resolves #15866