### PR TITLE
Switch to using the BCL HashCode type

### DIFF
--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/CaseExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/CaseExpression.cs
@@ -122,16 +122,14 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
 
         public override int GetHashCode()
         {
-            unchecked
+            var hash = new HashCode();
+            hash.Add(Operand);
+            for (var i = 0; i < WhenClauses.Count; i++)
             {
-                var hashCode = base.GetHashCode();
-                hashCode = (hashCode * 397) ^ (Operand?.GetHashCode() ?? 0);
-                hashCode = (hashCode * 397) ^ WhenClauses.Aggregate(
-                    0, (current, value) => current + ((current * 397) ^ value.GetHashCode()));
-                hashCode = (hashCode * 397) ^ (ElseResult?.GetHashCode() ?? 0);
-
-                return hashCode;
+                hash.Add(WhenClauses[i]);
             }
+            hash.Add(ElseResult);
+            return hash.ToHashCode();
         }
     }
 }

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/CaseWhenClause.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/CaseWhenClause.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
 {
     public class CaseWhenClause
@@ -24,15 +26,6 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             => Test.Equals(caseWhenClause.Test)
             && Result.Equals(caseWhenClause.Result);
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = Test.GetHashCode();
-                hashCode = (hashCode * 397) ^ Result.GetHashCode();
-
-                return hashCode;
-            }
-        }
+        public override int GetHashCode() => HashCode.Combine(Test, Result);
     }
 }

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/ColumnExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/ColumnExpression.cs
@@ -64,18 +64,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             && Table.Equals(columnExpression.Table)
             && Nullable == columnExpression.Nullable;
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = base.GetHashCode();
-                hashCode = (hashCode * 397) ^ Name.GetHashCode();
-                hashCode = (hashCode * 397) ^ Table.GetHashCode();
-                hashCode = (hashCode * 397) ^ Nullable.GetHashCode();
-
-                return hashCode;
-            }
-        }
+        public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Name, Table, Nullable);
 
         private string DebuggerDisplay() => $"{Table.Alias}.{Name}";
     }

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/ExistsExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/ExistsExpression.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -55,16 +56,6 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             && Subquery.Equals(existsExpression.Subquery)
             && Negated == existsExpression.Negated;
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = base.GetHashCode();
-                hashCode = (hashCode * 397) ^ Subquery.GetHashCode();
-                hashCode = (hashCode * 397) ^ Negated.GetHashCode();
-
-                return hashCode;
-            }
-        }
+        public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Subquery, Negated);
     }
 }

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/FromSqlExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/FromSqlExpression.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query.Internal;
@@ -34,15 +35,6 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             => base.Equals(fromSqlExpression)
                && string.Equals(Sql, fromSqlExpression.Sql);
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = base.GetHashCode();
-                hashCode = (hashCode * 397) ^ Sql.GetHashCode();
-
-                return hashCode;
-            }
-        }
+        public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Sql);
     }
 }

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/InExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/InExpression.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -72,18 +73,6 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             && (Values == null ? inExpression.Values == null : Values.Equals(inExpression.Values))
             && (Subquery == null ? inExpression.Subquery == null : Subquery.Equals(inExpression.Subquery));
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = base.GetHashCode();
-                hashCode = (hashCode * 397) ^ Item.GetHashCode();
-                hashCode = (hashCode * 397) ^ Negated.GetHashCode();
-                hashCode = (hashCode * 397) ^ (Values?.GetHashCode() ?? 0);
-                hashCode = (hashCode * 397) ^ (Subquery?.GetHashCode() ?? 0);
-
-                return hashCode;
-            }
-        }
+        public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Item, Negated, Values, Subquery);
     }
 }

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/JoinExpressionBase.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/JoinExpressionBase.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
 {
     public abstract class JoinExpressionBase : TableExpressionBase
@@ -23,15 +25,6 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             => base.Equals(joinExpressionBase)
             && Table.Equals(joinExpressionBase.Table);
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = base.GetHashCode();
-                hashCode = (hashCode * 397) ^ Table.GetHashCode();
-
-                return hashCode;
-            }
-        }
+        public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Table);
     }
 }

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/LikeExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/LikeExpression.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -60,17 +61,6 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             && Pattern.Equals(likeExpression.Pattern)
             && EscapeChar.Equals(likeExpression.EscapeChar);
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = base.GetHashCode();
-                hashCode = (hashCode * 397) ^ Match.GetHashCode();
-                hashCode = (hashCode * 397) ^ Pattern.GetHashCode();
-                hashCode = (hashCode * 397) ^ (EscapeChar?.GetHashCode() ?? 0);
-
-                return hashCode;
-            }
-        }
+        public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Match, Pattern, EscapeChar);
     }
 }

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/OrderingExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/OrderingExpression.cs
@@ -46,15 +46,6 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             => Expression.Equals(orderingExpression.Expression)
             && Ascending == orderingExpression.Ascending;
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = Expression.GetHashCode();
-                hashCode = (hashCode * 397) ^ Ascending.GetHashCode();
-
-                return hashCode;
-            }
-        }
+        public override int GetHashCode() => HashCode.Combine(Expression, Ascending);
     }
 }

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/PredicateJoinExpressionBase.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/PredicateJoinExpressionBase.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
 {
     public abstract class PredicateJoinExpressionBase : JoinExpressionBase
@@ -23,15 +25,6 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             => base.Equals(predicateJoinExpressionBase)
             && JoinPredicate.Equals(predicateJoinExpressionBase.JoinPredicate);
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = base.GetHashCode();
-                hashCode = (hashCode * 397) ^ JoinPredicate.GetHashCode();
-
-                return hashCode;
-            }
-        }
+        public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), JoinPredicate);
     }
 }

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/ProjectionExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/ProjectionExpression.cs
@@ -51,16 +51,6 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             => string.Equals(Alias, projectionExpression.Alias)
             && Expression.Equals(projectionExpression.Expression);
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = base.GetHashCode();
-                hashCode = (hashCode * 397) ^ Alias.GetHashCode();
-                hashCode = (hashCode * 397) ^ Expression.GetHashCode();
-
-                return hashCode;
-            }
-        }
+        public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Alias, Expression);
     }
 }

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SelectExpression.cs
@@ -948,30 +948,33 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
 
         public override int GetHashCode()
         {
-            unchecked
+            var hash = new HashCode();
+            hash.Add(base.GetHashCode());
+            foreach (var projectionMapping in _projectionMapping)
             {
-                var hashCode = base.GetHashCode();
-                foreach (var projectionMapping in _projectionMapping)
-                {
-                    hashCode = (hashCode * 397) ^ projectionMapping.Key.GetHashCode();
-                    hashCode = (hashCode * 397) ^ projectionMapping.Value.GetHashCode();
-                }
-
-                hashCode = (hashCode * 397) ^ _tables.Aggregate(
-                    0, (current, value) => current + ((current * 397) ^ value.GetHashCode()));
-
-                hashCode = (hashCode * 397) ^ (Predicate?.GetHashCode() ?? 0);
-
-                hashCode = (hashCode * 397) ^ _orderings.Aggregate(
-                    0, (current, value) => current + ((current * 397) ^ value.GetHashCode()));
-
-                hashCode = (hashCode * 397) ^ (Offset?.GetHashCode() ?? 0);
-                hashCode = (hashCode * 397) ^ (Limit?.GetHashCode() ?? 0);
-                hashCode = (hashCode * 397) ^ IsDistinct.GetHashCode();
-
-                return hashCode;
+                hash.Add(projectionMapping.Key);
+                hash.Add(projectionMapping.Value);
             }
+
+            foreach (var table in _tables)
+            {
+                hash.Add(table);
+            }
+
+            hash.Add(Predicate);
+
+            foreach (var ordering in _orderings)
+            {
+                hash.Add(ordering);
+            }
+
+            hash.Add(Offset);
+            hash.Add(Limit);
+            hash.Add(IsDistinct);
+
+            return hash.ToHashCode();
         }
