### PR TITLE
Add SqlServerValueGenerationStrategy.None

### DIFF
--- a/EFCore.sln.DotSettings
+++ b/EFCore.sln.DotSettings
@@ -187,10 +187,10 @@ Licensed under the Apache License, Version 2.0. See License.txt in the project r
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsWrapperSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EXml_002ECodeStyle_002EFormatSettingsUpgrade_002EXmlMoveToCommonFormatterSettingsUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=annotatable/@EntryIndexedValue">True</s:Boolean>
-	
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=keyless/@EntryIndexedValue">True</s:Boolean>
-	
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=navigations/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=requiredness/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=sqlite/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=unignore/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=unignore/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=fixup/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=attacher/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/EFCore.SqlServer/Extensions/SqlServerPropertyExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerPropertyExtensions.cs
@@ -200,16 +200,16 @@ namespace Microsoft.EntityFrameworkCore
         ///         Returns the <see cref="SqlServerValueGenerationStrategy" /> to use for the property.
         ///     </para>
         ///     <para>
-        ///         If no strategy is set for the property, then the strategy to use will be taken from the <see cref="IModel" />
+        ///         If no strategy is set for the property, then the strategy to use will be taken from the <see cref="IModel" />.
         ///     </para>
         /// </summary>
-        /// <returns> The strategy, or <c>null</c> if none was set. </returns>
-        public static SqlServerValueGenerationStrategy? GetSqlServerValueGenerationStrategy([NotNull] this IProperty property)
+        /// <returns> The strategy, or <see cref="SqlServerValueGenerationStrategy.None"/> if none was set. </returns>
+        public static SqlServerValueGenerationStrategy GetSqlServerValueGenerationStrategy([NotNull] this IProperty property)
         {
-            var annotation = property.FindAnnotation(SqlServerAnnotationNames.ValueGenerationStrategy);
+            var annotation = property[SqlServerAnnotationNames.ValueGenerationStrategy];
             if (annotation != null)
             {
-                return (SqlServerValueGenerationStrategy?)annotation.Value;
+                return (SqlServerValueGenerationStrategy)annotation;
             }
 
             var sharedTablePrincipalPrimaryKeyProperty = property.FindSharedTableRootPrimaryKeyProperty();
@@ -217,8 +217,8 @@ namespace Microsoft.EntityFrameworkCore
             {
                 return sharedTablePrincipalPrimaryKeyProperty.GetSqlServerValueGenerationStrategy()
                        == SqlServerValueGenerationStrategy.IdentityColumn
-                    ? (SqlServerValueGenerationStrategy?)SqlServerValueGenerationStrategy.IdentityColumn
-                    : null;
+                    ? SqlServerValueGenerationStrategy.IdentityColumn
+                    : SqlServerValueGenerationStrategy.None;
             }
 
             if (property.ValueGenerated != ValueGenerated.OnAdd
@@ -226,7 +226,7 @@ namespace Microsoft.EntityFrameworkCore
                 || property.GetDefaultValueSql() != null
                 || property.GetComputedColumnSql() != null)
             {
-                return null;
+                return SqlServerValueGenerationStrategy.None;
             }
 
             var modelStrategy = property.DeclaringEntityType.Model.GetSqlServerValueGenerationStrategy();
@@ -239,8 +239,8 @@ namespace Microsoft.EntityFrameworkCore
 
             return modelStrategy == SqlServerValueGenerationStrategy.IdentityColumn
                    && IsCompatibleWithValueGeneration(property)
-                ? (SqlServerValueGenerationStrategy?)SqlServerValueGenerationStrategy.IdentityColumn
-                : null;
+                ? SqlServerValueGenerationStrategy.IdentityColumn
+                : SqlServerValueGenerationStrategy.None;
         }
 
         /// <summary>
@@ -253,7 +253,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             CheckSqlServerValueGenerationStrategy(property, value);
 
-            property.SetAnnotation(SqlServerAnnotationNames.ValueGenerationStrategy, value);
+            property.SetOrRemoveAnnotation(SqlServerAnnotationNames.ValueGenerationStrategy, value);
         }
 
         /// <summary>
@@ -267,7 +267,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             CheckSqlServerValueGenerationStrategy(property, value);
 
-            property.SetAnnotation(SqlServerAnnotationNames.ValueGenerationStrategy, value, fromDataAnnotation);
+            property.SetOrRemoveAnnotation(SqlServerAnnotationNames.ValueGenerationStrategy, value, fromDataAnnotation);
         }
 
         private static void CheckSqlServerValueGenerationStrategy(IProperty property, SqlServerValueGenerationStrategy? value)

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerStoreGenerationConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerStoreGenerationConvention.cs
@@ -100,7 +100,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         protected override void Validate(IConventionProperty property)
         {
             if (property.GetSqlServerValueGenerationStrategyConfigurationSource() != null
-                && property.GetSqlServerValueGenerationStrategy() != null)
+                && property.GetSqlServerValueGenerationStrategy() != SqlServerValueGenerationStrategy.None)
             {
                 if (property.GetDefaultValue() != null)
                 {

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerValueGenerationConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerValueGenerationConvention.cs
@@ -68,8 +68,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         /// <returns> The store value generation strategy to set for the given property. </returns>
         public static new ValueGenerated? GetValueGenerated([NotNull] IProperty property)
             => RelationalValueGenerationConvention.GetValueGenerated(property)
-                ?? ((property as IConventionProperty)?.GetSqlServerValueGenerationStrategyConfigurationSource() != null
-                    && property.GetSqlServerValueGenerationStrategy() != null
+                ?? (property.GetSqlServerValueGenerationStrategy() != SqlServerValueGenerationStrategy.None
                     ? ValueGenerated.OnAdd
                     : (ValueGenerated?)null);
     }

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerValueGenerationStrategyConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerValueGenerationStrategyConvention.cs
@@ -54,7 +54,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 foreach (var property in entityType.GetDeclaredProperties())
                 {
                     // Needed for the annotation to show up in the model snapshot
-                    property.Builder.ForSqlServerHasValueGenerationStrategy(property.GetSqlServerValueGenerationStrategy());
+                    var strategy = property.GetSqlServerValueGenerationStrategy();
+                    if (strategy != SqlServerValueGenerationStrategy.None)
+                    {
+                        property.Builder.ForSqlServerHasValueGenerationStrategy(strategy);
+                    }
                 }
             }
         }

--- a/src/EFCore.SqlServer/Metadata/SqlServerValueGenerationStrategy.cs
+++ b/src/EFCore.SqlServer/Metadata/SqlServerValueGenerationStrategy.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+// ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -9,6 +10,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata
     /// </summary>
     public enum SqlServerValueGenerationStrategy
     {
+        /// <summary>
+        ///     No SQL Server-specific strategy
+        /// </summary>
+        None,
+
         /// <summary>
         ///     <para>
         ///         A sequence-based hi-lo pattern where blocks of IDs are allocated from the server and

--- a/src/EFCore/DbContextOptionsBuilder.cs
+++ b/src/EFCore/DbContextOptionsBuilder.cs
@@ -71,8 +71,13 @@ namespace Microsoft.EntityFrameworkCore
         public virtual bool IsConfigured => _options.Extensions.Any(e => e.ApplyServices(new ServiceCollection()));
 
         /// <summary>
-        ///     Sets the model to be used for the context. If the model is set, then <see cref="DbContext.OnModelCreating(ModelBuilder)" />
-        ///     will not be run.
+        ///     <para>
+        ///         Sets the model to be used for the context. If the model is set, then <see cref="DbContext.OnModelCreating(ModelBuilder)" />
+        ///         will not be run.
+        ///     </para>
+        ///     <para>
+        ///         If setting an externally created model <see cref="ModelBuilder.FinalizeModel()"/> should be called first.
+        ///     </para>
         /// </summary>
         /// <param name="model"> The model to be used. </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>

--- a/src/EFCore/Extensions/MutableModelExtensions.cs
+++ b/src/EFCore/Extensions/MutableModelExtensions.cs
@@ -215,5 +215,14 @@ namespace Microsoft.EntityFrameworkCore
         public static void RemoveOwned([NotNull] this IMutableModel model, [NotNull] Type clrType)
             => Check.NotNull((Model)model, nameof(model)).RemoveOwned(
                 Check.NotNull(clrType, nameof(clrType)));
+
+        /// <summary>
+        ///     Forces post-processing on the model such that it is ready for use by the runtime. This post
+        ///     processing happens automatically when using <see cref="DbContext.OnModelCreating"/>; this method allows it to be run
+        ///     explicitly in cases where the automatic execution is not possible.
+        /// </summary>
+        /// <param name="model"> The model to finalize. </param>
+        /// <returns> The finalized <see cref="IModel" />. </returns>
+        public static IModel FinalizeModel([NotNull] this IMutableModel model) => model.AsModel().FinalizeModel();
     }
 }

--- a/src/EFCore/Infrastructure/ModelValidator.cs
+++ b/src/EFCore/Infrastructure/ModelValidator.cs
@@ -53,6 +53,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <param name="logger"> The logger to use. </param>
         public virtual void Validate(IModel model, IDiagnosticsLogger<DbLoggerCategory.Model.Validation> logger)
         {
+            ((Model)model).MakeReadonly();
+
             ValidateNoShadowEntities(model, logger);
             ValidateIgnoredMembers(model, logger);
             ValidatePropertyMapping(model, logger);

--- a/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.cs
@@ -73,11 +73,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             [NotNull] string name,
             [CanBeNull] IConventionAnnotation annotation,
             [CanBeNull] IConventionAnnotation oldAnnotation)
-            => _scope.OnModelAnnotationChanged(
+        {
+            if (CoreAnnotationNames.AllNames.Contains(name))
+            {
+                return annotation;
+            }
+
+            return _scope.OnModelAnnotationChanged(
                 modelBuilder,
                 name,
                 annotation,
                 oldAnnotation);
+        }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -142,11 +149,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             [NotNull] string name,
             [CanBeNull] IConventionAnnotation annotation,
             [CanBeNull] IConventionAnnotation oldAnnotation)
-            => _scope.OnEntityTypeAnnotationChanged(
+        {
+            if (CoreAnnotationNames.AllNames.Contains(name))
+            {
+                return annotation;
+            }
+
+            return _scope.OnEntityTypeAnnotationChanged(
                 entityTypeBuilder,
                 name,
                 annotation,
                 oldAnnotation);
+        }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -234,11 +248,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             [NotNull] string name,
             [CanBeNull] IConventionAnnotation annotation,
             [CanBeNull] IConventionAnnotation oldAnnotation)
-            => _scope.OnForeignKeyAnnotationChanged(
+        {
+            if (CoreAnnotationNames.AllNames.Contains(name))
+            {
+                return annotation;
+            }
+
+            return _scope.OnForeignKeyAnnotationChanged(
                 relationshipBuilder,
                 name,
                 annotation,
                 oldAnnotation);
+        }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -296,11 +317,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             [NotNull] string name,
             [CanBeNull] IConventionAnnotation annotation,
             [CanBeNull] IConventionAnnotation oldAnnotation)
-            => _scope.OnKeyAnnotationChanged(
+        {
+            if (CoreAnnotationNames.AllNames.Contains(name))
+            {
+                return annotation;
+            }
+
+            return _scope.OnKeyAnnotationChanged(
                 keyBuilder,
                 name,
                 annotation,
                 oldAnnotation);
+        }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -352,11 +380,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             [NotNull] string name,
             [CanBeNull] IConventionAnnotation annotation,
             [CanBeNull] IConventionAnnotation oldAnnotation)
-            => _scope.OnIndexAnnotationChanged(
+        {
+            if (CoreAnnotationNames.AllNames.Contains(name))
+            {
+                return annotation;
+            }
+
+            return _scope.OnIndexAnnotationChanged(
                 indexBuilder,
                 name,
                 annotation,
                 oldAnnotation);
+        }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -397,11 +432,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             [NotNull] string name,
             [CanBeNull] IConventionAnnotation annotation,
             [CanBeNull] IConventionAnnotation oldAnnotation)
-            => _scope.OnPropertyAnnotationChanged(
+        {
+            if (CoreAnnotationNames.AllNames.Contains(name))
+            {
+                return annotation;
+            }
+
+            return _scope.OnPropertyAnnotationChanged(
                 propertyBuilder,
                 name,
                 annotation,
                 oldAnnotation);
+        }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/CoreAnnotationNames.cs
+++ b/src/EFCore/Metadata/Internal/CoreAnnotationNames.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -218,5 +220,41 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public const string DuplicateServiceProperties = "ServicePropertyDiscoveryConvention:DuplicateServiceProperties";
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public static readonly ISet<string> AllNames = new HashSet<string>
+        {
+            MaxLength,
+            Unicode,
+            ProductVersion,
+            ValueGeneratorFactory,
+            PropertyAccessMode,
+            NavigationAccessMode,
+            ChangeTrackingStrategy,
+            OwnedTypes,
+            DiscriminatorProperty,
+            DiscriminatorValue,
+            ConstructorBinding,
+            TypeMapping,
+            ValueConverter,
+            ValueComparer,
+            KeyValueComparer,
+            StructuralValueComparer,
+            AfterSaveBehavior,
+            BeforeSaveBehavior,
+            QueryFilter,
+            DefiningQuery,
+            EagerLoaded,
+            ProviderClrType,
+            InverseNavigations,
+            NavigationCandidates,
+            AmbiguousNavigations,
+            DuplicateServiceProperties
+        };
     }
 }

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -348,7 +348,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 _baseType._directlyDerivedTypes.Add(this);
             }
 
-            PropertyMetadataChanged();
             UpdateBaseTypeConfigurationSource(configurationSource);
             newBaseType?.UpdateConfigurationSource(configurationSource);
 
@@ -588,7 +587,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 SetPrimaryKeyConfigurationSource(null);
             }
 
-            PropertyMetadataChanged();
             return (Key)Model.ConventionDispatcher.OnPrimaryKeyChanged(Builder, newKey, oldPrimaryKey);
         }
 
@@ -748,8 +746,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
             }
 
-            PropertyMetadataChanged();
-
             return (Key)Model.ConventionDispatcher.OnKeyAdded(key.Builder)?.Metadata;
         }
 
@@ -853,8 +849,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
             }
 
-            PropertyMetadataChanged();
-
             return (Key)Model.ConventionDispatcher.OnKeyRemoved(Builder, key);
         }
 
@@ -928,8 +922,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             OnForeignKeyUpdated(foreignKey);
-
-            PropertyMetadataChanged();
 
             return (ForeignKey)Model.ConventionDispatcher.OnForeignKeyAdded(foreignKey.Builder)?.Metadata;
         }
@@ -1264,8 +1256,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             foreignKey.Builder = null;
 
-            PropertyMetadataChanged();
-
             if (foreignKey.DependentToPrincipal != null)
             {
                 Model.ConventionDispatcher.OnNavigationRemoved(
@@ -1413,8 +1403,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             _navigations.Add(name, navigation);
 
-            PropertyMetadataChanged();
-
             return navigation;
         }
 
@@ -1516,8 +1504,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             _navigations.Remove(name);
-
-            PropertyMetadataChanged();
 
             return navigation;
         }
@@ -1914,7 +1900,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 configurationSource, typeConfigurationSource);
 
             _properties.Add(property.Name, property);
-            PropertyMetadataChanged();
 
             return (Property)Model.ConventionDispatcher.OnPropertyAdded(property.Builder)?.Metadata;
         }
@@ -2048,8 +2033,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Debug.Assert(removed);
             property.Builder = null;
 
-            PropertyMetadataChanged();
-
             return property;
         }
 
@@ -2089,29 +2072,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual IEnumerable<Property> GetProperties()
             => _baseType?.GetProperties().Concat(_properties.Values) ?? _properties.Values;
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public override void PropertyMetadataChanged()
-        {
-            foreach (var property in GetProperties())
-            {
-                property.PropertyIndexes = null;
-            }
-
-            foreach (var navigation in GetNavigations())
-            {
-                navigation.PropertyIndexes = null;
-            }
-
-            // This path should only kick in when the model is still mutable and therefore access does not need
-            // to be thread-safe.
-            _counts = null;
-        }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
+++ b/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -298,8 +299,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static PropertyCounts CalculateCounts([NotNull] this IEntityType entityType)
+        public static PropertyCounts CalculateCounts([NotNull] this EntityType entityType)
         {
+            Debug.Assert(entityType.Model.ConventionDispatcher == null, "Should not be called on a mutable model");
+
             var index = 0;
             var navigationIndex = 0;
             var originalValueIndex = 0;
@@ -327,7 +330,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     relationshipIndex: property.IsKeyOrForeignKey() ? relationshipIndex++ : -1,
                     storeGenerationIndex: property.MayBeStoreGenerated() ? storeGenerationIndex++ : -1);
 
-                property.SetIndexes(indexes);
+                property.PropertyIndexes = indexes;
             }
 
             var isNotifying = entityType.GetChangeTrackingStrategy() != ChangeTrackingStrategy.Snapshot;
@@ -341,7 +344,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     relationshipIndex: navigation.IsCollection() && isNotifying ? -1 : relationshipIndex++,
                     storeGenerationIndex: -1);
 
-                navigation.SetIndexes(indexes);
+                navigation.PropertyIndexes = indexes;
             }
 
             foreach (var serviceProperty in entityType.GetDeclaredServiceProperties())
@@ -353,7 +356,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     relationshipIndex: -1,
                     storeGenerationIndex: -1);
 
-                serviceProperty.SetIndexes(indexes);
+                serviceProperty.PropertyIndexes = indexes;
             }
 
             return new PropertyCounts(

--- a/src/EFCore/Metadata/Internal/Model.cs
+++ b/src/EFCore/Metadata/Internal/Model.cs
@@ -843,12 +843,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual IModel FinalizeModel()
         {
             var finalModel = (Model)ConventionDispatcher.OnModelFinalized(Builder)?.Metadata;
-            if (finalModel != null)
-            {
-                finalModel.ConventionDispatcher = null;
-            }
+            return finalModel?.MakeReadonly();
+        }
 
-            return finalModel;
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual IModel MakeReadonly()
+        {
+            ConventionDispatcher = null;
+            return this;
         }
 
         /// <summary>

--- a/src/EFCore/Metadata/Internal/Navigation.cs
+++ b/src/EFCore/Metadata/Internal/Navigation.cs
@@ -110,14 +110,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        protected override void PropertyMetadataChanged() => DeclaringType.PropertyMetadataChanged();
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
         public static bool IsCompatible(
             [NotNull] string navigationName,
             [CanBeNull] MemberInfo navigationProperty,

--- a/src/EFCore/Metadata/Internal/Property.cs
+++ b/src/EFCore/Metadata/Internal/Property.cs
@@ -76,14 +76,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        protected override void PropertyMetadataChanged() => DeclaringType.PropertyMetadataChanged();
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
         public override TypeBase DeclaringType
         {
             [DebuggerStepThrough] get => DeclaringEntityType;
@@ -302,8 +294,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (IsConcurrencyToken != concurrencyToken)
             {
                 _isConcurrencyToken = concurrencyToken;
-
-                PropertyMetadataChanged();
             }
 
             if (concurrencyToken == null)

--- a/src/EFCore/Metadata/Internal/PropertyBase.cs
+++ b/src/EFCore/Metadata/Internal/PropertyBase.cs
@@ -162,8 +162,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var oldFieldInfo = FieldInfo;
             _fieldInfo = fieldInfo;
 
-            PropertyMetadataChanged();
-
             OnFieldInfoSet(fieldInfo, oldFieldInfo);
         }
 
@@ -197,7 +195,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 if (shouldThrow)
                 {
                     throw new InvalidOperationException(
-                        CoreStrings.MissingBackingField(fieldInfo.Name, propertyName, entityClrType.ShortDisplayName()));
+                        CoreStrings.MissingBackingField(fieldInfo.Name, propertyName, entityClrType?.ShortDisplayName()));
                 }
 
                 return false;
@@ -254,14 +252,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
             }
         }
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        protected abstract void PropertyMetadataChanged();
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/PropertyBaseExtensions.cs
+++ b/src/EFCore/Metadata/Internal/PropertyBaseExtensions.cs
@@ -79,15 +79,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static void SetIndexes([NotNull] this IPropertyBase propertyBase, [CanBeNull] PropertyIndexes indexes)
-            => propertyBase.AsPropertyBase().PropertyIndexes = indexes;
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
         public static PropertyAccessors GetPropertyAccessors([NotNull] this IPropertyBase propertyBase)
             => propertyBase.AsPropertyBase().Accessors;
 

--- a/src/EFCore/Metadata/Internal/ServiceProperty.cs
+++ b/src/EFCore/Metadata/Internal/ServiceProperty.cs
@@ -71,14 +71,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        protected override void PropertyMetadataChanged() => DeclaringType.PropertyMetadataChanged();
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
         public override Type ClrType { get; }
 
         /// <summary>
@@ -132,12 +124,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual void SetParameterBinding(ServiceParameterBinding parameterBinding, ConfigurationSource configurationSource)
         {
-            if (_parameterBinding != parameterBinding)
-            {
-                _parameterBinding = parameterBinding;
-
-                PropertyMetadataChanged();
-            }
+            _parameterBinding = parameterBinding;
 
             UpdateParameterBindingConfigurationSource(configurationSource);
         }

--- a/src/EFCore/Metadata/Internal/TypeBase.cs
+++ b/src/EFCore/Metadata/Internal/TypeBase.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
@@ -106,14 +105,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual void UpdateConfigurationSource(ConfigurationSource configurationSource)
             => _configurationSource = _configurationSource.Max(configurationSource);
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public abstract void PropertyMetadataChanged();
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/ModelBuilder.cs
+++ b/src/EFCore/ModelBuilder.cs
@@ -490,9 +490,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     processing happens automatically when using <see cref="DbContext.OnModelCreating"/>; this method allows it to be run
         ///     explicitly in cases where the automatic execution is not possible.
         /// </summary>
-        /// <returns>
-        ///     The finalized <see cref="IModel" />.
-        /// </returns>
+        /// <returns> The finalized <see cref="IModel" />. </returns>
         public virtual IModel FinalizeModel() => Builder.Metadata.FinalizeModel();
 
         private InternalModelBuilder Builder => this.GetInfrastructure();

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
@@ -213,7 +213,17 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             var generator = new TestCSharpSnapshotGenerator(
                 new CSharpSnapshotGeneratorDependencies(codeHelper));
 
