### PR TITLE
Query: Remove implicit convert nodes in query to avoid unnecessary cast in generated SQL

### DIFF
--- a/src/EFCore.Relational/Query/Pipeline/ISqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/Pipeline/ISqlExpressionFactory.cs
@@ -16,6 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
         SqlExpression ApplyTypeMapping(SqlExpression sqlExpression, RelationalTypeMapping typeMapping);
         SqlExpression ApplyDefaultTypeMapping(SqlExpression sqlExpression);
         RelationalTypeMapping GetTypeMappingForValue(object value);
+        RelationalTypeMapping FindMapping(Type type);
         #endregion
 
         #region Binary

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressionFactory.cs
@@ -205,6 +205,11 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
         {
             return _typeMappingSource.GetMappingForValue(value);
         }
+
+        public virtual RelationalTypeMapping FindMapping(Type type)
+        {
+            return _typeMappingSource.FindMapping(type);
+        }
         #endregion
 
         #region Binary

--- a/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
@@ -500,6 +500,12 @@ namespace Microsoft.EntityFrameworkCore.Storage
         {
             if (Converter != null)
             {
+                if (value?.GetType().IsInteger() == true
+                    && ClrType.UnwrapNullableType().IsEnum)
+                {
+                    value = Enum.ToObject(ClrType.UnwrapNullableType(), value);
+                }
+
                 value = Converter.ConvertToProvider(value);
             }
 

--- a/test/EFCore.Cosmos.FunctionalTests/BuiltInDataTypesCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/BuiltInDataTypesCosmosTest.cs
@@ -45,6 +45,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
 
             public override bool SupportsBinaryKeys => true;
 
+            public override bool SupportsDecimalComparisons => true;
+
             public override DateTime DefaultDateTime => new DateTime();
 
             protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)

--- a/test/EFCore.Cosmos.FunctionalTests/CustomConvertersCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/CustomConvertersCosmosTest.cs
@@ -49,6 +49,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
 
             public override bool SupportsBinaryKeys => true;
 
+            public override bool SupportsDecimalComparisons => true;
+
             public override DateTime DefaultDateTime => new DateTime();
 
             protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)

--- a/test/EFCore.InMemory.FunctionalTests/BuiltInDataTypesInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/BuiltInDataTypesInMemoryTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore
@@ -12,6 +13,12 @@ namespace Microsoft.EntityFrameworkCore
         public BuiltInDataTypesInMemoryTest(BuiltInDataTypesInMemoryFixture fixture)
             : base(fixture)
         {
+        }
+
+        [ConditionalFact(Skip = "Issue#15711")]
+        public override void Can_insert_and_read_back_with_string_key()
+        {
+            base.Can_insert_and_read_back_with_string_key();
         }
 
         public class BuiltInDataTypesInMemoryFixture : BuiltInDataTypesFixtureBase
@@ -27,6 +34,8 @@ namespace Microsoft.EntityFrameworkCore
             public override bool SupportsLargeStringComparisons => true;
 
             public override bool SupportsBinaryKeys => false;
+
+            public override bool SupportsDecimalComparisons => true;
 
             public override DateTime DefaultDateTime => new DateTime();
         }

--- a/test/EFCore.InMemory.FunctionalTests/ConvertToProviderTypesInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/ConvertToProviderTypesInMemoryTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore
 {
@@ -12,6 +13,12 @@ namespace Microsoft.EntityFrameworkCore
         public ConvertToProviderTypesInMemoryTest(ConvertToProviderTypesInMemoryFixture fixture)
             : base(fixture)
         {
+        }
+
+        [ConditionalFact(Skip = "Issue#15711")]
+        public override void Can_insert_and_read_back_with_string_key()
+        {
+            base.Can_insert_and_read_back_with_string_key();
         }
 
         public class ConvertToProviderTypesInMemoryFixture : ConvertToProviderTypesFixtureBase
@@ -27,6 +34,8 @@ namespace Microsoft.EntityFrameworkCore
             public override bool SupportsLargeStringComparisons => true;
 
             public override bool SupportsBinaryKeys => false;
+
+            public override bool SupportsDecimalComparisons => true;
 
             public override DateTime DefaultDateTime => new DateTime();
         }