+
         public override void Print(ExpressionPrinter expressionPrinter)
         {
             expressionPrinter.StringBuilder.AppendLine("Projection Mapping:");

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SqlBinaryExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SqlBinaryExpression.cs
@@ -128,17 +128,6 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             && Left.Equals(sqlBinaryExpression.Left)
             && Right.Equals(sqlBinaryExpression.Right);
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = base.GetHashCode();
-                hashCode = (hashCode * 397) ^ OperatorType.GetHashCode();
-                hashCode = (hashCode * 397) ^ Left.GetHashCode();
-                hashCode = (hashCode * 397) ^ Right.GetHashCode();
-
-                return hashCode;
-            }
-        }
+        public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), OperatorType, Left, Right);
     }
 }

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SqlConstantExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SqlConstantExpression.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Query.Internal;
@@ -62,15 +63,6 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
                 ? sqlConstantExpression.Value == null
                 : Value.Equals(sqlConstantExpression.Value));
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = base.GetHashCode();
-                hashCode = (hashCode * 397) ^ (Value?.GetHashCode() ?? 0);
-
-                return hashCode;
-            }
-        }
+        public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Value);
     }
 }

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SqlExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SqlExpression.cs
@@ -36,15 +36,6 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             => Type == sqlExpression.Type
             && TypeMapping?.Equals(sqlExpression.TypeMapping) == true;
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = Type.GetHashCode();
-                hashCode = (hashCode * 397) ^ (TypeMapping?.GetHashCode() ?? 0);
-
-                return hashCode;
-            }
-        }
+        public override int GetHashCode() => HashCode.Combine(Type, TypeMapping);
     }
 }

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SqlFragmentExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SqlFragmentExpression.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 
@@ -29,15 +30,6 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             => base.Equals(sqlFragmentExpression)
             && string.Equals(Sql, sqlFragmentExpression.Sql);
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = base.GetHashCode();
-                hashCode = (hashCode * 397) ^ Sql.GetHashCode();
-
-                return hashCode;
-            }
-        }
+        public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Sql);
     }
 }

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SqlFunctionExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SqlFunctionExpression.cs
@@ -176,18 +176,16 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
 
         public override int GetHashCode()
         {
-            unchecked
+            var hash = new HashCode();
+            hash.Add(base.GetHashCode());
+            hash.Add(FunctionName);
+            hash.Add(Schema);
+            hash.Add(Instance);
+            for (var i = 0; i < Arguments.Count; i++)
             {
-                var hashCode = base.GetHashCode();
-                hashCode = (hashCode * 397) ^ FunctionName.GetHashCode();
-                hashCode = (hashCode * 397) ^ (Schema?.GetHashCode() ?? 0);
-                hashCode = (hashCode * 397) ^ (Instance?.GetHashCode() ?? 0);
-                hashCode = (hashCode * 397) ^ Arguments.Aggregate(
-                    0, (current, value) => current + ((current * 397) ^ value.GetHashCode()));
-
-
-                return hashCode;
+                hash.Add(Arguments[i]);
             }
+            return hash.ToHashCode();
         }
     }
 }

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SqlParameterExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SqlParameterExpression.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -35,15 +36,6 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             => base.Equals(sqlParameterExpression)
             && string.Equals(Name, sqlParameterExpression.Name);
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = base.GetHashCode();
-                hashCode = (hashCode * 397) ^ Name.GetHashCode();
-
-                return hashCode;
-            }
-        }
+        public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Name);
     }
 }

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SqlUnaryExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SqlUnaryExpression.cs
@@ -78,16 +78,6 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             && OperatorType == sqlUnaryExpression.OperatorType
             && Operand.Equals(sqlUnaryExpression.Operand);
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = base.GetHashCode();
-                hashCode = (hashCode * 397) ^ OperatorType.GetHashCode();
-                hashCode = (hashCode * 397) ^ Operand.GetHashCode();
-
-                return hashCode;
-            }
-        }
+        public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), OperatorType, Operand);
     }
 }

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SubSelectExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SubSelectExpression.cs
@@ -53,15 +53,6 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             => base.Equals(subSelectExpression)
             && Subquery.Equals(subSelectExpression.Subquery);
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = base.GetHashCode();
-                hashCode = (hashCode * 397) ^ Subquery.GetHashCode();
-
-                return hashCode;
-            }
-        }
+        public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Subquery);
     }
 }

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/TableExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/TableExpression.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 
@@ -37,16 +38,6 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             // This should be reference equal only.
             => obj != null && ReferenceEquals(this, obj);
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = base.GetHashCode();
-                hashCode = (hashCode * 397) ^ Table.GetHashCode();
-                hashCode = (hashCode * 397) ^ (Schema?.GetHashCode() ?? 0);
-
-                return hashCode;
-            }
-        }
+        public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Table, Schema);
     }
 }

