### PR TITLE
Fix to #16076 - Query: Nav rewrite type mismatch

### DIFF
--- a/test/EFCore.Specification.Tests/Query/AsyncSimpleQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AsyncSimpleQueryTestBase.cs
@@ -78,7 +78,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15043")]
+        [ConditionalFact(Skip = "issue #15611")]
         public virtual async Task ToArray_on_nav_subquery_in_projection()
         {
             using (var context = CreateContext())


### PR DESCRIPTION
Problem was that when rewriting collection navigations into IQueryable, if the collection is composed on, we would always removing MaterializeCollectionNavigation. However, if the method was an instance method, e.g. List<T>.ToArray, we should preserve the original collection type, so that the method call is still possible to make.
Fix is to look at the declaring type of instance method, and only strip MaterializeCollectionNavigation if the instance type is IQueryable.