### PR TITLE
Adds DbContext to CommandEventData

### DIFF
--- a/src/EFCore.Relational/Diagnostics/CommandEndEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/CommandEndEventData.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="eventDefinition"> The event definition. </param>
         /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
         /// <param name="command"> The <see cref="DbCommand" />. </param>
-        /// <param name="context"> The <see cref="DbContext" /> currently being used, ot null if not known. </param>
+        /// <param name="context"> The <see cref="DbContext" /> currently being used, to null if not known. </param>
         /// <param name="executeMethod"> The <see cref="DbCommand" /> method. </param>
         /// <param name="commandId"> A correlation ID that identifies the <see cref="DbCommand" /> instance being used. </param>
         /// <param name="connectionId"> A correlation ID that identifies the <see cref="DbConnection" /> instance being used. </param>

--- a/src/EFCore.Relational/Diagnostics/CommandEndEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/CommandEndEventData.cs
@@ -19,34 +19,20 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <param name="eventDefinition"> The event definition. </param>
         /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
-        /// <param name="command">
-        ///     The <see cref="DbCommand" />.
-        /// </param>
-        /// <param name="executeMethod">
-        ///     The <see cref="DbCommand" /> method.
-        /// </param>
-        /// <param name="commandId">
-        ///     A correlation ID that identifies the <see cref="DbCommand" /> instance being used.
-        /// </param>
-        /// <param name="connectionId">
-        ///     A correlation ID that identifies the <see cref="DbConnection" /> instance being used.
-        /// </param>
-        /// <param name="async">
-        ///     Indicates whether or not the command was executed asynchronously.
-        /// </param>
-        /// <param name="logParameterValues">
-        ///     Indicates whether or not the application allows logging of parameter values.
-        /// </param>
-        /// <param name="startTime">
-        ///     The start time of this event.
-        /// </param>
-        /// <param name="duration">
-        ///     The duration this event.
-        /// </param>
+        /// <param name="command"> The <see cref="DbCommand" />. </param>
+        /// <param name="context"> The <see cref="DbContext" /> currently being used, ot null if not known. </param>
+        /// <param name="executeMethod"> The <see cref="DbCommand" /> method. </param>
+        /// <param name="commandId"> A correlation ID that identifies the <see cref="DbCommand" /> instance being used. </param>
+        /// <param name="connectionId"> A correlation ID that identifies the <see cref="DbConnection" /> instance being used. </param>
+        /// <param name="async"> Indicates whether or not the command was executed asynchronously. </param>
+        /// <param name="logParameterValues"> Indicates whether or not the application allows logging of parameter values. </param>
+        /// <param name="startTime"> The start time of this event. </param>
+        /// <param name="duration"> The duration this event. </param>
         public CommandEndEventData(
             [NotNull] EventDefinitionBase eventDefinition,
             [NotNull] Func<EventDefinitionBase, EventData, string> messageGenerator,
             [NotNull] DbCommand command,
+            [CanBeNull] DbContext context,
             DbCommandMethod executeMethod,
             Guid commandId,
             Guid connectionId,
@@ -54,7 +40,17 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             bool logParameterValues,
             DateTimeOffset startTime,
             TimeSpan duration)
-            : base(eventDefinition, messageGenerator, command, executeMethod, commandId, connectionId, async, logParameterValues, startTime)
+            : base(
+                eventDefinition,
+                messageGenerator,
+                command,
+                context,
+                executeMethod,
+                commandId,
+                connectionId,
+                async,
+                logParameterValues,
+                startTime)
             => Duration = duration;
 
         /// <summary>

--- a/src/EFCore.Relational/Diagnostics/CommandErrorEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/CommandErrorEventData.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="eventDefinition"> The event definition. </param>
         /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
         /// <param name="command"> The <see cref="DbCommand" /> that was executing when it failed. </param>
-        /// <param name="context"> The <see cref="DbContext" /> currently being used, ot null if not known. </param>
+        /// <param name="context"> The <see cref="DbContext" /> currently being used, to null if not known. </param>
         /// <param name="executeMethod"> The <see cref="DbCommand" /> method that was used to execute the command. </param>
         /// <param name="commandId"> A correlation ID that identifies the <see cref="DbCommand" /> instance being used. </param>
         /// <param name="connectionId"> A correlation ID that identifies the <see cref="DbConnection" /> instance being used. </param>

--- a/src/EFCore.Relational/Diagnostics/CommandErrorEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/CommandErrorEventData.cs
@@ -18,37 +18,21 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <param name="eventDefinition"> The event definition. </param>
         /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
-        /// <param name="command">
-        ///     The <see cref="DbCommand" /> that was executing when it failed.
-        /// </param>
-        /// <param name="executeMethod">
-        ///     The <see cref="DbCommand" /> method that was used to execute the command.
-        /// </param>
-        /// <param name="commandId">
-        ///     A correlation ID that identifies the <see cref="DbCommand" /> instance being used.
-        /// </param>
-        /// <param name="connectionId">
-        ///     A correlation ID that identifies the <see cref="DbConnection" /> instance being used.
-        /// </param>
-        /// <param name="exception">
-        ///     The exception that was thrown when execution failed.
-        /// </param>
-        /// <param name="async">
-        ///     Indicates whether or not the command was executed asynchronously.
-        /// </param>
-        /// <param name="logParameterValues">
-        ///     Indicates whether or not the application allows logging of parameter values.
-        /// </param>
-        /// <param name="startTime">
-        ///     The start time of this event.
-        /// </param>
-        /// <param name="duration">
-        ///     The duration this event.
-        /// </param>
+        /// <param name="command"> The <see cref="DbCommand" /> that was executing when it failed. </param>
+        /// <param name="context"> The <see cref="DbContext" /> currently being used, ot null if not known. </param>
+        /// <param name="executeMethod"> The <see cref="DbCommand" /> method that was used to execute the command. </param>
+        /// <param name="commandId"> A correlation ID that identifies the <see cref="DbCommand" /> instance being used. </param>
+        /// <param name="connectionId"> A correlation ID that identifies the <see cref="DbConnection" /> instance being used. </param>
+        /// <param name="exception"> The exception that was thrown when execution failed. </param>
+        /// <param name="async"> Indicates whether or not the command was executed asynchronously. </param>
+        /// <param name="logParameterValues"> Indicates whether or not the application allows logging of parameter values. </param>
+        /// <param name="startTime"> The start time of this event. </param>
+        /// <param name="duration"> The duration this event. </param>
         public CommandErrorEventData(
             [NotNull] EventDefinitionBase eventDefinition,
             [NotNull] Func<EventDefinitionBase, EventData, string> messageGenerator,
             [NotNull] DbCommand command,
+            [CanBeNull] DbContext context,
             DbCommandMethod executeMethod,
             Guid commandId,
             Guid connectionId,
@@ -57,7 +41,18 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             bool logParameterValues,
             DateTimeOffset startTime,
             TimeSpan duration)
-            : base(eventDefinition, messageGenerator, command, executeMethod, commandId, connectionId, async, logParameterValues, startTime, duration)
+            : base(
+                eventDefinition,
+                messageGenerator,
+                command,
+                context,
+                executeMethod,
+                commandId,
+                connectionId,
+                async,
+                logParameterValues,
+                startTime,
+                duration)
             => Exception = exception;
 
         /// <summary>

--- a/src/EFCore.Relational/Diagnostics/CommandEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/CommandEventData.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="eventDefinition"> The event definition. </param>
         /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
         /// <param name="command"> The <see cref="DbCommand" />. </param>
-        /// <param name="context"> The <see cref="DbContext" /> currently being used, ot null if not known. </param>
+        /// <param name="context"> The <see cref="DbContext" /> currently being used, to null if not known. </param>
         /// <param name="executeMethod"> The <see cref="DbCommand" /> method. </param>
         /// <param name="commandId"> A correlation ID that identifies the <see cref="DbCommand" /> instance being used. </param>
         /// <param name="connectionId"> A correlation ID that identifies the <see cref="DbConnection" /> instance being used. </param>

--- a/src/EFCore.Relational/Diagnostics/CommandEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/CommandEventData.cs
@@ -12,45 +12,33 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     ///     The <see cref="DiagnosticSource" /> event payload for
     ///     <see cref="RelationalEventId" /> command events.
     /// </summary>