-            foreach (var field in typeof(CoreAnnotationNames).GetFields().Concat(
+            var coreAnnotations = typeof(CoreAnnotationNames).GetFields().Where(f => f.FieldType == typeof(string)).ToList();
+
+            foreach (var field in coreAnnotations)
+            {
+                var annotationName = (string)field.GetValue(null);
+
+                Assert.True(CoreAnnotationNames.AllNames.Contains(annotationName),
+                    nameof(CoreAnnotationNames) + "." + nameof(CoreAnnotationNames.AllNames) + " doesn't contain " + annotationName);
+            }
+
+            foreach (var field in coreAnnotations.Concat(
                 typeof(RelationalAnnotationNames).GetFields().Where(f => f.Name != "Prefix")))
             {
                 var annotationName = (string)field.GetValue(null);

--- a/test/EFCore.InMemory.FunctionalTests/EndToEndTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/EndToEndTest.cs
@@ -31,7 +31,6 @@ namespace Microsoft.EntityFrameworkCore
         private void Can_add_update_delete_end_to_end<T>()
             where T : class, new()
         {
-            var type = typeof(T);
             var modelBuilder = new ModelBuilder(InMemoryConventionSetBuilder.Build());
             modelBuilder.Entity<T>(eb =>
             {
@@ -40,7 +39,7 @@ namespace Microsoft.EntityFrameworkCore
             });
 
             var optionsBuilder = new DbContextOptionsBuilder()
-                .UseModel(modelBuilder.Model)
+                .UseModel(modelBuilder.FinalizeModel())
                 .UseInMemoryDatabase(nameof(EndToEndInMemoryTest))
                 .UseInternalServiceProvider(Fixture.ServiceProvider);
 

--- a/test/EFCore.InMemory.FunctionalTests/ShadowStateUpdateTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/ShadowStateUpdateTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore
             customerType.AddProperty("Name", typeof(string));
 
             var optionsBuilder = new DbContextOptionsBuilder()
-                .UseModel(model)
+                .UseModel(model.FinalizeModel())
                 .UseInMemoryDatabase(nameof(ShadowStateUpdateTest))
                 .UseInternalServiceProvider(_fixture.ServiceProvider);
 

--- a/test/EFCore.Relational.Tests/Update/ModificationCommandComparerTest.cs
+++ b/test/EFCore.Relational.Tests/Update/ModificationCommandComparerTest.cs
@@ -20,16 +20,15 @@ namespace Microsoft.EntityFrameworkCore.Update
         {
             IMutableModel model = new Model();
             var entityType = model.AddEntityType(typeof(object));
+            var key = entityType.AddProperty("Id", typeof(int));
+            entityType.SetPrimaryKey(key);
 
             var optionsBuilder = new DbContextOptionsBuilder()
-                .UseModel(model)
+                .UseModel(model.FinalizeModel())
                 .UseInMemoryDatabase(Guid.NewGuid().ToString())
                 .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider);
 
             var stateManager = new DbContext(optionsBuilder.Options).GetService<IStateManager>();
-
-            var key = entityType.AddProperty("Id", typeof(int));
-            entityType.SetPrimaryKey(key);
 
             var entry1 = stateManager.GetOrCreateEntry(new object());
             entry1[key] = 1;
@@ -156,16 +155,16 @@ namespace Microsoft.EntityFrameworkCore.Update
             IMutableModel model = new Model();
             var entityType = model.AddEntityType(typeof(object));
 
-            var optionsBuilder = new DbContextOptionsBuilder()
-                .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
-                .UseModel(model)
-                .UseInMemoryDatabase(Guid.NewGuid().ToString());
-
-            var stateManager = new DbContext(optionsBuilder.Options).GetService<IStateManager>();
-
             var keyProperty = entityType.AddProperty("Id", typeof(T));
             keyProperty.IsNullable = false;
             entityType.SetPrimaryKey(keyProperty);
+
+            var optionsBuilder = new DbContextOptionsBuilder()
+                .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                .UseModel(model.FinalizeModel())
+                .UseInMemoryDatabase(Guid.NewGuid().ToString());
+
+            var stateManager = new DbContext(optionsBuilder.Options).GetService<IStateManager>();
 
             var entry1 = stateManager.GetOrCreateEntry(new object());
             entry1[keyProperty] = value1;

--- a/test/EFCore.Relational.Tests/Update/UpdateSqlGeneratorTestBase.cs
+++ b/test/EFCore.Relational.Tests/Update/UpdateSqlGeneratorTestBase.cs
@@ -27,8 +27,8 @@ namespace Microsoft.EntityFrameworkCore.Update
             CreateSqlGenerator().AppendDeleteOperation(stringBuilder, command, 0);
 
             Assert.Equal(
-                "DELETE FROM " + SchemaPrefix + OpenDelimeter + "Ducks" + CloseDelimeter + "" + Environment.NewLine +
-                "WHERE " + OpenDelimeter + "Id" + CloseDelimeter + " = @p0;" + Environment.NewLine +
+                "DELETE FROM " + SchemaPrefix + OpenDelimiter + "Ducks" + CloseDelimiter + "" + Environment.NewLine +
+                "WHERE " + OpenDelimiter + "Id" + CloseDelimiter + " = @p0;" + Environment.NewLine +
                 "SELECT " + RowsAffected + ";" + Environment.NewLine + Environment.NewLine,
                 stringBuilder.ToString());
         }
@@ -42,8 +42,8 @@ namespace Microsoft.EntityFrameworkCore.Update
             CreateSqlGenerator().AppendDeleteOperation(stringBuilder, command, 0);
 
             Assert.Equal(
-                "DELETE FROM " + SchemaPrefix + OpenDelimeter + "Ducks" + CloseDelimeter + "" + Environment.NewLine +
-                "WHERE " + OpenDelimeter + "Id" + CloseDelimeter + " = @p0 AND " + OpenDelimeter + "ConcurrencyToken" + CloseDelimeter
+                "DELETE FROM " + SchemaPrefix + OpenDelimiter + "Ducks" + CloseDelimiter + "" + Environment.NewLine +
+                "WHERE " + OpenDelimiter + "Id" + CloseDelimiter + " = @p0 AND " + OpenDelimiter + "ConcurrencyToken" + CloseDelimiter
                 + " IS NULL;" + Environment.NewLine +
                 "SELECT " + RowsAffected + ";" + Environment.NewLine + Environment.NewLine,
                 stringBuilder.ToString());
@@ -64,14 +64,14 @@ namespace Microsoft.EntityFrameworkCore.Update
             StringBuilder stringBuilder)
         {
             Assert.Equal(
-                "INSERT INTO " + SchemaPrefix + OpenDelimeter + "Ducks" + CloseDelimeter + " (" + OpenDelimeter + "Name" + CloseDelimeter
-                + ", " + OpenDelimeter + "Quacks" + CloseDelimeter + ", " + OpenDelimeter + "ConcurrencyToken" + CloseDelimeter + ")"
+                "INSERT INTO " + SchemaPrefix + OpenDelimiter + "Ducks" + CloseDelimiter + " (" + OpenDelimiter + "Name" + CloseDelimiter
+                + ", " + OpenDelimiter + "Quacks" + CloseDelimiter + ", " + OpenDelimiter + "ConcurrencyToken" + CloseDelimiter + ")"
                 + Environment.NewLine +
                 "VALUES (@p0, @p1, @p2);" + Environment.NewLine +
-                "SELECT " + OpenDelimeter + "Id" + CloseDelimeter + ", " + OpenDelimeter + "Computed" + CloseDelimeter + ""
+                "SELECT " + OpenDelimiter + "Id" + CloseDelimiter + ", " + OpenDelimiter + "Computed" + CloseDelimiter + ""
                 + Environment.NewLine +
-                "FROM " + SchemaPrefix + OpenDelimeter + "Ducks" + CloseDelimeter + "" + Environment.NewLine +
-                "WHERE " + RowsAffected + " = 1 AND " + OpenDelimeter + "Id" + CloseDelimeter + " = " + Identity + ";" + Environment.NewLine
+                "FROM " + SchemaPrefix + OpenDelimiter + "Ducks" + CloseDelimiter + "" + Environment.NewLine +
+                "WHERE " + RowsAffected + " = 1 AND " + OpenDelimiter + "Id" + CloseDelimiter + " = " + Identity + ";" + Environment.NewLine
                 + Environment.NewLine,
                 stringBuilder.ToString());
         }
@@ -86,9 +86,9 @@ namespace Microsoft.EntityFrameworkCore.Update
             CreateSqlGenerator().AppendInsertOperation(stringBuilder, command, 0);
 
             Assert.Equal(
-                "INSERT INTO " + SchemaPrefix + OpenDelimeter + "Ducks" + CloseDelimeter + " (" +
-                OpenDelimeter + "Id" + CloseDelimeter + ", " + OpenDelimeter + "Name" + CloseDelimeter + ", " + OpenDelimeter + "Quacks"
-                + CloseDelimeter + ", " + OpenDelimeter + "ConcurrencyToken" + CloseDelimeter + ")" + Environment.NewLine +
+                "INSERT INTO " + SchemaPrefix + OpenDelimiter + "Ducks" + CloseDelimiter + " (" +
+                OpenDelimiter + "Id" + CloseDelimiter + ", " + OpenDelimiter + "Name" + CloseDelimiter + ", " + OpenDelimiter + "Quacks"
+                + CloseDelimiter + ", " + OpenDelimiter + "ConcurrencyToken" + CloseDelimiter + ")" + Environment.NewLine +
                 "VALUES (@p0, @p1, @p2, @p3);" + Environment.NewLine,
                 stringBuilder.ToString());
         }
@@ -108,14 +108,14 @@ namespace Microsoft.EntityFrameworkCore.Update
             StringBuilder stringBuilder)
         {
             Assert.Equal(
-                "INSERT INTO " + SchemaPrefix + OpenDelimeter + "Ducks" + CloseDelimeter + " (" + OpenDelimeter + "Id" +
-                CloseDelimeter + ", " + OpenDelimeter + "Name" + CloseDelimeter + ", " + OpenDelimeter + "Quacks" + CloseDelimeter + ", "
-                + OpenDelimeter +
-                "ConcurrencyToken" + CloseDelimeter + ")" + Environment.NewLine +
+                "INSERT INTO " + SchemaPrefix + OpenDelimiter + "Ducks" + CloseDelimiter + " (" + OpenDelimiter + "Id" +
+                CloseDelimiter + ", " + OpenDelimiter + "Name" + CloseDelimiter + ", " + OpenDelimiter + "Quacks" + CloseDelimiter + ", "
+                + OpenDelimiter +
+                "ConcurrencyToken" + CloseDelimiter + ")" + Environment.NewLine +
                 "VALUES (@p0, @p1, @p2, @p3);" + Environment.NewLine +
-                "SELECT " + OpenDelimeter + "Computed" + CloseDelimeter + "" + Environment.NewLine +
-                "FROM " + SchemaPrefix + OpenDelimeter + "Ducks" + CloseDelimeter + "" + Environment.NewLine +
-                "WHERE " + RowsAffected + " = 1 AND " + OpenDelimeter + "Id" + CloseDelimeter + " = @p0;" + Environment.NewLine
+                "SELECT " + OpenDelimiter + "Computed" + CloseDelimiter + "" + Environment.NewLine +
+                "FROM " + SchemaPrefix + OpenDelimiter + "Ducks" + CloseDelimiter + "" + Environment.NewLine +
+                "WHERE " + RowsAffected + " = 1 AND " + OpenDelimiter + "Id" + CloseDelimiter + " = @p0;" + Environment.NewLine
                 + Environment.NewLine,
                 stringBuilder.ToString());
         }
@@ -134,13 +134,13 @@ namespace Microsoft.EntityFrameworkCore.Update
         protected virtual void AppendInsertOperation_appends_insert_and_select_for_only_identity_verification(StringBuilder stringBuilder)
         {
             Assert.Equal(
-                "INSERT INTO " + SchemaPrefix + OpenDelimeter + "Ducks" + CloseDelimeter + " (" + OpenDelimeter + "Name" +
-                CloseDelimeter + ", " + OpenDelimeter + "Quacks" + CloseDelimeter + ", " + OpenDelimeter + "ConcurrencyToken"
-                + CloseDelimeter + ")" + Environment.NewLine +
+                "INSERT INTO " + SchemaPrefix + OpenDelimiter + "Ducks" + CloseDelimiter + " (" + OpenDelimiter + "Name" +
+                CloseDelimiter + ", " + OpenDelimiter + "Quacks" + CloseDelimiter + ", " + OpenDelimiter + "ConcurrencyToken"
+                + CloseDelimiter + ")" + Environment.NewLine +
                 "VALUES (@p0, @p1, @p2);" + Environment.NewLine +
-                "SELECT " + OpenDelimeter + "Id" + CloseDelimeter + "" + Environment.NewLine +
-                "FROM " + SchemaPrefix + OpenDelimeter + "Ducks" + CloseDelimeter + "" + Environment.NewLine +
-                "WHERE " + RowsAffected + " = 1 AND " + OpenDelimeter + "Id" + CloseDelimeter + " = " + Identity + ";" + Environment.NewLine
+                "SELECT " + OpenDelimiter + "Id" + CloseDelimiter + "" + Environment.NewLine +
+                "FROM " + SchemaPrefix + OpenDelimiter + "Ducks" + CloseDelimiter + "" + Environment.NewLine +
+                "WHERE " + RowsAffected + " = 1 AND " + OpenDelimiter + "Id" + CloseDelimiter + " = " + Identity + ";" + Environment.NewLine
                 + Environment.NewLine,
                 stringBuilder.ToString());
         }
@@ -160,12 +160,12 @@ namespace Microsoft.EntityFrameworkCore.Update
             StringBuilder stringBuilder)
         {
             Assert.Equal(
-                "INSERT INTO " + SchemaPrefix + OpenDelimeter + "Ducks" + CloseDelimeter + "" + Environment.NewLine +
+                "INSERT INTO " + SchemaPrefix + OpenDelimiter + "Ducks" + CloseDelimiter + "" + Environment.NewLine +
                 "DEFAULT VALUES;" + Environment.NewLine +
-                "SELECT " + OpenDelimeter + "Id" + CloseDelimeter + ", " + OpenDelimeter + "Computed" + CloseDelimeter + ""
+                "SELECT " + OpenDelimiter + "Id" + CloseDelimiter + ", " + OpenDelimiter + "Computed" + CloseDelimiter + ""
                 + Environment.NewLine +
-                "FROM " + SchemaPrefix + OpenDelimeter + "Ducks" + CloseDelimeter + "" + Environment.NewLine +
-                "WHERE " + RowsAffected + " = 1 AND " + OpenDelimeter + "Id" + CloseDelimeter + " = " + Identity + ";" + Environment.NewLine
+                "FROM " + SchemaPrefix + OpenDelimiter + "Ducks" + CloseDelimiter + "" + Environment.NewLine +
+                "WHERE " + RowsAffected + " = 1 AND " + OpenDelimiter + "Id" + CloseDelimiter + " = " + Identity + ";" + Environment.NewLine
                 + Environment.NewLine,
                 stringBuilder.ToString());
         }
@@ -185,11 +185,11 @@ namespace Microsoft.EntityFrameworkCore.Update
             StringBuilder stringBuilder)
         {
             Assert.Equal(
-                "INSERT INTO " + SchemaPrefix + OpenDelimeter + "Ducks" + CloseDelimeter + "" + Environment.NewLine +
+                "INSERT INTO " + SchemaPrefix + OpenDelimiter + "Ducks" + CloseDelimiter + "" + Environment.NewLine +
                 "DEFAULT VALUES;" + Environment.NewLine +
-                "SELECT " + OpenDelimeter + "Id" + CloseDelimeter + "" + Environment.NewLine +
-                "FROM " + SchemaPrefix + OpenDelimeter + "Ducks" + CloseDelimeter + "" + Environment.NewLine +
-                "WHERE " + RowsAffected + " = 1 AND " + OpenDelimeter + "Id" + CloseDelimeter + " = " + Identity + ";" + Environment.NewLine
+                "SELECT " + OpenDelimiter + "Id" + CloseDelimiter + "" + Environment.NewLine +
+                "FROM " + SchemaPrefix + OpenDelimiter + "Ducks" + CloseDelimiter + "" + Environment.NewLine +
+                "WHERE " + RowsAffected + " = 1 AND " + OpenDelimiter + "Id" + CloseDelimiter + " = " + Identity + ";" + Environment.NewLine
                 + Environment.NewLine,
                 stringBuilder.ToString());
         }
@@ -209,14 +209,14 @@ namespace Microsoft.EntityFrameworkCore.Update
             StringBuilder stringBuilder)
         {
             Assert.Equal(
-                "UPDATE " + SchemaPrefix + OpenDelimeter + "Ducks" + CloseDelimeter + " SET " + OpenDelimeter + "Name" + CloseDelimeter +
-                " = @p0, " + OpenDelimeter + "Quacks" + CloseDelimeter + " = @p1, " + OpenDelimeter + "ConcurrencyToken" + CloseDelimeter
+                "UPDATE " + SchemaPrefix + OpenDelimiter + "Ducks" + CloseDelimiter + " SET " + OpenDelimiter + "Name" + CloseDelimiter +
+                " = @p0, " + OpenDelimiter + "Quacks" + CloseDelimiter + " = @p1, " + OpenDelimiter + "ConcurrencyToken" + CloseDelimiter
                 + " = @p2" + Environment.NewLine +
-                "WHERE " + OpenDelimeter + "Id" + CloseDelimeter + " = @p3 AND " + OpenDelimeter + "ConcurrencyToken" + CloseDelimeter
+                "WHERE " + OpenDelimiter + "Id" + CloseDelimiter + " = @p3 AND " + OpenDelimiter + "ConcurrencyToken" + CloseDelimiter
                 + " IS NULL;" + Environment.NewLine +
-                "SELECT " + OpenDelimeter + "Computed" + CloseDelimeter + "" + Environment.NewLine +
-                "FROM " + SchemaPrefix + OpenDelimeter + "Ducks" + CloseDelimeter + "" + Environment.NewLine +
-                "WHERE " + RowsAffected + " = 1 AND " + OpenDelimeter + "Id" + CloseDelimeter + " = @p3;" + Environment.NewLine
+                "SELECT " + OpenDelimiter + "Computed" + CloseDelimiter + "" + Environment.NewLine +
+                "FROM " + SchemaPrefix + OpenDelimiter + "Ducks" + CloseDelimiter + "" + Environment.NewLine +
+                "WHERE " + RowsAffected + " = 1 AND " + OpenDelimiter + "Id" + CloseDelimiter + " = @p3;" + Environment.NewLine
                 + Environment.NewLine,
                 stringBuilder.ToString());
         }
@@ -230,10 +230,10 @@ namespace Microsoft.EntityFrameworkCore.Update
             CreateSqlGenerator().AppendUpdateOperation(stringBuilder, command, 0);
 
             Assert.Equal(
-                "UPDATE " + SchemaPrefix + OpenDelimeter + "Ducks" + CloseDelimeter + " SET " +
-                OpenDelimeter + "Name" + CloseDelimeter + " = @p0, " + OpenDelimeter + "Quacks" + CloseDelimeter + " = @p1, " +
-                OpenDelimeter + "ConcurrencyToken" + CloseDelimeter + " = @p2" + Environment.NewLine +
-                "WHERE " + OpenDelimeter + "Id" + CloseDelimeter + " = @p3;" + Environment.NewLine +
+                "UPDATE " + SchemaPrefix + OpenDelimiter + "Ducks" + CloseDelimiter + " SET " +
+                OpenDelimiter + "Name" + CloseDelimiter + " = @p0, " + OpenDelimiter + "Quacks" + CloseDelimiter + " = @p1, " +
+                OpenDelimiter + "ConcurrencyToken" + CloseDelimiter + " = @p2" + Environment.NewLine +
+                "WHERE " + OpenDelimiter + "Id" + CloseDelimiter + " = @p3;" + Environment.NewLine +
                 "SELECT " + RowsAffected + ";" + Environment.NewLine + Environment.NewLine,
                 stringBuilder.ToString());
         }
@@ -247,10 +247,10 @@ namespace Microsoft.EntityFrameworkCore.Update
             CreateSqlGenerator().AppendUpdateOperation(stringBuilder, command, 0);
 
             Assert.Equal(
-                "UPDATE " + SchemaPrefix + OpenDelimeter + "Ducks" + CloseDelimeter + " SET " +
-                OpenDelimeter + "Name" + CloseDelimeter + " = @p0, " + OpenDelimeter + "Quacks" + CloseDelimeter + " = @p1, " +
-                OpenDelimeter + "ConcurrencyToken" + CloseDelimeter + " = @p2" + Environment.NewLine +
-                "WHERE " + OpenDelimeter + "Id" + CloseDelimeter + " = @p3 AND " + OpenDelimeter + "ConcurrencyToken" + CloseDelimeter
+                "UPDATE " + SchemaPrefix + OpenDelimiter + "Ducks" + CloseDelimiter + " SET " +
+                OpenDelimiter + "Name" + CloseDelimiter + " = @p0, " + OpenDelimiter + "Quacks" + CloseDelimiter + " = @p1, " +
+                OpenDelimiter + "ConcurrencyToken" + CloseDelimiter + " = @p2" + Environment.NewLine +
+                "WHERE " + OpenDelimiter + "Id" + CloseDelimiter + " = @p3 AND " + OpenDelimiter + "ConcurrencyToken" + CloseDelimiter
                 + " IS NULL;" + Environment.NewLine +
                 "SELECT " + RowsAffected + ";" + Environment.NewLine + Environment.NewLine,
                 stringBuilder.ToString());
