### PR TITLE
Don't pull entity types from the context when building the Migrations history table

### DIFF
--- a/src/EFCore.Relational/Migrations/HistoryRepository.cs
+++ b/src/EFCore.Relational/Migrations/HistoryRepository.cs
@@ -10,6 +10,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -92,8 +94,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         {
             if (_model == null)
             {
-                var modelBuilder = new ModelBuilder(Dependencies.ConventionSetBuilder.CreateConventionSet());
+                var conventionSet = Dependencies.ConventionSetBuilder.CreateConventionSet();
+                ConventionSet.Remove(conventionSet.ModelInitializedConventions, typeof(DbSetFindingConvention));
 
+                var modelBuilder = new ModelBuilder(conventionSet);
                 modelBuilder.Entity<HistoryRow>(
                     x =>
                     {

--- a/test/EFCore.Relational.Specification.Tests/MigrationsFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/MigrationsFixtureBase.cs
@@ -40,6 +40,13 @@ namespace Microsoft.EntityFrameworkCore
                 : base(options)
             {
             }
+
+            public DbSet<Foo> Foos { get; set; }
+        }
+
+        public class Foo
+        {
+            public int Id { get; set; }
         }
 
         [DbContext(typeof(MigrationsContext))]

--- a/test/EFCore.SqlServer.FunctionalTests/MigrationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/MigrationsSqlServerTest.cs
@@ -359,6 +359,9 @@ CreatedTable
     Id int NOT NULL
     ColumnWithDefaultToDrop int NULL DEFAULT ((0))
     ColumnWithDefaultToAlter int NULL DEFAULT ((1))
+
+Foos
+    Id int NOT NULL
 ",
                 sql,
                 ignoreLineEndingDifferences: true);
@@ -372,6 +375,9 @@ CreatedTable
 CreatedTable
     Id int NOT NULL
     ColumnWithDefaultToAlter int NULL
+
+Foos
+    Id int NOT NULL
 ",
                 sql,
                 ignoreLineEndingDifferences: true);

--- a/test/EFCore.Sqlite.FunctionalTests/MigrationsSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/MigrationsSqliteTest.cs
@@ -185,6 +185,13 @@ CreatedTable
     Id INTEGER NOT NULL
     ColumnWithDefaultToDrop INTEGER NULL DEFAULT 0
     ColumnWithDefaultToAlter INTEGER NULL DEFAULT 1
+
+Foos
+    Id INTEGER NOT NULL
+
+sqlite_sequence
+    name  NULL
+    seq  NULL
 ",
                 sql,
                 ignoreLineEndingDifferences: true);
@@ -214,6 +221,13 @@ CreatedTable
     Id INTEGER NOT NULL
     ColumnWithDefaultToDrop INTEGER NULL DEFAULT 0
     ColumnWithDefaultToAlter INTEGER NULL DEFAULT 1
+
+Foos
+    Id INTEGER NOT NULL
+
+sqlite_sequence
+    name  NULL
+    seq  NULL
 ",
                 sql,
                 ignoreLineEndingDifferences: true);


### PR DESCRIPTION
I think this is one of the root causes of the ASP.NET failures in https://github.com/aspnet/AspNetCore/pull/10939#issuecomment-500473365

The issue is that now that we discover DbSets from a context as a convention, re-using the convention-laden ModelBuilder for creating the history table also brings in types from the context.

For now, the fix is to remove this convention, but we may want to consider other options for building the history table.
