### PR TITLE
Re-enable most relational graph update tests

### DIFF
--- a/test/EFCore.Specification.Tests/GraphUpdatesFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdatesFixtureBase.cs
@@ -377,7 +377,7 @@ namespace Microsoft.EntityFrameworkCore
                                 });
                     });
 
-                modelBuilder.Entity<OptionalOverlaping2>(
+                modelBuilder.Entity<OptionalOverlapping2>(
                     eb =>
                     {
                         eb.Property(e => e.Id).ValueGeneratedNever();
@@ -642,13 +642,13 @@ namespace Microsoft.EntityFrameworkCore
                         new RequiredComposite1
                         {
                             Id = 1,
-                            CompositeChildren = new ObservableHashSet<OptionalOverlaping2>(ReferenceEqualityComparer.Instance)
+                            CompositeChildren = new ObservableHashSet<OptionalOverlapping2>(ReferenceEqualityComparer.Instance)
                             {
-                                new OptionalOverlaping2
+                                new OptionalOverlapping2
                                 {
                                     Id = 1
                                 },
-                                new OptionalOverlaping2
+                                new OptionalOverlapping2
                                 {
                                     Id = 2
                                 }
@@ -657,13 +657,13 @@ namespace Microsoft.EntityFrameworkCore
                         new RequiredComposite1
                         {
                             Id = 2,
-                            CompositeChildren = new ObservableHashSet<OptionalOverlaping2>(ReferenceEqualityComparer.Instance)
+                            CompositeChildren = new ObservableHashSet<OptionalOverlapping2>(ReferenceEqualityComparer.Instance)
                             {
-                                new OptionalOverlaping2
+                                new OptionalOverlapping2
                                 {
                                     Id = 3
                                 },
-                                new OptionalOverlaping2
+                                new OptionalOverlapping2
                                 {
                                     Id = 4
                                 }
@@ -719,70 +719,158 @@ namespace Microsoft.EntityFrameworkCore
         protected Expression<Func<Root, bool>> IsTheRoot => r => r.AlternateId == Fixture.RootAK;
 
         protected Root LoadRequiredGraph(DbContext context)
-            => context.Set<Root>()
-                .Include(e => e.RequiredChildren).ThenInclude(e => e.Children)
-                .Include(e => e.RequiredSingle).ThenInclude(e => e.Single)
-                .Single(IsTheRoot);
+        {
+            context.Set<Required1>().Load();
+            context.Set<Required2>().Load();
+            context.Set<RequiredSingle1>().Include(e => e.Single).Load();
+
+            return context.Set<Root>().Single(IsTheRoot);
+
+            // Issue #15318 Change this back to a single query with Includes:
+            // return context.Set<Root>()
+            //     .Include(e => e.RequiredChildren).ThenInclude(e => e.Children)
+            //     .Include(e => e.RequiredSingle).ThenInclude(e => e.Single)
+            //     .Single(IsTheRoot);
+        }
 
         protected Root LoadOptionalGraph(DbContext context)
-            => context.Set<Root>()
-                .Include(e => e.OptionalChildren).ThenInclude(e => e.Children)
-                .Include(e => e.OptionalChildren).ThenInclude(e => e.CompositeChildren)
-                .Include(e => e.OptionalSingle).ThenInclude(e => e.Single)
-                .Include(e => e.OptionalSingleDerived).ThenInclude(e => e.Single)
-                .Include(e => e.OptionalSingleMoreDerived).ThenInclude(e => e.Single)
-                .Single(IsTheRoot);
+        {
+            context.Set<Optional1>().Load();
+            context.Set<Optional2>().Load();
+            context.Set<OptionalComposite2>().Load();
+            context.Set<OptionalSingle1>().Include(e => e.Single).Load();
+            context.Set<OptionalSingle1Derived>().Include(e => e.Single).Load();
+            context.Set<OptionalSingle1MoreDerived>().Include(e => e.Single).Load();
+
+            return context.Set<Root>().Single(IsTheRoot);
+
+            // Issue #15318 Change this back to a single query with Includes:
+            // return context.Set<Root>()
+            //     .Include(e => e.OptionalChildren).ThenInclude(e => e.Children)
+            //     .Include(e => e.OptionalChildren).ThenInclude(e => e.CompositeChildren)
+            //     .Include(e => e.OptionalSingle).ThenInclude(e => e.Single)
+            //     .Include(e => e.OptionalSingleDerived).ThenInclude(e => e.Single)
+            //     .Include(e => e.OptionalSingleMoreDerived).ThenInclude(e => e.Single)
+            //     .Single(IsTheRoot);
+        }
 
         protected Root LoadRequiredNonPkGraph(DbContext context)
-            => context.Set<Root>()
-                .Include(e => e.RequiredNonPkSingle).ThenInclude(e => e.Single)
-                .Include(e => e.RequiredNonPkSingleDerived).ThenInclude(e => e.Single)
-                .Include(e => e.RequiredNonPkSingleDerived).ThenInclude(e => e.Root)
-                .Include(e => e.RequiredNonPkSingleMoreDerived).ThenInclude(e => e.Single)
-                .Include(e => e.RequiredNonPkSingleMoreDerived).ThenInclude(e => e.Root)
-                .Include(e => e.RequiredNonPkSingleMoreDerived).ThenInclude(e => e.DerivedRoot)
-                .Single(IsTheRoot);
+        {
+            context.Set<RequiredNonPkSingle1>().Include(e => e.Single).Load();
+            context.Set<RequiredNonPkSingle1Derived>().Include(e => e.Single).Load();
+            context.Set<RequiredNonPkSingle1Derived>().Include(e => e.Root).Load();
+            context.Set<RequiredNonPkSingle1MoreDerived>().Include(e => e.Single).Load();
+            context.Set<RequiredNonPkSingle1MoreDerived>().Include(e => e.Root).Load();
+            context.Set<RequiredNonPkSingle1MoreDerived>().Include(e => e.DerivedRoot).Load();
+
+            return context.Set<Root>().Single(IsTheRoot);
+
+            // Issue #15318 Change this back to a single query with Includes:
+            // return context.Set<Root>()
+            //     .Include(e => e.RequiredNonPkSingle).ThenInclude(e => e.Single)
+            //     .Include(e => e.RequiredNonPkSingleDerived).ThenInclude(e => e.Single)
+            //     .Include(e => e.RequiredNonPkSingleDerived).ThenInclude(e => e.Root)
+            //     .Include(e => e.RequiredNonPkSingleMoreDerived).ThenInclude(e => e.Single)
+            //     .Include(e => e.RequiredNonPkSingleMoreDerived).ThenInclude(e => e.Root)
+            //     .Include(e => e.RequiredNonPkSingleMoreDerived).ThenInclude(e => e.DerivedRoot)
+            //     .Single(IsTheRoot);
+        }
 
         protected Root LoadRequiredAkGraph(DbContext context)
-            => context.Set<Root>()
-                .Include(e => e.RequiredChildrenAk).ThenInclude(e => e.Children)
-                .Include(e => e.RequiredChildrenAk).ThenInclude(e => e.CompositeChildren)
-                .Include(e => e.RequiredSingleAk).ThenInclude(e => e.Single)
-                .Include(e => e.RequiredSingleAk).ThenInclude(e => e.SingleComposite)
-                .Single(IsTheRoot);
+        {
+            context.Set<RequiredAk1>().Load();
+            context.Set<RequiredAk2>().Load();
+            context.Set<RequiredComposite2>().Load();
+            context.Set<RequiredSingleAk1>().Include(e => e.Single).Load();
+            context.Set<RequiredSingleAk1>().Include(e => e.SingleComposite).Load();
+
+            return context.Set<Root>().Single(IsTheRoot);
+
+            // Issue #15318 Change this back to a single query with Includes:
+            // return context.Set<Root>()
+            //     .Include(e => e.RequiredChildrenAk).ThenInclude(e => e.Children)
+            //     .Include(e => e.RequiredChildrenAk).ThenInclude(e => e.CompositeChildren)
+            //     .Include(e => e.RequiredSingleAk).ThenInclude(e => e.Single)
+            //     .Include(e => e.RequiredSingleAk).ThenInclude(e => e.SingleComposite)
+            //     .Single(IsTheRoot);
+        }
 
         protected Root LoadOptionalAkGraph(DbContext context)
-            => context.Set<Root>()
-                .Include(e => e.OptionalChildrenAk).ThenInclude(e => e.Children)
-                .Include(e => e.OptionalChildrenAk).ThenInclude(e => e.CompositeChildren)
-                .Include(e => e.OptionalSingleAk).ThenInclude(e => e.Single)
-                .Include(e => e.OptionalSingleAk).ThenInclude(e => e.SingleComposite)
-                .Include(e => e.OptionalSingleAkDerived).ThenInclude(e => e.Single)
-                .Include(e => e.OptionalSingleAkMoreDerived).ThenInclude(e => e.Single)
-                .Single(IsTheRoot);
+        {
+            context.Set<OptionalAk1>().Load();
+            context.Set<OptionalAk2>().Load();
+            context.Set<OptionalComposite2>().Load();
+            context.Set<OptionalSingleAk1>().Include(e => e.Single).Load();
+            context.Set<OptionalSingleAk1>().Include(e => e.SingleComposite).Load();
+            context.Set<OptionalSingleAk1Derived>().Include(e => e.Single).Load();
+            context.Set<OptionalSingleAk1MoreDerived>().Include(e => e.Single).Load();
+
+            return context.Set<Root>().Single(IsTheRoot);
+
+            // Issue #15318 Change this back to a single query with Includes:
+            // return context.Set<Root>()
+            //     .Include(e => e.OptionalChildrenAk).ThenInclude(e => e.Children)
+            //     .Include(e => e.OptionalChildrenAk).ThenInclude(e => e.CompositeChildren)
+            //     .Include(e => e.OptionalSingleAk).ThenInclude(e => e.Single)
+            //     .Include(e => e.OptionalSingleAk).ThenInclude(e => e.SingleComposite)
+            //     .Include(e => e.OptionalSingleAkDerived).ThenInclude(e => e.Single)
+            //     .Include(e => e.OptionalSingleAkMoreDerived).ThenInclude(e => e.Single)
+            //     .Single(IsTheRoot);
+        }
 
         protected Root LoadRequiredNonPkAkGraph(DbContext context)
-            => context.Set<Root>()
-                .Include(e => e.RequiredNonPkSingleAk).ThenInclude(e => e.Single)
-                .Include(e => e.RequiredNonPkSingleAkDerived).ThenInclude(e => e.Single)
-                .Include(e => e.RequiredNonPkSingleAkDerived).ThenInclude(e => e.Root)
-                .Include(e => e.RequiredNonPkSingleAkMoreDerived).ThenInclude(e => e.Single)
-                .Include(e => e.RequiredNonPkSingleAkMoreDerived).ThenInclude(e => e.Root)
-                .Include(e => e.RequiredNonPkSingleAkMoreDerived).ThenInclude(e => e.DerivedRoot)
-                .Single(IsTheRoot);
+        {
+            context.Set<RequiredNonPkSingleAk1>().Include(e => e.Single).Load();
+            context.Set<RequiredNonPkSingleAk1Derived>().Include(e => e.Single).Load();
+            context.Set<RequiredNonPkSingleAk1Derived>().Include(e => e.Root).Load();
+            context.Set<RequiredNonPkSingleAk1MoreDerived>().Include(e => e.Single).Load();
+            context.Set<RequiredNonPkSingleAk1MoreDerived>().Include(e => e.Root).Load();
+            context.Set<RequiredNonPkSingleAk1MoreDerived>().Include(e => e.DerivedRoot).Load();
+
+            return context.Set<Root>().Single(IsTheRoot);
+
+            // Issue #15318 Change this back to a single query with Includes:
+            // return context.Set<Root>()
+            //     .Include(e => e.RequiredNonPkSingleAk).ThenInclude(e => e.Single)
+            //     .Include(e => e.RequiredNonPkSingleAkDerived).ThenInclude(e => e.Single)
+            //     .Include(e => e.RequiredNonPkSingleAkDerived).ThenInclude(e => e.Root)
+            //     .Include(e => e.RequiredNonPkSingleAkMoreDerived).ThenInclude(e => e.Single)
+            //     .Include(e => e.RequiredNonPkSingleAkMoreDerived).ThenInclude(e => e.Root)
+            //     .Include(e => e.RequiredNonPkSingleAkMoreDerived).ThenInclude(e => e.DerivedRoot)
+            //     .Single(IsTheRoot);
+        }
 
         protected Root LoadOptionalOneToManyGraph(DbContext context)
-            => context.Set<Root>()
-                .Include(e => e.OptionalChildren).ThenInclude(e => e.Children)
-                .Include(e => e.OptionalChildren).ThenInclude(e => e.CompositeChildren)
-                .Include(e => e.OptionalChildrenAk).ThenInclude(e => e.Children)
-                .Include(e => e.OptionalChildrenAk).ThenInclude(e => e.CompositeChildren)
-                .Single(IsTheRoot);
+        {
+            context.Set<Optional1>().Load();
+            context.Set<Optional2>().Load();
+            context.Set<OptionalComposite2>().Load();
+            context.Set<OptionalAk1>().Load();
+            context.Set<OptionalAk2>().Load();
+
+            return context.Set<Root>().Single(IsTheRoot);
+
+            // Issue #15318 Change this back to a single query with Includes:
+            // return context.Set<Root>()
+            //     .Include(e => e.OptionalChildren).ThenInclude(e => e.Children)
+            //     .Include(e => e.OptionalChildren).ThenInclude(e => e.CompositeChildren)
+            //     .Include(e => e.OptionalChildrenAk).ThenInclude(e => e.Children)
+            //     .Include(e => e.OptionalChildrenAk).ThenInclude(e => e.CompositeChildren)
+            //     .Single(IsTheRoot);
+        }
 
         protected Root LoadRequiredCompositeGraph(DbContext context)
-            => context.Set<Root>()
-                .Include(e => e.RequiredCompositeChildren).ThenInclude(e => e.CompositeChildren)
-                .Single(IsTheRoot);
+        {
+            context.Set<RequiredComposite1>().Load();
+            context.Set<OptionalOverlapping2>().Load();
+
+            return context.Set<Root>().Single(IsTheRoot);
+
+            // Issue #15318 Change this back to a single query with Includes:
+            // return context.Set<Root>()
+            //     .Include(e => e.RequiredCompositeChildren).ThenInclude(e => e.CompositeChildren)
+            //     .Single(IsTheRoot);
+        }
 
         private static void AssertEntries(IReadOnlyList<EntityEntry> expectedEntries, IReadOnlyList<EntityEntry> actualEntries)
         {
@@ -1896,8 +1984,8 @@ namespace Microsoft.EntityFrameworkCore
             private Guid _parentAlternateId;
             private Root _parent;
 
-            private ICollection<OptionalOverlaping2> _compositeChildren =
-                new ObservableHashSet<OptionalOverlaping2>(ReferenceEqualityComparer.Instance);
+            private ICollection<OptionalOverlapping2> _compositeChildren =
+                new ObservableHashSet<OptionalOverlapping2>(ReferenceEqualityComparer.Instance);
 
             public int Id
             {
@@ -1923,7 +2011,7 @@ namespace Microsoft.EntityFrameworkCore
                 return _id == other?.Id;
             }
 
-            public ICollection<OptionalOverlaping2> CompositeChildren
+            public ICollection<OptionalOverlapping2> CompositeChildren
             {
                 get => _compositeChildren;
                 set => SetWithNotify(value, ref _compositeChildren);
@@ -1932,7 +2020,7 @@ namespace Microsoft.EntityFrameworkCore
             public override int GetHashCode() => _id;
         }
 
-        protected class OptionalOverlaping2 : NotifyingEntity
+        protected class OptionalOverlapping2 : NotifyingEntity
         {
             private int _id;
             private Guid _parentAlternateId;
@@ -1972,7 +2060,7 @@ namespace Microsoft.EntityFrameworkCore
 
             public override bool Equals(object obj)
             {
-                var other = obj as OptionalOverlaping2;
+                var other = obj as OptionalOverlapping2;
                 return _id == other?.Id;
             }
 

--- a/test/EFCore.Specification.Tests/GraphUpdatesTestBase.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdatesTestBase.cs
@@ -1170,7 +1170,7 @@ namespace Microsoft.EntityFrameworkCore
                 });
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory (Skip = "Issue #15318")]
         [InlineData((int)ChangeMechanism.Principal, false, CascadeTiming.OnSaveChanges)]
         [InlineData((int)ChangeMechanism.Principal, true, CascadeTiming.OnSaveChanges)]
         [InlineData((int)ChangeMechanism.Dependent, false, CascadeTiming.OnSaveChanges)]
@@ -2300,8 +2300,8 @@ namespace Microsoft.EntityFrameworkCore
             IReadOnlyList<EntityEntry> entries = null;
             var childCount = 0;
             RequiredComposite1 oldParent = null;
-            OptionalOverlaping2 oldChild1 = null;
-            OptionalOverlaping2 oldChild2 = null;
+            OptionalOverlapping2 oldChild1 = null;
+            OptionalOverlapping2 oldChild2 = null;
             RequiredComposite1 newParent = null;
 
             ExecuteWithStrategyInTransaction(
@@ -2313,13 +2313,13 @@ namespace Microsoft.EntityFrameworkCore
                         {
                             Id = 3,
                             Parent = context.Set<Root>().Single(IsTheRoot),
-                            CompositeChildren = new ObservableHashSet<OptionalOverlaping2>(ReferenceEqualityComparer.Instance)
+                            CompositeChildren = new ObservableHashSet<OptionalOverlapping2>(ReferenceEqualityComparer.Instance)
                             {
-                                new OptionalOverlaping2
+                                new OptionalOverlapping2
                                 {
                                     Id = 5
                                 },
-                                new OptionalOverlaping2
+                                new OptionalOverlapping2
                                 {
                                     Id = 6
                                 }
@@ -2336,7 +2336,7 @@ namespace Microsoft.EntityFrameworkCore
 
                     root = LoadRequiredCompositeGraph(context);
 
-                    childCount = context.Set<OptionalOverlaping2>().Count();
+                    childCount = context.Set<OptionalOverlapping2>().Count();
 
                     oldParent = root.RequiredCompositeChildren.OrderBy(e => e.Id).First();
 
@@ -2394,7 +2394,7 @@ namespace Microsoft.EntityFrameworkCore
 
                     entries = context.ChangeTracker.Entries().ToList();
 
-                    Assert.Equal(childCount, context.Set<OptionalOverlaping2>().Count());
+                    Assert.Equal(childCount, context.Set<OptionalOverlapping2>().Count());
                 },
                 context =>
                 {
@@ -2406,8 +2406,8 @@ namespace Microsoft.EntityFrameworkCore
                     oldParent = context.Set<RequiredComposite1>().Single(e => e.Id == oldParent.Id);
                     newParent = context.Set<RequiredComposite1>().Single(e => e.Id == newParent.Id);
 
-                    oldChild1 = context.Set<OptionalOverlaping2>().Single(e => e.Id == oldChild1.Id);
-                    oldChild2 = context.Set<OptionalOverlaping2>().Single(e => e.Id == oldChild2.Id);
+                    oldChild1 = context.Set<OptionalOverlapping2>().Single(e => e.Id == oldChild1.Id);
+                    oldChild2 = context.Set<OptionalOverlapping2>().Single(e => e.Id == oldChild2.Id);
 
                     Assert.Same(oldChild2, oldParent.CompositeChildren.Single());
                     Assert.Same(oldParent, oldChild2.Parent);
@@ -2423,7 +2423,7 @@ namespace Microsoft.EntityFrameworkCore
 
                     AssertEntries(entries, context.ChangeTracker.Entries().ToList());
 
-                    Assert.Equal(childCount, context.Set<OptionalOverlaping2>().Count());
+                    Assert.Equal(childCount, context.Set<OptionalOverlapping2>().Count());
                 });
         }
 
@@ -2453,7 +2453,7 @@ namespace Microsoft.EntityFrameworkCore
                     var parent = root.RequiredCompositeChildren.OrderBy(e => e.Id).First();
                     var child = parent.CompositeChildren.OrderBy(e => e.Id).First();
 
-                    var childCount = context.Set<OptionalOverlaping2>().Count();
+                    var childCount = context.Set<OptionalOverlapping2>().Count();
 
                     if ((changeMechanism & ChangeMechanism.Principal) != 0)
                     {
@@ -2483,7 +2483,7 @@ namespace Microsoft.EntityFrameworkCore
                     Assert.Equal(root.AlternateId, child.ParentAlternateId);
                     Assert.Same(root, child.Root);
 
-                    Assert.Equal(childCount, context.Set<OptionalOverlaping2>().Count());
+                    Assert.Equal(childCount, context.Set<OptionalOverlapping2>().Count());
                 });
         }
 
@@ -3735,7 +3735,7 @@ namespace Microsoft.EntityFrameworkCore
                 });
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue #15318")]
         [InlineData((int)ChangeMechanism.Principal, false, CascadeTiming.OnSaveChanges)]
         [InlineData((int)ChangeMechanism.Principal, true, CascadeTiming.OnSaveChanges)]
         [InlineData((int)ChangeMechanism.Dependent, false, CascadeTiming.OnSaveChanges)]
@@ -5968,7 +5968,10 @@ namespace Microsoft.EntityFrameworkCore
                     context.ChangeTracker.CascadeDeleteTiming = cascadeDeleteTiming ?? CascadeTiming.Never;
                     context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming ?? CascadeTiming.Never;
 
-                    var root = context.Set<Root>().Include(e => e.RequiredChildren).Single(IsTheRoot);
+                    // Issue #15318 Change this back to a single query with Includes:
+                    // var root = context.Set<Root>().Include(e => e.RequiredChildren).Single(IsTheRoot);
+                    var root = context.Set<Root>().Single(IsTheRoot);
+                    context.Set<Required1>().Load();
 
                     var removed = root.RequiredChildren.Single(e => e.Id == removedId);
 
@@ -6222,7 +6225,10 @@ namespace Microsoft.EntityFrameworkCore
                     context.ChangeTracker.CascadeDeleteTiming = cascadeDeleteTiming ?? CascadeTiming.Never;
                     context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming ?? CascadeTiming.Never;
 
-                    var root = context.Set<Root>().Include(e => e.RequiredChildrenAk).Single(IsTheRoot);
+                    // Issue #15318 Change this back to a single query with Includes:
+                    // var root = context.Set<Root>().Include(e => e.RequiredChildrenAk).Single(IsTheRoot);
+                    var root = context.Set<Root>().Single(IsTheRoot);
+                    context.Set<RequiredAk1>().Load();
 
                     var removed = root.RequiredChildrenAk.Single(e => e.Id == removedId);
 
@@ -6477,7 +6483,10 @@ namespace Microsoft.EntityFrameworkCore
                     context.ChangeTracker.CascadeDeleteTiming = cascadeDeleteTiming ?? CascadeTiming.Never;
                     context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming ?? CascadeTiming.Never;
 
-                    var root = context.Set<Root>().Include(e => e.OptionalChildren).Single(IsTheRoot);
+                    // Issue #15318 Change this back to a single query with Includes:
+                    // var root = context.Set<Root>().Include(e => e.OptionalChildren).Single(IsTheRoot);
+                    var root = context.Set<Root>().Single(IsTheRoot);
+                    context.Entry(root).Collection(e => e.OptionalChildren).Load();
 
                     var removed = root.OptionalChildren.First(e => e.Id == removedId);
 
@@ -6651,7 +6660,10 @@ namespace Microsoft.EntityFrameworkCore
                     context.ChangeTracker.CascadeDeleteTiming = cascadeDeleteTiming ?? CascadeTiming.Never;
                     context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming ?? CascadeTiming.Never;
 
-                    var root = context.Set<Root>().Include(e => e.OptionalChildrenAk).Single(IsTheRoot);
+                    // Issue #15318 Change this back to a single query with Includes:
+                    // var root = context.Set<Root>().Include(e => e.OptionalChildrenAk).Single(IsTheRoot);
+                    var root = context.Set<Root>().Single(IsTheRoot);
+                    context.Entry(root).Collection(e => e.OptionalChildrenAk).Load();
 
                     var removed = root.OptionalChildrenAk.First(e => e.Id == removedId);
 

--- a/test/EFCore.Specification.Tests/ProxyGraphUpdatesFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/ProxyGraphUpdatesFixtureBase.cs
@@ -371,7 +371,7 @@ namespace Microsoft.EntityFrameworkCore
                                 });
                     });
 
