### PR TITLE
Query: Dry code for generating column alias

### DIFF
--- a/src/EFCore.Relational/Query/Pipeline/EntityProjectionExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/EntityProjectionExpression.cs
@@ -14,12 +14,13 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
         private readonly IDictionary<IProperty, ColumnExpression> _propertyExpressionsCache
             = new Dictionary<IProperty, ColumnExpression>();
         private readonly TableExpressionBase _innerTable;
+        private readonly bool _nullable;
 
         public EntityProjectionExpression(IEntityType entityType, TableExpressionBase innerTable, bool nullable)
         {
             EntityType = entityType.RootType();
             _innerTable = innerTable;
-            Nullable = nullable;
+            _nullable = nullable;
         }
 
         public EntityProjectionExpression(IEntityType entityType, IDictionary<IProperty, ColumnExpression> propertyExpressions)
@@ -35,7 +36,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                 var table = (TableExpressionBase)visitor.Visit(_innerTable);
 
                 return table != _innerTable
-                    ? new EntityProjectionExpression(EntityType, table, Nullable)
+                    ? new EntityProjectionExpression(EntityType, table, _nullable)
                     : this;
             }
             else
@@ -75,7 +76,6 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
         }
 
         public IEntityType EntityType { get; }
-        public bool Nullable { get; }
         public override ExpressionType NodeType => ExpressionType.Extension;
         public override Type Type => EntityType.ClrType;
 
@@ -88,7 +88,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 
             if (!_propertyExpressionsCache.TryGetValue(property, out var expression))
             {
-                expression = new ColumnExpression(property, _innerTable, Nullable);
+                expression = new ColumnExpression(property, _innerTable, _nullable);
                 _propertyExpressionsCache[property] = expression;
             }
 

--- a/src/EFCore.Relational/Query/Pipeline/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Pipeline/QuerySqlGenerator.cs
@@ -73,7 +73,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
         {
             IDisposable subQueryIndent = null;
 
-            if (!string.IsNullOrEmpty(selectExpression.Alias))
+            if (selectExpression.Alias != null)
             {
                 _relationalCommandBuilder.AppendLine("(");
                 subQueryIndent = _relationalCommandBuilder.Indent();
@@ -136,7 +136,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 
             GenerateLimitOffset(selectExpression);
 
-            if (!string.IsNullOrEmpty(selectExpression.Alias))
+            if (selectExpression.Alias != null)
             {
                 subQueryIndent.Dispose();
 
@@ -155,7 +155,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                 && !(projectionExpression.Expression is ColumnExpression column
                      && string.Equals(column.Name, projectionExpression.Alias)))
             {
-                _relationalCommandBuilder.Append(" AS " + projectionExpression.Alias);
+                _relationalCommandBuilder.Append(" AS " + _sqlGenerationHelper.DelimitIdentifier(projectionExpression.Alias));
             }
 
             return projectionExpression;

--- a/src/EFCore.Relational/Query/Pipeline/RelationalProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Pipeline/RelationalProjectionBindingRemovingExpressionVisitor.cs
@@ -115,7 +115,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
             private object GetProjectionIndex(ProjectionBindingExpression projectionBindingExpression)
             {
                 return projectionBindingExpression.ProjectionMember != null
-                    ? ((ConstantExpression)_selectExpression.GetProjectionExpression(projectionBindingExpression.ProjectionMember)).Value
+                    ? ((ConstantExpression)_selectExpression.GetMappedProjection(projectionBindingExpression.ProjectionMember)).Value
                     : (projectionBindingExpression.Index != null
                         ? (object)projectionBindingExpression.Index
                         : projectionBindingExpression.IndexMap);

--- a/src/EFCore.Relational/Query/Pipeline/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Pipeline/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -70,7 +70,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
             if (translation != null)
             {
                 selectExpression.ApplyPredicate(_sqlExpressionFactory.Not(translation));
-                selectExpression.ReplaceProjection(new Dictionary<ProjectionMember, Expression>());
+                selectExpression.ReplaceProjectionMapping(new Dictionary<ProjectionMember, Expression>());
                 if (selectExpression.Limit == null
                     && selectExpression.Offset == null)
                 {
@@ -95,7 +95,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
             }
 
             var selectExpression = (SelectExpression)source.QueryExpression;
-            selectExpression.ReplaceProjection(new Dictionary<ProjectionMember, Expression>());
+            selectExpression.ReplaceProjectionMapping(new Dictionary<ProjectionMember, Expression>());
             if (selectExpression.Limit == null
                 && selectExpression.Offset == null)
             {
@@ -123,7 +123,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                 source = TranslateSelect(source, selector);
             }
 
-            var projection = (SqlExpression)selectExpression.GetProjectionExpression(new ProjectionMember());
+            var projection = (SqlExpression)selectExpression.GetMappedProjection(new ProjectionMember());
 
             var inputType = projection.Type.UnwrapNullableType();
             if (inputType == typeof(int)
@@ -213,7 +213,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
             };
 
             selectExpression.ClearOrdering();
-            selectExpression.ReplaceProjection(projectionMapping);
+            selectExpression.ReplaceProjectionMapping(projectionMapping);
             source.ShaperExpression = new ProjectionBindingExpression(source.QueryExpression, new ProjectionMember(), typeof(int));
 
             return source;
@@ -488,7 +488,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
             };
 
             selectExpression.ClearOrdering();
-            selectExpression.ReplaceProjection(projectionMapping);
+            selectExpression.ReplaceProjectionMapping(projectionMapping);
             source.ShaperExpression = new ProjectionBindingExpression(source.QueryExpression, new ProjectionMember(), typeof(long));
 
             return source;
@@ -508,7 +508,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                 source = TranslateSelect(source, selector);
             }
 
-            var projection = (SqlExpression)selectExpression.GetProjectionExpression(new ProjectionMember());
+            var projection = (SqlExpression)selectExpression.GetMappedProjection(new ProjectionMember());
 
             projection = _sqlExpressionFactory.Function("MAX", new[] { projection }, resultType, projection.TypeMapping);
 
@@ -529,7 +529,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                 source = TranslateSelect(source, selector);
             }
 
-            var projection = (SqlExpression)selectExpression.GetProjectionExpression(new ProjectionMember());
+            var projection = (SqlExpression)selectExpression.GetMappedProjection(new ProjectionMember());
 
             projection = _sqlExpressionFactory.Function("MIN", new[] { projection }, resultType, projection.TypeMapping);
 
@@ -773,7 +773,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
             }
 
             var serverOutputType = resultType.UnwrapNullableType();
