### PR TITLE
Add Add correlation ID for `DbContext`…

### DIFF
--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -66,6 +66,9 @@ namespace Microsoft.EntityFrameworkCore
         private bool _initializing;
         private bool _disposed;
 
+        private readonly Guid _contextId = Guid.NewGuid();
+        private int _lease;
+
         /// <summary>
         ///     <para>
         ///         Initializes a new instance of the <see cref="DbContext" /> class. The
@@ -138,6 +141,18 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         /// <summary>
+        ///     <para>
+        ///         A unique identifier for the context instance and pool lease, if any.
+        ///     </para>
+        ///     <para>
+        ///         This identifier is primarily intended as a correlation ID for logging and debugging such
+        ///         that it is easy to identify that multiple events are using the same or different context instances.
+        ///     </para>
+        /// </summary>
+        public virtual DbContextId ContextId
+            => new DbContextId(_contextId, _lease);
+
+        /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
@@ -207,7 +222,8 @@ namespace Microsoft.EntityFrameworkCore
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         [EntityFrameworkInternal]
-        IDiagnosticsLogger<DbLoggerCategory.Infrastructure> IDbContextDependencies.InfrastructureLogger => DbContextDependencies.InfrastructureLogger;
+        IDiagnosticsLogger<DbLoggerCategory.Infrastructure> IDbContextDependencies.InfrastructureLogger
+            => DbContextDependencies.InfrastructureLogger;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -478,7 +494,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             if (ChangeTracker.AutoDetectChangesEnabled)
             {
-                 entry.DetectChanges();
+                entry.DetectChanges();
             }
         }
 
@@ -584,6 +600,7 @@ namespace Microsoft.EntityFrameworkCore
         void IDbContextPoolable.SetPool(IDbContextPool contextPool)
         {
             _dbContextPool = contextPool;
+            _lease = 1;
         }
 
         /// <summary>
@@ -610,6 +627,7 @@ namespace Microsoft.EntityFrameworkCore
         void IDbContextPoolable.Resurrect(DbContextPoolConfigurationSnapshot configurationSnapshot)
         {
             _disposed = false;
+            ++_lease;
 
             if (configurationSnapshot.AutoDetectChangesEnabled != null)
             {
@@ -904,7 +922,7 @@ namespace Microsoft.EntityFrameworkCore
         ///         to anything other than the CLR default for the property type.
         ///     </para>
         ///     <para>
-        ///         For entity types without generated keys, the state set is always <see cref="EntityState.Unchanged"/>.
+        ///         For entity types without generated keys, the state set is always <see cref="EntityState.Unchanged" />.
         ///     </para>
         ///     <para>
         ///         Use <see cref="EntityEntry.State" /> to set the state of only a single entity.
@@ -947,7 +965,7 @@ namespace Microsoft.EntityFrameworkCore
         ///         to anything other than the CLR default for the property type.
         ///     </para>
         ///     <para>
-        ///         For entity types without generated keys, the state set is always <see cref="EntityState.Modified"/>.
+        ///         For entity types without generated keys, the state set is always <see cref="EntityState.Modified" />.
         ///     </para>
         ///     <para>
         ///         Use <see cref="EntityEntry.State" /> to set the state of only a single entity.
@@ -1108,7 +1126,7 @@ namespace Microsoft.EntityFrameworkCore
         ///         to anything other than the CLR default for the property type.
         ///     </para>
         ///     <para>
-        ///         For entity types without generated keys, the state set is always <see cref="EntityState.Unchanged"/>.
+        ///         For entity types without generated keys, the state set is always <see cref="EntityState.Unchanged" />.
         ///     </para>
         ///     <para>
         ///         Use <see cref="EntityEntry.State" /> to set the state of only a single entity.
@@ -1149,7 +1167,7 @@ namespace Microsoft.EntityFrameworkCore
         ///         to anything other than the CLR default for the property type.
         ///     </para>
         ///     <para>
-        ///         For entity types without generated keys, the state set is always <see cref="EntityState.Modified"/>.
+        ///         For entity types without generated keys, the state set is always <see cref="EntityState.Modified" />.
         ///     </para>
         ///     <para>
         ///         Use <see cref="EntityEntry.State" /> to set the state of only a single entity.
@@ -1280,7 +1298,7 @@ namespace Microsoft.EntityFrameworkCore
         ///         to anything other than the CLR default for the property type.
         ///     </para>
         ///     <para>
-        ///         For entity types without generated keys, the state set is always <see cref="EntityState.Unchanged"/>.
+        ///         For entity types without generated keys, the state set is always <see cref="EntityState.Unchanged" />.
         ///     </para>
         ///     <para>
         ///         Use <see cref="EntityEntry.State" /> to set the state of only a single entity.
@@ -1317,7 +1335,7 @@ namespace Microsoft.EntityFrameworkCore
         ///         to anything other than the CLR default for the property type.
         ///     </para>
         ///     <para>
-        ///         For entity types without generated keys, the state set is always <see cref="EntityState.Modified"/>.
+        ///         For entity types without generated keys, the state set is always <see cref="EntityState.Modified" />.
         ///     </para>
         ///     <para>
         ///         Use <see cref="EntityEntry.State" /> to set the state of only a single entity.
@@ -1435,7 +1453,7 @@ namespace Microsoft.EntityFrameworkCore
         ///         to anything other than the CLR default for the property type.
         ///     </para>
         ///     <para>
-        ///         For entity types without generated keys, the state set is always <see cref="EntityState.Unchanged"/>.
+        ///         For entity types without generated keys, the state set is always <see cref="EntityState.Unchanged" />.
         ///     </para>
         ///     <para>
         ///         Use <see cref="EntityEntry.State" /> to set the state of only a single entity.
@@ -1472,7 +1490,7 @@ namespace Microsoft.EntityFrameworkCore
         ///         to anything other than the CLR default for the property type.
         ///     </para>
         ///     <para>
-        ///         For entity types without generated keys, the state set is always <see cref="EntityState.Modified"/>.
+        ///         For entity types without generated keys, the state set is always <see cref="EntityState.Modified" />.
         ///     </para>
         ///     <para>
         ///         Use <see cref="EntityEntry.State" /> to set the state of only a single entity.
@@ -1574,7 +1592,8 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns>The entity found, or null.</returns>
-        public virtual ValueTask<object> FindAsync([NotNull] Type entityType, [CanBeNull] object[] keyValues, CancellationToken cancellationToken)
+        public virtual ValueTask<object> FindAsync(
+            [NotNull] Type entityType, [CanBeNull] object[] keyValues, CancellationToken cancellationToken)
         {
             CheckDisposed();
 

--- a/src/EFCore/DbContextId.cs
+++ b/src/EFCore/DbContextId.cs
@@ -1,0 +1,100 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    ///     <para>
+    ///         A unique identifier for the context instance and pool lease, if any.
+    ///     </para>
+    ///     <para>
+    ///         This identifier is primarily intended as a correlation ID for logging and debugging such
+    ///         that it is easy to identify that multiple events are using the same or different context instances.
+    ///     </para>
+    /// </summary>
+    public readonly struct DbContextId
+    {
+        /// <summary>
+        ///     Compares this ID to another ID to see if they represent the same leased context.
+        /// </summary>
+        /// <param name="other"> The other ID. </param>
+        /// <returns> True if they represent the same leased context; false otherwise. </returns>
+        public bool Equals(DbContextId other)
+            => InstanceId == other.InstanceId
+               && Lease == other.Lease;
+
+        /// <summary>
+        ///     Compares this ID to another ID to see if they represent the same leased context.
+        /// </summary>
+        /// <param name="obj"> The other ID. </param>
+        /// <returns> True if they represent the same leased context; false otherwise. </returns>
+        public override bool Equals(object obj)
+            => obj is DbContextId other && Equals(other);
+
+        /// <summary>
+        ///     A hash code for this ID.
+        /// </summary>
+        /// <returns> The hash code. </returns>
+        public override int GetHashCode()
+            => HashCode.Combine(InstanceId, Lease);
+
+        /// <summary>
+        ///     Compares one ID to another ID to see if they represent the same leased context.
+        /// </summary>
+        /// <param name="left"> The first ID. </param>
+        /// <param name="right"> The second ID. </param>
+        /// <returns> True if they represent the same leased context; false otherwise. </returns>
+        public static bool operator ==(DbContextId left, DbContextId right) => left.Equals(right);
+
+        /// <summary>
+        ///     Compares one ID to another ID to see if they represent different leased contexts.
+        /// </summary>
+        /// <param name="left"> The first ID. </param>
+        /// <param name="right"> The second ID. </param>
+        /// <returns> True if they represent different leased contexts; false otherwise. </returns>
+        public static bool operator !=(DbContextId left, DbContextId right) => !left.Equals(right);
+
+        /// <summary>
+        ///     Creates a new <see cref="DbContextId" /> with the given <see cref="InstanceId" /> and lease number.
+        /// </summary>
+        /// <param name="id"> A unique identifier for the <see cref="DbContext" /> being used. </param>
+        /// <param name="lease"> A number indicating whether this is the first, second, third, etc. lease of this instance. </param>
+        public DbContextId(Guid id, int lease)
+        {
+            InstanceId = id;
+            Lease = lease;
+        }
+
+        /// <summary>
+        ///     <para>
+        ///         A unique identifier for the <see cref="DbContext" /> being used.
+        ///     </para>
+        ///     <para>
+        ///         When context pooling is being used, then this ID must be combined with
+        ///         the <see cref="Lease" /> in order to get a unique ID for the effective instance being used.
+        ///     </para>
+        /// </summary>
+        public Guid InstanceId { get; }
+
+        /// <summary>
+        ///     <para>
+        ///         A number that is incremented each time this particular <see cref="DbContext" /> instance is leased
+        ///         from the context pool.
+        ///     </para>
+        ///     <para>
+        ///         Will be zero if context pooling is not being used.
+        ///     </para>
+        /// </summary>
+        public int Lease { get; }
+
+        /// <summary>Returns the fully qualified type name of this instance.</summary>
+        /// <returns>The fully qualified type name.</returns>
+        public override string ToString()
+        {
+            return InstanceId + ":" + Lease.ToString(CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/test/EFCore.Relational.Specification.Tests/CommandInterceptionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/CommandInterceptionTestBase.cs
@@ -32,17 +32,22 @@ namespace Microsoft.EntityFrameworkCore
             var (context, interceptor) = CreateContext<PassiveReaderCommandInterceptor>(inject);
             using (context)
             {
-                var results = async
-                    ? await context.Set<Singularity>().ToListAsync()
-                    : context.Set<Singularity>().ToList();
+                using (var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId))
+                {
+                    var results = async
+                        ? await context.Set<Singularity>().ToListAsync()
+                        : context.Set<Singularity>().ToList();
 
-                Assert.Equal(2, results.Count);
-                Assert.Equal(77, results[0].Id);
-                Assert.Equal(88, results[1].Id);
-                Assert.Equal("Black Hole", results[0].Type);
-                Assert.Equal("Bing Bang", results[1].Type);
+                    Assert.Equal(2, results.Count);
+                    Assert.Equal(77, results[0].Id);
+                    Assert.Equal(88, results[1].Id);
+                    Assert.Equal("Black Hole", results[0].Type);
+                    Assert.Equal("Bing Bang", results[1].Type);
 
-                AssertNormalOutcome(context, interceptor, async);
+                    AssertNormalOutcome(context, interceptor, async);
+
+                    AssertExecutedEvents(listener);
+                }
             }
 
             return interceptor.CommandText;
@@ -74,15 +79,20 @@ namespace Microsoft.EntityFrameworkCore
 
                 var commandParameterObject = new RelationalCommandParameterObject(connection, null, context, logger);
 
-                var result = async
-                    ? await command.ExecuteScalarAsync(commandParameterObject)
-                    : command.ExecuteScalar(commandParameterObject);
+                using (var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId))
+                {
+                    var result = async
+                        ? await command.ExecuteScalarAsync(commandParameterObject)
+                        : command.ExecuteScalar(commandParameterObject);
 
-                Assert.Equal(1, Convert.ToInt32(result));
+                    Assert.Equal(1, Convert.ToInt32(result));
 
-                AssertNormalOutcome(context, interceptor, async);
+                    AssertNormalOutcome(context, interceptor, async);
 
-                AssertSql(sql, interceptor.CommandText);
+                    AssertSql(sql, interceptor.CommandText);
+
+                    AssertExecutedEvents(listener);
+                }
             }
         }
 
@@ -108,15 +118,20 @@ namespace Microsoft.EntityFrameworkCore
                 {
                     const string nonQuery = "DELETE FROM Singularity WHERE Id = 77";
 
-                    var result = async
-                        ? await context.Database.ExecuteSqlRawAsync(nonQuery)
-                        : context.Database.ExecuteSqlRaw(nonQuery);
+                    using (var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId))
+                    {
+                        var result = async
+                            ? await context.Database.ExecuteSqlRawAsync(nonQuery)
+                            : context.Database.ExecuteSqlRaw(nonQuery);
 
-                    Assert.Equal(1, result);
+                        Assert.Equal(1, result);
 
-                    AssertNormalOutcome(context, interceptor, async);
+                        AssertNormalOutcome(context, interceptor, async);
 
-                    AssertSql(nonQuery, interceptor.CommandText);
+                        AssertSql(nonQuery, interceptor.CommandText);
+
+                        AssertExecutedEvents(listener);
+                    }
                 }
             }
         }
