### PR TITLE
Query: Reenable tests

### DIFF
--- a/src/EFCore.InMemory/Query/Pipeline/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Pipeline/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
@@ -62,7 +62,17 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Pipeline
         protected override ShapedQueryExpression TranslateAverage(ShapedQueryExpression source, LambdaExpression selector, Type resultType)
             => TranslateScalarAggregate(source, selector, nameof(Enumerable.Average));
 
-        protected override ShapedQueryExpression TranslateCast(ShapedQueryExpression source, Type resultType) => throw new NotImplementedException();
+        protected override ShapedQueryExpression TranslateCast(ShapedQueryExpression source, Type resultType)
+        {
+            if (source.ShaperExpression.Type == resultType)
+            {
+                return source;
+            }
+
+            source.ShaperExpression = Expression.Convert(source.ShaperExpression, resultType);
+
+            return source;
+        }
 
         protected override ShapedQueryExpression TranslateConcat(ShapedQueryExpression source1, ShapedQueryExpression source2) => throw new NotImplementedException();
 

--- a/src/EFCore.Relational/Query/Pipeline/RelationalProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Pipeline/RelationalProjectionBindingRemovingExpressionVisitor.cs
@@ -7,6 +7,7 @@ using System.Data.Common;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Query.Pipeline;
@@ -48,6 +49,15 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 
                     return Expression.MakeBinary(ExpressionType.Assign, binaryExpression.Left, updatedExpression);
                 }
+
+                if (binaryExpression.NodeType == ExpressionType.Assign
+                    && binaryExpression.Left is MemberExpression memberExpression
+                    && memberExpression.Member is FieldInfo fieldInfo
+                    && fieldInfo.IsInitOnly)
+                {
+                    return memberExpression.Assign(Visit(binaryExpression.Right));
+                }
+
 
                 return base.VisitBinary(binaryExpression);
             }

--- a/src/EFCore.SqlServer.NTS/Storage/Internal/SqlServerGeometryTypeMapping.cs
+++ b/src/EFCore.SqlServer.NTS/Storage/Internal/SqlServerGeometryTypeMapping.cs
@@ -13,6 +13,7 @@ using Microsoft.Data.SqlClient; // Note: Hard reference to SqlClient here.
 using Microsoft.EntityFrameworkCore.SqlServer.Storage.ValueConversion.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using NetTopologySuite.Geometries;
 using NetTopologySuite.IO;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
@@ -80,6 +81,10 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
             var builder = new StringBuilder();
             var geometry = (IGeometry)value;
             var defaultSrid = geometry.SRID == (_isGeography ? 4326 : 0);
+            if (geometry == Point.Empty)
+            {
+                defaultSrid = true;
+            }
 
             builder
                 .Append(_isGeography ? "geography" : "geometry")

--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -391,7 +391,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <summary>
         ///     <para>
         ///         Saves all changes made in this context to the database.
-        ///     </para>     
+        ///     </para>
         ///     <para>
         ///         This method will automatically call <see cref="ChangeTracking.ChangeTracker.DetectChanges" /> to discover any
         ///         changes to entity instances before saving to the underlying database. This can be disabled via
@@ -414,7 +414,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <summary>
         ///     <para>
         ///         Saves all changes made in this context to the database.
-        ///     </para>     
+        ///     </para>
         ///     <para>
         ///         This method will automatically call <see cref="ChangeTracking.ChangeTracker.DetectChanges" /> to discover any
         ///         changes to entity instances before saving to the underlying database. This can be disabled via
@@ -485,7 +485,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <summary>
         ///     <para>
         ///         Saves all changes made in this context to the database.
-        ///     </para>     
+        ///     </para>
         ///     <para>
         ///         This method will automatically call <see cref="ChangeTracking.ChangeTracker.DetectChanges" /> to discover any
         ///         changes to entity instances before saving to the underlying database. This can be disabled via
@@ -515,7 +515,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <summary>
         ///     <para>
         ///         Saves all changes made in this context to the database.
-        ///     </para>     
+        ///     </para>
         ///     <para>
         ///         This method will automatically call <see cref="ChangeTracking.ChangeTracker.DetectChanges" /> to discover any
         ///         changes to entity instances before saving to the underlying database. This can be disabled via

--- a/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
+++ b/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
@@ -327,58 +327,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static bool IsNullPropagationCandidate(
-            [NotNull] this ConditionalExpression conditionalExpression,
-            out Expression testExpression,
-            out Expression resultExpression)
-        {
-            Check.NotNull(conditionalExpression, nameof(conditionalExpression));
-
-            testExpression = null;
-            resultExpression = null;
-
-            if (!(conditionalExpression.Test is BinaryExpression binaryTest)
-                || !(binaryTest.NodeType == ExpressionType.Equal
-                     || binaryTest.NodeType == ExpressionType.NotEqual))
-            {
-                return false;
-            }
-
-            var isLeftNullConstant = binaryTest.Left.IsNullConstantExpression();
-            var isRightNullConstant = binaryTest.Right.IsNullConstantExpression();
-
-            if (isLeftNullConstant == isRightNullConstant)
-            {
-                return false;
-            }
-
-            if (binaryTest.NodeType == ExpressionType.Equal)
-            {
-                if (!conditionalExpression.IfTrue.IsNullConstantExpression())
-                {
-                    return false;
-                }
-            }
-            else
-            {
-                if (!conditionalExpression.IfFalse.IsNullConstantExpression())
-                {
-                    return false;
-                }
-            }
-
-            testExpression = isLeftNullConstant ? binaryTest.Right : binaryTest.Left;
-            resultExpression = binaryTest.NodeType == ExpressionType.Equal ? conditionalExpression.IfFalse : conditionalExpression.IfTrue;
-
-            return true;
-        }
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
         public static Expression Assign(
             [NotNull] this MemberExpression memberExpression,
             [NotNull] Expression valueExpression)

--- a/src/EFCore/Query/Pipeline/ShapedQueryExpressionVisitor.cs
+++ b/src/EFCore/Query/Pipeline/ShapedQueryExpressionVisitor.cs
@@ -279,9 +279,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
                 {
                     expressions.Add(Expression.Condition(
                         (primaryKey != null
-                            ? primaryKey.Properties
-                            : entityType.GetProperties())
-                                .Select(p =>
+                            ? primaryKey.Properties.Select(p =>
                                     Expression.Equal(
                                         _entityMaterializerSource.CreateReadValueExpression(
                                             entityShaperExpression.ValueBufferExpression,
@@ -289,7 +287,17 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
                                             p.GetIndex(),
                                             p),
                                         Expression.Constant(null)))
-                                    .Aggregate((a, b) => Expression.OrElse(a, b)),
+                                    .Aggregate((a, b) => Expression.OrElse(a, b))
+                            : entityType.GetProperties()
+                                .Select(p =>
+                                        Expression.Equal(
+                                            _entityMaterializerSource.CreateReadValueExpression(
+                                                entityShaperExpression.ValueBufferExpression,
+                                                typeof(object),
+                                                p.GetIndex(),
+                                                p),
+                                            Expression.Constant(null)))
+                                        .Aggregate((a, b) => Expression.AndAlso(a, b))),
                             Expression.Constant(null, entityType.ClrType),
                             MaterializeEntity(entityType, valueBuffer)));
                 }

--- a/test/EFCore.InMemory.FunctionalTests/CustomConvertersInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/CustomConvertersInMemoryTest.cs
@@ -25,6 +25,12 @@ namespace Microsoft.EntityFrameworkCore
             base.Can_insert_and_read_back_with_string_key();
         }
 
