### PR TITLE
Break out metadata/info about an extension from the interface

### DIFF
--- a/src/EFCore.Relational/Infrastructure/RelationalOptionsExtension.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalOptionsExtension.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;
 using System.Text;
@@ -39,7 +38,6 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         private string _migrationsHistoryTableName;
         private string _migrationsHistoryTableSchema;
         private Func<ExecutionStrategyDependencies, IExecutionStrategy> _executionStrategyFactory;
-        private string _logFragment;
 
         /// <summary>
         ///     Creates a new set of options with everything set to default values.
@@ -67,6 +65,11 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             _migrationsHistoryTableSchema = copyFrom._migrationsHistoryTableSchema;
             _executionStrategyFactory = copyFrom._executionStrategyFactory;
         }
+
+        /// <summary>
+        ///    Information/metadata about the extension.
+        /// </summary>
+        public abstract DbContextOptionsExtensionInfo Info { get; }
 
         /// <summary>
         ///     Override this method in a derived class to ensure that any clone created is also of that class.
@@ -340,15 +343,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     required services when EF is creating an service provider.
         /// </summary>
         /// <param name="services"> The collection to add services to. </param>
-        /// <returns> True if a database provider and was registered; false otherwise. </returns>
-        public abstract bool ApplyServices(IServiceCollection services);
-
-        /// <summary>
-        ///     Returns a hash code created from any options that would cause a new <see cref="IServiceProvider" />
-        ///     to be needed. Most extensions do not have any such options and should return zero.
-        /// </summary>
-        /// <returns> A hash over options that require a new service provider when changed. </returns>
-        public virtual long GetServiceProviderHashCode() => 0;
+        public abstract void ApplyServices(IServiceCollection services);
 
         /// <summary>
         ///     Gives the extension a chance to validate that all options in the extension are valid.
@@ -361,63 +356,90 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         }
 
         /// <summary>
-        ///     Populates a dictionary of information that may change between uses of the
-        ///     extension such that it can be compared to a previous configuration for
-        ///     this option and differences can be logged. The dictionary key should be prefixed by the
-        ///     extension name. For example, <c>"SqlServer:"</c>.
+        ///    Information/metadata for a <see cref="RelationalOptionsExtension"/>.
         /// </summary>