@@ -270,24 +270,24 @@ namespace Microsoft.EntityFrameworkCore.Update
         protected virtual void AppendUpdateOperation_appends_select_for_computed_property_verification(StringBuilder stringBuilder)
         {
             Assert.Equal(
-                "UPDATE " + SchemaPrefix + OpenDelimeter + "Ducks" + CloseDelimeter + " SET " +
-                OpenDelimeter + "Name" + CloseDelimeter + " = @p0, " + OpenDelimeter + "Quacks" + CloseDelimeter + " = @p1, " +
-                OpenDelimeter + "ConcurrencyToken" + CloseDelimeter + " = @p2" + Environment.NewLine +
-                "WHERE " + OpenDelimeter + "Id" + CloseDelimeter + " = @p3;" + Environment.NewLine +
-                "SELECT " + OpenDelimeter + "Computed" + CloseDelimeter + "" + Environment.NewLine +
-                "FROM " + SchemaPrefix + OpenDelimeter + "Ducks" + CloseDelimeter + "" + Environment.NewLine +
-                "WHERE " + RowsAffected + " = 1 AND " + OpenDelimeter + "Id" + CloseDelimeter + " = @p3;" + Environment.NewLine
+                "UPDATE " + SchemaPrefix + OpenDelimiter + "Ducks" + CloseDelimiter + " SET " +
+                OpenDelimiter + "Name" + CloseDelimiter + " = @p0, " + OpenDelimiter + "Quacks" + CloseDelimiter + " = @p1, " +
+                OpenDelimiter + "ConcurrencyToken" + CloseDelimiter + " = @p2" + Environment.NewLine +
+                "WHERE " + OpenDelimiter + "Id" + CloseDelimiter + " = @p3;" + Environment.NewLine +
+                "SELECT " + OpenDelimiter + "Computed" + CloseDelimiter + "" + Environment.NewLine +
+                "FROM " + SchemaPrefix + OpenDelimiter + "Ducks" + CloseDelimiter + "" + Environment.NewLine +
+                "WHERE " + RowsAffected + " = 1 AND " + OpenDelimiter + "Id" + CloseDelimiter + " = @p3;" + Environment.NewLine
                 + Environment.NewLine,
                 stringBuilder.ToString());
         }
 
         [Fact]
-        public virtual void GenerateNextSequenceValueOperation_returns_statement_with_sanatized_sequence()
+        public virtual void GenerateNextSequenceValueOperation_returns_statement_with_sanitized_sequence()
         {
-            var statement = CreateSqlGenerator().GenerateNextSequenceValueOperation("sequence" + CloseDelimeter + "; --", null);
+            var statement = CreateSqlGenerator().GenerateNextSequenceValueOperation("sequence" + CloseDelimiter + "; --", null);
 
             Assert.Equal(
-                "SELECT NEXT VALUE FOR " + OpenDelimeter + "sequence" + CloseDelimeter + CloseDelimeter + "; --" + CloseDelimeter,
+                "SELECT NEXT VALUE FOR " + OpenDelimiter + "sequence" + CloseDelimiter + CloseDelimiter + "; --" + CloseDelimiter,
                 statement);
         }
 
@@ -297,7 +297,7 @@ namespace Microsoft.EntityFrameworkCore.Update
             var statement = CreateSqlGenerator().GenerateNextSequenceValueOperation("mysequence", "dbo");
 
             Assert.Equal(
-                "SELECT NEXT VALUE FOR " + SchemaPrefix + OpenDelimeter + "mysequence" + CloseDelimeter,
+                "SELECT NEXT VALUE FOR " + SchemaPrefix + OpenDelimiter + "mysequence" + CloseDelimiter,
                 statement);
         }
 
@@ -307,19 +307,19 @@ namespace Microsoft.EntityFrameworkCore.Update
 
         protected abstract string Identity { get; }
 
-        protected virtual string OpenDelimeter => "\"";
+        protected virtual string OpenDelimiter => "\"";
 
-        protected virtual string CloseDelimeter => "\"";
+        protected virtual string CloseDelimiter => "\"";
 
         protected virtual string Schema => "dbo";
 
         protected virtual string SchemaPrefix =>
-            string.IsNullOrEmpty(Schema) ? string.Empty : OpenDelimeter + Schema + CloseDelimeter + ".";
+            string.IsNullOrEmpty(Schema) ? string.Empty : OpenDelimiter + Schema + CloseDelimiter + ".";
 
         protected ModificationCommand CreateInsertCommand(bool identityKey = true, bool isComputed = true, bool defaultsOnly = false)
         {
             var duckType = GetDuckType();
-            var stateManager = TestHelpers.CreateContextServices(duckType.Model).GetRequiredService<IStateManager>();
+            var stateManager = TestHelpers.CreateContextServices(duckType.Model.FinalizeModel()).GetRequiredService<IStateManager>();
             var entry = stateManager.GetOrCreateEntry(new Duck());
             var generator = new ParameterNameGenerator();
 
@@ -356,7 +356,7 @@ namespace Microsoft.EntityFrameworkCore.Update
         protected ModificationCommand CreateUpdateCommand(bool isComputed = true, bool concurrencyToken = true)
         {
             var duckType = GetDuckType();
-            var stateManager = TestHelpers.CreateContextServices(duckType.Model).GetRequiredService<IStateManager>();
+            var stateManager = TestHelpers.CreateContextServices(duckType.Model.FinalizeModel()).GetRequiredService<IStateManager>();
             var entry = stateManager.GetOrCreateEntry(new Duck());
             var generator = new ParameterNameGenerator();
 
@@ -388,7 +388,7 @@ namespace Microsoft.EntityFrameworkCore.Update
         protected ModificationCommand CreateDeleteCommand(bool concurrencyToken = true)
         {
             var duckType = GetDuckType();
-            var stateManager = TestHelpers.CreateContextServices(duckType.Model).GetRequiredService<IStateManager>();
+            var stateManager = TestHelpers.CreateContextServices(duckType.Model.FinalizeModel()).GetRequiredService<IStateManager>();
             var entry = stateManager.GetOrCreateEntry(new Duck());
             var generator = new ParameterNameGenerator();
 

--- a/test/EFCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
@@ -131,13 +131,13 @@ namespace Microsoft.EntityFrameworkCore
             var entity = modelBuilder.Model.FindEntityType(typeof(GeneratedEntityNonInteger));
 
             var stringProperty = entity.FindProperty(nameof(GeneratedEntityNonInteger.String));
-            Assert.Null(stringProperty.GetSqlServerValueGenerationStrategy());
+            Assert.Equal(SqlServerValueGenerationStrategy.None, stringProperty.GetSqlServerValueGenerationStrategy());
 
             var dateTimeProperty = entity.FindProperty(nameof(GeneratedEntityNonInteger.DateTime));
-            Assert.Null(dateTimeProperty.GetSqlServerValueGenerationStrategy());
+            Assert.Equal(SqlServerValueGenerationStrategy.None, dateTimeProperty.GetSqlServerValueGenerationStrategy());
 
             var guidProperty = entity.FindProperty(nameof(GeneratedEntityNonInteger.Guid));
-            Assert.Null(guidProperty.GetSqlServerValueGenerationStrategy());
+            Assert.Equal(SqlServerValueGenerationStrategy.None, guidProperty.GetSqlServerValueGenerationStrategy());
 
             return modelBuilder;
         }

--- a/test/EFCore.SqlServer.Tests/Metadata/SqlServerBuilderExtensionsTest.cs
+++ b/test/EFCore.SqlServer.Tests/Metadata/SqlServerBuilderExtensionsTest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             var model = modelBuilder.Model;
             var property = model.FindEntityType(typeof(Customer)).FindProperty(nameof(Customer.Id));
 
-            Assert.Null(property.GetSqlServerValueGenerationStrategy());
+            Assert.Equal(SqlServerValueGenerationStrategy.None, property.GetSqlServerValueGenerationStrategy());
             Assert.Equal(ValueGenerated.OnAdd, property.ValueGenerated);
         }
 
@@ -43,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             var model = modelBuilder.Model;
             var property = model.FindEntityType(typeof(Customer)).FindProperty(nameof(Customer.Id));
 
-            Assert.Null(property.GetSqlServerValueGenerationStrategy());
+            Assert.Equal(SqlServerValueGenerationStrategy.None, property.GetSqlServerValueGenerationStrategy());
             Assert.Equal(ValueGenerated.OnAdd, property.ValueGenerated);
         }
 
@@ -409,19 +409,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
             var model = modelBuilder.Model;
             var idProperty = model.FindEntityType(typeof(Customer)).FindProperty(nameof(Customer.Id));
-            Assert.Null(idProperty.GetSqlServerValueGenerationStrategy());
+            Assert.Equal(SqlServerValueGenerationStrategy.None, idProperty.GetSqlServerValueGenerationStrategy());
             Assert.Equal(ValueGenerated.OnAdd, idProperty.ValueGenerated);
             Assert.Equal(1, idProperty.GetDefaultValue());
             Assert.Equal(1, idProperty.GetDefaultValue());
 
             var nameProperty = model.FindEntityType(typeof(Customer)).FindProperty(nameof(Customer.Name));
-            Assert.Null(nameProperty.GetSqlServerValueGenerationStrategy());
+            Assert.Equal(SqlServerValueGenerationStrategy.None, nameProperty.GetSqlServerValueGenerationStrategy());
             Assert.Equal(ValueGenerated.OnAddOrUpdate, nameProperty.ValueGenerated);
             Assert.Equal("Default", nameProperty.GetComputedColumnSql());
             Assert.Equal("Default", nameProperty.GetComputedColumnSql());
 
             var offsetProperty = model.FindEntityType(typeof(Customer)).FindProperty(nameof(Customer.Offset));
-            Assert.Null(offsetProperty.GetSqlServerValueGenerationStrategy());
+            Assert.Equal(SqlServerValueGenerationStrategy.None, offsetProperty.GetSqlServerValueGenerationStrategy());
             Assert.Equal(ValueGenerated.OnAdd, offsetProperty.ValueGenerated);
             Assert.Equal("Now", offsetProperty.GetDefaultValueSql());
             Assert.Equal("Now", offsetProperty.GetDefaultValueSql());

--- a/test/EFCore.SqlServer.Tests/Metadata/SqlServerMetadataExtensionsTest.cs
+++ b/test/EFCore.SqlServer.Tests/Metadata/SqlServerMetadataExtensionsTest.cs
@@ -308,7 +308,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                 .Property(e => e.Id)
                 .Metadata;
 
-            Assert.Null(property.GetSqlServerValueGenerationStrategy());
+            Assert.Equal(SqlServerValueGenerationStrategy.None, property.GetSqlServerValueGenerationStrategy());
             Assert.Equal(ValueGenerated.OnAdd, property.ValueGenerated);
 
             property.SetSqlServerValueGenerationStrategy(SqlServerValueGenerationStrategy.SequenceHiLo);
@@ -318,7 +318,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
             property.SetSqlServerValueGenerationStrategy(null);
 
-            Assert.Null(property.GetSqlServerValueGenerationStrategy());
+            Assert.Equal(SqlServerValueGenerationStrategy.None, property.GetSqlServerValueGenerationStrategy());
             Assert.Equal(ValueGenerated.OnAdd, property.ValueGenerated);
         }
 
@@ -329,10 +329,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
             var property = modelBuilder
                 .Entity<Customer>()
-                .Property(e => e.NullableInt)
+                .Property(e => e.NullableInt).ValueGeneratedOnAdd()
                 .Metadata;
 
-            Assert.Null(property.GetSqlServerValueGenerationStrategy());
+            Assert.Equal(SqlServerValueGenerationStrategy.IdentityColumn, property.GetSqlServerValueGenerationStrategy());
 
             property.SetSqlServerValueGenerationStrategy(SqlServerValueGenerationStrategy.SequenceHiLo);
 
@@ -340,7 +340,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
             property.SetSqlServerValueGenerationStrategy(null);
 
-            Assert.Null(property.GetSqlServerValueGenerationStrategy());
+            Assert.Equal(SqlServerValueGenerationStrategy.IdentityColumn, property.GetSqlServerValueGenerationStrategy());
         }
 
         [Fact]

--- a/test/EFCore.SqlServer.Tests/Update/SqlServerUpdateSqlGeneratorTest.cs
+++ b/test/EFCore.SqlServer.Tests/Update/SqlServerUpdateSqlGeneratorTest.cs
@@ -193,9 +193,9 @@ DEFAULT VALUES;
 
         protected override string Identity => throw new NotImplementedException();
 
-        protected override string OpenDelimeter => "[";
+        protected override string OpenDelimiter => "[";
 
-        protected override string CloseDelimeter => "]";
+        protected override string CloseDelimiter => "]";
 
         private void AssertBaseline(string expected, string actual)
         {

--- a/test/EFCore.Sqlite.Tests/Update/SqliteUpdateSqlGeneratorTest.cs
+++ b/test/EFCore.Sqlite.Tests/Update/SqliteUpdateSqlGeneratorTest.cs
@@ -32,10 +32,10 @@ namespace Microsoft.EntityFrameworkCore.Update
             Assert.Equal(SqliteStrings.SequencesNotSupported, ex.Message);
         }
 
-        public override void GenerateNextSequenceValueOperation_returns_statement_with_sanatized_sequence()
+        public override void GenerateNextSequenceValueOperation_returns_statement_with_sanitized_sequence()
         {
             var ex = Assert.Throws<NotSupportedException>(
-                () => base.GenerateNextSequenceValueOperation_returns_statement_with_sanatized_sequence());
+                () => base.GenerateNextSequenceValueOperation_returns_statement_with_sanitized_sequence());
             Assert.Equal(SqliteStrings.SequencesNotSupported, ex.Message);
         }
     }

--- a/test/EFCore.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
@@ -15,6 +15,9 @@ using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
+// ReSharper disable UnusedMember.Local
+// ReSharper disable UnusedAutoPropertyAccessor.Local
+// ReSharper disable MemberHidesStaticFromOuterClass
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 {
@@ -312,6 +315,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             }
         }
 
+        // ReSharper disable once ParameterOnlyUsedForPreconditionCheck.Local
         private static void AssertDetected(EntityEntry<Baxter> entityEntry, PropertyEntry<Baxter, int[]> propertyEntry)
         {
             Assert.Equal(EntityState.Modified, entityEntry.State);
@@ -1188,7 +1192,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             var contextServices = CreateContextServices(BuildModelWithChanged());
 
-            var changeDetector = contextServices.GetRequiredService<IChangeDetector>();
             var stateManager = contextServices.GetRequiredService<IStateManager>();
 
             var product1 = new ProductWithChanged
@@ -1234,7 +1237,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         [Fact]
         public void Brings_in_single_new_entity_set_on_reference_navigation()
         {
-            var contextServices = CreateContextServices(BuildModel());
+            var contextServices = CreateContextServices();
 
             var changeDetector = contextServices.GetRequiredService<IChangeDetector>();
             var stateManager = contextServices.GetRequiredService<IStateManager>();
@@ -1271,7 +1274,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         [Fact]
         public void Brings_in_new_entity_set_on_principal_of_one_to_one_navigation()
         {
-            var contextServices = CreateContextServices(BuildModel());
+            var contextServices = CreateContextServices();
 
             var changeDetector = contextServices.GetRequiredService<IChangeDetector>();
             var stateManager = contextServices.GetRequiredService<IStateManager>();
@@ -1299,7 +1302,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         [Fact]
         public void Brings_in_new_entity_set_on_dependent_of_one_to_one_navigation()
         {
-            var contextServices = CreateContextServices(BuildModel());
+            var contextServices = CreateContextServices();
 
             var changeDetector = contextServices.GetRequiredService<IChangeDetector>();
             var stateManager = contextServices.GetRequiredService<IStateManager>();
@@ -1329,7 +1332,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         [Fact]
         public void Brings_in_single_new_entity_set_on_collection_navigation()
         {
-            var contextServices = CreateContextServices(BuildModel());
+            var contextServices = CreateContextServices();
 
             var changeDetector = contextServices.GetRequiredService<IChangeDetector>();
             var stateManager = contextServices.GetRequiredService<IStateManager>();
@@ -1374,7 +1377,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         [Fact]
         public void Brings_in_new_entity_set_on_principal_of_one_to_one_self_ref()
         {
-            var contextServices = CreateContextServices(BuildModel());
+            var contextServices = CreateContextServices();
 
             var changeDetector = contextServices.GetRequiredService<IChangeDetector>();
             var stateManager = contextServices.GetRequiredService<IStateManager>();
@@ -1397,7 +1400,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         [Fact]
         public void Brings_in_new_entity_set_on_dependent_of_one_to_one_self_ref()
         {
-            var contextServices = CreateContextServices(BuildModel());
+            var contextServices = CreateContextServices();
 
             var changeDetector = contextServices.GetRequiredService<IChangeDetector>();
             var stateManager = contextServices.GetRequiredService<IStateManager>();
@@ -1742,7 +1745,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             var contextServices = CreateContextServices(BuildNotifyingModel());
 
-            var changeDetector = contextServices.GetRequiredService<IChangeDetector>();
             var stateManager = contextServices.GetRequiredService<IStateManager>();
 
             var product1 = new NotifyingProduct
@@ -1791,7 +1793,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             var contextServices = CreateContextServices(BuildNotifyingModel());
 
-            var changeDetector = contextServices.GetRequiredService<IChangeDetector>();
             var stateManager = contextServices.GetRequiredService<IStateManager>();
 
             var product1 = new NotifyingProduct
@@ -2084,7 +2085,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 .HasOne(e => e.Husband).WithOne(e => e.Wife)
                 .HasForeignKey<Person>(e => e.HusbandId);
 
-            return builder.Model;
+            return builder.Model.FinalizeModel();
         }
 
         private class NotifyingCategory : NotifyingEntity
@@ -2180,7 +2181,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 set => SetWithNotify(value, ref _name);
             }
 
-            public virtual NotifyingCategory Category
+            public NotifyingCategory Category
             {
                 get => _category;
                 set => SetWithNotify(value, ref _category);
@@ -2312,7 +2313,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 .HasOne(e => e.Husband).WithOne(e => e.Wife)
                 .HasForeignKey<NotifyingPerson>(e => e.HusbandId);
 
-            return builder.Model;
+            return builder.Model.FinalizeModel();
         }
 
         private class CategoryWithChanged : INotifyPropertyChanged
@@ -2352,7 +2353,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 .HasMany(e => e.Products).WithOne(e => e.Category)
                 .HasForeignKey(e => e.DependentId);
 
-            return builder.Model;
+            return builder.Model.FinalizeModel();
         }
 
         private static InternalEntityEntry CreateInternalEntry<TEntity>(IServiceProvider contextServices,
@@ -2420,9 +2421,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             public override void NavigationCollectionChanged(
                 InternalEntityEntry entry, INavigation navigation, IEnumerable<object> added, IEnumerable<object> removed)
             {
+                // ReSharper disable PossibleMultipleEnumeration
                 CollectionChange = Tuple.Create(entry, navigation, added, removed);
 
                 base.NavigationCollectionChanged(entry, navigation, added, removed);
+                // ReSharper restore PossibleMultipleEnumeration
             }
 
             public override void KeyPropertyChanged(

--- a/test/EFCore.Tests/ChangeTracking/Internal/InternalEntityEntryFactoryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/InternalEntityEntryFactoryTest.cs
@@ -20,6 +20,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             var entityType = model.AddEntityType("RedHook");
             entityType.AddProperty("Long", typeof(int));
             entityType.AddProperty("Hammer", typeof(string));
+            model.FinalizeModel();
 
             var contextServices = InMemoryTestHelpers.Instance.CreateContextServices(model);
             var stateManager = contextServices.GetRequiredService<IStateManager>();
@@ -41,6 +42,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             var entityType = model.AddEntityType(typeof(RedHook));
             entityType.AddProperty("Long", typeof(int));
             entityType.AddProperty("Hammer", typeof(string));
+            model.FinalizeModel();
 
             var contextServices = InMemoryTestHelpers.Instance.CreateContextServices(model);
             var stateManager = contextServices.GetRequiredService<IStateManager>();
@@ -63,6 +65,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             var entityType = model.AddEntityType(typeof(RedHook));
             entityType.AddProperty("Long", typeof(int));
             entityType.AddProperty("Spanner", typeof(string));
+            model.FinalizeModel();
 
             var contextServices = InMemoryTestHelpers.Instance.CreateContextServices(model);
             var stateManager = contextServices.GetRequiredService<IStateManager>();

--- a/test/EFCore.Tests/ChangeTracking/Internal/InternalEntryEntrySubscriberTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/InternalEntryEntrySubscriberTest.cs
@@ -11,10 +11,13 @@ using System.Runtime.CompilerServices;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
+// ReSharper disable UnusedMember.Local
+// ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 {
     public class InternalEntryEntrySubscriberTest
@@ -571,7 +574,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     b.HasChangeTrackingStrategy(changeTrackingStrategy);
                 });
 
-            return builder.Model;
+            return builder.Model.FinalizeModel();
         }
 
         private class FullNotificationEntity : INotifyPropertyChanging, INotifyPropertyChanged

--- a/test/EFCore.Tests/ChangeTracking/Internal/InternalMixedEntityEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/InternalMixedEntityEntryTest.cs
@@ -28,10 +28,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         [Fact]
         public void Can_set_and_get_property_value_from_CLR_object()
         {
-            var model = BuildModel();
+            var model = BuildModel(finalize: false);
             var entityType = model.FindEntityType(typeof(SomeEntity).FullName);
             var keyProperty = entityType.AddProperty("Id_", typeof(int));
             var nonKeyProperty = entityType.FindProperty("Name");
+            model.FinalizeModel();
             var configuration = InMemoryTestHelpers.Instance.CreateContextServices(model);
 
             var entity = new SomeEntity
@@ -74,7 +75,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         [Fact]
-        public void All_original_values_can_be_accessed_for_entity_that_does_no_notifiction()
+        public void All_original_values_can_be_accessed_for_entity_that_does_no_notification()
         {
             var model = BuildModel();
             var entityType = model.FindEntityType(typeof(SomeEntity).FullName);
@@ -88,11 +89,12 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         [Fact]
-        public void All_original_values_can_be_accessed_for_entity_that_does_changed_only_notifictions_if_eager_values_on()
+        public void All_original_values_can_be_accessed_for_entity_that_does_changed_only_notifications_if_eager_values_on()
         {
-            var model = BuildModel();
+            var model = BuildModel(finalize: false);
             var entityType = model.FindEntityType(typeof(ChangedOnlyEntity).FullName);
             entityType.SetChangeTrackingStrategy(ChangeTrackingStrategy.Snapshot);
+            model.FinalizeModel();
 
             AllOriginalValuesTest(
                 model, entityType, new ChangedOnlyEntity
@@ -129,7 +131,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     Name = "Kool"
                 }, needsDetectChanges: false);
 
-        protected override IMutableModel BuildModel()
+        protected override IMutableModel BuildModel(bool finalize = true)
         {
             var modelBuilder = new ModelBuilder(new ConventionSet());
             var model = modelBuilder.Model;
@@ -191,7 +193,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     owned.Property(e => e.Value);
                 });
 
-            return (Model)model;
+            return finalize ? (IMutableModel)model.FinalizeModel() : model;
         }
     }
 }

--- a/test/EFCore.Tests/ChangeTracking/Internal/InternalShadowEntityEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/InternalShadowEntityEntryTest.cs
@@ -10,7 +10,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 {
     public class InternalShadowEntityEntryTest : InternalEntityEntryTestBase
     {
-        protected override IMutableModel BuildModel()
+        protected override IMutableModel BuildModel(bool finalize = true)
         {
             var modelBuilder = new ModelBuilder(new ConventionSet());
             var model = modelBuilder.Model;
@@ -71,7 +71,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     owned.Property<string>(nameof(OwnedClass.Value));
                 });
 
-            return (Model)model;
+            return finalize ? (IMutableModel)model.FinalizeModel() : model;
         }
     }
 }

