### PR TITLE
[WIP] Concatenating null with not null string resulting in null

### DIFF
--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressionFactory.cs
@@ -174,6 +174,27 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                     break;
 
                 case ExpressionType.Add:
+                {
+                    inferredTypeMapping = typeMapping ?? ExpressionExtensions.InferTypeMapping(left, right);
+                    resultType = left.Type;
+                    resultTypeMapping = inferredTypeMapping;
+
+                    if (left.Type == typeof(string)
+                        && left is ColumnExpression leftColumnExpression
+                        && leftColumnExpression.Nullable)
+                    {
+                        left = Coalesce(left, Constant(string.Empty));
+                    }
+
+                    if (right.Type == typeof(string)
+                        && right is ColumnExpression rightColumnExpression
+                        && rightColumnExpression.Nullable)
+                    {
+                        right = Coalesce(right, Constant(string.Empty));
+                    }
+                }
+                break;
+
                 case ExpressionType.Subtract:
                 case ExpressionType.Multiply:
                 case ExpressionType.Divide:

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -3873,6 +3873,17 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
+        public virtual void String_concat_with_null_produces_string()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Customers.Select(c => new { c.City, c.Region, Concat = c.City + " " + c.Region }).ToList();
+
+                Assert.All(query, t => Assert.Equal(t.City + " " + t.Region, t.Concat));
+            }
+        }
+
+        [ConditionalFact]
         public virtual void Select_bitwise_or()
         {
             using (var context = CreateContext())

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -2880,6 +2880,15 @@ FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]");
         }
 
+        public override void String_concat_with_null_produces_string()
+        {
+            base.String_concat_with_null_produces_string();
+
+            AssertSql(
+                @"SELECT [c].[City], [c].[Region], (COALESCE([c].[City], N'') + N' ') + COALESCE([c].[Region], N'') AS [Concat]
+FROM [Customers] AS [c]");
+        }
+
         public override void Select_bitwise_or()
         {
             base.Select_bitwise_or();


### PR DESCRIPTION
DO NOT COMMIT THIS - work in progress.

Looking for some feedback on WIP for issue #3836.

My attack plan was to include a Coalesce function call with all string concatenations. This does produce somewhat ugly SQL for a ton of common scenarios. I changed the check to only wrap references to nullable columns in Coalesce but this will miss a ton of different possible outcomes.

Looking for some guidance on what you fancy doing here, uglify everything or only cover some really specific examples?

I've not updated all the unit tests to match this change yet so there are broken tests.