### PR TITLE
Entity equality: Contains and OrderBy

### DIFF
--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2124,6 +2124,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 GetString("SubqueryWithCompositeKeyNotSupported", nameof(entityType)),
                 entityType);
 
+        /// <summary>
+        ///     Cannot translate a Contains() operator on entity '{entityType}' because it has a composite key.
+        /// </summary>
+        public static string EntityEqualityContainsWithCompositeKeyNotSupported([CanBeNull] object entityType)
+            => string.Format(
+                GetString("EntityEqualityContainsWithCompositeKeyNotSupported", nameof(entityType)),
+                entityType);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1177,4 +1177,7 @@
   <data name="SubqueryWithCompositeKeyNotSupported" xml:space="preserve">
     <value>This query would cause multiple evaluation of a subquery because entity '{entityType}' has a composite key. Rewrite your query avoiding the subquery.</value>
   </data>
+  <data name="EntityEqualityContainsWithCompositeKeyNotSupported" xml:space="preserve">
+    <value>Cannot translate a Contains() operator on entity '{entityType}' because it has a composite key.</value>
+  </data>
 </root>

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
@@ -1736,7 +1736,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 1);
         }
 
-        [ConditionalFact(Skip = "#15939")]
+        [ConditionalFact(Skip = "#15855")]
         public virtual void Contains_over_entityType_should_rewrite_to_identity_equality()
         {
             using (var context = CreateContext())
@@ -1744,6 +1744,19 @@ namespace Microsoft.EntityFrameworkCore.Query
                 var query
                     = context.Orders.Where(o => o.CustomerID == "VINET")
                         .Contains(context.Orders.Single(o => o.OrderID == 10248));
+
+                Assert.True(query);
+            }
+        }
+
+        [ConditionalFact(Skip = "#15855")]
+        public virtual void Contains_over_entityType_with_null_should_rewrite_to_identity_equality()
+        {
+            using (var context = CreateContext())
+            {
+                var query
+                    = context.Orders.Where(o => o.CustomerID == "VINET")
+                        .Contains(null);
 
                 Assert.True(query);
             }

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -527,6 +527,24 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
+        public virtual Task Entity_equality_orderby(bool isAsync)
+            => AssertQuery<Customer>(
+                isAsync,
+                cs => cs.OrderBy(c => c),
+                entryCount: 91,
+                assertOrder: true);
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Entity_equality_orderby_descending_composite_key(bool isAsync)
+            => AssertQuery<OrderDetail>(
+                isAsync,
+                od => od.OrderByDescending(o => o),
+                entryCount: 2155,
+                assertOrder: true);
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual Task Null_conditional_simple(bool isAsync)
         {
             var c = Expression.Parameter(typeof(Customer));

--- a/test/EFCore.Specification.Tests/TestModels/Northwind/Customer.cs
+++ b/test/EFCore.Specification.Tests/TestModels/Northwind/Customer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -9,7 +10,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.Northwind
 {
-    public class Customer
+    public class Customer : IComparable<Customer>
     {
         public Customer()
         {
@@ -58,6 +59,9 @@ namespace Microsoft.EntityFrameworkCore.TestModels.Northwind
         public static bool operator ==(Customer left, Customer right) => Equals(left, right);
 
         public static bool operator !=(Customer left, Customer right) => !Equals(left, right);
+
+        public int CompareTo(Customer other) =>
+            other == null ? 1 : CustomerID.CompareTo(other.CustomerID);
 
         public override int GetHashCode() => CustomerID.GetHashCode();
 

--- a/test/EFCore.Specification.Tests/TestModels/Northwind/OrderDetail.cs
+++ b/test/EFCore.Specification.Tests/TestModels/Northwind/OrderDetail.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.Northwind
 {
-    public class OrderDetail
+    public class OrderDetail : IComparable<OrderDetail>
     {
         public int OrderID { get; set; }
         public int ProductID { get; set; }
@@ -34,5 +34,18 @@ namespace Microsoft.EntityFrameworkCore.TestModels.Northwind
         }
 
         public override int GetHashCode() => HashCode.Combine(OrderID, ProductID);
+
+        public int CompareTo(OrderDetail other)
+        {
+            if (other == null)
+            {
+                return 1;
+            }
+
+            var comp1 = OrderID.CompareTo(other.OrderID);
+            return comp1 == 0
+                ? ProductID.CompareTo(other.ProductID)
+                : comp1;
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.ResultOperators.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.ResultOperators.cs
@@ -1209,6 +1209,14 @@ SELECT CASE
 END");
         }
 
+        public override void Contains_over_entityType_with_null_should_rewrite_to_identity_equality()
+        {
+            base.Contains_over_entityType_with_null_should_rewrite_to_identity_equality();
+
+            AssertSql(
+                @"TODO");
+        }
+
         public override void Contains_over_entityType_should_materialize_when_composite()
         {
             base.Contains_over_entityType_should_materialize_when_composite();

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -283,6 +283,26 @@ FROM [Customers] AS [c]
 WHERE CAST(0 AS bit) = CAST(1 AS bit)");
         }
 
+        public override async Task Entity_equality_orderby(bool isAsync)
+        {
+            await base.Entity_equality_orderby(isAsync);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]");
+        }
+
+        public override async Task Entity_equality_orderby_descending_composite_key(bool isAsync)
+        {
+            await base.Entity_equality_orderby_descending_composite_key(isAsync);
+
+            AssertSql(
+                @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
+FROM [Order Details] AS [o]
+ORDER BY [o].[OrderID] DESC, [o].[ProductID] DESC");
+        }
+
         public override async Task Queryable_reprojection(bool isAsync)
         {
             await base.Queryable_reprojection(isAsync);


### PR DESCRIPTION
Closes #15939

For Contains, I realized half-way through that the test (Contains_over_entityType_should_rewrite_to_identity_equality) depends on #15855, since the second query sends the ID selected in the first query. Am still submitting the implementation - the expression tree generated internally looks good. I can also hold off until #15855 is done.

Also, I tested the case `Orders.Contains(null)` and was surprised to see the null is parameterized. Is this intended?

Finally, unrelated to EE: I understand the need to split into two queries for Single, since the 1-element verification needs to happen client-side. However, for First, FOD, Last, LOD we can translate as a single query:

```sql
SELECT (
    SELECT TOP(1) [o].[OrderID]
    FROM [Orders] AS [o]
    WHERE [o].[OrderID] = 10248)
IN (
    SELECT [o].[OrderID]
    FROM [Orders] AS [o]
    WHERE [o].[CustomerID] = N'VINET'
)");
```

(this is PostgreSQL, SQLServer requires the surrounding CASE for boolean). Is this optimization already tracked somewhere, should I open an issue?

For OrderBy, note that I've implemented support for composite keys, where we split the comparison into multiple OrderBy().ThenBy() operators.