@@ -139,19 +154,24 @@ namespace Microsoft.EntityFrameworkCore
             var (context, interceptor) = CreateContext<SuppressingReaderCommandInterceptor>(inject);
             using (context)
             {
-                var results = async
-                    ? await context.Set<Singularity>().ToListAsync()
-                    : context.Set<Singularity>().ToList();
+                using (var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId))
+                {
+                    var results = async
+                        ? await context.Set<Singularity>().ToListAsync()
+                        : context.Set<Singularity>().ToList();
 
-                Assert.Equal(3, results.Count);
-                Assert.Equal(977, results[0].Id);
-                Assert.Equal(988, results[1].Id);
-                Assert.Equal(999, results[2].Id);
-                Assert.Equal("<977>", results[0].Type);
-                Assert.Equal("<988>", results[1].Type);
-                Assert.Equal("<999>", results[2].Type);
+                    Assert.Equal(3, results.Count);
+                    Assert.Equal(977, results[0].Id);
+                    Assert.Equal(988, results[1].Id);
+                    Assert.Equal(999, results[2].Id);
+                    Assert.Equal("<977>", results[0].Type);
+                    Assert.Equal("<988>", results[1].Type);
+                    Assert.Equal("<999>", results[2].Type);
 
-                AssertNormalOutcome(context, interceptor, async);
+                    AssertNormalOutcome(context, interceptor, async);
+
+                    AssertExecutedEvents(listener);
+                }
             }
 
             return interceptor.CommandText;
@@ -204,15 +224,20 @@ namespace Microsoft.EntityFrameworkCore
 
                 var commandParameterObject = new RelationalCommandParameterObject(connection, null, context, logger);
 
