### PR TITLE
[TINY] Fix to #15863 - Query: incorrect results due to invalid subquery pushdown logic

### DIFF
--- a/src/EFCore.Relational/Query/Pipeline/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Pipeline/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -13,6 +13,7 @@ using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Query.Pipeline;
 using Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions;
+using System.IO;
 
 namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 {
@@ -586,7 +587,9 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
         protected override ShapedQueryExpression TranslateOrderBy(ShapedQueryExpression source, LambdaExpression keySelector, bool ascending)
         {
             var selectExpression = (SelectExpression)source.QueryExpression;
-            if (selectExpression.IsDistinct)
+            if (selectExpression.IsDistinct
+                || selectExpression.Limit != null
+                || selectExpression.Offset != null)
             {
                 selectExpression.PushdownIntoSubQuery();
             }

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/OrderingExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/OrderingExpression.cs
@@ -33,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
         {
             expressionPrinter.Visit(Expression);
 
-            expressionPrinter.StringBuilder.Append(Ascending ? "ASC" : "DESC");
+            expressionPrinter.StringBuilder.Append(Ascending ? " ASC" : " DESC");
         }
 
         public override bool Equals(object obj)

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SelectExpression.cs
@@ -738,12 +738,15 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             else
             {
                 projectionMapping = new Dictionary<ProjectionMember, Expression>();
-                foreach (var mapping in _projectionMapping)
+                if (_projectionMapping != null)
                 {
-                    var newProjection = visitor.Visit(mapping.Value);
-                    changed |= newProjection != mapping.Value;
+                    foreach (var mapping in _projectionMapping)
+                    {
+                        var newProjection = visitor.Visit(mapping.Value);
+                        changed |= newProjection != mapping.Value;
 
-                    projectionMapping[mapping.Key] = newProjection;
+                        projectionMapping[mapping.Key] = newProjection;
+                    }
                 }
             }
 
@@ -861,9 +864,12 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             string alias)
         {
             var projectionMapping = new Dictionary<ProjectionMember, Expression>();
-            foreach (var kvp in _projectionMapping)
+            if (_projectionMapping != null)
             {
-                projectionMapping[kvp.Key] = kvp.Value;
+                foreach (var kvp in _projectionMapping)
+                {
+                    projectionMapping[kvp.Key] = kvp.Value;
+                }
             }
 
             return new SelectExpression(alias, projections, tables, orderings)
@@ -969,8 +975,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             if (Orderings.Any())
             {
                 var orderings = Orderings.ToList();
-                if (orderings.Count > 0
-                    && (Limit != null || Offset != null))
+                if (orderings.Count > 0)
                 {
                     expressionPrinter.StringBuilder.AppendLine().Append("ORDER BY ");
                     expressionPrinter.VisitList(orderings);

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -3416,7 +3416,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.Name1 + " " + e.Name2);
         }
 
-        [ConditionalTheory(Skip = "issue #15863")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Subquery_with_result_operator_is_not_lifted(bool isAsync)
         {
@@ -3424,6 +3424,55 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 gs => from g in gs.Where(g => !g.HasSoulPatch).OrderBy(g => g.FullName).Take(2).AsTracking()
                       orderby g.Rank
+                      select g.FullName,
+                assertOrder: true);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Skip_with_orderby_followed_by_orderBy_is_pushed_down(bool isAsync)
+        {
+            return AssertQuery<Gear>(
+                isAsync,
+                gs => from g in gs.Where(g => !g.HasSoulPatch).OrderBy(g => g.FullName).Skip(1)
+                      orderby g.Rank
+                      select g.FullName,
+                assertOrder: true);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Take_without_orderby_followed_by_orderBy_is_pushed_down1(bool isAsync)
+        {
+            return AssertQuery<Gear>(
+                isAsync,
+                gs => from g in gs.Where(g => !g.HasSoulPatch).Take(999).OrderBy(g => g.FullName)
+                      orderby g.Rank
+                      select g.FullName,
+                assertOrder: true);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Take_without_orderby_followed_by_orderBy_is_pushed_down2(bool isAsync)
+        {
+            return AssertQuery<Gear>(
+                isAsync,
+                gs => from g in gs.Where(g => !g.HasSoulPatch).Take(999)
+                      orderby g.FullName
+                      orderby g.Rank
+                      select g.FullName,
+                assertOrder: true);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Take_without_orderby_followed_by_orderBy_is_pushed_down3(bool isAsync)
+        {
+            return AssertQuery<Gear>(
+                isAsync,
+                gs => from g in gs.Where(g => !g.HasSoulPatch).Take(999)
+                      orderby g.FullName, g.Rank
                       select g.FullName,
                 assertOrder: true);
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -3617,12 +3617,78 @@ ORDER BY [Name1]");
 
 SELECT [t].[FullName]
 FROM (
-    SELECT TOP(@__p_0) [g].*
+    SELECT TOP(@__p_0) [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
     FROM [Gears] AS [g]
-    WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[HasSoulPatch] = CAST(0 AS bit))
+    WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND NOT ([g].[HasSoulPatch] = CAST(1 AS bit))
     ORDER BY [g].[FullName]
 ) AS [t]
 ORDER BY [t].[Rank]");
+        }
+
+        public override async Task Skip_with_orderby_followed_by_orderBy_is_pushed_down(bool isAsync)
+        {
+            await base.Skip_with_orderby_followed_by_orderBy_is_pushed_down(isAsync);
+
+            AssertSql(
+                @"@__p_0='1'
+
+SELECT [t].[FullName]
+FROM (
+    SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+    FROM [Gears] AS [g]
+    WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND NOT ([g].[HasSoulPatch] = CAST(1 AS bit))
+    ORDER BY [g].[FullName]
+    OFFSET @__p_0 ROWS
+) AS [t]
+ORDER BY [t].[Rank]");
+        }
+
+        public override async Task Take_without_orderby_followed_by_orderBy_is_pushed_down1(bool isAsync)
+        {
+            await base.Take_without_orderby_followed_by_orderBy_is_pushed_down1(isAsync);
+
+            AssertSql(
+                @"@__p_0='999'
+
+SELECT [t].[FullName]
+FROM (
+    SELECT TOP(@__p_0) [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+    FROM [Gears] AS [g]
+    WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND NOT ([g].[HasSoulPatch] = CAST(1 AS bit))
+) AS [t]
+ORDER BY [t].[Rank]");
+        }
+
+        public override async Task Take_without_orderby_followed_by_orderBy_is_pushed_down2(bool isAsync)
+        {
+            await base.Take_without_orderby_followed_by_orderBy_is_pushed_down2(isAsync);
+
+            AssertSql(
+                @"@__p_0='999'
+
+SELECT [t].[FullName]
+FROM (
+    SELECT TOP(@__p_0) [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+    FROM [Gears] AS [g]
+    WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND NOT ([g].[HasSoulPatch] = CAST(1 AS bit))
+) AS [t]
+ORDER BY [t].[Rank]");
+        }
+
+        public override async Task Take_without_orderby_followed_by_orderBy_is_pushed_down3(bool isAsync)
+        {
+            await base.Take_without_orderby_followed_by_orderBy_is_pushed_down3(isAsync);
+
+            AssertSql(
+                @"@__p_0='999'
+
+SELECT [t].[FullName]
+FROM (
+    SELECT TOP(@__p_0) [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+    FROM [Gears] AS [g]
+    WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND NOT ([g].[HasSoulPatch] = CAST(1 AS bit))
+) AS [t]
+ORDER BY [t].[FullName], [t].[Rank]");
         }
 
         public override async Task Select_length_of_string_property(bool isAsync)


### PR DESCRIPTION
Problem was that when translating Skip/Take we were not performing pushdown when the select expression already had orderings defined