-    public class CommandEventData : EventData
+    public class CommandEventData : DbContextEventData
     {
         /// <summary>
         ///     Constructs the event payload.
         /// </summary>
         /// <param name="eventDefinition"> The event definition. </param>
         /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
-        /// <param name="command">
-        ///     The <see cref="DbCommand" />.
-        /// </param>
-        /// <param name="executeMethod">
-        ///     The <see cref="DbCommand" /> method.
-        /// </param>
-        /// <param name="commandId">
-        ///     A correlation ID that identifies the <see cref="DbCommand" /> instance being used.
-        /// </param>
-        /// <param name="connectionId">
-        ///     A correlation ID that identifies the <see cref="DbConnection" /> instance being used.
-        /// </param>
-        /// <param name="async">
-        ///     Indicates whether or not the command was executed asynchronously.
-        /// </param>
-        /// <param name="logParameterValues">
-        ///     Indicates whether or not the application allows logging of parameter values.
-        /// </param>
-        /// <param name="startTime">
-        ///     The start time of this event.
-        /// </param>
+        /// <param name="command"> The <see cref="DbCommand" />. </param>
+        /// <param name="context"> The <see cref="DbContext" /> currently being used, ot null if not known. </param>
+        /// <param name="executeMethod"> The <see cref="DbCommand" /> method. </param>
+        /// <param name="commandId"> A correlation ID that identifies the <see cref="DbCommand" /> instance being used. </param>
+        /// <param name="connectionId"> A correlation ID that identifies the <see cref="DbConnection" /> instance being used. </param>
+        /// <param name="async"> Indicates whether or not the command was executed asynchronously. </param>
+        /// <param name="logParameterValues"> Indicates whether or not the application allows logging of parameter values. </param>
+        /// <param name="startTime"> The start time of this event. </param>
         public CommandEventData(
             [NotNull] EventDefinitionBase eventDefinition,
             [NotNull] Func<EventDefinitionBase, EventData, string> messageGenerator,
             [NotNull] DbCommand command,
+            [CanBeNull] DbContext context,
             DbCommandMethod executeMethod,
             Guid commandId,
             Guid connectionId,
             bool async,
             bool logParameterValues,
             DateTimeOffset startTime)
-            : base(eventDefinition, messageGenerator)
+            : base(eventDefinition, messageGenerator, context)
         {
             Command = command;
             CommandId = commandId;

--- a/src/EFCore.Relational/Diagnostics/CommandExecutedEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/CommandExecutedEventData.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="eventDefinition"> The event definition. </param>
         /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
         /// <param name="command"> The <see cref="DbCommand" /> that was executing when it failed. </param>
-        /// <param name="context"> The <see cref="DbContext" /> currently being used, ot null if not known. </param>
+        /// <param name="context"> The <see cref="DbContext" /> currently being used, to null if not known. </param>
         /// <param name="executeMethod"> The <see cref="DbCommand" /> method that was used to execute the command. </param>
         /// <param name="commandId"> A correlation ID that identifies the <see cref="DbCommand" /> instance being used. </param>
         /// <param name="connectionId"> A correlation ID that identifies the <see cref="DbConnection" /> instance being used. </param>

--- a/src/EFCore.Relational/Diagnostics/CommandExecutedEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/CommandExecutedEventData.cs
@@ -18,37 +18,21 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <param name="eventDefinition"> The event definition. </param>
         /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
-        /// <param name="command">
-        ///     The <see cref="DbCommand" /> that was executing when it failed.
-        /// </param>
-        /// <param name="executeMethod">
-        ///     The <see cref="DbCommand" /> method that was used to execute the command.
-        /// </param>
-        /// <param name="commandId">
-        ///     A correlation ID that identifies the <see cref="DbCommand" /> instance being used.
-        /// </param>
-        /// <param name="connectionId">
-        ///     A correlation ID that identifies the <see cref="DbConnection" /> instance being used.
-        /// </param>
-        /// <param name="result">
-        ///     The result of executing the operation.
-        /// </param>
-        /// <param name="async">
-        ///     Indicates whether or not the command was executed asynchronously.
-        /// </param>
-        /// <param name="logParameterValues">
-        ///     Indicates whether or not the application allows logging of parameter values.
-        /// </param>
-        /// <param name="startTime">
-        ///     The start time of this event.
-        /// </param>
-        /// <param name="duration">
-        ///     The duration this event.
-        /// </param>
+        /// <param name="command"> The <see cref="DbCommand" /> that was executing when it failed. </param>
+        /// <param name="context"> The <see cref="DbContext" /> currently being used, ot null if not known. </param>
+        /// <param name="executeMethod"> The <see cref="DbCommand" /> method that was used to execute the command. </param>
+        /// <param name="commandId"> A correlation ID that identifies the <see cref="DbCommand" /> instance being used. </param>
+        /// <param name="connectionId"> A correlation ID that identifies the <see cref="DbConnection" /> instance being used. </param>
+        /// <param name="result"> The result of executing the operation. </param>
+        /// <param name="async"> Indicates whether or not the command was executed asynchronously. </param>
+        /// <param name="logParameterValues"> Indicates whether or not the application allows logging of parameter values. </param>
+        /// <param name="startTime"> The start time of this event. </param>
+        /// <param name="duration"> The duration this event. </param>
         public CommandExecutedEventData(
             [NotNull] EventDefinitionBase eventDefinition,
             [NotNull] Func<EventDefinitionBase, EventData, string> messageGenerator,
             [NotNull] DbCommand command,
+            [CanBeNull] DbContext context,
             DbCommandMethod executeMethod,
             Guid commandId,
             Guid connectionId,
@@ -57,7 +41,18 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             bool logParameterValues,
             DateTimeOffset startTime,
             TimeSpan duration)
-            : base(eventDefinition, messageGenerator, command, executeMethod, commandId, connectionId, async, logParameterValues, startTime, duration)
+            : base(
+                eventDefinition,
+                messageGenerator,
+                command,
+                context,
+                executeMethod,
+                commandId,
+                connectionId,
+                async,
+                logParameterValues,
+                startTime,
+                duration)
             => Result = result;
 
         /// <summary>

--- a/src/EFCore.Relational/Diagnostics/RelationalLoggerExtensions.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalLoggerExtensions.cs
@@ -42,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <param name="diagnostics"> The diagnostics logger to use. </param>
         /// <param name="command"> The database command object. </param>
-        /// <param name="context"> The <see cref="DbContext" /> currently being used, ot null if not known. </param>
+        /// <param name="context"> The <see cref="DbContext" /> currently being used, to null if not known. </param>
         /// <param name="commandId"> The correlation ID associated with the given <see cref="DbCommand" />. </param>
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="startTime"> The time that execution began. </param>
@@ -91,7 +91,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <param name="diagnostics"> The diagnostics logger to use. </param>
         /// <param name="command"> The database command object. </param>
-        /// <param name="context"> The <see cref="DbContext" /> currently being used, ot null if not known. </param>
+        /// <param name="context"> The <see cref="DbContext" /> currently being used, to null if not known. </param>
         /// <param name="commandId"> The correlation ID associated with the given <see cref="DbCommand" />. </param>
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="startTime"> The time that execution began. </param>
@@ -140,7 +140,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <param name="diagnostics"> The diagnostics logger to use. </param>
         /// <param name="command"> The database command object. </param>
-        /// <param name="context"> The <see cref="DbContext" /> currently being used, ot null if not known. </param>
+        /// <param name="context"> The <see cref="DbContext" /> currently being used, to null if not known. </param>
         /// <param name="commandId"> The correlation ID associated with the given <see cref="DbCommand" />. </param>
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="startTime"> The time that execution began. </param>
@@ -189,7 +189,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <param name="diagnostics"> The diagnostics logger to use. </param>
         /// <param name="command"> The database command object. </param>
-        /// <param name="context"> The <see cref="DbContext" /> currently being used, ot null if not known. </param>
+        /// <param name="context"> The <see cref="DbContext" /> currently being used, to null if not known. </param>
         /// <param name="commandId"> The correlation ID associated with the given <see cref="DbCommand" />. </param>
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="startTime"> The time that execution began. </param>
@@ -240,7 +240,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <param name="diagnostics"> The diagnostics logger to use. </param>
         /// <param name="command"> The database command object. </param>
-        /// <param name="context"> The <see cref="DbContext" /> currently being used, ot null if not known. </param>
+        /// <param name="context"> The <see cref="DbContext" /> currently being used, to null if not known. </param>
         /// <param name="commandId"> The correlation ID associated with the given <see cref="DbCommand" />. </param>
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="startTime"> The time that execution began. </param>
@@ -291,7 +291,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <param name="diagnostics"> The diagnostics logger to use. </param>
         /// <param name="command"> The database command object. </param>
-        /// <param name="context"> The <see cref="DbContext" /> currently being used, ot null if not known. </param>
+        /// <param name="context"> The <see cref="DbContext" /> currently being used, to null if not known. </param>
         /// <param name="commandId"> The correlation ID associated with the given <see cref="DbCommand" />. </param>
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="startTime"> The time that execution began. </param>
@@ -413,7 +413,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <param name="diagnostics"> The diagnostics logger to use. </param>
         /// <param name="command"> The database command object. </param>
-        /// <param name="context"> The <see cref="DbContext" /> currently being used, ot null if not known. </param>
+        /// <param name="context"> The <see cref="DbContext" /> currently being used, to null if not known. </param>
         /// <param name="commandId"> The correlation ID associated with the given <see cref="DbCommand" />. </param>
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="methodResult"> The return value from the underlying method execution. </param>
@@ -468,7 +468,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <param name="diagnostics"> The diagnostics logger to use. </param>
         /// <param name="command"> The database command object. </param>
-        /// <param name="context"> The <see cref="DbContext" /> currently being used, ot null if not known. </param>
+        /// <param name="context"> The <see cref="DbContext" /> currently being used, to null if not known. </param>
         /// <param name="commandId"> The correlation ID associated with the given <see cref="DbCommand" />. </param>
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="methodResult"> The return value from the underlying method execution. </param>
@@ -523,7 +523,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <param name="diagnostics"> The diagnostics logger to use. </param>
         /// <param name="command"> The database command object. </param>
-        /// <param name="context"> The <see cref="DbContext" /> currently being used, ot null if not known. </param>
+        /// <param name="context"> The <see cref="DbContext" /> currently being used, to null if not known. </param>
         /// <param name="commandId"> The correlation ID associated with the given <see cref="DbCommand" />. </param>
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="methodResult"> The return value from the underlying method execution. </param>
@@ -578,7 +578,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <param name="diagnostics"> The diagnostics logger to use. </param>
         /// <param name="command"> The database command object. </param>
-        /// <param name="context"> The <see cref="DbContext" /> currently being used, ot null if not known. </param>
+        /// <param name="context"> The <see cref="DbContext" /> currently being used, to null if not known. </param>
         /// <param name="commandId"> The correlation ID associated with the given <see cref="DbCommand" />. </param>
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="methodResult"> The return value from the underlying method execution. </param>
@@ -635,7 +635,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <param name="diagnostics"> The diagnostics logger to use. </param>
         /// <param name="command"> The database command object. </param>
-        /// <param name="context"> The <see cref="DbContext" /> currently being used, ot null if not known. </param>
+        /// <param name="context"> The <see cref="DbContext" /> currently being used, to null if not known. </param>
         /// <param name="commandId"> The correlation ID associated with the given <see cref="DbCommand" />. </param>
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="methodResult"> The return value from the underlying method execution. </param>
@@ -692,7 +692,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <param name="diagnostics"> The diagnostics logger to use. </param>
         /// <param name="command"> The database command object. </param>
-        /// <param name="context"> The <see cref="DbContext" /> currently being used, ot null if not known. </param>
+        /// <param name="context"> The <see cref="DbContext" /> currently being used, to null if not known. </param>
         /// <param name="commandId"> The correlation ID associated with the given <see cref="DbCommand" />. </param>
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="methodResult"> The return value from the underlying method execution. </param>
@@ -821,7 +821,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <param name="diagnostics"> The diagnostics logger to use. </param>
         /// <param name="command"> The database command object. </param>
-        /// <param name="context"> The <see cref="DbContext" /> currently being used, ot null if not known. </param>
+        /// <param name="context"> The <see cref="DbContext" /> currently being used, to null if not known. </param>
         /// <param name="executeMethod"> Represents the method that will be called to execute the command. </param>
         /// <param name="commandId"> The correlation ID associated with the given <see cref="DbCommand" />. </param>
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>

--- a/src/EFCore.Relational/Diagnostics/RelationalLoggerExtensions.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalLoggerExtensions.cs
@@ -42,6 +42,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <param name="diagnostics"> The diagnostics logger to use. </param>
         /// <param name="command"> The database command object. </param>
+        /// <param name="context"> The <see cref="DbContext" /> currently being used, ot null if not known. </param>
         /// <param name="commandId"> The correlation ID associated with the given <see cref="DbCommand" />. </param>
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="startTime"> The time that execution began. </param>
@@ -49,6 +50,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public static InterceptionResult<DbDataReader>? CommandReaderExecuting(
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
             [NotNull] DbCommand command,
+            [CanBeNull] DbContext context,
             Guid commandId,
             Guid connectionId,
             DateTimeOffset startTime)
@@ -66,6 +68,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 var eventData = BroadcastCommandExecuting(
                     diagnostics,
                     command,
+                    context,
                     DbCommandMethod.ExecuteReader,
                     commandId,
                     connectionId,
@@ -88,6 +91,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <param name="diagnostics"> The diagnostics logger to use. </param>
         /// <param name="command"> The database command object. </param>
+        /// <param name="context"> The <see cref="DbContext" /> currently being used, ot null if not known. </param>
         /// <param name="commandId"> The correlation ID associated with the given <see cref="DbCommand" />. </param>
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="startTime"> The time that execution began. </param>
@@ -95,6 +99,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public static InterceptionResult<object>? CommandScalarExecuting(
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
             [NotNull] DbCommand command,
+            [CanBeNull] DbContext context,
             Guid commandId,
             Guid connectionId,
             DateTimeOffset startTime)
@@ -112,6 +117,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 var eventData = BroadcastCommandExecuting(
                     diagnostics,
                     command,
+                    context,
                     DbCommandMethod.ExecuteScalar,
                     commandId,
                     connectionId,
@@ -134,6 +140,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <param name="diagnostics"> The diagnostics logger to use. </param>
         /// <param name="command"> The database command object. </param>
+        /// <param name="context"> The <see cref="DbContext" /> currently being used, ot null if not known. </param>
         /// <param name="commandId"> The correlation ID associated with the given <see cref="DbCommand" />. </param>
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="startTime"> The time that execution began. </param>
@@ -141,6 +148,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public static InterceptionResult<int>? CommandNonQueryExecuting(
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
             [NotNull] DbCommand command,
+            [CanBeNull] DbContext context,
             Guid commandId,
             Guid connectionId,
             DateTimeOffset startTime)
@@ -158,6 +166,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 var eventData = BroadcastCommandExecuting(
                     diagnostics,
                     command,
+                    context,
                     DbCommandMethod.ExecuteNonQuery,
                     commandId,
                     connectionId,
@@ -180,6 +189,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <param name="diagnostics"> The diagnostics logger to use. </param>
         /// <param name="command"> The database command object. </param>
+        /// <param name="context"> The <see cref="DbContext" /> currently being used, ot null if not known. </param>
         /// <param name="commandId"> The correlation ID associated with the given <see cref="DbCommand" />. </param>
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="startTime"> The time that execution began. </param>
@@ -188,6 +198,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public static Task<InterceptionResult<DbDataReader>?> CommandReaderExecutingAsync(
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
             [NotNull] DbCommand command,
+            [CanBeNull] DbContext context,
             Guid commandId,
             Guid connectionId,
             DateTimeOffset startTime,
@@ -206,6 +217,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 var eventData = BroadcastCommandExecuting(
                     diagnostics,
                     command,
+                    context,
                     DbCommandMethod.ExecuteReader,
                     commandId,
                     connectionId,
@@ -228,6 +240,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <param name="diagnostics"> The diagnostics logger to use. </param>
         /// <param name="command"> The database command object. </param>
+        /// <param name="context"> The <see cref="DbContext" /> currently being used, ot null if not known. </param>
         /// <param name="commandId"> The correlation ID associated with the given <see cref="DbCommand" />. </param>
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="startTime"> The time that execution began. </param>
@@ -236,6 +249,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public static Task<InterceptionResult<object>?> CommandScalarExecutingAsync(
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
             [NotNull] DbCommand command,
+            [CanBeNull] DbContext context,
             Guid commandId,
             Guid connectionId,
             DateTimeOffset startTime,
@@ -254,6 +268,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 var eventData = BroadcastCommandExecuting(
                     diagnostics,
                     command,
+                    context,
                     DbCommandMethod.ExecuteScalar,
                     commandId,
                     connectionId,
@@ -276,6 +291,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <param name="diagnostics"> The diagnostics logger to use. </param>
         /// <param name="command"> The database command object. </param>
+        /// <param name="context"> The <see cref="DbContext" /> currently being used, ot null if not known. </param>
         /// <param name="commandId"> The correlation ID associated with the given <see cref="DbCommand" />. </param>
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="startTime"> The time that execution began. </param>
@@ -284,6 +300,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public static Task<InterceptionResult<int>?> CommandNonQueryExecutingAsync(
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
             [NotNull] DbCommand command,
+            [CanBeNull] DbContext context,
             Guid commandId,
             Guid connectionId,
             DateTimeOffset startTime,
@@ -302,6 +319,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 var eventData = BroadcastCommandExecuting(
                     diagnostics,
                     command,
+                    context,
                     DbCommandMethod.ExecuteNonQuery,
                     commandId,
                     connectionId,
@@ -322,6 +340,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         private static CommandEventData BroadcastCommandExecuting(
             IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
             DbCommand command,
+            DbContext context,
             DbCommandMethod executeMethod,
             Guid commandId,
             Guid connectionId,
@@ -334,6 +353,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 definition,
                 CommandExecuting,
                 command,
+                context,
                 executeMethod,
                 commandId,
                 connectionId,
@@ -393,6 +413,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <param name="diagnostics"> The diagnostics logger to use. </param>
         /// <param name="command"> The database command object. </param>
+        /// <param name="context"> The <see cref="DbContext" /> currently being used, ot null if not known. </param>
         /// <param name="commandId"> The correlation ID associated with the given <see cref="DbCommand" />. </param>
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="methodResult"> The return value from the underlying method execution. </param>
@@ -402,6 +423,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public static DbDataReader CommandReaderExecuted(
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
             [NotNull] DbCommand command,
+            [CanBeNull] DbContext context,
             Guid commandId,
             Guid connectionId,
             [CanBeNull] DbDataReader methodResult,
@@ -421,6 +443,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 var eventData = BroadcastCommandExecuted(
                     diagnostics,
                     command,
+                    context,
                     DbCommandMethod.ExecuteReader,
                     commandId,
                     connectionId,
@@ -445,6 +468,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <param name="diagnostics"> The diagnostics logger to use. </param>
         /// <param name="command"> The database command object. </param>
+        /// <param name="context"> The <see cref="DbContext" /> currently being used, ot null if not known. </param>
         /// <param name="commandId"> The correlation ID associated with the given <see cref="DbCommand" />. </param>
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="methodResult"> The return value from the underlying method execution. </param>
@@ -454,6 +478,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public static object CommandScalarExecuted(
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
             [NotNull] DbCommand command,
+            [CanBeNull] DbContext context,
             Guid commandId,
             Guid connectionId,
             [CanBeNull] object methodResult,
@@ -473,6 +498,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 var eventData = BroadcastCommandExecuted(
                     diagnostics,
                     command,
+                    context,
                     DbCommandMethod.ExecuteScalar,
                     commandId,
                     connectionId,
@@ -497,6 +523,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <param name="diagnostics"> The diagnostics logger to use. </param>
         /// <param name="command"> The database command object. </param>
+        /// <param name="context"> The <see cref="DbContext" /> currently being used, ot null if not known. </param>
         /// <param name="commandId"> The correlation ID associated with the given <see cref="DbCommand" />. </param>
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="methodResult"> The return value from the underlying method execution. </param>
@@ -506,6 +533,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public static int CommandNonQueryExecuted(
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
             [NotNull] DbCommand command,
+            [CanBeNull] DbContext context,
             Guid commandId,
             Guid connectionId,
             int methodResult,
@@ -525,6 +553,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 var eventData = BroadcastCommandExecuted(
                     diagnostics,
                     command,
+                    context,
                     DbCommandMethod.ExecuteNonQuery,
                     commandId,
                     connectionId,
@@ -549,6 +578,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <param name="diagnostics"> The diagnostics logger to use. </param>
         /// <param name="command"> The database command object. </param>
+        /// <param name="context"> The <see cref="DbContext" /> currently being used, ot null if not known. </param>
         /// <param name="commandId"> The correlation ID associated with the given <see cref="DbCommand" />. </param>
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="methodResult"> The return value from the underlying method execution. </param>
@@ -559,6 +589,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public static Task<DbDataReader> CommandReaderExecutedAsync(
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
             [NotNull] DbCommand command,
+            [CanBeNull] DbContext context,
             Guid commandId,
             Guid connectionId,
             [CanBeNull] DbDataReader methodResult,
@@ -579,6 +610,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 var eventData = BroadcastCommandExecuted(
                     diagnostics,
                     command,
+                    context,
                     DbCommandMethod.ExecuteReader,
                     commandId,
                     connectionId,
@@ -603,6 +635,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <param name="diagnostics"> The diagnostics logger to use. </param>
         /// <param name="command"> The database command object. </param>
+        /// <param name="context"> The <see cref="DbContext" /> currently being used, ot null if not known. </param>
         /// <param name="commandId"> The correlation ID associated with the given <see cref="DbCommand" />. </param>
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="methodResult"> The return value from the underlying method execution. </param>
@@ -613,6 +646,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public static Task<object> CommandScalarExecutedAsync(
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
             [NotNull] DbCommand command,
+            [CanBeNull] DbContext context,
             Guid commandId,
             Guid connectionId,
             [CanBeNull] object methodResult,
@@ -633,6 +667,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 var eventData = BroadcastCommandExecuted(
                     diagnostics,
                     command,
+                    context,
                     DbCommandMethod.ExecuteScalar,
                     commandId,
                     connectionId,
@@ -657,6 +692,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <param name="diagnostics"> The diagnostics logger to use. </param>
         /// <param name="command"> The database command object. </param>
+        /// <param name="context"> The <see cref="DbContext" /> currently being used, ot null if not known. </param>
         /// <param name="commandId"> The correlation ID associated with the given <see cref="DbCommand" />. </param>
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="methodResult"> The return value from the underlying method execution. </param>
@@ -667,6 +703,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public static Task<int> CommandNonQueryExecutedAsync(
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
             [NotNull] DbCommand command,
+            [CanBeNull] DbContext context,
             Guid commandId,
             Guid connectionId,
             int methodResult,
@@ -687,6 +724,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 var eventData = BroadcastCommandExecuted(
                     diagnostics,
                     command,
+                    context,
                     DbCommandMethod.ExecuteNonQuery,
                     commandId,
                     connectionId,
@@ -709,6 +747,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         private static CommandExecutedEventData BroadcastCommandExecuted(
             IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
             DbCommand command,
+            DbContext context,
             DbCommandMethod executeMethod,
             Guid commandId,
             Guid connectionId,
@@ -723,6 +762,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 definition,
                 CommandExecuted,
                 command,
+                context,
                 executeMethod,
                 commandId,
                 connectionId,
@@ -781,6 +821,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <param name="diagnostics"> The diagnostics logger to use. </param>
         /// <param name="command"> The database command object. </param>
+        /// <param name="context"> The <see cref="DbContext" /> currently being used, ot null if not known. </param>
         /// <param name="executeMethod"> Represents the method that will be called to execute the command. </param>
         /// <param name="commandId"> The correlation ID associated with the given <see cref="DbCommand" />. </param>
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
@@ -791,6 +832,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public static void CommandError(
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
             [NotNull] DbCommand command,
+            [CanBeNull] DbContext context,
             DbCommandMethod executeMethod,
             Guid commandId,
             Guid connectionId,
@@ -823,6 +865,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                         definition,
                         CommandError,
                         command,
+                        context,
                         executeMethod,
                         commandId,
                         connectionId,

--- a/src/EFCore.Relational/Extensions/RelationalDatabaseFacadeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalDatabaseFacadeExtensions.cs
@@ -220,9 +220,11 @@ namespace Microsoft.EntityFrameworkCore
                 return rawSqlCommand
                     .RelationalCommand
                     .ExecuteNonQuery(
-                        databaseFacade.GetRelationalService<IRelationalConnection>(),
-                        rawSqlCommand.ParameterValues,
-                        logger);
+                        new RelationalCommandParameterObject(
+                            databaseFacade.GetRelationalService<IRelationalConnection>(),
+                            rawSqlCommand.ParameterValues,
+                            databaseFacade.GetService<ICurrentDbContext>().Context,
+                            logger));
             }
         }
 
@@ -384,9 +386,11 @@ namespace Microsoft.EntityFrameworkCore
                 return await rawSqlCommand
                     .RelationalCommand
                     .ExecuteNonQueryAsync(
-                        databaseFacade.GetRelationalService<IRelationalConnection>(),
-                        rawSqlCommand.ParameterValues,
-                        logger,
+                        new RelationalCommandParameterObject(
+                            databaseFacade.GetRelationalService<IRelationalConnection>(),
+                            rawSqlCommand.ParameterValues,
+                            databaseFacade.GetService<ICurrentDbContext>().Context,
+                            logger),
                         cancellationToken);
             }
         }
@@ -498,9 +502,11 @@ namespace Microsoft.EntityFrameworkCore
                 return rawSqlCommand
                     .RelationalCommand
                     .ExecuteNonQuery(
-                        databaseFacade.GetRelationalService<IRelationalConnection>(),
-                        rawSqlCommand.ParameterValues,
-                        logger);
+                        new RelationalCommandParameterObject(
+                            databaseFacade.GetRelationalService<IRelationalConnection>(),
+                            rawSqlCommand.ParameterValues,
+                            databaseFacade.GetService<ICurrentDbContext>().Context,
+                            logger));
             }
         }
 
@@ -648,9 +654,11 @@ namespace Microsoft.EntityFrameworkCore
                 return await rawSqlCommand
                     .RelationalCommand
                     .ExecuteNonQueryAsync(
-                        databaseFacade.GetRelationalService<IRelationalConnection>(),
-                        rawSqlCommand.ParameterValues,
-                        logger,
+                        new RelationalCommandParameterObject(
+                            databaseFacade.GetRelationalService<IRelationalConnection>(),
+                            rawSqlCommand.ParameterValues,
+                            databaseFacade.GetService<ICurrentDbContext>().Context,
+                            logger),
                         cancellationToken);
             }
         }

--- a/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
+++ b/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Internal;
@@ -76,6 +77,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 { typeof(IMigrationsAssembly), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IBatchExecutor), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IRelationalConnection), new ServiceCharacteristics(ServiceLifetime.Scoped) },
+                { typeof(IRelationalDatabaseFacadeDependencies), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IRelationalDatabaseCreator), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IHistoryRepository), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(INamedConnectionStringResolver), new ServiceCharacteristics(ServiceLifetime.Scoped) },
@@ -153,6 +155,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             TryAdd<INamedConnectionStringResolver, NamedConnectionStringResolver>();
             TryAdd<IEvaluatableExpressionFilter, RelationalEvaluatableExpressionFilter>();
             TryAdd<IRelationalTransactionFactory, RelationalTransactionFactory>();
+            TryAdd<IDatabaseFacadeDependencies>(p => p.GetService<IRelationalDatabaseFacadeDependencies>());
+            TryAdd<IRelationalDatabaseFacadeDependencies, RelationalDatabaseFacadeDependencies>();
             TryAdd<IRelationalInterceptors, RelationalInterceptors>();
             TryAdd<IInterceptors>(p => p.GetService<IRelationalInterceptors>());
 

--- a/src/EFCore.Relational/Internal/IRelationalDatabaseFacadeDependencies.cs
+++ b/src/EFCore.Relational/Internal/IRelationalDatabaseFacadeDependencies.cs
@@ -1,0 +1,41 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    /// <summary>
+    ///     <para>
+    ///         This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///         the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///         any release. You should only use it directly in your code with extreme caution and knowing that
+    ///         doing so can result in application failures when updating to a new Entity Framework Core release.
+    ///     </para>
+    ///     <para>
+    ///         The service lifetime is <see cref="ServiceLifetime.Scoped"/>. This means that each
+    ///         <see cref="DbContext"/> instance will use its own instance of this service.
+    ///         The implementation may depend on other services registered with any lifetime.
+    ///         The implementation does not need to be thread-safe.
+    ///     </para>
+    /// </summary>
+    public interface IRelationalDatabaseFacadeDependencies : IDatabaseFacadeDependencies
+    {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        IRelationalConnection RelationalConnection { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        IRawSqlCommandBuilder RawSqlCommandBuilder { get; }
+    }
+}

--- a/src/EFCore.Relational/Internal/RelationalDatabaseFacadeDependencies.cs
+++ b/src/EFCore.Relational/Internal/RelationalDatabaseFacadeDependencies.cs
@@ -1,0 +1,56 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    public class RelationalDatabaseFacadeDependencies : DatabaseFacadeDependencies, IRelationalDatabaseFacadeDependencies
+    {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public RelationalDatabaseFacadeDependencies(
+            [NotNull] IDbContextTransactionManager transactionManager,
+            [NotNull] IDatabaseCreator databaseCreator,
+            [NotNull] IExecutionStrategyFactory executionStrategyFactory,
+            [NotNull] IEnumerable<IDatabaseProvider> databaseProviders,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> commandLogger,
+            [NotNull] IConcurrencyDetector concurrencyDetector,
+            [NotNull] IRelationalConnection relationalConnection,
+            [NotNull] IRawSqlCommandBuilder rawSqlCommandBuilder)
+            : base(
+                transactionManager,
+                databaseCreator,
+                executionStrategyFactory,
+                databaseProviders,
+                commandLogger,
+                concurrencyDetector)
+        {
+            RelationalConnection = relationalConnection;
+            RawSqlCommandBuilder = rawSqlCommandBuilder;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual IRelationalConnection RelationalConnection { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual IRawSqlCommandBuilder RawSqlCommandBuilder { get; }
+    }
+}

--- a/src/EFCore.Relational/Migrations/HistoryRepository.cs
+++ b/src/EFCore.Relational/Migrations/HistoryRepository.cs
@@ -132,7 +132,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         public virtual bool Exists()
             => Dependencies.DatabaseCreator.Exists()
                && InterpretExistsResult(
-                   Dependencies.RawSqlCommandBuilder.Build(ExistsSql).ExecuteScalar(Dependencies.Connection, null,  Dependencies.CommandLogger));
+                   Dependencies.RawSqlCommandBuilder.Build(ExistsSql).ExecuteScalar(
+                       new RelationalCommandParameterObject(
+                           Dependencies.Connection,
+                           null,
+                           Dependencies.CurrentDbContext.Context,
+                           Dependencies.CommandLogger)));
 
         /// <summary>
         ///     Checks whether or not the history table exists.
@@ -146,7 +151,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             => await Dependencies.DatabaseCreator.ExistsAsync(cancellationToken)
                && InterpretExistsResult(
                    await Dependencies.RawSqlCommandBuilder.Build(ExistsSql).ExecuteScalarAsync(
-                       Dependencies.Connection, null, Dependencies.CommandLogger, cancellationToken: cancellationToken));
+                       new RelationalCommandParameterObject(
+                           Dependencies.Connection,
+                           null,
+                           Dependencies.CurrentDbContext.Context,
+                           Dependencies.CommandLogger),
+                       cancellationToken));
 
         /// <summary>
         ///     Interprets the result of executing <see cref="ExistsSql" />.
@@ -204,7 +214,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             {
                 var command = Dependencies.RawSqlCommandBuilder.Build(GetAppliedMigrationsSql);
 
-                using (var reader = command.ExecuteReader(Dependencies.Connection, null, Dependencies.CommandLogger))
+                using (var reader = command.ExecuteReader(
+                    new RelationalCommandParameterObject(
+                        Dependencies.Connection,
+                        null,
+                        Dependencies.CurrentDbContext.Context,
+                        Dependencies.CommandLogger)))
                 {
                     while (reader.Read())
                     {
@@ -233,7 +248,13 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             {
                 var command = Dependencies.RawSqlCommandBuilder.Build(GetAppliedMigrationsSql);
 
-                using (var reader = await command.ExecuteReaderAsync(Dependencies.Connection, null, Dependencies.CommandLogger, cancellationToken: cancellationToken))
+                using (var reader = await command.ExecuteReaderAsync(
+                    new RelationalCommandParameterObject(
+                        Dependencies.Connection,
+                        null,
+                        Dependencies.CurrentDbContext.Context,
+                        Dependencies.CommandLogger),
+                    cancellationToken))
                 {
                     while (await reader.ReadAsync(cancellationToken))
                     {

--- a/src/EFCore.Relational/Migrations/HistoryRepositoryDependencies.cs
+++ b/src/EFCore.Relational/Migrations/HistoryRepositoryDependencies.cs
@@ -72,6 +72,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         /// <param name="sqlGenerationHelper"> Helpers for generating update SQL. </param>
         /// <param name="conventionSetBuilder"> The convention set to use when creating the model. </param>
         /// <param name="typeMappingSource"> The type mapper. </param>
+        /// <param name="currentDbContext"> Contains the <see cref="DbContext"/> currently in use. </param>
         /// <param name="modelLogger"> The logger for model building events. </param>
         /// <param name="commandLogger"> The command logger. </param>
         [EntityFrameworkInternal]
@@ -85,6 +86,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             [NotNull] ISqlGenerationHelper sqlGenerationHelper,
             [NotNull] IConventionSetBuilder conventionSetBuilder,
             [NotNull] IRelationalTypeMappingSource typeMappingSource,
+            [NotNull] ICurrentDbContext currentDbContext,
             [NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> modelLogger,
             [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> commandLogger)
         {
@@ -97,6 +99,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             Check.NotNull(sqlGenerationHelper, nameof(sqlGenerationHelper));
             Check.NotNull(conventionSetBuilder, nameof(conventionSetBuilder));
             Check.NotNull(typeMappingSource, nameof(typeMappingSource));
+            Check.NotNull(currentDbContext, nameof(currentDbContext));
             Check.NotNull(modelLogger, nameof(modelLogger));
             Check.NotNull(commandLogger, nameof(commandLogger));
 
@@ -109,6 +112,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             SqlGenerationHelper = sqlGenerationHelper;
             ConventionSetBuilder = conventionSetBuilder;
             TypeMappingSource = typeMappingSource;
+            CurrentDbContext = currentDbContext;
             ModelLogger = modelLogger;
             CommandLogger = commandLogger;
         }
@@ -159,6 +163,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         public IRelationalTypeMappingSource TypeMappingSource { get; }
 
         /// <summary>
+        ///    Contains the <see cref="DbContext"/> currently in use.
+        /// </summary>
+        public ICurrentDbContext CurrentDbContext { get; }
+
+        /// <summary>
         ///     The model logger
         /// </summary>
         public IDiagnosticsLogger<DbLoggerCategory.Model> ModelLogger { get; }
@@ -184,6 +193,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 SqlGenerationHelper,
                 ConventionSetBuilder,
                 TypeMappingSource,
+                CurrentDbContext,
                 ModelLogger,
                 CommandLogger);
 
@@ -203,6 +213,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 SqlGenerationHelper,
                 ConventionSetBuilder,
                 TypeMappingSource,
+                CurrentDbContext,
                 ModelLogger,
                 CommandLogger);
 
@@ -222,6 +233,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 SqlGenerationHelper,
                 ConventionSetBuilder,
                 TypeMappingSource,
+                CurrentDbContext,
                 ModelLogger,
                 CommandLogger);
 
@@ -241,6 +253,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 SqlGenerationHelper,
                 ConventionSetBuilder,
                 TypeMappingSource,
+                CurrentDbContext,
                 ModelLogger,
                 CommandLogger);
 
@@ -260,6 +273,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 SqlGenerationHelper,
                 ConventionSetBuilder,
                 TypeMappingSource,
+                CurrentDbContext,
                 ModelLogger,
                 CommandLogger);
 
@@ -279,6 +293,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 SqlGenerationHelper,
                 ConventionSetBuilder,
                 TypeMappingSource,
+                CurrentDbContext,
                 ModelLogger,
                 CommandLogger);
 
@@ -298,6 +313,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 sqlGenerationHelper,
                 ConventionSetBuilder,
                 TypeMappingSource,
+                CurrentDbContext,
                 ModelLogger,
                 CommandLogger);
 
@@ -317,6 +333,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 SqlGenerationHelper,
                 conventionSetBuilder,
                 TypeMappingSource,
+                CurrentDbContext,
                 ModelLogger,
                 CommandLogger);
 
@@ -336,6 +353,27 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 SqlGenerationHelper,
                 ConventionSetBuilder,
                 typeMappingSource,
+                CurrentDbContext,
+                ModelLogger,
+                CommandLogger);
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="currentDbContext"> The type mapper. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public HistoryRepositoryDependencies With([NotNull] ICurrentDbContext currentDbContext)
+            => new HistoryRepositoryDependencies(
+                DatabaseCreator,
+                RawSqlCommandBuilder,
+                Connection,
+                Options,
+                ModelDiffer,
+                MigrationsSqlGenerator,
+                SqlGenerationHelper,
+                ConventionSetBuilder,
+                TypeMappingSource,
+                currentDbContext,
                 ModelLogger,
                 CommandLogger);
 
@@ -355,6 +393,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 SqlGenerationHelper,
                 ConventionSetBuilder,
                 TypeMappingSource,
+                CurrentDbContext,
                 modelLogger,
                 CommandLogger);
 
@@ -374,6 +413,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 SqlGenerationHelper,
                 ConventionSetBuilder,
                 TypeMappingSource,
+                CurrentDbContext,
                 ModelLogger,
                 commandLogger);
     }

--- a/src/EFCore.Relational/Migrations/MigrationCommand.cs
+++ b/src/EFCore.Relational/Migrations/MigrationCommand.cs
@@ -17,22 +17,26 @@ namespace Microsoft.EntityFrameworkCore.Migrations
     public class MigrationCommand
     {
         private readonly IRelationalCommand _relationalCommand;
+        private readonly DbContext _context;
         private readonly IDiagnosticsLogger<DbLoggerCategory.Database.Command> _logger;
 
         /// <summary>
         ///     Creates a new instance of the command.
         /// </summary>
         /// <param name="relationalCommand"> The underlying <see cref="IRelationalCommand" /> that will be used to execute the command. </param>
+        /// <param name="context"> The current <see cref="DbContext"/> or null if not known. </param>
         /// <param name="logger"> The command logger. </param>
         /// <param name="transactionSuppressed"> Indicates whether or not transactions should be suppressed while executing the command. </param>
         public MigrationCommand(
             [NotNull] IRelationalCommand relationalCommand,
+            [CanBeNull] DbContext context,
             [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
             bool transactionSuppressed = false)
         {
             Check.NotNull(relationalCommand, nameof(relationalCommand));
 
             _relationalCommand = relationalCommand;
+            _context = context;
             _logger = logger;
             TransactionSuppressed = transactionSuppressed;
         }
@@ -57,9 +61,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             [NotNull] IRelationalConnection connection,
             [CanBeNull] IReadOnlyDictionary<string, object> parameterValues = null)
             => _relationalCommand.ExecuteNonQuery(
-                Check.NotNull(connection, nameof(connection)),
-                parameterValues,
-                _logger);
+                new RelationalCommandParameterObject(
+                    connection,
+                    parameterValues,
+                    _context,
+                    _logger));
 
         /// <summary>
         ///     Executes the command and returns the number of rows affected.
@@ -73,9 +79,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             [CanBeNull] IReadOnlyDictionary<string, object> parameterValues = null,
             CancellationToken cancellationToken = default)
             => _relationalCommand.ExecuteNonQueryAsync(
-                Check.NotNull(connection, nameof(connection)),
-                parameterValues,
-                _logger,
+                new RelationalCommandParameterObject(
+                    connection,
+                    parameterValues,
+                    _context,
+                    _logger),
                 cancellationToken);
     }
 }

--- a/src/EFCore.Relational/Migrations/MigrationCommandListBuilder.cs
+++ b/src/EFCore.Relational/Migrations/MigrationCommandListBuilder.cs
@@ -51,7 +51,13 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         {
             if (_commandBuilder.CommandTextLength != 0)
             {
-                _commands.Add(new MigrationCommand(_commandBuilder.Build(), _dependencies.Logger, suppressTransaction));
+                _commands.Add(
+                    new MigrationCommand(
+                        _commandBuilder.Build(),
+                        _dependencies.CurrentDbContext.Context,
+                        _dependencies.Logger,
+                        suppressTransaction));
+
                 _commandBuilder = _dependencies.CommandBuilderFactory.Create();
             }
 

--- a/src/EFCore.Relational/Migrations/MigrationsSqlGeneratorDependencies.cs
+++ b/src/EFCore.Relational/Migrations/MigrationsSqlGeneratorDependencies.cs
@@ -59,6 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         /// <param name="updateSqlGenerator"> High level SQL generator. </param>
         /// <param name="sqlGenerationHelper"> Helpers for SQL generation. </param>
         /// <param name="typeMappingSource"> The type mapper. </param>
+        /// <param name="currentDbContext"> Contains the <see cref="DbContext"/> currently in use. </param>
         /// <param name="logger"> A logger. </param>
         [EntityFrameworkInternal]
         public MigrationsSqlGeneratorDependencies(
@@ -66,18 +67,21 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             [NotNull] IUpdateSqlGenerator updateSqlGenerator,
             [NotNull] ISqlGenerationHelper sqlGenerationHelper,
             [NotNull] IRelationalTypeMappingSource typeMappingSource,
+            [NotNull] ICurrentDbContext currentDbContext,
             [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger)
         {
             Check.NotNull(commandBuilderFactory, nameof(commandBuilderFactory));
             Check.NotNull(updateSqlGenerator, nameof(updateSqlGenerator));
             Check.NotNull(sqlGenerationHelper, nameof(sqlGenerationHelper));
             Check.NotNull(typeMappingSource, nameof(typeMappingSource));
+            Check.NotNull(currentDbContext, nameof(currentDbContext));
             Check.NotNull(logger, nameof(logger));
 
             CommandBuilderFactory = commandBuilderFactory;
             SqlGenerationHelper = sqlGenerationHelper;
             UpdateSqlGenerator = updateSqlGenerator;
             TypeMappingSource = typeMappingSource;
+            CurrentDbContext = currentDbContext;
             Logger = logger;
         }
 
@@ -102,6 +106,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         public IRelationalTypeMappingSource TypeMappingSource { get; }
 
         /// <summary>
+        ///    Contains the <see cref="DbContext"/> currently in use.
+        /// </summary>
+        public ICurrentDbContext CurrentDbContext { get; }
+
+        /// <summary>
         ///     A logger.
         /// </summary>
         public IDiagnosticsLogger<DbLoggerCategory.Database.Command> Logger { get; }
@@ -117,6 +126,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 UpdateSqlGenerator,
                 SqlGenerationHelper,
                 TypeMappingSource,
+                CurrentDbContext,
                 Logger);
 
         /// <summary>
@@ -130,6 +140,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 updateSqlGenerator,
                 SqlGenerationHelper,
                 TypeMappingSource,
+                CurrentDbContext,
                 Logger);
 
         /// <summary>
@@ -143,6 +154,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 UpdateSqlGenerator,
                 sqlGenerationHelper,
                 TypeMappingSource,
+                CurrentDbContext,
                 Logger);
 
         /// <summary>
@@ -156,6 +168,21 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 UpdateSqlGenerator,
                 SqlGenerationHelper,
                 typeMappingSource,
+                CurrentDbContext,
+                Logger);
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="currentDbContext"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public MigrationsSqlGeneratorDependencies With([NotNull] ICurrentDbContext currentDbContext)
+            => new MigrationsSqlGeneratorDependencies(
+                CommandBuilderFactory,
+                UpdateSqlGenerator,
+                SqlGenerationHelper,
+                TypeMappingSource,
+                currentDbContext,
                 Logger);
 
         /// <summary>