--- a/src/EFCore.Relational/Query/RelationalCompiledQueryCacheKeyGenerator.cs
+++ b/src/EFCore.Relational/Query/RelationalCompiledQueryCacheKeyGenerator.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -118,13 +119,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             /// <returns>
             ///     The hash code for the key.
             /// </returns>
-            public override int GetHashCode()
-            {
-                unchecked
-                {
-                    return (_compiledQueryCacheKey.GetHashCode() * 397) ^ _useRelationalNulls.GetHashCode();
-                }
-            }
+            public override int GetHashCode() => HashCode.Combine(_compiledQueryCacheKey, _useRelationalNulls);
         }
     }
 }

--- a/src/EFCore.Relational/Storage/RelationalTypeMappingInfo.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMappingInfo.cs
@@ -250,12 +250,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Returns a hash code for this object.
         /// </summary>
         /// <returns> The hash code. </returns>
-        public override int GetHashCode()
-        {
-            var hashCode = _coreTypeMappingInfo.GetHashCode();
-            hashCode = (hashCode * 397) ^ (StoreTypeName?.GetHashCode() ?? 0);
-            hashCode = (hashCode * 397) ^ (IsFixedLength?.GetHashCode() ?? 0);
-            return hashCode;
-        }
+        public override int GetHashCode() => HashCode.Combine(_coreTypeMappingInfo, StoreTypeName, IsFixedLength);
     }
 }

--- a/src/EFCore.Relational/Storage/TypeMaterializationInfo.cs
+++ b/src/EFCore.Relational/Storage/TypeMaterializationInfo.cs
@@ -152,17 +152,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <returns> A hash code for the current object. </returns>
         public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = ProviderClrType.GetHashCode();
