### PR TITLE
Set operation support (except navigation/include)

### DIFF
--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -586,6 +586,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public static string PendingAmbientTransaction
             => GetString("PendingAmbientTransaction");
 
+        /// <summary>
+        ///     Set operations (Union, Concat, Intersect, Except) are only supported over entity types within the same type hierarchy.
+        /// </summary>
+        public static string SetOperationNotWithinEntityTypeHierarchy
+            => GetString("SetOperationNotWithinEntityTypeHierarchy");
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -481,4 +481,7 @@
   <data name="PendingAmbientTransaction" xml:space="preserve">
     <value>This connection was used with an ambient transaction. The original ambient transaction needs to be completed before this connection can be used outside of it.</value>
   </data>
+  <data name="SetOperationNotWithinEntityTypeHierarchy" xml:space="preserve">
+    <value>Set operations (Union, Concat, Intersect, Except) are only supported over entity types within the same type hierarchy.</value>
+  </data>
 </root>

--- a/src/EFCore.Relational/Query/Pipeline/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Pipeline/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -13,6 +13,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Query.Pipeline;
 using Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions;
 using System.Diagnostics;
+using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 {
@@ -150,7 +151,13 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
             return source;
         }
 
-        protected override ShapedQueryExpression TranslateConcat(ShapedQueryExpression source1, ShapedQueryExpression source2) => throw new NotImplementedException();
+        protected override ShapedQueryExpression TranslateConcat(ShapedQueryExpression source1, ShapedQueryExpression source2)
+        {
+            var operand1 = (SelectExpression)source1.QueryExpression;
+            var operand2 = (SelectExpression)source2.QueryExpression;
+            source1.ShaperExpression = operand1.ApplySetOperation(SetOperationType.UnionAll, operand2, source1.ShaperExpression);
+            return source1;
+        }
 
         protected override ShapedQueryExpression TranslateContains(ShapedQueryExpression source, Expression item)
         {
@@ -212,7 +219,13 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 
         protected override ShapedQueryExpression TranslateElementAtOrDefault(ShapedQueryExpression source, Expression index, bool returnDefault) => throw new NotImplementedException();
 
-        protected override ShapedQueryExpression TranslateExcept(ShapedQueryExpression source1, ShapedQueryExpression source2) => throw new NotImplementedException();
+        protected override ShapedQueryExpression TranslateExcept(ShapedQueryExpression source1, ShapedQueryExpression source2)
+        {
+            var operand1 = (SelectExpression)source1.QueryExpression;
+            var operand2 = (SelectExpression)source2.QueryExpression;
+            source1.ShaperExpression = operand1.ApplySetOperation(SetOperationType.Except, operand2, source1.ShaperExpression);
+            return source1;
+        }
 
         protected override ShapedQueryExpression TranslateFirstOrDefault(ShapedQueryExpression source, LambdaExpression predicate, Type returnType, bool returnDefault)
         {
@@ -279,7 +292,13 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
             throw new NotImplementedException();
         }
 
-        protected override ShapedQueryExpression TranslateIntersect(ShapedQueryExpression source1, ShapedQueryExpression source2) => throw new NotImplementedException();
+        protected override ShapedQueryExpression TranslateIntersect(ShapedQueryExpression source1, ShapedQueryExpression source2)
+        {
+            var operand1 = (SelectExpression)source1.QueryExpression;
+            var operand2 = (SelectExpression)source2.QueryExpression;
+            source1.ShaperExpression = operand1.ApplySetOperation(SetOperationType.Intersect, operand2, source1.ShaperExpression);
+            return source1;
+        }
 
         protected override ShapedQueryExpression TranslateJoin(
             ShapedQueryExpression outer,
@@ -730,7 +749,13 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
             throw new InvalidOperationException();
         }
 
-        protected override ShapedQueryExpression TranslateUnion(ShapedQueryExpression source1, ShapedQueryExpression source2) => throw new NotImplementedException();
+        protected override ShapedQueryExpression TranslateUnion(ShapedQueryExpression source1, ShapedQueryExpression source2)
+        {
+            var operand1 = (SelectExpression)source1.QueryExpression;
+            var operand2 = (SelectExpression)source2.QueryExpression;
+            source1.ShaperExpression = operand1.ApplySetOperation(SetOperationType.Union, operand2, source1.ShaperExpression);
+            return source1;
+        }
 
         protected override ShapedQueryExpression TranslateWhere(ShapedQueryExpression source, LambdaExpression predicate)
         {

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/ColumnExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/ColumnExpression.cs
@@ -48,9 +48,14 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
         public ColumnExpression MakeNullable()
             => new ColumnExpression(Name, Table, Type.MakeNullable(), TypeMapping, true);
 
-
         public override void Print(ExpressionPrinter expressionPrinter)
-            => expressionPrinter.StringBuilder.Append(Table.Alias).Append(".").Append(Name);
+        {
+            if (Table.Alias != null)
+            {
+                expressionPrinter.StringBuilder.Append(Table.Alias).Append(".");
+            }
+            expressionPrinter.StringBuilder.Append(Name);
+        }
 
         public override bool Equals(object obj)
             => obj != null
@@ -66,6 +71,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
 
         public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Name, Table, Nullable);
 
-        private string DebuggerDisplay() => $"{Table.Alias}.{Name}";
+        private string DebuggerDisplay()
+            => Table.Alias == null ? Name : $"{Table.Alias}.{Name}";
     }
 }