-        /// <param name="debugInfo"> The dictionary to populate. </param>
-        public abstract void PopulateDebugInfo(IDictionary<string, string> debugInfo);
-
-        /// <summary>
-        ///     Creates a message fragment for logging typically containing information about
-        ///     any useful non-default options that have been configured.
-        /// </summary>
-        public virtual string LogFragment
+        protected abstract class RelationalExtensionInfo : DbContextOptionsExtensionInfo
         {
-            get
+            private string _logFragment;
+
+            /// <summary>
+            ///     Creates a new <see cref="RelationalOptionsExtension.RelationalExtensionInfo" /> instance containing
+            ///     info/metadata for the given extension.
+            /// </summary>
+            /// <param name="extension"> The extension. </param>
+            protected RelationalExtensionInfo(IDbContextOptionsExtension extension)
+                : base(extension)
             {
-                if (_logFragment == null)
+            }
+
+            /// <summary>
+            ///     The extension for which this instance contains metadata.
+            /// </summary>
+            public new virtual RelationalOptionsExtension Extension
+                => (RelationalOptionsExtension)base.Extension;
+
+            /// <summary>
+            ///     True, since this is a database provider base class.
+            /// </summary>
+            public override bool IsDatabaseProvider => true;
+
+            /// <summary>
+            ///     Returns a hash code created from any options that would cause a new <see cref="IServiceProvider" />
+            ///     to be needed. Most extensions do not have any such options and should return zero.
+            /// </summary>
+            /// <returns> A hash over options that require a new service provider when changed. </returns>
+            public override long GetServiceProviderHashCode() => 0;
+
+            /// <summary>
+            ///     A message fragment for logging typically containing information about
+            ///     any useful non-default options that have been configured.
+            /// </summary>
+            public override string LogFragment
+            {
+                get
                 {
-                    var builder = new StringBuilder();
-
-                    if (_commandTimeout != null)
+                    if (_logFragment == null)
                     {
-                        builder.Append("CommandTimeout=").Append(_commandTimeout).Append(' ');
-                    }
+                        var builder = new StringBuilder();
 
-                    if (_maxBatchSize != null)
-                    {
-                        builder.Append("MaxBatchSize=").Append(_maxBatchSize).Append(' ');
-                    }
-
-                    if (_useRelationalNulls)
-                    {
-                        builder.Append("UseRelationalNulls ");
-                    }
-
-                    if (_migrationsAssembly != null)
-                    {
-                        builder.Append("MigrationsAssembly=").Append(_migrationsAssembly).Append(' ');
-                    }
-
-                    if (_migrationsHistoryTableName != null
-                        || _migrationsHistoryTableSchema != null)
-                    {
-                        builder.Append("MigrationsHistoryTable=");
-
-                        if (_migrationsHistoryTableSchema != null)
+                        if (Extension._commandTimeout != null)
                         {
-                            builder.Append(_migrationsHistoryTableSchema).Append('.');
+                            builder.Append("CommandTimeout=").Append(Extension._commandTimeout).Append(' ');
                         }
 
-                        builder.Append(_migrationsHistoryTableName ?? HistoryRepository.DefaultTableName).Append(' ');
+                        if (Extension._maxBatchSize != null)
+                        {
+                            builder.Append("MaxBatchSize=").Append(Extension._maxBatchSize).Append(' ');
+                        }
+
+                        if (Extension._useRelationalNulls)
+                        {
+                            builder.Append("UseRelationalNulls ");
+                        }
+
+                        if (Extension._migrationsAssembly != null)
+                        {
+                            builder.Append("MigrationsAssembly=").Append(Extension._migrationsAssembly).Append(' ');
+                        }
+
+                        if (Extension._migrationsHistoryTableName != null
+                            || Extension._migrationsHistoryTableSchema != null)
+                        {
+                            builder.Append("MigrationsHistoryTable=");
+
+                            if (Extension._migrationsHistoryTableSchema != null)
+                            {
+                                builder.Append(Extension._migrationsHistoryTableSchema).Append('.');
+                            }
+
+                            builder.Append(Extension._migrationsHistoryTableName ?? HistoryRepository.DefaultTableName).Append(' ');
+                        }
+
+                        _logFragment = builder.ToString();
                     }
 
-                    _logFragment = builder.ToString();
+                    return _logFragment;
                 }
-
-                return _logFragment;
             }
         }
     }

--- a/src/EFCore.SqlServer.NTS/Infrastructure/Internal/SqlServerNetTopologySuiteOptionsExtension.cs
+++ b/src/EFCore.SqlServer.NTS/Infrastructure/Internal/SqlServerNetTopologySuiteOptionsExtension.cs
@@ -20,13 +20,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Infrastructure.Internal
     /// </summary>
     public class SqlServerNetTopologySuiteOptionsExtension : IDbContextOptionsExtension
     {
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public virtual string LogFragment => "using NetTopologySuite ";
+        private DbContextOptionsExtensionInfo _info;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -34,12 +28,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Infrastructure.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual bool ApplyServices(IServiceCollection services)
-        {
-            services.AddEntityFrameworkSqlServerNetTopologySuite();
-
-            return false;
-        }
+        public virtual void ApplyServices(IServiceCollection services)
+            => services.AddEntityFrameworkSqlServerNetTopologySuite();
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -47,18 +37,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Infrastructure.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual long GetServiceProviderHashCode() => 0;
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public virtual void PopulateDebugInfo(IDictionary<string, string> debugInfo)
-        {
-            debugInfo["SqlServer:" + nameof(SqlServerNetTopologySuiteDbContextOptionsBuilderExtensions.UseNetTopologySuite)] = "1";
-        }
+        public virtual DbContextOptionsExtensionInfo Info
+            => _info ??= new ExtensionInfo(this);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -80,6 +60,26 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Infrastructure.Internal
                     }
                 }
             }
+        }
+
+        private sealed class ExtensionInfo : DbContextOptionsExtensionInfo
+        {
+            public ExtensionInfo(IDbContextOptionsExtension extension)
+                : base(extension)
+            {
+            }
+
+            private new SqlServerNetTopologySuiteOptionsExtension Extension
+                => (SqlServerNetTopologySuiteOptionsExtension)base.Extension;
+
+            public override bool IsDatabaseProvider => false;
+
+            public override long GetServiceProviderHashCode() => 0;
+
+            public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
+                => debugInfo["SqlServer:" + nameof(SqlServerNetTopologySuiteDbContextOptionsBuilderExtensions.UseNetTopologySuite)] = "1";
+
+            public override string LogFragment => "using NetTopologySuite ";
         }
     }
 }