-                hashCode = (hashCode * 397) ^ ModelClrType.GetHashCode();
-                hashCode = (hashCode * 397) ^ (Mapping?.GetHashCode() ?? 0);
-                hashCode = (hashCode * 397) ^ (Property?.GetHashCode() ?? 0);
-                hashCode = (hashCode * 397) ^ Index;
-                hashCode = (hashCode * 397) ^ (IsFromLeftOuterJoin?.GetHashCode() ?? 0);
-                return hashCode;
-            }
-        }
+            => HashCode.Combine(ProviderClrType, ModelClrType, Mapping, Property, Index, IsFromLeftOuterJoin);
     }
 }

--- a/src/EFCore.Relational/Storage/TypedRelationalValueBufferFactoryFactory.cs
+++ b/src/EFCore.Relational/Storage/TypedRelationalValueBufferFactoryFactory.cs
@@ -86,7 +86,15 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 => TypeMaterializationInfo.SequenceEqual(other.TypeMaterializationInfo);
 
             public override int GetHashCode()
-                => TypeMaterializationInfo.Aggregate(0, (t, v) => (t * 397) ^ v.GetHashCode());
+            {
+                var hash = new HashCode();
+                // ReSharper disable once ForCanBeConvertedToForeach
+                for (var i = 0; i < TypeMaterializationInfo.Count; i++)
+                {
+                    hash.Add(TypeMaterializationInfo[i]);
+                }
+                return hash.ToHashCode();
+            }
         }
 
         private readonly ConcurrentDictionary<CacheKey, TypedRelationalValueBufferFactory> _cache

--- a/src/EFCore.Relational/Update/Internal/KeyValueIndex.cs
+++ b/src/EFCore.Relational/Update/Internal/KeyValueIndex.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -71,9 +72,13 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public override int GetHashCode()
-            => (((((typeof(TKey).GetHashCode() * 397)
-                   ^ _fromOriginalValues.GetHashCode()) * 397)
-                 ^ _foreignKey.GetHashCode()) * 397)
-               ^ _keyComparer.GetHashCode(_keyValue);
+        {
+            var hash = new HashCode();
+            hash.Add(typeof(TKey));
+            hash.Add(_fromOriginalValues);
+            hash.Add(_foreignKey);
+            hash.Add(_keyValue, _keyComparer);
+            return hash.ToHashCode();
+        }
     }
 }

--- a/src/EFCore.SqlServer/Query/Expressions/Internal/RowNumberExpression.cs
+++ b/src/EFCore.SqlServer/Query/Expressions/Internal/RowNumberExpression.cs
@@ -113,6 +113,13 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Expressions.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public override int GetHashCode()
-            => _orderings.Aggregate(0, (current, ordering) => current + ((current * 397) ^ ordering.GetHashCode()));
+        {
+            var hash = new HashCode();
+            foreach (var ordering in _orderings)
+            {
+                hash.Add(ordering);
+            }
+            return hash.ToHashCode();
+        }
     }
 }

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerCompiledQueryCacheKeyGenerator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerCompiledQueryCacheKeyGenerator.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query;
@@ -70,13 +71,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                 => _relationalCompiledQueryCacheKey.Equals(other._relationalCompiledQueryCacheKey)
                    && _useRowNumberOffset == other._useRowNumberOffset;
 
-            public override int GetHashCode()
-            {
-                unchecked
-                {
-                    return (_relationalCompiledQueryCacheKey.GetHashCode() * 397) ^ _useRowNumberOffset.GetHashCode();
-                }
-            }
+            public override int GetHashCode() => HashCode.Combine(_relationalCompiledQueryCacheKey, _useRowNumberOffset);
         }
     }
 }

--- a/src/EFCore/ChangeTracking/Internal/CompositeValueFactory.cs
+++ b/src/EFCore/ChangeTracking/Internal/CompositeValueFactory.cs
@@ -218,16 +218,12 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             public int GetHashCode(object[] obj)
             {
-                var hashCode = 0;
-
-                // ReSharper disable once ForCanBeConvertedToForeach
-                // ReSharper disable once LoopCanBeConvertedToQuery
-                for (var i = 0; i < obj.Length; i++)
+                var hash = new HashCode();
+                foreach (var value in obj)
                 {
-                    hashCode = (hashCode * 397) ^ (obj[i]?.GetHashCode() ?? 0);
+                    hash.Add(value);
                 }
-
-                return hashCode;
+                return hash.ToHashCode();
             }
         }
 

--- a/src/EFCore/Internal/ReferenceEnumerableEqualityComparer.cs
+++ b/src/EFCore/Internal/ReferenceEnumerableEqualityComparer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -29,6 +30,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public int GetHashCode(TEnumerable obj) => obj.Aggregate(0, (t, v) => (t * 397) ^ v.GetHashCode());
+        public int GetHashCode(TEnumerable obj)
+        {
+            var hash = new HashCode();
+            foreach (var value in obj)
+            {
+                hash.Add(value);
+            }
+            return hash.ToHashCode();
+        }
     }
 }