--- a/test/EFCore.Tests/ChangeTracking/Internal/KeyPropagatorTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/KeyPropagatorTest.cs
@@ -4,11 +4,14 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.EntityFrameworkCore.ValueGeneration.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
+// ReSharper disable CollectionNeverUpdated.Local
+// ReSharper disable ClassNeverInstantiated.Local
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 {
     public class KeyPropagatorTest
@@ -410,7 +413,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 }
             }
 
-            return builder.Model;
+            return builder.Model.FinalizeModel();
         }
     }
 }

--- a/test/EFCore.Tests/ChangeTracking/Internal/NavigationFixerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/NavigationFixerTest.cs
@@ -6,10 +6,15 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
+// ReSharper disable UnusedMember.Local
+// ReSharper disable InconsistentNaming
+// ReSharper disable CollectionNeverUpdated.Local
+// ReSharper disable UnusedAutoPropertyAccessor.Local
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 {
     public class NavigationFixerTest
@@ -1648,7 +1653,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             builder.Entity<ProductTag>();
 
-            return builder.Model;
+            return builder.Model.FinalizeModel();
         }
 
         private static INavigationFixer CreateNavigationFixer(IServiceProvider contextServices)

--- a/test/EFCore.Tests/ChangeTracking/Internal/StateManagerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/StateManagerTest.cs
@@ -6,11 +6,13 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
+// ReSharper disable MemberCanBePrivate.Local
 // ReSharper disable UnusedMember.Local
 // ReSharper disable UnusedAutoPropertyAccessor.Local
 // ReSharper disable InconsistentNaming
@@ -1021,7 +1023,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                         Id = Guid.NewGuid(),
                         DependentId = 78
                     }));
-            var productEntry5 = stateManager.StartTracking(
+            stateManager.StartTracking(
                 stateManager.GetOrCreateEntry(
                     new Product
                     {
@@ -1091,7 +1093,13 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             public string Id { get; set; }
         }
 
-        private static IMutableModel BuildModel()
+        private class Location
+        {
+            public int Id { get; set; }
+            public string Planet { get; set; }
+        }
+
+        private static IModel BuildModel()
         {
             var builder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
 
@@ -1108,15 +1116,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             builder.Entity<Dogegory>();
 
-            builder.Entity(
-                "Location", eb =>
-                {
-                    eb.Property<int>("Id");
-                    eb.Property<string>("Planet");
-                    eb.HasKey("Id");
-                });
+            builder.Entity<Location>();
 
-            return builder.Model;
+            return builder.Model.FinalizeModel();
         }
     }
 }

--- a/test/EFCore.Tests/ChangeTracking/PropertyEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/PropertyEntryTest.cs
@@ -10,6 +10,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
+// ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.ChangeTracking
 {
     public class PropertyEntryTest
@@ -1250,11 +1251,12 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
             }
         }
 
-        public static IMutableModel BuildModel(
+        public static IModel BuildModel(
             ChangeTrackingStrategy fullNotificationStrategy = ChangeTrackingStrategy.ChangingAndChangedNotifications,
-            ModelBuilder builder = null)
+            ModelBuilder builder = null,
+            bool finalize = true)
         {
-            builder = builder ?? InMemoryTestHelpers.Instance.CreateConventionBuilder();
+            builder ??= InMemoryTestHelpers.Instance.CreateConventionBuilder();
 
             builder.HasChangeTrackingStrategy(fullNotificationStrategy);
 
@@ -1282,7 +1284,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                     b.Property(e => e.ConcurrentPrimate).IsConcurrencyToken();
                 });
 
-            return builder.Model;
+            return finalize ? builder.Model.FinalizeModel() : builder.Model;
         }
 
         private class PrimateContext : DbContext
@@ -1303,7 +1305,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
             protected internal override void OnModelCreating(ModelBuilder modelBuilder)
             {
-                BuildModel(_fullNotificationStrategy, modelBuilder);
+                BuildModel(_fullNotificationStrategy, modelBuilder, finalize: false);
             }
         }
     }

--- a/test/EFCore.Tests/DbContextOptionsTest.cs
+++ b/test/EFCore.Tests/DbContextOptionsTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             var model = new Model();
 
-            var optionsBuilder = new DbContextOptionsBuilder().UseModel(model);
+            var optionsBuilder = new DbContextOptionsBuilder().UseModel(model.FinalizeModel());
 
             Assert.Same(model, optionsBuilder.Options.FindExtension<CoreOptionsExtension>().Model);
         }
@@ -42,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             var model = new Model();
 
-            var optionsBuilder = new DbContextOptionsBuilder().UseModel(model).EnableSensitiveDataLogging();
+            var optionsBuilder = new DbContextOptionsBuilder().UseModel(model.FinalizeModel()).EnableSensitiveDataLogging();
 
             Assert.Same(model, optionsBuilder.Options.FindExtension<CoreOptionsExtension>().Model);
             Assert.True(optionsBuilder.Options.FindExtension<CoreOptionsExtension>().IsSensitiveDataLoggingEnabled);

--- a/test/EFCore.Tests/DbContextTest.cs
+++ b/test/EFCore.Tests/DbContextTest.cs
@@ -121,7 +121,7 @@ namespace Microsoft.EntityFrameworkCore
             optionsBuilder
                 .UseInMemoryDatabase(Guid.NewGuid().ToString())
                 .UseInternalServiceProvider(InMemoryTestHelpers.Instance.CreateServiceProvider())
-                .UseModel(model);
+                .UseModel(model.FinalizeModel());
             using (var context = new DbContext(optionsBuilder.Options))
             {
                 var ex = Assert.Throws<InvalidOperationException>(() => context.Set<User>().Local);
@@ -143,7 +143,7 @@ namespace Microsoft.EntityFrameworkCore
                 new DbContextOptionsBuilder()
                     .UseInternalServiceProvider(serviceProvider)
                     .UseInMemoryDatabase(Guid.NewGuid().ToString())
-                    .UseModel(model)
+                    .UseModel(model.FinalizeModel())
                     .Options))
             {
                 var changeDetector = (FakeChangeDetector)context.GetService<IChangeDetector>();
@@ -335,12 +335,12 @@ namespace Microsoft.EntityFrameworkCore
         [Fact]
         public void Context_will_use_explicit_model_if_set_in_config()
         {
-            IConventionModel model = new Model();
+            IMutableModel model = new Model();
             model.AddEntityType(typeof(TheGu));
 
             using (var context = new EarlyLearningCenter(
                 InMemoryTestHelpers.Instance.CreateServiceProvider(),
-                new DbContextOptionsBuilder().UseModel(model).Options))
+                new DbContextOptionsBuilder().UseModel(model.FinalizeModel()).Options))
             {
                 Assert.Equal(
                     new[] { typeof(TheGu).FullName },

--- a/test/EFCore.Tests/ExceptionTest.cs
+++ b/test/EFCore.Tests/ExceptionTest.cs
@@ -179,13 +179,19 @@ namespace Microsoft.EntityFrameworkCore
         private class FakeInternalEntityEntry : InternalEntityEntry
         {
             public FakeInternalEntityEntry()
-                : base(
-                    new FakeStateManager(),
-                    new Model(new ConventionSet()).AddEntityType(typeof(object), ConfigurationSource.Convention))
+                : base(new FakeStateManager(), CreateEntityType())
             {
             }
 
             public override object Entity { get; }
+        }
+
+        private static  IEntityType CreateEntityType()
+        {
+            var model = new Model(new ConventionSet());
+            var entityType = model.AddEntityType(typeof(object), ConfigurationSource.Convention);
+            model.FinalizeModel();
+            return entityType;
         }
 
         private TException SerializeAndDeserialize<TException>(TException exception) where TException : Exception

--- a/test/EFCore.Tests/Infrastructure/CoreEventIdTest.cs
+++ b/test/EFCore.Tests/Infrastructure/CoreEventIdTest.cs
@@ -30,6 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             var otherKey = otherEntityType.AddKey(otherProperty, ConfigurationSource.Convention);
             var foreignKey = new ForeignKey(new[] { property }, otherKey, entityType, otherEntityType, ConfigurationSource.Convention);
             var navigation = new Navigation("N", propertyInfo, null, foreignKey);
+            entityType.Model.FinalizeModel();
             var options = new DbContextOptionsBuilder()
                 .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
                 .UseInMemoryDatabase("D").Options;

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
@@ -68,7 +68,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             var keyProperty = entityType.AddProperty("Key", typeof(int));
             entityType.SetPrimaryKey(keyProperty);
 
-            VerifyWarning(CoreResources.LogShadowPropertyCreated(new TestLogger<TestLoggingDefinitions>()).GenerateMessage("Key", "A"), model, LogLevel.Debug);
+            VerifyWarning(CoreResources.LogShadowPropertyCreated(new TestLogger<TestLoggingDefinitions>())
+                .GenerateMessage("Key", "A"), (IMutableModel)model, LogLevel.Debug);
         }
 
         [Fact]

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTestBase.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTestBase.cs
@@ -10,12 +10,12 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;
 
+// ReSharper disable MemberHidesStaticFromOuterClass
 namespace Microsoft.EntityFrameworkCore.Infrastructure
 {
     public abstract class ModelValidatorTestBase
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         {
             if (startingPropertyIndex == -1)
             {
-                startingPropertyIndex = entityType.PropertyCount() - 1;
+                startingPropertyIndex = entityType.GetProperties().Count() - 1;
             }
 
             var keyProperties = new IMutableProperty[propertyCount];
@@ -196,7 +196,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
         protected ListLoggerFactory LoggerFactory { get; }
 
-        protected virtual void VerifyWarning(string expectedMessage, IModel model, LogLevel level = LogLevel.Warning)
+        protected virtual void VerifyWarning(string expectedMessage, IMutableModel model, LogLevel level = LogLevel.Warning)
         {
             Validate(model);
 
@@ -204,13 +204,13 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             Assert.Equal(expectedMessage, logEntry.Message);
         }
 
-        protected virtual void VerifyError(string expectedMessage, IModel model)
+        protected virtual void VerifyError(string expectedMessage, IMutableModel model)
         {
             var message = Assert.Throws<InvalidOperationException>(() => Validate(model)).Message;
             Assert.Equal(expectedMessage, message);
         }
 
-        protected virtual void Validate(IModel model) => ((Model)model).FinalizeModel();
+        protected virtual void Validate(IMutableModel model) => model.FinalizeModel();
 
         protected DiagnosticsLogger<DbLoggerCategory.Model.Validation> CreateValidationLogger(bool sensitiveDataLoggingEnabled = false)
         {

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/ConventionDispatcherTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/ConventionDispatcherTest.cs
@@ -184,6 +184,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Equal(new[] { "bar", null }, convention1.Calls);
             Assert.Equal(new[] { "bar", null }, convention2.Calls);
             Assert.Empty(convention3.Calls);
+
+            builder.Metadata[CoreAnnotationNames.ProductVersion] = "bar";
+            Assert.Equal(new[] { "bar", null }, convention1.Calls);
         }
 
         private class ModelAnnotationChangedConvention : IModelAnnotationChangedConvention
@@ -803,6 +806,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Equal(new[] { "bar", null }, convention1.Calls);
             Assert.Equal(new[] { "bar", null }, convention2.Calls);
             Assert.Empty(convention3.Calls);
+
+            entityBuilder.Metadata[CoreAnnotationNames.PropertyAccessMode] = PropertyAccessMode.Field;
+            Assert.Equal(new[] { "bar", null }, convention1.Calls);
         }
 
         private class EntityTypeAnnotationChangedConvention : IEntityTypeAnnotationChangedConvention
@@ -1475,7 +1481,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         [InlineData(false, true)]
         [InlineData(true, true)]
         [Theory]
-        public void OnFForeignKeyAnnotationChanged_calls_conventions_in_order(bool useBuilder, bool useScope)
+        public void OnForeignKeyAnnotationChanged_calls_conventions_in_order(bool useBuilder, bool useScope)
         {
             var conventions = new ConventionSet();
 
@@ -1538,6 +1544,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Equal(new[] { "bar", null }, convention1.Calls);
             Assert.Equal(new[] { "bar", null }, convention2.Calls);
             Assert.Empty(convention3.Calls);
+
+            foreignKey[CoreAnnotationNames.EagerLoaded] = true;
+
+            Assert.Equal(new[] { "bar", null }, convention1.Calls);
         }
 
         private class ForeignKeyAnnotationChangedConvention : IForeignKeyAnnotationChangedConvention
@@ -1970,6 +1980,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Equal(new[] { "bar", null }, convention1.Calls);
             Assert.Equal(new[] { "bar", null }, convention2.Calls);
             Assert.Empty(convention3.Calls);
+
+            key[CoreAnnotationNames.Unicode] = false;
+
+            Assert.Equal(new[] { "bar", null }, convention1.Calls);
         }
 
         private class KeyAnnotationChangedConvention : IKeyAnnotationChangedConvention
@@ -2303,6 +2317,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Equal(new[] { "bar", null }, convention1.Calls);
             Assert.Equal(new[] { "bar", null }, convention2.Calls);
             Assert.Empty(convention3.Calls);
+
+            indexBuilder.Metadata[CoreAnnotationNames.MaxLength] = 20;
+
+            Assert.Equal(new[] { "bar", null }, convention1.Calls);
         }
 
         private class IndexAnnotationChangedConvention : IIndexAnnotationChangedConvention
@@ -2732,6 +2750,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Equal(new[] { "bar", null }, convention1.Calls);
             Assert.Equal(new[] { "bar", null }, convention2.Calls);
             Assert.Empty(convention3.Calls);
+
+            propertyBuilder.Metadata[CoreAnnotationNames.AfterSaveBehavior] = PropertySaveBehavior.Ignore;
+
+            Assert.Equal(new[] { "bar", null }, convention1.Calls);
         }
 
         private class PropertyAnnotationChangedConvention : IPropertyAnnotationChangedConvention

--- a/test/EFCore.Tests/Metadata/Internal/EntityMaterializerSourceTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/EntityMaterializerSourceTest.cs
@@ -36,6 +36,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         new PropertyParameterBinding(entityType.FindProperty(nameof(SomeEntity.Goo)))
                     }
                 );
+            ((Model)entityType.Model).FinalizeModel();
 
             var factory = GetMaterializer(new EntityMaterializerSource(), entityType);
 
@@ -71,6 +72,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         new PropertyParameterBinding(entityType.FindProperty(nameof(SomeEntity.Goo)))
                     },
                     entityType.ClrType);
+            ((Model)entityType.Model).FinalizeModel();
 
             var factory = GetMaterializer(new EntityMaterializerSource(), entityType);
 
@@ -110,6 +112,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                             })
                     },
                     entityType.ClrType);
+            ((Model)entityType.Model).FinalizeModel();
 
             var factory = GetMaterializer(new EntityMaterializerSource(), entityType);
 
@@ -145,6 +148,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         new EntityTypeParameterBinding()
                     },
                     entityType.ClrType);
+            ((Model)entityType.Model).FinalizeModel();
 
             var factory = GetMaterializer(new EntityMaterializerSource(), entityType);
 