--- a/src/EFCore.Sqlite.Core/Query/Pipeline/SqliteQuerySqlGenerator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Pipeline/SqliteQuerySqlGenerator.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Relational.Query.Pipeline;
 using Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions;
@@ -44,6 +45,23 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Pipeline
                     Visit(selectExpression.Offset);
                 }
             }
+        }
+
+        protected override void GenerateSetOperationOperand(
+            SelectExpression setOperationExpression,
+            SelectExpression operandExpression)
+        {
+            // Sqlite doesn't support parentheses around set operation operands
+
+            IDisposable indent = null;
+            if (!operandExpression.IsSetOperation)
+            {
+                indent = Sql.Indent();
+            }
+
+            Visit(operandExpression);
+
+            indent?.Dispose();
         }
     }
 }

--- a/src/EFCore/Extensions/EntityTypeExtensions.cs
+++ b/src/EFCore/Extensions/EntityTypeExtensions.cs
@@ -98,6 +98,26 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         /// <summary>
+        ///     Returns the closest entity type that is a parent of both given entity types. If one of the given entities is
+        ///     a parent of the other, that parent is returned. Returns null if the two entity types aren't in the same hierarchy.
+        /// </summary>
+        /// <param name="entityType1"> An entity type.</param>
+        /// <param name="entityType2"> Another entity type.</param>
+        /// <returns>
+        ///     The closest common parent of <paramref name="entityType1"/> and <paramref name="entityType2"/>,
+        ///     or null if they have not common parent.
+        /// </returns>
+        public static IEntityType GetClosestCommonParent([NotNull] this IEntityType entityType1, [NotNull] IEntityType entityType2)
+        {
+            Check.NotNull(entityType1, nameof(entityType1));
+            Check.NotNull(entityType2, nameof(entityType2));
+
+            return entityType1
+                .GetAllBaseTypesInclusiveAscending()
+                .FirstOrDefault(i => entityType2.GetAllBaseTypesInclusiveAscending().Any(j => j == i));
+        }
+
+        /// <summary>
         ///     Determines if an entity type derives from (but is not the same as) a given entity type.
         /// </summary>
         /// <param name="entityType"> The derived entity type. </param>
@@ -141,15 +161,28 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         /// <summary>
-        ///     Returns all base types of the given <see cref="IEntityType" />, including the type itself.
+        ///     Returns all base types of the given <see cref="IEntityType" />, including the type itself, top to bottom.
         /// </summary>
         /// <param name="entityType"> The entity type. </param>
         /// <returns> Base types. </returns>
         public static IEnumerable<IEntityType> GetAllBaseTypesInclusive([NotNull] this IEntityType entityType)
-            => new List<IEntityType>(entityType.GetAllBaseTypes())
+            => GetAllBaseTypesInclusiveAscending(entityType).Reverse();
+
+        /// <summary>
+        ///     Returns all base types of the given <see cref="IEntityType" />, including the type itself, bottom to top.
+        /// </summary>
+        /// <param name="entityType"> The entity type. </param>
+        /// <returns> Base types. </returns>
+        public static IEnumerable<IEntityType> GetAllBaseTypesInclusiveAscending([NotNull] this IEntityType entityType)
+        {
+            Check.NotNull(entityType, nameof(entityType));
+
+            while (entityType != null)
             {
-                entityType
-            };
+                yield return entityType;
+                entityType = entityType.BaseType;
+            }
+        }
 
         /// <summary>
         ///     <para>