-                var result = async
-                    ? await command.ExecuteScalarAsync(commandParameterObject)
-                    : command.ExecuteScalar(commandParameterObject);
+                using (var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId))
+                {
+                    var result = async
+                        ? await command.ExecuteScalarAsync(commandParameterObject)
+                        : command.ExecuteScalar(commandParameterObject);
 
-                Assert.Equal(SuppressingScalarCommandInterceptor.InterceptedResult, result);
+                    Assert.Equal(SuppressingScalarCommandInterceptor.InterceptedResult, result);
 
-                AssertNormalOutcome(context, interceptor, async);
+                    AssertNormalOutcome(context, interceptor, async);
 
-                AssertSql(sql, interceptor.CommandText);
+                    AssertSql(sql, interceptor.CommandText);
+
+                    AssertExecutedEvents(listener);
+                }
             }
         }
 
@@ -262,15 +287,20 @@ namespace Microsoft.EntityFrameworkCore
                 {
                     const string nonQuery = "DELETE FROM Singularity WHERE Id = 77";
 
-                    var result = async
-                        ? await context.Database.ExecuteSqlRawAsync(nonQuery)
-                        : context.Database.ExecuteSqlRaw(nonQuery);
+                    using (var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId))
+                    {
+                        var result = async
+                            ? await context.Database.ExecuteSqlRawAsync(nonQuery)
+                            : context.Database.ExecuteSqlRaw(nonQuery);
 
-                    Assert.Equal(2, result);
+                        Assert.Equal(2, result);
 
-                    AssertNormalOutcome(context, interceptor, async);
+                        AssertNormalOutcome(context, interceptor, async);
 
-                    AssertSql(nonQuery, interceptor.CommandText);
+                        AssertSql(nonQuery, interceptor.CommandText);
+
+                        AssertExecutedEvents(listener);
+                    }
                 }
             }
         }
@@ -314,17 +344,22 @@ namespace Microsoft.EntityFrameworkCore
             var (context, interceptor) = CreateContext<MutatingReaderCommandInterceptor>(inject);
             using (context)
             {
-                var results = async
-                    ? await context.Set<Singularity>().ToListAsync()
-                    : context.Set<Singularity>().ToList();
+                using (var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId))
+                {
+                    var results = async
+                        ? await context.Set<Singularity>().ToListAsync()
+                        : context.Set<Singularity>().ToList();
 
-                Assert.Equal(2, results.Count);
-                Assert.Equal(77, results[0].Id);
-                Assert.Equal(88, results[1].Id);
-                Assert.Equal("Black Hole?", results[0].Type);
-                Assert.Equal("Bing Bang?", results[1].Type);
+                    Assert.Equal(2, results.Count);
+                    Assert.Equal(77, results[0].Id);
+                    Assert.Equal(88, results[1].Id);
+                    Assert.Equal("Black Hole?", results[0].Type);
+                    Assert.Equal("Bing Bang?", results[1].Type);
 
-                AssertNormalOutcome(context, interceptor, async);
+                    AssertNormalOutcome(context, interceptor, async);
+
+                    AssertExecutedEvents(listener);
+                }
             }
 
             return interceptor.CommandText;
@@ -380,15 +415,20 @@ namespace Microsoft.EntityFrameworkCore
 
                 var commandParameterObject = new RelationalCommandParameterObject(connection, null, context, logger);
 
-                var result = async
-                    ? await command.ExecuteScalarAsync(commandParameterObject)
-                    : command.ExecuteScalar(commandParameterObject);
+                using (var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId))
+                {
+                    var result = async
+                        ? await command.ExecuteScalarAsync(commandParameterObject)
+                        : command.ExecuteScalar(commandParameterObject);
 
-                Assert.Equal(2, Convert.ToInt32(result));
+                    Assert.Equal(2, Convert.ToInt32(result));
 
-                AssertNormalOutcome(context, interceptor, async);
+                    AssertNormalOutcome(context, interceptor, async);
 
-                AssertSql(MutatingScalarCommandInterceptor.MutatedSql, interceptor.CommandText);
+                    AssertSql(MutatingScalarCommandInterceptor.MutatedSql, interceptor.CommandText);
+
+                    AssertExecutedEvents(listener);
+                }
             }
         }
 
@@ -437,15 +477,20 @@ namespace Microsoft.EntityFrameworkCore
                 {
                     const string nonQuery = "DELETE FROM Singularity WHERE Id = 77";
 
-                    var result = async
-                        ? await context.Database.ExecuteSqlRawAsync(nonQuery)
-                        : context.Database.ExecuteSqlRaw(nonQuery);
+                    using (var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId))
+                    {
+                        var result = async
+                            ? await context.Database.ExecuteSqlRawAsync(nonQuery)
+                            : context.Database.ExecuteSqlRaw(nonQuery);
 
-                    Assert.Equal(0, result);
+                        Assert.Equal(0, result);
 
-                    AssertNormalOutcome(context, interceptor, async);
+                        AssertNormalOutcome(context, interceptor, async);
 
-                    AssertSql(MutatingNonQueryCommandInterceptor.MutatedSql, interceptor.CommandText);
+                        AssertSql(MutatingNonQueryCommandInterceptor.MutatedSql, interceptor.CommandText);
+
+                        AssertExecutedEvents(listener);
+                    }
                 }
             }
         }
@@ -491,17 +536,22 @@ namespace Microsoft.EntityFrameworkCore
             var (context, interceptor) = CreateContext<QueryReplacingReaderCommandInterceptor>(inject);
             using (context)
             {
-                var results = async
-                    ? await context.Set<Singularity>().ToListAsync()
-                    : context.Set<Singularity>().ToList();
+                using (var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId))
+                {
+                    var results = async
+                        ? await context.Set<Singularity>().ToListAsync()
+                        : context.Set<Singularity>().ToList();
 
-                Assert.Equal(2, results.Count);
-                Assert.Equal(77, results[0].Id);
-                Assert.Equal(88, results[1].Id);
-                Assert.Equal("Black Hole?", results[0].Type);
-                Assert.Equal("Bing Bang?", results[1].Type);
+                    Assert.Equal(2, results.Count);
+                    Assert.Equal(77, results[0].Id);
+                    Assert.Equal(88, results[1].Id);
+                    Assert.Equal("Black Hole?", results[0].Type);
+                    Assert.Equal("Bing Bang?", results[1].Type);
 
-                AssertNormalOutcome(context, interceptor, async);
+                    AssertNormalOutcome(context, interceptor, async);
+
+                    AssertExecutedEvents(listener);
+                }
             }
 
             return interceptor.CommandText;
@@ -564,15 +614,20 @@ namespace Microsoft.EntityFrameworkCore
 
                 var commandParameterObject = new RelationalCommandParameterObject(connection, null, context, logger);
 
-                var result = async
-                    ? await command.ExecuteScalarAsync(commandParameterObject)
-                    : command.ExecuteScalar(commandParameterObject);
+                using (var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId))
+                {
+                    var result = async
+                        ? await command.ExecuteScalarAsync(commandParameterObject)
+                        : command.ExecuteScalar(commandParameterObject);
 
-                Assert.Equal(2, Convert.ToInt32(result));
+                    Assert.Equal(2, Convert.ToInt32(result));
 
-                AssertNormalOutcome(context, interceptor, async);
+                    AssertNormalOutcome(context, interceptor, async);
 
-                AssertSql(sql, interceptor.CommandText);
+                    AssertSql(sql, interceptor.CommandText);
+
+                    AssertExecutedEvents(listener);
+                }
             }
         }
 
@@ -629,15 +684,20 @@ namespace Microsoft.EntityFrameworkCore
                 {
                     const string nonQuery = "DELETE FROM Singularity WHERE Id = 78";
 
-                    var result = async
-                        ? await context.Database.ExecuteSqlRawAsync(nonQuery)
-                        : context.Database.ExecuteSqlRaw(nonQuery);
+                    using (var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId))
+                    {
+                        var result = async
+                            ? await context.Database.ExecuteSqlRawAsync(nonQuery)
+                            : context.Database.ExecuteSqlRaw(nonQuery);
 
-                    Assert.Equal(1, result);
+                        Assert.Equal(1, result);
 
-                    AssertNormalOutcome(context, interceptor, async);
+                        AssertNormalOutcome(context, interceptor, async);
 
-                    AssertSql(nonQuery, interceptor.CommandText);
+                        AssertSql(nonQuery, interceptor.CommandText);
+
+                        AssertExecutedEvents(listener);
+                    }
                 }
             }
         }