--- a/test/EFCore.InMemory.FunctionalTests/CustomConvertersInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/CustomConvertersInMemoryTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore
 {
@@ -18,6 +19,12 @@ namespace Microsoft.EntityFrameworkCore
         {
         }
 
+        [ConditionalFact(Skip = "Issue#15711")]
+        public override void Can_insert_and_read_back_with_string_key()
+        {
+            base.Can_insert_and_read_back_with_string_key();
+        }
+
         public class CustomConvertersInMemoryFixture : CustomConvertersFixtureBase
         {
             public override bool StrictEquality => true;
@@ -31,6 +38,8 @@ namespace Microsoft.EntityFrameworkCore
             protected override ITestStoreFactory TestStoreFactory => InMemoryTestStoreFactory.Instance;
 
             public override bool SupportsBinaryKeys => false;
+
+            public override bool SupportsDecimalComparisons => true;
 
             public override DateTime DefaultDateTime => new DateTime();
         }

--- a/test/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
+++ b/test/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
@@ -52,7 +52,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Theory(Skip = "QueryIssue")]
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public virtual async Task Can_filter_projection_with_inline_enum_variable(bool async)
@@ -202,7 +202,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual void Can_query_using_any_data_type()
         {
             using (var context = CreateContext())
@@ -215,7 +215,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual void Can_query_using_any_data_type_shadow()
         {
             using (var context = CreateContext())
@@ -260,7 +260,7 @@ namespace Microsoft.EntityFrameworkCore
                             e => e.Id == 11
                                  && EF.Property<double>(e, nameof(BuiltInDataTypes.TestDouble)) == param4).ToList().Single());
                 }
-                else
+                else if (Fixture.SupportsDecimalComparisons)
                 {
                     double? param4l = -1.234567891;
                     double? param4h = -1.234567889;
@@ -311,7 +311,7 @@ namespace Microsoft.EntityFrameworkCore
                             e => e.Id == 11
                                  && EF.Property<float>(e, nameof(BuiltInDataTypes.TestSingle)) == param9).ToList().Single());
                 }
-                else
+                else if (Fixture.SupportsDecimalComparisons)
                 {
                     var param9l = -1.2341F;
                     var param9h = -1.2339F;
@@ -548,7 +548,7 @@ namespace Microsoft.EntityFrameworkCore
             return entityEntry;
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual void Can_query_using_any_nullable_data_type()
         {
             using (var context = CreateContext())
@@ -561,7 +561,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual void Can_query_using_any_data_type_nullable_shadow()
         {
             using (var context = CreateContext())
@@ -610,7 +610,7 @@ namespace Microsoft.EntityFrameworkCore
                                      && EF.Property<double?>(e, nameof(BuiltInNullableDataTypes.TestNullableDouble)) == param4).ToList()
                             .Single());
                 }
-                else
+                else if (Fixture.SupportsDecimalComparisons)
                 {
                     double? param4l = -1.234567891;
                     double? param4h = -1.234567889;
@@ -665,7 +665,7 @@ namespace Microsoft.EntityFrameworkCore
                                      && EF.Property<float?>(e, nameof(BuiltInNullableDataTypes.TestNullableSingle)) == param9).ToList()
                             .Single());
                 }
-                else
+                else if (Fixture.SupportsDecimalComparisons)
                 {
                     float? param9l = -1.2341F;
                     float? param9h = -1.2339F;
@@ -696,19 +696,19 @@ namespace Microsoft.EntityFrameworkCore
                 Enum64? param12 = Enum64.SomeValue;
                 Assert.Same(
                     entity,
-                    set.Where(e => e.Id == 11 && EF.Property<Enum64>(e, nameof(BuiltInNullableDataTypes.Enum64)) == param12).ToList()
+                    set.Where(e => e.Id == 11 && EF.Property<Enum64?>(e, nameof(BuiltInNullableDataTypes.Enum64)) == param12).ToList()
                         .Single());
 
                 Enum32? param13 = Enum32.SomeValue;
                 Assert.Same(
                     entity,
-                    set.Where(e => e.Id == 11 && EF.Property<Enum32>(e, nameof(BuiltInNullableDataTypes.Enum32)) == param13).ToList()
+                    set.Where(e => e.Id == 11 && EF.Property<Enum32?>(e, nameof(BuiltInNullableDataTypes.Enum32)) == param13).ToList()
                         .Single());
 
                 Enum16? param14 = Enum16.SomeValue;
                 Assert.Same(
                     entity,
-                    set.Where(e => e.Id == 11 && EF.Property<Enum16>(e, nameof(BuiltInNullableDataTypes.Enum16)) == param14).ToList()
+                    set.Where(e => e.Id == 11 && EF.Property<Enum16?>(e, nameof(BuiltInNullableDataTypes.Enum16)) == param14).ToList()
                         .Single());
 
                 if (entityType.FindProperty(nameof(BuiltInNullableDataTypes.Enum8)) != null)
@@ -716,7 +716,7 @@ namespace Microsoft.EntityFrameworkCore
                     Enum8? param15 = Enum8.SomeValue;
                     Assert.Same(
                         entity,
-                        set.Where(e => e.Id == 11 && EF.Property<Enum8>(e, nameof(BuiltInNullableDataTypes.Enum8)) == param15).ToList()
+                        set.Where(e => e.Id == 11 && EF.Property<Enum8?>(e, nameof(BuiltInNullableDataTypes.Enum8)) == param15).ToList()
                             .Single());
                 }
 
