### PR TITLE
Repair and disable failing benchmarks

### DIFF
--- a/benchmark/Shared.EFCore/Query/RawSqlQueryTests.cs
+++ b/benchmark/Shared.EFCore/Query/RawSqlQueryTests.cs
@@ -95,7 +95,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Query
             var query = _context.Products
                 .FromSqlRaw(@"SELECT * FROM ""Products""")
                 .ApplyTracking(Tracking)
-                .Where(p => p.CurrentPrice >= 10 && p.CurrentPrice <= 14)
+                .Where(p => p.ActualStockLevel >= 2 && p.ActualStockLevel <= 6)
                 .OrderBy(p => p.Name);
 
             if (Async)

--- a/benchmark/Shared.EFCore/Query/SimpleQueryTests.cs
+++ b/benchmark/Shared.EFCore/Query/SimpleQueryTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Query
         {
             var query = _context.Products
                 .ApplyTracking(Tracking)
-                .Where(p => p.Retail < 15);
+                .Where(p => p.ActualStockLevel < 5);
 
             if (Async)
             {
@@ -82,7 +82,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Query
         {
             var query = _context.Products
                 .ApplyTracking(Tracking)
-                .OrderBy(p => p.Retail);
+                .OrderBy(p => p.ActualStockLevel);
 
             if (Async)
             {
@@ -128,15 +128,16 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Query
             }
         }
 
-        [Benchmark]
+        // Disabled because of current state of query pipeline
+        // [Benchmark]
         public virtual async Task GroupBy()
         {
             var query = _context.Products
-                .GroupBy(p => p.Retail)
+                .GroupBy(p => p.ActualStockLevel)
                 .Select(
                     g => new
                     {
-                        Retail = g.Key,
+                        ActualStockLevel = g.Key,
                         Products = g
                     });
 


### PR DESCRIPTION
Our current query pipeline makes some benchmarks fail. Unfortunately the ASP.NET perf lab currently ignores the entire benchmark suite if any benchmark fails, so disabled those benchmarks for now. This should allow us to start tracking some basic query scenarios.

Also modified benchmarks to access int rather decimal (the latter is limited on Sqlite).

We may want to add some more benchmarks - will look into this at some point (but if someone has ideas...).

FYI to manually run benchmarks on the console, just go into benchmark/EFCore.Sqlite.Benchmarks and do `dotnet run -c Release -f netcoreapp3.0 -- --inProcess`. You can add `--filter` to invoke a specific suite or method.