@@ -692,23 +752,28 @@ namespace Microsoft.EntityFrameworkCore
             var (context, interceptor) = CreateContext<ResultReplacingReaderCommandInterceptor>(inject);
             using (context)
             {
-                var results = async
-                    ? await context.Set<Singularity>().ToListAsync()
-                    : context.Set<Singularity>().ToList();
+                using (var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId))
+                {
+                    var results = async
+                        ? await context.Set<Singularity>().ToListAsync()
+                        : context.Set<Singularity>().ToList();
 
-                Assert.Equal(5, results.Count);
-                Assert.Equal(77, results[0].Id);
-                Assert.Equal(88, results[1].Id);
-                Assert.Equal(977, results[2].Id);
-                Assert.Equal(988, results[3].Id);
-                Assert.Equal(999, results[4].Id);
-                Assert.Equal("Black Hole", results[0].Type);
-                Assert.Equal("Bing Bang", results[1].Type);
-                Assert.Equal("<977>", results[2].Type);
-                Assert.Equal("<988>", results[3].Type);
-                Assert.Equal("<999>", results[4].Type);
+                    Assert.Equal(5, results.Count);
+                    Assert.Equal(77, results[0].Id);
+                    Assert.Equal(88, results[1].Id);
+                    Assert.Equal(977, results[2].Id);
+                    Assert.Equal(988, results[3].Id);
+                    Assert.Equal(999, results[4].Id);
+                    Assert.Equal("Black Hole", results[0].Type);
+                    Assert.Equal("Bing Bang", results[1].Type);
+                    Assert.Equal("<977>", results[2].Type);
+                    Assert.Equal("<988>", results[3].Type);
+                    Assert.Equal("<999>", results[4].Type);
 
-                AssertNormalOutcome(context, interceptor, async);
+                    AssertNormalOutcome(context, interceptor, async);
+
+                    AssertExecutedEvents(listener);
+                }
             }
 
             return interceptor.CommandText;
@@ -814,15 +879,20 @@ namespace Microsoft.EntityFrameworkCore
 
                 var commandParameterObject = new RelationalCommandParameterObject(connection, null, context, logger);
 
-                var result = async
-                    ? await command.ExecuteScalarAsync(commandParameterObject)
-                    : command.ExecuteScalar(commandParameterObject);
+                using (var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId))
+                {
+                    var result = async
+                        ? await command.ExecuteScalarAsync(commandParameterObject)
+                        : command.ExecuteScalar(commandParameterObject);
 
-                Assert.Equal(ResultReplacingScalarCommandInterceptor.InterceptedResult, result);
+                    Assert.Equal(ResultReplacingScalarCommandInterceptor.InterceptedResult, result);
 
-                AssertNormalOutcome(context, interceptor, async);
+                    AssertNormalOutcome(context, interceptor, async);
 
-                AssertSql(sql, interceptor.CommandText);
+                    AssertSql(sql, interceptor.CommandText);
+
+                    AssertExecutedEvents(listener);
+                }
             }
         }
 
@@ -862,7 +932,7 @@ namespace Microsoft.EntityFrameworkCore
         [InlineData(true, false)]
         [InlineData(false, true)]
         [InlineData(true, true)]
-        public virtual async Task Intercept_non_query_to_replaceresult(bool async, bool inject)
+        public virtual async Task Intercept_non_query_to_replace_result(bool async, bool inject)
         {
             var (context, interceptor) = CreateContext<ResultReplacingNonQueryCommandInterceptor>(inject);
             using (context)
@@ -871,15 +941,20 @@ namespace Microsoft.EntityFrameworkCore
                 {
                     const string nonQuery = "DELETE FROM Singularity WHERE Id = 78";
 
-                    var result = async
-                        ? await context.Database.ExecuteSqlRawAsync(nonQuery)
-                        : context.Database.ExecuteSqlRaw(nonQuery);
+                    using (var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId))
+                    {
+                        var result = async
+                            ? await context.Database.ExecuteSqlRawAsync(nonQuery)
+                            : context.Database.ExecuteSqlRaw(nonQuery);
 
-                    Assert.Equal(7, result);
+                        Assert.Equal(7, result);
 
-                    AssertNormalOutcome(context, interceptor, async);
+                        AssertNormalOutcome(context, interceptor, async);
 
-                    AssertSql(nonQuery, interceptor.CommandText);
+                        AssertSql(nonQuery, interceptor.CommandText);
+
+                        AssertExecutedEvents(listener);
+                    }
                 }
             }
         }
@@ -1396,6 +1471,11 @@ namespace Microsoft.EntityFrameworkCore
             Assert.True(interceptor.FailedCalled);
             Assert.Same(context, interceptor.Context);
         }
+
+        private static void AssertExecutedEvents(ITestDiagnosticListener listener)
+            => listener.AssertEventsInOrder(
+                RelationalEventId.CommandExecuting.Name,
+                RelationalEventId.CommandExecuted.Name);
 
         protected abstract class CommandInterceptorBase : IDbCommandInterceptor
         {

--- a/test/EFCore.Relational.Specification.Tests/ConnectionInterceptionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/ConnectionInterceptionTestBase.cs
@@ -34,29 +34,34 @@ namespace Microsoft.EntityFrameworkCore
                     connection.Close();
                 }
 
-                if (async)
+                using (var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId))
                 {
-                    await context.Database.OpenConnectionAsync();
-                }
-                else
-                {
-                    context.Database.OpenConnection();
-                }
+                    if (async)
+                    {
+                        await context.Database.OpenConnectionAsync();
+                    }
+                    else
+                    {
+                        context.Database.OpenConnection();
+                    }
 
-                AssertNormalOpen(context, interceptor, async);
+                    AssertNormalOpen(context, interceptor, async);
 
-                interceptor.Reset();
+                    interceptor.Reset();
 
-                if (async)
-                {
-                    await context.Database.CloseConnectionAsync();
+                    if (async)
+                    {
+                        await context.Database.CloseConnectionAsync();
+                    }
+                    else
+                    {
+                        context.Database.CloseConnection();
+                    }
+
+                    AssertNormalClose(context, interceptor, async);
+
+                    AsertOpenCloseEvents(listener);
                 }
-                else
-                {
-                    context.Database.CloseConnection();
-                }
-
-                AssertNormalClose(context, interceptor, async);
 
                 if (startedOpen)
                 {
@@ -81,29 +86,34 @@ namespace Microsoft.EntityFrameworkCore
                     connection.Close();
                 }
 
-                if (async)
+                using (var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId))
                 {
-                    await context.Database.OpenConnectionAsync();
-                }
-                else
-                {
-                    context.Database.OpenConnection();
-                }
+                    if (async)
+                    {
+                        await context.Database.OpenConnectionAsync();
+                    }
+                    else
+                    {
+                        context.Database.OpenConnection();
+                    }
 
-                AssertNormalOpen(context, interceptor, async);
+                    AssertNormalOpen(context, interceptor, async);
 
-                interceptor.Reset();
+                    interceptor.Reset();
 
-                if (async)
-                {
-                    await context.Database.CloseConnectionAsync();
+                    if (async)
+                    {
+                        await context.Database.CloseConnectionAsync();
+                    }
+                    else
+                    {
+                        context.Database.CloseConnection();
+                    }
+
+                    AssertNormalClose(context, interceptor, async);
+
+                    AsertOpenCloseEvents(listener);
                 }
