### PR TITLE
Query: Throw for unknown method encountered in QueryableMethodTranslator

### DIFF
--- a/src/EFCore.Cosmos/Query/Pipeline/CosmosQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Pipeline/CosmosQueryableMethodTranslatingExpressionVisitor.cs
@@ -23,6 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Pipeline
             ISqlExpressionFactory sqlExpressionFactory,
             IMemberTranslatorProvider memberTranslatorProvider,
             IMethodCallTranslatorProvider methodCallTranslatorProvider)
+            : base(subquery: false)
         {
             _model = model;
             _sqlExpressionFactory = sqlExpressionFactory;

--- a/src/EFCore.InMemory/Query/Pipeline/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Pipeline/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
@@ -18,6 +18,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Pipeline
         private readonly IModel _model;
 
         public InMemoryQueryableMethodTranslatingExpressionVisitor(IModel model)
+            : base(subquery: false)
         {
             _expressionTranslator = new InMemoryExpressionTranslatingExpressionVisitor();
             _projectionBindingExpressionVisitor = new InMemoryProjectionBindingExpressionVisitor(_expressionTranslator);

--- a/src/EFCore.Relational/Query/Pipeline/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Pipeline/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -28,6 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
             IModel model,
             IRelationalSqlTranslatingExpressionVisitorFactory relationalSqlTranslatingExpressionVisitorFactory,
             ISqlExpressionFactory sqlExpressionFactory)
+            : base(subquery: false)
         {
             _sqlTranslator = relationalSqlTranslatingExpressionVisitorFactory.Create(model, this);
             _projectionBindingExpressionVisitor = new RelationalProjectionBindingExpressionVisitor(this, _sqlTranslator);
@@ -39,6 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
             IModel model,
             RelationalSqlTranslatingExpressionVisitor sqlTranslator,
             ISqlExpressionFactory sqlExpressionFactory)
+            : base(subquery: true)
         {
             _model = model;
             _sqlTranslator = sqlTranslator;


### PR DESCRIPTION
Except for the subquery case
This visitor should only translate methods on Queryable so it should not do base eval for others.
All other methods should be passed through SqlTranslator (as they appear inside a lambda)
For subquery, we don't want to throw since we don't know if the subquery has client methods or not (projection case)
This is required for supporting collections/single non-scalar in projection.