@@ -189,6 +193,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public void Can_create_materializer_for_entity_with_auto_properties()
         {
             var entityType = CreateEntityType();
+            ((Model)entityType.Model).FinalizeModel();
 
             var factory = GetMaterializer(new EntityMaterializerSource(), entityType);
 
@@ -214,6 +219,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             entityType.AddProperty(SomeEntityWithFields.GooProperty).SetField("_goo");
             entityType.AddProperty(SomeEntityWithFields.IdProperty).SetField("_id");
             entityType.AddProperty(SomeEntityWithFields.MaybeEnumProperty).SetField("_maybeEnum");
+            ((Model)entityType.Model).FinalizeModel();
 
             var factory = GetMaterializer(new EntityMaterializerSource(), entityType);
 
@@ -237,6 +243,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             entityType.AddProperty(SomeEntity.FooProperty);
             entityType.AddProperty(SomeEntity.GooProperty);
             entityType.AddProperty(SomeEntity.IdProperty);
+            ((Model)entityType.Model).FinalizeModel();
 
             var factory = GetMaterializer(new EntityMaterializerSource(), entityType);
 
@@ -260,6 +267,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             entityType.AddProperty("FooShadow", typeof(string));
             entityType.AddProperty(SomeEntity.GooProperty);
             entityType.AddProperty("GooShadow", typeof(Guid));
+            ((Model)entityType.Model).FinalizeModel();
 
             var factory = GetMaterializer(new EntityMaterializerSource(), entityType);
 

--- a/test/EFCore.Tests/Metadata/Internal/EntityTypeBaseTypeTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/EntityTypeBaseTypeTest.cs
@@ -111,6 +111,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             b.BaseType = a;
             c.BaseType = a;
 
+            model.FinalizeModel();
+
             Assert.Equal(new[] { "E", "G" }, a.GetProperties().Select(p => p.Name).ToArray());
             Assert.Equal(new[] { "E", "G", "F", "H" }, b.GetProperties().Select(p => p.Name).ToArray());
             Assert.Equal(new[] { "E", "G", "H", "I" }, c.GetProperties().Select(p => p.Name).ToArray());
@@ -144,6 +146,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             c.AddProperty(C.HProperty);
             c.AddProperty("I", typeof(string));
 
+            model.FinalizeModel();
+
             Assert.Equal(new[] { "E", "G" }, a.GetProperties().Select(p => p.Name).ToArray());
             Assert.Equal(new[] { "E", "G", "F", "H" }, b.GetProperties().Select(p => p.Name).ToArray());
             Assert.Equal(new[] { "E", "G", "H", "I" }, c.GetProperties().Select(p => p.Name).ToArray());
@@ -167,21 +171,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             Assert.Equal(new[] { "F", "H" }, c.GetProperties().Select(p => p.Name).ToArray());
             Assert.Equal(new[] { "F", "H", "E", "G" }, d.GetProperties().Select(p => p.Name).ToArray());
-            Assert.Equal(new[] { 0, 1 }, c.GetProperties().Select(p => p.GetIndex()));
-            Assert.Equal(new[] { 0, 1, 2, 3 }, d.GetProperties().Select(p => p.GetIndex()));
 
             d.BaseType = null;
 
             Assert.Equal(new[] { "F", "H" }, c.GetProperties().Select(p => p.Name).ToArray());
             Assert.Equal(new[] { "E", "G" }, d.GetProperties().Select(p => p.Name).ToArray());
-            Assert.Equal(new[] { 0, 1 }, c.GetProperties().Select(p => p.GetIndex()));
-            Assert.Equal(new[] { 0, 1 }, d.GetProperties().Select(p => p.GetIndex()));
 
             var a = model.AddEntityType(typeof(A));
             a.AddProperty(A.EProperty);
             a.AddProperty(A.GProperty);
 
             c.BaseType = a;
+
+            model.FinalizeModel();
 
             Assert.Equal(new[] { "E", "G" }, a.GetProperties().Select(p => p.Name).ToArray());
             Assert.Equal(new[] { "E", "G", "F", "H" }, c.GetProperties().Select(p => p.Name).ToArray());
@@ -348,6 +350,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             b.BaseType = a;
 
+            model.FinalizeModel();
+
             Assert.Equal(
                 new[] { new[] { "E" }, new[] { "G" } },
                 a.GetKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
@@ -377,6 +381,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             a.SetPrimaryKey(a.FindProperty("G"));
             a.AddKey(a.FindProperty("E"));
+
+            model.FinalizeModel();
 
             Assert.Equal(
                 new[] { new[] { "E" }, new[] { "G" } },

--- a/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
@@ -1748,6 +1748,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             entityType.AddProperty("Id_", typeof(int));
             entityType.AddProperty("Mane_", typeof(int));
 
+            ((Model)entityType.Model).FinalizeModel();
+
             Assert.Equal(0, entityType.FindProperty("Id_").GetIndex());
             Assert.Equal(1, entityType.FindProperty("Mane_").GetIndex());
             Assert.Equal(2, entityType.FindProperty("Name").GetIndex());
@@ -1757,150 +1759,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Assert.Equal(-1, entityType.FindProperty("Name").GetShadowIndex());
 
             Assert.Equal(2, entityType.ShadowPropertyCount());
-        }
-
-        [Fact]
-        public void Indexes_are_rebuilt_when_more_properties_added_or_relevant_state_changes()
-        {
-            var entityType = BuildFullNotificationEntityModel().FindEntityType(typeof(FullNotificationEntity));
-            entityType.SetChangeTrackingStrategy(ChangeTrackingStrategy.ChangingAndChangedNotifications);
-
-            Assert.Equal(0, entityType.FindProperty("Id").GetIndex());
-            Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetIndex());
-            Assert.Equal(2, entityType.FindProperty("Name").GetIndex());
-            Assert.Equal(3, entityType.FindProperty("Token").GetIndex());
-            Assert.Equal(0, entityType.FindNavigation("CollectionNav").GetIndex());
-            Assert.Equal(1, entityType.FindNavigation("ReferenceNav").GetIndex());
-
-            Assert.Equal(-1, entityType.FindProperty("Id").GetShadowIndex());
-            Assert.Equal(-1, entityType.FindProperty("AnotherEntityId").GetShadowIndex());
-            Assert.Equal(-1, entityType.FindProperty("Name").GetShadowIndex());
-            Assert.Equal(-1, entityType.FindProperty("Token").GetShadowIndex());
-
-            Assert.Equal(0, entityType.FindProperty("Id").GetOriginalValueIndex());
-            Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetOriginalValueIndex());
-            Assert.Equal(-1, entityType.FindProperty("Name").GetOriginalValueIndex());
-            Assert.Equal(2, entityType.FindProperty("Token").GetOriginalValueIndex());
-
-            Assert.Equal(0, entityType.FindProperty("Id").GetRelationshipIndex());
-            Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetRelationshipIndex());
-            Assert.Equal(-1, entityType.FindProperty("Name").GetRelationshipIndex());
-            Assert.Equal(-1, entityType.FindProperty("Token").GetRelationshipIndex());
-            Assert.Equal(-1, entityType.FindNavigation("CollectionNav").GetRelationshipIndex());
-            Assert.Equal(2, entityType.FindNavigation("ReferenceNav").GetRelationshipIndex());
-
-            Assert.Equal(0, entityType.FindProperty("Id").GetStoreGeneratedIndex());
-            Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetStoreGeneratedIndex());
-            Assert.Equal(-1, entityType.FindProperty("Name").GetStoreGeneratedIndex());
-            Assert.Equal(-1, entityType.FindProperty("Token").GetStoreGeneratedIndex());
-            Assert.Equal(-1, entityType.FindNavigation("CollectionNav").GetStoreGeneratedIndex());
-            Assert.Equal(-1, entityType.FindNavigation("ReferenceNav").GetStoreGeneratedIndex());
-
-            Assert.Equal(0, entityType.ShadowPropertyCount());
-            Assert.Equal(3, entityType.OriginalValueCount());
-            Assert.Equal(3, entityType.RelationshipPropertyCount());
-            Assert.Equal(2, entityType.StoreGeneratedCount());
-
-            var gameProperty = entityType.AddProperty("Game", typeof(int));
-            gameProperty.IsConcurrencyToken = true;
-
-            var maneProperty = entityType.AddProperty("Mane", typeof(int));
-            maneProperty.IsConcurrencyToken = true;
-
-            Assert.Equal(0, entityType.FindProperty("Id").GetIndex());
-            Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetIndex());
-            Assert.Equal(2, entityType.FindProperty("Game").GetIndex());
-            Assert.Equal(3, entityType.FindProperty("Mane").GetIndex());
-            Assert.Equal(4, entityType.FindProperty("Name").GetIndex());
-            Assert.Equal(5, entityType.FindProperty("Token").GetIndex());
-            Assert.Equal(0, entityType.FindNavigation("CollectionNav").GetIndex());
-            Assert.Equal(1, entityType.FindNavigation("ReferenceNav").GetIndex());
-
-            Assert.Equal(-1, entityType.FindProperty("Id").GetShadowIndex());
-            Assert.Equal(-1, entityType.FindProperty("AnotherEntityId").GetShadowIndex());
-            Assert.Equal(0, entityType.FindProperty("Game").GetShadowIndex());
-            Assert.Equal(1, entityType.FindProperty("Mane").GetShadowIndex());
-            Assert.Equal(-1, entityType.FindProperty("Name").GetShadowIndex());
-            Assert.Equal(-1, entityType.FindProperty("Token").GetShadowIndex());
-
-            Assert.Equal(0, entityType.FindProperty("Id").GetOriginalValueIndex());
-            Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetOriginalValueIndex());
-            Assert.Equal(2, entityType.FindProperty("Game").GetOriginalValueIndex());
-            Assert.Equal(3, entityType.FindProperty("Mane").GetOriginalValueIndex());
-            Assert.Equal(-1, entityType.FindProperty("Name").GetOriginalValueIndex());
-            Assert.Equal(4, entityType.FindProperty("Token").GetOriginalValueIndex());
-
-            Assert.Equal(0, entityType.FindProperty("Id").GetRelationshipIndex());
-            Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetRelationshipIndex());
-            Assert.Equal(-1, entityType.FindProperty("Game").GetRelationshipIndex());
-            Assert.Equal(-1, entityType.FindProperty("Mane").GetRelationshipIndex());
-            Assert.Equal(-1, entityType.FindProperty("Name").GetRelationshipIndex());
-            Assert.Equal(-1, entityType.FindProperty("Token").GetRelationshipIndex());
-            Assert.Equal(-1, entityType.FindNavigation("CollectionNav").GetRelationshipIndex());
-            Assert.Equal(2, entityType.FindNavigation("ReferenceNav").GetRelationshipIndex());
-
-            Assert.Equal(0, entityType.FindProperty("Id").GetStoreGeneratedIndex());
-            Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetStoreGeneratedIndex());
-            Assert.Equal(-1, entityType.FindProperty("Game").GetStoreGeneratedIndex());
-            Assert.Equal(-1, entityType.FindProperty("Mane").GetStoreGeneratedIndex());
-            Assert.Equal(-1, entityType.FindProperty("Name").GetStoreGeneratedIndex());
-            Assert.Equal(-1, entityType.FindProperty("Token").GetStoreGeneratedIndex());
-            Assert.Equal(-1, entityType.FindNavigation("CollectionNav").GetStoreGeneratedIndex());
-            Assert.Equal(-1, entityType.FindNavigation("ReferenceNav").GetStoreGeneratedIndex());
-
-            Assert.Equal(2, entityType.ShadowPropertyCount());
-            Assert.Equal(5, entityType.OriginalValueCount());
-            Assert.Equal(3, entityType.RelationshipPropertyCount());
-            Assert.Equal(2, entityType.StoreGeneratedCount());
-
-            gameProperty.IsConcurrencyToken = false;
-            entityType.FindProperty("Name").IsConcurrencyToken = true;
-
-            Assert.Equal(0, entityType.FindProperty("Id").GetIndex());
-            Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetIndex());
-            Assert.Equal(2, entityType.FindProperty("Game").GetIndex());
-            Assert.Equal(3, entityType.FindProperty("Mane").GetIndex());
-            Assert.Equal(4, entityType.FindProperty("Name").GetIndex());
-            Assert.Equal(5, entityType.FindProperty("Token").GetIndex());
-            Assert.Equal(0, entityType.FindNavigation("CollectionNav").GetIndex());
-            Assert.Equal(1, entityType.FindNavigation("ReferenceNav").GetIndex());
-
-            Assert.Equal(-1, entityType.FindProperty("Id").GetShadowIndex());
-            Assert.Equal(-1, entityType.FindProperty("AnotherEntityId").GetShadowIndex());
-            Assert.Equal(0, entityType.FindProperty("Game").GetShadowIndex());
-            Assert.Equal(1, entityType.FindProperty("Mane").GetShadowIndex());
-            Assert.Equal(-1, entityType.FindProperty("Name").GetShadowIndex());
-            Assert.Equal(-1, entityType.FindProperty("Token").GetShadowIndex());
-
-            Assert.Equal(0, entityType.FindProperty("Id").GetOriginalValueIndex());
-            Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetOriginalValueIndex());
-            Assert.Equal(-1, entityType.FindProperty("Game").GetOriginalValueIndex());
-            Assert.Equal(2, entityType.FindProperty("Mane").GetOriginalValueIndex());
-            Assert.Equal(3, entityType.FindProperty("Name").GetOriginalValueIndex());
-            Assert.Equal(4, entityType.FindProperty("Token").GetOriginalValueIndex());
-
-            Assert.Equal(0, entityType.FindProperty("Id").GetRelationshipIndex());
-            Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetRelationshipIndex());
-            Assert.Equal(-1, entityType.FindProperty("Game").GetRelationshipIndex());
-            Assert.Equal(-1, entityType.FindProperty("Mane").GetRelationshipIndex());
-            Assert.Equal(-1, entityType.FindProperty("Name").GetRelationshipIndex());
-            Assert.Equal(-1, entityType.FindProperty("Token").GetRelationshipIndex());
-            Assert.Equal(-1, entityType.FindNavigation("CollectionNav").GetRelationshipIndex());
-            Assert.Equal(2, entityType.FindNavigation("ReferenceNav").GetRelationshipIndex());
-
-            Assert.Equal(0, entityType.FindProperty("Id").GetStoreGeneratedIndex());
-            Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetStoreGeneratedIndex());
-            Assert.Equal(-1, entityType.FindProperty("Game").GetStoreGeneratedIndex());
-            Assert.Equal(-1, entityType.FindProperty("Mane").GetStoreGeneratedIndex());
-            Assert.Equal(-1, entityType.FindProperty("Name").GetStoreGeneratedIndex());
-            Assert.Equal(-1, entityType.FindProperty("Token").GetStoreGeneratedIndex());
-            Assert.Equal(-1, entityType.FindNavigation("CollectionNav").GetStoreGeneratedIndex());
-            Assert.Equal(-1, entityType.FindNavigation("ReferenceNav").GetStoreGeneratedIndex());
-
-            Assert.Equal(2, entityType.ShadowPropertyCount());
-            Assert.Equal(5, entityType.OriginalValueCount());
-            Assert.Equal(3, entityType.RelationshipPropertyCount());
-            Assert.Equal(2, entityType.StoreGeneratedCount());
         }
 
         [Fact]
@@ -2094,6 +1952,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var i3 = customerType.AddIndex(new[] { idProperty, nameProperty });
             var i1 = customerType.AddIndex(idProperty);
 
+            model.FinalizeModel();
+
             Assert.True(new[] { i1, i2, i3, i4 }.SequenceEqual(customerType.GetIndexes()));
         }
 
@@ -2152,7 +2012,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         [Fact]
         public void Change_tracking_from_model_is_used_by_default_for_shadow_entities()
         {
-            IMutableModel model = CreateModel();
+            var model = CreateModel();
             var entityType = model.AddEntityType("Z'ha'dum");
 
             Assert.Equal(ChangeTrackingStrategy.Snapshot, entityType.GetChangeTrackingStrategy());
@@ -2188,7 +2048,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         [Fact]
         public void Change_tracking_can_be_set_to_snapshot_or_changed_only_for_changed_only_entities()
         {
-            IMutableModel model = CreateModel();
+            var model = CreateModel();
             model.SetChangeTrackingStrategy(ChangeTrackingStrategy.ChangingAndChangedNotifications);
             var entityType = model.AddEntityType(typeof(ChangedOnlyEntity));
 
@@ -2218,7 +2078,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         [Fact]
         public void Change_tracking_can_be_set_to_snapshot_only_for_non_notifying_entities()
         {
-            IMutableModel model = CreateModel();
+            var model = CreateModel();
             model.SetChangeTrackingStrategy(ChangeTrackingStrategy.ChangingAndChangedNotifications);
             var entityType = model.AddEntityType(typeof(Customer));
 
@@ -2250,6 +2110,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             var entityType = BuildFullNotificationEntityModel().FindEntityType(typeof(FullNotificationEntity));
             entityType.SetChangeTrackingStrategy(ChangeTrackingStrategy.Snapshot);
+            ((Model)entityType.Model).FinalizeModel();
 
             Assert.Equal(0, entityType.FindProperty("Id").GetOriginalValueIndex());
             Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetOriginalValueIndex());
@@ -2264,6 +2125,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             var entityType = BuildFullNotificationEntityModel().FindEntityType(typeof(FullNotificationEntity));
             entityType.SetChangeTrackingStrategy(ChangeTrackingStrategy.Snapshot);
+            ((Model)entityType.Model).FinalizeModel();
 
             Assert.Equal(0, entityType.FindProperty("Id").GetRelationshipIndex());
             Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetRelationshipIndex());
@@ -2280,6 +2142,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             var entityType = BuildFullNotificationEntityModel().FindEntityType(typeof(FullNotificationEntity));
             entityType.SetChangeTrackingStrategy(ChangeTrackingStrategy.ChangedNotifications);
+            ((Model)entityType.Model).FinalizeModel();
 
             Assert.Equal(0, entityType.FindProperty("Id").GetOriginalValueIndex());
             Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetOriginalValueIndex());
@@ -2294,6 +2157,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             var entityType = BuildFullNotificationEntityModel().FindEntityType(typeof(FullNotificationEntity));
             entityType.SetChangeTrackingStrategy(ChangeTrackingStrategy.ChangedNotifications);
+            ((Model)entityType.Model).FinalizeModel();
 
             Assert.Equal(0, entityType.FindProperty("Id").GetRelationshipIndex());
             Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetRelationshipIndex());
@@ -2310,6 +2174,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             var entityType = BuildFullNotificationEntityModel().FindEntityType(typeof(FullNotificationEntity));
             entityType.SetChangeTrackingStrategy(ChangeTrackingStrategy.ChangingAndChangedNotifications);
+            ((Model)entityType.Model).FinalizeModel();
 
             Assert.Equal(0, entityType.FindProperty("Id").GetOriginalValueIndex());
             Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetOriginalValueIndex());
@@ -2324,6 +2189,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             var entityType = BuildFullNotificationEntityModel().FindEntityType(typeof(FullNotificationEntity));
             entityType.SetChangeTrackingStrategy(ChangeTrackingStrategy.ChangingAndChangedNotifications);
+            ((Model)entityType.Model).FinalizeModel();
 
             Assert.Equal(0, entityType.FindProperty("Id").GetRelationshipIndex());
             Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetRelationshipIndex());
@@ -2340,6 +2206,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             var entityType = BuildFullNotificationEntityModel().FindEntityType(typeof(FullNotificationEntity));
             entityType.SetChangeTrackingStrategy(ChangeTrackingStrategy.ChangingAndChangedNotificationsWithOriginalValues);
+            ((Model)entityType.Model).FinalizeModel();
 
             Assert.Equal(0, entityType.FindProperty("Id").GetOriginalValueIndex());
             Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetOriginalValueIndex());
@@ -2354,6 +2221,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             var entityType = BuildFullNotificationEntityModel().FindEntityType(typeof(FullNotificationEntity));
             entityType.SetChangeTrackingStrategy(ChangeTrackingStrategy.ChangingAndChangedNotificationsWithOriginalValues);
+            ((Model)entityType.Model).FinalizeModel();
 
             Assert.Equal(0, entityType.FindProperty("Id").GetRelationshipIndex());
             Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetRelationshipIndex());

--- a/test/EFCore.Tests/Metadata/Internal/PropertyAccessorsFactoryTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/PropertyAccessorsFactoryTest.cs
@@ -21,6 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var entityType = model.AddEntityType(typeof(IndexedClass));
             entityType.AddProperty("Id", typeof(int));
             var propertyA = entityType.AddIndexedProperty("PropertyA", typeof(string));
+            model.FinalizeModel();
 
             var contextServices = InMemoryTestHelpers.Instance.CreateContextServices(model);
             var stateManager = contextServices.GetRequiredService<IStateManager>();
@@ -44,8 +45,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             IMutableModel model = new Model();
             var entityType = model.AddEntityType(typeof(NonIndexedClass));
-            var id = entityType.AddProperty("Id", typeof(int));
+            entityType.AddProperty("Id", typeof(int));
             var propA = entityType.AddProperty("PropA", typeof(string));
+            model.FinalizeModel();
 
             var contextServices = InMemoryTestHelpers.Instance.CreateContextServices(model);
             var stateManager = contextServices.GetRequiredService<IStateManager>();
@@ -61,22 +63,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Assert.Equal("ValueA", ((Func<InternalEntityEntry, string>)propertyAccessors.RelationshipSnapshotGetter)(entry));
 
             var valueBuffer = new ValueBuffer(new object[] { 1, "ValueA" });