--- a/src/EFCore/Metadata/Internal/EntityTypePathComparer.cs
+++ b/src/EFCore/Metadata/Internal/EntityTypePathComparer.cs
@@ -13,7 +13,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public class EntityTypePathComparer : IComparer<IEntityType>
+    public class EntityTypePathComparer : IComparer<IEntityType>, IEqualityComparer<IEntityType>
     {
         private EntityTypePathComparer()
         {
@@ -35,6 +35,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual int Compare(IEntityType x, IEntityType y)
         {
+            if (ReferenceEquals(x, y))
+            {
+                return 0;
+            }
+
+            if (x == null)
+            {
+                return -1;
+            }
+
+            if (y == null)
+            {
+                return 1;
+            }
+
             var result = StringComparer.Ordinal.Compare(x.Name, y.Name);
             if (result != 0)
             {
@@ -73,27 +88,31 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
         }
 
+        /// <summary>Determines whether the specified objects are equal.</summary>
+        /// <param name="x">The first object of type T to compare.</param>
+        /// <param name="y">The second object of type T to compare.</param>
+        /// <returns>true if the specified objects are equal; otherwise, false.</returns>
+        public bool Equals(IEntityType x, IEntityType y) => Compare(x, y) == 0;
+
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual int GetHashCode([NotNull] IEntityType entityType)
+        public virtual int GetHashCode(IEntityType entityType)
         {
-            var result = 0;
+            var hash = new HashCode();
             while (true)
             {
-                result = (result * 397)
-                         ^ StringComparer.Ordinal.GetHashCode(entityType.Name);
+                hash.Add(entityType.Name, StringComparer.Ordinal);
                 var definingNavigationName = entityType.DefiningNavigationName;
                 if (definingNavigationName == null)
                 {
-                    return result;
+                    return hash.ToHashCode();
                 }
 
-                result = (result * 397)
-                         ^ StringComparer.Ordinal.GetHashCode(definingNavigationName);
+                hash.Add(definingNavigationName, StringComparer.Ordinal);
                 entityType = entityType.DefiningEntityType;
             }
         }

--- a/src/EFCore/Metadata/Internal/ForeignKeyComparer.cs
+++ b/src/EFCore/Metadata/Internal/ForeignKeyComparer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
@@ -64,11 +65,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual int GetHashCode(IForeignKey obj) =>
-            unchecked(
-                ((((PropertyListComparer.Instance.GetHashCode(obj.PrincipalKey.Properties) * 397)
-                   ^ PropertyListComparer.Instance.GetHashCode(obj.Properties)) * 397)
-                 ^ EntityTypePathComparer.Instance.GetHashCode(obj.PrincipalEntityType)) * 397)
-            ^ EntityTypePathComparer.Instance.GetHashCode(obj.DeclaringEntityType);
+        public virtual int GetHashCode(IForeignKey obj)
+        {
+            var hashCode = new HashCode();
+            hashCode.Add(obj.PrincipalKey.Properties, PropertyListComparer.Instance);
+            hashCode.Add(obj.Properties, PropertyListComparer.Instance);
+            hashCode.Add(obj.PrincipalEntityType, EntityTypePathComparer.Instance);
+            hashCode.Add(obj.DeclaringEntityType, EntityTypePathComparer.Instance);
+            return hashCode.ToHashCode();
+        }
     }
 }

--- a/src/EFCore/Metadata/Internal/PropertyListComparer.cs
+++ b/src/EFCore/Metadata/Internal/PropertyListComparer.cs
@@ -69,6 +69,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public int GetHashCode(IReadOnlyList<IProperty> obj)
-            => obj.Aggregate(0, (hash, p) => unchecked((hash * 397) ^ p.GetHashCode()));
+        {
+            var hash = new HashCode();
+            for (var i = 0; i < obj.Count; i++)
+            {
+                hash.Add(obj[i]);
+            }
+            return hash.ToHashCode();
+        }
     }
 }

--- a/src/EFCore/Query/CompiledQueryCacheKeyGenerator.cs
+++ b/src/EFCore/Query/CompiledQueryCacheKeyGenerator.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -135,14 +136,12 @@ namespace Microsoft.EntityFrameworkCore.Query
             /// </returns>
             public override int GetHashCode()
             {
-                unchecked
-                {
-                    var hashCode = ExpressionEqualityComparer.Instance.GetHashCode(_query);
-                    hashCode = (hashCode * 397) ^ _model.GetHashCode();
-                    hashCode = (hashCode * 397) ^ (int)_queryTrackingBehavior;
-                    hashCode = (hashCode * 397) ^ _async.GetHashCode();
-                    return hashCode;
-                }
+                var hash = new HashCode();
+                hash.Add(_query, ExpressionEqualityComparer.Instance);
+                hash.Add(_model);
+                hash.Add(_queryTrackingBehavior);
+                hash.Add(_async);
+                return hash.ToHashCode();
             }
         }
     }