--- a/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerOptionsExtension.cs
+++ b/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerOptionsExtension.cs
@@ -6,7 +6,6 @@ using System.Globalization;
 using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Infrastructure.Internal
@@ -19,9 +18,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Infrastructure.Internal
     /// </summary>
     public class SqlServerOptionsExtension : RelationalOptionsExtension
     {
-        private long? _serviceProviderHash;
+        private DbContextOptionsExtensionInfo _info;
         private bool? _rowNumberPaging;
-        private string _logFragment;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -46,6 +44,15 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Infrastructure.Internal
         {
             _rowNumberPaging = copyFrom._rowNumberPaging;
         }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public override DbContextOptionsExtensionInfo Info
+            => _info ??= new ExtensionInfo(this);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -85,69 +92,59 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Infrastructure.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public override long GetServiceProviderHashCode()
+        public override void ApplyServices(IServiceCollection services)
+            => services.AddEntityFrameworkSqlServer();
+
+        private sealed class ExtensionInfo : RelationalExtensionInfo
         {
-            if (_serviceProviderHash == null)
+            private long? _serviceProviderHash;
+            private string _logFragment;
+
+            public ExtensionInfo(IDbContextOptionsExtension extension)
+                : base(extension)
             {
-                _serviceProviderHash = (base.GetServiceProviderHashCode() * 397) ^ (_rowNumberPaging?.GetHashCode() ?? 0L);
             }
 
-            return _serviceProviderHash.Value;
-        }
+            private new SqlServerOptionsExtension Extension
+                => (SqlServerOptionsExtension)base.Extension;
 
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
-        {
-            debugInfo["SqlServer:" + nameof(SqlServerDbContextOptionsBuilder.UseRowNumberForPaging)]
-                = (_rowNumberPaging?.GetHashCode() ?? 0L).ToString(CultureInfo.InvariantCulture);
-        }
+            public override bool IsDatabaseProvider => true;
 
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public override bool ApplyServices(IServiceCollection services)
-        {
-            Check.NotNull(services, nameof(services));
-
-            services.AddEntityFrameworkSqlServer();
-
-            return true;
-        }
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public override string LogFragment
-        {
-            get
+            public override string LogFragment
             {
-                if (_logFragment == null)
+                get
                 {
-                    var builder = new StringBuilder();
-
-                    builder.Append(base.LogFragment);
-
-                    if (_rowNumberPaging == true)
+                    if (_logFragment == null)
                     {
-                        builder.Append("RowNumberPaging ");
+                        var builder = new StringBuilder();
+
+                        builder.Append(base.LogFragment);
+
+                        if (Extension._rowNumberPaging == true)
+                        {
+                            builder.Append("RowNumberPaging ");
+                        }
+
+                        _logFragment = builder.ToString();
                     }
 
-                    _logFragment = builder.ToString();
+                    return _logFragment;
+                }
+            }
+
+            public override long GetServiceProviderHashCode()
+            {
+                if (_serviceProviderHash == null)
+                {
+                    _serviceProviderHash = (base.GetServiceProviderHashCode() * 397) ^ (Extension._rowNumberPaging?.GetHashCode() ?? 0L);
                 }
 
-                return _logFragment;
+                return _serviceProviderHash.Value;
             }
+
+            public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
+                => debugInfo["SqlServer:" + nameof(SqlServerDbContextOptionsBuilder.UseRowNumberForPaging)]
+                    = (Extension._rowNumberPaging?.GetHashCode() ?? 0L).ToString(CultureInfo.InvariantCulture);
         }
     }
 }

