### PR TITLE
Fix to #15381 - QueryRewrite: string based include should include all navigations with the same name for scenarios with inheritance

### DIFF
--- a/src/EFCore/Query/NavigationExpansion/IncludeExpression.cs
+++ b/src/EFCore/Query/NavigationExpansion/IncludeExpression.cs
@@ -42,13 +42,12 @@ namespace Microsoft.EntityFrameworkCore.Query.NavigationExpansion
 
         public virtual void Print(ExpressionPrinter expressionPrinter)
         {
-            expressionPrinter.StringBuilder.AppendLine("Include(");
-            expressionPrinter.StringBuilder.IncrementIndent();
             expressionPrinter.Visit(EntityExpression);
-            expressionPrinter.StringBuilder.AppendLine(", ");
+            expressionPrinter.StringBuilder.AppendLine($".Include[{Navigation.Name}](");
+            expressionPrinter.StringBuilder.IncrementIndent();
             expressionPrinter.Visit(NavigationExpression);
-            expressionPrinter.StringBuilder.AppendLine($", {Navigation.Name})");
             expressionPrinter.StringBuilder.DecrementIndent();
+            expressionPrinter.StringBuilder.AppendLine(")");
         }
     }
 }

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -5232,7 +5232,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "Issue#16090")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task String_include_multiple_derived_navigation_with_same_name_and_same_type(bool isAsync)
         {
@@ -5248,7 +5248,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 expectedIncludes);
         }
 
-        [ConditionalTheory(Skip = "Issue#16090")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task String_include_multiple_derived_navigation_with_same_name_and_different_type(bool isAsync)
         {
@@ -5264,11 +5264,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 expectedIncludes);
         }
 
-        [ConditionalTheory(Skip = "Issue#16090")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual Task
-            String_include_multiple_derived_navigation_with_same_name_and_different_type_nested_also_includes_partially_matching_navigation_chains(
-                bool isAsync)
+        public virtual Task String_include_multiple_derived_navigation_with_same_name_and_different_type_nested_also_includes_partially_matching_navigation_chains(bool isAsync)
         {
             var expectedIncludes = new List<IExpectedInclude>
             {
@@ -5283,7 +5281,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 expectedIncludes);
         }
 
-        [ConditionalTheory(Skip = "Issue#16090")]
+        [ConditionalTheory(Skip = "Issue#15611")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task String_include_multiple_derived_collection_navigation_with_same_name_and_same_type(bool isAsync)
         {
@@ -5299,7 +5297,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 expectedIncludes);
         }
 
-        [ConditionalTheory(Skip = "Issue#16090")]
+        [ConditionalTheory(Skip = "Issue#15611")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task String_include_multiple_derived_collection_navigation_with_same_name_and_different_type(bool isAsync)
         {
@@ -5315,11 +5313,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 expectedIncludes);
         }
 
-        [ConditionalTheory(Skip = "Issue#16090")]
+        [ConditionalTheory(Skip = "Issue#15611")]
         [MemberData(nameof(IsAsyncData))]
-        public virtual Task
-            String_include_multiple_derived_collection_navigation_with_same_name_and_different_type_nested_also_includes_partially_matching_navigation_chains(
-                bool isAsync)
+        public virtual Task String_include_multiple_derived_collection_navigation_with_same_name_and_different_type_nested_also_includes_partially_matching_navigation_chains(bool isAsync)
         {
             var expectedIncludes = new List<IExpectedInclude>
             {
@@ -5334,7 +5330,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 expectedIncludes);
         }
 
-        [ConditionalTheory(Skip = "Issue#16090")]
+        [ConditionalTheory(Skip = "Issue#15611")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task String_include_multiple_derived_navigations_complex(bool isAsync)
         {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -3760,13 +3760,9 @@ INNER JOIN (
 ORDER BY [t0].[Id]");
         }
 
-        public override async Task
-            String_include_multiple_derived_collection_navigation_with_same_name_and_different_type_nested_also_includes_partially_matching_navigation_chains(
-                bool isAsync)
+        public override async Task String_include_multiple_derived_collection_navigation_with_same_name_and_different_type_nested_also_includes_partially_matching_navigation_chains(bool isAsync)
         {
-            await base
-                .String_include_multiple_derived_collection_navigation_with_same_name_and_different_type_nested_also_includes_partially_matching_navigation_chains(
-                    isAsync);
+            await base.String_include_multiple_derived_collection_navigation_with_same_name_and_different_type_nested_also_includes_partially_matching_navigation_chains(isAsync);
 
             AssertSql(
                 @"SELECT [i].[Id], [i].[Discriminator], [i].[InheritanceBase2Id], [i].[InheritanceBase2Id1], [i].[Name]


### PR DESCRIPTION
Improved the logic that converts string based include to lambdas:
- if navigation is not found on type itself, all of its derived types are tested,
- if multiple navigations with same name are found, each navigation becomes it's own path,
- at least one valid navigation needs to be found for each element of the "chain" specified in the Include method.

Also fixed a minor bug later in the include pipeline that was exposed by the fix.