-            Assert.Equal("ValueA", ((Func<ValueBuffer, object>)propertyAccessors.ValueBufferGetter)(valueBuffer));
+            Assert.Equal("ValueA", propertyAccessors.ValueBufferGetter(valueBuffer));
         }
 
         private class IndexedClass
         {
-            private Dictionary<string, object> _internalValues = new Dictionary<string, object>()
-                {
+            private readonly Dictionary<string, object> _internalValues = new Dictionary<string, object>
+            {
                     { "PropertyA", "ValueA" }
                 };
 
             internal int Id { get; set; }
 
-            public object this[string name]
-            {
-                get => _internalValues[name];
-            }
+            public object this[string name] => _internalValues[name];
         }
 
         private class NonIndexedClass

--- a/test/EFCore.Tests/Metadata/Internal/PropertyBaseTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/PropertyBaseTest.cs
@@ -31,571 +31,543 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public void Get_MemberInfos_for_auto_props()
         {
             const string field = "<Foo>k__BackingField";
-            var property = CreateProperty<AutoProp>(field);
-            Assert.False(property.IsShadowProperty());
 
-            MemberInfoTest(property, null, field, field, field);
-            MemberInfoTest(property, PropertyAccessMode.Field, field, field, field);
-            MemberInfoTest(property, PropertyAccessMode.FieldDuringConstruction, field, Property, Property);
-            MemberInfoTest(property, PropertyAccessMode.Property, Property, Property, Property);
-            MemberInfoTest(property, PropertyAccessMode.PreferField, field, field, field);
-            MemberInfoTest(property, PropertyAccessMode.PreferFieldDuringConstruction, field, Property, Property);
-            MemberInfoTest(property, PropertyAccessMode.PreferProperty, Property, Property, Property);
+            MemberInfoTest(CreateProperty<AutoProp>(field), null, field, field, field);
+            MemberInfoTest(CreateProperty<AutoProp>(field), PropertyAccessMode.Field, field, field, field);
+            MemberInfoTest(CreateProperty<AutoProp>(field), PropertyAccessMode.FieldDuringConstruction, field, Property, Property);
+            MemberInfoTest(CreateProperty<AutoProp>(field), PropertyAccessMode.Property, Property, Property, Property);
+            MemberInfoTest(CreateProperty<AutoProp>(field), PropertyAccessMode.PreferField, field, field, field);
+            MemberInfoTest(CreateProperty<AutoProp>(field), PropertyAccessMode.PreferFieldDuringConstruction, field, Property, Property);
+            MemberInfoTest(CreateProperty<AutoProp>(field), PropertyAccessMode.PreferProperty, Property, Property, Property);
         }
 
         [Fact]
         public void Get_MemberInfos_for_full_props()
         {
             const string field = "_foo";
-            var property = CreateProperty<FullProp>(field);
-            Assert.False(property.IsShadowProperty());
 
-            MemberInfoTest(property, null, field, field, field);
-            MemberInfoTest(property, PropertyAccessMode.Field, field, field, field);
-            MemberInfoTest(property, PropertyAccessMode.FieldDuringConstruction, field, Property, Property);
-            MemberInfoTest(property, PropertyAccessMode.Property, Property, Property, Property);
-            MemberInfoTest(property, PropertyAccessMode.PreferField, field, field, field);
-            MemberInfoTest(property, PropertyAccessMode.PreferFieldDuringConstruction, field, Property, Property);
-            MemberInfoTest(property, PropertyAccessMode.PreferProperty, Property, Property, Property);
+            MemberInfoTest(CreateProperty<FullProp>(field), null, field, field, field);
+            MemberInfoTest(CreateProperty<FullProp>(field), PropertyAccessMode.Field, field, field, field);
+            MemberInfoTest(CreateProperty<FullProp>(field), PropertyAccessMode.FieldDuringConstruction, field, Property, Property);
+            MemberInfoTest(CreateProperty<FullProp>(field), PropertyAccessMode.Property, Property, Property, Property);
+            MemberInfoTest(CreateProperty<FullProp>(field), PropertyAccessMode.PreferField, field, field, field);
+            MemberInfoTest(CreateProperty<FullProp>(field), PropertyAccessMode.PreferFieldDuringConstruction, field, Property, Property);
+            MemberInfoTest(CreateProperty<FullProp>(field), PropertyAccessMode.PreferProperty, Property, Property, Property);
         }
 
         [Fact]
         public void Get_MemberInfos_for_read_only_props()
         {
             const string field = "_foo";
-            var property = CreateProperty<ReadOnlyProp>(field);
-            Assert.False(property.IsShadowProperty());
 
-            MemberInfoTest(property, null, field, field, field);
-            MemberInfoTest(property, PropertyAccessMode.Field, field, field, field);
-            MemberInfoTest(property, PropertyAccessMode.FieldDuringConstruction, field, field, Property);
-            MemberInfoTest(property, PropertyAccessMode.Property, NoSetter<ReadOnlyProp>(), NoSetter<ReadOnlyProp>(), Property);
-            MemberInfoTest(property, PropertyAccessMode.PreferField, field, field, field);
-            MemberInfoTest(property, PropertyAccessMode.PreferFieldDuringConstruction, field, field, Property);
-            MemberInfoTest(property, PropertyAccessMode.PreferProperty, field, field, Property);
+            MemberInfoTest(CreateProperty<ReadOnlyProp>(field), null, field, field, field);
+            MemberInfoTest(CreateProperty<ReadOnlyProp>(field), PropertyAccessMode.Field, field, field, field);
+            MemberInfoTest(CreateProperty<ReadOnlyProp>(field), PropertyAccessMode.FieldDuringConstruction, field, field, Property);
+            MemberInfoTest(CreateProperty<ReadOnlyProp>(field), PropertyAccessMode.Property, NoSetter<ReadOnlyProp>(), NoSetter<ReadOnlyProp>(), Property);
+            MemberInfoTest(CreateProperty<ReadOnlyProp>(field), PropertyAccessMode.PreferField, field, field, field);
+            MemberInfoTest(CreateProperty<ReadOnlyProp>(field), PropertyAccessMode.PreferFieldDuringConstruction, field, field, Property);
+            MemberInfoTest(CreateProperty<ReadOnlyProp>(field), PropertyAccessMode.PreferProperty, field, field, Property);
         }
 
         [Fact]
         public void Get_MemberInfos_for_read_only_auto_props()
         {
             const string field = "<Foo>k__BackingField";
-            var property = CreateProperty<ReadOnlyAutoProp>(field);
-            Assert.False(property.IsShadowProperty());
 
-            MemberInfoTest(property, null, field, field, field);
-            MemberInfoTest(property, PropertyAccessMode.Field, field, field, field);
-            MemberInfoTest(property, PropertyAccessMode.FieldDuringConstruction, field, field, Property);
-            MemberInfoTest(property, PropertyAccessMode.Property, NoSetter<ReadOnlyAutoProp>(), NoSetter<ReadOnlyAutoProp>(), Property);
-            MemberInfoTest(property, PropertyAccessMode.PreferField, field, field, field);
-            MemberInfoTest(property, PropertyAccessMode.PreferFieldDuringConstruction, field, field, Property);
-            MemberInfoTest(property, PropertyAccessMode.PreferProperty, field, field, Property);
+            MemberInfoTest(CreateProperty<ReadOnlyAutoProp>(field), null, field, field, field);
+            MemberInfoTest(CreateProperty<ReadOnlyAutoProp>(field), PropertyAccessMode.Field, field, field, field);
+            MemberInfoTest(CreateProperty<ReadOnlyAutoProp>(field), PropertyAccessMode.FieldDuringConstruction, field, field, Property);
+            MemberInfoTest(CreateProperty<ReadOnlyAutoProp>(field), PropertyAccessMode.Property, NoSetter<ReadOnlyAutoProp>(), NoSetter<ReadOnlyAutoProp>(), Property);
+            MemberInfoTest(CreateProperty<ReadOnlyAutoProp>(field), PropertyAccessMode.PreferField, field, field, field);
+            MemberInfoTest(CreateProperty<ReadOnlyAutoProp>(field), PropertyAccessMode.PreferFieldDuringConstruction, field, field, Property);
+            MemberInfoTest(CreateProperty<ReadOnlyAutoProp>(field), PropertyAccessMode.PreferProperty, field, field, Property);
         }
 
         [Fact]
         public void Get_MemberInfos_for_read_only_field_props()
         {
             const string field = "_foo";
-            var property = CreateProperty<ReadOnlyFieldProp>(field);
-            Assert.False(property.IsShadowProperty());
 
-            MemberInfoTest(property, null, field, field, field);
-            MemberInfoTest(property, PropertyAccessMode.Field, field, field, field);
-            MemberInfoTest(property, PropertyAccessMode.FieldDuringConstruction, field, field, Property);
-            MemberInfoTest(property, PropertyAccessMode.Property, NoSetter<ReadOnlyFieldProp>(), NoSetter<ReadOnlyFieldProp>(), Property);
-            MemberInfoTest(property, PropertyAccessMode.PreferField, field, field, field);
-            MemberInfoTest(property, PropertyAccessMode.PreferFieldDuringConstruction, field, field, Property);
-            MemberInfoTest(property, PropertyAccessMode.PreferProperty, field, field, Property);
+            MemberInfoTest(CreateProperty<ReadOnlyFieldProp>(field), null, field, field, field);
+            MemberInfoTest(CreateProperty<ReadOnlyFieldProp>(field), PropertyAccessMode.Field, field, field, field);
+            MemberInfoTest(CreateProperty<ReadOnlyFieldProp>(field), PropertyAccessMode.FieldDuringConstruction, field, field, Property);
+            MemberInfoTest(CreateProperty<ReadOnlyFieldProp>(field), PropertyAccessMode.Property, NoSetter<ReadOnlyFieldProp>(), NoSetter<ReadOnlyFieldProp>(), Property);
+            MemberInfoTest(CreateProperty<ReadOnlyFieldProp>(field), PropertyAccessMode.PreferField, field, field, field);
+            MemberInfoTest(CreateProperty<ReadOnlyFieldProp>(field), PropertyAccessMode.PreferFieldDuringConstruction, field, field, Property);
+            MemberInfoTest(CreateProperty<ReadOnlyFieldProp>(field), PropertyAccessMode.PreferProperty, field, field, Property);
         }
 
         [Fact]
         public void Get_MemberInfos_for_write_only_props()
         {
             const string field = "_foo";
-            var property = CreateProperty<WriteOnlyProp>(field);
-            Assert.False(property.IsShadowProperty());
 
-            MemberInfoTest(property, null, field, field, field);
-            MemberInfoTest(property, PropertyAccessMode.Field, field, field, field);
-            MemberInfoTest(property, PropertyAccessMode.FieldDuringConstruction, field, Property, field);
-            MemberInfoTest(property, PropertyAccessMode.Property, Property, Property, NoGetter<WriteOnlyProp>());
-            MemberInfoTest(property, PropertyAccessMode.PreferField, field, field, field);
-            MemberInfoTest(property, PropertyAccessMode.PreferFieldDuringConstruction, field, Property, field);
-            MemberInfoTest(property, PropertyAccessMode.PreferProperty, Property, Property, field);
+            MemberInfoTest(CreateProperty<WriteOnlyProp>(field), null, field, field, field);
+            MemberInfoTest(CreateProperty<WriteOnlyProp>(field), PropertyAccessMode.Field, field, field, field);
+            MemberInfoTest(CreateProperty<WriteOnlyProp>(field), PropertyAccessMode.FieldDuringConstruction, field, Property, field);
+            MemberInfoTest(CreateProperty<WriteOnlyProp>(field), PropertyAccessMode.Property, Property, Property, NoGetter<WriteOnlyProp>());
+            MemberInfoTest(CreateProperty<WriteOnlyProp>(field), PropertyAccessMode.PreferField, field, field, field);
+            MemberInfoTest(CreateProperty<WriteOnlyProp>(field), PropertyAccessMode.PreferFieldDuringConstruction, field, Property, field);
+            MemberInfoTest(CreateProperty<WriteOnlyProp>(field), PropertyAccessMode.PreferProperty, Property, Property, field);
         }
 
         [Fact]
         public void Get_MemberInfos_for_field_only_props()
         {
             const string field = "_foo";
-            var property = CreateProperty<FieldOnly>(field, field);
-            Assert.False(property.IsShadowProperty());
 
-            MemberInfoTest(property, null, field, field, field);
-            MemberInfoTest(property, PropertyAccessMode.Field, field, field, field);
-            MemberInfoTest(property, PropertyAccessMode.FieldDuringConstruction, field, field, field);
+            MemberInfoTest(CreateProperty<FieldOnly>(field, field), null, field, field, field);
+            MemberInfoTest(CreateProperty<FieldOnly>(field, field), PropertyAccessMode.Field, field, field, field);
+            MemberInfoTest(CreateProperty<FieldOnly>(field, field), PropertyAccessMode.FieldDuringConstruction, field, field, field);
             MemberInfoTest(
-                property, PropertyAccessMode.Property, NoProperty<FieldOnly>(field), NoProperty<FieldOnly>(field),
+                CreateProperty<FieldOnly>(field, field), PropertyAccessMode.Property, NoProperty<FieldOnly>(field), NoProperty<FieldOnly>(field),
                 NoProperty<FieldOnly>(field));
-            MemberInfoTest(property, PropertyAccessMode.PreferField, field, field, field);
-            MemberInfoTest(property, PropertyAccessMode.PreferFieldDuringConstruction, field, field, field);
-            MemberInfoTest(property, PropertyAccessMode.PreferProperty, field, field, field);
+            MemberInfoTest(CreateProperty<FieldOnly>(field, field), PropertyAccessMode.PreferField, field, field, field);
+            MemberInfoTest(CreateProperty<FieldOnly>(field, field), PropertyAccessMode.PreferFieldDuringConstruction, field, field, field);
+            MemberInfoTest(CreateProperty<FieldOnly>(field, field), PropertyAccessMode.PreferProperty, field, field, field);
         }
 
         [Fact]
         public void Get_MemberInfos_for_read_only_field_only_props()
         {
             const string field = "_foo";
-            var property = CreateProperty<ReadOnlyFieldOnly>(field, field);
-            Assert.False(property.IsShadowProperty());
 
-            MemberInfoTest(property, null, field, field, field);
-            MemberInfoTest(property, PropertyAccessMode.Field, field, field, field);
-            MemberInfoTest(property, PropertyAccessMode.FieldDuringConstruction, field, field, field);
+            MemberInfoTest(CreateProperty<ReadOnlyFieldOnly>(field, field), null, field, field, field);
+            MemberInfoTest(CreateProperty<ReadOnlyFieldOnly>(field, field), PropertyAccessMode.Field, field, field, field);
+            MemberInfoTest(CreateProperty<ReadOnlyFieldOnly>(field, field), PropertyAccessMode.FieldDuringConstruction, field, field, field);
             MemberInfoTest(
-                property, PropertyAccessMode.Property, NoProperty<ReadOnlyFieldOnly>(field), NoProperty<ReadOnlyFieldOnly>(field),
-                NoProperty<ReadOnlyFieldOnly>(field));
-            MemberInfoTest(property, PropertyAccessMode.PreferField, field, field, field);
-            MemberInfoTest(property, PropertyAccessMode.PreferFieldDuringConstruction, field, field, field);
-            MemberInfoTest(property, PropertyAccessMode.PreferProperty, field, field, field);
+                CreateProperty<ReadOnlyFieldOnly>(field, field), PropertyAccessMode.Property, NoProperty<ReadOnlyFieldOnly>(field),
+                NoProperty<ReadOnlyFieldOnly>(field), NoProperty<ReadOnlyFieldOnly>(field));
+            MemberInfoTest(CreateProperty<ReadOnlyFieldOnly>(field, field), PropertyAccessMode.PreferField, field, field, field);
+            MemberInfoTest(CreateProperty<ReadOnlyFieldOnly>(field, field), PropertyAccessMode.PreferFieldDuringConstruction, field, field, field);
+            MemberInfoTest(CreateProperty<ReadOnlyFieldOnly>(field, field), PropertyAccessMode.PreferProperty, field, field, field);
         }
 
         [Fact]
         public void Get_MemberInfos_for_full_props_with_field_not_found()
         {
-            var property = CreateProperty<FullPropNoField>(null);
-            Assert.False(property.IsShadowProperty());
-
-            MemberInfoTest(property, null, Property, Property, Property);
-            MemberInfoTest(
-                property, PropertyAccessMode.Field, NoField<FullPropNoField>(), NoField<FullPropNoField>(), NoField<FullPropNoField>());
-            MemberInfoTest(property, PropertyAccessMode.FieldDuringConstruction, NoField<FullPropNoField>(), Property, Property);
-            MemberInfoTest(property, PropertyAccessMode.Property, Property, Property, Property);
-            MemberInfoTest(property, PropertyAccessMode.PreferField, Property, Property, Property);
-            MemberInfoTest(property, PropertyAccessMode.PreferFieldDuringConstruction, Property, Property, Property);
-            MemberInfoTest(property, PropertyAccessMode.PreferProperty, Property, Property, Property);
+            MemberInfoTest(CreateProperty<FullPropNoField>(null), null, Property, Property, Property);
+            MemberInfoTest(CreateProperty<FullPropNoField>(null), PropertyAccessMode.Field, NoField<FullPropNoField>(),
+                NoField<FullPropNoField>(), NoField<FullPropNoField>());
+            MemberInfoTest(CreateProperty<FullPropNoField>(null), PropertyAccessMode.FieldDuringConstruction,
+                NoField<FullPropNoField>(), Property, Property);
+            MemberInfoTest(CreateProperty<FullPropNoField>(null), PropertyAccessMode.Property, Property, Property, Property);
+            MemberInfoTest(CreateProperty<FullPropNoField>(null), PropertyAccessMode.PreferField, Property, Property, Property);
+            MemberInfoTest(CreateProperty<FullPropNoField>(null), PropertyAccessMode.PreferFieldDuringConstruction, Property, Property, Property);
+            MemberInfoTest(CreateProperty<FullPropNoField>(null), PropertyAccessMode.PreferProperty, Property, Property, Property);
         }
 
         [Fact]
         public void Get_MemberInfos_for_read_only_props_with_field_not_found()
         {
-            var property = CreateProperty<ReadOnlyPropNoField>(null);
-            Assert.False(property.IsShadowProperty());
-
-            MemberInfoTest(property, null, NoFieldOrSetter<ReadOnlyPropNoField>(), NoFieldOrSetter<ReadOnlyPropNoField>(), Property);
             MemberInfoTest(
-                property, PropertyAccessMode.Field, NoField<ReadOnlyPropNoField>(), NoField<ReadOnlyPropNoField>(),
-                NoField<ReadOnlyPropNoField>());
+                CreateProperty<ReadOnlyPropNoField>(null), null,
+                NoFieldOrSetter<ReadOnlyPropNoField>(), NoFieldOrSetter<ReadOnlyPropNoField>(), Property);
             MemberInfoTest(
-                property, PropertyAccessMode.FieldDuringConstruction, NoField<ReadOnlyPropNoField>(),
-                NoFieldOrSetter<ReadOnlyPropNoField>(), Property);
+                CreateProperty<ReadOnlyPropNoField>(null), PropertyAccessMode.Field,
+                NoField<ReadOnlyPropNoField>(), NoField<ReadOnlyPropNoField>(), NoField<ReadOnlyPropNoField>());
             MemberInfoTest(
-                property, PropertyAccessMode.Property, NoSetter<ReadOnlyPropNoField>(), NoSetter<ReadOnlyPropNoField>(), Property);
+                CreateProperty<ReadOnlyPropNoField>(null), PropertyAccessMode.FieldDuringConstruction,
+                NoField<ReadOnlyPropNoField>(), NoFieldOrSetter<ReadOnlyPropNoField>(), Property);
             MemberInfoTest(
-                property, PropertyAccessMode.PreferField, NoFieldOrSetter<ReadOnlyPropNoField>(), NoFieldOrSetter<ReadOnlyPropNoField>(),
-                Property);
+                CreateProperty<ReadOnlyPropNoField>(null), PropertyAccessMode.Property,
+                NoSetter<ReadOnlyPropNoField>(), NoSetter<ReadOnlyPropNoField>(), Property);
             MemberInfoTest(
-                property, PropertyAccessMode.PreferFieldDuringConstruction, NoFieldOrSetter<ReadOnlyPropNoField>(),
-                NoFieldOrSetter<ReadOnlyPropNoField>(), Property);
+                CreateProperty<ReadOnlyPropNoField>(null), PropertyAccessMode.PreferField,
+                NoFieldOrSetter<ReadOnlyPropNoField>(), NoFieldOrSetter<ReadOnlyPropNoField>(), Property);
             MemberInfoTest(
-                property, PropertyAccessMode.PreferProperty, NoFieldOrSetter<ReadOnlyPropNoField>(), NoFieldOrSetter<ReadOnlyPropNoField>(),
-                Property);
+                CreateProperty<ReadOnlyPropNoField>(null), PropertyAccessMode.PreferFieldDuringConstruction,
+                NoFieldOrSetter<ReadOnlyPropNoField>(), NoFieldOrSetter<ReadOnlyPropNoField>(), Property);
+            MemberInfoTest(
+                CreateProperty<ReadOnlyPropNoField>(null), PropertyAccessMode.PreferProperty,
+                NoFieldOrSetter<ReadOnlyPropNoField>(), NoFieldOrSetter<ReadOnlyPropNoField>(), Property);
         }
 
         [Fact]
         public void Get_MemberInfos_for_write_only_props_with_field_not_found()
         {
-            var property = CreateProperty<WriteOnlyPropNoField>(null);
-            Assert.False(property.IsShadowProperty());
-
-            MemberInfoTest(property, null, Property, Property, NoFieldOrGetter<WriteOnlyPropNoField>());
+            MemberInfoTest(CreateProperty<WriteOnlyPropNoField>(null), null, Property, Property, NoFieldOrGetter<WriteOnlyPropNoField>());
             MemberInfoTest(
-                property, PropertyAccessMode.Field, NoField<WriteOnlyPropNoField>(), NoField<WriteOnlyPropNoField>(),
-                NoField<WriteOnlyPropNoField>());
+                CreateProperty<WriteOnlyPropNoField>(null), PropertyAccessMode.Field,
+                NoField<WriteOnlyPropNoField>(), NoField<WriteOnlyPropNoField>(), NoField<WriteOnlyPropNoField>());
             MemberInfoTest(
-                property, PropertyAccessMode.FieldDuringConstruction, NoField<WriteOnlyPropNoField>(), Property,
-                NoFieldOrGetter<WriteOnlyPropNoField>());
-            MemberInfoTest(property, PropertyAccessMode.Property, Property, Property, NoGetter<WriteOnlyPropNoField>());
-            MemberInfoTest(property, PropertyAccessMode.PreferField, Property, Property, NoFieldOrGetter<WriteOnlyPropNoField>());
+                CreateProperty<WriteOnlyPropNoField>(null), PropertyAccessMode.FieldDuringConstruction,
+                NoField<WriteOnlyPropNoField>(), Property, NoFieldOrGetter<WriteOnlyPropNoField>());
             MemberInfoTest(
-                property, PropertyAccessMode.PreferFieldDuringConstruction, Property, Property, NoFieldOrGetter<WriteOnlyPropNoField>());
-            MemberInfoTest(property, PropertyAccessMode.PreferProperty, Property, Property, NoFieldOrGetter<WriteOnlyPropNoField>());
+                CreateProperty<WriteOnlyPropNoField>(null), PropertyAccessMode.Property,
+                Property, Property, NoGetter<WriteOnlyPropNoField>());
+            MemberInfoTest(
+                CreateProperty<WriteOnlyPropNoField>(null), PropertyAccessMode.PreferField,
+                Property, Property, NoFieldOrGetter<WriteOnlyPropNoField>());
+            MemberInfoTest(
+                CreateProperty<WriteOnlyPropNoField>(null), PropertyAccessMode.PreferFieldDuringConstruction,
+                Property, Property, NoFieldOrGetter<WriteOnlyPropNoField>());
+            MemberInfoTest(
+                CreateProperty<WriteOnlyPropNoField>(null), PropertyAccessMode.PreferProperty,
+                Property, Property, NoFieldOrGetter<WriteOnlyPropNoField>());
         }
 
         [Fact]
         public void Get_MemberInfos_for_full_props_private_setter_in_base()
         {
             const string field = "_foo";
-            var property = CreateProperty<PrivateSetterInBase>(field);
-            Assert.False(property.IsShadowProperty());
 
-            MemberInfoTest(property, null, field, field, field);
-            MemberInfoTest(property, PropertyAccessMode.Field, field, field, field);
-            MemberInfoTest(property, PropertyAccessMode.FieldDuringConstruction, field, Property, Property);
-            MemberInfoTest(property, PropertyAccessMode.Property, Property, Property, Property);
-            MemberInfoTest(property, PropertyAccessMode.PreferField, field, field, field);
-            MemberInfoTest(property, PropertyAccessMode.PreferFieldDuringConstruction, field, Property, Property);
-            MemberInfoTest(property, PropertyAccessMode.PreferProperty, Property, Property, Property);
+            MemberInfoTest(CreateProperty<PrivateSetterInBase>(field), null, field, field, field);
+            MemberInfoTest(CreateProperty<PrivateSetterInBase>(field), PropertyAccessMode.Field, field, field, field);
+            MemberInfoTest(CreateProperty<PrivateSetterInBase>(field), PropertyAccessMode.FieldDuringConstruction, field, Property, Property);
+            MemberInfoTest(CreateProperty<PrivateSetterInBase>(field), PropertyAccessMode.Property, Property, Property, Property);
+            MemberInfoTest(CreateProperty<PrivateSetterInBase>(field), PropertyAccessMode.PreferField, field, field, field);
+            MemberInfoTest(CreateProperty<PrivateSetterInBase>(field), PropertyAccessMode.PreferFieldDuringConstruction, field, Property, Property);
+            MemberInfoTest(CreateProperty<PrivateSetterInBase>(field), PropertyAccessMode.PreferProperty, Property, Property, Property);
         }
 
         [Fact]
         public void Get_MemberInfos_for_full_props_private_getter_in_base()
         {
             const string field = "_foo";
-            var property = CreateProperty<PrivateGetterInBase>(field);
-            Assert.False(property.IsShadowProperty());
 
-            MemberInfoTest(property, null, field, field, field);
-            MemberInfoTest(property, PropertyAccessMode.Field, field, field, field);
-            MemberInfoTest(property, PropertyAccessMode.FieldDuringConstruction, field, Property, Property);
-            MemberInfoTest(property, PropertyAccessMode.Property, Property, Property, Property);
-            MemberInfoTest(property, PropertyAccessMode.PreferField, field, field, field);
-            MemberInfoTest(property, PropertyAccessMode.PreferFieldDuringConstruction, field, Property, Property);
-            MemberInfoTest(property, PropertyAccessMode.PreferProperty, Property, Property, Property);
+            MemberInfoTest(CreateProperty<PrivateGetterInBase>(field), null, field, field, field);
+            MemberInfoTest(CreateProperty<PrivateGetterInBase>(field), PropertyAccessMode.Field, field, field, field);
+            MemberInfoTest(CreateProperty<PrivateGetterInBase>(field), PropertyAccessMode.FieldDuringConstruction, field, Property, Property);
+            MemberInfoTest(CreateProperty<PrivateGetterInBase>(field), PropertyAccessMode.Property, Property, Property, Property);
+            MemberInfoTest(CreateProperty<PrivateGetterInBase>(field), PropertyAccessMode.PreferField, field, field, field);
+            MemberInfoTest(CreateProperty<PrivateGetterInBase>(field), PropertyAccessMode.PreferFieldDuringConstruction, field, Property, Property);
+            MemberInfoTest(CreateProperty<PrivateGetterInBase>(field), PropertyAccessMode.PreferProperty, Property, Property, Property);
         }
 
         [Fact]
         public void Get_MemberInfos_for_auto_prop_navigations()
         {
             const string field = "<Reference>k__BackingField";
-            var navigation = CreateReferenceNavigation<AutoProp>(field);
 
-            MemberInfoTest(navigation, null, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.Field, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.FieldDuringConstruction, field, Reference, Reference);
-            MemberInfoTest(navigation, PropertyAccessMode.Property, Reference, Reference, Reference);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferField, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferFieldDuringConstruction, field, Reference, Reference);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferProperty, Reference, Reference, Reference);
+            MemberInfoTest(CreateReferenceNavigation<AutoProp>(field), null, field, field, field);
+            MemberInfoTest(CreateReferenceNavigation<AutoProp>(field), PropertyAccessMode.Field, field, field, field);
+            MemberInfoTest(CreateReferenceNavigation<AutoProp>(field), PropertyAccessMode.FieldDuringConstruction, field, Reference, Reference);
+            MemberInfoTest(CreateReferenceNavigation<AutoProp>(field), PropertyAccessMode.Property, Reference, Reference, Reference);
+            MemberInfoTest(CreateReferenceNavigation<AutoProp>(field), PropertyAccessMode.PreferField, field, field, field);
+            MemberInfoTest(CreateReferenceNavigation<AutoProp>(field), PropertyAccessMode.PreferFieldDuringConstruction, field, Reference, Reference);
+            MemberInfoTest(CreateReferenceNavigation<AutoProp>(field), PropertyAccessMode.PreferProperty, Reference, Reference, Reference);
         }
 
         [Fact]
         public void Get_MemberInfos_for_full_prop_navigations()
         {
             const string field = "_reference";
-            var navigation = CreateReferenceNavigation<FullProp>(field);
 
-            MemberInfoTest(navigation, null, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.Field, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.FieldDuringConstruction, field, Reference, Reference);
-            MemberInfoTest(navigation, PropertyAccessMode.Property, Reference, Reference, Reference);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferField, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferFieldDuringConstruction, field, Reference, Reference);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferProperty, Reference, Reference, Reference);
+            MemberInfoTest(CreateReferenceNavigation<FullProp>(field), null, field, field, field);
+            MemberInfoTest(CreateReferenceNavigation<FullProp>(field), PropertyAccessMode.Field, field, field, field);
+            MemberInfoTest(CreateReferenceNavigation<FullProp>(field), PropertyAccessMode.FieldDuringConstruction, field, Reference, Reference);
+            MemberInfoTest(CreateReferenceNavigation<FullProp>(field), PropertyAccessMode.Property, Reference, Reference, Reference);
+            MemberInfoTest(CreateReferenceNavigation<FullProp>(field), PropertyAccessMode.PreferField, field, field, field);
+            MemberInfoTest(CreateReferenceNavigation<FullProp>(field), PropertyAccessMode.PreferFieldDuringConstruction, field, Reference, Reference);
+            MemberInfoTest(CreateReferenceNavigation<FullProp>(field), PropertyAccessMode.PreferProperty, Reference, Reference, Reference);
         }
 
         [Fact]
         public void Get_MemberInfos_for_read_only_prop_navigations()
         {
             const string field = "_reference";
-            var navigation = CreateReferenceNavigation<ReadOnlyProp>(field);
 
-            MemberInfoTest(navigation, null, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.Field, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.FieldDuringConstruction, field, field, Reference);
-            MemberInfoTest(navigation, PropertyAccessMode.Property, NoSetterRef<ReadOnlyProp>(), NoSetterRef<ReadOnlyProp>(), Reference);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferField, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferFieldDuringConstruction, field, field, Reference);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferProperty, field, field, Reference);
+            MemberInfoTest(CreateReferenceNavigation<ReadOnlyProp>(field), null, field, field, field);
+            MemberInfoTest(CreateReferenceNavigation<ReadOnlyProp>(field), PropertyAccessMode.Field, field, field, field);
+            MemberInfoTest(CreateReferenceNavigation<ReadOnlyProp>(field), PropertyAccessMode.FieldDuringConstruction, field, field, Reference);
+            MemberInfoTest(CreateReferenceNavigation<ReadOnlyProp>(field), PropertyAccessMode.Property, NoSetterRef<ReadOnlyProp>(), NoSetterRef<ReadOnlyProp>(), Reference);
+            MemberInfoTest(CreateReferenceNavigation<ReadOnlyProp>(field), PropertyAccessMode.PreferField, field, field, field);
+            MemberInfoTest(CreateReferenceNavigation<ReadOnlyProp>(field), PropertyAccessMode.PreferFieldDuringConstruction, field, field, Reference);
+            MemberInfoTest(CreateReferenceNavigation<ReadOnlyProp>(field), PropertyAccessMode.PreferProperty, field, field, Reference);
         }
 
         [Fact]
         public void Get_MemberInfos_for_read_only_auto_prop_navigations()
         {
             const string field = "<Reference>k__BackingField";
-            var navigation = CreateReferenceNavigation<ReadOnlyAutoProp>(field);
 
-            MemberInfoTest(navigation, null, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.Field, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.FieldDuringConstruction, field, field, Reference);
+            MemberInfoTest(CreateReferenceNavigation<ReadOnlyAutoProp>(field), null, field, field, field);
+            MemberInfoTest(CreateReferenceNavigation<ReadOnlyAutoProp>(field), PropertyAccessMode.Field, field, field, field);
+            MemberInfoTest(CreateReferenceNavigation<ReadOnlyAutoProp>(field), PropertyAccessMode.FieldDuringConstruction, field, field, Reference);
             MemberInfoTest(
-                navigation, PropertyAccessMode.Property, NoSetterRef<ReadOnlyAutoProp>(), NoSetterRef<ReadOnlyAutoProp>(), Reference);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferField, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferFieldDuringConstruction, field, field, Reference);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferProperty, field, field, Reference);
+                CreateReferenceNavigation<ReadOnlyAutoProp>(field), PropertyAccessMode.Property, NoSetterRef<ReadOnlyAutoProp>(), NoSetterRef<ReadOnlyAutoProp>(), Reference);
+            MemberInfoTest(CreateReferenceNavigation<ReadOnlyAutoProp>(field), PropertyAccessMode.PreferField, field, field, field);
+            MemberInfoTest(CreateReferenceNavigation<ReadOnlyAutoProp>(field), PropertyAccessMode.PreferFieldDuringConstruction, field, field, Reference);
+            MemberInfoTest(CreateReferenceNavigation<ReadOnlyAutoProp>(field), PropertyAccessMode.PreferProperty, field, field, Reference);
         }
 
         [Fact]
         public void Get_MemberInfos_for_read_only_field_prop_navigations()
         {
             const string field = "_reference";
-            var navigation = CreateReferenceNavigation<ReadOnlyFieldProp>(field);
 
-            MemberInfoTest(navigation, null, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.Field, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.FieldDuringConstruction, field, field, Reference);
+            MemberInfoTest(CreateReferenceNavigation<ReadOnlyFieldProp>(field), null, field, field, field);
+            MemberInfoTest(CreateReferenceNavigation<ReadOnlyFieldProp>(field), PropertyAccessMode.Field, field, field, field);
+            MemberInfoTest(CreateReferenceNavigation<ReadOnlyFieldProp>(field), PropertyAccessMode.FieldDuringConstruction, field, field, Reference);
             MemberInfoTest(
-                navigation, PropertyAccessMode.Property, NoSetterRef<ReadOnlyFieldProp>(), NoSetterRef<ReadOnlyFieldProp>(), Reference);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferField, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferFieldDuringConstruction, field, field, Reference);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferProperty, field, field, Reference);
+                CreateReferenceNavigation<ReadOnlyFieldProp>(field), PropertyAccessMode.Property, NoSetterRef<ReadOnlyFieldProp>(), NoSetterRef<ReadOnlyFieldProp>(), Reference);
+            MemberInfoTest(CreateReferenceNavigation<ReadOnlyFieldProp>(field), PropertyAccessMode.PreferField, field, field, field);
+            MemberInfoTest(CreateReferenceNavigation<ReadOnlyFieldProp>(field), PropertyAccessMode.PreferFieldDuringConstruction, field, field, Reference);
+            MemberInfoTest(CreateReferenceNavigation<ReadOnlyFieldProp>(field), PropertyAccessMode.PreferProperty, field, field, Reference);
         }
 
         [Fact]
         public void Get_MemberInfos_for_write_only_prop_navigations()
         {
             const string field = "_reference";
-            var navigation = CreateReferenceNavigation<WriteOnlyProp>(field);
 
-            MemberInfoTest(navigation, null, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.Field, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.FieldDuringConstruction, field, Reference, field);
-            MemberInfoTest(navigation, PropertyAccessMode.Property, Reference, Reference, NoGetterRef<WriteOnlyProp>());
-            MemberInfoTest(navigation, PropertyAccessMode.PreferField, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferFieldDuringConstruction, field, Reference, field);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferProperty, Reference, Reference, field);
+            MemberInfoTest(CreateReferenceNavigation<WriteOnlyProp>(field), null, field, field, field);
+            MemberInfoTest(CreateReferenceNavigation<WriteOnlyProp>(field), PropertyAccessMode.Field, field, field, field);
+            MemberInfoTest(CreateReferenceNavigation<WriteOnlyProp>(field), PropertyAccessMode.FieldDuringConstruction, field, Reference, field);
+            MemberInfoTest(CreateReferenceNavigation<WriteOnlyProp>(field), PropertyAccessMode.Property, Reference, Reference, NoGetterRef<WriteOnlyProp>());
+            MemberInfoTest(CreateReferenceNavigation<WriteOnlyProp>(field), PropertyAccessMode.PreferField, field, field, field);
+            MemberInfoTest(CreateReferenceNavigation<WriteOnlyProp>(field), PropertyAccessMode.PreferFieldDuringConstruction, field, Reference, field);
+            MemberInfoTest(CreateReferenceNavigation<WriteOnlyProp>(field), PropertyAccessMode.PreferProperty, Reference, Reference, field);
         }
 
         [Fact]
         public void Get_MemberInfos_for_full_prop_navigations_with_field_not_found()
         {
-            var navigation = CreateReferenceNavigation<FullPropNoField>(null);
-
-            MemberInfoTest(navigation, null, Reference, Reference, Reference);
+            MemberInfoTest(CreateReferenceNavigation<FullPropNoField>(null), null, Reference, Reference, Reference);
             MemberInfoTest(
-                navigation, PropertyAccessMode.Field, NoFieldRef<FullPropNoField>(), NoFieldRef<FullPropNoField>(),
+                CreateReferenceNavigation<FullPropNoField>(null), PropertyAccessMode.Field, NoFieldRef<FullPropNoField>(), NoFieldRef<FullPropNoField>(),
                 NoFieldRef<FullPropNoField>());
-            MemberInfoTest(navigation, PropertyAccessMode.FieldDuringConstruction, NoFieldRef<FullPropNoField>(), Reference, Reference);
-            MemberInfoTest(navigation, PropertyAccessMode.Property, Reference, Reference, Reference);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferField, Reference, Reference, Reference);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferFieldDuringConstruction, Reference, Reference, Reference);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferProperty, Reference, Reference, Reference);
+            MemberInfoTest(CreateReferenceNavigation<FullPropNoField>(null), PropertyAccessMode.FieldDuringConstruction, NoFieldRef<FullPropNoField>(), Reference, Reference);
+            MemberInfoTest(CreateReferenceNavigation<FullPropNoField>(null), PropertyAccessMode.Property, Reference, Reference, Reference);
+            MemberInfoTest(CreateReferenceNavigation<FullPropNoField>(null), PropertyAccessMode.PreferField, Reference, Reference, Reference);
+            MemberInfoTest(CreateReferenceNavigation<FullPropNoField>(null), PropertyAccessMode.PreferFieldDuringConstruction, Reference, Reference, Reference);
+            MemberInfoTest(CreateReferenceNavigation<FullPropNoField>(null), PropertyAccessMode.PreferProperty, Reference, Reference, Reference);
         }
 
         [Fact]
         public void Get_MemberInfos_for_read_only_prop_navigations_with_field_not_found()
         {
-            var navigation = CreateReferenceNavigation<ReadOnlyPropNoField>(null);
-
             MemberInfoTest(
-                navigation, null, NoFieldOrSetterRef<ReadOnlyPropNoField>(), NoFieldOrSetterRef<ReadOnlyPropNoField>(), Reference);
+                CreateReferenceNavigation<ReadOnlyPropNoField>(null), null, NoFieldOrSetterRef<ReadOnlyPropNoField>(), NoFieldOrSetterRef<ReadOnlyPropNoField>(), Reference);
             MemberInfoTest(
-                navigation, PropertyAccessMode.Field, NoFieldRef<ReadOnlyPropNoField>(), NoFieldRef<ReadOnlyPropNoField>(),
+                CreateReferenceNavigation<ReadOnlyPropNoField>(null), PropertyAccessMode.Field, NoFieldRef<ReadOnlyPropNoField>(), NoFieldRef<ReadOnlyPropNoField>(),
                 NoFieldRef<ReadOnlyPropNoField>());
             MemberInfoTest(
-                navigation, PropertyAccessMode.FieldDuringConstruction, NoFieldRef<ReadOnlyPropNoField>(),
+                CreateReferenceNavigation<ReadOnlyPropNoField>(null), PropertyAccessMode.FieldDuringConstruction, NoFieldRef<ReadOnlyPropNoField>(),
                 NoFieldOrSetterRef<ReadOnlyPropNoField>(), Reference);
             MemberInfoTest(
-                navigation, PropertyAccessMode.Property, NoSetterRef<ReadOnlyPropNoField>(), NoSetterRef<ReadOnlyPropNoField>(), Reference);
+                CreateReferenceNavigation<ReadOnlyPropNoField>(null), PropertyAccessMode.Property, NoSetterRef<ReadOnlyPropNoField>(), NoSetterRef<ReadOnlyPropNoField>(), Reference);
             MemberInfoTest(
-                navigation, PropertyAccessMode.PreferField, NoFieldOrSetterRef<ReadOnlyPropNoField>(),
+                CreateReferenceNavigation<ReadOnlyPropNoField>(null), PropertyAccessMode.PreferField, NoFieldOrSetterRef<ReadOnlyPropNoField>(),
                 NoFieldOrSetterRef<ReadOnlyPropNoField>(), Reference);
             MemberInfoTest(
-                navigation, PropertyAccessMode.PreferFieldDuringConstruction, NoFieldOrSetterRef<ReadOnlyPropNoField>(),
+                CreateReferenceNavigation<ReadOnlyPropNoField>(null), PropertyAccessMode.PreferFieldDuringConstruction, NoFieldOrSetterRef<ReadOnlyPropNoField>(),
                 NoFieldOrSetterRef<ReadOnlyPropNoField>(), Reference);
             MemberInfoTest(
-                navigation, PropertyAccessMode.PreferProperty, NoFieldOrSetterRef<ReadOnlyPropNoField>(),
+                CreateReferenceNavigation<ReadOnlyPropNoField>(null), PropertyAccessMode.PreferProperty, NoFieldOrSetterRef<ReadOnlyPropNoField>(),
                 NoFieldOrSetterRef<ReadOnlyPropNoField>(), Reference);
         }
 
         [Fact]
         public void Get_MemberInfos_for_write_only_prop_navigations_with_field_not_found()
         {
-            var navigation = CreateReferenceNavigation<WriteOnlyPropNoField>(null);
-
-            MemberInfoTest(navigation, null, Reference, Reference, NoFieldOrGetterRef<WriteOnlyPropNoField>());
+            MemberInfoTest(CreateReferenceNavigation<WriteOnlyPropNoField>(null), null,
+                Reference, Reference, NoFieldOrGetterRef<WriteOnlyPropNoField>());
             MemberInfoTest(
-                navigation, PropertyAccessMode.Field, NoFieldRef<WriteOnlyPropNoField>(), NoFieldRef<WriteOnlyPropNoField>(),
-                NoFieldRef<WriteOnlyPropNoField>());
+                CreateReferenceNavigation<WriteOnlyPropNoField>(null), PropertyAccessMode.Field,
+                NoFieldRef<WriteOnlyPropNoField>(), NoFieldRef<WriteOnlyPropNoField>(), NoFieldRef<WriteOnlyPropNoField>());
             MemberInfoTest(
-                navigation, PropertyAccessMode.FieldDuringConstruction, NoFieldRef<WriteOnlyPropNoField>(), Reference,
-                NoFieldOrGetterRef<WriteOnlyPropNoField>());
-            MemberInfoTest(navigation, PropertyAccessMode.Property, Reference, Reference, NoGetterRef<WriteOnlyPropNoField>());
-            MemberInfoTest(navigation, PropertyAccessMode.PreferField, Reference, Reference, NoFieldOrGetterRef<WriteOnlyPropNoField>());
+                CreateReferenceNavigation<WriteOnlyPropNoField>(null), PropertyAccessMode.FieldDuringConstruction,
+                NoFieldRef<WriteOnlyPropNoField>(), Reference, NoFieldOrGetterRef<WriteOnlyPropNoField>());
+            MemberInfoTest(CreateReferenceNavigation<WriteOnlyPropNoField>(null), PropertyAccessMode.Property,
+                Reference, Reference, NoGetterRef<WriteOnlyPropNoField>());
+            MemberInfoTest(CreateReferenceNavigation<WriteOnlyPropNoField>(null), PropertyAccessMode.PreferField,
+                Reference, Reference, NoFieldOrGetterRef<WriteOnlyPropNoField>());
             MemberInfoTest(
-                navigation, PropertyAccessMode.PreferFieldDuringConstruction, Reference, Reference,
-                NoFieldOrGetterRef<WriteOnlyPropNoField>());
-            MemberInfoTest(navigation, PropertyAccessMode.PreferProperty, Reference, Reference, NoFieldOrGetterRef<WriteOnlyPropNoField>());
+                CreateReferenceNavigation<WriteOnlyPropNoField>(null), PropertyAccessMode.PreferFieldDuringConstruction,
+                Reference, Reference, NoFieldOrGetterRef<WriteOnlyPropNoField>());
+            MemberInfoTest(CreateReferenceNavigation<WriteOnlyPropNoField>(null), PropertyAccessMode.PreferProperty,
+                Reference, Reference, NoFieldOrGetterRef<WriteOnlyPropNoField>());
         }
 
         [Fact]
         public void Get_MemberInfos_for_full_prop_navigations_private_setter_in_base()
         {
             const string field = "_reference";
-            var navigation = CreateReferenceNavigation<PrivateSetterInBase>(field);
 
-            MemberInfoTest(navigation, null, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.Field, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.FieldDuringConstruction, field, Reference, Reference);
-            MemberInfoTest(navigation, PropertyAccessMode.Property, Reference, Reference, Reference);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferField, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferFieldDuringConstruction, field, Reference, Reference);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferProperty, Reference, Reference, Reference);
+            MemberInfoTest(CreateReferenceNavigation<PrivateSetterInBase>(field), null, field, field, field);
+            MemberInfoTest(CreateReferenceNavigation<PrivateSetterInBase>(field), PropertyAccessMode.Field, field, field, field);
+            MemberInfoTest(CreateReferenceNavigation<PrivateSetterInBase>(field), PropertyAccessMode.FieldDuringConstruction, field, Reference, Reference);
+            MemberInfoTest(CreateReferenceNavigation<PrivateSetterInBase>(field), PropertyAccessMode.Property, Reference, Reference, Reference);
+            MemberInfoTest(CreateReferenceNavigation<PrivateSetterInBase>(field), PropertyAccessMode.PreferField, field, field, field);
+            MemberInfoTest(CreateReferenceNavigation<PrivateSetterInBase>(field), PropertyAccessMode.PreferFieldDuringConstruction, field, Reference, Reference);
+            MemberInfoTest(CreateReferenceNavigation<PrivateSetterInBase>(field), PropertyAccessMode.PreferProperty, Reference, Reference, Reference);
         }
 
         [Fact]
         public void Get_MemberInfos_for_full_prop_navigations_private_getter_in_base()
         {
             const string field = "_reference";
-            var navigation = CreateReferenceNavigation<PrivateGetterInBase>(field);
 
-            MemberInfoTest(navigation, null, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.Field, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.FieldDuringConstruction, field, Reference, Reference);
-            MemberInfoTest(navigation, PropertyAccessMode.Property, Reference, Reference, Reference);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferField, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferFieldDuringConstruction, field, Reference, Reference);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferProperty, Reference, Reference, Reference);
+            MemberInfoTest(CreateReferenceNavigation<PrivateGetterInBase>(field), null, field, field, field);
+            MemberInfoTest(CreateReferenceNavigation<PrivateGetterInBase>(field), PropertyAccessMode.Field, field, field, field);
+            MemberInfoTest(CreateReferenceNavigation<PrivateGetterInBase>(field), PropertyAccessMode.FieldDuringConstruction, field,
+                Reference, Reference);
+            MemberInfoTest(CreateReferenceNavigation<PrivateGetterInBase>(field), PropertyAccessMode.Property, Reference, Reference, Reference);
+            MemberInfoTest(CreateReferenceNavigation<PrivateGetterInBase>(field), PropertyAccessMode.PreferField, field, field, field);
+            MemberInfoTest(CreateReferenceNavigation<PrivateGetterInBase>(field), PropertyAccessMode.PreferFieldDuringConstruction, field,
+                Reference, Reference);
+            MemberInfoTest(CreateReferenceNavigation<PrivateGetterInBase>(field), PropertyAccessMode.PreferProperty, Reference, Reference, Reference);
         }
 
         [Fact]
         public void Get_MemberInfos_for_auto_prop_collection_navigations()
         {
             const string field = "<Collection>k__BackingField";
-            var navigation = CreateCollectionNavigation<AutoProp>(field);
 
-            MemberInfoTest(navigation, null, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.Field, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.FieldDuringConstruction, field, Collection, Collection);
-            MemberInfoTest(navigation, PropertyAccessMode.Property, Collection, Collection, Collection);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferField, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferFieldDuringConstruction, field, Collection, Collection);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferProperty, Collection, Collection, Collection);
+            MemberInfoTest(CreateCollectionNavigation<AutoProp>(field), null, field, field, field);
+            MemberInfoTest(CreateCollectionNavigation<AutoProp>(field), PropertyAccessMode.Field, field, field, field);
+            MemberInfoTest(CreateCollectionNavigation<AutoProp>(field), PropertyAccessMode.FieldDuringConstruction, field, Collection, Collection);
+            MemberInfoTest(CreateCollectionNavigation<AutoProp>(field), PropertyAccessMode.Property, Collection, Collection, Collection);
+            MemberInfoTest(CreateCollectionNavigation<AutoProp>(field), PropertyAccessMode.PreferField, field, field, field);
+            MemberInfoTest(CreateCollectionNavigation<AutoProp>(field), PropertyAccessMode.PreferFieldDuringConstruction, field, Collection, Collection);
+            MemberInfoTest(CreateCollectionNavigation<AutoProp>(field), PropertyAccessMode.PreferProperty, Collection, Collection, Collection);
         }
 
         [Fact]
         public void Get_MemberInfos_for_full_prop_collection_navigations()
         {
             const string field = "_collection";
-            var navigation = CreateCollectionNavigation<FullProp>(field);
 
-            MemberInfoTest(navigation, null, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.Field, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.FieldDuringConstruction, field, Collection, Collection);
-            MemberInfoTest(navigation, PropertyAccessMode.Property, Collection, Collection, Collection);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferField, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferFieldDuringConstruction, field, Collection, Collection);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferProperty, Collection, Collection, Collection);
+            MemberInfoTest(CreateCollectionNavigation<FullProp>(field), null, field, field, field);
+            MemberInfoTest(CreateCollectionNavigation<FullProp>(field), PropertyAccessMode.Field, field, field, field);
+            MemberInfoTest(CreateCollectionNavigation<FullProp>(field), PropertyAccessMode.FieldDuringConstruction, field, Collection, Collection);
+            MemberInfoTest(CreateCollectionNavigation<FullProp>(field), PropertyAccessMode.Property, Collection, Collection, Collection);
+            MemberInfoTest(CreateCollectionNavigation<FullProp>(field), PropertyAccessMode.PreferField, field, field, field);
+            MemberInfoTest(CreateCollectionNavigation<FullProp>(field), PropertyAccessMode.PreferFieldDuringConstruction, field, Collection, Collection);
+            MemberInfoTest(CreateCollectionNavigation<FullProp>(field), PropertyAccessMode.PreferProperty, Collection, Collection, Collection);
         }
 
         [Fact]
         public void Get_MemberInfos_for_read_only_prop_collection_navigations()
         {
             const string field = "_collection";
-            var navigation = CreateCollectionNavigation<ReadOnlyProp>(field);
 
-            MemberInfoTest(navigation, null, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.Field, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.FieldDuringConstruction, field, field, Collection);
-            MemberInfoTest(navigation, PropertyAccessMode.Property, null, null, Collection);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferField, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferFieldDuringConstruction, field, field, Collection);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferProperty, field, field, Collection);
+            MemberInfoTest(CreateCollectionNavigation<ReadOnlyProp>(field), null, field, field, field);
+            MemberInfoTest(CreateCollectionNavigation<ReadOnlyProp>(field), PropertyAccessMode.Field, field, field, field);
+            MemberInfoTest(CreateCollectionNavigation<ReadOnlyProp>(field), PropertyAccessMode.FieldDuringConstruction, field, field, Collection);
+            MemberInfoTest(CreateCollectionNavigation<ReadOnlyProp>(field), PropertyAccessMode.Property, null, null, Collection);
+            MemberInfoTest(CreateCollectionNavigation<ReadOnlyProp>(field), PropertyAccessMode.PreferField, field, field, field);
+            MemberInfoTest(CreateCollectionNavigation<ReadOnlyProp>(field), PropertyAccessMode.PreferFieldDuringConstruction, field, field, Collection);
+            MemberInfoTest(CreateCollectionNavigation<ReadOnlyProp>(field), PropertyAccessMode.PreferProperty, field, field, Collection);
         }
 
         [Fact]
         public void Get_MemberInfos_for_read_only_auto_prop_collection_navigations()
         {
             const string field = "<Collection>k__BackingField";
-            var navigation = CreateCollectionNavigation<ReadOnlyAutoProp>(field);
 
-            MemberInfoTest(navigation, null, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.Field, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.FieldDuringConstruction, field, field, Collection);
-            MemberInfoTest(navigation, PropertyAccessMode.Property, null, null, Collection);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferField, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferFieldDuringConstruction, field, field, Collection);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferProperty, field, field, Collection);
+            MemberInfoTest(CreateCollectionNavigation<ReadOnlyAutoProp>(field), null, field, field, field);
+            MemberInfoTest(CreateCollectionNavigation<ReadOnlyAutoProp>(field), PropertyAccessMode.Field, field, field, field);
+            MemberInfoTest(CreateCollectionNavigation<ReadOnlyAutoProp>(field), PropertyAccessMode.FieldDuringConstruction, field, field, Collection);
+            MemberInfoTest(CreateCollectionNavigation<ReadOnlyAutoProp>(field), PropertyAccessMode.Property, null, null, Collection);
+            MemberInfoTest(CreateCollectionNavigation<ReadOnlyAutoProp>(field), PropertyAccessMode.PreferField, field, field, field);
+            MemberInfoTest(CreateCollectionNavigation<ReadOnlyAutoProp>(field), PropertyAccessMode.PreferFieldDuringConstruction,
+                field, field, Collection);
+            MemberInfoTest(CreateCollectionNavigation<ReadOnlyAutoProp>(field), PropertyAccessMode.PreferProperty, field, field, Collection);
         }
 
         [Fact]
         public void Get_MemberInfos_for_read_only_field_prop_collection_navigations()
         {
             const string field = "_collection";
-            var navigation = CreateCollectionNavigation<ReadOnlyFieldProp>(field);
 
-            MemberInfoTest(navigation, null, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.Field, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.FieldDuringConstruction, field, field, Collection);
-            MemberInfoTest(navigation, PropertyAccessMode.Property, null, null, Collection);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferField, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferFieldDuringConstruction, field, field, Collection);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferProperty, field, field, Collection);
+            MemberInfoTest(CreateCollectionNavigation<ReadOnlyFieldProp>(field), null, field, field, field);
+            MemberInfoTest(CreateCollectionNavigation<ReadOnlyFieldProp>(field), PropertyAccessMode.Field, field, field, field);
+            MemberInfoTest(CreateCollectionNavigation<ReadOnlyFieldProp>(field), PropertyAccessMode.FieldDuringConstruction, field, field, Collection);
+            MemberInfoTest(CreateCollectionNavigation<ReadOnlyFieldProp>(field), PropertyAccessMode.Property, null, null, Collection);
+            MemberInfoTest(CreateCollectionNavigation<ReadOnlyFieldProp>(field), PropertyAccessMode.PreferField, field, field, field);
+            MemberInfoTest(CreateCollectionNavigation<ReadOnlyFieldProp>(field), PropertyAccessMode.PreferFieldDuringConstruction,
+                field, field, Collection);
+            MemberInfoTest(CreateCollectionNavigation<ReadOnlyFieldProp>(field), PropertyAccessMode.PreferProperty, field, field, Collection);
         }
 
         [Fact]
         public void Get_MemberInfos_for_write_only_prop_collection_navigations()
         {
             const string field = "_collection";
-            var navigation = CreateCollectionNavigation<WriteOnlyProp>(field);
 
-            MemberInfoTest(navigation, null, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.Field, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.FieldDuringConstruction, field, Collection, field);
-            MemberInfoTest(navigation, PropertyAccessMode.Property, Collection, Collection, NoGetterColl<WriteOnlyProp>());
-            MemberInfoTest(navigation, PropertyAccessMode.PreferField, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferFieldDuringConstruction, field, Collection, field);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferProperty, Collection, Collection, field);
+            MemberInfoTest(CreateCollectionNavigation<WriteOnlyProp>(field), null, field, field, field);
+            MemberInfoTest(CreateCollectionNavigation<WriteOnlyProp>(field), PropertyAccessMode.Field, field, field, field);
+            MemberInfoTest(CreateCollectionNavigation<WriteOnlyProp>(field), PropertyAccessMode.FieldDuringConstruction, field, Collection, field);
+            MemberInfoTest(CreateCollectionNavigation<WriteOnlyProp>(field), PropertyAccessMode.Property,
+                Collection, Collection, NoGetterColl<WriteOnlyProp>());
+            MemberInfoTest(CreateCollectionNavigation<WriteOnlyProp>(field), PropertyAccessMode.PreferField, field, field, field);
+            MemberInfoTest(CreateCollectionNavigation<WriteOnlyProp>(field), PropertyAccessMode.PreferFieldDuringConstruction, field, Collection, field);
+            MemberInfoTest(CreateCollectionNavigation<WriteOnlyProp>(field), PropertyAccessMode.PreferProperty, Collection, Collection, field);
         }
 
         [Fact]
         public void Get_MemberInfos_for_full_prop_collection_navigations_with_field_not_found()
         {
-            var navigation = CreateCollectionNavigation<FullPropNoField>(null);
-
-            MemberInfoTest(navigation, null, Collection, Collection, Collection);
-            MemberInfoTest(navigation, PropertyAccessMode.Field, null, null, NoFieldColl<FullPropNoField>());
-            MemberInfoTest(navigation, PropertyAccessMode.FieldDuringConstruction, null, Collection, Collection);
-            MemberInfoTest(navigation, PropertyAccessMode.Property, Collection, Collection, Collection);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferField, Collection, Collection, Collection);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferFieldDuringConstruction, Collection, Collection, Collection);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferProperty, Collection, Collection, Collection);
+            MemberInfoTest(CreateCollectionNavigation<FullPropNoField>(null), null, Collection, Collection, Collection);
+            MemberInfoTest(CreateCollectionNavigation<FullPropNoField>(null), PropertyAccessMode.Field, null, null, NoFieldColl<FullPropNoField>());
+            MemberInfoTest(CreateCollectionNavigation<FullPropNoField>(null), PropertyAccessMode.FieldDuringConstruction, null, Collection, Collection);
+            MemberInfoTest(CreateCollectionNavigation<FullPropNoField>(null), PropertyAccessMode.Property, Collection, Collection, Collection);
+            MemberInfoTest(CreateCollectionNavigation<FullPropNoField>(null), PropertyAccessMode.PreferField, Collection, Collection, Collection);
+            MemberInfoTest(CreateCollectionNavigation<FullPropNoField>(null), PropertyAccessMode.PreferFieldDuringConstruction,
+                Collection, Collection, Collection);
+            MemberInfoTest(CreateCollectionNavigation<FullPropNoField>(null), PropertyAccessMode.PreferProperty, Collection, Collection, Collection);
         }
 
         [Fact]
         public void Get_MemberInfos_for_read_only_prop_collection_navigations_with_field_not_found()
         {
-            var navigation = CreateCollectionNavigation<ReadOnlyPropNoField>(null);
-
-            MemberInfoTest(navigation, null, null, null, Collection);
-            MemberInfoTest(navigation, PropertyAccessMode.Field, null, null, NoFieldColl<ReadOnlyPropNoField>());
-            MemberInfoTest(navigation, PropertyAccessMode.FieldDuringConstruction, null, null, Collection);
-            MemberInfoTest(navigation, PropertyAccessMode.Property, null, null, Collection);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferField, null, null, Collection);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferFieldDuringConstruction, null, null, Collection);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferProperty, null, null, Collection);
+            MemberInfoTest(CreateCollectionNavigation<ReadOnlyPropNoField>(null), null, null, null, Collection);
+            MemberInfoTest(CreateCollectionNavigation<ReadOnlyPropNoField>(null), PropertyAccessMode.Field,
+                null, null, NoFieldColl<ReadOnlyPropNoField>());
+            MemberInfoTest(CreateCollectionNavigation<ReadOnlyPropNoField>(null), PropertyAccessMode.FieldDuringConstruction, null, null, Collection);
+            MemberInfoTest(CreateCollectionNavigation<ReadOnlyPropNoField>(null), PropertyAccessMode.Property, null, null, Collection);
+            MemberInfoTest(CreateCollectionNavigation<ReadOnlyPropNoField>(null), PropertyAccessMode.PreferField, null, null, Collection);
+            MemberInfoTest(CreateCollectionNavigation<ReadOnlyPropNoField>(null), PropertyAccessMode.PreferFieldDuringConstruction,
+                null, null, Collection);
+            MemberInfoTest(CreateCollectionNavigation<ReadOnlyPropNoField>(null), PropertyAccessMode.PreferProperty, null, null, Collection);
         }
 
         [Fact]
         public void Get_MemberInfos_for_write_only_prop_collection_navigations_with_field_not_found()
         {
-            var navigation = CreateCollectionNavigation<WriteOnlyPropNoField>(null);
-
-            MemberInfoTest(navigation, null, Collection, Collection, NoFieldOrGetterColl<WriteOnlyPropNoField>());
-            MemberInfoTest(navigation, PropertyAccessMode.Field, null, null, NoFieldColl<WriteOnlyPropNoField>());
-            MemberInfoTest(
-                navigation, PropertyAccessMode.FieldDuringConstruction, null, Collection, NoFieldOrGetterColl<WriteOnlyPropNoField>());
-            MemberInfoTest(navigation, PropertyAccessMode.Property, Collection, Collection, NoGetterColl<WriteOnlyPropNoField>());
-            MemberInfoTest(navigation, PropertyAccessMode.PreferField, Collection, Collection, NoFieldOrGetterColl<WriteOnlyPropNoField>());
-            MemberInfoTest(
-                navigation, PropertyAccessMode.PreferProperty, Collection, Collection, NoFieldOrGetterColl<WriteOnlyPropNoField>());
+            MemberInfoTest(CreateCollectionNavigation<WriteOnlyPropNoField>(null), null,
+                Collection, Collection, NoFieldOrGetterColl<WriteOnlyPropNoField>());
+            MemberInfoTest(CreateCollectionNavigation<WriteOnlyPropNoField>(null), PropertyAccessMode.Field,
+                null, null, NoFieldColl<WriteOnlyPropNoField>());
+            MemberInfoTest(CreateCollectionNavigation<WriteOnlyPropNoField>(null), PropertyAccessMode.FieldDuringConstruction,
+                null, Collection, NoFieldOrGetterColl<WriteOnlyPropNoField>());
+            MemberInfoTest(CreateCollectionNavigation<WriteOnlyPropNoField>(null), PropertyAccessMode.Property,
+                Collection, Collection, NoGetterColl<WriteOnlyPropNoField>());
+            MemberInfoTest(CreateCollectionNavigation<WriteOnlyPropNoField>(null), PropertyAccessMode.PreferField,
+                Collection, Collection, NoFieldOrGetterColl<WriteOnlyPropNoField>());
+            MemberInfoTest(CreateCollectionNavigation<WriteOnlyPropNoField>(null), PropertyAccessMode.PreferProperty,
+                Collection, Collection, NoFieldOrGetterColl<WriteOnlyPropNoField>());
         }
 
         [Fact]
         public void Get_MemberInfos_for_full_prop_collection_navigations_private_setter_in_base()
         {
             const string field = "_collection";
-            var navigation = CreateCollectionNavigation<PrivateSetterInBase>(field);
 
-            MemberInfoTest(navigation, null, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.Field, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.FieldDuringConstruction, field, Collection, Collection);
-            MemberInfoTest(navigation, PropertyAccessMode.Property, Collection, Collection, Collection);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferField, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferProperty, Collection, Collection, Collection);
+            MemberInfoTest(CreateCollectionNavigation<PrivateSetterInBase>(field), null, field, field, field);
+            MemberInfoTest(CreateCollectionNavigation<PrivateSetterInBase>(field), PropertyAccessMode.Field, field, field, field);
+            MemberInfoTest(CreateCollectionNavigation<PrivateSetterInBase>(field), PropertyAccessMode.FieldDuringConstruction, field,
+                Collection, Collection);
+            MemberInfoTest(CreateCollectionNavigation<PrivateSetterInBase>(field), PropertyAccessMode.Property, Collection, Collection, Collection);
+            MemberInfoTest(CreateCollectionNavigation<PrivateSetterInBase>(field), PropertyAccessMode.PreferField, field, field, field);
+            MemberInfoTest(CreateCollectionNavigation<PrivateSetterInBase>(field), PropertyAccessMode.PreferProperty, Collection, Collection, Collection);
         }
 
         [Fact]
         public void Get_MemberInfos_for_full_prop_collection_navigations_private_getter_in_base()
         {
             const string field = "_collection";
-            var navigation = CreateCollectionNavigation<PrivateGetterInBase>(field);
 
-            MemberInfoTest(navigation, null, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.Field, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.FieldDuringConstruction, field, Collection, Collection);
-            MemberInfoTest(navigation, PropertyAccessMode.Property, Collection, Collection, Collection);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferField, field, field, field);
-            MemberInfoTest(navigation, PropertyAccessMode.PreferProperty, Collection, Collection, Collection);
+            MemberInfoTest(CreateCollectionNavigation<PrivateGetterInBase>(field), null, field, field, field);
+            MemberInfoTest(CreateCollectionNavigation<PrivateGetterInBase>(field), PropertyAccessMode.Field, field, field, field);
+            MemberInfoTest(CreateCollectionNavigation<PrivateGetterInBase>(field), PropertyAccessMode.FieldDuringConstruction,
+                field, Collection, Collection);
+            MemberInfoTest(CreateCollectionNavigation<PrivateGetterInBase>(field), PropertyAccessMode.Property, Collection, Collection, Collection);
+            MemberInfoTest(CreateCollectionNavigation<PrivateGetterInBase>(field), PropertyAccessMode.PreferField, field, field, field);
+            MemberInfoTest(CreateCollectionNavigation<PrivateGetterInBase>(field), PropertyAccessMode.PreferProperty, Collection, Collection, Collection);
         }
 
         private static string NoProperty<TEntity>(string fieldName)