-                else
-                {
-                    context.Database.CloseConnection();
-                }
-
-                AssertNormalClose(context, interceptor, async);
 
                 if (startedOpen)
                 {
@@ -139,38 +149,43 @@ namespace Microsoft.EntityFrameworkCore
                     connection.Close();
                 }
 
-                if (async)
+                using (var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId))
                 {
-                    await context.Database.OpenConnectionAsync();
-                }
-                else
-                {
-                    context.Database.OpenConnection();
-                }
+                    if (async)
+                    {
+                        await context.Database.OpenConnectionAsync();
+                    }
+                    else
+                    {
+                        context.Database.OpenConnection();
+                    }
 
-                AssertNormalOpen(context, interceptor1, async);
-                AssertNormalOpen(context, interceptor2, async);
-                AssertNormalOpen(context, interceptor3, async);
-                AssertNormalOpen(context, interceptor4, async);
+                    AssertNormalOpen(context, interceptor1, async);
+                    AssertNormalOpen(context, interceptor2, async);
+                    AssertNormalOpen(context, interceptor3, async);
+                    AssertNormalOpen(context, interceptor4, async);
 
-                interceptor1.Reset();
-                interceptor2.Reset();
-                interceptor3.Reset();
-                interceptor4.Reset();
+                    interceptor1.Reset();
+                    interceptor2.Reset();
+                    interceptor3.Reset();
+                    interceptor4.Reset();
 
-                if (async)
-                {
-                    await context.Database.CloseConnectionAsync();
+                    if (async)
+                    {
+                        await context.Database.CloseConnectionAsync();
+                    }
+                    else
+                    {
+                        context.Database.CloseConnection();
+                    }
+
+                    AssertNormalClose(context, interceptor1, async);
+                    AssertNormalClose(context, interceptor2, async);
+                    AssertNormalClose(context, interceptor3, async);
+                    AssertNormalClose(context, interceptor4, async);
+
+                    AsertOpenCloseEvents(listener);
                 }
-                else
-                {
-                    context.Database.CloseConnection();
-                }
-
-                AssertNormalClose(context, interceptor1, async);
-                AssertNormalClose(context, interceptor2, async);
-                AssertNormalClose(context, interceptor3, async);
-                AssertNormalClose(context, interceptor4, async);
 
                 if (startedOpen)
                 {
@@ -262,6 +277,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             public DbContext Context { get; set; }
             public Exception Exception { get; set; }
+            public DbContextId ContextId { get; set; }
             public Guid ConnectionId { get; set; }
             public bool AsyncCalled { get; set; }
             public bool SyncCalled { get; set; }
@@ -275,6 +291,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 Context = null;
                 Exception = null;
+                ContextId = default;
                 ConnectionId = default;
                 AsyncCalled = false;
                 SyncCalled = false;
@@ -400,8 +417,10 @@ namespace Microsoft.EntityFrameworkCore
             {
                 Assert.NotNull(eventData.Context);
                 Assert.NotEqual(default, eventData.ConnectionId);
+                Assert.NotEqual(default, eventData.Context.ContextId);
 
                 Context = eventData.Context;
+                ContextId = Context.ContextId;
                 ConnectionId = eventData.ConnectionId;
                 OpeningCalled = true;
             }
@@ -410,6 +429,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 Assert.Same(Context, eventData.Context);
                 Assert.Equal(ConnectionId, eventData.ConnectionId);
+                Assert.Equal(ContextId, eventData.Context.ContextId);
 
                 OpenedCalled = true;
             }
@@ -418,8 +438,10 @@ namespace Microsoft.EntityFrameworkCore
             {
                 Assert.NotNull(eventData.Context);
                 Assert.NotEqual(default, eventData.ConnectionId);
+                Assert.NotEqual(default, eventData.Context.ContextId);
 
                 Context = eventData.Context;
+                ContextId = Context.ContextId;
                 ConnectionId = eventData.ConnectionId;
                 ClosingCalled = true;
             }
@@ -428,6 +450,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 Assert.Same(Context, eventData.Context);
                 Assert.Equal(ConnectionId, eventData.ConnectionId);
+                Assert.Equal(ContextId, eventData.Context.ContextId);
 
                 ClosedCalled = true;
             }
@@ -436,6 +459,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 Assert.Same(Context, eventData.Context);
                 Assert.Equal(ConnectionId, eventData.ConnectionId);
+                Assert.Equal(ContextId, eventData.Context.ContextId);
                 Assert.NotNull(eventData.Exception);
 
                 Exception = eventData.Exception;
@@ -481,5 +505,12 @@ namespace Microsoft.EntityFrameworkCore
             Assert.True(interceptor.FailedCalled);
             Assert.Same(context, interceptor.Context);
         }
+
+        private static void AsertOpenCloseEvents(ITestDiagnosticListener listener)
+            => listener.AssertEventsInOrder(
+                RelationalEventId.ConnectionOpening.Name,
+                RelationalEventId.ConnectionOpened.Name,
+                RelationalEventId.ConnectionClosing.Name,
+                RelationalEventId.ConnectionClosed.Name);
     }
 }

--- a/test/EFCore.Specification.Tests/InterceptionTestBase.cs
+++ b/test/EFCore.Specification.Tests/InterceptionTestBase.cs
@@ -1,8 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -107,8 +109,98 @@ namespace Microsoft.EntityFrameworkCore
             IEnumerable<IInterceptor> injectedInterceptors = null)
             => new UniverseContext(Fixture.CreateOptions(appInterceptors, injectedInterceptors ?? Enumerable.Empty<IInterceptor>()));
 