@@ -169,6 +196,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 UpdateSqlGenerator,
                 SqlGenerationHelper,
                 TypeMappingSource,
+                CurrentDbContext,
                 logger);
     }
 }

--- a/src/EFCore.Relational/Query/Pipeline/AsyncQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Pipeline/AsyncQueryingEnumerable.cs
@@ -97,9 +97,11 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 
                             _dataReader
                                 = await relationalCommand.ExecuteReaderAsync(
-                                    _relationalQueryContext.Connection,
-                                    _relationalQueryContext.ParameterValues,
-                                    _relationalQueryContext.CommandLogger,
+                                    new RelationalCommandParameterObject(
+                                        _relationalQueryContext.Connection,
+                                        _relationalQueryContext.ParameterValues,
+                                        _relationalQueryContext.Context,
+                                        _relationalQueryContext.CommandLogger),
                                     _cancellationToken);
 
                             if (selectExpression.IsNonComposedFromSql())

--- a/src/EFCore.Relational/Query/Pipeline/QueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Pipeline/QueryingEnumerable.cs
@@ -93,9 +93,11 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 
                             _dataReader
                                 = relationalCommand.ExecuteReader(
-                                    _relationalQueryContext.Connection,
-                                    _relationalQueryContext.ParameterValues,
-                                    _relationalQueryContext.CommandLogger);
+                                    new RelationalCommandParameterObject(
+                                        _relationalQueryContext.Connection,
+                                        _relationalQueryContext.ParameterValues,
+                                        _relationalQueryContext.Context,
+                                        _relationalQueryContext.CommandLogger));
 
                             if (selectExpression.IsNonComposedFromSql())
                             {

--- a/src/EFCore.Relational/Storage/IRelationalCommand.cs
+++ b/src/EFCore.Relational/Storage/IRelationalCommand.cs
@@ -4,8 +4,6 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace Microsoft.EntityFrameworkCore.Storage
 {
@@ -33,85 +31,58 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <summary>
         ///     Executes the command with no results.
         /// </summary>
-        /// <param name="connection"> The connection to execute against. </param>
-        /// <param name="parameterValues"> The values for the parameters. </param>
-        /// <param name="logger"> The command logger. </param>
+        /// <param name="parameterObject"> Parameters for this method. </param>
         /// <returns> The number of rows affected. </returns>
-        int ExecuteNonQuery(
-            [NotNull] IRelationalConnection connection,
-            [CanBeNull] IReadOnlyDictionary<string, object> parameterValues,
-            [CanBeNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger);
+        int ExecuteNonQuery(RelationalCommandParameterObject parameterObject);
 
         /// <summary>
         ///     Asynchronously executes the command with no results.
         /// </summary>
-        /// <param name="connection"> The connection to execute against. </param>
-        /// <param name="parameterValues"> The values for the parameters. </param>
-        /// <param name="logger"> The command logger. </param>
+        /// <param name="parameterObject"> Parameters for this method. </param>
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns>
         ///     A task that represents the asynchronous operation. The task result contains the number of rows affected.
         /// </returns>
         Task<int> ExecuteNonQueryAsync(
-            [NotNull] IRelationalConnection connection,
-            [CanBeNull] IReadOnlyDictionary<string, object> parameterValues,
-            [CanBeNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
+            RelationalCommandParameterObject parameterObject,
             CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     Executes the command with a single scalar result.
         /// </summary>
-        /// <param name="connection"> The connection to execute against. </param>
-        /// <param name="parameterValues"> The values for the parameters. </param>
-        /// <param name="logger"> The command logger. </param>
+        /// <param name="parameterObject"> Parameters for this method. </param>
         /// <returns> The result of the command. </returns>
-        object ExecuteScalar(
-            [NotNull] IRelationalConnection connection,
-            [CanBeNull] IReadOnlyDictionary<string, object> parameterValues,
-            [CanBeNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger);
+        object ExecuteScalar(RelationalCommandParameterObject parameterObject);
 
         /// <summary>
         ///     Asynchronously executes the command with a single scalar result.
         /// </summary>
-        /// <param name="connection"> The connection to execute against. </param>
-        /// <param name="parameterValues"> The values for the parameters. </param>
-        /// <param name="logger"> The command logger. </param>
+        /// <param name="parameterObject"> Parameters for this method. </param>
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns>
         ///     A task that represents the asynchronous operation. The task result contains the result of the command.
         /// </returns>
         Task<object> ExecuteScalarAsync(
-            [NotNull] IRelationalConnection connection,
-            [CanBeNull] IReadOnlyDictionary<string, object> parameterValues,
-            [CanBeNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
+            RelationalCommandParameterObject parameterObject,
             CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     Executes the command with a <see cref="RelationalDataReader" /> result.
         /// </summary>
-        /// <param name="connection"> The connection to execute against. </param>
-        /// <param name="parameterValues"> The values for the parameters. </param>
-        /// <param name="logger"> The command logger. </param>
+        /// <param name="parameterObject"> Parameters for this method. </param>
         /// <returns> The result of the command. </returns>
-        RelationalDataReader ExecuteReader(
-            [NotNull] IRelationalConnection connection,
-            [CanBeNull] IReadOnlyDictionary<string, object> parameterValues,
-            [CanBeNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger);
+        RelationalDataReader ExecuteReader(RelationalCommandParameterObject parameterObject);
 
         /// <summary>
         ///     Asynchronously executes the command with a <see cref="RelationalDataReader" /> result.
         /// </summary>
-        /// <param name="connection"> The connection to execute against. </param>
-        /// <param name="parameterValues"> The values for the parameters. </param>
-        /// <param name="logger"> The command logger. </param>
+        /// <param name="parameterObject"> Parameters for this method. </param>
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns>
         ///     A task that represents the asynchronous operation. The task result contains the result of the command.
         /// </returns>
         Task<RelationalDataReader> ExecuteReaderAsync(
-            [NotNull] IRelationalConnection connection,
-            [CanBeNull] IReadOnlyDictionary<string, object> parameterValues,
-            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
+            RelationalCommandParameterObject parameterObject,
             CancellationToken cancellationToken = default);
     }
 }

--- a/src/EFCore.Relational/Storage/RelationalCommandParameterObject.cs
+++ b/src/EFCore.Relational/Storage/RelationalCommandParameterObject.cs
@@ -1,0 +1,69 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Storage
+{
+    /// <summary>
+    ///     <para>
+    ///         A parameter object for the execution methods on <see cref="RelationalCommand" />.
+    ///     </para>
+    ///     <para>
+    ///         This type is typically used by database providers (and other extensions). It is generally
+    ///         not used in application code.
+    ///     </para>
+    /// </summary>
+    public readonly struct RelationalCommandParameterObject
+    {
+        /// <summary>
+        ///     <para>
+        ///         Creates a new parameter object for the given parameters.
+        ///     </para>
+        ///     <para>
+        ///         This type is typically used by database providers (and other extensions). It is generally
+        ///         not used in application code.
+        ///     </para>
+        /// </summary>
+        /// <param name="connection"> The connection on which the command will execute. </param>
+        /// <param name="parameterValues"> The SQL parameter values to use, or null if none. </param>
+        /// <param name="context"> The current <see cref="DbContext"/> instance, or null if it is not known. </param>
+        /// <param name="logger"> A logger, or null if no logger is available. </param>
+        public RelationalCommandParameterObject(
+            [NotNull] IRelationalConnection connection,
+            [CanBeNull] IReadOnlyDictionary<string, object> parameterValues,
+            [CanBeNull] DbContext context,
+            [CanBeNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger)
+        {
+            Check.NotNull(connection, nameof(connection));
+
+            Connection = connection;
+            ParameterValues = parameterValues;
+            Context = context;
+            Logger = logger;
+        }
+
+        /// <summary>
+        ///     The connection on which the command will execute.
+        /// </summary>
+        public IRelationalConnection Connection { get; }
+
+        /// <summary>
+        ///     The SQL parameter values to use, or null if none.
+        /// </summary>
+        public IReadOnlyDictionary<string, object> ParameterValues { get; }
+
+        /// <summary>
+        ///     The current <see cref="DbContext"/> instance, or null if it is not known.
+        /// </summary>
+        public DbContext Context { get; }
+
+        /// <summary>
+        ///     A logger, or null if no logger is available.
+        /// </summary>
+        public IDiagnosticsLogger<DbLoggerCategory.Database.Command> Logger { get; }
+    }
+}

--- a/src/EFCore.Relational/Storage/RelationalDatabaseCreatorDependencies.cs
+++ b/src/EFCore.Relational/Storage/RelationalDatabaseCreatorDependencies.cs
@@ -62,6 +62,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="migrationCommandExecutor"> The <see cref="IMigrationCommandExecutor" /> to be used. </param>
         /// <param name="sqlGenerationHelper"> The <see cref="ISqlGenerationHelper" /> to be used. </param>
         /// <param name="executionStrategyFactory">The <see cref="IExecutionStrategyFactory" /> to be used. </param>
+        /// <param name="currentDbContext"> Contains the <see cref="DbContext"/> currently in use. </param>
         /// <param name="commandLogger"> The command logger. </param>
         [EntityFrameworkInternal]
         public RelationalDatabaseCreatorDependencies(
@@ -72,6 +73,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             [NotNull] IMigrationCommandExecutor migrationCommandExecutor,
             [NotNull] ISqlGenerationHelper sqlGenerationHelper,
             [NotNull] IExecutionStrategyFactory executionStrategyFactory,
+            [NotNull] ICurrentDbContext currentDbContext,
             [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> commandLogger)
         {
             Check.NotNull(model, nameof(model));
@@ -81,6 +83,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Check.NotNull(migrationCommandExecutor, nameof(migrationCommandExecutor));
             Check.NotNull(sqlGenerationHelper, nameof(sqlGenerationHelper));
             Check.NotNull(executionStrategyFactory, nameof(executionStrategyFactory));
+            Check.NotNull(currentDbContext, nameof(currentDbContext));
             Check.NotNull(commandLogger, nameof(commandLogger));
 
             Model = model;
@@ -90,6 +93,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             MigrationCommandExecutor = migrationCommandExecutor;
             SqlGenerationHelper = sqlGenerationHelper;
             ExecutionStrategyFactory = executionStrategyFactory;
+            CurrentDbContext = currentDbContext;
             CommandLogger = commandLogger;
         }
 
@@ -134,6 +138,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public IDiagnosticsLogger<DbLoggerCategory.Database.Command> CommandLogger { get; }
 
         /// <summary>
+        ///    Contains the <see cref="DbContext"/> currently in use.
+        /// </summary>
+        public ICurrentDbContext CurrentDbContext { get; }
+
+        /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
         /// </summary>
         /// <param name="model"> A replacement for the current dependency of this type. </param>
@@ -147,6 +156,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 MigrationCommandExecutor,
                 SqlGenerationHelper,
                 ExecutionStrategyFactory,
+                CurrentDbContext,
                 CommandLogger);
 
         /// <summary>
@@ -163,6 +173,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 MigrationCommandExecutor,
                 SqlGenerationHelper,
                 ExecutionStrategyFactory,
+                CurrentDbContext,
                 CommandLogger);
 
         /// <summary>
@@ -179,6 +190,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 MigrationCommandExecutor,
                 SqlGenerationHelper,
                 ExecutionStrategyFactory,
+                CurrentDbContext,
                 CommandLogger);
 
         /// <summary>
@@ -195,6 +207,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 MigrationCommandExecutor,
                 SqlGenerationHelper,
                 ExecutionStrategyFactory,
+                CurrentDbContext,
                 CommandLogger);
 
         /// <summary>
@@ -211,6 +224,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 migrationCommandExecutor,
                 SqlGenerationHelper,
                 ExecutionStrategyFactory,
+                CurrentDbContext,
                 CommandLogger);
 
         /// <summary>
@@ -227,6 +241,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 MigrationCommandExecutor,
                 sqlGenerationHelper,
                 ExecutionStrategyFactory,
+                CurrentDbContext,
                 CommandLogger);
 
         /// <summary>
@@ -243,6 +258,24 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 MigrationCommandExecutor,
                 SqlGenerationHelper,
                 executionStrategyFactory,
+                CurrentDbContext,
+                CommandLogger);
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="currentDbContext"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public RelationalDatabaseCreatorDependencies With([NotNull] ICurrentDbContext currentDbContext)
+            => new RelationalDatabaseCreatorDependencies(
+                Model,
+                Connection,
+                ModelDiffer,
+                MigrationsSqlGenerator,
+                MigrationCommandExecutor,
+                SqlGenerationHelper,
+                ExecutionStrategyFactory,
+                currentDbContext,
                 CommandLogger);
 
         /// <summary>
@@ -259,6 +292,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 MigrationCommandExecutor,
                 SqlGenerationHelper,
                 ExecutionStrategyFactory,
+                CurrentDbContext,
                 commandLogger);
     }
 }