+        [ConditionalFact(Skip = "Issue#15711")]
+        public override void Can_query_and_update_with_nullable_converter_on_primary_key()
+        {
+            base.Can_query_and_update_with_nullable_converter_on_primary_key();
+        }
+
         public class CustomConvertersInMemoryFixture : CustomConvertersFixtureBase
         {
             public override bool StrictEquality => true;

--- a/test/EFCore.InMemory.FunctionalTests/FieldMappingInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/FieldMappingInMemoryTest.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore
 {
@@ -11,6 +12,132 @@ namespace Microsoft.EntityFrameworkCore
         public FieldMappingInMemoryTest(FieldMappingInMemoryFixture fixture)
             : base(fixture)
         {
+        }
+
+        [ConditionalFact(Skip = "Issue#15711")]
+        public override void Field_mapping_with_conversion_does_not_throw()
+        {
+            base.Field_mapping_with_conversion_does_not_throw();
+        }
+
+        [ConditionalTheory(Skip = "Issue#15711")]
+        public override void Include_collection_auto_props(bool tracking)
+        {
+            base.Include_collection_auto_props(tracking);
+        }
+
+        [ConditionalTheory(Skip = "Issue#15711")]
+        public override void Include_collection_fields_only(bool tracking)
+        {
+            base.Include_collection_fields_only(tracking);
+        }
+
+        [ConditionalTheory(Skip = "Issue#15711")]
+        public override void Include_collection_fields_only_for_navs_too(bool tracking)
+        {
+            base.Include_collection_fields_only_for_navs_too(tracking);
+        }
+
+        [ConditionalTheory(Skip = "Issue#15711")]
+        public override void Include_collection_full_props(bool tracking)
+        {
+            base.Include_collection_full_props(tracking);
+        }
+
+        [ConditionalTheory(Skip = "Issue#15711")]
+        public override void Include_collection_full_props_with_named_fields(bool tracking)
+        {
+            base.Include_collection_full_props_with_named_fields(tracking);
+        }
+
+        [ConditionalTheory(Skip = "Issue#15711")]
+        public override void Include_collection_hiding_props(bool tracking)
+        {
+            base.Include_collection_hiding_props(tracking);
+        }
+
+        [ConditionalTheory(Skip = "Issue#15711")]
+        public override void Include_collection_read_only_props(bool tracking)
+        {
+            base.Include_collection_read_only_props(tracking);
+        }
+
+        [ConditionalTheory(Skip = "Issue#15711")]
+        public override void Include_collection_read_only_props_with_named_fields(bool tracking)
+        {
+            base.Include_collection_read_only_props_with_named_fields(tracking);
+        }
+
+        [ConditionalTheory(Skip = "Issue#15711")]
+        public override void Include_collection_write_only_props(bool tracking)
+        {
+            base.Include_collection_write_only_props(tracking);
+        }
+
+        [ConditionalTheory(Skip = "Issue#15711")]
+        public override void Include_collection_write_only_props_with_named_fields(bool tracking)
+        {
+            base.Include_collection_write_only_props_with_named_fields(tracking);
+        }
+
+        [ConditionalTheory(Skip = "Issue#15711")]
+        public override void Include_reference_auto_props(bool tracking)
+        {
+            base.Include_reference_auto_props(tracking);
+        }
+
+        [ConditionalTheory(Skip = "Issue#15711")]
+        public override void Include_reference_fields_only(bool tracking)
+        {
+            base.Include_reference_fields_only(tracking);
+        }
+
+        [ConditionalTheory(Skip = "Issue#15711")]
+        public override void Include_reference_fields_only_only_for_navs_too(bool tracking)
+        {
+            base.Include_reference_fields_only_only_for_navs_too(tracking);
+        }
+
+        [ConditionalTheory(Skip = "Issue#15711")]
+        public override void Include_reference_full_props(bool tracking)
+        {
+            base.Include_reference_full_props(tracking);
+        }
+
+        [ConditionalTheory(Skip = "Issue#15711")]
+        public override void Include_reference_full_props_with_named_fields(bool tracking)
+        {
+            base.Include_reference_full_props_with_named_fields(tracking);
+        }
+
+        [ConditionalTheory(Skip = "Issue#15711")]
+        public override void Include_reference_hiding_props(bool tracking)
+        {
+            base.Include_reference_hiding_props(tracking);
+        }
+
+        [ConditionalTheory(Skip = "Issue#15711")]
+        public override void Include_reference_read_only_props(bool tracking)
+        {
+            base.Include_reference_read_only_props(tracking);
+        }
+
+        [ConditionalTheory(Skip = "Issue#15711")]
+        public override void Include_reference_read_only_props_with_named_fields(bool tracking)
+        {
+            base.Include_reference_read_only_props_with_named_fields(tracking);
+        }
+
+        [ConditionalTheory(Skip = "Issue#15711")]
+        public override void Include_reference_write_only_props(bool tracking)
+        {
+            base.Include_reference_write_only_props(tracking);
+        }
+
+        [ConditionalTheory(Skip = "Issue#15711")]
+        public override void Include_reference_write_only_props_with_named_fields(bool tracking)
+        {
+            base.Include_reference_write_only_props_with_named_fields(tracking);
         }
 
         protected override void Update<TBlog>(string navigation)

--- a/test/EFCore.InMemory.FunctionalTests/InMemoryComplianceTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/InMemoryComplianceTest.cs
@@ -41,6 +41,8 @@ namespace Microsoft.EntityFrameworkCore
             typeof(SpatialQueryTestBase<>),
             typeof(UpdatesTestBase<>),
             typeof(FindTestBase<>),
+            typeof(NotificationEntitiesTestBase<>),
+            typeof(PropertyValuesTestBase<>),
         };
 
         protected override Assembly TargetAssembly { get; } = typeof(InMemoryComplianceTest).Assembly;

--- a/test/EFCore.InMemory.FunctionalTests/LazyLoadProxyInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/LazyLoadProxyInMemoryTest.cs
@@ -1,7 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore
 {
@@ -10,6 +12,60 @@ namespace Microsoft.EntityFrameworkCore
         public LazyLoadProxyInMemoryTest(LoadInMemoryFixture fixture)
             : base(fixture)
         {
+        }
+
+        [ConditionalTheory(Skip = "Issue#15711")]
+        public override void Lazy_load_collection_already_loaded(EntityState state, CascadeTiming cascadeDeleteTiming)
+        {
+            base.Lazy_load_collection_already_loaded(state, cascadeDeleteTiming);
+        }
+
+        [ConditionalFact(Skip = "Issue#15711")]
+        public override void Lazy_load_collection_for_no_tracking_does_not_throw_if_populated()
+        {
+            base.Lazy_load_collection_for_no_tracking_does_not_throw_if_populated();
+        }
+
+        [ConditionalFact(Skip = "Issue#15711")]
+        public override void Lazy_load_reference_to_principal_for_no_tracking_does_not_throw_if_populated()
+        {
+            base.Lazy_load_reference_to_principal_for_no_tracking_does_not_throw_if_populated();
+        }
+
+        [ConditionalFact(Skip = "Issue#15711")]
+        public override void Lazy_load_reference_to_dependent_for_no_does_not_throw_if_populated()
+        {
+            base.Lazy_load_reference_to_dependent_for_no_does_not_throw_if_populated();
+        }
+
+        [ConditionalTheory(Skip = "Issue#15711")]
+        public override void Lazy_load_many_to_one_reference_to_principal_already_loaded(EntityState state, CascadeTiming cascadeDeleteTiming)
+        {
+            base.Lazy_load_many_to_one_reference_to_principal_already_loaded(state, cascadeDeleteTiming);
+        }
+
+        [ConditionalTheory(Skip = "Issue#15711")]
+        public override void Lazy_load_one_to_one_PK_to_PK_reference_to_dependent_already_loaded(EntityState state)
+        {
+            base.Lazy_load_one_to_one_PK_to_PK_reference_to_dependent_already_loaded(state);
+        }
+
+        [ConditionalTheory(Skip = "Issue#15711")]
+        public override void Lazy_load_one_to_one_PK_to_PK_reference_to_principal_already_loaded(EntityState state)
+        {
+            base.Lazy_load_one_to_one_PK_to_PK_reference_to_principal_already_loaded(state);
+        }
+
+        [ConditionalTheory(Skip = "Issue#15711")]
+        public override void Lazy_load_one_to_one_reference_to_dependent_already_loaded(EntityState state, CascadeTiming cascadeDeleteTiming)
+        {
+            base.Lazy_load_one_to_one_reference_to_dependent_already_loaded(state, cascadeDeleteTiming);
+        }
+
+        [ConditionalTheory(Skip = "Issue#15711")]
+        public override void Lazy_load_one_to_one_reference_to_principal_already_loaded(EntityState state)
+        {
+            base.Lazy_load_one_to_one_reference_to_principal_already_loaded(state);
         }
 
         public class LoadInMemoryFixture : LoadFixtureBase

--- a/test/EFCore.InMemory.FunctionalTests/NotificationEntitiesInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/NotificationEntitiesInMemoryTest.cs
@@ -5,8 +5,7 @@ using Microsoft.EntityFrameworkCore.TestUtilities;
 
 namespace Microsoft.EntityFrameworkCore
 {
-    public class NotificationEntitiesInMemoryTest : NotificationEntitiesTestBase<
-        NotificationEntitiesInMemoryTest.NotificationEntitiesInMemoryFixture>
+    internal class NotificationEntitiesInMemoryTest : NotificationEntitiesTestBase<NotificationEntitiesInMemoryTest.NotificationEntitiesInMemoryFixture>
     {
         public NotificationEntitiesInMemoryTest(NotificationEntitiesInMemoryFixture fixture)
             : base(fixture)

--- a/test/EFCore.InMemory.FunctionalTests/PropertyValuesInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/PropertyValuesInMemoryTest.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.TestUtilities;
 
 namespace Microsoft.EntityFrameworkCore
 {
-    public class PropertyValuesInMemoryTest : PropertyValuesTestBase<PropertyValuesInMemoryTest.PropertyValuesInMemoryFixture>
+    internal class PropertyValuesInMemoryTest : PropertyValuesTestBase<PropertyValuesInMemoryTest.PropertyValuesInMemoryFixture>
     {
         public PropertyValuesInMemoryTest(PropertyValuesInMemoryFixture fixture)
             : base(fixture)

--- a/test/EFCore.InMemory.FunctionalTests/SpatialInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/SpatialInMemoryTest.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore
 {
@@ -11,6 +12,12 @@ namespace Microsoft.EntityFrameworkCore
         public SpatialInMemoryTest(SpatialInMemoryFixture fixture)
             : base(fixture)
         {
+        }
+
+        [ConditionalFact(Skip = "Issue#15711")]
+        public override void Mutation_of_tracked_values_does_not_mutate_values_in_store()
+        {
+            base.Mutation_of_tracked_values_does_not_mutate_values_in_store();
         }
 
         protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)

--- a/test/EFCore.InMemory.FunctionalTests/WithConstructorsInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/WithConstructorsInMemoryTest.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore
@@ -21,6 +22,7 @@ namespace Microsoft.EntityFrameworkCore
             base.Query_with_keyless_type();
         }
 
+        [ConditionalFact(Skip = "Issue#15711")]
         public override void Query_and_update_using_constructors_with_property_parameters()
         {
             base.Query_and_update_using_constructors_with_property_parameters();

--- a/test/EFCore.Relational.Specification.Tests/Query/AsyncFromSqlQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/AsyncFromSqlQueryTestBase.cs
@@ -303,7 +303,7 @@ FROM [Customers]"))
             }
         }
 
-        [Fact(Skip = "issue #15611")]
+        [Fact(Skip = "issue #15991")]
         public virtual async Task FromSqlRaw_queryable_simple_include()
         {
             using (var context = CreateContext())
@@ -316,14 +316,14 @@ FROM [Customers]"))
             }
         }
 
-        [Fact(Skip = "issue #15611")]
+        [Fact(Skip = "issue #15991")]
         public virtual async Task FromSqlRaw_queryable_simple_composed_include()
         {
             using (var context = CreateContext())
             {
                 var actual = await context.Set<Customer>().FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Customers]"))
-                    .Where(c => c.City == "London")
                     .Include(c => c.Orders)
+                    .Where(c => c.City == "London")
                     .ToArrayAsync();
 
                 Assert.Equal(46, actual.SelectMany(c => c.Orders).Count());
@@ -361,7 +361,7 @@ FROM [Customers]"))
             }
         }
 
-        [Fact(Skip = "issue #15611")]
+        [Fact]
         public virtual async Task Include_does_not_close_user_opened_connection_for_empty_result()
         {
             Fixture.TestStore.CloseConnection();
@@ -391,7 +391,7 @@ FROM [Customers]"))
             Fixture.TestStore.OpenConnection();
         }
 
-        [Fact(Skip = "issue #15611")]
+        [Fact]
         public virtual async Task Include_closed_connection_opened_by_it_when_buffering()
         {
             Fixture.TestStore.CloseConnection();

--- a/test/EFCore.Relational.Specification.Tests/Query/FromSqlQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/FromSqlQueryTestBase.cs
@@ -661,7 +661,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
             }
         }
 
-        [Fact(Skip = "issue #15611")]
+        [Fact(Skip = "issue #15991")]
         public virtual void FromSqlRaw_queryable_simple_include()
         {
             using (var context = CreateContext())
@@ -674,14 +674,14 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
             }
         }
 
