### PR TITLE
Fix DiagnosticListener memory leak

### DIFF
--- a/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
+++ b/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
@@ -266,7 +266,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             TryAdd<IShapedQueryOptimizerFactory, ShapedQueryOptimizerFactory>();
 
             ServiceCollectionMap
-                .TryAddSingleton<DiagnosticSource>(new DiagnosticListener(DbLoggerCategory.Name));
+                .TryAddSingleton<DiagnosticSource>(p => new DiagnosticListener(DbLoggerCategory.Name));
 
             ServiceCollectionMap.GetInfrastructure()
                 .AddDependencySingleton<LazyLoaderParameterBindingFactoryDependencies>()


### PR DESCRIPTION
When IsConfigured is called, it applies all services. This caused a DiagnosticListener to get instantiated on each DbContext instantiation, and since it wasn't disposed it caused a leak.

Fixes #15173