--- a/src/EFCore.Relational/Update/ModificationCommandBatchFactoryDependencies.cs
+++ b/src/EFCore.Relational/Update/ModificationCommandBatchFactoryDependencies.cs
@@ -3,6 +3,7 @@
 
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -51,12 +52,14 @@ namespace Microsoft.EntityFrameworkCore.Update
         /// <param name="commandBuilderFactory"> The command builder factory. </param>
         /// <param name="sqlGenerationHelper"> The sql generator. </param>
         /// <param name="updateSqlGenerator"> The update generator. </param>
+        /// <param name="currentDbContext"> Contains the <see cref="DbContext"/> currently in use. </param>
         /// <param name="logger"> A logger. </param>
         public ModificationCommandBatchFactoryDependencies(
             [NotNull] IRelationalCommandBuilderFactory commandBuilderFactory,
             [NotNull] ISqlGenerationHelper sqlGenerationHelper,
             [NotNull] IUpdateSqlGenerator updateSqlGenerator,
             [NotNull] IRelationalValueBufferFactoryFactory valueBufferFactoryFactory,
+            [NotNull] ICurrentDbContext currentDbContext,
             [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger)
         {
             Check.NotNull(commandBuilderFactory, nameof(commandBuilderFactory));
@@ -69,6 +72,7 @@ namespace Microsoft.EntityFrameworkCore.Update
             SqlGenerationHelper = sqlGenerationHelper;
             UpdateSqlGenerator = updateSqlGenerator;
             ValueBufferFactoryFactory = valueBufferFactoryFactory;
+            CurrentDbContext = currentDbContext;
             Logger = logger;
         }
 
@@ -98,6 +102,11 @@ namespace Microsoft.EntityFrameworkCore.Update
         public IRelationalValueBufferFactoryFactory ValueBufferFactoryFactory { get; }
 
         /// <summary>
+        ///    Contains the <see cref="DbContext"/> currently in use.
+        /// </summary>
+        public ICurrentDbContext CurrentDbContext { get; }
+
+        /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
         /// </summary>
         /// <param name="logger"> A replacement for the current dependency of this type. </param>
@@ -108,6 +117,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                 SqlGenerationHelper,
                 UpdateSqlGenerator,
                 ValueBufferFactoryFactory,
+                CurrentDbContext,
                 logger);
 
         /// <summary>