--- a/src/EFCore.Sqlite.NTS/Infrastructure/Internal/SqliteNetTopologySuiteOptionsExtension.cs
+++ b/src/EFCore.Sqlite.NTS/Infrastructure/Internal/SqliteNetTopologySuiteOptionsExtension.cs
@@ -20,13 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Infrastructure.Internal
     /// </summary>
     public class SqliteNetTopologySuiteOptionsExtension : IDbContextOptionsExtension
     {
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public virtual string LogFragment => "using NetTopologySuite ";
+        private DbContextOptionsExtensionInfo _info;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -34,12 +28,8 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Infrastructure.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual bool ApplyServices(IServiceCollection services)
-        {
-            services.AddEntityFrameworkSqliteNetTopologySuite();
-
-            return false;
-        }
+        public virtual DbContextOptionsExtensionInfo Info
+            => _info ??= new ExtensionInfo(this);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -47,7 +37,8 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Infrastructure.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual long GetServiceProviderHashCode() => 0;
+        public virtual void ApplyServices(IServiceCollection services)
+            => services.AddEntityFrameworkSqliteNetTopologySuite();
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -71,15 +62,24 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Infrastructure.Internal
             }
         }
 
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public virtual void PopulateDebugInfo(IDictionary<string, string> debugInfo)
+        private sealed class ExtensionInfo : DbContextOptionsExtensionInfo
         {
-            debugInfo["NetTopologySuite"] = "1";
+            public ExtensionInfo(IDbContextOptionsExtension extension)
+                : base(extension)
+            {
+            }
+
+            private new SqliteNetTopologySuiteOptionsExtension Extension
+                => (SqliteNetTopologySuiteOptionsExtension)base.Extension;
+
+            public override bool IsDatabaseProvider => false;
+
+            public override string LogFragment => "using NetTopologySuite ";
+
+            public override long GetServiceProviderHashCode() => 0;
+
+            public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
+                => debugInfo["NetTopologySuite"] = "1";
         }
     }
 }

--- a/src/EFCore/DbContextOptionsBuilder.cs
+++ b/src/EFCore/DbContextOptionsBuilder.cs
@@ -68,7 +68,7 @@ namespace Microsoft.EntityFrameworkCore
         ///         <see cref="DbContext.OnConfiguring(DbContextOptionsBuilder)" />.
         ///     </para>
         /// </summary>
-        public virtual bool IsConfigured => _options.Extensions.Any(e => e.ApplyServices(new ServiceCollection()));
+        public virtual bool IsConfigured => _options.Extensions.Any(e => e.Info.IsDatabaseProvider);
 
         /// <summary>
         ///     <para>

--- a/src/EFCore/Infrastructure/DbContextOptionsExtensionInfo.cs
+++ b/src/EFCore/Infrastructure/DbContextOptionsExtensionInfo.cs
@@ -1,0 +1,57 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Infrastructure
+{
+    /// <summary>
+    ///    Information/metadata for an <see cref="IDbContextOptionsExtension"/>.
+    /// </summary>
+    public abstract class DbContextOptionsExtensionInfo
+    {
+        /// <summary>
+        ///     Creates a new <see cref="DbContextOptionsExtensionInfo" /> instance containing
+        ///     info/metadata for the given extension.
+        /// </summary>
+        /// <param name="extension"> The extension. </param>
+        protected DbContextOptionsExtensionInfo(IDbContextOptionsExtension extension)
+        {
+            Extension = extension;
+        }
+
+        /// <summary>
+        ///     The extension for which this instance contains metadata.
+        /// </summary>
+        public virtual IDbContextOptionsExtension Extension { get; }
+
+        /// <summary>
+        ///     True if the extension is a database provider; false otherwise.
+        /// </summary>
+        public abstract bool IsDatabaseProvider { get; }
+
+        /// <summary>
+        ///     A message fragment for logging typically containing information about
+        ///     any useful non-default options that have been configured.
+        /// </summary>
+        public abstract string LogFragment { get; }
+
+        /// <summary>
+        ///     Returns a hash code created from any options that would cause a new <see cref="IServiceProvider" />
+        ///     to be needed. Most extensions do not have any such options and should return zero.
+        /// </summary>
+        /// <returns> A hash over options that require a new service provider when changed. </returns>
+        public abstract long GetServiceProviderHashCode();
+
+        /// <summary>
+        ///     Populates a dictionary of information that may change between uses of the
+        ///     extension such that it can be compared to a previous configuration for
+        ///     this option and differences can be logged. The dictionary key should be prefixed by the
+        ///     extension name. For example, <c>"SqlServer:"</c>.
+        /// </summary>
+        /// <param name="debugInfo"> The dictionary to populate. </param>
+        public abstract void PopulateDebugInfo([NotNull] IDictionary<string, string> debugInfo);
+    }
+}

