### PR TITLE
Correcting navigation expansion handling of owned navigations

### DIFF
--- a/src/EFCore/Query/NavigationExpansion/NavigationExpansionHelpers.cs
+++ b/src/EFCore/Query/NavigationExpansion/NavigationExpansionHelpers.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Extensions.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -182,8 +183,13 @@ namespace Microsoft.EntityFrameworkCore.Query.NavigationExpansion
                 foreach (var mapping in state.SourceMappings)
                 {
                     var nodes = include
-                        ? mapping.NavigationTree.Flatten().Where(n => (n.Included == NavigationTreeNodeIncludeMode.ReferenceComplete || n.ExpansionMode == NavigationTreeNodeExpansionMode.ReferenceComplete) && n != navigationTree)
-                        : mapping.NavigationTree.Flatten().Where(n => n.ExpansionMode == NavigationTreeNodeExpansionMode.ReferenceComplete && n != navigationTree);
+                        ? mapping.NavigationTree.Flatten().Where(n => (n.Included == NavigationTreeNodeIncludeMode.ReferenceComplete
+                            || n.ExpansionMode == NavigationTreeNodeExpansionMode.ReferenceComplete
+                            || n.Navigation.ForeignKey.IsOwnership)
+                                && n != navigationTree)
+                        : mapping.NavigationTree.Flatten().Where(n => (n.ExpansionMode == NavigationTreeNodeExpansionMode.ReferenceComplete
+                            || n.Navigation.ForeignKey.IsOwnership)
+                                && n != navigationTree);
 
                     foreach (var navigationTreeNode in nodes)
                     {

--- a/src/EFCore/Query/NavigationExpansion/Visitors/CollectionNavigationRewritingVisitor.cs
+++ b/src/EFCore/Query/NavigationExpansion/Visitors/CollectionNavigationRewritingVisitor.cs
@@ -195,9 +195,9 @@ namespace Microsoft.EntityFrameworkCore.Query.NavigationExpansion.Visitors
                     && navigationBindingExpression.NavigationTreeNode.Navigation is INavigation lastNavigation
                     && lastNavigation.IsCollection())
                 {
-                    var result = CreateCollectionNavigationExpression(navigationBindingExpression.NavigationTreeNode, navigationBindingExpression.RootParameter, navigationBindingExpression.SourceMapping);
-
-                    return result;
+                    return lastNavigation.ForeignKey.IsOwnership
+                        ? NavigationExpansionHelpers.CreateNavigationExpansionRoot(navigationBindingExpression, lastNavigation.GetTargetType(), lastNavigation)
+                        : CreateCollectionNavigationExpression(navigationBindingExpression.NavigationTreeNode, navigationBindingExpression.RootParameter, navigationBindingExpression.SourceMapping);
                 }
                 else
                 {

--- a/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
@@ -29,9 +29,9 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""LeafB"") OR ((c[""Discriminator""] = ""LeafA"") OR ((c[""Discriminator""] = ""Branch"") OR (c[""Discriminator""] = ""OwnedPerson""))))");
         }
 
-        public override void Navigation_rewrite_on_owned_reference()
+        public override void Navigation_rewrite_on_owned_reference_projecting_entity()
         {
-            base.Navigation_rewrite_on_owned_reference();
+            base.Navigation_rewrite_on_owned_reference_projecting_entity();
 
             AssertSql(
                 @"SELECT c

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
@@ -547,9 +547,9 @@ INNER JOIN (
 ORDER BY [t18].[Id]");
         }
 
-        public override void Navigation_rewrite_on_owned_reference()
+        public override void Navigation_rewrite_on_owned_reference_projecting_scalar()
         {
-            base.Navigation_rewrite_on_owned_reference();
+            base.Navigation_rewrite_on_owned_reference_projecting_scalar();
 
             AssertSql(
                 @"SELECT [t0].[PersonAddress_Country_Name]
@@ -565,6 +565,14 @@ LEFT JOIN (
     WHERE [p.PersonAddress.Country].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson') AND [p.PersonAddress.Country].[PersonAddress_Country_PlanetId] IS NOT NULL
 ) AS [t0] ON [t].[Id] = [t0].[Id]
 WHERE [p].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson') AND ([t0].[PersonAddress_Country_Name] = N'USA')");
+        }
+
+        public override void Navigation_rewrite_on_owned_reference_projecting_entity()
+        {
+            base.Navigation_rewrite_on_owned_reference_projecting_entity();
+
+            AssertSql(
+                @"");
         }
 
         public override void Navigation_rewrite_on_owned_collection()
@@ -593,6 +601,22 @@ INNER JOIN (
     ) > 0)
 ) AS [t] ON [p.Orders].[ClientId] = [t].[Id]
 ORDER BY [t].[Id]");
+        }
+
+        public override void Navigation_rewrite_on_owned_collection_with_composition()
+        {
+            base.Navigation_rewrite_on_owned_collection_with_composition();
+
+            AssertSql(
+                @"");
+        }
+
+        public override void Navigation_rewrite_on_owned_collection_with_composition_complex()
+        {
+            base.Navigation_rewrite_on_owned_collection_with_composition_complex();
+
+            AssertSql(
+                @"");
         }
 
         public override void Select_many_on_owned_collection()
@@ -625,6 +649,38 @@ LEFT JOIN (
 ) AS [t0] ON [t].[Id] = [t0].[Id]
 LEFT JOIN [Planet] AS [p.PersonAddress.Country.Planet] ON [t0].[PersonAddress_Country_PlanetId] = [p.PersonAddress.Country.Planet].[Id]
 WHERE [p].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')");
+        }
+
+        public override void Filter_owned_entity_chained_with_regular_entity_followed_by_projecting_owned_collection()
+        {
+            base.Filter_owned_entity_chained_with_regular_entity_followed_by_projecting_owned_collection();
+
+            AssertSql(
+                @"");
+        }
+
+        public override void Project_multiple_owned_navigations()
+        {
+            base.Project_multiple_owned_navigations();
+
+            AssertSql(
+                @"");
+        }
+
+        public override void Project_multiple_owned_navigations_with_expansion_on_owned_collections()
+        {
+            base.Project_multiple_owned_navigations_with_expansion_on_owned_collections();
+
+            AssertSql(
+                @"");
+        }
+
+        public override void Navigation_rewrite_on_owned_reference_followed_by_regular_entity_filter()
+        {
+            base.Navigation_rewrite_on_owned_reference_followed_by_regular_entity_filter();
+
+            AssertSql(
+                @"");
         }
 
         public override void Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_property()


### PR DESCRIPTION
Navigation expansion should not try expand owned navigations. We still add them to navigation tree for tracking purposes but we don't inject LeftJoin calls when processing them.
Collection navigations are converted directly to NavigationExpansionExpressions whose root is the navigation itself to avoid rewrite to a subquery.