@@ -121,6 +131,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                 SqlGenerationHelper,
                 UpdateSqlGenerator,
                 valueBufferFactoryFactory,
+                CurrentDbContext,
                 Logger);
 
         /// <summary>
@@ -134,6 +145,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                 SqlGenerationHelper,
                 UpdateSqlGenerator,
                 ValueBufferFactoryFactory,
+                CurrentDbContext,
                 Logger);
 
         /// <summary>
@@ -147,6 +159,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                 sqlGenerationHelper,
                 UpdateSqlGenerator,
                 ValueBufferFactoryFactory,
+                CurrentDbContext,
                 Logger);
 
         /// <summary>
@@ -160,6 +173,21 @@ namespace Microsoft.EntityFrameworkCore.Update
                 SqlGenerationHelper,
                 updateSqlGenerator,
                 ValueBufferFactoryFactory,
+                CurrentDbContext,
+                Logger);
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="currentDbContext"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public ModificationCommandBatchFactoryDependencies With([NotNull] ICurrentDbContext currentDbContext)
+            => new ModificationCommandBatchFactoryDependencies(
+                CommandBuilderFactory,
+                SqlGenerationHelper,
+                UpdateSqlGenerator,
+                ValueBufferFactoryFactory,
+                currentDbContext,
                 Logger);
     }
 }

--- a/src/EFCore.Relational/Update/ReaderModificationCommandBatch.cs
+++ b/src/EFCore.Relational/Update/ReaderModificationCommandBatch.cs
@@ -25,8 +25,6 @@ namespace Microsoft.EntityFrameworkCore.Update
     /// </summary>
     public abstract class ReaderModificationCommandBatch : ModificationCommandBatch
     {
-        private readonly IRelationalCommandBuilderFactory _commandBuilderFactory;
-        private readonly IRelationalValueBufferFactoryFactory _valueBufferFactoryFactory;
         private readonly List<ModificationCommand> _modificationCommands = new List<ModificationCommand>();
 
         /// <summary>
@@ -37,12 +35,18 @@ namespace Microsoft.EntityFrameworkCore.Update
         {
             Check.NotNull(dependencies, nameof(dependencies));
 
-            _commandBuilderFactory = dependencies.CommandBuilderFactory;
-            SqlGenerationHelper = dependencies.SqlGenerationHelper;
-            UpdateSqlGenerator = dependencies.UpdateSqlGenerator;
-            _valueBufferFactoryFactory = dependencies.ValueBufferFactoryFactory;
-            Logger = dependencies.Logger;
+            Dependencies = dependencies;
         }
+
+        /// <summary>
+        ///     Service dependencies.
+        /// </summary>
+        public virtual ModificationCommandBatchFactoryDependencies Dependencies { get; }
+
+        /// <summary>
+        ///     The update SQL generator.
+        /// </summary>
+        protected virtual IUpdateSqlGenerator UpdateSqlGenerator => Dependencies.UpdateSqlGenerator;
 
         /// <summary>
         ///     Gets or sets the cached command text for the commands in the batch.
@@ -53,21 +57,6 @@ namespace Microsoft.EntityFrameworkCore.Update
         ///     The ordinal of the last command for which command text was built.
         /// </summary>
         protected virtual int LastCachedCommandIndex { get; set; }
-
-        /// <summary>
-        ///     A helper for SQL generation.
-        /// </summary>
-        protected virtual ISqlGenerationHelper SqlGenerationHelper { get; }
-
-        /// <summary>
-        ///     A SQL generator for insert, update, and delete commands.
-        /// </summary>
-        protected virtual IUpdateSqlGenerator UpdateSqlGenerator { get; }
-
-        /// <summary>
-        ///     A logger.
-        /// </summary>
-        protected virtual IDiagnosticsLogger<DbLoggerCategory.Database.Command> Logger { get; }
 
         /// <summary>
         ///     The list of conceptual insert/update/delete <see cref="ModificationCommands" />s in the batch.
@@ -194,7 +183,7 @@ namespace Microsoft.EntityFrameworkCore.Update
         /// <returns> The command. </returns>
         protected virtual RawSqlCommand CreateStoreCommand()
         {
-            var commandBuilder = _commandBuilderFactory
+            var commandBuilder = Dependencies.CommandBuilderFactory
                 .Create()
                 .Append(GetCommandText());
 
@@ -212,7 +201,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                     {
                         commandBuilder.AddParameter(
                             columnModification.ParameterName,
-                            SqlGenerationHelper.GenerateParameterName(columnModification.ParameterName),
+                            Dependencies.SqlGenerationHelper.GenerateParameterName(columnModification.ParameterName),
                             columnModification.Property);
 
                         parameterValues.Add(columnModification.ParameterName, columnModification.Value);
@@ -222,7 +211,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                     {
                         commandBuilder.AddParameter(
                             columnModification.OriginalParameterName,
-                            SqlGenerationHelper.GenerateParameterName(columnModification.OriginalParameterName),
+                            Dependencies.SqlGenerationHelper.GenerateParameterName(columnModification.OriginalParameterName),
                             columnModification.Property);
 
                         parameterValues.Add(columnModification.OriginalParameterName, columnModification.OriginalValue);
@@ -247,9 +236,11 @@ namespace Microsoft.EntityFrameworkCore.Update
             try
             {
                 using (var dataReader = storeCommand.RelationalCommand.ExecuteReader(
-                    connection,
-                    storeCommand.ParameterValues,
-                    Logger))
+                    new RelationalCommandParameterObject(
+                        connection,
+                        storeCommand.ParameterValues,
+                        Dependencies.CurrentDbContext.Context,
+                        Dependencies.Logger)))
                 {
                     Consume(dataReader);
                 }
@@ -282,9 +273,11 @@ namespace Microsoft.EntityFrameworkCore.Update
             try
             {
                 using (var dataReader = await storeCommand.RelationalCommand.ExecuteReaderAsync(
-                    connection,
-                    storeCommand.ParameterValues,
-                    Logger,
+                    new RelationalCommandParameterObject(
+                        connection,
+                        storeCommand.ParameterValues,
+                        Dependencies.CurrentDbContext.Context,
+                        Dependencies.Logger),
                     cancellationToken))
                 {
                     await ConsumeAsync(dataReader, cancellationToken);
@@ -326,7 +319,7 @@ namespace Microsoft.EntityFrameworkCore.Update
         /// </param>
         /// <returns> The factory. </returns>
         protected virtual IRelationalValueBufferFactory CreateValueBufferFactory([NotNull] IReadOnlyList<ColumnModification> columnModifications)
-            => _valueBufferFactoryFactory
+            => Dependencies.ValueBufferFactoryFactory
                 .Create(
                     Check.NotNull(columnModifications, nameof(columnModifications))
                         .Where(c => c.IsRead)

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerDatabaseCreator.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerDatabaseCreator.cs
@@ -118,9 +118,11 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
                     _connection,
                     connection => (int)CreateHasTablesCommand()
                                       .ExecuteScalar(
-                                          connection,
-                                          null,
-                                          Dependencies.CommandLogger) != 0);
+                                          new RelationalCommandParameterObject(
+                                              connection,
+                                              null,
+                                              Dependencies.CurrentDbContext.Context,
+                                              Dependencies.CommandLogger)) != 0);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -133,9 +135,11 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
                 _connection,
                 async (connection, ct) => (int)await CreateHasTablesCommand()
                                               .ExecuteScalarAsync(
-                                                  connection,
-                                                  null,
-                                                  Dependencies.CommandLogger,
+                                                  new RelationalCommandParameterObject(
+                                                      connection,
+                                                      null,
+                                                      Dependencies.CurrentDbContext.Context,
+                                                      Dependencies.CommandLogger),
                                                   cancellationToken: ct) != 0, cancellationToken);
 
         private IRelationalCommand CreateHasTablesCommand()

--- a/src/EFCore.SqlServer/ValueGeneration/Internal/SqlServerSequenceHiLoValueGenerator.cs
+++ b/src/EFCore.SqlServer/ValueGeneration/Internal/SqlServerSequenceHiLoValueGenerator.cs
@@ -60,7 +60,12 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.ValueGeneration.Internal
             => (long)Convert.ChangeType(
                 _rawSqlCommandBuilder
                     .Build(_sqlGenerator.GenerateNextSequenceValueOperation(_sequence.Name, _sequence.Schema))
-                    .ExecuteScalar(_connection, null, _commandLogger),
+                    .ExecuteScalar(
+                        new RelationalCommandParameterObject(
+                            _connection,
+                            null,
+                            null,
+                            _commandLogger)),
                 typeof(long),
                 CultureInfo.InvariantCulture);
 
@@ -74,7 +79,13 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.ValueGeneration.Internal
             => (long)Convert.ChangeType(
                 await _rawSqlCommandBuilder
                     .Build(_sqlGenerator.GenerateNextSequenceValueOperation(_sequence.Name, _sequence.Schema))
-                    .ExecuteScalarAsync(_connection, null, _commandLogger, cancellationToken: cancellationToken),
+                    .ExecuteScalarAsync(
+                        new RelationalCommandParameterObject(
+                            _connection,
+                            null,
+                            null,
+                            _commandLogger),
+                        cancellationToken),
                 typeof(long),
                 CultureInfo.InvariantCulture);
 

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteDatabaseCreator.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteDatabaseCreator.cs
@@ -58,7 +58,12 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal
             Dependencies.Connection.Open();
 
             _rawSqlCommandBuilder.Build("PRAGMA journal_mode = 'wal';")
-                .ExecuteNonQuery(Dependencies.Connection, null, Dependencies.CommandLogger);
+                .ExecuteNonQuery(
+                    new RelationalCommandParameterObject(
+                        Dependencies.Connection,
+                        null,
+                        null,
+                        Dependencies.CommandLogger));
 
             Dependencies.Connection.Close();
         }
@@ -96,7 +101,12 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal
         {
             var count = (long)_rawSqlCommandBuilder
                 .Build("SELECT COUNT(*) FROM \"sqlite_master\" WHERE \"type\" = 'table' AND \"rootpage\" IS NOT NULL;")
-                .ExecuteScalar(Dependencies.Connection, null, Dependencies.CommandLogger);
+                .ExecuteScalar(
+                    new RelationalCommandParameterObject(
+                        Dependencies.Connection,
+                        null,
+                        null,
+                        Dependencies.CommandLogger));
 
             return count != 0;
         }

--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -118,7 +118,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 CheckDisposed();
 
-                return _database ?? (_database = new DatabaseFacade(this));
+                return _database ??= new DatabaseFacade(this);
             }
         }
 