@@ -777,7 +777,7 @@ namespace Microsoft.EntityFrameworkCore
                     var param21 = EnumU64.SomeValue;
                     Assert.Same(
                         entity,
-                        set.Where(e => e.Id == 11 && EF.Property<EnumU64>(e, nameof(BuiltInNullableDataTypes.EnumU64)) == param21).ToList()
+                        set.Where(e => e.Id == 11 && EF.Property<EnumU64?>(e, nameof(BuiltInNullableDataTypes.EnumU64)) == param21).ToList()
                             .Single());
                 }
 
@@ -786,7 +786,7 @@ namespace Microsoft.EntityFrameworkCore
                     var param22 = EnumU32.SomeValue;
                     Assert.Same(
                         entity,
-                        set.Where(e => e.Id == 11 && EF.Property<EnumU32>(e, nameof(BuiltInNullableDataTypes.EnumU32)) == param22).ToList()
+                        set.Where(e => e.Id == 11 && EF.Property<EnumU32?>(e, nameof(BuiltInNullableDataTypes.EnumU32)) == param22).ToList()
                             .Single());
                 }
 
@@ -795,7 +795,7 @@ namespace Microsoft.EntityFrameworkCore
                     var param23 = EnumU16.SomeValue;
                     Assert.Same(
                         entity,
-                        set.Where(e => e.Id == 11 && EF.Property<EnumU16>(e, nameof(BuiltInNullableDataTypes.EnumU16)) == param23).ToList()
+                        set.Where(e => e.Id == 11 && EF.Property<EnumU16?>(e, nameof(BuiltInNullableDataTypes.EnumU16)) == param23).ToList()
                             .Single());
                 }
 
@@ -804,7 +804,7 @@ namespace Microsoft.EntityFrameworkCore
                     var param24 = EnumS8.SomeValue;
                     Assert.Same(
                         entity,
-                        set.Where(e => e.Id == 11 && EF.Property<EnumS8>(e, nameof(BuiltInNullableDataTypes.EnumS8)) == param24).ToList()
+                        set.Where(e => e.Id == 11 && EF.Property<EnumS8?>(e, nameof(BuiltInNullableDataTypes.EnumS8)) == param24).ToList()
                             .Single());
                 }
 
@@ -924,7 +924,7 @@ namespace Microsoft.EntityFrameworkCore
             return entityEntry;
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual void Can_query_using_any_nullable_data_type_as_literal()
         {
             using (var context = CreateContext())
@@ -981,15 +981,22 @@ namespace Microsoft.EntityFrameworkCore
                     context.Set<BuiltInNullableDataTypes>().Where(e => e.Id == 12 && e.TestNullableInt64 == -1234567890123456789L).ToList()
                         .Single());
 
-                Assert.Same(
-                    entity,
-                    Fixture.StrictEquality
-                        ? context.Set<BuiltInNullableDataTypes>().Where(e => e.Id == 12 && e.TestNullableDouble == -1.23456789).ToList()
-                            .Single()
-                        : context.Set<BuiltInNullableDataTypes>().Where(
+                if (Fixture.StrictEquality)
+                {
+                    Assert.Same(
+                        entity,
+                        context.Set<BuiltInNullableDataTypes>().Where(e => e.Id == 12 && e.TestNullableDouble == -1.23456789).ToList()
+                            .Single());
+                }
+                else if (Fixture.SupportsDecimalComparisons)
+                {
+                    Assert.Same(
+                        entity,
+                        context.Set<BuiltInNullableDataTypes>().Where(
                             e => e.Id == 12
-                                 && -e.TestNullableDouble + -1.23456789 < 1E-5
-                                 && -e.TestNullableDouble + -1.23456789 > -1E-5).ToList().Single());
+                                && -e.TestNullableDouble + -1.23456789 < 1E-5
+                                && -e.TestNullableDouble + -1.23456789 > -1E-5).ToList().Single());
+                }
 
                 Assert.Same(
                     entity,
@@ -1023,13 +1030,20 @@ namespace Microsoft.EntityFrameworkCore
                             .Where(e => e.Id == 12 && e.TestNullableTimeSpan == new TimeSpan(0, 10, 9, 8, 7)).ToList().Single());
                 }
 
