### PR TITLE
Add missing `CoherentParentDependency` attribute

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -5,57 +5,57 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5955ee2583d4509d37ecf55243e9e3c9af128487</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.PlatformAbstractions" Version="3.0.0-preview7-27813-08" CoherentParentDependency="Microsoft.Extensions.Logging">
+    <Dependency Name="Microsoft.DotNet.PlatformAbstractions" Version="3.0.0-preview7-27814-04" CoherentParentDependency="Microsoft.Extensions.Logging">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>2a663574a47d8ac25b9b959e5a9f9fa67fc97ecc</Sha>
+      <Sha>ff7bf431e5aa5091fbae6a43f6cfb0a9f44b5d80</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Caching.Memory" Version="3.0.0-preview7.19314.2">
+    <Dependency Name="Microsoft.Extensions.Caching.Memory" Version="3.0.0-preview7.19314.3">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>4c852659babc1b65c9ceb0afca9d5ec22735cc35</Sha>
+      <Sha>77105f217058a0909396cd6e73e94ba87e5da97f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.0.0-preview7.19314.2">
+    <Dependency Name="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.0.0-preview7.19314.3">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>4c852659babc1b65c9ceb0afca9d5ec22735cc35</Sha>
+      <Sha>77105f217058a0909396cd6e73e94ba87e5da97f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="3.0.0-preview7.19314.2">
+    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="3.0.0-preview7.19314.3">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>4c852659babc1b65c9ceb0afca9d5ec22735cc35</Sha>
+      <Sha>77105f217058a0909396cd6e73e94ba87e5da97f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration" Version="3.0.0-preview7.19314.2">
+    <Dependency Name="Microsoft.Extensions.Configuration" Version="3.0.0-preview7.19314.3">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>4c852659babc1b65c9ceb0afca9d5ec22735cc35</Sha>
+      <Sha>77105f217058a0909396cd6e73e94ba87e5da97f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="3.0.0-preview7.19314.2">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="3.0.0-preview7.19314.3">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>4c852659babc1b65c9ceb0afca9d5ec22735cc35</Sha>
+      <Sha>77105f217058a0909396cd6e73e94ba87e5da97f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="3.0.0-preview7-27813-08" CoherentParentDependency="Microsoft.Extensions.Logging">
+    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="3.0.0-preview7-27814-04" CoherentParentDependency="Microsoft.Extensions.Logging">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>2a663574a47d8ac25b9b959e5a9f9fa67fc97ecc</Sha>
+      <Sha>ff7bf431e5aa5091fbae6a43f6cfb0a9f44b5d80</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.HostFactoryResolver.Sources" Version="3.0.0-preview7.19314.2">
+    <Dependency Name="Microsoft.Extensions.HostFactoryResolver.Sources" Version="3.0.0-preview7.19314.3">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>4c852659babc1b65c9ceb0afca9d5ec22735cc35</Sha>
+      <Sha>77105f217058a0909396cd6e73e94ba87e5da97f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="3.0.0-preview7.19314.2">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="3.0.0-preview7.19314.3">
       <Uri>https://github.com/aspnet/Extensions</Uri>
-      <Sha>4c852659babc1b65c9ceb0afca9d5ec22735cc35</Sha>
+      <Sha>77105f217058a0909396cd6e73e94ba87e5da97f</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NETCore.Platforms" Version="3.0.0-preview7.19313.2" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5955ee2583d4509d37ecf55243e9e3c9af128487</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="3.0.0-preview7-27811-01">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="3.0.0-preview7-27814-04" CoherentParentDependency="Microsoft.Extensions.Logging">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>bba327461e7521b640be91127309760a18f12416</Sha>
+      <Sha>ff7bf431e5aa5091fbae6a43f6cfb0a9f44b5d80</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="3.0.0-preview7-27813-08" CoherentParentDependency="Microsoft.Extensions.Logging">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="3.0.0-preview7-27814-04" CoherentParentDependency="Microsoft.Extensions.Logging">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>2a663574a47d8ac25b9b959e5a9f9fa67fc97ecc</Sha>
+      <Sha>ff7bf431e5aa5091fbae6a43f6cfb0a9f44b5d80</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview7-27813-08" CoherentParentDependency="Microsoft.Extensions.Logging">
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview7-27814-04" CoherentParentDependency="Microsoft.Extensions.Logging">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>2a663574a47d8ac25b9b959e5a9f9fa67fc97ecc</Sha>
+      <Sha>ff7bf431e5aa5091fbae6a43f6cfb0a9f44b5d80</Sha>
     </Dependency>
     <Dependency Name="System.Collections.Immutable" Version="1.6.0-preview7.19313.2" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
       <Uri>https://github.com/dotnet/corefx</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -28,13 +28,13 @@
     <MicrosoftDataSqlClientPackageVersion>1.0.19128.1-Preview</MicrosoftDataSqlClientPackageVersion>
   </PropertyGroup>
   <PropertyGroup Label="Dependencies from aspnet/Extensions">