--- a/src/EFCore/Infrastructure/IDbContextOptionsExtension.cs
+++ b/src/EFCore/Infrastructure/IDbContextOptionsExtension.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -20,21 +19,18 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
     public interface IDbContextOptionsExtension
     {
         /// <summary>
+        ///     Information/metadata about the extension.
+        /// </summary>
+        DbContextOptionsExtensionInfo Info { get; }
+
+        /// <summary>
         ///     Adds the services required to make the selected options work. This is used when there
         ///     is no external <see cref="IServiceProvider" /> and EF is maintaining its own service
         ///     provider internally. This allows database providers (and other extensions) to register their
         ///     required services when EF is creating an service provider.
         /// </summary>
         /// <param name="services"> The collection to add services to. </param>
-        /// <returns> True if a database provider and was registered; false otherwise. </returns>
-        bool ApplyServices([NotNull] IServiceCollection services);
-
-        /// <summary>
-        ///     Returns a hash code created from any options that would cause a new <see cref="IServiceProvider" />
-        ///     to be needed. Most extensions do not have any such options and should return zero.
-        /// </summary>
-        /// <returns> A hash over options that require a new service provider when changed. </returns>
-        long GetServiceProviderHashCode();
+        void ApplyServices([NotNull] IServiceCollection services);
 
         /// <summary>
         ///     Gives the extension a chance to validate that all options in the extension are valid.
@@ -43,20 +39,5 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// </summary>
         /// <param name="options"> The options being validated. </param>
         void Validate([NotNull] IDbContextOptions options);
-
-        /// <summary>
-        ///     Creates a message fragment for logging typically containing information about
-        ///     any useful non-default options that have been configured.
-        /// </summary>
-        string LogFragment { get; }
-
-        /// <summary>
-        ///     Populates a dictionary of information that may change between uses of the
-        ///     extension such that it can be compared to a previous configuration for
-        ///     this option and differences can be logged. The dictionary key should be prefixed by the
-        ///     extension name. For example, <c>"SqlServer:"</c>.
-        /// </summary>
-        /// <param name="debugInfo"> The dictionary to populate. </param>
-        void PopulateDebugInfo([NotNull] IDictionary<string, string> debugInfo);
     }
 }

--- a/src/EFCore/Infrastructure/Internal/DbContextOptionsExtensions.cs
+++ b/src/EFCore/Infrastructure/Internal/DbContextOptionsExtensions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure.Internal
             var builder = new StringBuilder();
             foreach (var extension in contextOptions.Extensions)
             {
-                builder.Append(extension.LogFragment);
+                builder.Append(extension.Info.LogFragment);
             }
 
             var fragment = builder.ToString();

--- a/src/EFCore/Internal/ServiceProviderCache.cs
+++ b/src/EFCore/Internal/ServiceProviderCache.cs
@@ -67,7 +67,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 var debugInfo = new Dictionary<string, string>();
                 foreach (var optionsExtension in options.Extensions)
                 {
-                    optionsExtension.PopulateDebugInfo(debugInfo);
+                    optionsExtension.Info.PopulateDebugInfo(debugInfo);
                 }
 
                 debugInfo = debugInfo.OrderBy(v => debugInfo.Keys).ToDictionary(d => d.Key, v => v.Value);
@@ -149,7 +149,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
 
             var key = options.Extensions
                 .OrderBy(e => e.GetType().Name)
-                .Aggregate(0L, (t, e) => (t * 397) ^ ((long)e.GetType().GetHashCode() * 397) ^ e.GetServiceProviderHashCode());
+                .Aggregate(0L, (t, e) => (t * 397) ^ ((long)e.GetType().GetHashCode() * 397) ^ e.Info.GetServiceProviderHashCode());
 
             return _configurations.GetOrAdd(key, k => BuildServiceProvider()).ServiceProvider;
         }