-        [Fact(Skip = "issue #15611")]
+        [Fact(Skip = "issue #15991")]
         public virtual void FromSqlRaw_queryable_simple_composed_include()
         {
             using (var context = CreateContext())
             {
                 var actual = context.Set<Customer>().FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Customers]"))
-                    .Where(c => c.City == "London")
                     .Include(c => c.Orders)
+                    .Where(c => c.City == "London")
                     .ToArray();
 
                 Assert.Equal(46, actual.SelectMany(c => c.Orders).Count());
@@ -765,7 +765,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
             }
         }
 
-        [Fact(Skip = "Uses Include()")]
+        [Fact]
         public virtual void Include_does_not_close_user_opened_connection_for_empty_result()
         {
             Fixture.TestStore.CloseConnection();
@@ -816,7 +816,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
             }
         }
 
-        [Fact(Skip = "issue #15611")]
+        [Fact(Skip = "issue #15991")]
         public virtual void FromSqlRaw_with_SelectMany_and_include()
         {
             using (var context = CreateContext())
@@ -849,7 +849,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
             }
         }
 
-        [Fact(Skip = "issue #15611")]
+        [Fact(Skip = "issue #15991")]
         public virtual void FromSqlRaw_with_join_and_include()
         {
             using (var context = CreateContext())
@@ -877,7 +877,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
             }
         }
 
-        [Fact(Skip = "Uses Include()")]
+        [Fact]
         public virtual void Include_closed_connection_opened_by_it_when_buffering()
         {
             Fixture.TestStore.CloseConnection();

--- a/test/EFCore.Relational.Specification.Tests/Query/FromSqlSprocQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/FromSqlSprocQueryTestBase.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 using Xunit;
 
 // ReSharper disable InconsistentNaming
@@ -56,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact(Skip = "Issue#15889")]
+        [ConditionalFact(Skip = "Issue#14935")]
         public virtual void From_sql_queryable_stored_procedure_reprojection()
         {
             using (var context = CreateContext())

--- a/test/EFCore.Relational.Specification.Tests/TransactionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/TransactionTestBase.cs
@@ -895,7 +895,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Theory(Skip = "QueryIssue")]
+        [Theory]
         [InlineData(true)]
         [InlineData(false)]
         public virtual async Task QueryAsync_uses_explicit_transaction(bool autoTransaction)
@@ -1265,7 +1265,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Theory(Skip = "QueryIssue")]
+        [Theory]
         [InlineData(true)]
         [InlineData(false)]
         public virtual async Task Externally_closed_connections_are_handled_correctly(bool async)

--- a/test/EFCore.Specification.Tests/CustomConvertersTestBase.cs
+++ b/test/EFCore.Specification.Tests/CustomConvertersTestBase.cs
@@ -128,7 +128,7 @@ namespace Microsoft.EntityFrameworkCore
             public SocialSecurityNumber? SSN { get; set; }
         }
 
