### PR TITLE
Query: Convert SubSelectExpression to search condition as necessary

### DIFF
--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -7504,6 +7504,15 @@ namespace Microsoft.EntityFrameworkCore.Query
                 gs => gs.Select(g => new { Gear = g }).Take(25).Select(e => e.Gear.Weapons.OrderBy(w => w.Id).FirstOrDefault()));
         }
 
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Bool_projection_from_subquery_treated_appropriately_in_where(bool isAsync)
+        {
+            return AssertQuery<City, Gear>(
+                isAsync,
+                (cs, gs) => cs.Where(c => gs.OrderBy(g => g.Nickname).ThenBy(g => g.SquadId).FirstOrDefault().HasSoulPatch));
+        }
+
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext();
 
         protected virtual void ClearLog()

--- a/test/EFCore.Specification.Tests/TestUtilities/TestHelpers.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/TestHelpers.cs
@@ -300,8 +300,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 }
             }
 
-            elementSorter = elementSorter ?? (e => e);
-            elementAsserter = elementAsserter ?? Assert.Equal;
+            elementSorter ??= (e => e);
+            elementAsserter ??= Assert.Equal;
             if (!verifyOrdered)
             {
                 expected = expected.OrderBy(elementSorter).ToList();
@@ -340,7 +340,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 }
             }
 
-            elementAsserter = elementAsserter ?? Assert.Equal;
+            elementAsserter ??= Assert.Equal;
             if (!verifyOrdered)
             {
                 expected = expected.OrderBy(elementSorter).ToList();
@@ -380,7 +380,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 }
             }
 
-            elementAsserter = elementAsserter ?? Assert.Equal;
+            elementAsserter ??= Assert.Equal;
             if (!verifyOrdered)
             {
                 expected = expected.OrderBy(elementSorter).ToList();

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -8565,6 +8565,20 @@ ORDER BY (
                 @"");
         }
 
+        public override async Task Bool_projection_from_subquery_treated_appropriately_in_where(bool isAsync)
+        {
+            await base.Bool_projection_from_subquery_treated_appropriately_in_where(isAsync);
+
+            AssertSql(
+                @"SELECT [c].[Name], [c].[Location], [c].[Nation]
+FROM [Cities] AS [c]
+WHERE (
+    SELECT TOP(1) [g].[HasSoulPatch]
+    FROM [Gears] AS [g]
+    WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
+    ORDER BY [g].[Nickname], [g].[SquadId]) = CAST(1 AS bit)");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Fix for #14900