@@ -126,8 +126,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     Provides access to information and operations for entity instances this context is tracking.
         /// </summary>
         public virtual ChangeTracker ChangeTracker
-            => _changeTracker
-               ?? (_changeTracker = InternalServiceProvider.GetRequiredService<IChangeTrackerFactory>().Create());
+            => _changeTracker ??= InternalServiceProvider.GetRequiredService<IChangeTrackerFactory>().Create();
 
         /// <summary>
         ///     The metadata about the shape of entities, the relationships between them, and how they map to the database.
@@ -336,7 +335,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 CheckDisposed();
 
-                return _dbContextDependencies ?? (_dbContextDependencies = InternalServiceProvider.GetRequiredService<IDbContextDependencies>());
+                return _dbContextDependencies ??= InternalServiceProvider.GetRequiredService<IDbContextDependencies>();
             }
         }
 

--- a/src/EFCore/Diagnostics/DbContextEventData.cs
+++ b/src/EFCore/Diagnostics/DbContextEventData.cs
@@ -18,11 +18,11 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <param name="eventDefinition"> The event definition. </param>
         /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
-        /// <param name="context"> The current <see cref="DbContext" />. </param>
+        /// <param name="context"> The current <see cref="DbContext" />, or null if not known. </param>
         public DbContextEventData(
             [NotNull] EventDefinitionBase eventDefinition,
             [NotNull] Func<EventDefinitionBase, EventData, string> messageGenerator,
-            [NotNull] DbContext context)
+            [CanBeNull] DbContext context)
             : base(eventDefinition, messageGenerator)
         {
             Context = context;

--- a/src/EFCore/Extensions/TransactionsDatabaseFacadeExtensions.cs
+++ b/src/EFCore/Extensions/TransactionsDatabaseFacadeExtensions.cs
@@ -5,6 +5,7 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -25,7 +26,7 @@ namespace System.Transactions
         public static void EnlistTransaction([NotNull] this DatabaseFacade databaseFacade, [CanBeNull] Transaction transaction)
         {
             Check.NotNull(databaseFacade, nameof(databaseFacade));
-            if (databaseFacade.GetService<IDbContextTransactionManager>() is ITransactionEnlistmentManager transactionManager)
+            if (((IDatabaseFacadeDependenciesAccessor)databaseFacade).Dependencies.TransactionManager is ITransactionEnlistmentManager transactionManager)
             {
                 transactionManager.EnlistTransaction(transaction);
             }
@@ -43,7 +44,7 @@ namespace System.Transactions
         public static Transaction GetEnlistedTransaction([NotNull] this DatabaseFacade databaseFacade)
         {
             Check.NotNull(databaseFacade, nameof(databaseFacade));
-            if (databaseFacade.GetService<IDbContextTransactionManager>() is ITransactionEnlistmentManager transactionManager)
+            if (((IDatabaseFacadeDependenciesAccessor)databaseFacade).Dependencies.TransactionManager is ITransactionEnlistmentManager transactionManager)
             {
                 return transactionManager.EnlistedTransaction;
             }

--- a/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
+++ b/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
@@ -118,6 +118,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 { typeof(IUpdateAdapterFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(ICurrentDbContext), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IDbContextDependencies), new ServiceCharacteristics(ServiceLifetime.Scoped) },
+                { typeof(IDatabaseFacadeDependencies), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IDbContextOptions), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IDatabase), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IDatabaseCreator), new ServiceCharacteristics(ServiceLifetime.Scoped) },
@@ -228,6 +229,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             TryAdd<IChangeDetector, ChangeDetector>();
             TryAdd<IDbContextServices, DbContextServices>();
             TryAdd<IDbContextDependencies, DbContextDependencies>();
+            TryAdd<IDatabaseFacadeDependencies, DatabaseFacadeDependencies>();
             TryAdd<IValueGeneratorSelector, ValueGeneratorSelector>();
             TryAdd<IModelValidator, ModelValidator>();
             TryAdd<IExecutionStrategyFactory, ExecutionStrategyFactory>();

--- a/src/EFCore/Internal/IDatabaseFacadeDependencies.cs
+++ b/src/EFCore/Internal/IDatabaseFacadeDependencies.cs
@@ -1,0 +1,76 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    /// <summary>
+    ///     <para>
+    ///         This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///         the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///         any release. You should only use it directly in your code with extreme caution and knowing that
+    ///         doing so can result in application failures when updating to a new Entity Framework Core release.
+    ///     </para>
+    ///     <para>
+    ///         The service lifetime is <see cref="ServiceLifetime.Scoped"/>. This means that each
+    ///         <see cref="DbContext"/> instance will use its own instance of this service.
+    ///         The implementation may depend on other services registered with any lifetime.
+    ///         The implementation does not need to be thread-safe.
+    ///     </para>
+    /// </summary>
+    // This is used by Relational, but is still internal since it's only for an optimization; no provider needs access.
+    public interface IDatabaseFacadeDependencies
+    {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        IDbContextTransactionManager TransactionManager { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        IDatabaseCreator DatabaseCreator { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        IExecutionStrategyFactory ExecutionStrategyFactory { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        IEnumerable<IDatabaseProvider> DatabaseProviders { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        IDiagnosticsLogger<DbLoggerCategory.Database.Command> CommandLogger { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        IConcurrencyDetector ConcurrencyDetector { get; }
+    }
+}

--- a/src/EFCore/Internal/IDatabaseFacadeDependenciesAccessor.cs
+++ b/src/EFCore/Internal/IDatabaseFacadeDependenciesAccessor.cs
@@ -1,0 +1,31 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    // This is used by Relational, but is still internal since it's only for an optimization; no provider needs access.
+    public interface IDatabaseFacadeDependenciesAccessor
+    {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        IDatabaseFacadeDependencies Dependencies { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        DbContext Context { get; }
+    }
+}

--- a/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
@@ -107,6 +107,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                         services.GetRequiredService<IMigrationCommandExecutor>(),
                         services.GetRequiredService<IRelationalConnection>(),
                         services.GetRequiredService<ISqlGenerationHelper>(),
+                        services.GetRequiredService<ICurrentDbContext>(),
                         services.GetRequiredService<IDiagnosticsLogger<DbLoggerCategory.Migrations>>(),
                         services.GetRequiredService<IDiagnosticsLogger<DbLoggerCategory.Database.Command>>(),
                         services.GetRequiredService<IDatabaseProvider>())));

--- a/test/EFCore.Relational.Specification.Tests/InterceptionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/InterceptionTestBase.cs
@@ -60,6 +60,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotEqual(interceptor.AsyncCalled, interceptor.SyncCalled);
                 Assert.True(interceptor.ExecutingCalled);
                 Assert.True(interceptor.ExecutedCalled);
+                Assert.Same(context, interceptor.Context);
             }
 
             return interceptor.CommandText;
@@ -91,18 +92,26 @@ namespace Microsoft.EntityFrameworkCore
 
                 if (async)
                 {
-                    Assert.Equal(1, Convert.ToInt32(await command.ExecuteScalarAsync(connection, null, logger)));
+                    Assert.Equal(
+                        1, Convert.ToInt32(
+                            await command.ExecuteScalarAsync(
+                                new RelationalCommandParameterObject(
+                                    connection, null, context, logger))));
                     Assert.True(interceptor.AsyncCalled);
                 }
                 else
                 {
-                    Assert.Equal(1, Convert.ToInt32(command.ExecuteScalar(connection, null, logger)));
+                    Assert.Equal(
+                        1, Convert.ToInt32(
+                            command.ExecuteScalar(
+                                new RelationalCommandParameterObject(connection, null, context, logger))));
                     Assert.True(interceptor.SyncCalled);
                 }
 
                 Assert.NotEqual(interceptor.AsyncCalled, interceptor.SyncCalled);
                 Assert.True(interceptor.ExecutingCalled);
                 Assert.True(interceptor.ExecutedCalled);
+                Assert.Same(context, interceptor.Context);
 
                 AssertSql(sql, interceptor.CommandText);
             }
@@ -144,6 +153,7 @@ namespace Microsoft.EntityFrameworkCore
                     Assert.NotEqual(interceptor.AsyncCalled, interceptor.SyncCalled);
                     Assert.True(interceptor.ExecutingCalled);
                     Assert.True(interceptor.ExecutedCalled);
+                    Assert.Same(context, interceptor.Context);
 
                     AssertSql(nonQuery, interceptor.CommandText);
                 }
@@ -192,6 +202,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotEqual(interceptor.AsyncCalled, interceptor.SyncCalled);
                 Assert.True(interceptor.ExecutingCalled);
                 Assert.True(interceptor.ExecutedCalled);
+                Assert.Same(context, interceptor.Context);
             }
 
             return interceptor.CommandText;
@@ -246,7 +257,9 @@ namespace Microsoft.EntityFrameworkCore
                 {
                     Assert.Equal(
                         SuppressingScalarCommandInterceptor.InterceptedResult,
-                        await command.ExecuteScalarAsync(connection, null, logger));
+                        await command.ExecuteScalarAsync(
+                            new RelationalCommandParameterObject(
+                                connection, null, context, logger)));
 
                     Assert.True(interceptor.AsyncCalled);
                 }
@@ -254,7 +267,9 @@ namespace Microsoft.EntityFrameworkCore
                 {
                     Assert.Equal(
                         SuppressingScalarCommandInterceptor.InterceptedResult,
-                        command.ExecuteScalar(connection, null, logger));
+                        command.ExecuteScalar(
+                            new RelationalCommandParameterObject(
+                                connection, null, context, logger)));
 
                     Assert.True(interceptor.SyncCalled);
                 }
@@ -262,6 +277,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotEqual(interceptor.AsyncCalled, interceptor.SyncCalled);
                 Assert.True(interceptor.ExecutingCalled);
                 Assert.True(interceptor.ExecutedCalled);
+                Assert.Same(context, interceptor.Context);
 
                 AssertSql(sql, interceptor.CommandText);
             }
@@ -327,6 +343,7 @@ namespace Microsoft.EntityFrameworkCore
                     Assert.NotEqual(interceptor.AsyncCalled, interceptor.SyncCalled);
                     Assert.True(interceptor.ExecutingCalled);
                     Assert.True(interceptor.ExecutedCalled);
+                    Assert.Same(context, interceptor.Context);
 
                     AssertSql(nonQuery, interceptor.CommandText);
                 }
@@ -394,6 +411,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotEqual(interceptor.AsyncCalled, interceptor.SyncCalled);
                 Assert.True(interceptor.ExecutingCalled);
                 Assert.True(interceptor.ExecutedCalled);
+                Assert.Same(context, interceptor.Context);
             }
 
             return interceptor.CommandText;
@@ -449,18 +467,24 @@ namespace Microsoft.EntityFrameworkCore
 
                 if (async)
                 {
-                    Assert.Equal(2, Convert.ToInt32(await command.ExecuteScalarAsync(connection, null, logger)));
+                    Assert.Equal(2, Convert.ToInt32(await command.ExecuteScalarAsync(
+                        new RelationalCommandParameterObject(connection, null, context, logger))));
                     Assert.True(interceptor.AsyncCalled);
                 }
                 else
                 {
-                    Assert.Equal(2, Convert.ToInt32(command.ExecuteScalar(connection, null, logger)));
+                    Assert.Equal(
+                        2, Convert.ToInt32(
+                            command.ExecuteScalar(
+                                new RelationalCommandParameterObject(
+                                    connection, null, context, logger))));
                     Assert.True(interceptor.SyncCalled);
                 }
 
                 Assert.NotEqual(interceptor.AsyncCalled, interceptor.SyncCalled);
                 Assert.True(interceptor.ExecutingCalled);
                 Assert.True(interceptor.ExecutedCalled);
+                Assert.Same(context, interceptor.Context);
 
                 AssertSql(MutatingScalarCommandInterceptor.MutatedSql, interceptor.CommandText);
             }
@@ -525,6 +549,7 @@ namespace Microsoft.EntityFrameworkCore
                     Assert.NotEqual(interceptor.AsyncCalled, interceptor.SyncCalled);
                     Assert.True(interceptor.ExecutingCalled);
                     Assert.True(interceptor.ExecutedCalled);
+                    Assert.Same(context, interceptor.Context);
 
                     AssertSql(MutatingNonQueryCommandInterceptor.MutatedSql, interceptor.CommandText);
                 }
@@ -594,6 +619,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotEqual(interceptor.AsyncCalled, interceptor.SyncCalled);
                 Assert.True(interceptor.ExecutingCalled);
                 Assert.True(interceptor.ExecutedCalled);
+                Assert.Same(context, interceptor.Context);
             }
 
             return interceptor.CommandText;