-        [Fact(Skip = "TaskList#19")]
+        [Fact]
         public virtual void Can_query_and_update_with_nullable_converter_on_primary_key()
         {
             using (var context = CreateContext())
@@ -267,7 +267,7 @@ namespace Microsoft.EntityFrameworkCore
             public double Volume { get; }
         }
 
-        [Fact(Skip = "TaskList#19")]
+        [Fact]
         public virtual void Can_insert_and_read_back_with_case_insensitive_string_key()
         {
             using (var context = CreateContext())

--- a/test/EFCore.Specification.Tests/FieldMappingTestBase.cs
+++ b/test/EFCore.Specification.Tests/FieldMappingTestBase.cs
@@ -55,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "Tasklist#19#Include")]
+        [Fact]
         public virtual void Field_mapping_with_conversion_does_not_throw()
         {
             using (var context = CreateContext())
@@ -99,7 +99,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Theory(Skip = "Tasklist#19#Include")]
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Include_collection_auto_props(bool tracking)
@@ -110,7 +110,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Theory(Skip = "Tasklist#19#Include")]
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Include_reference_auto_props(bool tracking)
@@ -162,7 +162,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Theory(Skip = "Tasklist#19#Include")]
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Include_collection_hiding_props(bool tracking)
@@ -173,7 +173,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Theory(Skip = "Tasklist#19#Include")]
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Include_reference_hiding_props(bool tracking)
@@ -225,7 +225,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Theory(Skip = "Tasklist#19#Include")]
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Include_collection_full_props(bool tracking)
@@ -236,7 +236,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Theory(Skip = "Tasklist#19#Include")]
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Include_reference_full_props(bool tracking)
@@ -288,7 +288,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Theory(Skip = "Tasklist#19#Include")]
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Include_collection_full_props_with_named_fields(bool tracking)
@@ -299,7 +299,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Theory(Skip = "Tasklist#19#Include")]
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Include_reference_full_props_with_named_fields(bool tracking)
@@ -351,7 +351,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Theory(Skip = "Tasklist#19#Include")]
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Include_collection_read_only_props(bool tracking)
@@ -362,7 +362,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Theory(Skip = "Tasklist#19#Include")]
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Include_reference_read_only_props(bool tracking)
@@ -414,7 +414,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Theory(Skip = "Tasklist#19#Include")]
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Include_collection_read_only_props_with_named_fields(bool tracking)
@@ -425,7 +425,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Theory(Skip = "Tasklist#19#Include")]
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Include_reference_read_only_props_with_named_fields(bool tracking)
@@ -489,7 +489,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Theory(Skip = "Tasklist#19#Include")]
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Include_collection_write_only_props(bool tracking)
@@ -500,7 +500,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Theory(Skip = "Tasklist#19#Include")]
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Include_reference_write_only_props(bool tracking)
@@ -552,7 +552,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Theory(Skip = "Tasklist#19#Include")]
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Include_collection_write_only_props_with_named_fields(bool tracking)
@@ -563,7 +563,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Theory(Skip = "Tasklist#19#Include")]
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Include_reference_write_only_props_with_named_fields(bool tracking)
@@ -615,7 +615,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Theory(Skip = "Tasklist#19#Include")]
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Include_collection_fields_only(bool tracking)
@@ -626,7 +626,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Theory(Skip = "Tasklist#19#Include")]
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Include_reference_fields_only(bool tracking)
@@ -678,7 +678,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Theory(Skip = "Tasklist#19#Include")]
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Include_collection_fields_only_for_navs_too(bool tracking)
@@ -689,7 +689,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Theory(Skip = "Tasklist#19#Include")]
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public virtual void Include_reference_fields_only_only_for_navs_too(bool tracking)

--- a/test/EFCore.Specification.Tests/LazyLoadProxyTestBase.cs
+++ b/test/EFCore.Specification.Tests/LazyLoadProxyTestBase.cs
@@ -755,7 +755,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Theory(Skip = "issue #15318")]
+        [Theory]
         [InlineData(EntityState.Unchanged, CascadeTiming.Immediate)]
         [InlineData(EntityState.Modified, CascadeTiming.Immediate)]
         [InlineData(EntityState.Deleted, CascadeTiming.Immediate)]
@@ -807,7 +807,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Theory(Skip = "issue #15318")]
+        [Theory]
         [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges)]
         [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges)]
         [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges)]
@@ -855,7 +855,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Theory(Skip = "issue #15318")]
+        [Theory]
         [InlineData(EntityState.Unchanged)]
         [InlineData(EntityState.Modified)]
         [InlineData(EntityState.Deleted)]
@@ -895,7 +895,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Theory(Skip = "issue #15318")]
+        [Theory]
         [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges)]
         [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges)]
         [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges)]
@@ -954,7 +954,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Theory(Skip = "issue #15318")]
+        [Theory]
         [InlineData(EntityState.Unchanged)]
         [InlineData(EntityState.Modified)]
         [InlineData(EntityState.Deleted)]
@@ -994,7 +994,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Theory(Skip = "issue #15318")]
+        [Theory]
         [InlineData(EntityState.Unchanged)]
         [InlineData(EntityState.Modified)]
         [InlineData(EntityState.Deleted)]
@@ -1697,7 +1697,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "issue #15318")]
+        [Fact]
         public virtual void Lazy_load_collection_for_no_tracking_does_not_throw_if_populated()
         {
             using (var context = CreateContext(lazyLoadingEnabled: true))
@@ -1712,7 +1712,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "issue #15318")]
+        [Fact]
         public virtual void Lazy_load_reference_to_principal_for_no_tracking_does_not_throw_if_populated()
         {
             using (var context = CreateContext(lazyLoadingEnabled: true))
@@ -1727,7 +1727,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "issue #15318")]
+        [Fact]
         public virtual void Lazy_load_reference_to_dependent_for_no_does_not_throw_if_populated()
         {
             using (var context = CreateContext(lazyLoadingEnabled: true))
@@ -1742,7 +1742,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Theory(Skip = "QueryIssue")]
+        [Theory]
         [InlineData(EntityState.Unchanged, true)]
         [InlineData(EntityState.Unchanged, false)]
         [InlineData(EntityState.Modified, true)]
