### PR TITLE
Fix DiagnosticListener memory leak

### DIFF
--- a/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
+++ b/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
@@ -292,7 +292,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             TryAdd<IParameterBindingFactory, EntityTypeParameterBindingFactory>();
 
             ServiceCollectionMap
-                .TryAddSingleton<DiagnosticSource>(new DiagnosticListener(DbLoggerCategory.Name));
+                .TryAddSingleton<DiagnosticSource>(p => new DiagnosticListener(DbLoggerCategory.Name));
 
             ServiceCollectionMap.GetInfrastructure()
                 .AddDependencySingleton<DatabaseProviderDependencies>()


### PR DESCRIPTION
When IsConfigured is called, it applies all services. This caused a DiagnosticListener to get instantiated on each DbContext instantiation, and since it wasn't disposed it caused a leak.

Fixes #15173

PR for master (3.0): #16046

(cherry picked from commit 904ad9cd6ec357e491936924b0704416e37afc32)