### PR TITLE
IAsyncDisposable plumbing

### DIFF
--- a/src/EFCore.Cosmos/Storage/Internal/CosmosClientWrapper.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosClientWrapper.cs
@@ -15,6 +15,7 @@ using Microsoft.Azure.Cosmos;
 using Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
@@ -507,23 +508,21 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
 
                     _jsonReader.Close();
                     _jsonReader = null;
-                    _reader.Dispose();
+                    await _reader.DisposeAsyncIfAvailable();
                     _reader = null;
-                    _responseStream.Dispose();
+                    await _responseStream.DisposeAsync();
                     _responseStream = null;
                     return await MoveNextAsync();
                 }
 
-                public ValueTask DisposeAsync()
+                public async ValueTask DisposeAsync()
                 {
                     _jsonReader?.Close();
                     _jsonReader = null;
-                    _reader?.Dispose();
+                    await _reader.DisposeAsyncIfAvailable();
                     _reader = null;
-                    _responseStream?.Dispose();
+                    await _responseStream.DisposeAsync();
                     _responseStream = null;
-
-                    return default;
                 }
             }
         }

--- a/src/EFCore.Cosmos/Storage/Internal/CosmosTransactionManager.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosTransactionManager.cs
@@ -78,5 +78,18 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         public virtual void ResetState()
         {
         }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual ValueTask ResetStateAsync()
+        {
+            ResetState();
+
+            return default;
+        }
     }
 }

--- a/src/EFCore.InMemory/Query/Pipeline/InMemoryShapedQueryExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Pipeline/InMemoryShapedQueryExpressionVisitor.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.InMemory.Query.Internal;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.Internal;
@@ -255,10 +256,10 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Pipeline
 
                 public ValueTask DisposeAsync()
                 {
-                    _enumerator?.Dispose();
+                    var enumerator = _enumerator;
                     _enumerator = null;
 
-                    return default;
+                    return enumerator.DisposeAsyncIfAvailable();
                 }
             }
         }

--- a/src/EFCore.InMemory/Storage/Internal/InMemoryTransaction.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryTransaction.cs
@@ -71,5 +71,14 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
         public virtual void Dispose()
         {
         }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual ValueTask DisposeAsync()
+            => default;
     }
 }

--- a/src/EFCore.InMemory/Storage/Internal/InMemoryTransactionManager.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryTransactionManager.cs
@@ -126,5 +126,18 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
         public virtual void ResetState()
         {
         }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual ValueTask ResetStateAsync()
+        {
+            ResetState();
+
+            return default;
+        }
     }
 }