--- a/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
+++ b/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
@@ -55,19 +55,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public static IEnumerable<IEntityType> GetAllBaseTypes([NotNull] this IEntityType entityType)
-        {
-            var baseTypes = new List<IEntityType>();
-            var currentEntityType = entityType;
-            while (currentEntityType.BaseType != null)
-            {
-                currentEntityType = currentEntityType.BaseType;
-                baseTypes.Add(currentEntityType);
-            }
+            => entityType.GetAllBaseTypesAscending().Reverse();
 
-            baseTypes.Reverse();
-
-            return baseTypes;
-        }
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public static IEnumerable<IEntityType> GetAllBaseTypesAscending([NotNull] this IEntityType entityType)
+            => entityType.GetAllBaseTypesInclusiveAscending().Skip(1);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Query/Pipeline/ShapedQueryExpression.cs
+++ b/src/EFCore/Query/Pipeline/ShapedQueryExpression.cs
@@ -61,5 +61,4 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
         SingleWithDefault
 #pragma warning restore SA1602 // Enumeration items should be documented
     }
-
 }

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.SetOperations.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.SetOperations.cs
@@ -1,0 +1,166 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.TestModels.Northwind;
+using Xunit;
+
+// ReSharper disable InconsistentNaming
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public abstract partial class SimpleQueryTestBase<TFixture>
+    {
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Union(bool isAsync)
+            => AssertQuery<Customer>(isAsync, cs => cs
+                    .Where(c => c.City == "Berlin")
+                    .Union(cs.Where(c => c.City == "London")),
+                entryCount: 7);
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Concat(bool isAsync)
+            => AssertQuery<Customer>(isAsync, cs => cs
+                    .Where(c => c.City == "Berlin")
+                    .Concat(cs.Where(c => c.City == "London")),
+                entryCount: 7);
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Intersect(bool isAsync)
+        {
+            return AssertQuery<Customer>(isAsync, cs => cs
+                    .Where(c => c.City == "London")
+                    .Intersect(cs.Where(c => c.ContactName.Contains("Thomas"))),
+                entryCount: 1);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Except(bool isAsync)
+        {
+            return AssertQuery<Customer>(isAsync, cs => cs
+                    .Where(c => c.City == "London")
+                    .Except(cs.Where(c => c.ContactName.Contains("Thomas"))),
+                entryCount: 5);
+        }
+
+        // OrderBy, Skip and Take are typically supported on the set operation itself (no need for query pushdown)
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Union_OrderBy_Skip_Take(bool isAsync)
+            => AssertQuery<Customer>(isAsync, cs => cs
+                    .Where(c => c.City == "Berlin")
+                    .Union(cs.Where(c => c.City == "London"))
+                    .OrderBy(c => c.ContactName)
+                    .Skip(1)
+                    .Take(1),
+                entryCount: 1,
+                assertOrder: true);
+
+        // Should cause pushdown into a subquery
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Union_Where(bool isAsync)
+            => AssertQuery<Customer>(isAsync, cs => cs
+                    .Where(c => c.City == "Berlin")
+                    .Union(cs.Where(c => c.City == "London"))
+                    .Where(c => c.ContactName.Contains("Thomas")),  // pushdown
+                entryCount: 1);
+
+        // Should cause pushdown into a subquery, keeping the ordering, offset and limit inside the subquery
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Union_Skip_Take_OrderBy_ThenBy_Where(bool isAsync)
+            => AssertQuery<Customer>(
+                isAsync, cs => cs
+                    .Where(c => c.City == "Berlin")
+                    .Union(cs.Where(c => c.City == "London"))
+                    .OrderBy(c => c.Region)
+                    .ThenBy(c => c.City)
+                    .Skip(0)  // prevent pushdown from removing OrderBy
+                    .Where(c => c.ContactName.Contains("Thomas")),  // pushdown
+                entryCount: 1);
+
+        // Nested set operation with same operation type - no parentheses are needed.
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Union_Union(bool isAsync)
+            => AssertQuery<Customer>(isAsync, cs => cs
+                    .Where(c => c.City == "Berlin")
+                    .Union(cs.Where(c => c.City == "London"))
+                    .Union(cs.Where(c => c.City == "Mannheim")),
+                entryCount: 8);
+
+        // Nested set operation but with different operation type. On SqlServer and PostgreSQL INTERSECT binds
+        // more tightly than UNION/EXCEPT, so parentheses are needed.
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Union_Intersect(bool isAsync)
+            => AssertQuery<Customer>(isAsync, cs => cs
+                    .Where(c => c.City == "Berlin")
+                    .Union(cs.Where(c => c.City == "London"))
+                    .Intersect(cs.Where(c => c.ContactName.Contains("Thomas"))),
+                entryCount: 1);
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Union_Take_Union_Take(bool isAsync)
+            => AssertQuery<Customer>(isAsync, cs => cs
+                    .Where(c => c.City == "Berlin")
+                    .Union(cs.Where(c => c.City == "London"))
+                    .Take(1)
+                    .Union(cs.Where(c => c.City == "Mannheim"))
+                    .Take(1),
+                entryCount: 666);
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Select_Union(bool isAsync)
+            => AssertQuery<Customer>(isAsync, cs => cs
+                    .Where(c => c.City == "Berlin")
+                    .Select(c => c.Address)
+                    .Union(cs
+                        .Where(c => c.City == "London")
+                        .Select(c => c.Address)));
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Union_Select(bool isAsync)
+            => AssertQuery<Customer>(isAsync, cs => cs
+                .Where(c => c.City == "Berlin")
+                .Union(cs.Where(c => c.City == "London"))
+                .Select(c => c.Address)
+                .Where(a => a.Contains("Hanover")));
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Select_Union_unrelated(bool isAsync)
+            => AssertQuery<Customer, Product>(isAsync, (cs, pd) => cs
+                    .Select(c => c.ContactName)
+                    .Union(pd.Select(p => p.ProductName))
+                    .Where(x => x.StartsWith("C"))
+                    .OrderBy(x => x),
+                assertOrder: true);
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Select_Union_different_fields_in_anonymous_with_subquery(bool isAsync)
+            => AssertQuery<Customer>(isAsync, cs => cs
+                .Where(c => c.City == "Berlin")
+                .Select(c => new { Foo = c.City, Customer = c })   // Foo is City
+                .Union(cs
+                    .Where(c => c.City == "London")
+                    .Select(c => new { Foo = c.Region, Customer = c }))  // Foo is Region
+                .OrderBy(x => x.Foo)
+                .Skip(1)
+                .Take(10)
+                .Where(x => x.Foo == "Berlin"),
+                entryCount: 1);
+    }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -5471,6 +5471,60 @@ LEFT JOIN [Children] AS [c] ON [p].[ChildId] = [c].[Id]");
 
         #endregion
 
+        #region Bug12549
+
+        [ConditionalFact]
+        public virtual void Union_and_insert_12549()
+        {
+            using (CreateDatabase12549())
+            {
+                using (var context = new MyContext12549(_options))
+                {
+                    var id1 = 1;
+                    var id2 = 2;
+
+                    var ids1 = context.Set<Table1_12549>()
+                        .Where(x => x.Id == id1)
+                        .Select(x => x.Id);
+
+                    var ids2 = context.Set<Table2_12549>()
+                        .Where(x => x.Id == id2)
+                        .Select(x => x.Id);
+
+                    var results = ids1.Union(ids2).ToList();
+
+                    context.AddRange(new Table1_12549(), new Table2_12549(), new Table1_12549(), new Table2_12549());
+                    context.SaveChanges();
+                }
+            }
+        }
+
+        private SqlServerTestStore CreateDatabase12549()
+            => CreateTestStore(() => new MyContext12549(_options), context => {});
+
+        public class MyContext12549 : DbContext
+        {
+            public DbSet<Table1_12549> Table1 { get; set; }
+            public DbSet<Table2_12549> Table2 { get; set; }
+
+            public MyContext12549(DbContextOptions options)
+                : base(options)
+            {
+            }
+        }
+
+        public class Table1_12549
+        {
+            public int Id { get; set; }
+        }
+
+        public class Table2_12549
+        {
+            public int Id { get; set; }
+        }
+
+        #endregion
+
         private DbContextOptions _options;
 
         private SqlServerTestStore CreateTestStore<TContext>(

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.SetOperations.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.SetOperations.cs
@@ -1,0 +1,244 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public partial class SimpleQuerySqlServerTest
+    {
+        public override async Task Union(bool isAsync)
+        {
+            await base.Union(isAsync);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE ([c].[City] = N'Berlin') AND [c].[City] IS NOT NULL
+UNION
+SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+FROM [Customers] AS [c0]
+WHERE ([c0].[City] = N'London') AND [c0].[City] IS NOT NULL");
+        }
+
+        public override async Task Concat(bool isAsync)
+        {
+            await base.Concat(isAsync);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE ([c].[City] = N'Berlin') AND [c].[City] IS NOT NULL
+UNION ALL
+SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+FROM [Customers] AS [c0]
+WHERE ([c0].[City] = N'London') AND [c0].[City] IS NOT NULL");
+        }
+
+        public override async Task Intersect(bool isAsync)
+        {
+            await base.Intersect(isAsync);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE ([c].[City] = N'London') AND [c].[City] IS NOT NULL
+INTERSECT
+SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+FROM [Customers] AS [c0]
+WHERE CHARINDEX(N'Thomas', [c0].[ContactName]) > 0");
+        }
+
+        public override async Task Except(bool isAsync)
+        {
+            await base.Except(isAsync);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE ([c].[City] = N'London') AND [c].[City] IS NOT NULL
+EXCEPT
+SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+FROM [Customers] AS [c0]
+WHERE CHARINDEX(N'Thomas', [c0].[ContactName]) > 0");        }
+
+        public override async Task Union_OrderBy_Skip_Take(bool isAsync)
+        {
+            await base.Union_OrderBy_Skip_Take(isAsync);
+
+            AssertSql(
+                @"@__p_0='1'
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE ([c].[City] = N'Berlin') AND [c].[City] IS NOT NULL
+UNION
+SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+FROM [Customers] AS [c0]
+WHERE ([c0].[City] = N'London') AND [c0].[City] IS NOT NULL
+ORDER BY [ContactName]
+OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY");
+        }
+
+        public override async Task Union_Where(bool isAsync)
+        {
+            await base.Union_Where(isAsync);
+
+            AssertSql(
+                @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE ([c].[City] = N'Berlin') AND [c].[City] IS NOT NULL
+    UNION
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    WHERE ([c0].[City] = N'London') AND [c0].[City] IS NOT NULL
+) AS [t]
+WHERE CHARINDEX(N'Thomas', [t].[ContactName]) > 0");
+        }
+
+        public override async Task Union_Skip_Take_OrderBy_ThenBy_Where(bool isAsync)
+        {
+            await base.Union_Skip_Take_OrderBy_ThenBy_Where(isAsync);
+
+            AssertSql(
+                @"@__p_0='0'
+
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE ([c].[City] = N'Berlin') AND [c].[City] IS NOT NULL
+    UNION
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    WHERE ([c0].[City] = N'London') AND [c0].[City] IS NOT NULL
+    ORDER BY [Region], [City]
+    OFFSET @__p_0 ROWS
+) AS [t]
+WHERE CHARINDEX(N'Thomas', [t].[ContactName]) > 0
+ORDER BY [t].[Region], [t].[City]");
+        }
+
+        public override async Task Union_Union(bool isAsync)
+        {
+            await base.Union_Union(isAsync);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE ([c].[City] = N'Berlin') AND [c].[City] IS NOT NULL
+UNION
+SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+FROM [Customers] AS [c0]
+WHERE ([c0].[City] = N'London') AND [c0].[City] IS NOT NULL
+UNION
+SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
+FROM [Customers] AS [c1]
+WHERE ([c1].[City] = N'Mannheim') AND [c1].[City] IS NOT NULL");
+        }
+
+        public override async Task Union_Intersect(bool isAsync)
+        {
+            await base.Union_Intersect(isAsync);
+
+            AssertSql(
+                @"(
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE ([c].[City] = N'Berlin') AND [c].[City] IS NOT NULL
+    UNION
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    WHERE ([c0].[City] = N'London') AND [c0].[City] IS NOT NULL
+)
+INTERSECT
+SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
+FROM [Customers] AS [c1]
+WHERE CHARINDEX(N'Thomas', [c1].[ContactName]) > 0");
+        }
+
+        [ConditionalTheory(Skip = "Need to push down set operation on take without orderby+skip on SQL Server, waiting on design")]
+        public override async Task Union_Take_Union_Take(bool isAsync)
+        {
+            await base.Union_Take_Union_Take(isAsync);
+
+            throw new NotImplementedException("Take is being ignored");
+            //AssertSql(@"");
+        }
+
+        public override async Task Select_Union(bool isAsync)
+        {
+            await base.Select_Union(isAsync);
+
+            AssertSql(@"SELECT [c].[Address]
+FROM [Customers] AS [c]
+WHERE ([c].[City] = N'Berlin') AND [c].[City] IS NOT NULL
+UNION
+SELECT [c0].[Address]
+FROM [Customers] AS [c0]
+WHERE ([c0].[City] = N'London') AND [c0].[City] IS NOT NULL");
+        }
+
+        public override async Task Union_Select(bool isAsync)
+        {
+            await base.Union_Select(isAsync);
+
+            AssertSql(@"SELECT [t].[Address]
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE ([c].[City] = N'Berlin') AND [c].[City] IS NOT NULL
+    UNION
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    WHERE ([c0].[City] = N'London') AND [c0].[City] IS NOT NULL
+) AS [t]
+WHERE CHARINDEX(N'Hanover', [t].[Address]) > 0");
+        }
+
+        public override async Task Select_Union_unrelated(bool isAsync)
+        {
+            await base.Select_Union_unrelated(isAsync);
+
+            AssertSql(
+                @"SELECT [t].[ContactName]
+FROM (
+    SELECT [c].[ContactName]
+    FROM [Customers] AS [c]
+    UNION
+    SELECT [p].[ProductName]
+    FROM [Products] AS [p]
+) AS [t]
+WHERE [t].[ContactName] IS NOT NULL AND ([t].[ContactName] LIKE N'C%')
+ORDER BY [t].[ContactName]");
+        }
+
+        public override async Task Select_Union_different_fields_in_anonymous_with_subquery(bool isAsync)
+        {
+            await base.Select_Union_different_fields_in_anonymous_with_subquery(isAsync);
+
+            AssertSql(
+                @"@__p_0='1'
+@__p_1='10'
+
+SELECT [t].[Foo], [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
+FROM (
+    SELECT [c].[City] AS [Foo], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE ([c].[City] = N'Berlin') AND [c].[City] IS NOT NULL
+    UNION
+    SELECT [c0].[Region] AS [Foo], [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    WHERE ([c0].[City] = N'London') AND [c0].[City] IS NOT NULL
+    ORDER BY [Foo]
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+WHERE ([t].[Foo] = N'Berlin') AND [t].[Foo] IS NOT NULL
+ORDER BY [t].[Foo]");
+        }
+    }
+}

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
@@ -93,6 +93,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         // Skip for SQLite. Issue #14935. Cannot eval 'Sum()'
         public override Task Sum_with_division_on_decimal_no_significant_digits(bool isAsync) => null;
 
+        // Sqlite does not support LIMIT on set operation operands, nor subqueries, so this is untranslatable.
+        public override Task Union_Take_Union_Take(bool isAsync) => Task.CompletedTask;
+
         // Skip for SQLite. Issue #14935. Cannot eval 'where (Convert([o].OrderDate, Nullable`1) == Convert(DateTimeOffset.Now, Nullable`1))'
         public override Task Where_datetimeoffset_now_component(bool isAsync) => null;
 


### PR DESCRIPTION
This is a first draft for set operation support (UNION/UNION ALL/INTERSECT/EXCEPT). @smitpatel I'm looking for feedback on the general direction before I go any further etc.

Some important notes on database-specific quirks/capabilities (which have informed the design) have been posted in https://github.com/aspnet/EntityFrameworkCore/issues/6812#issuecomment-502827316.

### Design notes

Set operations are currently represented as a special kind of SelectExpression, with an enum marker has been added (SetOperationType). Each such SelectExpression represents a single set operation with exactly two operands.

RelationalQueryableMethodTranslatingExpressionVisitor performs pushdown of set operations into a subquery on most LINQ operations, in one place. As part of this, I have refactored translation of queryable operators into their own method.