-                Assert.Same(
-                    entity,
-                    Fixture.StrictEquality
-                        ? context.Set<BuiltInNullableDataTypes>().Where(e => e.Id == 12 && e.TestNullableSingle == -1.234F).ToList()
-                            .Single()
-                        : context.Set<BuiltInNullableDataTypes>().Where(e => e.Id == 12 && -e.TestNullableSingle + -1.234F < 1E-5).ToList()
+                if (Fixture.StrictEquality)
+                {
+                    Assert.Same(
+                        entity,
+                        context.Set<BuiltInNullableDataTypes>().Where(e => e.Id == 12 && e.TestNullableSingle == -1.234F).ToList()
                             .Single());
+                }
+                else if (Fixture.SupportsDecimalComparisons)
+                {
+                    Assert.Same(
+                        entity,
+                        context.Set<BuiltInNullableDataTypes>().Where(e => e.Id == 12 && -e.TestNullableSingle + -1.234F < 1E-5).ToList()
+                            .Single());
+                }
 
                 Assert.Same(
                     entity,
@@ -1134,7 +1148,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "Tasklist#8")]
+        [Fact]
         public virtual void Can_query_with_null_parameters_using_any_nullable_data_type()
         {
             using (var context = CreateContext())
@@ -1416,7 +1430,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "Tasklist#19")]
+        [Fact]
         public virtual void Can_insert_and_read_back_with_binary_key()
         {
             if (!Fixture.SupportsBinaryKeys)
@@ -1477,7 +1491,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "Tasklist#19")]
+        [Fact]
         public virtual void Can_insert_and_read_back_with_string_key()
         {
             using (var context = CreateContext())
@@ -1825,6 +1839,8 @@ namespace Microsoft.EntityFrameworkCore
             public abstract bool SupportsLargeStringComparisons { get; }
 
             public abstract bool SupportsBinaryKeys { get; }
+
+            public abstract bool SupportsDecimalComparisons { get; }
 
             public abstract DateTime DefaultDateTime { get; }
         }

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -699,9 +699,10 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 gs => gs.Where(g => ((short)g.Rank & (short)1) == 1));
 
-            await AssertQuery<Gear>(
-                isAsync,
-                gs => gs.Where(g => ((char)g.Rank & '\x0001') == '\x0001'));
+            // Issue#15950
+            //await AssertQuery<Gear>(
+            //    isAsync,
+            //    gs => gs.Where(g => ((char)g.Rank & '\x0001') == '\x0001'));
         }
 
         [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
@@ -465,7 +465,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory(Skip = "TaskList#8")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual async Task Where_simple_closure_via_query_cache_nullable_type(bool isAsync)
         {
@@ -491,7 +491,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 1);
         }
 
-        [ConditionalTheory(Skip = "TaskList#8")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual async Task Where_simple_closure_via_query_cache_nullable_type_reverse(bool isAsync)
         {
@@ -809,7 +809,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 5);
         }
 
-        [ConditionalTheory(Skip = "TaskList#8")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual async Task Where_equals_on_null_nullable_int_types(bool isAsync)
         {

--- a/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
@@ -412,12 +412,11 @@ WHERE (DATEDIFF(NANOSECOND, [m].[TimeSpanAsTime], @__timeSpan_1) = 0) AND DATEDI
                 ulong? param42 = ulong.MaxValue;
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.UlongAsBigint == param42));
 
-                // TODO: Issue#15330
-                //ushort? param43 = ushort.MaxValue;
-                //Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.UShortAsSmallint == param43));
+                ushort? param43 = ushort.MaxValue;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.UShortAsSmallint == param43));
 