@@ -168,7 +168,9 @@ namespace Microsoft.EntityFrameworkCore.Internal
 
             foreach (var extension in options.Extensions)
             {
-                if (extension.ApplyServices(services))
+                extension.ApplyServices(services);
+
+                if (extension.Info.IsDatabaseProvider)
                 {
                     coreServicesAdded = true;
                 }

--- a/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalOptionsExtension.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalOptionsExtension.cs
@@ -14,6 +14,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider
 {
     public class FakeRelationalOptionsExtension : RelationalOptionsExtension
     {
+        private DbContextOptionsExtensionInfo _info;
+
         public FakeRelationalOptionsExtension()
         {
         }
@@ -23,19 +25,14 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider
         {
         }
 
+        public override DbContextOptionsExtensionInfo Info
+            => _info ??= new ExtensionInfo(this);
+
         protected override RelationalOptionsExtension Clone()
             => new FakeRelationalOptionsExtension(this);
 
-        public override bool ApplyServices(IServiceCollection services)
-        {
-            AddEntityFrameworkRelationalDatabase(services);
-
-            return true;
-        }
-
-        public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
-        {
-        }
+        public override void ApplyServices(IServiceCollection services)
+            => AddEntityFrameworkRelationalDatabase(services);
 
         public static IServiceCollection AddEntityFrameworkRelationalDatabase(IServiceCollection serviceCollection)
         {
@@ -56,5 +53,18 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider
 
             return serviceCollection;
         }
+
+        private sealed class ExtensionInfo : RelationalExtensionInfo
+        {
+            public ExtensionInfo(IDbContextOptionsExtension extension)
+                : base(extension)
+            {
+            }
+
+            public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
+            {
+            }
+        }
+
     }
 }

--- a/test/EFCore.Tests/ServiceProviderCacheTest.cs
+++ b/test/EFCore.Tests/ServiceProviderCacheTest.cs
@@ -225,37 +225,73 @@ namespace Microsoft.EntityFrameworkCore
 
         private class FakeDbContextOptionsExtension1 : IDbContextOptionsExtension
         {
-            public virtual bool ApplyServices(IServiceCollection services) => false;
+            private DbContextOptionsExtensionInfo _info;
 
-            public virtual long GetServiceProviderHashCode() => 0;
+            public string Something { get; set; }
+
+            public DbContextOptionsExtensionInfo Info
+                => _info ??= new ExtensionInfo(this);
+
+            public virtual void ApplyServices(IServiceCollection services)
+            {
+            }
 
             public virtual void Validate(IDbContextOptions options)
             {
             }
 
-            public virtual string LogFragment => "";
-
-            public void PopulateDebugInfo(IDictionary<string, string> debugInfo)
+            private sealed class ExtensionInfo : DbContextOptionsExtensionInfo
             {
-                debugInfo["Fake1"] = "1";
+                public ExtensionInfo(IDbContextOptionsExtension extension)
+                    : base(extension)
+                {
+                }
+
+                public override bool IsDatabaseProvider => false;
+
+                public override long GetServiceProviderHashCode() => 0;
+
+                public override string LogFragment => "";
+
+                public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
+                {
+                    debugInfo["Fake1"] = "1";
+                }
             }
         }
 
         private class FakeDbContextOptionsExtension2 : IDbContextOptionsExtension
         {
-            public virtual bool ApplyServices(IServiceCollection services) => false;
+            private DbContextOptionsExtensionInfo _info;
 
-            public virtual long GetServiceProviderHashCode() => 0;
+            public DbContextOptionsExtensionInfo Info
+                => _info ??= new ExtensionInfo(this);
+
+            public virtual void ApplyServices(IServiceCollection services)
+            {
+            }
 
             public virtual void Validate(IDbContextOptions options)
             {
             }
 
-            public virtual string LogFragment => "";
-
-            public void PopulateDebugInfo(IDictionary<string, string> debugInfo)
+            private sealed class ExtensionInfo : DbContextOptionsExtensionInfo
             {
-                debugInfo["Fake2"] = "1";
+                public ExtensionInfo(IDbContextOptionsExtension extension)
+                    : base(extension)
+                {
+                }
+
+                public override bool IsDatabaseProvider => false;
+
+                public override long GetServiceProviderHashCode() => 0;
+
+                public override string LogFragment => "";
+
+                public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
+                {
+                    debugInfo["Fake2"] = "1";
+                }
             }
         }
     }


### PR DESCRIPTION
Also stop calling ApplyServices to find out if an extension is a database provider.

Fixes #16119 
Fixes #16045

Doing this refactoring because we keep having to add/change methods here, so putting them in a composed abstract base class to avoid breaking the interface each time.