-    <MicrosoftExtensionsCachingMemoryPackageVersion>3.0.0-preview7.19314.2</MicrosoftExtensionsCachingMemoryPackageVersion>
-    <MicrosoftExtensionsConfigurationPackageVersion>3.0.0-preview7.19314.2</MicrosoftExtensionsConfigurationPackageVersion>
-    <MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>3.0.0-preview7.19314.2</MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>
-    <MicrosoftExtensionsConfigurationJsonPackageVersion>3.0.0-preview7.19314.2</MicrosoftExtensionsConfigurationJsonPackageVersion>
-    <MicrosoftExtensionsDependencyInjectionPackageVersion>3.0.0-preview7.19314.2</MicrosoftExtensionsDependencyInjectionPackageVersion>
-    <MicrosoftExtensionsHostFactoryResolverSourcesPackageVersion>3.0.0-preview7.19314.2</MicrosoftExtensionsHostFactoryResolverSourcesPackageVersion>
-    <MicrosoftExtensionsLoggingPackageVersion>3.0.0-preview7.19314.2</MicrosoftExtensionsLoggingPackageVersion>
+    <MicrosoftExtensionsCachingMemoryPackageVersion>3.0.0-preview7.19314.3</MicrosoftExtensionsCachingMemoryPackageVersion>
+    <MicrosoftExtensionsConfigurationPackageVersion>3.0.0-preview7.19314.3</MicrosoftExtensionsConfigurationPackageVersion>
+    <MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>3.0.0-preview7.19314.3</MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>
+    <MicrosoftExtensionsConfigurationJsonPackageVersion>3.0.0-preview7.19314.3</MicrosoftExtensionsConfigurationJsonPackageVersion>
+    <MicrosoftExtensionsDependencyInjectionPackageVersion>3.0.0-preview7.19314.3</MicrosoftExtensionsDependencyInjectionPackageVersion>
+    <MicrosoftExtensionsHostFactoryResolverSourcesPackageVersion>3.0.0-preview7.19314.3</MicrosoftExtensionsHostFactoryResolverSourcesPackageVersion>
+    <MicrosoftExtensionsLoggingPackageVersion>3.0.0-preview7.19314.3</MicrosoftExtensionsLoggingPackageVersion>
   </PropertyGroup>
   <PropertyGroup Label="Dependencies from dotnet/corefx">
     <MicrosoftCSharpPackageVersion>4.6.0-preview7.19313.2</MicrosoftCSharpPackageVersion>
@@ -44,11 +44,11 @@
     <SystemDiagnosticsDiagnosticSourcePackageVersion>4.6.0-preview7.19313.2</SystemDiagnosticsDiagnosticSourcePackageVersion>
   </PropertyGroup>
   <PropertyGroup Label="Dependencies from dotnet/core-setup">
-    <MicrosoftDotNetPlatformAbstractionsPackageVersion>3.0.0-preview7-27813-08</MicrosoftDotNetPlatformAbstractionsPackageVersion>
-    <MicrosoftExtensionsDependencyModelPackageVersion>3.0.0-preview7-27813-08</MicrosoftExtensionsDependencyModelPackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>3.0.0-preview7-27811-01</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>3.0.0-preview7-27813-08</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview7-27813-08</NETStandardLibraryRefPackageVersion>
+    <MicrosoftDotNetPlatformAbstractionsPackageVersion>3.0.0-preview7-27814-04</MicrosoftDotNetPlatformAbstractionsPackageVersion>
+    <MicrosoftExtensionsDependencyModelPackageVersion>3.0.0-preview7-27814-04</MicrosoftExtensionsDependencyModelPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>3.0.0-preview7-27814-04</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>3.0.0-preview7-27814-04</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
+    <NETStandardLibraryRefPackageVersion>2.1.0-preview7-27814-04</NETStandardLibraryRefPackageVersion>
   </PropertyGroup>
   <PropertyGroup Label="Dependency version settings">
     <!--

