### PR TITLE
Query: Set reference navigation loaded when referenced entity is null…

### DIFF
--- a/src/EFCore.Relational/Query/Pipeline/IncludeCompilingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Pipeline/IncludeCompilingExpressionVisitor.cs
@@ -46,7 +46,15 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
             {
                 var relatedEntity = innerShaper(queryContext, dbDataReader, resultCoordinator);
 
-                if (!trackingQuery)
+                if (trackingQuery)
+                {
+                    // For non-null relatedEntity StateManager will set the flag
+                    if (ReferenceEquals(relatedEntity, null))
+                    {
+                        queryContext.StateManager.TryGetEntry(entity).SetIsLoaded(navigation);
+                    }
+                }
+                else
                 {
                     SetIsLoadedNoTracking(entity, navigation);
                     if (!ReferenceEquals(relatedEntity, null))

--- a/test/EFCore.Specification.Tests/Query/IncludeTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/IncludeTestBase.cs
@@ -4099,7 +4099,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory(Skip = "#15949")]
+        [ConditionalTheory]
         [InlineData(false, false)]
         [InlineData(true, false)]
         public virtual async Task Include_empty_reference_sets_IsLoaded(bool useString, bool async)


### PR DESCRIPTION
… in tracking query