+        public interface ITestDiagnosticListener : IDisposable
+        {
+            void AssertEventsInOrder(params string[] eventNames);
+        }
+
+        public class NullDiagnosticListener: ITestDiagnosticListener
+        {
+            public void AssertEventsInOrder(params string[] eventNames)
+            {
+            }
+
+            public void Dispose()
+            {
+            }
+        }
+
+        public class TestDiagnosticListener : ITestDiagnosticListener, IObserver<DiagnosticListener>, IObserver<KeyValuePair<string, object>>
+        {
+            private readonly DbContextId _contextId;
+            private readonly IDisposable _subscription;
+            private readonly List<string> _events = new List<string>();
+
+            public TestDiagnosticListener(DbContextId contextId)
+            {
+                _contextId = contextId;
+                _subscription = DiagnosticListener.AllListeners.Subscribe(this);
+            }
+
+            public void OnCompleted()
+            {
+            }
+
+            public void OnError(Exception error)
+            {
+            }
+
+
+            public void AssertEventsInOrder(params string[] eventNames)
+            {
+                Assert.True(_events.Count >= eventNames.Length);
+
+                var lastIndex = -1;
+                for (var i = 0; i < eventNames.Length; i++)
+                {
+                    var indexFound = _events.IndexOf(eventNames[i]);
+
+                    if (indexFound < 0)
+                    {
+                        Assert.True(false, $"Event {eventNames[i]} not found.");
+                    }
+
+                    if (indexFound < lastIndex)
+                    {
+                        Assert.True(false, $"Event {eventNames[i]} found before {eventNames[i - 1]}.");
+                    }
+
+                    lastIndex = indexFound;
+                }
+            }
+
+            public void OnNext(DiagnosticListener listener)
+            {
+                if (listener?.Name == DbLoggerCategory.Name)
+                {
+                    listener.Subscribe(this);
+                }
+            }
+
+            public void OnNext(KeyValuePair<string, object> value)
+            {
+                var eventData = value.Value as DbContextEventData;
+                if (eventData?.Context?.ContextId == _contextId)
+                {
+                    _events.Add(value.Key);
+                }
+            }
+
+            public void Dispose()
+            {
+                _subscription.Dispose();
+            }
+        }
+
         public abstract class InterceptionFixtureBase : SharedStoreFixtureBase<UniverseContext>
         {
+            protected abstract bool ShouldSubscribeToDiagnosticListener { get; }
+
+            public virtual ITestDiagnosticListener SubscribeToDiagnosticListener(DbContextId contextId)
+                => ShouldSubscribeToDiagnosticListener
+                    ? (ITestDiagnosticListener)new TestDiagnosticListener(contextId)
+                    : new NullDiagnosticListener();
+
             public virtual DbContextOptions CreateOptions(
                 IEnumerable<IInterceptor> appInterceptors,
                 IEnumerable<IInterceptor> injectedInterceptors)

--- a/test/EFCore.SqlServer.FunctionalTests/CommandInterceptionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/CommandInterceptionSqlServerTest.cs
@@ -10,10 +10,9 @@ using Xunit;
 
 namespace Microsoft.EntityFrameworkCore
 {
-    public class CommandInterceptionSqlServerTest
-        : CommandInterceptionTestBase, IClassFixture<CommandInterceptionSqlServerTest.InterceptionSqlServerFixture>
+    public abstract class CommandInterceptionSqlServerTestBase : CommandInterceptionTestBase
     {
-        public CommandInterceptionSqlServerTest(InterceptionSqlServerFixture fixture)
+        protected CommandInterceptionSqlServerTestBase(InterceptionSqlServerFixtureBase fixture)
             : base(fixture)
         {
         }
@@ -45,16 +44,43 @@ namespace Microsoft.EntityFrameworkCore
             return null;
         }
 
-        public class InterceptionSqlServerFixture : InterceptionFixtureBase
+        public abstract class InterceptionSqlServerFixtureBase : InterceptionFixtureBase
         {
             protected override string StoreName => "CommandInterception";
-
             protected override ITestStoreFactory TestStoreFactory => SqlServerTestStoreFactory.Instance;
 
             protected override IServiceCollection InjectInterceptors(
                 IServiceCollection serviceCollection,
                 IEnumerable<IInterceptor> injectedInterceptors)
                 => base.InjectInterceptors(serviceCollection.AddEntityFrameworkSqlServer(), injectedInterceptors);
+        }
+
+        public class CommandInterceptionSqlServerTest
+            : CommandInterceptionSqlServerTestBase, IClassFixture<CommandInterceptionSqlServerTest.InterceptionSqlServerFixture>
+        {
+            public CommandInterceptionSqlServerTest(InterceptionSqlServerFixture fixture)
+                : base(fixture)
+            {
+            }
+
+            public class InterceptionSqlServerFixture : InterceptionSqlServerFixtureBase
+            {
+                protected override bool ShouldSubscribeToDiagnosticListener => false;
+            }
+        }
+
+        public class CommandInterceptionWithDiagnosticsSqlServerTest
+            : CommandInterceptionSqlServerTestBase, IClassFixture<CommandInterceptionWithDiagnosticsSqlServerTest.InterceptionSqlServerFixture>
+        {
+            public CommandInterceptionWithDiagnosticsSqlServerTest(InterceptionSqlServerFixture fixture)
+                : base(fixture)
+            {
+            }
+
+            public class InterceptionSqlServerFixture : InterceptionSqlServerFixtureBase
+            {
+                protected override bool ShouldSubscribeToDiagnosticListener => true;
+            }
         }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/ConnectionInterceptionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ConnectionInterceptionSqlServerTest.cs
@@ -1,7 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -9,18 +12,16 @@ using Xunit;
 
 namespace Microsoft.EntityFrameworkCore
 {
-    public class ConnectionInterceptionSqlServerTest
-        : ConnectionInterceptionTestBase, IClassFixture<ConnectionInterceptionSqlServerTest.InterceptionSqlServerFixture>
+    public abstract class ConnectionInterceptionSqlServerTestBase : ConnectionInterceptionTestBase
     {
-        public ConnectionInterceptionSqlServerTest(InterceptionSqlServerFixture fixture)
+        protected ConnectionInterceptionSqlServerTestBase(InterceptionSqlServerFixtureBase fixture)
             : base(fixture)
         {
         }
 
-        public class InterceptionSqlServerFixture : InterceptionFixtureBase
+        public abstract class InterceptionSqlServerFixtureBase : InterceptionFixtureBase
         {
             protected override string StoreName => "ConnectionInterception";
-
             protected override ITestStoreFactory TestStoreFactory => SqlServerTestStoreFactory.Instance;
 
             protected override IServiceCollection InjectInterceptors(
@@ -30,6 +31,48 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         protected override BadUniverseContext CreateBadUniverse(DbContextOptionsBuilder optionsBuilder)
-            => new BadUniverseContext(optionsBuilder.UseSqlServer("Database = IIzBad").Options);
+            => new BadUniverseContext(optionsBuilder.UseSqlServer(new FakeDbConnection()).Options);
+
+        public class FakeDbConnection : DbConnection
+        {
+            public override string ConnectionString { get; set; }
+            public override string Database => "Database";
+            public override string DataSource => "DataSource";
+            public override string ServerVersion => throw new NotImplementedException();
+            public override ConnectionState State => ConnectionState.Closed;
+            public override void ChangeDatabase(string databaseName) => throw new NotImplementedException();
+            public override void Close() => throw new NotImplementedException();
+            public override void Open() => throw new NotImplementedException();
+            protected override DbTransaction BeginDbTransaction(System.Data.IsolationLevel isolationLevel) => throw new NotImplementedException();
+            protected override DbCommand CreateDbCommand() => throw new NotImplementedException();
+        }
+
+        public class ConnectionInterceptionSqlServerTest
+            : ConnectionInterceptionSqlServerTestBase, IClassFixture<ConnectionInterceptionSqlServerTest.InterceptionSqlServerFixture>
+        {
+            public ConnectionInterceptionSqlServerTest(InterceptionSqlServerFixture fixture)
+                : base(fixture)
+            {
+            }
+
+            public class InterceptionSqlServerFixture : InterceptionSqlServerFixtureBase
+            {
+                protected override bool ShouldSubscribeToDiagnosticListener => false;
+            }
+        }
+
+        public class ConnectionInterceptionWithDiagnosticsSqlServerTest
+            : ConnectionInterceptionSqlServerTestBase, IClassFixture<ConnectionInterceptionWithDiagnosticsSqlServerTest.InterceptionSqlServerFixture>
+        {
+            public ConnectionInterceptionWithDiagnosticsSqlServerTest(InterceptionSqlServerFixture fixture)
+                : base(fixture)
+            {
+            }
+
+            public class InterceptionSqlServerFixture : InterceptionSqlServerFixtureBase
+            {
+                protected override bool ShouldSubscribeToDiagnosticListener => true;
+            }
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
@@ -65,7 +65,6 @@ namespace Microsoft.EntityFrameworkCore
             public DefaultOptionsPooledContext(DbContextOptions options)
                 : base(options)
             {
-                //ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
             }
         }
 
@@ -191,29 +190,116 @@ namespace Microsoft.EntityFrameworkCore
             var serviceProvider = BuildServiceProvider<DbContext>();
 
             var serviceScope1 = serviceProvider.CreateScope();
-
             var context1 = serviceScope1.ServiceProvider.GetService<DbContext>();
 
             var serviceScope2 = serviceProvider.CreateScope();
-
             var context2 = serviceScope2.ServiceProvider.GetService<DbContext>();
 
             Assert.NotSame(context1, context2);
 
+            var id1 = context1.ContextId;
+            var id2 = context2.ContextId;
+
+            Assert.NotEqual(default, id1.InstanceId);
+            Assert.NotEqual(id1, id2);
+            Assert.NotEqual(id1.InstanceId, id2.InstanceId);
+            Assert.Equal(1, id1.Lease);
+            Assert.Equal(1, id2.Lease);
+
             serviceScope1.Dispose();
             serviceScope2.Dispose();
 
-            var serviceScope3 = serviceProvider.CreateScope();
+            var id1d = context1.ContextId;
+            var id2d = context2.ContextId;
 
+            Assert.Equal(id1, id1d);
+            Assert.Equal(id1.InstanceId, id1d.InstanceId);
+            Assert.Equal(1, id1d.Lease);
+            Assert.Equal(1, id2d.Lease);
+
+            var serviceScope3 = serviceProvider.CreateScope();
             var context3 = serviceScope3.ServiceProvider.GetService<DbContext>();
 
+            var id1r = context3.ContextId;
+
             Assert.Same(context1, context3);
+            Assert.Equal(id1.InstanceId, id1r.InstanceId);
+            Assert.NotEqual(default, id1r.InstanceId);
+            Assert.NotEqual(id1, id1r);
+            Assert.Equal(2, id1r.Lease);
 
             var serviceScope4 = serviceProvider.CreateScope();
-
             var context4 = serviceScope4.ServiceProvider.GetService<DbContext>();
 
+            var id2r = context4.ContextId;
+
             Assert.Same(context2, context4);
+            Assert.Equal(id2.InstanceId, id2r.InstanceId);
+            Assert.NotEqual(default, id2r.InstanceId);
+            Assert.NotEqual(id2, id2r);
+            Assert.Equal(2, id2r.Lease);
+        }
+
+        [ConditionalFact]
+        public void ContextIds_make_sense_when_not_pooling()
+        {
+            var serviceProvider = new ServiceCollection()
+                .AddDbContext<DbContext>(
+                    ob
+                        => ob.UseSqlServer(SqlServerNorthwindTestStoreFactory.NorthwindConnectionString)
+                            .EnableServiceProviderCaching(false))
+                .BuildServiceProvider();
+
+            var serviceScope1 = serviceProvider.CreateScope();
+            var context1 = serviceScope1.ServiceProvider.GetService<DbContext>();
+
+            var serviceScope2 = serviceProvider.CreateScope();
+            var context2 = serviceScope2.ServiceProvider.GetService<DbContext>();
+
+            Assert.NotSame(context1, context2);
+
+            var id1 = context1.ContextId;
+            var id2 = context2.ContextId;
+
+            Assert.NotEqual(default, id1.InstanceId);
+            Assert.NotEqual(default, id2.InstanceId);
+
+            Assert.NotEqual(id1, id2);
+            Assert.Equal(0, id1.Lease);
+            Assert.Equal(0, id2.Lease);
+
+            serviceScope1.Dispose();
+            serviceScope2.Dispose();
+
+            var id1d = context1.ContextId;
+            var id2d = context2.ContextId;
+
+            Assert.Equal(id1.InstanceId, id1d.InstanceId);
+            Assert.Equal(id2.InstanceId, id2d.InstanceId);
+            Assert.Equal(0, id1d.Lease);
+            Assert.Equal(0, id2d.Lease);
+
+            var serviceScope3 = serviceProvider.CreateScope();
+            var context3 = serviceScope3.ServiceProvider.GetService<DbContext>();
+
+            var id1r = context3.ContextId;
+
+            Assert.NotSame(context1, context3);
+            Assert.NotEqual(default, id1r.InstanceId);
+            Assert.NotEqual(id1.InstanceId, id1r.InstanceId);
+            Assert.NotEqual(id1, id1r);
+            Assert.Equal(0, id1r.Lease);
+
+            var serviceScope4 = serviceProvider.CreateScope();
+            var context4 = serviceScope4.ServiceProvider.GetService<DbContext>();
+
+            var id2r = context4.ContextId;
+
+            Assert.NotSame(context2, context4);
+            Assert.NotEqual(default, id2r.InstanceId);
+            Assert.NotEqual(id2.InstanceId, id2r.InstanceId);
+            Assert.NotEqual(id2, id2r);
+            Assert.Equal(0, id2r.Lease);
         }
 
         [ConditionalTheory]

--- a/test/EFCore.SqlServer.FunctionalTests/TransactionInterceptionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TransactionInterceptionSqlServerTest.cs
@@ -9,24 +9,50 @@ using Xunit;
 
 namespace Microsoft.EntityFrameworkCore
 {
-    public class TransactionInterceptionSqlServerTest
-        : TransactionInterceptionTestBase, IClassFixture<TransactionInterceptionSqlServerTest.InterceptionSqlServerFixture>
+    public abstract class TransactionInterceptionSqlServerTestBase : TransactionInterceptionTestBase
     {
-        public TransactionInterceptionSqlServerTest(InterceptionSqlServerFixture fixture)
+        protected TransactionInterceptionSqlServerTestBase(InterceptionSqlServerFixtureBase fixture)
             : base(fixture)
         {
         }
 
-        public class InterceptionSqlServerFixture : InterceptionFixtureBase
+        public abstract class InterceptionSqlServerFixtureBase : InterceptionFixtureBase
         {
             protected override string StoreName => "TransactionInterception";
-
             protected override ITestStoreFactory TestStoreFactory => SqlServerTestStoreFactory.Instance;
 
             protected override IServiceCollection InjectInterceptors(
                 IServiceCollection serviceCollection,
                 IEnumerable<IInterceptor> injectedInterceptors)
                 => base.InjectInterceptors(serviceCollection.AddEntityFrameworkSqlServer(), injectedInterceptors);
+        }
+
+        public class TransactionInterceptionSqlServerTest
+            : TransactionInterceptionSqlServerTestBase, IClassFixture<TransactionInterceptionSqlServerTest.InterceptionSqlServerFixture>
+        {
+            public TransactionInterceptionSqlServerTest(InterceptionSqlServerFixture fixture)
+                : base(fixture)
+            {
+            }
+
+            public class InterceptionSqlServerFixture : InterceptionSqlServerFixtureBase
+            {
+                protected override bool ShouldSubscribeToDiagnosticListener => false;
+            }
+        }
+
+        public class TransactionInterceptionWithDiagnosticsSqlServerTest
+            : TransactionInterceptionSqlServerTestBase, IClassFixture<TransactionInterceptionWithDiagnosticsSqlServerTest.InterceptionSqlServerFixture>
+        {
+            public TransactionInterceptionWithDiagnosticsSqlServerTest(InterceptionSqlServerFixture fixture)
+                : base(fixture)
+            {
+            }
+
+            public class InterceptionSqlServerFixture : InterceptionSqlServerFixtureBase
+            {
+                protected override bool ShouldSubscribeToDiagnosticListener => true;
+            }
         }
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/CommandInterceptionSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/CommandInterceptionSqliteTest.cs
@@ -10,10 +10,9 @@ using Xunit;
 
 namespace Microsoft.EntityFrameworkCore
 {
-    public class CommandInterceptionSqliteTest
-        : CommandInterceptionTestBase, IClassFixture<CommandInterceptionSqliteTest.InterceptionSqliteFixture>
+    public abstract class CommandInterceptionSqliteTestBase : CommandInterceptionTestBase
     {
-        public CommandInterceptionSqliteTest(InterceptionSqliteFixture fixture)
+        protected CommandInterceptionSqliteTestBase(InterceptionSqliteFixtureBase fixture)
             : base(fixture)
         {
         }
@@ -45,16 +44,43 @@ namespace Microsoft.EntityFrameworkCore
             return null;
         }
 
-        public class InterceptionSqliteFixture : InterceptionFixtureBase
+        public abstract class InterceptionSqliteFixtureBase : InterceptionFixtureBase
         {
             protected override string StoreName => "CommandInterception";
-
             protected override ITestStoreFactory TestStoreFactory => SqliteTestStoreFactory.Instance;
 
             protected override IServiceCollection InjectInterceptors(
                 IServiceCollection serviceCollection,
                 IEnumerable<IInterceptor> injectedInterceptors)
                 => base.InjectInterceptors(serviceCollection.AddEntityFrameworkSqlite(), injectedInterceptors);
+        }
+
+        public class CommandInterceptionSqliteTest
+            : CommandInterceptionSqliteTestBase, IClassFixture<CommandInterceptionSqliteTest.InterceptionSqliteFixture>
+        {
+            public CommandInterceptionSqliteTest(InterceptionSqliteFixture fixture)
+                : base(fixture)
+            {
+            }
+
+            public class InterceptionSqliteFixture : InterceptionSqliteFixtureBase
+            {
+                protected override bool ShouldSubscribeToDiagnosticListener => false;
+            }
+        }
+
+        public class CommandInterceptionWithDiagnosticsSqliteTest
+            : CommandInterceptionSqliteTestBase, IClassFixture<CommandInterceptionWithDiagnosticsSqliteTest.InterceptionSqliteFixture>
+        {
+            public CommandInterceptionWithDiagnosticsSqliteTest(InterceptionSqliteFixture fixture)
+                : base(fixture)
+            {
+            }
+
+            public class InterceptionSqliteFixture : InterceptionSqliteFixtureBase
+            {
+                protected override bool ShouldSubscribeToDiagnosticListener => true;
+            }
         }
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/ConnectionInterceptionSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/ConnectionInterceptionSqliteTest.cs
@@ -9,10 +9,9 @@ using Xunit;
 
 namespace Microsoft.EntityFrameworkCore
 {
-    public class ConnectionInterceptionSqliteTest
-        : ConnectionInterceptionTestBase, IClassFixture<ConnectionInterceptionSqliteTest.InterceptionSqliteFixture>
+    public abstract class ConnectionInterceptionSqliteTestBase : ConnectionInterceptionTestBase
     {
-        public ConnectionInterceptionSqliteTest(InterceptionSqliteFixture fixture)
+        protected ConnectionInterceptionSqliteTestBase(InterceptionSqliteFixtureBase fixture)
             : base(fixture)
         {
         }
@@ -20,16 +19,43 @@ namespace Microsoft.EntityFrameworkCore
         protected override BadUniverseContext CreateBadUniverse(DbContextOptionsBuilder optionsBuilder)
             => new BadUniverseContext(optionsBuilder.UseSqlite("Data Source=file:data.db?mode=invalidmode").Options);
 
-        public class InterceptionSqliteFixture : InterceptionFixtureBase
+        public abstract class InterceptionSqliteFixtureBase : InterceptionFixtureBase
         {
             protected override string StoreName => "ConnectionInterception";
-
             protected override ITestStoreFactory TestStoreFactory => SqliteTestStoreFactory.Instance;
 
             protected override IServiceCollection InjectInterceptors(
                 IServiceCollection serviceCollection,
                 IEnumerable<IInterceptor> injectedInterceptors)
                 => base.InjectInterceptors(serviceCollection.AddEntityFrameworkSqlite(), injectedInterceptors);
+        }
+
+        public class ConnectionInterceptionSqliteTest
+            : ConnectionInterceptionSqliteTestBase, IClassFixture<ConnectionInterceptionSqliteTest.InterceptionSqliteFixture>
+        {
+            public ConnectionInterceptionSqliteTest(InterceptionSqliteFixture fixture)
+                : base(fixture)
+            {
+            }
+
+            public class InterceptionSqliteFixture : InterceptionSqliteFixtureBase
+            {
+                protected override bool ShouldSubscribeToDiagnosticListener => false;
+            }
+        }
+
+        public class ConnectionInterceptionWithDiagnosticsSqliteTest
+            : ConnectionInterceptionSqliteTestBase, IClassFixture<ConnectionInterceptionWithDiagnosticsSqliteTest.InterceptionSqliteFixture>
+        {
+            public ConnectionInterceptionWithDiagnosticsSqliteTest(InterceptionSqliteFixture fixture)
+                : base(fixture)
+            {
+            }
+
+            public class InterceptionSqliteFixture : InterceptionSqliteFixtureBase
+            {
+                protected override bool ShouldSubscribeToDiagnosticListener => true;
+            }
         }
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/TransactionInterceptionSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/TransactionInterceptionSqliteTest.cs
@@ -9,24 +9,50 @@ using Xunit;
 
 namespace Microsoft.EntityFrameworkCore
 {
-    public class TransactionInterceptionSqliteTest
-        : TransactionInterceptionTestBase, IClassFixture<TransactionInterceptionSqliteTest.InterceptionSqliteFixture>
+    public abstract class TransactionInterceptionSqliteTestBase : TransactionInterceptionTestBase
     {
-        public TransactionInterceptionSqliteTest(InterceptionSqliteFixture fixture)
+        protected TransactionInterceptionSqliteTestBase(InterceptionSqliteFixtureBase fixture)
             : base(fixture)
         {
         }
 
-        public class InterceptionSqliteFixture : InterceptionFixtureBase
+        public abstract class InterceptionSqliteFixtureBase : InterceptionFixtureBase
         {
             protected override string StoreName => "TransactionInterception";
-
             protected override ITestStoreFactory TestStoreFactory => SqliteTestStoreFactory.Instance;
 
             protected override IServiceCollection InjectInterceptors(
                 IServiceCollection serviceCollection,
                 IEnumerable<IInterceptor> injectedInterceptors)
                 => base.InjectInterceptors(serviceCollection.AddEntityFrameworkSqlite(), injectedInterceptors);
+        }
+
+        public class TransactionInterceptionSqliteTest
+            : TransactionInterceptionSqliteTestBase, IClassFixture<TransactionInterceptionSqliteTest.InterceptionSqliteFixture>
+        {
+            public TransactionInterceptionSqliteTest(InterceptionSqliteFixture fixture)
+                : base(fixture)
+            {
+            }
+
+            public class InterceptionSqliteFixture : InterceptionSqliteFixtureBase
+            {
+                protected override bool ShouldSubscribeToDiagnosticListener => false;
+            }
+        }
+
+        public class TransactionInterceptionWithDiagnosticsSqliteTest
+            : TransactionInterceptionSqliteTestBase, IClassFixture<TransactionInterceptionWithDiagnosticsSqliteTest.InterceptionSqliteFixture>
+        {
+            public TransactionInterceptionWithDiagnosticsSqliteTest(InterceptionSqliteFixture fixture)
+                : base(fixture)
+            {
+            }
+
+            public class InterceptionSqliteFixture : InterceptionSqliteFixtureBase
+            {
+                protected override bool ShouldSubscribeToDiagnosticListener => true;
+            }
         }
     }
 }

--- a/test/EFCore.Tests/DbContextTest.cs
+++ b/test/EFCore.Tests/DbContextTest.cs
@@ -944,7 +944,7 @@ namespace Microsoft.EntityFrameworkCore
             await Assert.ThrowsAsync<ObjectDisposedException>(() => context.FindAsync(typeof(Random), 77).AsTask());
 
             var methodCount = typeof(DbContext).GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly).Count();
-            var expectedMethodCount = 42;
+            var expectedMethodCount = 43;
             Assert.True(
                 methodCount == expectedMethodCount,
                 userMessage: $"Expected {expectedMethodCount} methods on DbContext but found {methodCount}. " +
@@ -957,6 +957,7 @@ namespace Microsoft.EntityFrameworkCore
             var expectedProperties = new List<string>
             {
                 nameof(DbContext.ChangeTracker),
+                nameof(DbContext.ContextId), // By-design, does not throw for disposed context
                 nameof(DbContext.Database),
                 nameof(DbContext.Model)
             };


### PR DESCRIPTION
Add Add correlation ID for `DbContext` like we have for `DbCommand` and `DbConnection`

Based on more feedback, now one ID and a lease number.

Fixes #16201

Better test coverage for interceptors and Diagnostics registered at the same time

Fixes #16352