--- a/src/EFCore/Query/Internal/AnonymousObject.cs
+++ b/src/EFCore/Query/Internal/AnonymousObject.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
@@ -109,13 +110,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         /// </summary>
         public override int GetHashCode()
         {
-            unchecked
+            var hash = new HashCode();
+            foreach (var value in _values)
             {
-                return _values.Aggregate(
-                    0,
-                    (current, argument)
-                        => current + ((current * 397) ^ (argument?.GetHashCode() ?? 0)));
+                hash.Add(value);
             }
+            return hash.ToHashCode();
         }
 
         /// <summary>

--- a/src/EFCore/Query/Internal/MaterializedAnonymousObject.cs
+++ b/src/EFCore/Query/Internal/MaterializedAnonymousObject.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
@@ -117,13 +118,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         /// </summary>
         public override int GetHashCode()
         {
-            unchecked
+            var hash = new HashCode();
+            foreach (var value in _values)
             {
-                return _values.Aggregate(
-                    0,
-                    (current, argument)
-                        => current + ((current * 397) ^ (argument?.GetHashCode() ?? 0)));
+                hash.Add(value);
             }
+            return hash.ToHashCode();
         }
 
         /// <summary>

--- a/src/EFCore/Query/Pipeline/ProjectionBindingExpression.cs
+++ b/src/EFCore/Query/Pipeline/ProjectionBindingExpression.cs
@@ -62,19 +62,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
             // Using reference equality here since if we are this far, we don't need to compare this.
             && IndexMap == projectionBindingExpression.IndexMap;
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = base.GetHashCode();
-                hashCode = (hashCode * 397) ^ QueryExpression.GetHashCode();
-                hashCode = (hashCode * 397) ^ (ProjectionMember?.GetHashCode() ?? 0);
-                hashCode = (hashCode * 397) ^ (Index?.GetHashCode() ?? 0);
-                hashCode = (hashCode * 397) ^ (IndexMap?.GetHashCode() ?? 0);
-
-                return hashCode;
-            }
-        }
+        public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), QueryExpression, ProjectionMember, Index, IndexMap);
 
         #endregion
 

--- a/src/EFCore/Query/Pipeline/ProjectionMember.cs
+++ b/src/EFCore/Query/Pipeline/ProjectionMember.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Reflection;
@@ -43,10 +44,13 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
 
         public override int GetHashCode()
         {
-            unchecked
+            var hash = new HashCode();
+            for (var i = 0; i < _memberChain.Count; i++)
             {
-                return _memberChain.Aggregate(seed: 0, (current, value) => (current * 397) ^ value.GetHashCode());
+                hash.Add(_memberChain[i]);
             }
+
+            return hash.ToHashCode();
         }
 
         public override bool Equals(object obj)

--- a/src/EFCore/Storage/TypeMappingInfo.cs
+++ b/src/EFCore/Storage/TypeMappingInfo.cs
@@ -257,15 +257,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <returns> The hash code. </returns>
         public override int GetHashCode()
-        {
-            var hashCode = ClrType?.GetHashCode() ?? 0;
-            hashCode = (hashCode * 397) ^ IsKeyOrIndex.GetHashCode();
-            hashCode = (hashCode * 397) ^ (Size?.GetHashCode() ?? 0);
-            hashCode = (hashCode * 397) ^ (IsUnicode?.GetHashCode() ?? 0);
-            hashCode = (hashCode * 397) ^ (IsRowVersion?.GetHashCode() ?? 0);
-            hashCode = (hashCode * 397) ^ (Scale?.GetHashCode() ?? 0);
-            hashCode = (hashCode * 397) ^ (Precision?.GetHashCode() ?? 0);
-            return hashCode;
-        }
+            => HashCode.Combine(ClrType, IsKeyOrIndex, Size, IsUnicode, IsRowVersion, Scale, Precision);
     }
 }

--- a/src/EFCore/Storage/ValueBuffer.cs
+++ b/src/EFCore/Storage/ValueBuffer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
@@ -143,12 +144,18 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </returns>
         public override int GetHashCode()
         {
-            unchecked
+            if (_values == null)
             {
-                return _values != null
-                    ? _values.Aggregate((_offset.GetHashCode()), (current, value) => (current * 397) ^ (value?.GetHashCode() ?? 0))
-                    : _offset.GetHashCode();
+                return _offset.GetHashCode();
             }
+
+            var hash = new HashCode();
+            hash.Add(_offset);
+            foreach (var value in _values)
+            {
+                hash.Add(value);
+            }
+            return hash.ToHashCode();
         }
     }
 }

--- a/src/EFCore/ValueGeneration/ValueGeneratorCache.cs
+++ b/src/EFCore/ValueGeneration/ValueGeneratorCache.cs
@@ -61,13 +61,7 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration
                 return obj is null ? false : obj is CacheKey cacheKey && Equals(cacheKey);
             }
 
-            public override int GetHashCode()
-            {
-                unchecked
-                {
-                    return (Property.GetHashCode() * 397) ^ EntityType.GetHashCode();
-                }
-            }
+            public override int GetHashCode() => HashCode.Combine(Property, EntityType);
         }
 
         /// <summary>