@@ -652,6 +624,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             var property = entityType.AddProperty(propertyName, typeof(int));
             property.SetField(fieldName);
+            Assert.False(property.IsShadowProperty());
             return property;
         }
 

--- a/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
@@ -613,6 +613,8 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
                 var entityType = (IEntityType)model.FindEntityType(typeof(Quarks));
 
+                modelBuilder.FinalizeModel();
+
                 Assert.False(entityType.FindProperty("Up").IsShadowProperty());
                 Assert.False(entityType.FindProperty("Down").IsShadowProperty());
                 Assert.True(entityType.FindProperty("Gluon").IsShadowProperty());
@@ -625,7 +627,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             }
 
             [Fact]
-            public virtual void Properties_can_be_made_concurency_tokens()
+            public virtual void Properties_can_be_made_concurrency_tokens()
             {
                 var modelBuilder = CreateModelBuilder();
                 var model = modelBuilder.Model;
@@ -643,6 +645,8 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                     });
 
                 var entityType = (IEntityType)model.FindEntityType(typeof(Quarks));
+
+                modelBuilder.FinalizeModel();
 
                 Assert.False(entityType.FindProperty(Customer.IdProperty.Name).IsConcurrencyToken);
                 Assert.True(entityType.FindProperty("Up").IsConcurrencyToken);