-                //sbyte? param44 = sbyte.MinValue;
-                //Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.SbyteAsTinyint == param44));
+                sbyte? param44 = sbyte.MinValue;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.SbyteAsTinyint == param44));
 
                 uint? param45 = uint.MaxValue;
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.UintAsBigint == param45));
@@ -435,37 +434,37 @@ WHERE (DATEDIFF(NANOSECOND, [m].[TimeSpanAsTime], @__timeSpan_1) = 0) AND DATEDI
                 Assert.Same(
                     entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.GuidAsUniqueidentifier == param49));
 
-                //char? param50 = 'A';
-                //Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.CharAsVarcharMax == param50));
+                char? param50 = 'A';
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.CharAsVarcharMax == param50));
 
-                //char? param51 = 'B';
-                //Assert.Same(
-                //    entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.CharAsAsCharVaryingMax == param51));
+                char? param51 = 'B';
+                Assert.Same(
+                    entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.CharAsAsCharVaryingMax == param51));
 
-                //char? param52 = 'C';
-                //Assert.Same(
-                //    entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.CharAsCharacterVaryingMax == param52));
+                char? param52 = 'C';
+                Assert.Same(
+                    entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.CharAsCharacterVaryingMax == param52));
 
-                //char? param53 = 'D';
-                //Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.CharAsNvarcharMax == param53));
+                char? param53 = 'D';
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.CharAsNvarcharMax == param53));
 
-                //char? param54 = 'E';
-                //Assert.Same(
-                //    entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.CharAsNationalCharVaryingMax == param54));
+                char? param54 = 'E';
+                Assert.Same(
+                    entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.CharAsNationalCharVaryingMax == param54));
 
-                //char? param55 = 'F';
-                //Assert.Same(
-                //    entity,
-                //    context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.CharAsNationalCharacterVaryingMax == param55));
+                char? param55 = 'F';
+                Assert.Same(
+                    entity,
+                    context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.CharAsNationalCharacterVaryingMax == param55));
 
-                //char? param58 = 'I';
-                //Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.CharAsInt == param58));
+                char? param58 = 'I';
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.CharAsInt == param58));
 
-                //StringEnumU16? param59 = StringEnumU16.Value4;
-                //Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.EnumAsNvarchar20 == param59));
+                StringEnumU16? param59 = StringEnumU16.Value4;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.EnumAsNvarchar20 == param59));
 
-                //StringEnum16? param60 = StringEnum16.Value2;
-                //Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.EnumAsVarcharMax == param60));
+                StringEnum16? param60 = StringEnum16.Value2;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.EnumAsVarcharMax == param60));
 
                 // Issue #14935. Cannot eval 'where [e].SqlVariantString.Equals(__param61_0)'
                 // Added AsEnumerable()
@@ -479,7 +478,7 @@ WHERE (DATEDIFF(NANOSECOND, [m].[TimeSpanAsTime], @__timeSpan_1) = 0) AND DATEDI
             }
         }
 
-        [Fact(Skip = "TaskList#8")]
+        [Fact]
         public virtual void Can_query_using_any_mapped_data_types_with_nulls()
         {
             using (var context = CreateContext())
@@ -571,11 +570,12 @@ WHERE (DATEDIFF(NANOSECOND, [m].[TimeSpanAsTime], @__timeSpan_1) = 0) AND DATEDI
                     entity,
                     context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.StringAsNationalCharacterVaryingMax == param29));
 
-                string param30 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.StringAsText == param30));
+                // TODO: See issue#15953
+                //string param30 = null;
+                //Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.StringAsText == param30));
 
-                string param31 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.StringAsNtext == param31));
+                //string param31 = null;
+                //Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.StringAsNtext == param31));
 
                 byte[] param35 = null;
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.BytesAsVarbinaryMax == param35));
@@ -584,8 +584,8 @@ WHERE (DATEDIFF(NANOSECOND, [m].[TimeSpanAsTime], @__timeSpan_1) = 0) AND DATEDI
                 Assert.Same(
                     entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.BytesAsBinaryVaryingMax == param36));
 
-                byte[] param37 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.BytesAsImage == param37));
+                //byte[] param37 = null;
+                //Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.BytesAsImage == param37));
 
                 decimal? param38 = null;
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.Decimal == param38));
@@ -647,11 +647,11 @@ WHERE (DATEDIFF(NANOSECOND, [m].[TimeSpanAsTime], @__timeSpan_1) = 0) AND DATEDI
                     entity,
                     context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.CharAsNationalCharacterVaryingMax == param55));
 