--- a/test/EFCore.Relational.Specification.Tests/TransactionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/TransactionTestBase.cs
@@ -1377,8 +1377,7 @@ namespace Microsoft.EntityFrameworkCore
 
             public override string ToString() => "Id = " + Id + ", Name = " + Name;
 
-            // ReSharper disable NonReadonlyMemberInGetHashCode
-            public override int GetHashCode() => Id.GetHashCode() * 397 ^ Name.GetHashCode();
+            public override int GetHashCode() => HashCode.Combine(Id, Name);
         }
     }
 }

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -1770,15 +1770,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 return string.Equals(Id, other.Id) && Count == other.Count;
             }
 
-            public override int GetHashCode()
-            {
-                unchecked
-                {
-                    // ReSharper disable NonReadonlyMemberInGetHashCode
-                    return ((Id?.GetHashCode() ?? 0) * 397) ^ Count;
-                    // ReSharper restore NonReadonlyMemberInGetHashCode
-                }
-            }
+            public override int GetHashCode() => HashCode.Combine(Id, Count);
         }
 
         [ConditionalTheory(Skip = "Issue#15611")]

--- a/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/Level1.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/Level1.cs
@@ -45,14 +45,6 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel
             return Id == other.Id && string.Equals(Name, other.Name) && Date.Equals(other.Date);
         }
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = Id;
-                hashCode = (hashCode * 397) ^ (Name?.GetHashCode() ?? 0);
-                return (hashCode * 397) ^ Date.GetHashCode();
-            }
-        }
+        public override int GetHashCode() => HashCode.Combine(Id, Name, Date);
     }
 }

--- a/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/Level2.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/Level2.cs
@@ -57,16 +57,6 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel
                    && Level1_Required_Id == other.Level1_Required_Id && Level1_Optional_Id == other.Level1_Optional_Id;
         }
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = Id;
-                hashCode = (hashCode * 397) ^ (Name?.GetHashCode() ?? 0);
-                hashCode = (hashCode * 397) ^ Date.GetHashCode();
-                hashCode = (hashCode * 397) ^ Level1_Required_Id;
-                return (hashCode * 397) ^ (Level1_Optional_Id?.GetHashCode() ?? 0);
-            }
-        }
+        public override int GetHashCode() => HashCode.Combine(Id, Name, Date, Level1_Required_Id, Level1_Optional_Id);
     }
 }

--- a/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/Level3.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/Level3.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 
 // ReSharper disable NonReadonlyMemberInGetHashCode
@@ -55,15 +56,6 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel
                    && Level2_Optional_Id == other.Level2_Optional_Id;
         }
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = Id;
-                hashCode = (hashCode * 397) ^ (Name?.GetHashCode() ?? 0);
-                hashCode = (hashCode * 397) ^ Level2_Required_Id;
-                return (hashCode * 397) ^ (Level2_Optional_Id?.GetHashCode() ?? 0);
-            }
-        }
+        public override int GetHashCode() => HashCode.Combine(Id, Name, Level2_Required_Id, Level2_Optional_Id);
     }
 }

--- a/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/Level4.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/Level4.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 
 // ReSharper disable NonReadonlyMemberInGetHashCode
@@ -46,15 +47,6 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel
                    && Level3_Optional_Id == other.Level3_Optional_Id;
         }
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = Id;
-                hashCode = (hashCode * 397) ^ (Name?.GetHashCode() ?? 0);
-                hashCode = (hashCode * 397) ^ Level3_Required_Id;
-                return (hashCode * 397) ^ (Level3_Optional_Id?.GetHashCode() ?? 0);
-            }
-        }
+        public override int GetHashCode() => HashCode.Combine(Id, Name, Level3_Required_Id, Level3_Optional_Id);
     }
 }

--- a/test/EFCore.Specification.Tests/TestModels/Northwind/OrderDetail.cs
+++ b/test/EFCore.Specification.Tests/TestModels/Northwind/OrderDetail.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.EntityFrameworkCore.TestModels.Northwind
 {
     public class OrderDetail
@@ -31,12 +33,6 @@ namespace Microsoft.EntityFrameworkCore.TestModels.Northwind
                   && Equals((OrderDetail)obj);
         }
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                return (OrderID * 397) ^ ProductID;
-            }
-        }
+        public override int GetHashCode() => HashCode.Combine(OrderID, ProductID);
     }
 }

--- a/test/EFCore.Specification.Tests/TestModels/TransportationModel/CombustionEngine.cs
+++ b/test/EFCore.Specification.Tests/TestModels/TransportationModel/CombustionEngine.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
 {
     public abstract class CombustionEngine : Engine
@@ -12,8 +14,6 @@ namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
                && base.Equals(other)
                && Equals(FuelTank, other.FuelTank);
 
-        public override int GetHashCode()
-            => base.GetHashCode() * 397
-               ^ FuelTank.GetHashCode();
+        public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), FuelTank);
     }
 }