--- a/test/EFCore.Tests/ModelBuilding/OneToManyTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OneToManyTestBase.cs
@@ -2748,7 +2748,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                         });
 
                 var contextOptions = new DbContextOptionsBuilder()
-                    .UseModel(modelBuilder.Model)
+                    .UseModel(((Model)modelBuilder.Model).FinalizeModel())
                     .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
                     .UseInMemoryDatabase("Can_use_self_referencing_overlapping_FK_PK")
                     .Options;

--- a/test/EFCore.Tests/ModelBuilding/OneToOneTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OneToOneTestBase.cs
@@ -1221,8 +1221,8 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var fkProperty = dependentType.FindProperty("OrderId");
                 var principalProperty = principalType.FindProperty("OrderId");
 
-                var principalPropertyCount = principalType.PropertyCount();
-                var dependentPropertyCount = dependentType.PropertyCount();
+                var principalPropertyCount = principalType.GetProperties().Count();
+                var dependentPropertyCount = dependentType.GetProperties().Count();
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
@@ -1230,6 +1230,8 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                     .Entity<Order>().HasOne(e => e.Details).WithOne(e => e.Order)
                     .HasForeignKey<OrderDetails>(e => e.OrderId)
                     .HasPrincipalKey<Order>(e => e.OrderId);
+
+                modelBuilder.FinalizeModel();
 
                 var fk = dependentType.GetForeignKeys().Single();
                 Assert.Same(fkProperty, fk.Properties.Single());
@@ -1239,8 +1241,8 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Assert.Equal("Details", principalType.GetNavigations().Single().Name);
                 Assert.Same(fk, dependentType.GetNavigations().Single().ForeignKey);
                 Assert.Same(fk, principalType.GetNavigations().Single().ForeignKey);
-                Assert.Equal(principalPropertyCount, principalType.PropertyCount());
-                Assert.Equal(dependentPropertyCount, dependentType.PropertyCount());
+                Assert.Equal(principalPropertyCount, principalType.GetProperties().Count());
+                Assert.Equal(dependentPropertyCount, dependentType.GetProperties().Count());
                 Assert.Empty(principalType.GetForeignKeys());
                 Assert.Same(principalKey, principalType.GetKeys().Single());
                 Assert.Same(dependentKey, dependentType.GetKeys().Single());
@@ -1266,8 +1268,8 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var fkProperty = dependentType.FindProperty("OrderId");
                 var principalProperty = principalType.FindProperty("OrderId");
 
-                var principalPropertyCount = principalType.PropertyCount();
-                var dependentPropertyCount = dependentType.PropertyCount();
+                var principalPropertyCount = principalType.GetProperties().Count();
+                var dependentPropertyCount = dependentType.GetProperties().Count();
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
@@ -1275,6 +1277,8 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                     .Entity<Order>().HasOne(e => e.Details).WithOne(e => e.Order)
                     .HasPrincipalKey<Order>(e => e.OrderId)
                     .HasForeignKey<OrderDetails>(e => e.OrderId);
+
+                modelBuilder.FinalizeModel();
 
                 var fk = dependentType.GetForeignKeys().Single();
                 Assert.Same(fkProperty, fk.Properties.Single());
@@ -1284,8 +1288,8 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Assert.Equal("Details", principalType.GetNavigations().Single().Name);
                 Assert.Same(fk, dependentType.GetNavigations().Single().ForeignKey);
                 Assert.Same(fk, principalType.GetNavigations().Single().ForeignKey);
-                Assert.Equal(principalPropertyCount, principalType.PropertyCount());
-                Assert.Equal(dependentPropertyCount, dependentType.PropertyCount());
+                Assert.Equal(principalPropertyCount, principalType.GetProperties().Count());
+                Assert.Equal(dependentPropertyCount, dependentType.GetProperties().Count());
                 Assert.Empty(principalType.GetForeignKeys());
                 Assert.Same(principalKey, principalType.GetKeys().Single());
                 Assert.Same(dependentKey, dependentType.GetKeys().Single());
@@ -4411,7 +4415,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                     });
 
                 var contextOptions = new DbContextOptionsBuilder()
-                    .UseModel(modelBuilder.Model)
+                    .UseModel(modelBuilder.Model.FinalizeModel())
                     .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
                     .UseInMemoryDatabase("Can_use_self_referencing_overlapping_FK_PK_one_to_one")
                     .Options;


### PR DESCRIPTION
Filter out core annotations from conventions.
Remove PropertyMetadataChanged() and don't calculate counts while the model is mutable.

Part of #214