--- a/test/EFCore.Tests/Metadata/Conventions/NonNullableNavigationConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/NonNullableNavigationConventionTest.cs
@@ -288,12 +288,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             [ForeignKey("PrincipalFk")]
             [InverseProperty("Dependent")]
-            public Principal? Principal { get; set; }
+            public Principal Principal { get; set; }
 
-            public Principal? AnotherPrincipal { get; set; }
+            public Principal AnotherPrincipal { get; set; }
 
             [ForeignKey("PrincipalId, PrincipalFk")]
-            public Principal? CompositePrincipal { get; set; }
+            public Principal CompositePrincipal { get; set; }
         }
     }
 }

--- a/test/EFCore.Tests/Metadata/Conventions/NonNullableNavigationConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/NonNullableNavigationConventionTest.cs
@@ -138,14 +138,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             navigation = RunConvention(relationshipBuilder, navigation);
 
-            Assert.Equal(nameof(Principal), navigation.ForeignKey.DeclaringEntityType.DisplayName());
-            Assert.True(navigation.ForeignKey.IsRequired);
+            Assert.Equal(nameof(Dependent), navigation.ForeignKey.DeclaringEntityType.DisplayName());
+            Assert.False(navigation.ForeignKey.IsRequired);
 
-            var logEntry = ListLoggerFactory.Log.Single();
-            Assert.Equal(LogLevel.Debug, logEntry.Level);
-            Assert.Equal(
-                CoreResources.LogNonNullableOnDependent(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
-                    nameof(Principal.Dependent), nameof(Principal)), logEntry.Message);
+            Assert.Empty(ListLoggerFactory.Log);
         }
 
         [ConditionalFact]
@@ -155,7 +151,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             var model = (Model)modelBuilder.Model;
             modelBuilder.Entity<BlogDetails>();
 
-            Assert.True(
+            Assert.False(
                 model.FindEntityType(typeof(BlogDetails)).GetForeignKeys().Single(fk => fk.PrincipalEntityType?.ClrType == typeof(Blog))
                     .IsRequired);
         }
@@ -167,15 +163,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             var model = (Model)modelBuilder.Model;
             modelBuilder.Entity<BlogDetails>().HasOne(b => b.Blog).WithOne(b => b.BlogDetails);
 
-            Assert.True(
+            Assert.False(
                 model.FindEntityType(typeof(BlogDetails)).GetForeignKeys()
                     .Single(fk => fk.PrincipalEntityType?.ClrType == typeof(Blog)).IsRequired);
 
-            var logEntry = ListLoggerFactory.Log.Single();
-            Assert.Equal(LogLevel.Debug, logEntry.Level);
-            Assert.Equal(
-                CoreResources.LogNonNullableReferenceOnBothNavigations(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
-                    nameof(Blog), nameof(Blog.BlogDetails), nameof(BlogDetails), nameof(BlogDetails.Blog)), logEntry.Message);
+            Assert.Empty(ListLoggerFactory.Log);
         }
 
         private Navigation RunConvention(InternalRelationshipBuilder relationshipBuilder, Navigation navigation)

--- a/test/EFCore.Tests/Metadata/Conventions/NonNullableNavigationConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/NonNullableNavigationConventionTest.cs
@@ -233,9 +233,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             return modelLogger;
         }
 
-#nullable enable
-#pragma warning disable CS8618
-
         private class Blog
         {
             public int Id { get; set; }
@@ -298,7 +295,5 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             [ForeignKey("PrincipalId, PrincipalFk")]
             public Principal? CompositePrincipal { get; set; }
         }
-#pragma warning restore CS8618
-#nullable disable
     }
 }


### PR DESCRIPTION
- align Microsoft.NETCore.App.Ref version with other core-setup dependencies