--- a/test/EFCore.Specification.Tests/TestModels/TransportationModel/Engine.cs
+++ b/test/EFCore.Specification.Tests/TestModels/TransportationModel/Engine.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
 {
     public class Engine
@@ -14,8 +16,6 @@ namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
                && VehicleName == other.VehicleName
                && Description == other.Description;
 
-        public override int GetHashCode()
-            => VehicleName.GetHashCode() * 397
-               ^ Description.GetHashCode();
+        public override int GetHashCode() => HashCode.Combine(VehicleName, Description);
     }
 }

--- a/test/EFCore.Specification.Tests/TestModels/TransportationModel/FuelTank.cs
+++ b/test/EFCore.Specification.Tests/TestModels/TransportationModel/FuelTank.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
 {
     public class FuelTank
@@ -19,8 +21,6 @@ namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
                && Capacity == other.Capacity;
 
         public override int GetHashCode()
-            => (VehicleName.GetHashCode() * 397
-                ^ FuelType.GetHashCode()) * 397
-               ^ Capacity.GetHashCode();
+            => HashCode.Combine(VehicleName, FuelType, Capacity);
     }
 }

--- a/test/EFCore.Specification.Tests/TestModels/TransportationModel/Operator.cs
+++ b/test/EFCore.Specification.Tests/TestModels/TransportationModel/Operator.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
 {
     public class Operator
@@ -15,7 +17,6 @@ namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
                && Name == other.Name;
 
         public override int GetHashCode()
-            => VehicleName.GetHashCode() * 397
-               ^ Name.GetHashCode();
+            => HashCode.Combine(VehicleName, Name);
     }
 }

--- a/test/EFCore.Specification.Tests/TestModels/TransportationModel/PoweredVehicle.cs
+++ b/test/EFCore.Specification.Tests/TestModels/TransportationModel/PoweredVehicle.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
 {
     public class PoweredVehicle : Vehicle
@@ -12,8 +14,6 @@ namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
                && base.Equals(other)
                && Equals(Engine, other.Engine);
 
-        public override int GetHashCode()
-            => base.GetHashCode() * 397
-               ^ Engine.GetHashCode();
+        public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Engine);
     }
 }

--- a/test/EFCore.Specification.Tests/TestModels/TransportationModel/SolidFuelTank.cs
+++ b/test/EFCore.Specification.Tests/TestModels/TransportationModel/SolidFuelTank.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
 {
     public class SolidFuelTank : FuelTank
@@ -13,8 +15,6 @@ namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
                && base.Equals(other)
                && GrainGeometry == other.GrainGeometry;
 
-        public override int GetHashCode()
-            => base.GetHashCode() * 397
-               ^ GrainGeometry.GetHashCode();
+        public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), GrainGeometry);
     }
 }

--- a/test/EFCore.Specification.Tests/TestModels/TransportationModel/SolidRocket.cs
+++ b/test/EFCore.Specification.Tests/TestModels/TransportationModel/SolidRocket.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
 {
     public class SolidRocket : ContinuousCombustionEngine
@@ -12,7 +14,6 @@ namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
                && base.Equals(other);
 
         public override int GetHashCode()
-            => base.GetHashCode() * 397
-               ^ SolidFuelTank.GetHashCode();
+            => HashCode.Combine(base.GetHashCode(), SolidFuelTank);
     }
 }

--- a/test/EFCore.Specification.Tests/TestModels/TransportationModel/Vehicle.cs
+++ b/test/EFCore.Specification.Tests/TestModels/TransportationModel/Vehicle.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
 {
     public class Vehicle
@@ -15,9 +17,6 @@ namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
                && SeatingCapacity == other.SeatingCapacity
                && Equals(Operator, other.Operator);
 
-        public override int GetHashCode()
-            => (Name.GetHashCode() * 397
-                ^ SeatingCapacity.GetHashCode()) * 397
-               ^ Operator.GetHashCode();
+        public override int GetHashCode() => HashCode.Combine(Name, SeatingCapacity, Operator);
     }
 }


### PR DESCRIPTION
Also remove allocations from GetHashCode() methods by refraining from using LINQ.

Notes:
* I deliberately refrained from calling `Aggregate()` (or other LINQ) since we don't really want `GetHashCode()` to allocate.
* In at least some cases we should consider caching the hash code to avoid recomputing, but am leaving that for some other time. This is precisely why 
* I've left out GetServiceProviderHashCode(), because it returns a long. Is there any specific reason we're return a long hash code rather than the standard int? Maybe we should change to int and use `HashCode` there as well?
* In cases where a class calls `base.GetHashCode()`, I simply passed that value `HashCode.Combine()` in the subclass. That means double-hashing occurs, which I think should be OK (opinions/insights??). Otherwise we'd need to expose getting a `HashCode` instance from base classes (not even possible with base classes we don't own, e.g. Expression).