@@ -656,18 +682,23 @@ namespace Microsoft.EntityFrameworkCore
 
                 if (async)
                 {
-                    Assert.Equal(2, Convert.ToInt32(await command.ExecuteScalarAsync(connection, null, logger)));
+                    Assert.Equal(2, Convert.ToInt32(await command.ExecuteScalarAsync(
+                        new RelationalCommandParameterObject(connection, null, context, logger))));
                     Assert.True(interceptor.AsyncCalled);
                 }
                 else
                 {
-                    Assert.Equal(2, Convert.ToInt32(command.ExecuteScalar(connection, null, logger)));
+                    Assert.Equal(
+                        2, Convert.ToInt32(
+                            command.ExecuteScalar(
+                                new RelationalCommandParameterObject(connection, null, context, logger))));
                     Assert.True(interceptor.SyncCalled);
                 }
 
                 Assert.NotEqual(interceptor.AsyncCalled, interceptor.SyncCalled);
                 Assert.True(interceptor.ExecutingCalled);
                 Assert.True(interceptor.ExecutedCalled);
+                Assert.Same(context, interceptor.Context);
 
                 AssertSql(sql, interceptor.CommandText);
             }
@@ -740,6 +771,7 @@ namespace Microsoft.EntityFrameworkCore
                     Assert.NotEqual(interceptor.AsyncCalled, interceptor.SyncCalled);
                     Assert.True(interceptor.ExecutingCalled);
                     Assert.True(interceptor.ExecutedCalled);
+                    Assert.Same(context, interceptor.Context);
 
                     AssertSql(nonQuery, interceptor.CommandText);
                 }
@@ -824,6 +856,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotEqual(interceptor.AsyncCalled, interceptor.SyncCalled);
                 Assert.True(interceptor.ExecutingCalled);
                 Assert.True(interceptor.ExecutedCalled);
+                Assert.Same(context, interceptor.Context);
             }
 
             return interceptor.CommandText;
@@ -931,7 +964,8 @@ namespace Microsoft.EntityFrameworkCore
                 {
                     Assert.Equal(
                         ResultReplacingScalarCommandInterceptor.InterceptedResult,
-                        await command.ExecuteScalarAsync(connection, null, logger));
+                        await command.ExecuteScalarAsync(
+                            new RelationalCommandParameterObject(connection, null, context, logger)));
 
                     Assert.True(interceptor.AsyncCalled);
                 }
@@ -939,7 +973,8 @@ namespace Microsoft.EntityFrameworkCore
                 {
                     Assert.Equal(
                         ResultReplacingScalarCommandInterceptor.InterceptedResult,
-                        command.ExecuteScalar(connection, null, logger));
+                        command.ExecuteScalar(
+                            new RelationalCommandParameterObject(connection, null, context, logger)));
 
                     Assert.True(interceptor.SyncCalled);
                 }
@@ -947,6 +982,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotEqual(interceptor.AsyncCalled, interceptor.SyncCalled);
                 Assert.True(interceptor.ExecutingCalled);
                 Assert.True(interceptor.ExecutedCalled);
+                Assert.Same(context, interceptor.Context);
 
                 AssertSql(sql, interceptor.CommandText);
             }
@@ -1011,6 +1047,7 @@ namespace Microsoft.EntityFrameworkCore
                     Assert.NotEqual(interceptor.AsyncCalled, interceptor.SyncCalled);
                     Assert.True(interceptor.ExecutingCalled);
                     Assert.True(interceptor.ExecutedCalled);
+                    Assert.Same(context, interceptor.Context);
 
                     AssertSql(nonQuery, interceptor.CommandText);
                 }
@@ -1077,8 +1114,10 @@ namespace Microsoft.EntityFrameworkCore
                 var logger = context.GetService<IDiagnosticsLogger<DbLoggerCategory.Database.Command>>();
 
                 var exception = async
-                    ? await Assert.ThrowsAsync<Exception>(() => command.ExecuteScalarAsync(connection, null, logger))
-                    : Assert.Throws<Exception>(() => command.ExecuteScalar(connection, null, logger));
+                    ? await Assert.ThrowsAsync<Exception>(() => command.ExecuteScalarAsync(
+                        new RelationalCommandParameterObject(connection, null, context, logger)))
+                    : Assert.Throws<Exception>(() => command.ExecuteScalar(
+                        new RelationalCommandParameterObject(connection, null, context, logger)));
 
                 Assert.Equal("Bang!", exception.Message);
             }
@@ -1205,6 +1244,8 @@ namespace Microsoft.EntityFrameworkCore
             Assert.True(interceptor2.ExecutingCalled);
             Assert.True(interceptor1.ExecutedCalled);
             Assert.True(interceptor2.ExecutedCalled);
+            Assert.Same(context, interceptor1.Context);
+            Assert.Same(context, interceptor2.Context);
         }
 
         [ConditionalTheory]
@@ -1229,8 +1270,10 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(
                 ResultReplacingScalarCommandInterceptor.InterceptedResult,
                 async
-                    ? await command.ExecuteScalarAsync(connection, null, logger)
-                    : command.ExecuteScalar(connection, null, logger));
+                    ? await command.ExecuteScalarAsync(
+                        new RelationalCommandParameterObject(connection, null, context, logger))
+                    : command.ExecuteScalar(
+                        new RelationalCommandParameterObject(connection, null, context, logger)));
         }
 
         [ConditionalTheory]
@@ -1436,6 +1479,7 @@ namespace Microsoft.EntityFrameworkCore
                 _commandMethod = commandMethod;
             }
 
+            public DbContext Context { get; set; }
             public string CommandText { get; set; }
             public Guid CommandId { get; set; }
             public Guid ConnectionId { get; set; }
@@ -1596,10 +1640,12 @@ namespace Microsoft.EntityFrameworkCore
 
             protected virtual void AssertExecuting(DbCommand command, CommandEventData eventData)
             {
+                Assert.NotNull(eventData.Context);
                 Assert.NotEqual(default, eventData.CommandId);
                 Assert.NotEqual(default, eventData.ConnectionId);
                 Assert.Equal(_commandMethod, eventData.ExecuteMethod);
 
+                Context = eventData.Context;
                 CommandText = command.CommandText;
                 CommandId = eventData.CommandId;
                 ConnectionId = eventData.ConnectionId;
@@ -1608,6 +1654,7 @@ namespace Microsoft.EntityFrameworkCore
 
             protected virtual void AssertExecuted(DbCommand command, CommandExecutedEventData eventData)
             {
+                Assert.Same(Context, eventData.Context);
                 Assert.Equal(CommandText, command.CommandText);
                 Assert.Equal(CommandId, eventData.CommandId);
                 Assert.Equal(ConnectionId, eventData.ConnectionId);

--- a/test/EFCore.Relational.Specification.Tests/TestUtilities/RelationalDatabaseCleaner.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestUtilities/RelationalDatabaseCleaner.cs
@@ -40,7 +40,6 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             var connection = facade.GetService<IRelationalConnection>();
             var sqlBuilder = facade.GetService<IRawSqlCommandBuilder>();
             var loggerFactory = facade.GetService<ILoggerFactory>();
-            var commandLogger = facade.GetService<IDiagnosticsLogger<DbLoggerCategory.Database.Command>>();
 
             if (!creator.Exists())
             {

--- a/test/EFCore.Relational.Specification.Tests/TestUtilities/RelationalDatabaseCleaner.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestUtilities/RelationalDatabaseCleaner.cs
@@ -84,7 +84,9 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                     var customSql = BuildCustomSql(databaseModel);
                     if (!string.IsNullOrWhiteSpace(customSql))
                     {
-                        sqlBuilder.Build(customSql).ExecuteNonQuery(connection, null, null);
+                        sqlBuilder.Build(customSql).ExecuteNonQuery(
+                            new RelationalCommandParameterObject(
+                                connection,null, null,null));
                     }
 
                     if (operations.Count > 0)
@@ -96,7 +98,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                     customSql = BuildCustomEndingSql(databaseModel);
                     if (!string.IsNullOrWhiteSpace(customSql))
                     {
-                        sqlBuilder.Build(customSql).ExecuteNonQuery(connection, null, null);
+                        sqlBuilder.Build(customSql).ExecuteNonQuery(
+                            new RelationalCommandParameterObject(connection, null, null, null));
                     }
                 }
                 finally

--- a/test/EFCore.Relational.Tests/Migrations/MigrationCommandExecutorTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/MigrationCommandExecutorTest.cs
@@ -25,8 +25,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
             var commandList = new List<MigrationCommand>
             {
-                new MigrationCommand(CreateRelationalCommand(), logger),
-                new MigrationCommand(CreateRelationalCommand(), logger)
+                new MigrationCommand(CreateRelationalCommand(), null, logger),
+                new MigrationCommand(CreateRelationalCommand(), null, logger)
             };
 
             var migrationCommandExecutor = new MigrationCommandExecutor();
@@ -67,8 +67,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
             var commandList = new List<MigrationCommand>
             {
-                new MigrationCommand(CreateRelationalCommand(), logger, transactionSuppressed: true),
-                new MigrationCommand(CreateRelationalCommand(), logger, transactionSuppressed: true)
+                new MigrationCommand(CreateRelationalCommand(), null, logger, transactionSuppressed: true),
+                new MigrationCommand(CreateRelationalCommand(), null, logger, transactionSuppressed: true)
             };
 
             var migrationCommandExecutor = new MigrationCommandExecutor();
@@ -103,8 +103,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
             var commandList = new List<MigrationCommand>
             {
-                new MigrationCommand(CreateRelationalCommand(), logger),
-                new MigrationCommand(CreateRelationalCommand(), logger, transactionSuppressed: true)
+                new MigrationCommand(CreateRelationalCommand(), null, logger),
+                new MigrationCommand(CreateRelationalCommand(), null, logger, transactionSuppressed: true)
             };
 
             var migrationCommandExecutor = new MigrationCommandExecutor();
@@ -144,8 +144,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
             var commandList = new List<MigrationCommand>
             {
-                new MigrationCommand(CreateRelationalCommand(), logger, transactionSuppressed: true),
-                new MigrationCommand(CreateRelationalCommand(), logger)
+                new MigrationCommand(CreateRelationalCommand(), null, logger, transactionSuppressed: true),
+                new MigrationCommand(CreateRelationalCommand(), null, logger)
             };
 
             var migrationCommandExecutor = new MigrationCommandExecutor();
@@ -185,9 +185,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
             var commandList = new List<MigrationCommand>
             {
-                new MigrationCommand(CreateRelationalCommand(commandText: "First"), logger),
-                new MigrationCommand(CreateRelationalCommand(commandText: "Second"), logger, transactionSuppressed: true),
-                new MigrationCommand(CreateRelationalCommand(commandText: "Third"), logger)
+                new MigrationCommand(CreateRelationalCommand(commandText: "First"), null, logger),
+                new MigrationCommand(CreateRelationalCommand(commandText: "Second"), null, logger, transactionSuppressed: true),
+                new MigrationCommand(CreateRelationalCommand(commandText: "Third"), null, logger)
             };
 
             var migrationCommandExecutor = new MigrationCommandExecutor();
@@ -260,7 +260,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
             var commandList = new List<MigrationCommand>
             {
-                new MigrationCommand(CreateRelationalCommand(), logger)
+                new MigrationCommand(CreateRelationalCommand(), null, logger)
             };
 
             var migrationCommandExecutor = new MigrationCommandExecutor();

--- a/test/EFCore.Relational.Tests/Migrations/MigrationCommandListBuilderTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/MigrationCommandListBuilderTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider;
@@ -136,7 +137,12 @@ Statement3
                             typeMappingSource)),
                     generationHelper,
                     typeMappingSource,
+                    new CurrentDbContext(new FakeDbContext()),
                     logger));
+        }
+
+        private class FakeDbContext : DbContext
+        {
         }
     }
 }

--- a/test/EFCore.Relational.Tests/RelationalEventIdTest.cs
+++ b/test/EFCore.Relational.Tests/RelationalEventIdTest.cs
@@ -73,7 +73,8 @@ namespace Microsoft.EntityFrameworkCore
                 { typeof(IProperty), () => property },
                 { typeof(TypeInfo), () => typeof(object).GetTypeInfo() },
                 { typeof(Type), () => typeof(object) },
-                { typeof(ValueConverter), () => new BoolToZeroOneConverter<int>() }
+                { typeof(ValueConverter), () => new BoolToZeroOneConverter<int>() },
+                { typeof(DbContext), () => new FakeDbContext() }
             };
 
             TestEventLogging(
@@ -106,6 +107,10 @@ namespace Microsoft.EntityFrameworkCore
                         }
                     }
                 });
+        }
+
+        private class FakeDbContext : DbContext
+        {
         }
 
         private class FakeMigration : Migration

--- a/test/EFCore.Relational.Tests/Storage/RelationalCommandTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalCommandTest.cs
@@ -43,7 +43,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
             var fakeConnection = CreateConnection();
             var relationalCommand = CreateRelationalCommand(commandText: "CommandText");
 
-            relationalCommand.ExecuteNonQuery(fakeConnection, null, null);
+            relationalCommand.ExecuteNonQuery(
+                new RelationalCommandParameterObject(fakeConnection, null, null, null));
 
             Assert.Equal(1, fakeConnection.DbConnections.Count);
             Assert.Equal(1, fakeConnection.DbConnections[0].DbCommands.Count);
@@ -64,7 +65,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
             var relationalCommand = CreateRelationalCommand();
 
-            relationalCommand.ExecuteNonQuery(fakeConnection, null, null);
+            relationalCommand.ExecuteNonQuery(
+                new RelationalCommandParameterObject(fakeConnection, null, null, null));
 
             Assert.Equal(1, fakeConnection.DbConnections.Count);
             Assert.Equal(1, fakeConnection.DbConnections[0].DbCommands.Count);
@@ -85,7 +87,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
             var relationalCommand = CreateRelationalCommand();
 
-            relationalCommand.ExecuteNonQuery(fakeConnection, null, null);
+            relationalCommand.ExecuteNonQuery(
+                new RelationalCommandParameterObject(fakeConnection, null, null, null));
 
             Assert.Equal(1, fakeConnection.DbConnections.Count);
             Assert.Equal(1, fakeConnection.DbConnections[0].DbCommands.Count);
@@ -118,7 +121,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
             var relationalCommand = CreateRelationalCommand();
 
             var result = relationalCommand.ExecuteNonQuery(
-                new FakeRelationalConnection(options), null, null);
+                new RelationalCommandParameterObject(
+                    new FakeRelationalConnection(options), null, null, null));
 
             Assert.Equal(1, result);
 
@@ -157,7 +161,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
             var relationalCommand = CreateRelationalCommand();
 
             var result = await relationalCommand.ExecuteNonQueryAsync(
-                new FakeRelationalConnection(options), null, null);
+                new RelationalCommandParameterObject(
+                    new FakeRelationalConnection(options), null, null, null));
 
             Assert.Equal(1, result);
 
@@ -196,7 +201,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
             var relationalCommand = CreateRelationalCommand();
 
             var result = (string)relationalCommand.ExecuteScalar(
-                new FakeRelationalConnection(options), null, null);
+                new RelationalCommandParameterObject(
+                    new FakeRelationalConnection(options), null, null, null));
 
             Assert.Equal("ExecuteScalar Result", result);
 
@@ -235,7 +241,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
             var relationalCommand = CreateRelationalCommand();
 
             var result = (string)await relationalCommand.ExecuteScalarAsync(
-                new FakeRelationalConnection(options), null, null);
+                new RelationalCommandParameterObject(
+                    new FakeRelationalConnection(options), null, null, null));
 
             Assert.Equal("ExecuteScalar Result", result);
 
