### PR TITLE
SqlServer Spatial: Enable calling methods on parameterized values

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -24,7 +24,7 @@
     <SQLitePCLRawCorePackageVersion>2.0.0-pre20190628101813</SQLitePCLRawCorePackageVersion>
     <StyleCopAnalyzersPackageVersion>1.1.1-beta.61</StyleCopAnalyzersPackageVersion>
     <BenchmarkDotNetPackageVersion>0.11.3</BenchmarkDotNetPackageVersion>
-    <MicrosoftDataSqlClientPackageVersion>1.0.19128.1-Preview</MicrosoftDataSqlClientPackageVersion>
+    <MicrosoftDataSqlClientPackageVersion>1.0.19189.1-Preview</MicrosoftDataSqlClientPackageVersion>
   </PropertyGroup>
   <PropertyGroup Label="Dependencies from aspnet/Extensions">
     <MicrosoftExtensionsCachingMemoryPackageVersion>3.0.0-preview8.19359.2</MicrosoftExtensionsCachingMemoryPackageVersion>

--- a/test/EFCore.Specification.Tests/Query/SpatialQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/SpatialQueryTestBase.cs
@@ -528,6 +528,24 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
+        public virtual Task Distance_on_converted_geometry_type_lhs(bool isAsync)
+        {
+            var point = new GeoPoint(1, 0);
+
+            return AssertQuery<GeoPointEntity>(
+                isAsync,
+                es => es.Select(
+                    e => new
+                    {
+                        e.Id,
+                        Distance = point.Distance(e.Location)
+                    }),
+                elementSorter: e => e.Id,
+                elementAsserter: (e, a) => { Assert.Equal(e.Id, a.Id); });
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual Task Distance_on_converted_geometry_type_constant(bool isAsync)
         {
             return AssertQuery<GeoPointEntity>(

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeographyTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeographyTest.cs
@@ -237,9 +237,20 @@ FROM [PointEntity] AS [p]");
             await base.Distance_on_converted_geometry_type(isAsync);
 
             AssertSql(
-                @"@__point_0='0xE6100000010C000000000000F03F0000000000000000' (Nullable = false) (Size = 22) (DbType = Binary)
+                @"@__point_0='0xE6100000010C000000000000F03F0000000000000000' (Nullable = false) (Size = 22) (DbType = Object)
 
 SELECT [g].[Id], [g].[Location].STDistance(@__point_0) AS [Distance]
+FROM [GeoPointEntity] AS [g]");
+        }
+
+        public override async Task Distance_on_converted_geometry_type_lhs(bool isAsync)
+        {
+            await base.Distance_on_converted_geometry_type_lhs(isAsync);
+
+            AssertSql(
+                @"@__point_0='0xE6100000010C000000000000F03F0000000000000000' (Nullable = false) (Size = 22) (DbType = Object)
+
+SELECT [g].[Id], @__point_0.STDistance([g].[Location]) AS [Distance]
 FROM [GeoPointEntity] AS [g]");
         }
 
@@ -276,7 +287,7 @@ FROM [LineStringEntity] AS [l]");
 
             // issue #15994
 //            AssertSql(
-//                @"@__point_0='0xE6100000010C00000000000000000000000000000000' (Size = 22) (DbType = Binary)
+//                @"@__point_0='0xE6100000010C00000000000000000000000000000000' (Size = 22) (DbType = Object)
 
 //SELECT [e].[Id], [e].[Point].STEquals(@__point_0) AS [EqualsTopologically]
 //FROM [PointEntity] AS [e]");
@@ -344,7 +355,7 @@ FROM [PolygonEntity] AS [p]");
 
             // issue #15994
 //            AssertSql(
-//                @"@__polygon_0='0xE610000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Binary)
+//                @"@__polygon_0='0xE610000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
 
 //SELECT [e].[Id], [e].[Polygon].STIntersection(@__polygon_0) AS [Intersection]
 //FROM [PolygonEntity] AS [e]");
@@ -356,7 +367,7 @@ FROM [PolygonEntity] AS [p]");
 
             // issue #15994
 //            AssertSql(
-//                @"@__lineString_0='0xE61000000114000000000000E0BF000000000000E03F000000000000E03F0000...' (Size = 38) (DbType = Binary)
+//                @"@__lineString_0='0xE61000000114000000000000E0BF000000000000E03F000000000000E03F0000...' (Size = 38) (DbType = Object)
 
 //SELECT [e].[Id], [e].[LineString].STIntersects(@__lineString_0) AS [Intersects]
 //FROM [LineStringEntity] AS [e]");
@@ -415,7 +426,7 @@ FROM [PointEntity] AS [p]");
             await base.IsWithinDistance(isAsync);
 
             AssertSql(
-                @"@__point_0='0xE6100000010C000000000000F03F0000000000000000' (Size = 22) (DbType = Binary)
+                @"@__point_0='0xE6100000010C000000000000F03F0000000000000000' (Size = 22) (DbType = Object)
 
 SELECT [p].[Id], CASE
     WHEN [p].[Point] IS NULL THEN NULL
@@ -509,7 +520,7 @@ FROM [PointEntity] AS [p]");
 
             // issue #15994
 //            AssertSql(
-//                @"@__polygon_0='0xE610000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Binary)
+//                @"@__polygon_0='0xE610000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
 
 //SELECT [e].[Id], [e].[Polygon].STOverlaps(@__polygon_0) AS [Overlaps]
 //FROM [PolygonEntity] AS [e]");
@@ -566,7 +577,7 @@ FROM [LineStringEntity] AS [l]");
 
             // issue #15994
 //            AssertSql(
-//                @"@__polygon_0='0xE610000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Binary)
+//                @"@__polygon_0='0xE610000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
 
 //SELECT [e].[Id], [e].[Polygon].STSymDifference(@__polygon_0) AS [SymmetricDifference]
 //FROM [PolygonEntity] AS [e]");
@@ -604,7 +615,7 @@ FROM [LineStringEntity] AS [l]");
 
             // issue #15994
 //            AssertSql(
-//                @"@__polygon_0='0xE610000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Binary)
+//                @"@__polygon_0='0xE610000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
 
 //SELECT [e].[Id], [e].[Polygon].STUnion(@__polygon_0) AS [Union]
 //FROM [PolygonEntity] AS [e]");
@@ -622,7 +633,7 @@ FROM [LineStringEntity] AS [l]");
 
             // issue #15994
 //            AssertSql(
-//                @"@__polygon_0='0xE6100000010405000000000000000000F0BF000000000000F0BF000000000000...' (Size = 112) (DbType = Binary)
+//                @"@__polygon_0='0xE6100000010405000000000000000000F0BF000000000000F0BF000000000000...' (Size = 112) (DbType = Object)
 
 //SELECT [e].[Id], [e].[Point].STWithin(@__polygon_0) AS [Within]
 //FROM [PointEntity] AS [e]");

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeometryTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeometryTest.cs
@@ -107,7 +107,7 @@ FROM [PolygonEntity] AS [p]");
 
             // issue #15994
 //            AssertSql(
-//                @"@__point_0='0x00000000010C000000000000D03F000000000000D03F' (Size = 22) (DbType = Binary)
+//                @"@__point_0='0x00000000010C000000000000D03F000000000000D03F' (Size = 22) (DbType = Object)
 
 //SELECT [e].[Id], [e].[Polygon].STContains(@__point_0) AS [Contains]
 //FROM [PolygonEntity] AS [e]");
@@ -159,7 +159,7 @@ FROM [LineStringEntity] AS [l]");
 
             // issue #15994
 //            AssertSql(
-//                @"@__lineString_0='0x000000000114000000000000E03F000000000000E0BF000000000000E03F0000...' (Size = 38) (DbType = Binary)
+//                @"@__lineString_0='0x000000000114000000000000E03F000000000000E0BF000000000000E03F0000...' (Size = 38) (DbType = Object)
 
 //SELECT [e].[Id], [e].[LineString].STCrosses(@__lineString_0) AS [Crosses]
 //FROM [LineStringEntity] AS [e]");
@@ -171,7 +171,7 @@ FROM [LineStringEntity] AS [l]");
 
             // issue #15994
 //            AssertSql(
-//                @"@__polygon_0='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Binary)
+//                @"@__polygon_0='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
 
 //SELECT [e].[Id], [e].[Polygon].STDifference(@__polygon_0) AS [Difference]
 //FROM [PolygonEntity] AS [e]");
@@ -183,9 +183,21 @@ FROM [LineStringEntity] AS [l]");
 
             // issue #15994
 //            AssertSql(
-//                @"@__point_0='0x00000000010C000000000000F03F0000000000000000' (Nullable = false) (Size = 22) (DbType = Binary)
+//                @"@__point_0='0x00000000010C000000000000F03F0000000000000000' (Nullable = false) (Size = 22) (DbType = Object)
 
 //SELECT [e].[Id], [e].[Location].STDistance(@__point_0) AS [Distance]
+//FROM [GeoPointEntity] AS [e]");
+        }
+
+        public override async Task Distance_on_converted_geometry_type_lhs(bool isAsync)
+        {
+            await base.Distance_on_converted_geometry_type_lhs(isAsync);
+
+            // issue #15994
+//            AssertSql(
+//                @"@__point_0='0x00000000010C000000000000F03F0000000000000000' (Nullable = false) (Size = 22) (DbType = Object)
+
+//SELECT [e].[Id], @__point_0.STDistance([e].[Location]) AS [Distance]
 //FROM [GeoPointEntity] AS [e]");
         }
 
@@ -265,7 +277,7 @@ FROM [PointEntity] AS [p]");
 
             // issue #15994
 //            AssertSql(
-//                @"@__point_0='0x00000000010C000000000000F03F000000000000F03F' (Size = 22) (DbType = Binary)
+//                @"@__point_0='0x00000000010C000000000000F03F000000000000F03F' (Size = 22) (DbType = Object)
 
 //SELECT [e].[Id], [e].[Polygon].STDisjoint(@__point_0) AS [Disjoint]
 //FROM [PolygonEntity] AS [e]");
@@ -277,7 +289,7 @@ FROM [PointEntity] AS [p]");
 
             // issue #15994
 //            AssertSql(
-//                @"@__point_0='0x00000000010C0000000000000000000000000000F03F' (Size = 22) (DbType = Binary)
+//                @"@__point_0='0x00000000010C0000000000000000000000000000F03F' (Size = 22) (DbType = Object)
 
 //SELECT [e].[Id], [e].[Point].STDistance(@__point_0) AS [Distance]
 //FROM [PointEntity] AS [e]");
@@ -289,7 +301,7 @@ FROM [PointEntity] AS [p]");
 
             // issue #15994
 //            AssertSql(
-//                @"@__point_0='0x00000000010C0000000000000000000000000000F03F' (Size = 22) (DbType = Binary)
+//                @"@__point_0='0x00000000010C0000000000000000000000000000F03F' (Size = 22) (DbType = Object)
 
 //SELECT [e].[Id], [e].[Geometry].STDistance(@__point_0) AS [Distance]
 //FROM [PointEntity] AS [e]");
@@ -319,7 +331,7 @@ FROM [PolygonEntity] AS [p]");
 
             // issue #15994
 //            AssertSql(
-//                @"@__point_0='0x00000000010C00000000000000000000000000000000' (Size = 22) (DbType = Binary)
+//                @"@__point_0='0x00000000010C00000000000000000000000000000000' (Size = 22) (DbType = Object)
 
 //SELECT [e].[Id], [e].[Point].STEquals(@__point_0) AS [EqualsTopologically]
 //FROM [PointEntity] AS [e]");
@@ -390,7 +402,7 @@ FROM [PolygonEntity] AS [p]");
 
             // issue #15994
 //            AssertSql(
-//                @"@__polygon_0='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Binary)
+//                @"@__polygon_0='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
 
 //SELECT [e].[Id], [e].[Polygon].STIntersection(@__polygon_0) AS [Intersection]
 //FROM [PolygonEntity] AS [e]");
@@ -402,7 +414,7 @@ FROM [PolygonEntity] AS [p]");
 
             // issue #15994
 //            AssertSql(
-//                @"@__lineString_0='0x000000000114000000000000E03F000000000000E0BF000000000000E03F0000...' (Size = 38) (DbType = Binary)
+//                @"@__lineString_0='0x000000000114000000000000E03F000000000000E0BF000000000000E03F0000...' (Size = 38) (DbType = Object)
 
 //SELECT [e].[Id], [e].[LineString].STIntersects(@__lineString_0) AS [Intersects]
 //FROM [LineStringEntity] AS [e]");
@@ -468,7 +480,7 @@ FROM [PointEntity] AS [p]");
 
             // issue #15994
 //            AssertSql(
-//                @"@__point_0='0x00000000010C0000000000000000000000000000F03F' (Size = 22) (DbType = Binary)
+//                @"@__point_0='0x00000000010C0000000000000000000000000000F03F' (Size = 22) (DbType = Object)
 
 //SELECT [e].[Id], CASE
 //    WHEN [e].[Point].STDistance(@__point_0) <= 1.0E0
@@ -558,7 +570,7 @@ FROM [PointEntity] AS [p]");
 
             // issue #15994
 //            AssertSql(
-//                @"@__polygon_0='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Binary)
+//                @"@__polygon_0='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
 
 //SELECT [e].[Id], [e].[Polygon].STOverlaps(@__polygon_0) AS [Overlaps]
 //FROM [PolygonEntity] AS [e]");
@@ -579,7 +591,7 @@ FROM [PolygonEntity] AS [p]");
 
             // issue #15994
 //            AssertSql(
-//                @"@__polygon_0='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Binary)
+//                @"@__polygon_0='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
 
 //SELECT [e].[Id], [e].[Polygon].STRelate(@__polygon_0, N'212111212') AS [Relate]
 //FROM [PolygonEntity] AS [e]");
@@ -624,7 +636,7 @@ FROM [LineStringEntity] AS [l]");
 
             // issue #15994
 //            AssertSql(
-//                @"@__polygon_0='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Binary)
+//                @"@__polygon_0='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
 
 //SELECT [e].[Id], [e].[Polygon].STSymDifference(@__polygon_0) AS [SymmetricDifference]
 //FROM [PolygonEntity] AS [e]");
@@ -656,7 +668,7 @@ FROM [LineStringEntity] AS [l]");
 
             // issue #15994
 //            AssertSql(
-//                @"@__polygon_0='0x000000000104040000000000000000000000000000000000F03F000000000000...' (Size = 96) (DbType = Binary)
+//                @"@__polygon_0='0x000000000104040000000000000000000000000000000000F03F000000000000...' (Size = 96) (DbType = Object)
 
 //SELECT [e].[Id], [e].[Polygon].STTouches(@__polygon_0) AS [Touches]
 //FROM [PolygonEntity] AS [e]");
@@ -668,7 +680,7 @@ FROM [LineStringEntity] AS [l]");
 
             // issue #15994
 //            AssertSql(
-//                @"@__polygon_0='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Binary)
+//                @"@__polygon_0='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
 
 //SELECT [e].[Id], [e].[Polygon].STUnion(@__polygon_0) AS [Union]
 //FROM [PolygonEntity] AS [e]");
@@ -686,7 +698,7 @@ FROM [LineStringEntity] AS [l]");
 
             // issue #15994
 //            AssertSql(
-//                @"@__polygon_0='0x00000000010405000000000000000000F0BF000000000000F0BF000000000000...' (Size = 112) (DbType = Binary)
+//                @"@__polygon_0='0x00000000010405000000000000000000F0BF000000000000F0BF000000000000...' (Size = 112) (DbType = Object)
 
 //SELECT [e].[Id], [e].[Point].STWithin(@__polygon_0) AS [Within]
 //FROM [PointEntity] AS [e]");

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SpatialQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SpatialQuerySqliteTest.cs
@@ -37,6 +37,17 @@ SELECT ""g"".""Id"", Distance(""g"".""Location"", @__point_0) AS ""Distance""
 FROM ""GeoPointEntity"" AS ""g""");
         }
 
+        public override async Task Distance_on_converted_geometry_type_lhs(bool isAsync)
+        {
+            await base.Distance_on_converted_geometry_type_lhs(isAsync);
+
+            AssertSql(
+                @"@__point_0='0x0001000000000000000000000000000000000000F03F00000000000000000000...' (Nullable = false) (Size = 60) (DbType = String)
+
+SELECT ""g"".""Id"", Distance(@__point_0, ""g"".""Location"") AS ""Distance""
+FROM ""GeoPointEntity"" AS ""g""");
+        }
+
         public override async Task Distance_on_converted_geometry_type_constant(bool isAsync)
         {
             await base.Distance_on_converted_geometry_type_constant(isAsync);


### PR DESCRIPTION
Fixes #14595

~~@divega Looks like dotnet/corefx#36678 isn't in Microsoft.Data.SqlClient. Tests pass after reverting 10e553acc21f495e1bbdb384b90ac0a6e334f5ff~~ (resolved)