### PR TITLE
Synchronize transactions across test threads.

### DIFF
--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerDatabaseCreatorTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerDatabaseCreatorTest.cs
@@ -702,24 +702,16 @@ namespace Microsoft.EntityFrameworkCore
     public class SqlServerDatabaseCreatorTest
     {
         public static IDisposable CreateTransactionScope(bool useTransaction)
-        {
-            return TestStore.CreateTransactionScope(useTransaction);
-        }
+            => TestStore.CreateTransactionScope(useTransaction);
 
         public static TestDatabaseCreator GetDatabaseCreator(SqlServerTestStore testStore)
-        {
-            return GetDatabaseCreator(testStore.ConnectionString);
-        }
+            => GetDatabaseCreator(testStore.ConnectionString);
 
         public static TestDatabaseCreator GetDatabaseCreator(string connectionString)
-        {
-            return GetDatabaseCreator(new BloggingContext(connectionString));
-        }
+            => GetDatabaseCreator(new BloggingContext(connectionString));
 
         public static TestDatabaseCreator GetDatabaseCreator(BloggingContext context)
-        {
-            return (TestDatabaseCreator)context.GetService<IRelationalDatabaseCreator>();
-        }
+            => (TestDatabaseCreator)context.GetService<IRelationalDatabaseCreator>();
 
         // ReSharper disable once ClassNeverInstantiated.Local
         private class TestSqlServerExecutionStrategyFactory : SqlServerExecutionStrategyFactory

--- a/test/EFCore.SqlServer.FunctionalTests/TransactionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TransactionSqlServerTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 

--- a/test/EFCore.Tests/Storage/ExecutionStrategyTest.cs
+++ b/test/EFCore.Tests/Storage/ExecutionStrategyTest.cs
@@ -118,7 +118,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         private void Execute_throws_for_an_ambient_transaction(Action<ExecutionStrategy> execute)
         {
             var mockExecutionStrategy = new TestExecutionStrategy(Context);
-            using (new TransactionScope())
+            using (TestStore.CreateTransactionScope())
             {
                 Assert.Equal(
                     CoreStrings.ExecutionStrategyExistingTransaction(
@@ -398,7 +398,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         private async Task ExecuteAsync_throws_for_an_ambient_transaction(Func<ExecutionStrategy, Task> executeAsync)
         {
             var mockExecutionStrategy = new TestExecutionStrategy(Context);
-            using (new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+            using (TestStore.CreateTransactionScope())
             {
                 Assert.Equal(
                     CoreStrings.ExecutionStrategyExistingTransaction(


### PR DESCRIPTION
This should prevent any distributed transactions.