-                char? param56 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.CharAsText == param56));
+                //char? param56 = null;
+                //Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.CharAsText == param56));
 
-                char? param57 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.CharAsNtext == param57));
+                //char? param57 = null;
+                //Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.CharAsNtext == param57));
 
                 char? param58 = null;
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.CharAsInt == param58));
@@ -3040,6 +3040,8 @@ UnicodeDataTypes.StringUnicode ---> [nullable nvarchar] [MaxLength = -1]
             public override bool SupportsUnicodeToAnsiConversion => true;
 
             public override bool SupportsLargeStringComparisons => true;
+
+            public override bool SupportsDecimalComparisons => true;
 
             protected override ITestStoreFactory TestStoreFactory
                 => SqlServerTestStoreFactory.Instance;

--- a/test/EFCore.SqlServer.FunctionalTests/ConvertToProviderTypesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ConvertToProviderTypesSqlServerTest.cs
@@ -190,6 +190,8 @@ UnicodeDataTypes.StringUnicode ---> [nullable nvarchar] [MaxLength = -1]
 
             public override bool SupportsBinaryKeys => true;
 
+            public override bool SupportsDecimalComparisons => true;
+
             public override DateTime DefaultDateTime => new DateTime();
 
             public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)

--- a/test/EFCore.SqlServer.FunctionalTests/CustomConvertersSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/CustomConvertersSqlServerTest.cs
@@ -181,6 +181,8 @@ User.Id ---> [uniqueidentifier]
 
             public override bool SupportsBinaryKeys => true;
 
+            public override bool SupportsDecimalComparisons => true;
+
             public override DateTime DefaultDateTime => new DateTime();
 
             public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)

--- a/test/EFCore.SqlServer.FunctionalTests/EverythingIsBytesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/EverythingIsBytesSqlServerTest.cs
@@ -175,6 +175,8 @@ UnicodeDataTypes.StringUnicode ---> [nullable varbinary] [MaxLength = -1]
 
             public override bool SupportsBinaryKeys => true;
 
+            public override bool SupportsDecimalComparisons => true;
+
             public override DateTime DefaultDateTime => new DateTime();
 
             public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)

--- a/test/EFCore.SqlServer.FunctionalTests/EverythingIsStringsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/EverythingIsStringsSqlServerTest.cs
@@ -176,6 +176,8 @@ UnicodeDataTypes.StringUnicode ---> [nullable nvarchar] [MaxLength = -1]
 
             public override bool SupportsBinaryKeys => true;
 
+            public override bool SupportsDecimalComparisons => true;
+
             public override DateTime DefaultDateTime => new DateTime();
 
             public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)

--- a/test/EFCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
@@ -1519,6 +1519,8 @@ LIMIT 1",
 
             public override bool SupportsLargeStringComparisons => true;
 
+            public override bool SupportsDecimalComparisons => false;
+
             protected override ITestStoreFactory TestStoreFactory => SqliteTestStoreFactory.Instance;
             public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ListLoggerFactory;
 

--- a/test/EFCore.Sqlite.FunctionalTests/ConvertToProviderTypesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/ConvertToProviderTypesSqliteTest.cs
@@ -28,6 +28,8 @@ namespace Microsoft.EntityFrameworkCore
 
             public override bool SupportsLargeStringComparisons => true;
 
+            public override bool SupportsDecimalComparisons => false;
+
             protected override ITestStoreFactory TestStoreFactory => SqliteTestStoreFactory.Instance;
             public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ListLoggerFactory;
 

--- a/test/EFCore.Sqlite.FunctionalTests/CustomConvertersSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/CustomConvertersSqliteTest.cs
@@ -29,6 +29,8 @@ namespace Microsoft.EntityFrameworkCore
 
             public override bool SupportsLargeStringComparisons => true;
 
+            public override bool SupportsDecimalComparisons => false;
+
             protected override ITestStoreFactory TestStoreFactory => SqliteTestStoreFactory.Instance;
             public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ListLoggerFactory;
 


### PR DESCRIPTION
Enable BuiltInDataTypeTests
- Preserve convert nodes around parameters/constants in parameter extracting.
- While translating to Sql, remove implicit convert nodes. Implicit convert nodes appear only for binary expressions since equality operators are not defined for all types
- Apply explicit cast in SQL only when converted type is mapped.
- Convert int value to enum value before printing literal (how old pipeline did it)

Resolves #14159
Resolves #15330
Resolves #15948

Supersedes type inference changes in #15820