-                modelBuilder.Entity<OptionalOverlaping2>(
+                modelBuilder.Entity<OptionalOverlapping2>(
                     eb =>
                     {
                         eb.Property(e => e.Id).ValueGeneratedNever();
@@ -620,13 +620,13 @@ namespace Microsoft.EntityFrameworkCore
                         new RequiredComposite1
                         {
                             Id = 1,
-                            CompositeChildren = new ObservableHashSet<OptionalOverlaping2>(ReferenceEqualityComparer.Instance)
+                            CompositeChildren = new ObservableHashSet<OptionalOverlapping2>(ReferenceEqualityComparer.Instance)
                             {
-                                new OptionalOverlaping2
+                                new OptionalOverlapping2
                                 {
                                     Id = 1
                                 },
-                                new OptionalOverlaping2
+                                new OptionalOverlapping2
                                 {
                                     Id = 2
                                 }
@@ -635,13 +635,13 @@ namespace Microsoft.EntityFrameworkCore
                         new RequiredComposite1
                         {
                             Id = 2,
-                            CompositeChildren = new ObservableHashSet<OptionalOverlaping2>(ReferenceEqualityComparer.Instance)
+                            CompositeChildren = new ObservableHashSet<OptionalOverlapping2>(ReferenceEqualityComparer.Instance)
                             {
-                                new OptionalOverlaping2
+                                new OptionalOverlapping2
                                 {
                                     Id = 3
                                 },
-                                new OptionalOverlaping2
+                                new OptionalOverlapping2
                                 {
                                     Id = 4
                                 }
@@ -1132,13 +1132,13 @@ namespace Microsoft.EntityFrameworkCore
                 return Id == other?.Id;
             }
 
-            public virtual ICollection<OptionalOverlaping2> CompositeChildren { get; set; }
-                = new ObservableHashSet<OptionalOverlaping2>(ReferenceEqualityComparer.Instance);
+            public virtual ICollection<OptionalOverlapping2> CompositeChildren { get; set; }
+                = new ObservableHashSet<OptionalOverlapping2>(ReferenceEqualityComparer.Instance);
 
             public override int GetHashCode() => Id;
         }
 
-        public class OptionalOverlaping2
+        public class OptionalOverlapping2
         {
             public virtual int Id { get; set; }
 
@@ -1152,7 +1152,7 @@ namespace Microsoft.EntityFrameworkCore
 
             public override bool Equals(object obj)
             {
-                var other = obj as OptionalOverlaping2;
+                var other = obj as OptionalOverlapping2;
                 return Id == other?.Id;
             }
 

--- a/test/EFCore.Specification.Tests/ProxyGraphUpdatesTestBase.cs
+++ b/test/EFCore.Specification.Tests/ProxyGraphUpdatesTestBase.cs
@@ -1370,8 +1370,8 @@ namespace Microsoft.EntityFrameworkCore
             Root root = null;
             var childCount = 0;
             RequiredComposite1 oldParent = null;
-            OptionalOverlaping2 oldChild1 = null;
-            OptionalOverlaping2 oldChild2 = null;
+            OptionalOverlapping2 oldChild1 = null;
+            OptionalOverlapping2 oldChild2 = null;
             RequiredComposite1 newParent = null;
 
             ExecuteWithStrategyInTransaction(
@@ -1383,10 +1383,10 @@ namespace Microsoft.EntityFrameworkCore
                         {
                             Id = 3,
                             Parent = context.Set<Root>().Single(IsTheRoot),
-                            CompositeChildren = new ObservableHashSet<OptionalOverlaping2>(ReferenceEqualityComparer.Instance)
+                            CompositeChildren = new ObservableHashSet<OptionalOverlapping2>(ReferenceEqualityComparer.Instance)
                             {
-                                new OptionalOverlaping2 { Id = 5 },
-                                new OptionalOverlaping2 { Id = 6 }
+                                new OptionalOverlapping2 { Id = 5 },
+                                new OptionalOverlapping2 { Id = 6 }
                             }
                         };
 
@@ -1398,7 +1398,7 @@ namespace Microsoft.EntityFrameworkCore
                 {
                     root = LoadRoot(context);
 
-                    childCount = context.Set<OptionalOverlaping2>().Count();
+                    childCount = context.Set<OptionalOverlapping2>().Count();
 
                     oldParent = root.RequiredCompositeChildren.OrderBy(e => e.Id).First();
 
@@ -1454,7 +1454,7 @@ namespace Microsoft.EntityFrameworkCore
                     Assert.Equal(root.AlternateId, oldChild1.ParentAlternateId);
                     Assert.Same(root, oldChild1.Root);
 
-                    Assert.Equal(childCount, context.Set<OptionalOverlaping2>().Count());
+                    Assert.Equal(childCount, context.Set<OptionalOverlapping2>().Count());
                 },
                 context =>
                 {
@@ -1463,8 +1463,8 @@ namespace Microsoft.EntityFrameworkCore
                     oldParent = context.Set<RequiredComposite1>().Single(e => e.Id == oldParent.Id);
                     newParent = context.Set<RequiredComposite1>().Single(e => e.Id == newParent.Id);
 
-                    oldChild1 = context.Set<OptionalOverlaping2>().Single(e => e.Id == oldChild1.Id);
-                    oldChild2 = context.Set<OptionalOverlaping2>().Single(e => e.Id == oldChild2.Id);
+                    oldChild1 = context.Set<OptionalOverlapping2>().Single(e => e.Id == oldChild1.Id);
+                    oldChild2 = context.Set<OptionalOverlapping2>().Single(e => e.Id == oldChild2.Id);
 
                     Assert.Same(oldChild2, oldParent.CompositeChildren.Single());
                     Assert.Same(oldParent, oldChild2.Parent);
@@ -1478,7 +1478,7 @@ namespace Microsoft.EntityFrameworkCore
                     Assert.Equal(oldParent.ParentAlternateId, oldChild1.ParentAlternateId);
                     Assert.Equal(root.AlternateId, oldChild1.ParentAlternateId);
 
-                    Assert.Equal(childCount, context.Set<OptionalOverlaping2>().Count());
+                    Assert.Equal(childCount, context.Set<OptionalOverlapping2>().Count());
                 });
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/GraphUpdatesSqlServerTestClientCascade.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GraphUpdatesSqlServerTestClientCascade.cs
@@ -5,8 +5,7 @@ using System.Linq;
 
 namespace Microsoft.EntityFrameworkCore
 {
-    // issue #15318
-    internal class GraphUpdatesSqlServerTestClientCascade : GraphUpdatesSqlServerTestBase<GraphUpdatesSqlServerTestClientCascade.GraphUpdatesWithClientCascadeSqlServerFixture>
+    public class GraphUpdatesSqlServerTestClientCascade : GraphUpdatesSqlServerTestBase<GraphUpdatesSqlServerTestClientCascade.GraphUpdatesWithClientCascadeSqlServerFixture>
     {
         public GraphUpdatesSqlServerTestClientCascade(GraphUpdatesWithClientCascadeSqlServerFixture fixture)
             : base(fixture)

--- a/test/EFCore.SqlServer.FunctionalTests/GraphUpdatesSqlServerTestClientNoAction.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GraphUpdatesSqlServerTestClientNoAction.cs
@@ -5,8 +5,7 @@ using System.Linq;
 
 namespace Microsoft.EntityFrameworkCore
 {
-    // issue #15318
-    internal class GraphUpdatesSqlServerTestClientNoAction : GraphUpdatesSqlServerTestBase<GraphUpdatesSqlServerTestClientNoAction.GraphUpdatesWithClientNoActionSqlServerFixture>
+    public class GraphUpdatesSqlServerTestClientNoAction : GraphUpdatesSqlServerTestBase<GraphUpdatesSqlServerTestClientNoAction.GraphUpdatesWithClientNoActionSqlServerFixture>
     {
         public GraphUpdatesSqlServerTestClientNoAction(GraphUpdatesWithClientNoActionSqlServerFixture fixture)
             : base(fixture)

--- a/test/EFCore.SqlServer.FunctionalTests/GraphUpdatesSqlServerTestIdentity.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GraphUpdatesSqlServerTestIdentity.cs
@@ -3,8 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore
 {
-    // issue #15318
-    internal class GraphUpdatesSqlServerTestIdentity : GraphUpdatesSqlServerTestBase<GraphUpdatesSqlServerTestIdentity.GraphUpdatesWithIdentitySqlServerFixture>
+    public class GraphUpdatesSqlServerTestIdentity : GraphUpdatesSqlServerTestBase<GraphUpdatesSqlServerTestIdentity.GraphUpdatesWithIdentitySqlServerFixture>
     {
         public GraphUpdatesSqlServerTestIdentity(GraphUpdatesWithIdentitySqlServerFixture fixture)
             : base(fixture)

--- a/test/EFCore.SqlServer.FunctionalTests/GraphUpdatesSqlServerTestSequence.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GraphUpdatesSqlServerTestSequence.cs
@@ -6,8 +6,7 @@ using Microsoft.EntityFrameworkCore.TestUtilities;
 namespace Microsoft.EntityFrameworkCore
 {
     [SqlServerCondition(SqlServerCondition.SupportsSequences)]
-    // issue #15318
-    internal class GraphUpdatesSqlServerTestSequence : GraphUpdatesSqlServerTestBase<
+    public class GraphUpdatesSqlServerTestSequence : GraphUpdatesSqlServerTestBase<
         GraphUpdatesSqlServerTestSequence.GraphUpdatesWithSequenceSqlServerFixture>
     {
         public GraphUpdatesSqlServerTestSequence(GraphUpdatesWithSequenceSqlServerFixture fixture)

--- a/test/EFCore.Sqlite.FunctionalTests/GraphUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/GraphUpdatesSqliteTest.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore
-{ 
+{
     public abstract class GraphUpdatesSqliteTest
     {
         public abstract class GraphUpdatesSqliteTestBase<TFixture> : GraphUpdatesTestBase<TFixture>
@@ -37,8 +37,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        // issue #15318
-        internal class SnapshotNotifications
+        public class SnapshotNotifications
             : GraphUpdatesSqliteTestBase<SnapshotNotifications.SnapshotNotificationsFixture>
         {
             public SnapshotNotifications(SnapshotNotificationsFixture fixture, ITestOutputHelper testOutputHelper)
@@ -61,8 +60,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        // issue #15318
-        internal class ChangedNotifications
+        public class ChangedNotifications
             : GraphUpdatesSqliteTestBase<ChangedNotifications.ChangedNotificationsFixture>
         {
             public ChangedNotifications(ChangedNotificationsFixture fixture)
@@ -83,8 +81,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        // issue #15318
-        internal class ChangedChangingNotifications
+        public class ChangedChangingNotifications
             : GraphUpdatesSqliteTestBase<ChangedChangingNotifications.ChangedChangingNotificationsFixture>
         {
             public ChangedChangingNotifications(ChangedChangingNotificationsFixture fixture)
@@ -105,8 +102,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        // issue #15318
-        internal class FullWithOriginalsNotifications
+        public class FullWithOriginalsNotifications
             : GraphUpdatesSqliteTestBase<FullWithOriginalsNotifications.FullWithOriginalsNotificationsFixture>
         {
             public FullWithOriginalsNotifications(FullWithOriginalsNotificationsFixture fixture)


### PR DESCRIPTION
Because they have a lot of coverage for things outside of query.

The queries should be reverted back to full `Include` queries once they work--still annotated with the same issue number: #15318