-            var projection = (SqlExpression)selectExpression.GetProjectionExpression(new ProjectionMember());
+            var projection = (SqlExpression)selectExpression.GetMappedProjection(new ProjectionMember());
 
             if (serverOutputType == typeof(float))
             {
@@ -866,7 +866,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
             ShapedQueryExpression source, Expression projection, bool throwOnNullResult, Type resultType)
         {
             var selectExpression = (SelectExpression)source.QueryExpression;
-            selectExpression.ReplaceProjection(
+            selectExpression.ReplaceProjectionMapping(
                 new Dictionary<ProjectionMember, Expression>
                 {
                     { new ProjectionMember(), projection }

--- a/src/EFCore.Relational/Query/Pipeline/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Pipeline/RelationalSqlTranslatingExpressionVisitor.cs
@@ -301,7 +301,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
             {
                 var selectExpression = (SelectExpression)projectionBindingExpression.QueryExpression;
 
-                return selectExpression.GetProjectionExpression(projectionBindingExpression.ProjectionMember);
+                return selectExpression.GetMappedProjection(projectionBindingExpression.ProjectionMember);
             }
 
             if (extensionExpression is NullConditionalExpression nullConditionalExpression)

--- a/src/EFCore.Relational/Query/Pipeline/SelectExpressionTableAliasUniquifyingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SelectExpressionTableAliasUniquifyingExpressionVisitor.cs
@@ -21,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
             {
                 case TableExpressionBase tableExpressionBase
                     when !_visitedTableExpressionBases.Contains(tableExpressionBase)
-                        && !string.IsNullOrEmpty(tableExpressionBase.Alias):
+                        && tableExpressionBase.Alias != null:
                     tableExpressionBase.Alias = GenerateUniqueAlias(tableExpressionBase.Alias);
                     _visitedTableExpressionBases.Add(tableExpressionBase);
                     return tableExpressionBase;

--- a/src/EFCore.Relational/Query/Pipeline/ShaperExpressionDedupingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Pipeline/ShaperExpressionDedupingExpressionVisitor.cs
@@ -91,7 +91,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
         private Expression GenerateKey(ProjectionBindingExpression projectionBindingExpression)
         {
             return projectionBindingExpression.ProjectionMember != null
-                ? _selectExpression.GetProjectionExpression(projectionBindingExpression.ProjectionMember)
+                ? _selectExpression.GetMappedProjection(projectionBindingExpression.ProjectionMember)
                 : projectionBindingExpression;
         }
     }

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressionFactory.cs
@@ -512,7 +512,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 
             if (projection != null)
             {
-                selectExpression.ReplaceProjection(new Dictionary<ProjectionMember, Expression>
+                selectExpression.ReplaceProjectionMapping(new Dictionary<ProjectionMember, Expression>
                 {
                     { new ProjectionMember(), projection }
                 });
@@ -550,7 +550,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                     return;
                 }
 
-                var discriminatorColumn = ((EntityProjectionExpression)selectExpression.GetProjectionExpression(new ProjectionMember()))
+                var discriminatorColumn = ((EntityProjectionExpression)selectExpression.GetMappedProjection(new ProjectionMember()))
                     .GetProperty(concreteEntityType.GetDiscriminatorProperty());
 
                 selectExpression.ApplyPredicate(
@@ -559,7 +559,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
             }
             else
             {
-                var discriminatorColumn = ((EntityProjectionExpression)selectExpression.GetProjectionExpression(new ProjectionMember()))
+                var discriminatorColumn = ((EntityProjectionExpression)selectExpression.GetMappedProjection(new ProjectionMember()))
                     .GetProperty(concreteEntityTypes[0].GetDiscriminatorProperty());
 
                 selectExpression.ApplyPredicate(

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/ColumnExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/ColumnExpression.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query.Internal;
@@ -9,6 +10,7 @@ using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
 {
+    [DebuggerDisplay("{DebuggerDisplay(),nq}")]
     public class ColumnExpression : SqlExpression
     {
         internal ColumnExpression(IProperty property, TableExpressionBase table, bool nullable)
@@ -74,5 +76,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
                 return hashCode;
             }
         }
+
+        private string DebuggerDisplay() => $"{Table.Alias}.{Name}";
     }
 }

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/JoinExpressionBase.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/JoinExpressionBase.cs
@@ -6,7 +6,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
     public abstract class JoinExpressionBase : TableExpressionBase
     {
         protected JoinExpressionBase(TableExpressionBase table)
-            : base("")
+            : base(null)
         {
             Table = table;
         }

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/TableExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/TableExpression.cs
@@ -1,13 +1,14 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
 {
     public class TableExpression : TableExpressionBase
     {
-        internal TableExpression(string table, string schema, string alias)
+        internal TableExpression(string table, string schema, [NotNull] string alias)
             : base(alias)
         {
             Table = table;

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/TableExpressionBase.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/TableExpressionBase.cs
@@ -3,14 +3,21 @@
 
 using System;
 using System.Linq.Expressions;
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query.Expressions.Internal;
 using Microsoft.EntityFrameworkCore.Query.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
 {
     public abstract class TableExpressionBase : Expression, IPrintable
     {
-        protected TableExpressionBase(string alias) => Alias = alias;
+        protected TableExpressionBase([CanBeNull] string alias)
+        {
+            Check.NullButNotEmpty(alias, nameof(alias));
+
+            Alias = alias;
+        }
 
         public string Alias { get; internal set; }
 
@@ -32,7 +39,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
         {
             unchecked
             {
-                var hashCode = Alias.GetHashCode();
+                var hashCode = (Alias?.GetHashCode() ?? 0);
 
                 return hashCode;
             }

--- a/src/EFCore/Query/Pipeline/ProjectionMember.cs
+++ b/src/EFCore/Query/Pipeline/ProjectionMember.cs
@@ -39,6 +39,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
             return new ProjectionMember(existingChain);
         }
 
+        public MemberInfo LastMember => _memberChain.LastOrDefault();
+
         public override int GetHashCode()
         {
             unchecked

--- a/test/EFCore.Relational.Specification.Tests/Query/InheritanceRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/InheritanceRelationalTestBase.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
         }
 
-        [ConditionalFact(Skip = "Issue#15704")]
+        [ConditionalFact]
         public virtual void FromSql_on_root()
         {
             using (var context = CreateContext())
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "Issue#15704")]
+        [ConditionalFact]
         public virtual void FromSql_on_derived()
         {
             using (var context = CreateContext())


### PR DESCRIPTION
Added AddToProjection method which de-dupe columns and assign unique alias if subquery
Also added ability to assign alias based on member name in anonymous type projection
TableExpressionBase.Alias is either null or non-empty string to make processing it easier
