### PR TITLE
[TINY] Fix to #16245 - Null semantics applies incorrectly for SqlFunction

### DIFF
--- a/src/EFCore.Relational/Query/Pipeline/NullSemanticsRewritingVisitor.cs
+++ b/src/EFCore.Relational/Query/Pipeline/NullSemanticsRewritingVisitor.cs
@@ -171,6 +171,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
 
         private SqlFunctionExpression VisitSqlFunctionExpression(SqlFunctionExpression sqlFunctionExpression)
         {
+            _isNullable = false;
             var newInstance = (SqlExpression)Visit(sqlFunctionExpression.Instance);
             var isNullable = _isNullable;
             var newArguments = new SqlExpression[sqlFunctionExpression.Arguments.Count];

--- a/src/EFCore.Relational/Query/Pipeline/NullSemanticsRewritingVisitor.cs
+++ b/src/EFCore.Relational/Query/Pipeline/NullSemanticsRewritingVisitor.cs
@@ -89,9 +89,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
 
         private SqlUnaryExpression VisitSqlUnaryExpression(SqlUnaryExpression sqlUnaryExpression)
         {
+            _isNullable = false;
             var newOperand = (SqlExpression)Visit(sqlUnaryExpression.Operand);
 
-            // IsNull/IsNotNull 
+            // IsNull/IsNotNull
             if (sqlUnaryExpression.OperatorType == ExpressionType.Equal
                 || sqlUnaryExpression.OperatorType == ExpressionType.NotEqual)
             {
@@ -103,6 +104,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
 
         private LikeExpression VisitLikeExpression(LikeExpression likeExpression)
         {
+            _isNullable = false;
             var newMatch = (SqlExpression)Visit(likeExpression.Match);
             var isNullable = _isNullable;
             var newPattern = (SqlExpression)Visit(likeExpression.Pattern);
@@ -149,6 +151,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
 
         private CaseExpression VisitCaseExpression(CaseExpression caseExpression)
         {
+            _isNullable = false;
             // if there is no 'else' there is a possibility of null, when none of the conditions are met
             // otherwise the result is nullable if any of the WhenClause results OR ElseResult is nullable
             var isNullable = caseExpression.ElseResult == null;
@@ -188,9 +191,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
 
         private SqlBinaryExpression VisitSqlBinaryExpression(SqlBinaryExpression sqlBinaryExpression)
         {
+            _isNullable = false;
             var newLeft = (SqlExpression)Visit(sqlBinaryExpression.Left);
             var leftNullable = _isNullable;
 
+            _isNullable = false;
             var newRight = (SqlExpression)Visit(sqlBinaryExpression.Right);
             var rightNullable = _isNullable;
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Functions.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Functions.cs
@@ -843,7 +843,7 @@ WHERE NEWID() <> '00000000-0000-0000-0000-000000000000'");
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (UPPER([c].[CustomerID]) = N'ALFKI') AND UPPER([c].[CustomerID]) IS NOT NULL");
+WHERE UPPER([c].[CustomerID]) = N'ALFKI'");
         }
 
         public override async Task Where_string_to_lower(bool isAsync)
@@ -853,7 +853,7 @@ WHERE (UPPER([c].[CustomerID]) = N'ALFKI') AND UPPER([c].[CustomerID]) IS NOT NU
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (LOWER([c].[CustomerID]) = N'alfki') AND LOWER([c].[CustomerID]) IS NOT NULL");
+WHERE LOWER([c].[CustomerID]) = N'alfki'");
         }
 
         public override async Task Where_functions_nested(bool isAsync)
@@ -863,7 +863,7 @@ WHERE (LOWER([c].[CustomerID]) = N'alfki') AND LOWER([c].[CustomerID]) IS NOT NU
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (POWER(CAST(CAST(LEN([c].[CustomerID]) AS int) AS float), 2.0E0) = 25.0E0) AND POWER(CAST(CAST(LEN([c].[CustomerID]) AS int) AS float), 2.0E0) IS NOT NULL");
+WHERE POWER(CAST(CAST(LEN([c].[CustomerID]) AS int) AS float), 2.0E0) = 25.0E0");
         }
 
         public override async Task Convert_ToByte(bool isAsync)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Where.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Where.cs
@@ -812,7 +812,7 @@ WHERE (SUBSTRING([c].[City], 1 + 1, 2) = N'ea') AND SUBSTRING([c].[City], 1 + 1,
             AssertSql(
                 @"SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE ((CONVERT(date, GETDATE()) = CONVERT(date, GETDATE())) AND (CONVERT(date, GETDATE()) IS NOT NULL AND CONVERT(date, GETDATE()) IS NOT NULL)) OR (CONVERT(date, GETDATE()) IS NULL AND CONVERT(date, GETDATE()) IS NULL)");
+WHERE CONVERT(date, GETDATE()) = CONVERT(date, GETDATE())");
         }
 
         public override async Task Where_datetime_date_component(bool isAsync)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -1153,7 +1153,7 @@ WHERE [c].[CustomerID] = N'ALFKI'");
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (CAST(LEN([c].[CustomerID]) AS int) = 5) AND CAST(LEN([c].[CustomerID]) AS int) IS NOT NULL");
+WHERE CAST(LEN([c].[CustomerID]) AS int) = 5");
         }
 
         public override async Task Queryable_simple(bool isAsync)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
@@ -204,7 +204,7 @@ LIMIT -1 OFFSET @__p_1");
 
 SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
 FROM ""Customers"" AS ""c""
-WHERE ((rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now', 'localtime'), '0'), '.') <> @__myDatetime_0) OR (rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now', 'localtime'), '0'), '.') IS NULL OR @__myDatetime_0 IS NULL)) AND (rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now', 'localtime'), '0'), '.') IS NOT NULL OR @__myDatetime_0 IS NOT NULL)");
+WHERE (rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now', 'localtime'), '0'), '.') <> @__myDatetime_0) OR @__myDatetime_0 IS NULL");
         }
 
         public override async Task Where_datetime_utcnow(bool isAsync)
@@ -216,7 +216,7 @@ WHERE ((rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now', 'localtime'), '0'), '.'
 
 SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
 FROM ""Customers"" AS ""c""
-WHERE ((rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now'), '0'), '.') <> @__myDatetime_0) OR (rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now'), '0'), '.') IS NULL OR @__myDatetime_0 IS NULL)) AND (rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now'), '0'), '.') IS NOT NULL OR @__myDatetime_0 IS NOT NULL)");
+WHERE (rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now'), '0'), '.') <> @__myDatetime_0) OR @__myDatetime_0 IS NULL");
         }
 
         public override async Task Where_datetime_today(bool isAsync)
@@ -226,7 +226,7 @@ WHERE ((rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now'), '0'), '.') <> @__myDat
             AssertSql(
                 @"SELECT ""e"".""EmployeeID"", ""e"".""City"", ""e"".""Country"", ""e"".""FirstName"", ""e"".""ReportsTo"", ""e"".""Title""
 FROM ""Employees"" AS ""e""
-WHERE ((rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now', 'localtime', 'start of day'), '0'), '.') = rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now', 'localtime', 'start of day'), '0'), '.')) AND (rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now', 'localtime', 'start of day'), '0'), '.') IS NOT NULL AND rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now', 'localtime', 'start of day'), '0'), '.') IS NOT NULL)) OR (rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now', 'localtime', 'start of day'), '0'), '.') IS NULL AND rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now', 'localtime', 'start of day'), '0'), '.') IS NULL)");
+WHERE rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now', 'localtime', 'start of day'), '0'), '.') = rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now', 'localtime', 'start of day'), '0'), '.')");
         }
 
         public override async Task Where_datetime_date_component(bool isAsync)
@@ -631,7 +631,7 @@ WHERE (""o"".""OrderID"" = 11077) AND (max(""o"".""OrderID"", ""o"".""ProductID"
             AssertSql(
                 @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
 FROM ""Customers"" AS ""c""
-WHERE (lower(""c"".""CustomerID"") = 'alfki') AND lower(""c"".""CustomerID"") IS NOT NULL");
+WHERE lower(""c"".""CustomerID"") = 'alfki'");
         }
 
         public override async Task Where_string_to_upper(bool isAsync)
@@ -641,7 +641,7 @@ WHERE (lower(""c"".""CustomerID"") = 'alfki') AND lower(""c"".""CustomerID"") IS
             AssertSql(
                 @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
 FROM ""Customers"" AS ""c""
-WHERE (upper(""c"".""CustomerID"") = 'ALFKI') AND upper(""c"".""CustomerID"") IS NOT NULL");
+WHERE upper(""c"".""CustomerID"") = 'ALFKI'");
         }
 
         public override async Task TrimStart_without_arguments_in_predicate(bool isAsync)


### PR DESCRIPTION
problem was that when we were computing a nullability of sql function, if the function didn't have instance, we would inherit nullability from the expression that was visited previously.
Fix is to only use nullability of instance expression if that expression is not null.