@@ -276,7 +283,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
             var relationalCommand = CreateRelationalCommand();
 
             var result = relationalCommand.ExecuteReader(
-                new FakeRelationalConnection(options), null, null);
+                new RelationalCommandParameterObject(
+                    new FakeRelationalConnection(options), null, null, null));
 
             Assert.Same(dbDataReader, result.DbDataReader);
             Assert.Equal(0, fakeDbConnection.CloseCount);
@@ -324,7 +332,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
             var relationalCommand = CreateRelationalCommand();
 
             var result = await relationalCommand.ExecuteReaderAsync(
-                new FakeRelationalConnection(options), null, null);
+                new RelationalCommandParameterObject(
+                    new FakeRelationalConnection(options), null, null, null));
 
             Assert.Same(dbDataReader, result.DbDataReader);
             Assert.Equal(0, fakeDbConnection.CloseCount);
@@ -353,42 +362,48 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 {
                     new CommandAction(
                         (connection, command, parameterValues, logger)
-                            => command.ExecuteNonQuery(connection, parameterValues, logger)),
+                            => command.ExecuteNonQuery(
+                                new RelationalCommandParameterObject(connection, parameterValues, null, logger))),
                     DbCommandMethod.ExecuteNonQuery,
                     false
                 },
                 {
                     new CommandAction(
                         (connection, command, parameterValues, logger)
-                            => command.ExecuteScalar(connection, parameterValues, logger)),
+                            => command.ExecuteScalar(
+                                new RelationalCommandParameterObject(connection, parameterValues, null, logger))),
                     DbCommandMethod.ExecuteScalar,
                     false
                 },
                 {
                     new CommandAction(
                         (connection, command, parameterValues, logger)
-                            => command.ExecuteReader(connection, parameterValues, logger)),
+                            => command.ExecuteReader(
+                                new RelationalCommandParameterObject(connection, parameterValues, null, logger))),
                     DbCommandMethod.ExecuteReader,
                     false
                 },
                 {
                     new CommandFunc(
                         (connection, command, parameterValues, logger)
-                            => command.ExecuteNonQueryAsync(connection, parameterValues, logger)),
+                            => command.ExecuteNonQueryAsync(
+                                new RelationalCommandParameterObject(connection, parameterValues, null, logger))),
                     DbCommandMethod.ExecuteNonQuery,
                     true
                 },
                 {
                     new CommandFunc(
                         (connection, command, parameterValues, logger)
-                            => command.ExecuteScalarAsync(connection, parameterValues, logger)),
+                            => command.ExecuteScalarAsync(
+                                new RelationalCommandParameterObject(connection, parameterValues, null, logger))),
                     DbCommandMethod.ExecuteScalar,
                     true
                 },
                 {
                     new CommandFunc(
                         (connection, command, parameterValues, logger)
-                            => command.ExecuteReaderAsync(connection, parameterValues, logger)),
+                            => command.ExecuteReaderAsync(
+                                new RelationalCommandParameterObject(connection, parameterValues, null, logger))),
                     DbCommandMethod.ExecuteReader,
                     true
                 }

--- a/test/EFCore.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
+++ b/test/EFCore.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
@@ -588,6 +588,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                         new RelationalValueBufferFactoryDependencies(
                             typeMappingSource,
                             new CoreSingletonOptions())),
+                    new CurrentDbContext(new FakeDbContext()),
                     logger);
             }
 
@@ -611,6 +612,10 @@ namespace Microsoft.EntityFrameworkCore.Update
 
             public RawSqlCommand CreateStoreCommandBase()
                 => CreateStoreCommand();
+        }
+
+        private class FakeDbContext : DbContext
+        {
         }
 
         private const string ConnectionString = "Fake Connection String";

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestRelationalCommandBuilderFactory.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestRelationalCommandBuilderFactory.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 
@@ -81,7 +80,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 return this;
             }
-            
+
             public int CommandTextLength => Instance.Length;
         }
 
@@ -101,14 +100,12 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
             public IReadOnlyList<IRelationalParameter> Parameters => _realRelationalCommand.Parameters;
 
-            public int ExecuteNonQuery(
-                IRelationalConnection connection,
-                IReadOnlyDictionary<string, object> parameterValues,
-                IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger)
+            public int ExecuteNonQuery(RelationalCommandParameterObject parameterObject)
             {
+                var connection = parameterObject.Connection;
                 var errorNumber = PreExecution(connection);
 
-                var result = _realRelationalCommand.ExecuteNonQuery(connection, parameterValues, logger);
+                var result = _realRelationalCommand.ExecuteNonQuery(parameterObject);
                 if (errorNumber.HasValue)
                 {
                     connection.DbConnection.Close();
@@ -119,13 +116,13 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             }
 
             public Task<int> ExecuteNonQueryAsync(
-                IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues,
-                IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
+                RelationalCommandParameterObject parameterObject,
                 CancellationToken cancellationToken = new CancellationToken())
             {
+                var connection = parameterObject.Connection;
                 var errorNumber = PreExecution(connection);
 
-                var result = _realRelationalCommand.ExecuteNonQueryAsync(connection, parameterValues, logger, cancellationToken);
+                var result = _realRelationalCommand.ExecuteNonQueryAsync(parameterObject, cancellationToken);
                 if (errorNumber.HasValue)
                 {
                     connection.DbConnection.Close();
@@ -135,14 +132,12 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 return result;
             }
 
-            public object ExecuteScalar(
-                IRelationalConnection connection,
-                IReadOnlyDictionary<string, object> parameterValues,
-                IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger)
+            public object ExecuteScalar(RelationalCommandParameterObject parameterObject)
             {
+                var connection = parameterObject.Connection;
                 var errorNumber = PreExecution(connection);
 
-                var result = _realRelationalCommand.ExecuteScalar(connection, parameterValues, logger);
+                var result = _realRelationalCommand.ExecuteScalar(parameterObject);
                 if (errorNumber.HasValue)
                 {
                     connection.DbConnection.Close();
@@ -153,13 +148,13 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             }
 
             public async Task<object> ExecuteScalarAsync(
-                IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues,
-                IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
+                RelationalCommandParameterObject parameterObject,
                 CancellationToken cancellationToken = new CancellationToken())
             {
+                var connection = parameterObject.Connection;
                 var errorNumber = PreExecution(connection);
 
-                var result = await _realRelationalCommand.ExecuteScalarAsync(connection, parameterValues, logger, cancellationToken);
+                var result = await _realRelationalCommand.ExecuteScalarAsync(parameterObject, cancellationToken);
                 if (errorNumber.HasValue)
                 {
                     connection.DbConnection.Close();
@@ -169,14 +164,12 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 return result;
             }
 
-            public RelationalDataReader ExecuteReader(
-                IRelationalConnection connection,
-                IReadOnlyDictionary<string, object> parameterValues,
-                IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger)
+            public RelationalDataReader ExecuteReader(RelationalCommandParameterObject parameterObject)
             {
+                var connection = parameterObject.Connection;
                 var errorNumber = PreExecution(connection);
 
-                var result = _realRelationalCommand.ExecuteReader(connection, parameterValues, logger);
+                var result = _realRelationalCommand.ExecuteReader(parameterObject);
                 if (errorNumber.HasValue)
                 {
                     connection.DbConnection.Close();
@@ -188,13 +181,13 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             }
 
             public async Task<RelationalDataReader> ExecuteReaderAsync(
-                IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues,
-                IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
+                RelationalCommandParameterObject parameterObject,
                 CancellationToken cancellationToken = new CancellationToken())
             {
+                var connection = parameterObject.Connection;
                 var errorNumber = PreExecution(connection);
 
-                var result = await _realRelationalCommand.ExecuteReaderAsync(connection, parameterValues, logger, cancellationToken);
+                var result = await _realRelationalCommand.ExecuteReaderAsync(parameterObject, cancellationToken);
                 if (errorNumber.HasValue)
                 {
                     connection.DbConnection.Close();

--- a/test/EFCore.SqlServer.Tests/SqlServerDatabaseCreatorTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerDatabaseCreatorTest.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
@@ -261,47 +260,35 @@ namespace Microsoft.EntityFrameworkCore
 
             public IReadOnlyDictionary<string, object> ParameterValues => throw new NotImplementedException();
 
-            public int ExecuteNonQuery(
-                IRelationalConnection connection,
-                IReadOnlyDictionary<string, object> parameterValues,
-                IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger)
+            public int ExecuteNonQuery(RelationalCommandParameterObject parameterObject)
             {
                 return 0;
             }
 
             public Task<int> ExecuteNonQueryAsync(
-                IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues,
-                IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
+                RelationalCommandParameterObject parameterObject,
                 CancellationToken cancellationToken = default)
                 => Task.FromResult(0);
 
-            public RelationalDataReader ExecuteReader(
-                IRelationalConnection connection,
-                IReadOnlyDictionary<string, object> parameterValues,
-                IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger)
+            public RelationalDataReader ExecuteReader(RelationalCommandParameterObject parameterObject)
             {
                 throw new NotImplementedException();
             }
 
             public Task<RelationalDataReader> ExecuteReaderAsync(
-                IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues,
-                IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
+                RelationalCommandParameterObject parameterObject,
                 CancellationToken cancellationToken = default)
             {
                 throw new NotImplementedException();
             }
 
-            public object ExecuteScalar(
-                IRelationalConnection connection,
-                IReadOnlyDictionary<string, object> parameterValues,
-                IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger)
+            public object ExecuteScalar(RelationalCommandParameterObject parameterObject)
             {
                 throw new NotImplementedException();
             }
 
             public Task<object> ExecuteScalarAsync(
-                IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues,
-                IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
+                RelationalCommandParameterObject parameterObject,
                 CancellationToken cancellationToken = default)
             {
                 throw new NotImplementedException();

--- a/test/EFCore.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
@@ -7,7 +7,6 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
@@ -236,48 +235,33 @@ namespace Microsoft.EntityFrameworkCore
 
                 public IReadOnlyDictionary<string, object> ParameterValues => throw new NotImplementedException();
 
-                public int ExecuteNonQuery(
-                    IRelationalConnection connection,
-                    IReadOnlyDictionary<string, object> parameterValues,
-                    IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger)
+                public int ExecuteNonQuery(RelationalCommandParameterObject parameterObject)
                 {
                     throw new NotImplementedException();
                 }
 
                 public Task<int> ExecuteNonQueryAsync(
-                    IRelationalConnection connection,
-                    IReadOnlyDictionary<string, object> parameterValues,
-                    IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
+                    RelationalCommandParameterObject parameterObject,
                     CancellationToken cancellationToken = default)
                 {
                     throw new NotImplementedException();
                 }
 
-                public object ExecuteScalar(
-                    IRelationalConnection connection,
-                    IReadOnlyDictionary<string, object> parameterValues,
-                    IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger)
+                public object ExecuteScalar(RelationalCommandParameterObject parameterObject)
                     => Interlocked.Add(ref _commandBuilder._current, _commandBuilder._blockSize);
 
                 public Task<object> ExecuteScalarAsync(
-                    IRelationalConnection connection,
-                    IReadOnlyDictionary<string, object> parameterValues,
-                    IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
+                    RelationalCommandParameterObject parameterObject,
                     CancellationToken cancellationToken = default)
                     => Task.FromResult<object>(Interlocked.Add(ref _commandBuilder._current, _commandBuilder._blockSize));
 
-                public RelationalDataReader ExecuteReader(
-                    IRelationalConnection connection,
-                    IReadOnlyDictionary<string, object> parameterValues,
-                    IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger)
+                public RelationalDataReader ExecuteReader(RelationalCommandParameterObject parameterObject)
                 {
                     throw new NotImplementedException();
                 }
 
                 public Task<RelationalDataReader> ExecuteReaderAsync(
-                    IRelationalConnection connection,
-                    IReadOnlyDictionary<string, object> parameterValues,
-                    IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
+                    RelationalCommandParameterObject parameterObject,
                     CancellationToken cancellationToken = default)
                 {
                     throw new NotImplementedException();

--- a/test/EFCore.SqlServer.Tests/Update/SqlServerModificationCommandBatchFactoryTest.cs
+++ b/test/EFCore.SqlServer.Tests/Update/SqlServerModificationCommandBatchFactoryTest.cs
@@ -40,6 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                     new TypedRelationalValueBufferFactoryFactory(
                         new RelationalValueBufferFactoryDependencies(
                             typeMapper, new CoreSingletonOptions())),
+                    new CurrentDbContext(new FakeDbContext()),
                     logger),
                 optionsBuilder.Options);
 
@@ -76,6 +77,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                     new TypedRelationalValueBufferFactoryFactory(
                         new RelationalValueBufferFactoryDependencies(
                             typeMapper, new CoreSingletonOptions())),
+                    new CurrentDbContext(new FakeDbContext()),
                     logger),
                 optionsBuilder.Options);
 
@@ -83,6 +85,10 @@ namespace Microsoft.EntityFrameworkCore.Update
 
             Assert.True(batch.AddCommand(new ModificationCommand("T1", null, new ParameterNameGenerator().GenerateNext, false, null)));
             Assert.True(batch.AddCommand(new ModificationCommand("T1", null, new ParameterNameGenerator().GenerateNext, false, null)));
+        }
+
+        private class FakeDbContext : DbContext
+        {
         }
     }
 }

--- a/test/EFCore.SqlServer.Tests/Update/SqlServerModificationCommandBatchTest.cs
+++ b/test/EFCore.SqlServer.Tests/Update/SqlServerModificationCommandBatchTest.cs
@@ -37,6 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                     new TypedRelationalValueBufferFactoryFactory(
                         new RelationalValueBufferFactoryDependencies(
                             typeMapper, new CoreSingletonOptions())),
+                    new CurrentDbContext(new FakeDbContext()),
                     logger),
                 1);
 
@@ -46,6 +47,10 @@ namespace Microsoft.EntityFrameworkCore.Update
             Assert.False(
                 batch.AddCommand(
                     new ModificationCommand("T1", null, new ParameterNameGenerator().GenerateNext, false, null)));
+        }
+
+        private class FakeDbContext : DbContext
+        {
         }
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/BadDataSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/BadDataSqliteTest.cs
@@ -184,14 +184,14 @@ namespace Microsoft.EntityFrameworkCore.Query
                         _values = values;
                     }
 
-                    public override RelationalDataReader ExecuteReader(
-                        IRelationalConnection connection,
-                        IReadOnlyDictionary<string, object> parameterValues,
-                        IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger)
+                    public override RelationalDataReader ExecuteReader(RelationalCommandParameterObject parameterObject)
                     {
-                        var command = connection.DbConnection.CreateCommand();
+                        var command = parameterObject.Connection.DbConnection.CreateCommand();
                         command.CommandText = CommandText;
-                        return new BadDataRelationalDataReader(command, _values, logger);
+                        return new BadDataRelationalDataReader(
+                            command,
+                            _values,
+                            parameterObject.Logger);
                     }
 
                     private class BadDataRelationalDataReader : RelationalDataReader


### PR DESCRIPTION
Fixes #16159

Also introduced a parameter object for the `RelationalCommand` execution methods. This will make it easier to pass new things here without making a breaking change.

Did a little refactoring to simplify the code in `RelationalCommand` and avoid a couple of places where we were allocating.