@@ -1859,7 +1859,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual void Lazy_loading_shares_service__property_on_derived_types()
         {
             using (var context = CreateContext(lazyLoadingEnabled: true))

--- a/test/EFCore.Specification.Tests/MonsterFixupTestBase.cs
+++ b/test/EFCore.Specification.Tests/MonsterFixupTestBase.cs
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore
         protected TestStore TestStore { get; }
         protected DbContextOptions Options { get; }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual void Can_build_monster_model_and_seed_data_using_FKs()
         {
             CreateAndSeedDatabase(context => context.SeedUsingFKs());
@@ -38,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore
             NavigationVerification();
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual void Can_build_monster_model_and_seed_data_using_all_navigations()
         {
             CreateAndSeedDatabase(context => context.SeedUsingNavigations(dependentNavs: true, principalNavs: true));
@@ -48,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore
             NavigationVerification();
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual void Can_build_monster_model_and_seed_data_using_dependent_navigations()
         {
             CreateAndSeedDatabase(context => context.SeedUsingNavigations(dependentNavs: true, principalNavs: false));
@@ -58,7 +58,7 @@ namespace Microsoft.EntityFrameworkCore
             NavigationVerification();
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual void Can_build_monster_model_and_seed_data_using_principal_navigations()
         {
             CreateAndSeedDatabase(context => context.SeedUsingNavigations(dependentNavs: false, principalNavs: true));
@@ -68,7 +68,7 @@ namespace Microsoft.EntityFrameworkCore
             NavigationVerification();
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual void Can_build_monster_model_and_seed_data_using_navigations_with_deferred_add()
         {
             CreateAndSeedDatabase(context => context.SeedUsingNavigationsWithDeferredAdd());

--- a/test/EFCore.Specification.Tests/NotificationEntitiesTestBase.cs
+++ b/test/EFCore.Specification.Tests/NotificationEntitiesTestBase.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore
 
         protected virtual TFixture Fixture { get; }
 
-        [Fact(Skip = "issue #15318")] // Issue #4020
+        [Fact] // Issue #4020
         public virtual void Include_brings_entities_referenced_from_already_tracked_notification_entities_as_Unchanged()
         {
             using (var context = CreateContext())
@@ -34,7 +34,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "issue #15318")] // Issue #4020
+        [Fact] // Issue #4020
         public virtual void Include_brings_collections_referenced_from_already_tracked_notification_entities_as_Unchanged()
         {
             using (var context = CreateContext())

--- a/test/EFCore.Specification.Tests/OptimisticConcurrencyTestBase.cs
+++ b/test/EFCore.Specification.Tests/OptimisticConcurrencyTestBase.cs
@@ -76,7 +76,7 @@ namespace Microsoft.EntityFrameworkCore
 
         #region Concurrency resolution with FK associations
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task Simple_concurrency_exception_can_be_resolved_with_client_values()
         {
             return ConcurrencyTestAsync(
@@ -88,7 +88,7 @@ namespace Microsoft.EntityFrameworkCore
                 });
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task Simple_concurrency_exception_can_be_resolved_with_store_values()
         {
             return ConcurrencyTestAsync(
@@ -102,7 +102,7 @@ namespace Microsoft.EntityFrameworkCore
                 });
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task Simple_concurrency_exception_can_be_resolved_with_new_values()
         {
             return ConcurrencyTestAsync(
@@ -115,7 +115,7 @@ namespace Microsoft.EntityFrameworkCore
                 });
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task Simple_concurrency_exception_can_be_resolved_with_store_values_using_equivalent_of_accept_changes()
         {
             return ConcurrencyTestAsync(
@@ -414,7 +414,7 @@ namespace Microsoft.EntityFrameworkCore
                 c => Assert.Equal(1, c.Drivers.Single(d => d.Name == "Fernando Alonso").Wins));
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task
             Updating_then_deleting_the_same_entity_results_in_DbUpdateConcurrencyException_which_can_be_resolved_with_store_values()
         {
@@ -564,31 +564,31 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Theory(Skip = "QueryIssue")]
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public virtual async Task Calling_Reload_on_an_Unchanged_entity_makes_the_entity_unchanged(bool async)
             => await TestReloadPositive(EntityState.Unchanged, async);
 
-        [Theory(Skip = "QueryIssue")]
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public virtual async Task Calling_Reload_on_a_Modified_entity_makes_the_entity_unchanged(bool async)
             => await TestReloadPositive(EntityState.Modified, async);
 
-        [Theory(Skip = "QueryIssue")]
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public virtual async Task Calling_Reload_on_a_Deleted_entity_makes_the_entity_unchanged(bool async)
             => await TestReloadPositive(EntityState.Deleted, async);
 
-        [Theory(Skip = "QueryIssue")]
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public virtual async Task Calling_Reload_on_an_Added_entity_that_was_saved_elsewhere_makes_the_entity_unchanged(bool async)
             => await TestReloadPositive(EntityState.Added, async);
 
-        [Theory(Skip = "QueryIssue")]
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public virtual async Task Calling_Reload_on_a_Detached_entity_makes_the_entity_unchanged(bool async)

--- a/test/EFCore.Specification.Tests/PropertyValuesTestBase.cs
+++ b/test/EFCore.Specification.Tests/PropertyValuesTestBase.cs
@@ -38,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore
             return TestPropertyValuesScalars(e => Task.FromResult(e.OriginalValues), expectOriginalValues: true);
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task Scalar_store_values_can_be_accessed_as_a_property_dictionary()
         {
             return TestPropertyValuesScalars(e => Task.FromResult(e.GetDatabaseValues()), expectOriginalValues: true);
@@ -94,7 +94,7 @@ namespace Microsoft.EntityFrameworkCore
             return TestPropertyValuesScalarsIProperty(e => Task.FromResult(e.OriginalValues), expectOriginalValues: true);
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task Scalar_store_values_can_be_accessed_as_a_property_dictionary_using_IProperty()
         {
             return TestPropertyValuesScalarsIProperty(e => Task.FromResult(e.GetDatabaseValues()), expectOriginalValues: true);
@@ -139,25 +139,25 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task Scalar_current_values_of_a_derived_object_can_be_accessed_as_a_property_dictionary()
         {
             return TestPropertyValuesDerivedScalars(e => Task.FromResult(e.CurrentValues), expectOriginalValues: false);
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task Scalar_original_values_of_a_derived_object_can_be_accessed_as_a_property_dictionary()
         {
             return TestPropertyValuesDerivedScalars(e => Task.FromResult(e.OriginalValues), expectOriginalValues: true);
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task Scalar_store_values_of_a_derived_object_can_be_accessed_as_a_property_dictionary()
         {
             return TestPropertyValuesDerivedScalars(e => Task.FromResult(e.GetDatabaseValues()), expectOriginalValues: true);
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task Scalar_store_values_of_a_derived_object_can_be_accessed_asynchronously_as_a_property_dictionary()
         {
             return TestPropertyValuesDerivedScalars(e => e.GetDatabaseValuesAsync(), expectOriginalValues: true);
@@ -210,7 +210,7 @@ namespace Microsoft.EntityFrameworkCore
             return TestNonGenericPropertyValuesScalars(e => Task.FromResult(e.OriginalValues), expectOriginalValues: true);
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task Scalar_store_values_can_be_accessed_as_a_non_generic_property_dictionary()
         {
             return TestNonGenericPropertyValuesScalars(e => Task.FromResult(e.GetDatabaseValues()), expectOriginalValues: true);
@@ -276,7 +276,7 @@ namespace Microsoft.EntityFrameworkCore
             return TestNonGenericPropertyValuesScalarsIProperty(e => Task.FromResult(e.OriginalValues), expectOriginalValues: true);
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task Scalar_store_values_can_be_accessed_as_a_non_generic_property_dictionary_using_IProperty()
         {
             return TestNonGenericPropertyValuesScalarsIProperty(e => Task.FromResult(e.GetDatabaseValues()), expectOriginalValues: true);
@@ -327,25 +327,25 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task Scalar_current_values_of_a_derived_object_can_be_accessed_as_a_non_generic_property_dictionary()
         {
             return TestNonGenericPropertyValuesDerivedScalars(e => Task.FromResult(e.CurrentValues), expectOriginalValues: false);
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task Scalar_original_values_of_a_derived_object_can_be_accessed_as_a_non_generic_property_dictionary()
         {
             return TestNonGenericPropertyValuesDerivedScalars(e => Task.FromResult(e.OriginalValues), expectOriginalValues: true);
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task Scalar_store_values_of_a_derived_object_can_be_accessed_as_a_non_generic_property_dictionary()
         {
             return TestNonGenericPropertyValuesDerivedScalars(e => Task.FromResult(e.GetDatabaseValues()), expectOriginalValues: true);
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task Scalar_store_values_of_a_derived_object_can_be_accessed_asynchronously_as_a_non_generic_property_dictionary()
         {
             return TestNonGenericPropertyValuesDerivedScalars(e => e.GetDatabaseValuesAsync(), expectOriginalValues: true);
@@ -515,7 +515,7 @@ namespace Microsoft.EntityFrameworkCore
             return TestPropertyValuesClone(e => Task.FromResult(e.OriginalValues), expectOriginalValues: true);
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task Store_values_can_be_copied_into_an_object()
         {
             return TestPropertyValuesClone(e => Task.FromResult(e.GetDatabaseValues()), expectOriginalValues: true);
@@ -555,25 +555,25 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task Current_values_for_derived_object_can_be_copied_into_an_object()
         {
             return TestPropertyValuesDerivedClone(e => Task.FromResult(e.CurrentValues), expectOriginalValues: false);
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task Original_values_for_derived_object_can_be_copied_into_an_object()
         {
             return TestPropertyValuesDerivedClone(e => Task.FromResult(e.OriginalValues), expectOriginalValues: true);
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task Store_values_for_derived_object_can_be_copied_into_an_object()
         {
             return TestPropertyValuesDerivedClone(e => Task.FromResult(e.GetDatabaseValues()), expectOriginalValues: true);
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task Store_values_for_derived_object_can_be_copied_into_an_object_asynchronously()
         {
             return TestPropertyValuesDerivedClone(e => e.GetDatabaseValuesAsync(), expectOriginalValues: true);
@@ -622,7 +622,7 @@ namespace Microsoft.EntityFrameworkCore
             return TestNonGenericPropertyValuesClone(e => Task.FromResult(e.OriginalValues), expectOriginalValues: true);
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task Store_values_can_be_copied_non_generic_property_dictionary_into_an_object()
         {
             return TestNonGenericPropertyValuesClone(e => Task.FromResult(e.GetDatabaseValues()), expectOriginalValues: true);
@@ -674,7 +674,7 @@ namespace Microsoft.EntityFrameworkCore
             return TestPropertyValuesCloneToValues(e => Task.FromResult(e.OriginalValues), expectOriginalValues: true);
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task Store_values_can_be_copied_into_a_cloned_dictionary()
         {
             return TestPropertyValuesCloneToValues(e => Task.FromResult(e.GetDatabaseValues()), expectOriginalValues: true);
@@ -853,7 +853,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual void Using_bad_property_names_throws_derived()
         {
             using (var context = CreateContext())
@@ -906,7 +906,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual void Using_bad_IProperty_instances_throws_derived()
         {
             using (var context = CreateContext())
@@ -974,7 +974,7 @@ namespace Microsoft.EntityFrameworkCore
             return TestNonGenericPropertyValuesCloneToValues(e => Task.FromResult(e.OriginalValues), expectOriginalValues: true);
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task Store_values_can_be_copied_into_a_non_generic_cloned_dictionary()
         {
             return TestNonGenericPropertyValuesCloneToValues(e => Task.FromResult(e.GetDatabaseValues()), expectOriginalValues: true);
@@ -1065,7 +1065,7 @@ namespace Microsoft.EntityFrameworkCore
                 e => Task.FromResult(e.OriginalValues), EntityState.Deleted, expectOriginalValues: true);
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task Store_values_can_be_read_and_set_for_an_object_in_the_Deleted_state()
         {
             return TestPropertyValuesPositiveForState(
@@ -1092,7 +1092,7 @@ namespace Microsoft.EntityFrameworkCore
                 e => Task.FromResult(e.OriginalValues), EntityState.Unchanged, expectOriginalValues: true);
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task Store_values_can_be_read_and_set_for_an_object_in_the_Unchanged_state()
         {
             return TestPropertyValuesPositiveForState(
@@ -1119,7 +1119,7 @@ namespace Microsoft.EntityFrameworkCore
                 e => Task.FromResult(e.OriginalValues), EntityState.Modified, expectOriginalValues: true);
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task Store_values_can_be_read_and_set_for_an_object_in_the_Modified_state()
         {
             return TestPropertyValuesPositiveForState(
@@ -1146,7 +1146,7 @@ namespace Microsoft.EntityFrameworkCore
                 e => Task.FromResult(e.OriginalValues), EntityState.Added, expectOriginalValues: true);
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task Store_values_can_be_read_or_set_for_an_object_in_the_Added_state()
         {
             return TestPropertyValuesPositiveForState(
@@ -1173,7 +1173,7 @@ namespace Microsoft.EntityFrameworkCore
                 e => Task.FromResult(e.OriginalValues), EntityState.Detached, expectOriginalValues: true);
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task Store_values_can_be_read_or_set_for_a_Detached_object()
         {
             return TestPropertyValuesPositiveForState(
@@ -1209,7 +1209,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Theory(Skip = "QueryIssue")]
+        [Theory]
         [InlineData(EntityState.Unchanged, true)]
         [InlineData(EntityState.Unchanged, false)]
         [InlineData(EntityState.Modified, true)]
@@ -1249,7 +1249,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Theory(Skip = "QueryIssue")]
+        [Theory]
         [InlineData(EntityState.Unchanged, true)]
         [InlineData(EntityState.Unchanged, false)]
         [InlineData(EntityState.Modified, true)]
@@ -1912,7 +1912,7 @@ namespace Microsoft.EntityFrameworkCore
             return TestProperties(e => Task.FromResult(e.OriginalValues));
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task Properties_for_store_values_returns_properties()
         {
             return TestProperties(e => Task.FromResult(e.GetDatabaseValues()));
@@ -1951,13 +1951,13 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task GetDatabaseValues_for_entity_not_in_the_store_returns_null()
         {
             return GetDatabaseValues_for_entity_not_in_the_store_returns_null_implementation(e => Task.FromResult(e.GetDatabaseValues()));
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task GetDatabaseValuesAsync_for_entity_not_in_the_store_returns_null()
         {
             return GetDatabaseValues_for_entity_not_in_the_store_returns_null_implementation(e => e.GetDatabaseValuesAsync());
@@ -1979,14 +1979,14 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task NonGeneric_GetDatabaseValues_for_entity_not_in_the_store_returns_null()
         {
             return NonGeneric_GetDatabaseValues_for_entity_not_in_the_store_returns_null_implementation(
                 e => Task.FromResult(e.GetDatabaseValues()));
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task NonGeneric_GetDatabaseValuesAsync_for_entity_not_in_the_store_returns_null()
         {
             return NonGeneric_GetDatabaseValues_for_entity_not_in_the_store_returns_null_implementation(e => e.GetDatabaseValuesAsync());
@@ -2008,14 +2008,14 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task GetDatabaseValues_for_derived_entity_not_in_the_store_returns_null()
         {
             return GetDatabaseValues_for_derived_entity_not_in_the_store_returns_null_implementation(
                 e => Task.FromResult(e.GetDatabaseValues()));
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task GetDatabaseValuesAsync_for_derived_entity_not_in_the_store_returns_null()
         {
             return GetDatabaseValues_for_derived_entity_not_in_the_store_returns_null_implementation(e => e.GetDatabaseValuesAsync());
@@ -2040,14 +2040,14 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task NonGeneric_GetDatabaseValues_for_derived_entity_not_in_the_store_returns_null()
         {
             return NonGeneric_GetDatabaseValues_for_derived_entity_not_in_the_store_returns_null_implementation(
                 e => Task.FromResult(e.GetDatabaseValues()));
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task NonGeneric_GetDatabaseValuesAsync_for_derived_entity_not_in_the_store_returns_null()
         {
             return NonGeneric_GetDatabaseValues_for_derived_entity_not_in_the_store_returns_null_implementation(
@@ -2073,14 +2073,14 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task GetDatabaseValues_for_the_wrong_type_in_the_store_returns_null()
         {
             return GetDatabaseValues_for_the_wrong_type_in_the_store_returns_null_implementation(
                 e => Task.FromResult(e.GetDatabaseValues()));
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task GetDatabaseValuesAsync_for_the_wrong_type_in_the_store_returns_null()
         {
             return GetDatabaseValues_for_the_wrong_type_in_the_store_returns_null_implementation(e => e.GetDatabaseValuesAsync());
@@ -2112,14 +2112,14 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task NonGeneric_GetDatabaseValues_for_the_wrong_type_in_the_store_throws()
         {
             return NonGeneric_GetDatabaseValues_for_the_wrong_type_in_the_store_throws_implementation(
                 e => Task.FromResult(e.GetDatabaseValues()));
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual Task NonGeneric_GetDatabaseValuesAsync_for_the_wrong_type_in_the_store_throws()
         {
             return NonGeneric_GetDatabaseValues_for_the_wrong_type_in_the_store_throws_implementation(e => e.GetDatabaseValuesAsync());
@@ -2151,7 +2151,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public Task Store_values_really_are_store_values_not_current_or_original_values()
         {
             return Store_values_really_are_store_values_not_current_or_original_values_implementation(
@@ -2180,7 +2180,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual void Setting_store_values_does_not_change_current_or_original_values()
         {
             using (var context = CreateContext())

--- a/test/EFCore.Specification.Tests/Query/AsyncGearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AsyncGearsOfWarQueryTestBase.cs
@@ -91,7 +91,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public virtual async Task Cast_to_derived_type_causes_client_eval()
         {
             using (var context = CreateContext())
@@ -111,7 +111,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact(Skip = "#15711")]
         public virtual async Task GroupBy_Select_sum()
         {
             using (var ctx = CreateContext())

--- a/test/EFCore.Specification.Tests/Query/ChangeTrackingTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ChangeTrackingTestBase.cs
@@ -372,7 +372,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public virtual void Precendence_of_tracking_modifiers3()
         {
             using (var context = CreateContext())
@@ -390,7 +390,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public virtual void Precendence_of_tracking_modifiers4()
         {
             using (var context = CreateContext())
@@ -408,7 +408,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public virtual void Precendence_of_tracking_modifiers5()
         {
             using (var context = CreateContext())

--- a/test/EFCore.Specification.Tests/Query/FunkyDataQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/FunkyDataQueryTestBase.cs
@@ -525,7 +525,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public virtual void String_ends_with_equals_nullable_column()
         {
             using (var ctx = CreateContext())
@@ -576,7 +576,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public virtual void String_ends_with_not_equals_nullable_column()
         {
             using (var ctx = CreateContext())

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -1394,7 +1394,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery<Gear>(
                 isAsync,
                 gs => from g in gs
-                      // ReSharper disable once ConstantNullCoalescingCondition
+                          // ReSharper disable once ConstantNullCoalescingCondition
                       where (new
                       {
                           Name = g.LeaderNickname
@@ -1452,7 +1452,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery<Gear>(
                 isAsync,
                 gs => from g in gs
-                      // ReSharper disable once EqualExpressionComparison
+                          // ReSharper disable once EqualExpressionComparison
                       where new
                       {
                           Five = 5
@@ -2020,10 +2020,10 @@ namespace Microsoft.EntityFrameworkCore.Query
                 (ts, gs) =>
                     (from t in ts
                      join g in gs.OfType<Officer>() on new
-                         {
-                             id1 = t.GearSquadId,
-                             id2 = t.GearNickName
-                         }
+                     {
+                         id1 = t.GearSquadId,
+                         id2 = t.GearNickName
+                     }
                          equals new
                          {
                              id1 = (int?)g.SquadId,
@@ -2045,10 +2045,10 @@ namespace Microsoft.EntityFrameworkCore.Query
                 (gs, ts) =>
                     (from g in gs.OfType<Officer>()
                      join t in ts on new
-                         {
-                             id1 = (int?)g.SquadId,
-                             id2 = g.Nickname
-                         }
+                     {
+                         id1 = (int?)g.SquadId,
+                         id2 = g.Nickname
+                     }
                          equals new
                          {
                              id1 = t.GearSquadId,
@@ -2299,7 +2299,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       join g2 in gs.Include(g => g.Weapons)
                           on g1.LeaderNickname equals g2.Nickname into grouping
                       from g2 in grouping.DefaultIfEmpty()
-                      // ReSharper disable once MergeConditionalExpression
+                          // ReSharper disable once MergeConditionalExpression
 #pragma warning disable IDE0029 // Use coalesce expression
                       select g2 != null ? g2 : g1,
 #pragma warning restore IDE0029 // Use coalesce expression
@@ -2322,7 +2322,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       join g2 in gs.Include(g => g.Weapons)
                           on g1.LeaderNickname equals g2.Nickname into grouping
                       from g2 in grouping.DefaultIfEmpty()
-                      // ReSharper disable once MergeConditionalExpression
+                          // ReSharper disable once MergeConditionalExpression
 #pragma warning disable IDE0029 // Use coalesce expression
                       select new
                       {
@@ -4029,7 +4029,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             {
                 var query = from g1 in ctx.Gears
                             from g2 in ctx.Gears
-                            // ReSharper disable once PossibleUnintendedReferenceComparison
+                                // ReSharper disable once PossibleUnintendedReferenceComparison
                             where g1.Weapons == g2.Weapons
                             orderby g1.Nickname
                             select new
@@ -7479,23 +7479,25 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "Issue#15964")]
+        [ConditionalFact(Skip = "Issue#14935")]
         public virtual void Nav_rewrite_Distinct_with_convert()
         {
             using (var ctx = CreateContext())
             {
-                var query = ctx.Factions.Where(f => f.Capital.Name != "Foo").Select(f => (LocustHorde)f).Distinct().Where(lh => lh.Commander.Name != "Bar");
-                var result = query.ToList();
+                var result = ctx.Factions.Include(f => ((LocustHorde)f).Commander)
+                    .Where(f => f.Capital.Name != "Foo").Select(f => (LocustHorde)f)
+                    .Distinct().Where(lh => lh.Commander.Name != "Bar").ToList();
             }
         }
 
-        [ConditionalFact(Skip = "Issue#15964")]
+        [ConditionalFact(Skip = "Issue#14935")]
         public virtual void Nav_rewrite_Distinct_with_convert_anonymous()
         {
             using (var ctx = CreateContext())
             {
-                var query = ctx.Factions.Where(f => f.Capital.Name != "Foo").Select(f => new { horde = (LocustHorde)f }).Distinct().Where(lh => lh.horde.Commander.Name != "Bar");
-                var result = query.ToList();
+                var result = ctx.Factions.Include(f => ((LocustHorde)f).Commander)
+                    .Where(f => f.Capital.Name != "Foo").Select(f => new { horde = (LocustHorde)f })
+                    .Distinct().Where(lh => lh.horde.Commander.Name != "Bar").ToList();
             }
         }
 

--- a/test/EFCore.Specification.Tests/SpatialTestBase.cs
+++ b/test/EFCore.Specification.Tests/SpatialTestBase.cs
@@ -58,7 +58,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public virtual void Mutation_of_tracked_values_does_not_mutate_values_in_store()
         {
             Point CreatePoint(double y = 2.2)
@@ -119,21 +119,20 @@ namespace Microsoft.EntityFrameworkCore
                 });
         }
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public virtual void Translators_handle_static_members()
         {
             using (var db = Fixture.CreateContext())
             {
-                Enumerable.FirstOrDefault(
-                    from e in db.Set<PointEntity>()
-                    select new
-                    {
-                        e.Id,
-                        e.Point,
-                        Point.Empty,
-                        DateTime.UtcNow,
-                        Guid = Guid.NewGuid()
-                    });
+                (from e in db.Set<PointEntity>()
+                select new
+                {
+                    e.Id,
+                    e.Point,
+                    Point.Empty,
+                    DateTime.UtcNow,
+                    Guid = Guid.NewGuid()
+                }).FirstOrDefault();
             }
         }
 

--- a/test/EFCore.Specification.Tests/WithConstructorsTestBase.cs
+++ b/test/EFCore.Specification.Tests/WithConstructorsTestBase.cs
@@ -34,7 +34,7 @@ namespace Microsoft.EntityFrameworkCore
         {
         }
 
-        [Fact(Skip = "issue #15611")]
+        [Fact]
         public virtual void Query_and_update_using_constructors_with_property_parameters()
         {
             TestHelpers.ExecuteWithStrategyInTransaction(
@@ -95,13 +95,13 @@ namespace Microsoft.EntityFrameworkCore
                 });
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual void Query_with_keyless_type()
         {
             using (var context = CreateContext())
             {
 #pragma warning disable CS0618 // Type or member is obsolete
-                var blogs = context.Query<BlogQuery>().ToList();
+                var blogs = context.Query<BlogQuery>().AsNoTracking().ToList();
 #pragma warning restore CS0618 // Type or member is obsolete
 
                 Assert.Equal(1, blogs.Count);
@@ -396,7 +396,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual async Task Query_with_loader_injected_for_reference_async()
         {
             using (var context = CreateContext())
@@ -411,7 +411,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual async Task Query_with_loader_injected_for_collections_async()
         {
             using (var context = CreateContext())
@@ -452,7 +452,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual async Task Query_with_loader_delegate_injected_for_reference_async()
         {
             using (var context = CreateContext())
@@ -467,7 +467,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual async Task Query_with_loader_delegate_injected_for_collections_async()
         {
             using (var context = CreateContext())
@@ -729,7 +729,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual async Task Query_with_loader_delegate_injected_into_property_for_reference_async()
         {
             using (var context = CreateContext())
@@ -744,7 +744,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public virtual async Task Query_with_loader_delegate_injected_into_property_for_collections_async()
         {
             using (var context = CreateContext())

--- a/test/EFCore.SqlServer.FunctionalTests/NotificationEntitiesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/NotificationEntitiesSqlServerTest.cs
@@ -5,8 +5,8 @@ using Microsoft.EntityFrameworkCore.TestUtilities;
 
 namespace Microsoft.EntityFrameworkCore
 {
-    public class NotificationEntitiesSqlServerTest : NotificationEntitiesTestBase<
-        NotificationEntitiesSqlServerTest.NotificationEntitiesSqlServerFixture>
+    public class NotificationEntitiesSqlServerTest
+        : NotificationEntitiesTestBase<NotificationEntitiesSqlServerTest.NotificationEntitiesSqlServerFixture>
     {
         public NotificationEntitiesSqlServerTest(NotificationEntitiesSqlServerFixture fixture)
             : base(fixture)

--- a/test/EFCore.SqlServer.FunctionalTests/OptimisticConcurrencySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/OptimisticConcurrencySqlServerTest.cs
@@ -56,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public Task Database_concurrency_token_value_is_discarded_for_non_conflicting_entities()
         {
             byte[] firstVersion = null;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FunkyDataQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FunkyDataQuerySqlServerTest.cs
@@ -22,13 +22,13 @@ namespace Microsoft.EntityFrameworkCore.Query
             base.String_ends_with_equals_nullable_column();
 
             Assert.Equal(
-                @"SELECT [c].[Id], [c].[FirstName], [c].[LastName], [c].[NullableBool], [c2].[Id], [c2].[FirstName], [c2].[LastName], [c2].[NullableBool]
-FROM [FunkyCustomers] AS [c]
-CROSS JOIN [FunkyCustomers] AS [c2]
-WHERE CASE
-    WHEN (RIGHT([c].[FirstName], LEN([c2].[LastName])) = [c2].[LastName]) OR ([c2].[LastName] = N'')
-    THEN CAST(1 AS bit) ELSE CAST(0 AS bit)
-END = [c].[NullableBool]",
+                @"SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool], [f0].[Id], [f0].[FirstName], [f0].[LastName], [f0].[NullableBool]
+FROM [FunkyCustomers] AS [f]
+CROSS JOIN [FunkyCustomers] AS [f0]
+WHERE (CASE
+    WHEN (([f0].[LastName] = N'') AND [f0].[LastName] IS NOT NULL) OR ([f].[FirstName] IS NOT NULL AND ([f0].[LastName] IS NOT NULL AND (((RIGHT([f].[FirstName], LEN([f0].[LastName])) = [f0].[LastName]) AND (RIGHT([f].[FirstName], LEN([f0].[LastName])) IS NOT NULL AND [f0].[LastName] IS NOT NULL)) OR (RIGHT([f].[FirstName], LEN([f0].[LastName])) IS NULL AND [f0].[LastName] IS NULL)))) THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END = [f].[NullableBool]) AND [f].[NullableBool] IS NOT NULL",
                 Sql,
                 ignoreLineEndingDifferences: true);
         }
@@ -38,13 +38,13 @@ END = [c].[NullableBool]",
             base.String_ends_with_not_equals_nullable_column();
 
             Assert.Equal(
-                @"SELECT [c].[Id], [c].[FirstName], [c].[LastName], [c].[NullableBool], [c2].[Id], [c2].[FirstName], [c2].[LastName], [c2].[NullableBool]
-FROM [FunkyCustomers] AS [c]
-CROSS JOIN [FunkyCustomers] AS [c2]
+                @"SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool], [f0].[Id], [f0].[FirstName], [f0].[LastName], [f0].[NullableBool]
+FROM [FunkyCustomers] AS [f]
+CROSS JOIN [FunkyCustomers] AS [f0]
 WHERE (CASE
-    WHEN (RIGHT([c].[FirstName], LEN([c2].[LastName])) = [c2].[LastName]) OR ([c2].[LastName] = N'')
-    THEN CAST(1 AS bit) ELSE CAST(0 AS bit)
-END <> [c].[NullableBool]) OR [c].[NullableBool] IS NULL",
+    WHEN (([f0].[LastName] = N'') AND [f0].[LastName] IS NOT NULL) OR ([f].[FirstName] IS NOT NULL AND ([f0].[LastName] IS NOT NULL AND (((RIGHT([f].[FirstName], LEN([f0].[LastName])) = [f0].[LastName]) AND (RIGHT([f].[FirstName], LEN([f0].[LastName])) IS NOT NULL AND [f0].[LastName] IS NOT NULL)) OR (RIGHT([f].[FirstName], LEN([f0].[LastName])) IS NULL AND [f0].[LastName] IS NULL)))) THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END <> [f].[NullableBool]) OR [f].[NullableBool] IS NULL",
                 Sql,
                 ignoreLineEndingDifferences: true);
         }

--- a/test/EFCore.SqlServer.FunctionalTests/SequenceEndToEndTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SequenceEndToEndTest.cs
@@ -159,7 +159,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public async Task Can_use_sequence_end_to_end_async()
         {
             var serviceProvider = new ServiceCollection()
@@ -216,7 +216,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         [PlatformSkipCondition(TestPlatform.Linux, SkipReason = "Test is flaky on CI.")]
         public async Task Can_use_sequence_end_to_end_from_multiple_contexts_concurrently_async()
         {

--- a/test/EFCore.SqlServer.FunctionalTests/SequentialGuidEndToEndTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SequentialGuidEndToEndTest.cs
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore
 {
     public class SequentialGuidEndToEndTest : IDisposable
     {
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public async Task Can_use_sequential_GUID_end_to_end_async()
         {
             var serviceProvider = new ServiceCollection()
@@ -48,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public async Task Can_use_explicit_values()
         {
             var serviceProvider = new ServiceCollection()

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerConfigPatternsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerConfigPatternsTest.cs
@@ -433,7 +433,7 @@ namespace Microsoft.EntityFrameworkCore
 
         public class NestedContext
         {
-            [Fact(Skip = "QueryIssue")]
+            [Fact]
             public async Task Can_use_one_context_nested_inside_another_of_the_same_type()
             {
                 using (SqlServerTestStore.GetNorthwindStore())

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -620,7 +620,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public void Can_track_an_entity_with_more_than_10_properties()
         {
             using (var testDatabase = SqlServerTestStore.CreateInitialized(DatabaseName))
@@ -691,7 +691,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "issue #15318")]
+        [Fact(Skip = "issue #15992")]
         public void Can_set_reference_twice()
         {
             using (var testDatabase = SqlServerTestStore.CreateInitialized(DatabaseName))
@@ -740,7 +740,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "issue #15318")]
+        [Fact(Skip = "issue #15992")]
         public void Can_include_on_loaded_entity()
         {
             using (var testDatabase = SqlServerTestStore.CreateInitialized(DatabaseName))
@@ -995,7 +995,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact]
         public async Task Tracking_entities_asynchronously_returns_tracked_entities_back()
         {
             using (var testStore = SqlServerTestStore.GetNorthwindStore())

--- a/test/EFCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore
             //fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
-        [Fact(Skip = "QueryIssue")]
+        [Fact(Skip = "Issue#13487")]
         public void Translate_array_length()
         {
             using (var db = CreateContext())


### PR DESCRIPTION
Update test for #15889 to do client eval
Update test for #15964 to do client eval
Implement cast on InMemory
Fix bug when rewriting assignments to initonly fields
Fix literal generation for Point.Empty on SqlServer
Fix condition on when to materialize key less entityType