--- a/src/EFCore.Relational/Migrations/HistoryRepository.cs
+++ b/src/EFCore.Relational/Migrations/HistoryRepository.cs
@@ -11,7 +11,6 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
-using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -248,7 +247,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             {
                 var command = Dependencies.RawSqlCommandBuilder.Build(GetAppliedMigrationsSql);
 
-                using (var reader = await command.ExecuteReaderAsync(
+                await using(var reader = await command.ExecuteReaderAsync(
                     new RelationalCommandParameterObject(
                         Dependencies.Connection,
                         null,

--- a/src/EFCore.Relational/Query/Pipeline/AsyncQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Pipeline/AsyncQueryingEnumerable.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -172,8 +173,13 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 
                 public ValueTask DisposeAsync()
                 {
-                    _dataReader?.Dispose();
-                    _dataReader = null;
+                    if (_dataReader != null)
+                    {
+                        var dataReader = _dataReader;
+                        _dataReader = null;
+
+                        return dataReader.DisposeAsync();
+                    }
 
                     return default;
                 }

--- a/src/EFCore.Relational/Storage/IRelationalConnection.cs
+++ b/src/EFCore.Relational/Storage/IRelationalConnection.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
     ///         The implementation does not need to be thread-safe.
     ///     </para>
     /// </summary>
-    public interface IRelationalConnection : IRelationalTransactionManager, IDisposable
+    public interface IRelationalConnection : IRelationalTransactionManager, IDisposable, IAsyncDisposable
     {
         /// <summary>
         ///     Gets the connection string for the database.

--- a/src/EFCore.Relational/Storage/RelationalDatabaseCreator.cs
+++ b/src/EFCore.Relational/Storage/RelationalDatabaseCreator.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Transactions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -255,7 +256,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </returns>
         public virtual async Task<bool> EnsureCreatedAsync(CancellationToken cancellationToken = default)
         {
-            using (new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled))
+            var transactionScope = new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled);
+            try
             {
                 if (!await ExistsAsync(cancellationToken))
                 {
@@ -271,6 +273,10 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
                     return true;
                 }
+            }
+            finally
+            {
+                await transactionScope.DisposeAsyncIfAvailable();
             }
 
             return false;

--- a/src/EFCore.Relational/Update/Internal/BatchExecutor.cs
+++ b/src/EFCore.Relational/Update/Internal/BatchExecutor.cs
@@ -161,7 +161,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
             {
                 if (startedTransaction != null)
                 {
-                    startedTransaction.Dispose();
+                    await startedTransaction.DisposeAsync();
                 }
                 else
                 {

--- a/src/EFCore.Relational/Update/ReaderModificationCommandBatch.cs
+++ b/src/EFCore.Relational/Update/ReaderModificationCommandBatch.cs
@@ -272,7 +272,7 @@ namespace Microsoft.EntityFrameworkCore.Update
 
             try
             {
-                using (var dataReader = await storeCommand.RelationalCommand.ExecuteReaderAsync(
+                await using (var dataReader = await storeCommand.RelationalCommand.ExecuteReaderAsync(
                     new RelationalCommandParameterObject(
                         connection,
                         storeCommand.ParameterValues,

--- a/src/EFCore/ChangeTracking/ChangeTracker.cs
+++ b/src/EFCore/ChangeTracking/ChangeTracker.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -377,6 +378,13 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
             LazyLoadingEnabled = true;
             CascadeDeleteTiming = CascadeTiming.Immediate;
             DeleteOrphansTiming = CascadeTiming.Immediate;
+        }
+
+        ValueTask IResettableService.ResetStateAsync()
+        {
+            ((IResettableService)this).ResetState();
+
+            return default;
         }
 
         #region Hidden System.Object members

--- a/src/EFCore/ChangeTracking/Internal/StateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/StateManager.cs
@@ -699,6 +699,19 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public virtual ValueTask ResetStateAsync()
+        {
+            ResetState();
+
+            return default;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public virtual void RecordReferencedUntrackedEntity(
             object referencedEntity, INavigation navigation, InternalEntityEntry referencedFromEntry)
         {

--- a/src/EFCore/Infrastructure/IResettableService.cs
+++ b/src/EFCore/Infrastructure/IResettableService.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.Infrastructure
@@ -28,5 +29,11 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     Resets the service so that it can be used from the pool.
         /// </summary>
         void ResetState();
+
+        /// <summary>
+        ///     Resets the service so that it can be used from the pool.
+        /// </summary>
+        /// <returns> A task that represents the asynchronous operation. </returns>
+        ValueTask ResetStateAsync();
     }
 }

--- a/src/EFCore/Internal/DbContextPool.cs
+++ b/src/EFCore/Internal/DbContextPool.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -20,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public class DbContextPool<TContext> : IDbContextPool, IDisposable
+    public class DbContextPool<TContext> : IDbContextPool, IDisposable, IAsyncDisposable
         where TContext : DbContext
     {
         private const int DefaultPoolSize = 32;
@@ -40,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public sealed class Lease : IDisposable
+        public sealed class Lease : IDisposable, IAsyncDisposable
         {
             private DbContextPool<TContext> _contextPool;
 
@@ -79,6 +80,21 @@ namespace Microsoft.EntityFrameworkCore.Internal
                     Context = null;
                 }
             }
+
+            async ValueTask IAsyncDisposable.DisposeAsync()
+            {
+                if (_contextPool != null)
+                {
+                    if (!_contextPool.Return(Context))
+                    {
+                        ((IDbContextPoolable)Context).SetPool(null);
+                        await Context.DisposeAsync();
+                    }
+
+                    _contextPool = null;
+                    Context = null;
+                }
+            }
         }
 
         /// <summary>
@@ -104,14 +120,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
 
         private static Func<TContext> CreateActivator(DbContextOptions options)
         {
-            var ctors
+            var constructors
                 = typeof(TContext).GetTypeInfo().DeclaredConstructors
                     .Where(c => !c.IsStatic && c.IsPublic)
                     .ToArray();
 
-            if (ctors.Length == 1)
+            if (constructors.Length == 1)
             {
-                var parameters = ctors[0].GetParameters();
+                var parameters = constructors[0].GetParameters();
 
                 if (parameters.Length == 1
                     && (parameters[0].ParameterType == typeof(DbContextOptions)
@@ -119,7 +135,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 {
                     return
                         Expression.Lambda<Func<TContext>>(
-                                Expression.New(ctors[0], Expression.Constant(options)))
+                                Expression.New(constructors[0], Expression.Constant(options)))
                             .Compile();
                 }
             }
@@ -213,6 +229,23 @@ namespace Microsoft.EntityFrameworkCore.Internal
             {
                 ((IDbContextPoolable)context).SetPool(null);
                 context.Dispose();
+            }
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual async ValueTask DisposeAsync()
+        {
+            _maxSize = 0;
+
+            while (_pool.TryDequeue(out var context))
+            {
+                ((IDbContextPoolable)context).SetPool(null);
+                await context.DisposeAsync();
             }
         }
     }

--- a/src/EFCore/Internal/IDbContextPoolable.cs
+++ b/src/EFCore/Internal/IDbContextPoolable.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 
 namespace Microsoft.EntityFrameworkCore.Internal
@@ -44,5 +45,13 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         void ResetState();
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        ValueTask ResetStateAsync();
     }
 }

--- a/src/EFCore/Internal/InternalDbSet.cs
+++ b/src/EFCore/Internal/InternalDbSet.cs
@@ -372,5 +372,18 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         void IResettableService.ResetState() => _localView = null;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        ValueTask IResettableService.ResetStateAsync()
+        {
+            ((IResettableService)this).ResetState();
+
+            return default;
+        }
     }
 }

--- a/src/EFCore/Storage/ExecutionStrategyExtensions.cs
+++ b/src/EFCore/Storage/ExecutionStrategyExtensions.cs
@@ -745,7 +745,7 @@ namespace Microsoft.EntityFrameworkCore
                 async (c, s, ct) =>
                 {
                     Check.NotNull(beginTransaction, nameof(beginTransaction));
-                    using (var transaction = await beginTransaction(c, cancellationToken))
+                    await using (var transaction = await beginTransaction(c, cancellationToken))
                     {
                         s.CommitFailed = false;
                         s.Result = await s.Operation(s.State, ct);

--- a/src/EFCore/Storage/IDbContextTransaction.cs
+++ b/src/EFCore/Storage/IDbContextTransaction.cs
@@ -17,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
     ///         to be directly constructed in your application code.
     ///     </para>
     /// </summary>
-    public interface IDbContextTransaction : IDisposable
+    public interface IDbContextTransaction : IDisposable, IAsyncDisposable
     {
         /// <summary>
         ///     Gets the transaction identifier.

--- a/src/EFCore/ValueGeneration/HiLoValueGeneratorState.cs
+++ b/src/EFCore/ValueGeneration/HiLoValueGeneratorState.cs
@@ -100,7 +100,7 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration
             // gets a chance to use the new new value, so use a while here to do it all again.
             while (newValue.Low >= newValue.High)
             {
-                using (await _asyncLock.LockAsync())
+                using (await _asyncLock.LockAsync(cancellationToken))
                 {
                     // Once inside the lock check to see if another thread already got a new block, in which
                     // case just get a value out of the new block instead of requesting one.

--- a/src/Shared/DisposableExtensions.cs
+++ b/src/Shared/DisposableExtensions.cs
@@ -1,0 +1,39 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    internal static class DisposableExtensions
+    {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public static ValueTask DisposeAsyncIfAvailable([CanBeNull] this IDisposable disposable)
+        {
+            if (disposable != null)
+            {
+                if (disposable is IAsyncDisposable asyncDisposable)
+                {
+                    return asyncDisposable.DisposeAsync();
+                }
+
+                disposable.Dispose();
+            }
+
+            return default;
+        }
+    }
+}

--- a/test/EFCore.Relational.Tests/RelationalDatabaseFacadeExtensionsTest.cs
+++ b/test/EFCore.Relational.Tests/RelationalDatabaseFacadeExtensionsTest.cs
@@ -153,6 +153,8 @@ namespace Microsoft.EntityFrameworkCore
             {
             }
 
+            public ValueTask ResetStateAsync() => default;
+
             public IDbContextTransaction BeginTransaction()
             {
                 BeginCount++;

--- a/test/EFCore.Relational.Tests/RelationalEventIdTest.cs
+++ b/test/EFCore.Relational.Tests/RelationalEventIdTest.cs
@@ -169,10 +169,14 @@ namespace Microsoft.EntityFrameworkCore
                 throw new NotImplementedException();
 
             public void ResetState() => throw new NotImplementedException();
+            public ValueTask ResetStateAsync() => throw new NotImplementedException();
+
             public void RollbackTransaction() => throw new NotImplementedException();
             public IDbContextTransaction UseTransaction(DbTransaction transaction) => throw new NotImplementedException();
             public Task<IDbContextTransaction> UseTransactionAsync(
                 DbTransaction transaction, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+            public ValueTask DisposeAsync() => throw new NotImplementedException();
         }
 
         private class FakeDbConnection : DbConnection

--- a/test/EFCore.Relational.Tests/Storage/RelationalTransactionExtensionsTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalTransactionExtensionsTest.cs
@@ -62,6 +62,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             public void Rollback() => throw new NotImplementedException();
             public Task CommitAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task RollbackAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public ValueTask DisposeAsync() => throw new NotImplementedException();
         }
 
         private const string ConnectionString = "Fake Connection String";

--- a/test/EFCore.Sqlite.FunctionalTests/Query/BadDataSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/BadDataSqliteTest.cs
@@ -354,6 +354,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             {
             }
 
+            public ValueTask ResetStateAsync() => default;
+
             public IDbContextTransaction BeginTransaction() => throw new NotImplementedException();
 
             public Task<IDbContextTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default) =>
@@ -400,6 +402,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             public void Dispose()
             {
             }
+
+            public ValueTask DisposeAsync() => default;
         }
 
         public class BadDataSqliteFixture : NorthwindQuerySqliteFixture<NoopModelCustomizer>

--- a/test/EFCore.Tests/DatabaseFacadeTest.cs
+++ b/test/EFCore.Tests/DatabaseFacadeTest.cs
@@ -171,11 +171,13 @@ namespace Microsoft.EntityFrameworkCore
             public void EnlistTransaction(Transaction transaction) => throw new NotImplementedException();
 
             public void ResetState() => throw new NotImplementedException();
+            public ValueTask ResetStateAsync() => throw new NotImplementedException();
         }
 
         private class FakeDbContextTransaction : IDbContextTransaction
         {
             public void Dispose() => throw new NotImplementedException();
+            public ValueTask DisposeAsync() => throw new NotImplementedException();
             public Guid TransactionId { get; }
             public void Commit() => throw new NotImplementedException();
             public void Rollback() => throw new NotImplementedException();

--- a/test/EFCore.Tests/DbContextTest.cs
+++ b/test/EFCore.Tests/DbContextTest.cs
@@ -916,11 +916,21 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [ConditionalFact]
-        public async Task It_throws_object_disposed_exception()
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task It_throws_object_disposed_exception(bool async)
         {
             var context = new DbContext(new DbContextOptions<DbContext>());
-            context.Dispose();
+
+            if (async)
+            {
+                await context.DisposeAsync();
+            }
+            else
+            {
+                context.Dispose();
+            }
 
             // methods (tests all paths)
             Assert.Throws<ObjectDisposedException>(() => context.Add(new object()));
@@ -934,7 +944,7 @@ namespace Microsoft.EntityFrameworkCore
             await Assert.ThrowsAsync<ObjectDisposedException>(() => context.FindAsync(typeof(Random), 77).AsTask());
 
             var methodCount = typeof(DbContext).GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly).Count();
-            var expectedMethodCount = 41;
+            var expectedMethodCount = 42;
             Assert.True(
                 methodCount == expectedMethodCount,
                 userMessage: $"Expected {expectedMethodCount} methods on DbContext but found {methodCount}. " +

--- a/test/EFCore.Tests/Infrastructure/EntityFrameworkServicesBuilderTest.cs
+++ b/test/EFCore.Tests/Infrastructure/EntityFrameworkServicesBuilderTest.cs
@@ -344,6 +344,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             public void ResetState()
             {
             }
+
+            public ValueTask ResetStateAsync() => default;
         }
 
         private static DbContext CreateContext(IServiceProvider serviceProvider)

--- a/test/EFCore.Tests/TestUtilities/FakeStateManager.cs
+++ b/test/EFCore.Tests/TestUtilities/FakeStateManager.cs
@@ -34,6 +34,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         {
         }
 
+        public ValueTask ResetStateAsync() => default;
+
         public void Unsubscribe()
         {
         }

--- a/test/EFCore.Tests/TestUtilities/TestInMemoryTransactionManager.cs
+++ b/test/EFCore.Tests/TestUtilities/TestInMemoryTransactionManager.cs
@@ -76,6 +76,13 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 return Task.CompletedTask;
             }
+
+            public ValueTask DisposeAsync()
+            {
+                Dispose();
+
+                return default;
+            }
         }
     }
 }


### PR DESCRIPTION
Calls dynamically where things are likely to be `IAsyncDisposable` in the future, but aren't now, or for things that are but don't expose it in the API surface (e.g. IServiceScope).

Fixes #14427
