### PR TITLE
Fix to #15264 - QueryRewrite: incorporate query filters into nav rewrite

### DIFF
--- a/src/EFCore/Internal/EntityFinder.cs
+++ b/src/EFCore/Internal/EntityFinder.cs
@@ -222,7 +222,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 keyValues[i] = keyValue;
             }
 
-            return _queryRoot.AsNoTracking()//.IgnoreQueryFilters()
+            return _queryRoot.AsNoTracking().IgnoreQueryFilters()
                 .Where(BuildObjectLambda(properties, new ValueBuffer(keyValues)))
                 .Select(BuildProjection(entityType));
         }

--- a/src/EFCore/Query/NavigationExpansion/MaterializeCollectionNavigationExpression.cs
+++ b/src/EFCore/Query/NavigationExpansion/MaterializeCollectionNavigationExpression.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Query.Expressions.Internal;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Query.NavigationExpansion
+{
+    public class MaterializeCollectionNavigationExpression : Expression, IPrintable
+    {
+        private Type _returnType;
+        public MaterializeCollectionNavigationExpression(Expression operand, INavigation navigation)
+        {
+            Operand = operand;
+            Navigation = navigation;
+            _returnType = navigation.ClrType;
+        }
+
+        public virtual Expression Operand { get; }
+        public virtual INavigation Navigation { get; }
+
+        public override ExpressionType NodeType => ExpressionType.Extension;
+        public override Type Type => _returnType;
+        public override bool CanReduce => false;
+
+        protected override Expression VisitChildren(ExpressionVisitor visitor)
+        {
+            var newOperand = visitor.Visit(Operand);
+
+            return Update(newOperand);
+        }
+
+        public virtual MaterializeCollectionNavigationExpression Update(Expression operand)
+            => operand != Operand
+            ? new MaterializeCollectionNavigationExpression(operand, Navigation)
+            : this;
+
+        public virtual void Print(ExpressionPrinter expressionPrinter)
+        {
+            expressionPrinter.StringBuilder.Append($"MATERIALIZE_COLLECTION({ Navigation }, ");
+            expressionPrinter.Visit(Operand);
+            expressionPrinter.StringBuilder.Append(")");
+        }
+    }
+}

--- a/src/EFCore/Query/NavigationExpansion/NavigationExpansionHelpers.cs
+++ b/src/EFCore/Query/NavigationExpansion/NavigationExpansionHelpers.cs
@@ -11,6 +11,8 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Query.Expressions.Internal;
 using Microsoft.EntityFrameworkCore.Query.Internal;
+using Microsoft.EntityFrameworkCore.Query.NavigationExpansion.Visitors;
+using Microsoft.EntityFrameworkCore.Query.Pipeline;
 
 namespace Microsoft.EntityFrameworkCore.Query.NavigationExpansion
 {
@@ -19,7 +21,9 @@ namespace Microsoft.EntityFrameworkCore.Query.NavigationExpansion
         public static NavigationExpansionExpression CreateNavigationExpansionRoot(
             Expression operand,
             IEntityType entityType,
-            INavigation materializeCollectionNavigation)
+            INavigation materializeCollectionNavigation,
+            NavigationExpandingVisitor navigationExpandingVisitor,
+            QueryCompilationContext queryCompilationContext)
         {
             var sourceMapping = new SourceMapping
             {
@@ -39,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Query.NavigationExpansion
                     pendingSelectorParameter.Type),
                 pendingSelectorParameter);
 
-            return new NavigationExpansionExpression(
+            var result = new NavigationExpansionExpression(
                 operand,
                 new NavigationExpansionExpressionState(
                     pendingSelectorParameter,
@@ -53,6 +57,49 @@ namespace Microsoft.EntityFrameworkCore.Query.NavigationExpansion
                     customRootMappings: new List<List<string>>(),
                     materializeCollectionNavigation),
                 materializeCollectionNavigation?.ClrType ?? operand.Type);
+
+            var rootEntityType = entityType.RootType();
+            var queryFilterAnnotation = rootEntityType.FindAnnotation("QueryFilter");
+            if (queryFilterAnnotation != null
+                && !queryCompilationContext.IgnoreQueryFilters
+                && !navigationExpandingVisitor.AppliedQueryFilters.Contains(rootEntityType))
+            {
+                navigationExpandingVisitor.AppliedQueryFilters.Add(rootEntityType);
+                var filterPredicate = (LambdaExpression)queryFilterAnnotation.Value;
+
+                var parameterExtractingExpressionVisitor = new ParameterExtractingExpressionVisitor(
+                    queryCompilationContext.EvaluatableExpressionFilter,
+                    queryCompilationContext.ParameterValues,
+                    queryCompilationContext.ContextType,
+                    queryCompilationContext.Logger,
+                    parameterize: false,
+                    generateContextAccessors: true);
+
+                filterPredicate = (LambdaExpression)parameterExtractingExpressionVisitor.ExtractParameters(filterPredicate);
+
+                // in case of query filters we need to strip MaterializeCollectionNavigation from the initial collection and apply it after the filter
+                result = (NavigationExpansionExpression)RemoveMaterializeCollection(result);
+                var sequenceType = result.Type.GetSequenceType();
+
+                // if we are constructing EntityQueryable of a derived type, we need to re-map filter predicate to the correct derived type
+                var filterPredicateParameter = filterPredicate.Parameters[0];
+                if (filterPredicateParameter.Type != sequenceType)
+                {
+                    var newFilterPredicateParameter = Expression.Parameter(sequenceType, filterPredicateParameter.Name);
+                    filterPredicate = (LambdaExpression)new ExpressionReplacingVisitor(filterPredicateParameter, newFilterPredicateParameter).Visit(filterPredicate);
+                }
+
+                var whereMethod = LinqMethodHelpers.QueryableWhereMethodInfo.MakeGenericMethod(result.Type.GetSequenceType());
+                var filteredResult = (Expression)Expression.Call(whereMethod, result, filterPredicate);
+                if (materializeCollectionNavigation != null)
+                {
+                    filteredResult = new MaterializeCollectionNavigationExpression(result, materializeCollectionNavigation);
+                }
+
+                result = (NavigationExpansionExpression)navigationExpandingVisitor.Visit(filteredResult);
+            }
+
+            return result;
         }
 
         private static readonly MethodInfo _leftJoinMethodInfo = typeof(QueryableExtensions).GetTypeInfo()
@@ -65,7 +112,9 @@ namespace Microsoft.EntityFrameworkCore.Query.NavigationExpansion
             NavigationTreeNode navigationTree,
             NavigationExpansionExpressionState state,
             List<INavigation> navigationPath,
-            bool include)
+            bool include,
+            NavigationExpandingVisitor navigationExpandingVisitor,
+            QueryCompilationContext queryCompilationContext)
         {
             var joinNeeded = include
                 ? navigationTree.Included == NavigationTreeNodeIncludeMode.ReferencePending
@@ -73,140 +122,172 @@ namespace Microsoft.EntityFrameworkCore.Query.NavigationExpansion
 
             if (joinNeeded)
             {
-                var navigation = navigationTree.Navigation;
-                var sourceType = sourceExpression.Type.GetSequenceType();
-                var navigationTargetEntityType = navigation.GetTargetType();
-
-                var entityQueryable = NullAsyncQueryProvider.Instance.CreateEntityQueryableExpression(navigationTargetEntityType.ClrType);
-                var resultType = typeof(TransparentIdentifier<,>).MakeGenericType(sourceType, navigationTargetEntityType.ClrType);
-
-                var outerParameter = Expression.Parameter(sourceType, parameterExpression.Name);
-                var outerKeySelectorParameter = outerParameter;
-                var transparentIdentifierAccessorExpression = outerParameter.BuildPropertyAccess(navigationTree.Parent.ToMapping);
-
-                var outerKeySelectorBody = CreateKeyAccessExpression(
-                    transparentIdentifierAccessorExpression,
-                    navigation.IsDependentToPrincipal()
-                        ? navigation.ForeignKey.Properties
-                        : navigation.ForeignKey.PrincipalKey.Properties,
-                    addNullCheck: navigationTree.Parent != null && navigationTree.Parent.Optional);
-
-                var innerKeySelectorParameterType = navigationTargetEntityType.ClrType;
-                var innerKeySelectorParameter = Expression.Parameter(
-                    innerKeySelectorParameterType,
-                    parameterExpression.Name + "." + navigationTree.Navigation.Name);
-
-                var innerKeySelectorBody = CreateKeyAccessExpression(
-                    innerKeySelectorParameter,
-                    navigation.IsDependentToPrincipal()
-                        ? navigation.ForeignKey.PrincipalKey.Properties
-                        : navigation.ForeignKey.Properties);
-
-                if (outerKeySelectorBody.Type.IsNullableType()
-                    && !innerKeySelectorBody.Type.IsNullableType())
+                // TODO: hack/quirk to work-around potential bugs in the new navigation generation
+                if (queryCompilationContext.IgnoreQueryFilters)
                 {
-                    innerKeySelectorBody = Expression.Convert(innerKeySelectorBody, outerKeySelectorBody.Type);
-                }
-                else if (innerKeySelectorBody.Type.IsNullableType()
-                    && !outerKeySelectorBody.Type.IsNullableType())
-                {
-                    outerKeySelectorBody = Expression.Convert(outerKeySelectorBody, innerKeySelectorBody.Type);
-                }
-
-                var outerKeySelector = Expression.Lambda(
-                    outerKeySelectorBody,
-                    outerKeySelectorParameter);
-
-                var innerKeySelector = Expression.Lambda(
-                    innerKeySelectorBody,
-                    innerKeySelectorParameter);
-
-                if (!sourceExpression.Type.IsQueryableType())
-                {
-                    var asQueryableMethodInfo = LinqMethodHelpers.AsQueryable.MakeGenericMethod(sourceType);
-                    sourceExpression = Expression.Call(asQueryableMethodInfo, sourceExpression);
-                }
-
-                var joinMethodInfo = navigationTree.Optional
-                    ? _leftJoinMethodInfo.MakeGenericMethod(
-                        sourceType,
-                        navigationTargetEntityType.ClrType,
-                        outerKeySelector.Body.Type,
-                        resultType)
-                    : LinqMethodHelpers.QueryableJoinMethodInfo.MakeGenericMethod(
-                        sourceType,
-                        navigationTargetEntityType.ClrType,
-                        outerKeySelector.Body.Type,
-                        resultType);
-
-                var resultSelectorOuterParameterName = outerParameter.Name;
-                var resultSelectorOuterParameter = Expression.Parameter(sourceType, resultSelectorOuterParameterName);
-
-                var resultSelectorInnerParameterName = innerKeySelectorParameter.Name;
-                var resultSelectorInnerParameter = Expression.Parameter(navigationTargetEntityType.ClrType, resultSelectorInnerParameterName);
-
-                var transparentIdentifierCtorInfo
-                    = resultType.GetTypeInfo().GetConstructors().Single();
-
-                var transparentIdentifierOuterMemberInfo = resultType.GetTypeInfo().GetDeclaredField("Outer");
-                var transparentIdentifierInnerMemberInfo = resultType.GetTypeInfo().GetDeclaredField("Inner");
-
-                var resultSelector = Expression.Lambda(
-                    Expression.New(
-                        transparentIdentifierCtorInfo,
-                        new[] { resultSelectorOuterParameter, resultSelectorInnerParameter },
-                        new[] { transparentIdentifierOuterMemberInfo, transparentIdentifierInnerMemberInfo }),
-                    resultSelectorOuterParameter,
-                    resultSelectorInnerParameter);
-
-                var joinMethodCall = Expression.Call(
-                    joinMethodInfo,
-                    sourceExpression,
-                    entityQueryable,
-                    outerKeySelector,
-                    innerKeySelector,
-                    resultSelector);
-
-                sourceExpression = joinMethodCall;
-
-                var transparentIdentifierParameterName = resultSelectorInnerParameterName;
-                var transparentIdentifierParameter = Expression.Parameter(resultSelector.ReturnType, transparentIdentifierParameterName);
-                parameterExpression = transparentIdentifierParameter;
-
-                // remap navigation 'To' paths -> for this navigation prepend "Inner", for every other (already expanded) navigation prepend "Outer"
-                navigationTree.ToMapping.Insert(0, nameof(TransparentIdentifier<object, object>.Inner));
-                foreach (var mapping in state.SourceMappings)
-                {
-                    var nodes = include
-                        ? mapping.NavigationTree.Flatten().Where(n => (n.Included == NavigationTreeNodeIncludeMode.ReferenceComplete
-                            || n.ExpansionMode == NavigationTreeNodeExpansionMode.ReferenceComplete
-                            || n.Navigation.ForeignKey.IsOwnership)
-                                && n != navigationTree)
-                        : mapping.NavigationTree.Flatten().Where(n => (n.ExpansionMode == NavigationTreeNodeExpansionMode.ReferenceComplete
-                            || n.Navigation.ForeignKey.IsOwnership)
-                                && n != navigationTree);
-
-                    foreach (var navigationTreeNode in nodes)
-                    {
-                        navigationTreeNode.ToMapping.Insert(0, nameof(TransparentIdentifier<object, object>.Outer));
-                    }
-                }
-
-                foreach (var customRootMapping in state.CustomRootMappings)
-                {
-                    customRootMapping.Insert(0, nameof(TransparentIdentifier<object, object>.Outer));
-                }
-
-                if (include)
-                {
-                    navigationTree.Included = NavigationTreeNodeIncludeMode.ReferenceComplete;
+                    LegacyCodepath(ref sourceExpression, ref parameterExpression, navigationTree, state, navigationPath, include);
                 }
                 else
                 {
-                    navigationTree.ExpansionMode = NavigationTreeNodeExpansionMode.ReferenceComplete;
+                    var navigation = navigationTree.Navigation;
+                    var sourceType = sourceExpression.Type.GetSequenceType();
+                    var entityQueryable = NullAsyncQueryProvider.Instance.CreateEntityQueryableExpression(navigation.GetTargetType().ClrType);
+                    var navigationRoot = CreateNavigationExpansionRoot(entityQueryable, navigation.GetTargetType(), materializeCollectionNavigation: null, navigationExpandingVisitor, queryCompilationContext);
 
+                    var resultType = typeof(TransparentIdentifier<,>).MakeGenericType(sourceType, navigationRoot.State.CurrentParameter.Type);
+
+                    var outerParameter = Expression.Parameter(sourceType, parameterExpression.Name);
+                    var outerKeySelectorParameter = outerParameter;
+                    var outerTransparentIdentifierAccessorExpression = outerParameter.BuildPropertyAccess(navigationTree.Parent.ToMapping);
+
+                    var outerKeySelectorBody = CreateKeyAccessExpression(
+                        outerTransparentIdentifierAccessorExpression,
+                        navigation.IsDependentToPrincipal()
+                            ? navigation.ForeignKey.Properties
+                            : navigation.ForeignKey.PrincipalKey.Properties,
+                        addNullCheck: navigationTree.Parent != null && navigationTree.Parent.Optional);
+
+                    var innerKeySelectorParameter = Expression.Parameter(
+                        navigationRoot.State.CurrentParameter.Type,
+                        navigationRoot.State.CurrentParameter.Name + "." + navigationTree.Navigation.Name);
+
+                    // we are guaranteed to only have one SourceMapping here because it will either be a simple EntityQueryable (normal navigation expansion case)
+                    // or EntityQueryable with navigations from query filters - those however can only contain navigations that stem from the original, so it's all part of the same root, hence only one SourceMapping
+                    //
+                    // if the query filter is complex and contains Joins/GroupJoins etc that would spawn additional SourceMappings,
+                    // those mappings would be on the inner NavigationExpansionExpression, so we don't need to worry about them here.
+                    var navigationRootSourceMapping = navigationRoot.State.SourceMappings.Single();
+                    var innerTransparentIdentifierAccessorExpression = innerKeySelectorParameter.BuildPropertyAccess(navigationRootSourceMapping.NavigationTree.ToMapping);
+
+                    var innerKeySelectorBody = CreateKeyAccessExpression(
+                        innerTransparentIdentifierAccessorExpression,
+                        navigation.IsDependentToPrincipal()
+                            ? navigation.ForeignKey.PrincipalKey.Properties
+                            : navigation.ForeignKey.Properties);
+
+                    if (outerKeySelectorBody.Type.IsNullableType()
+                        && !innerKeySelectorBody.Type.IsNullableType())
+                    {
+                        innerKeySelectorBody = Expression.Convert(innerKeySelectorBody, outerKeySelectorBody.Type);
+                    }
+                    else if (innerKeySelectorBody.Type.IsNullableType()
+                        && !outerKeySelectorBody.Type.IsNullableType())
+                    {
+                        outerKeySelectorBody = Expression.Convert(outerKeySelectorBody, innerKeySelectorBody.Type);
+                    }
+
+                    var outerKeySelector = Expression.Lambda(
+                        outerKeySelectorBody,
+                        outerKeySelectorParameter);
+
+                    var innerKeySelector = Expression.Lambda(
+                        innerKeySelectorBody,
+                        innerKeySelectorParameter);
+
+                    if (!sourceExpression.Type.IsQueryableType())
+                    {
+                        var asQueryableMethodInfo = LinqMethodHelpers.AsQueryable.MakeGenericMethod(sourceType);
+                        sourceExpression = Expression.Call(asQueryableMethodInfo, sourceExpression);
+                    }
+
+                    var joinMethodInfo = navigationTree.Optional
+                        ? _leftJoinMethodInfo.MakeGenericMethod(
+                            sourceType,
+                            navigationRoot.State.CurrentParameter.Type,
+                            outerKeySelector.Body.Type,
+                            resultType)
+                        : LinqMethodHelpers.QueryableJoinMethodInfo.MakeGenericMethod(
+                            sourceType,
+                            navigationRoot.State.CurrentParameter.Type,
+                            outerKeySelector.Body.Type,
+                            resultType);
+
+                    var resultSelectorOuterParameterName = outerParameter.Name;
+                    var resultSelectorOuterParameter = Expression.Parameter(sourceType, resultSelectorOuterParameterName);
+
+                    var resultSelectorInnerParameterName = innerKeySelectorParameter.Name;
+                    var resultSelectorInnerParameter = Expression.Parameter(navigationRoot.State.CurrentParameter.Type, resultSelectorInnerParameterName);
+
+                    var transparentIdentifierCtorInfo
+                        = resultType.GetTypeInfo().GetConstructors().Single();
+
+                    var transparentIdentifierOuterMemberInfo = resultType.GetTypeInfo().GetDeclaredField("Outer");
+                    var transparentIdentifierInnerMemberInfo = resultType.GetTypeInfo().GetDeclaredField("Inner");
+
+                    var resultSelector = Expression.Lambda(
+                        Expression.New(
+                            transparentIdentifierCtorInfo,
+                            new[] { resultSelectorOuterParameter, resultSelectorInnerParameter },
+                            new[] { transparentIdentifierOuterMemberInfo, transparentIdentifierInnerMemberInfo }),
+                        resultSelectorOuterParameter,
+                        resultSelectorInnerParameter);
+
+                    var joinMethodCall = Expression.Call(
+                        joinMethodInfo,
+                        sourceExpression,
+                        navigationRoot.Operand,
+                        outerKeySelector,
+                        innerKeySelector,
+                        resultSelector);
+
+                    sourceExpression = joinMethodCall;
+
+                    var transparentIdentifierParameterName = resultSelectorInnerParameterName;
+                    var transparentIdentifierParameter = Expression.Parameter(resultSelector.ReturnType, transparentIdentifierParameterName);
+                    parameterExpression = transparentIdentifierParameter;
+
+                    // remap navigation 'To' paths -> for inner navigations (they should all be expanded by now) prepend "Inner", for every other (already expanded) navigation prepend "Outer"
+                    var innerNodes = include
+                        ? navigationRootSourceMapping.NavigationTree.Flatten().Where(n => (n.Included == NavigationTreeNodeIncludeMode.ReferenceComplete
+                            || n.ExpansionMode == NavigationTreeNodeExpansionMode.ReferenceComplete
+                            || n.Navigation.ForeignKey.IsOwnership)
+                                && n != navigationTree)
+                        : navigationRootSourceMapping.NavigationTree.Flatten().Where(n => (n.ExpansionMode == NavigationTreeNodeExpansionMode.ReferenceComplete
+                            || n.Navigation.ForeignKey.IsOwnership)
+                                && n != navigationTree);
+
+                    foreach (var innerNode in innerNodes)
+                    {
+                        innerNode.ToMapping.Insert(0, nameof(TransparentIdentifier<object, object>.Inner));
+                    }
+
+                    foreach (var mapping in state.SourceMappings)
+                    {
+                        var nodes = include
+                            ? mapping.NavigationTree.Flatten().Where(n => (n.Included == NavigationTreeNodeIncludeMode.ReferenceComplete
+                                || n.ExpansionMode == NavigationTreeNodeExpansionMode.ReferenceComplete
+                                || n.Navigation.ForeignKey.IsOwnership)
+                                    && n != navigationTree)
+                            : mapping.NavigationTree.Flatten().Where(n => (n.ExpansionMode == NavigationTreeNodeExpansionMode.ReferenceComplete
+                                || n.Navigation.ForeignKey.IsOwnership)
+                                    && n != navigationTree);
+
+                        foreach (var navigationTreeNode in nodes)
+                        {
+                            navigationTreeNode.ToMapping.Insert(0, nameof(TransparentIdentifier<object, object>.Outer));
+                        }
+                    }
+
+                    // TODO: there shouldn't be any custom root mappings for inner, but not 100% sure - think & TEST!
+                    foreach (var customRootMapping in state.CustomRootMappings)
+                    {
+                        customRootMapping.Insert(0, nameof(TransparentIdentifier<object, object>.Outer));
+                    }
+
+                    if (include)
+                    {
+                        navigationTree.Included = NavigationTreeNodeIncludeMode.ReferenceComplete;
+                    }
+                    else
+                    {
+                        navigationTree.ExpansionMode = NavigationTreeNodeExpansionMode.ReferenceComplete;
+                    }
+
+                    // finally, we need to incorporate the newly created navigation tree into the old one
+                    navigationRootSourceMapping.NavigationTree.SetNavigation(navigationTree.Navigation);
+                    navigationTree.Parent.AddChild(navigationRootSourceMapping.NavigationTree);
+                    navigationPath.Add(navigation);
                 }
-                navigationPath.Add(navigation);
             }
             else
             {
@@ -223,10 +304,156 @@ namespace Microsoft.EntityFrameworkCore.Query.NavigationExpansion
                     child,
                     state,
                     navigationPath.ToList(),
-                    include);
+                    include,
+                    navigationExpandingVisitor,
+                    queryCompilationContext);
             }
 
             return result;
+        }
+
+        private static void LegacyCodepath(
+            ref Expression sourceExpression,
+            ref ParameterExpression parameterExpression,
+            NavigationTreeNode navigationTree,
+            NavigationExpansionExpressionState state,
+            List<INavigation> navigationPath,
+            bool include)
+        {
+            var navigation = navigationTree.Navigation;
+            var sourceType = sourceExpression.Type.GetSequenceType();
+            var navigationTargetEntityType = navigation.GetTargetType();
+
+            var entityQueryable = NullAsyncQueryProvider.Instance.CreateEntityQueryableExpression(navigationTargetEntityType.ClrType);
+            var resultType = typeof(TransparentIdentifier<,>).MakeGenericType(sourceType, navigationTargetEntityType.ClrType);
+
+            var outerParameter = Expression.Parameter(sourceType, parameterExpression.Name);
+            var outerKeySelectorParameter = outerParameter;
+            var transparentIdentifierAccessorExpression = outerParameter.BuildPropertyAccess(navigationTree.Parent.ToMapping);
+
+            var outerKeySelectorBody = CreateKeyAccessExpression(
+                transparentIdentifierAccessorExpression,
+                navigation.IsDependentToPrincipal()
+                    ? navigation.ForeignKey.Properties
+                    : navigation.ForeignKey.PrincipalKey.Properties,
+                addNullCheck: navigationTree.Parent != null && navigationTree.Parent.Optional);
+
+            var innerKeySelectorParameterType = navigationTargetEntityType.ClrType;
+            var innerKeySelectorParameter = Expression.Parameter(
+                innerKeySelectorParameterType,
+                parameterExpression.Name + "." + navigationTree.Navigation.Name);
+
+            var innerKeySelectorBody = CreateKeyAccessExpression(
+                innerKeySelectorParameter,
+                navigation.IsDependentToPrincipal()
+                    ? navigation.ForeignKey.PrincipalKey.Properties
+                    : navigation.ForeignKey.Properties);
+
+            if (outerKeySelectorBody.Type.IsNullableType()
+                && !innerKeySelectorBody.Type.IsNullableType())
+            {
+                innerKeySelectorBody = Expression.Convert(innerKeySelectorBody, outerKeySelectorBody.Type);
+            }
+            else if (innerKeySelectorBody.Type.IsNullableType()
+                && !outerKeySelectorBody.Type.IsNullableType())
+            {
+                outerKeySelectorBody = Expression.Convert(outerKeySelectorBody, innerKeySelectorBody.Type);
+            }
+
+            var outerKeySelector = Expression.Lambda(
+                outerKeySelectorBody,
+                outerKeySelectorParameter);
+
+            var innerKeySelector = Expression.Lambda(
+                innerKeySelectorBody,
+                innerKeySelectorParameter);
+
+            if (!sourceExpression.Type.IsQueryableType())
+            {
+                var asQueryableMethodInfo = LinqMethodHelpers.AsQueryable.MakeGenericMethod(sourceType);
+                sourceExpression = Expression.Call(asQueryableMethodInfo, sourceExpression);
+            }
+
+            var joinMethodInfo = navigationTree.Optional
+                ? _leftJoinMethodInfo.MakeGenericMethod(
+                    sourceType,
+                    navigationTargetEntityType.ClrType,
+                    outerKeySelector.Body.Type,
+                    resultType)
+                : LinqMethodHelpers.QueryableJoinMethodInfo.MakeGenericMethod(
+                    sourceType,
+                    navigationTargetEntityType.ClrType,
+                    outerKeySelector.Body.Type,
+                    resultType);
+
+            var resultSelectorOuterParameterName = outerParameter.Name;
+            var resultSelectorOuterParameter = Expression.Parameter(sourceType, resultSelectorOuterParameterName);
+
+            var resultSelectorInnerParameterName = innerKeySelectorParameter.Name;
+            var resultSelectorInnerParameter = Expression.Parameter(navigationTargetEntityType.ClrType, resultSelectorInnerParameterName);
+
+            var transparentIdentifierCtorInfo
+                = resultType.GetTypeInfo().GetConstructors().Single();
+
+            var transparentIdentifierOuterMemberInfo = resultType.GetTypeInfo().GetDeclaredField("Outer");
+            var transparentIdentifierInnerMemberInfo = resultType.GetTypeInfo().GetDeclaredField("Inner");
+
+            var resultSelector = Expression.Lambda(
+                Expression.New(
+                    transparentIdentifierCtorInfo,
+                    new[] { resultSelectorOuterParameter, resultSelectorInnerParameter },
+                    new[] { transparentIdentifierOuterMemberInfo, transparentIdentifierInnerMemberInfo }),
+                resultSelectorOuterParameter,
+                resultSelectorInnerParameter);
+
+            var joinMethodCall = Expression.Call(
+                joinMethodInfo,
+                sourceExpression,
+                entityQueryable,
+                outerKeySelector,
+                innerKeySelector,
+                resultSelector);
+
+            sourceExpression = joinMethodCall;
+
+            var transparentIdentifierParameterName = resultSelectorInnerParameterName;
+            var transparentIdentifierParameter = Expression.Parameter(resultSelector.ReturnType, transparentIdentifierParameterName);
+            parameterExpression = transparentIdentifierParameter;
+
+            // remap navigation 'To' paths -> for this navigation prepend "Inner", for every other (already expanded) navigation prepend "Outer"
+            navigationTree.ToMapping.Insert(0, nameof(TransparentIdentifier<object, object>.Inner));
+            foreach (var mapping in state.SourceMappings)
+            {
+                var nodes = include
+                    ? mapping.NavigationTree.Flatten().Where(n => (n.Included == NavigationTreeNodeIncludeMode.ReferenceComplete
+                        || n.ExpansionMode == NavigationTreeNodeExpansionMode.ReferenceComplete
+                        || n.Navigation.ForeignKey.IsOwnership)
+                            && n != navigationTree)
+                    : mapping.NavigationTree.Flatten().Where(n => (n.ExpansionMode == NavigationTreeNodeExpansionMode.ReferenceComplete
+                        || n.Navigation.ForeignKey.IsOwnership)
+                            && n != navigationTree);
+
+                foreach (var navigationTreeNode in nodes)
+                {
+                    navigationTreeNode.ToMapping.Insert(0, nameof(TransparentIdentifier<object, object>.Outer));
+                }
+            }
+
+            foreach (var customRootMapping in state.CustomRootMappings)
+            {
+                customRootMapping.Insert(0, nameof(TransparentIdentifier<object, object>.Outer));
+            }
+
+            if (include)
+            {
+                navigationTree.Included = NavigationTreeNodeIncludeMode.ReferenceComplete;
+            }
+            else
+            {
+                navigationTree.ExpansionMode = NavigationTreeNodeExpansionMode.ReferenceComplete;
+
+            }
+            navigationPath.Add(navigation);
         }
 
         public static Expression CreateKeyAccessExpression(
@@ -289,6 +516,35 @@ namespace Microsoft.EntityFrameworkCore.Query.NavigationExpansion
             var collection = navigation.GetCollectionAccessor().Create(elements);
 
             return (TResult)collection;
+        }
+
+        public static Expression RemoveMaterializeCollection(Expression expression)
+        {
+            if (expression is NavigationExpansionExpression navigationExpansionExpression
+                && navigationExpansionExpression.State.MaterializeCollectionNavigation != null)
+            {
+                navigationExpansionExpression.State.MaterializeCollectionNavigation = null;
+
+                return new NavigationExpansionExpression(
+                    navigationExpansionExpression.Operand,
+                    navigationExpansionExpression.State,
+                    navigationExpansionExpression.Operand.Type);
+            }
+
+            if (expression is NavigationExpansionRootExpression navigationExpansionRootExpression
+                && navigationExpansionRootExpression.NavigationExpansion.State.MaterializeCollectionNavigation != null)
+            {
+                navigationExpansionRootExpression.NavigationExpansion.State.MaterializeCollectionNavigation = null;
+
+                var rewritten = new NavigationExpansionExpression(
+                    navigationExpansionRootExpression.NavigationExpansion.Operand,
+                    navigationExpansionRootExpression.NavigationExpansion.State,
+                    navigationExpansionRootExpression.NavigationExpansion.Operand.Type);
+
+                return new NavigationExpansionRootExpression(rewritten, navigationExpansionRootExpression.Mapping);
+            }
+
+            return expression;
         }
     }
 }

--- a/src/EFCore/Query/NavigationExpansion/Visitors/IncludeApplyingVisitor.cs
+++ b/src/EFCore/Query/NavigationExpansion/Visitors/IncludeApplyingVisitor.cs
@@ -4,11 +4,21 @@
 using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Query.Pipeline;
 
 namespace Microsoft.EntityFrameworkCore.Query.NavigationExpansion.Visitors
 {
     public class PendingSelectorIncludeRewriter : ExpressionVisitor
     {
+        private readonly NavigationExpandingVisitor _navigationExpandingVisitor;
+        private readonly QueryCompilationContext _queryCompilationContext;
+
+        public PendingSelectorIncludeRewriter(NavigationExpandingVisitor navigationExpandingVisitor, QueryCompilationContext queryCompilationContext)
+        {
+            _navigationExpandingVisitor = navigationExpandingVisitor;
+            _queryCompilationContext = queryCompilationContext;
+        }
+
         protected override Expression VisitMember(MemberExpression memberExpression) => memberExpression;
         protected override Expression VisitInvocation(InvocationExpression invocationExpression) => invocationExpression;
         protected override Expression VisitLambda<T>(Expression<T> lambdaExpression) => lambdaExpression;
@@ -88,7 +98,7 @@ namespace Microsoft.EntityFrameworkCore.Query.NavigationExpansion.Visitors
 
         private IncludeExpression CreateIncludeCollectionCall(Expression caller, NavigationTreeNode node, ParameterExpression rootParameter, SourceMapping sourceMapping)
         {
-            var included = CollectionNavigationRewritingVisitor.CreateCollectionNavigationExpression(node, rootParameter, sourceMapping);
+            var included = CollectionNavigationRewritingVisitor.CreateCollectionNavigationExpression(node, rootParameter, sourceMapping, _navigationExpandingVisitor, _queryCompilationContext);
 
             return new IncludeExpression(caller, included, node.Navigation);
         }

--- a/src/EFCore/Query/NavigationExpansion/Visitors/NavigationPropertyUnbindingVisitor.cs
+++ b/src/EFCore/Query/NavigationExpansion/Visitors/NavigationPropertyUnbindingVisitor.cs
@@ -3,16 +3,24 @@
 
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Query.Pipeline;
 
 namespace Microsoft.EntityFrameworkCore.Query.NavigationExpansion.Visitors
 {
     public class NavigationPropertyUnbindingVisitor : ExpressionVisitor
     {
         private readonly ParameterExpression _rootParameter;
+        private readonly NavigationExpandingVisitor _navigationExpandingVisitor;
+        private readonly QueryCompilationContext _queryCompilationContext;
 
-        public NavigationPropertyUnbindingVisitor(ParameterExpression rootParameter)
+        public NavigationPropertyUnbindingVisitor(
+            ParameterExpression rootParameter,
+            NavigationExpandingVisitor navigationExpandingVisitor,
+            QueryCompilationContext queryCompilationContext)
         {
             _rootParameter = rootParameter;
+            _navigationExpandingVisitor = navigationExpandingVisitor;
+            _queryCompilationContext = queryCompilationContext;
         }
 
         protected override Expression VisitExtension(Expression extensionExpression)
@@ -40,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore.Query.NavigationExpansion.Visitors
             if (extensionExpression is NavigationExpansionRootExpression
                 || extensionExpression is NavigationExpansionExpression)
             {
-                var result = new NavigationExpansionReducingVisitor().Visit(extensionExpression);
+                var result = new NavigationExpansionReducingVisitor(_navigationExpandingVisitor, _queryCompilationContext).Visit(extensionExpression);
 
                 return Visit(result);
             }

--- a/src/EFCore/Query/Pipeline/QueryCompilationContext.cs
+++ b/src/EFCore/Query/Pipeline/QueryCompilationContext.cs
@@ -2,7 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -19,6 +23,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
         private readonly IShapedQueryOptimizerFactory _shapedQueryOptimizerFactory;
         private readonly IShapedQueryCompilingExpressionVisitorFactory _shapedQueryCompilingExpressionVisitorFactory;
 
+        private readonly Parameters _parameters;
+
         public QueryCompilationContext(
             IModel model,
             IQueryOptimizerFactory queryOptimizerFactory,
@@ -28,6 +34,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
             ICurrentDbContext currentDbContext,
             IDbContextOptions contextOptions,
             IDiagnosticsLogger<DbLoggerCategory.Query> logger,
+            IEvaluatableExpressionFilter evaluatableExpressionFilter,
             bool async)
         {
             Async = async;
@@ -36,20 +43,27 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
             ContextOptions = contextOptions;
             ContextType = currentDbContext.Context.GetType();
             Logger = logger;
+            EvaluatableExpressionFilter = evaluatableExpressionFilter;
 
             _queryOptimizerFactory = queryOptimizerFactory;
             _queryableMethodTranslatingExpressionVisitorFactory = queryableMethodTranslatingExpressionVisitorFactory;
             _shapedQueryOptimizerFactory = shapedQueryOptimizerFactory;
             _shapedQueryCompilingExpressionVisitorFactory = shapedQueryCompilingExpressionVisitorFactory;
 
+            _parameters = new Parameters();
         }
 
         public bool Async { get; }
         public IModel Model { get; }
         public IDbContextOptions ContextOptions { get; }
         public bool TrackQueryResults { get; internal set; }
+        public bool IgnoreQueryFilters { get; internal set; }
         public virtual IDiagnosticsLogger<DbLoggerCategory.Query> Logger { get; }
         public virtual Type ContextType { get; }
+
+        public virtual IEvaluatableExpressionFilter EvaluatableExpressionFilter { get; set; }
+
+        internal virtual IParameterValues ParameterValues => _parameters;
 
         public virtual Func<QueryContext, TResult> CreateQueryExecutor<TResult>(Expression query)
         {
@@ -62,6 +76,16 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
             // Inject tracking
             query = _shapedQueryCompilingExpressionVisitorFactory.Create(this).Visit(query);
 
+            var setFilterParameterExpressions
+                = CreateSetFilterParametersExpressions(out var contextVariableExpression);
+
+            if (setFilterParameterExpressions != null)
+            {
+                query = Expression.Block(
+                    new[] { contextVariableExpression },
+                    setFilterParameterExpressions.Concat(new[] { query }));
+            }
+
             var queryExecutorExpression = Expression.Lambda<Func<QueryContext, TResult>>(
                 query,
                 QueryContextParameter);
@@ -73,6 +97,81 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
             finally
             {
                 Logger.QueryExecutionPlanned(new ExpressionPrinter(), queryExecutorExpression);
+            }
+        }
+
+        private static readonly MethodInfo _queryContextAddParameterMethodInfo
+            = typeof(QueryContext)
+                .GetTypeInfo()
+                .GetDeclaredMethod(nameof(QueryContext.AddParameter));
+
+        private static readonly PropertyInfo _queryContextContextPropertyInfo
+            = typeof(QueryContext)
+                .GetTypeInfo()
+                .GetDeclaredProperty(nameof(QueryContext.Context));
+
+        private IEnumerable<Expression> CreateSetFilterParametersExpressions(out ParameterExpression contextVariableExpression)
+        {
+            contextVariableExpression = null;
+
+            if (_parameters.ParameterValues.Count == 0)
+            {
+                return null;
+            }
+
+            contextVariableExpression = Expression.Variable(ContextType, "context");
+
+            var blockExpressions
+                = new List<Expression>
+                {
+                    Expression.Assign(
+                        contextVariableExpression,
+                        Expression.Convert(
+                            Expression.Property(
+                                QueryContextParameter,
+                                _queryContextContextPropertyInfo),
+                            ContextType))
+                };
+
+            foreach (var keyValuePair in _parameters.ParameterValues)
+            {
+                blockExpressions.Add(
+                    Expression.Call(
+                        QueryContextParameter,
+                        _queryContextAddParameterMethodInfo,
+                        Expression.Constant(keyValuePair.Key),
+                        Expression.Convert(
+                            Expression.Invoke(
+                                (LambdaExpression)keyValuePair.Value,
+                                contextVariableExpression),
+                            typeof(object))));
+            }
+
+            return blockExpressions;
+        }
+
+        private class Parameters : IParameterValues
+        {
+            private readonly IDictionary<string, object> _parameterValues = new Dictionary<string, object>();
+
+            public IReadOnlyDictionary<string, object> ParameterValues => (IReadOnlyDictionary<string, object>)_parameterValues;
+
+            public virtual void AddParameter(string name, object value)
+            {
+                _parameterValues.Add(name, value);
+            }
+
+            public virtual void SetParameter(string name, object value)
+            {
+                _parameterValues[name] = value;
+            }
+
+            public virtual object RemoveParameter(string name)
+            {
+                var value = _parameterValues[name];
+                _parameterValues.Remove(name);
+
+                return value;
             }
         }
     }

--- a/src/EFCore/Query/Pipeline/QueryCompilationContextFactory.cs
+++ b/src/EFCore/Query/Pipeline/QueryCompilationContextFactory.cs
@@ -4,6 +4,7 @@
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Query.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Query.Pipeline
 {
@@ -17,6 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
         private readonly ICurrentDbContext _currentDbContext;
         private readonly IDbContextOptions _contextOptions;
         private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
+        private readonly IEvaluatableExpressionFilter _evaluatableExpressionFilter;
 
         public QueryCompilationContextFactory(
             IModel model,
@@ -26,7 +28,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
             IShapedQueryCompilingExpressionVisitorFactory shapedQueryCompilingExpressionVisitorFactory,
             ICurrentDbContext currentDbContext,
             IDbContextOptions contextOptions,
-            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger,
+            IEvaluatableExpressionFilter evaluatableExpressionFilter)
         {
             _model = model;
             _queryOptimizerFactory = queryOptimizerFactory;
@@ -36,6 +39,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
             _currentDbContext = currentDbContext;
             _contextOptions = contextOptions;
             _logger = logger;
+            _evaluatableExpressionFilter = evaluatableExpressionFilter;
         }
 
         public QueryCompilationContext Create(bool async)
@@ -49,6 +53,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
                 _currentDbContext,
                 _contextOptions,
                 _logger,
+                _evaluatableExpressionFilter,
                 async);
 
             return queryCompilationContext;

--- a/src/EFCore/Query/Pipeline/QueryMetadataExtractingExpressionVisitor.cs
+++ b/src/EFCore/Query/Pipeline/QueryMetadataExtractingExpressionVisitor.cs
@@ -30,6 +30,15 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
 
                     return innerQueryable;
                 }
+
+                if (genericMethodDefinition == EntityFrameworkQueryableExtensions.IgnoreQueryFiltersMethodInfo)
+                {
+                    var innerQueryable = Visit(methodCallExpression.Arguments[0]);
+
+                    _queryCompilationContext.IgnoreQueryFilters = true;
+
+                    return innerQueryable;
+                }
             }
 
             return base.VisitMethodCall(methodCallExpression);

--- a/src/EFCore/Query/Pipeline/QueryOptimizingExpressionVisitor.cs
+++ b/src/EFCore/Query/Pipeline/QueryOptimizingExpressionVisitor.cs
@@ -19,13 +19,13 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
 
         public Expression Visit(Expression query)
         {
+            query = new QueryMetadataExtractingExpressionVisitor(_queryCompilationContext).Visit(query);
             query = new AllAnyToContainsRewritingExpressionVisitor().Visit(query);
             query = new GroupJoinFlatteningExpressionVisitor().Visit(query);
             query = new NullCheckRemovingExpressionVisitor().Visit(query);
             query = new EntityEqualityRewritingExpressionVisitor(_queryCompilationContext).Rewrite(query);
-            query = new NavigationExpander(_queryCompilationContext.Model).ExpandNavigations(query);
+            query = new NavigationExpander(_queryCompilationContext).ExpandNavigations(query);
             query = new EnumerableToQueryableReMappingExpressionVisitor().Visit(query);
-            query = new QueryMetadataExtractingExpressionVisitor(_queryCompilationContext).Visit(query);
             query = new NullCheckRemovingExpressionVisitor().Visit(query);
             query = new FunctionPreprocessingVisitor().Visit(query);
             new EnumerableVerifyingExpressionVisitor().Visit(query);

--- a/test/EFCore.InMemory.FunctionalTests/InMemoryComplianceTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/InMemoryComplianceTest.cs
@@ -19,10 +19,10 @@ namespace Microsoft.EntityFrameworkCore
             typeof(GraphUpdatesTestBase<>),                // issue #15318
             typeof(ProxyGraphUpdatesTestBase<>),           // issue #15318
             typeof(ComplexNavigationsWeakQueryTestBase<>), // issue #15285
-            typeof(FiltersInheritanceTestBase<>),          // issue #15264
-            typeof(FiltersTestBase<>),                     // issue #15264
             typeof(OwnedQueryTestBase<>),                  // issue #15285
             // Query pipeline
+            typeof(FiltersInheritanceTestBase<>),
+            typeof(FiltersTestBase<>),
             typeof(SimpleQueryTestBase<>),
             typeof(ConcurrencyDetectorTestBase<>),
             typeof(AsNoTrackingTestBase<>),

--- a/test/EFCore.InMemory.FunctionalTests/Query/FiltersInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/FiltersInMemoryTest.cs
@@ -5,7 +5,6 @@ using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
-    //issue #15264
     internal class FiltersInMemoryTest : FiltersTestBase<NorthwindQueryInMemoryFixture<NorthwindFiltersCustomizer>>
     {
         public FiltersInMemoryTest(NorthwindQueryInMemoryFixture<NorthwindFiltersCustomizer> fixture, ITestOutputHelper testOutputHelper)

--- a/test/EFCore.InMemory.FunctionalTests/Query/FiltersInheritanceInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/FiltersInheritanceInMemoryTest.cs
@@ -3,7 +3,6 @@
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
-    // issue #15264
     internal class FiltersInheritanceInMemoryTest : FiltersInheritanceTestBase<FiltersInheritanceInMemoryFixture>
     {
         public FiltersInheritanceInMemoryTest(FiltersInheritanceInMemoryFixture fixture)

--- a/test/EFCore.Specification.Tests/Query/FiltersInheritanceTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/FiltersInheritanceTestBase.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         protected TFixture Fixture { get; }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Can_use_of_type_animal()
         {
             using (var context = CreateContext())
@@ -31,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Can_use_is_kiwi()
         {
             using (var context = CreateContext())
@@ -42,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Can_use_is_kiwi_with_other_predicate()
         {
             using (var context = CreateContext())
@@ -53,7 +53,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Can_use_is_kiwi_in_projection()
         {
             using (var context = CreateContext())
@@ -66,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Can_use_of_type_bird()
         {
             using (var context = CreateContext())
@@ -79,7 +79,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Can_use_of_type_bird_predicate()
         {
             using (var context = CreateContext())
@@ -97,7 +97,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Can_use_of_type_bird_with_projection()
         {
             using (var context = CreateContext())
@@ -117,7 +117,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Can_use_of_type_bird_first()
         {
             using (var context = CreateContext())
@@ -130,7 +130,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Can_use_of_type_kiwi()
         {
             using (var context = CreateContext())
@@ -143,7 +143,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Can_use_derived_set()
         {
             using (var context = CreateContext())
@@ -155,7 +155,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Can_use_IgnoreQueryFilters_and_GetDatabaseValues()
         {
             using (var context = CreateContext())

--- a/test/EFCore.Specification.Tests/Query/FiltersTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/FiltersTestBase.cs
@@ -5,7 +5,6 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
-using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 using Xunit;
 
 // ReSharper disable StaticMemberInGenericType
@@ -29,38 +28,37 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         protected TFixture Fixture { get; }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Count_query()
         {
             Assert.Equal(7, _context.Customers.Count());
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Materialized_query()
         {
             Assert.Equal(7, _context.Customers.ToList().Count);
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Find()
         {
             Assert.Null(_context.Find<Customer>("ALFKI"));
         }
 
-        // also issue #15264
         [ConditionalFact(Skip = "Issue #14935. Cannot eval 'where ClientMethod([p])'")] 
         public virtual void Client_eval()
         {
             Assert.Equal(69, _context.Products.ToList().Count);
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual async Task Materialized_query_async()
         {
             Assert.Equal(7, (await _context.Customers.ToListAsync()).Count);
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Materialized_query_parameter()
         {
             _context.TenantPrefix = "F";
@@ -68,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Assert.Equal(8, _context.Customers.ToList().Count);
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Materialized_query_parameter_new_context()
         {
             Assert.Equal(7, _context.Customers.ToList().Count);
@@ -81,13 +79,13 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Projection_query()
         {
             Assert.Equal(7, _context.Customers.Select(c => c.CustomerID).ToList().Count);
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Projection_query_parameter()
         {
             _context.TenantPrefix = "F";
@@ -95,7 +93,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Assert.Equal(8, _context.Customers.Select(c => c.CustomerID).ToList().Count);
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Include_query()
         {
             var results = _context.Customers.Include(c => c.Orders).ToList();
@@ -103,7 +101,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Assert.Equal(7, results.Count);
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Include_query_opt_out()
         {
             var results = _context.Customers.Include(c => c.Orders).IgnoreQueryFilters().ToList();
@@ -111,16 +109,24 @@ namespace Microsoft.EntityFrameworkCore.Query
             Assert.Equal(91, results.Count);
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Included_many_to_one_query()
         {
             var results = _context.Orders.Include(o => o.Customer).ToList();
 
-            Assert.Equal(830, results.Count);
+            Assert.Equal(80, results.Count);
             Assert.True(results.All(o => o.Customer == null || o.CustomerID.StartsWith("B")));
         }
 
-        // also issue #15264
+        [ConditionalFact]
+        public virtual void Project_reference_that_itself_has_query_filter_with_another_reference()
+        {
+            var results = _context.OrderDetails.Select(od => od.Order).ToList();
+
+            Assert.Equal(5, results.Count);
+            Assert.True(results.All(o => o.Customer == null || o.CustomerID.StartsWith("B")));
+        }
+
         [ConditionalFact(Skip = "Issue #14935. Cannot eval 'where ClientMethod([p])'")]
         public virtual void Included_one_to_many_query_with_client_eval()
         {
@@ -133,7 +139,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                          || p.OrderDetails.All(od => od.Quantity > 50)));
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact(Skip = "issue #16293")]
         public virtual void Navs_query()
         {
             var results
@@ -146,7 +152,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Assert.Equal(5, results.Count);
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact(Skip = "issue #14551")]
         public virtual void Compiled_query()
         {
             var query = EF.CompileQuery(

--- a/test/EFCore.Specification.Tests/Query/QueryFilterFuncletizationTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/QueryFilterFuncletizationTestBase.cs
@@ -21,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         protected QueryFilterFuncletizationContext CreateContext() => Fixture.CreateContext();
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void DbContext_property_parameter_does_not_clash_with_closure_parameter_name()
         {
             using (var context = CreateContext())
@@ -31,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void DbContext_field_is_parameterized()
         {
             using (var context = CreateContext())
@@ -46,7 +46,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void DbContext_property_is_parameterized()
         {
             using (var context = CreateContext())
@@ -61,7 +61,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void DbContext_method_call_is_parameterized()
         {
             using (var context = CreateContext())
@@ -71,14 +71,14 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void DbContext_list_is_parameterized()
         {
             using (var context = CreateContext())
             {
                 // This throws because the default value of TenantIds is null which is NRE
                 var exception = Record.Exception(() => context.Set<ListFilter>().ToList());
-                Assert.True(exception is InvalidOperationException || exception is ArgumentNullException);
+                Assert.True(exception is InvalidOperationException || exception is ArgumentNullException || exception is NullReferenceException);
 
                 context.TenantIds = new List<int>();
                 var query = context.Set<ListFilter>().ToList();
@@ -101,7 +101,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void DbContext_property_chain_is_parameterized()
         {
             using (var context = CreateContext())
@@ -125,7 +125,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void DbContext_property_method_call_is_parameterized()
         {
             using (var context = CreateContext())
@@ -139,7 +139,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void DbContext_method_call_chain_is_parameterized()
         {
             using (var context = CreateContext())
@@ -149,7 +149,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void DbContext_complex_expression_is_parameterized()
         {
             using (var context = CreateContext())
@@ -167,7 +167,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void DbContext_property_based_filter_does_not_short_circuit()
         {
             using (var context = CreateContext())
@@ -184,7 +184,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void EntityTypeConfiguration_DbContext_field_is_parameterized()
         {
             using (var context = CreateContext())
@@ -199,7 +199,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void EntityTypeConfiguration_DbContext_property_is_parameterized()
         {
             using (var context = CreateContext())
@@ -214,7 +214,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void EntityTypeConfiguration_DbContext_method_call_is_parameterized()
         {
             using (var context = CreateContext())
@@ -224,7 +224,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void EntityTypeConfiguration_DbContext_property_chain_is_parameterized()
         {
             using (var context = CreateContext())
@@ -248,7 +248,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Local_method_DbContext_field_is_parameterized()
         {
             using (var context = CreateContext())
@@ -263,7 +263,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Local_static_method_DbContext_property_is_parameterized()
         {
             using (var context = CreateContext())
@@ -278,7 +278,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Remote_method_DbContext_property_method_call_is_parameterized()
         {
             using (var context = CreateContext())
@@ -292,7 +292,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Extension_method_DbContext_field_is_parameterized()
         {
             using (var context = CreateContext())
@@ -307,7 +307,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Extension_method_DbContext_property_chain_is_parameterized()
         {
             using (var context = CreateContext())
@@ -331,7 +331,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "See issue#13587")]
+        [ConditionalFact(Skip = "See issue#16319")]
         public virtual void Using_DbSet_in_filter_works()
         {
             using (var context = CreateContext())
@@ -340,7 +340,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "See issue#13587")]
+        [ConditionalFact(Skip = "See issue#16319")]
         public virtual void Using_Context_set_method_in_filter_works()
         {
             using (var context = CreateContext())
@@ -351,7 +351,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Static_member_from_dbContext_is_inlined()
         {
             using (var context = CreateContext())
@@ -362,7 +362,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Static_member_from_non_dbContext_is_inlined()
         {
             using (var context = CreateContext())
@@ -373,7 +373,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Local_variable_from_OnModelCreating_is_inlined()
         {
             using (var context = CreateContext())
@@ -384,7 +384,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Local_variable_from_OnModelCreating_can_throw_exception()
         {
             using (var context = CreateContext())
@@ -397,7 +397,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Method_parameter_is_inlined()
         {
             using (var context = CreateContext())
@@ -406,7 +406,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Using_multiple_context_in_filter_parametrize_only_current_context()
         {
             using (var context = CreateContext())

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.QueryTypes.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.QueryTypes.cs
@@ -56,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "Issue#15264")]
+        [ConditionalFact(Skip = "Issue#16323")]
         public virtual void QueryType_with_nav_defining_query()
         {
             using (var context = CreateContext())
@@ -70,7 +70,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory(Skip = "Issue#15264")]
+        [ConditionalTheory(Skip = "Issue#16323")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task QueryType_with_defining_query(bool isAsync)
         {
@@ -90,7 +90,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Select(cv => cv.Orders.Where(cc => true).ToList()));
         }
 
-        [ConditionalTheory(Skip = "Issue#15264")]
+        [ConditionalTheory(Skip = "Issue#15711")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task QueryType_with_mixed_tracking(bool isAsync)
         {
@@ -107,7 +107,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.c.CustomerID);
         }
 
-        [ConditionalTheory(Skip = "Issue#15264")]
+        [ConditionalTheory(Skip = "Issue#16323")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task QueryType_with_included_nav(bool isAsync)
         {
@@ -122,7 +122,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "Issue#15264")]
+        [ConditionalTheory(Skip = "Issue#16323")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task QueryType_with_included_navs_multi_level(bool isAsync)
         {
@@ -138,7 +138,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "Issue#15264")]
+        [ConditionalTheory(Skip = "Issue#16323")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task QueryType_select_where_navigation(bool isAsync)
         {
@@ -149,7 +149,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                        select ov);
         }
 
-        [ConditionalTheory(Skip = "Issue#15264")]
+        [ConditionalTheory(Skip = "Issue#16323")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task QueryType_select_where_navigation_multi_level(bool isAsync)
         {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FiltersInheritanceSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FiltersInheritanceSqlServerTest.cs
@@ -5,8 +5,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
-    // issue #15264
-    internal class FiltersInheritanceSqlServerTest : FiltersInheritanceTestBase<FiltersInheritanceSqlServerFixture>
+    public class FiltersInheritanceSqlServerTest : FiltersInheritanceTestBase<FiltersInheritanceSqlServerFixture>
     {
         public FiltersInheritanceSqlServerTest(FiltersInheritanceSqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
@@ -22,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             AssertSql(
                 @"SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
 FROM [Animal] AS [a]
-WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a].[CountryId] = 1)
+WHERE [a].[Discriminator] IN (N'Eagle', N'Kiwi') AND ([a].[CountryId] = 1)
 ORDER BY [a].[Species]");
         }
 
@@ -33,7 +32,7 @@ ORDER BY [a].[Species]");
             AssertSql(
                 @"SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
 FROM [Animal] AS [a]
-WHERE ([a].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a].[CountryId] = 1)) AND ([a].[Discriminator] = N'Kiwi')");
+WHERE ([a].[Discriminator] IN (N'Eagle', N'Kiwi') AND ([a].[CountryId] = 1)) AND ([a].[Discriminator] = N'Kiwi')");
         }
 
         public override void Can_use_is_kiwi_with_other_predicate()
@@ -43,7 +42,7 @@ WHERE ([a].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a].[CountryId] = 1)) AND
             AssertSql(
                 @"SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
 FROM [Animal] AS [a]
-WHERE ([a].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a].[CountryId] = 1)) AND (([a].[Discriminator] = N'Kiwi') AND ([a].[CountryId] = 1))");
+WHERE ([a].[Discriminator] IN (N'Eagle', N'Kiwi') AND ([a].[CountryId] = 1)) AND (([a].[Discriminator] = N'Kiwi') AND ([a].[CountryId] = 1))");
         }
 
         public override void Can_use_is_kiwi_in_projection()
@@ -52,11 +51,11 @@ WHERE ([a].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a].[CountryId] = 1)) AND
 
             AssertSql(
                 @"SELECT CASE
-    WHEN [a].[Discriminator] = N'Kiwi'
-    THEN CAST(1 AS bit) ELSE CAST(0 AS bit)
+    WHEN [a].[Discriminator] = N'Kiwi' THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
 END
 FROM [Animal] AS [a]
-WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a].[CountryId] = 1)");
+WHERE [a].[Discriminator] IN (N'Eagle', N'Kiwi') AND ([a].[CountryId] = 1)");
         }
 
         public override void Can_use_of_type_bird()
@@ -66,7 +65,7 @@ WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a].[CountryId] = 1)");
             AssertSql(
                 @"SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
 FROM [Animal] AS [a]
-WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a].[CountryId] = 1)
+WHERE ([a].[Discriminator] IN (N'Eagle', N'Kiwi') AND ([a].[CountryId] = 1)) AND [a].[Discriminator] IN (N'Eagle', N'Kiwi')
 ORDER BY [a].[Species]");
         }
 
@@ -77,7 +76,7 @@ ORDER BY [a].[Species]");
             AssertSql(
                 @"SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
 FROM [Animal] AS [a]
-WHERE ([a].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a].[CountryId] = 1)) AND ([a].[CountryId] = 1)
+WHERE (([a].[Discriminator] IN (N'Eagle', N'Kiwi') AND ([a].[CountryId] = 1)) AND ([a].[CountryId] = 1)) AND [a].[Discriminator] IN (N'Eagle', N'Kiwi')
 ORDER BY [a].[Species]");
         }
 
@@ -88,7 +87,7 @@ ORDER BY [a].[Species]");
             AssertSql(
                 @"SELECT [a].[EagleId]
 FROM [Animal] AS [a]
-WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a].[CountryId] = 1)");
+WHERE ([a].[Discriminator] IN (N'Eagle', N'Kiwi') AND ([a].[CountryId] = 1)) AND [a].[Discriminator] IN (N'Eagle', N'Kiwi')");
         }
 
         public override void Can_use_of_type_bird_first()
@@ -98,7 +97,7 @@ WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a].[CountryId] = 1)");
             AssertSql(
                 @"SELECT TOP(1) [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
 FROM [Animal] AS [a]
-WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a].[CountryId] = 1)
+WHERE ([a].[Discriminator] IN (N'Eagle', N'Kiwi') AND ([a].[CountryId] = 1)) AND [a].[Discriminator] IN (N'Eagle', N'Kiwi')
 ORDER BY [a].[Species]");
         }
 
@@ -109,7 +108,33 @@ ORDER BY [a].[Species]");
             AssertSql(
                 @"SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[FoundOn]
 FROM [Animal] AS [a]
-WHERE ([a].[Discriminator] = N'Kiwi') AND ([a].[CountryId] = 1)");
+WHERE ([a].[Discriminator] IN (N'Eagle', N'Kiwi') AND ([a].[CountryId] = 1)) AND ([a].[Discriminator] = N'Kiwi')");
+        }
+
+        public override void Can_use_derived_set()
+        {
+            base.Can_use_derived_set();
+
+            AssertSql(
+                @"SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group]
+FROM [Animal] AS [a]
+WHERE ([a].[Discriminator] = N'Eagle') AND ([a].[CountryId] = 1)");
+        }
+
+        public override void Can_use_IgnoreQueryFilters_and_GetDatabaseValues()
+        {
+            base.Can_use_IgnoreQueryFilters_and_GetDatabaseValues();
+
+            AssertSql(
+                @"SELECT TOP(2) [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group]
+FROM [Animal] AS [a]
+WHERE [a].[Discriminator] = N'Eagle'",
+                //
+                @"@__p_0='Aquila chrysaetos canadensis' (Size = 100)
+
+SELECT TOP(1) [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group]
+FROM [Animal] AS [a]
+WHERE ([a].[Discriminator] = N'Eagle') AND (([a].[Species] = @__p_0) AND @__p_0 IS NOT NULL)");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FiltersSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FiltersSqlServerTest.cs
@@ -9,8 +9,7 @@ using Xunit.Abstractions;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Query
 {
-    //issue #15264
-    internal class FiltersSqlServerTest : FiltersTestBase<NorthwindQuerySqlServerFixture<NorthwindFiltersCustomizer>>
+    public class FiltersSqlServerTest : FiltersTestBase<NorthwindQuerySqlServerFixture<NorthwindFiltersCustomizer>>
     {
         public FiltersSqlServerTest(NorthwindQuerySqlServerFixture<NorthwindFiltersCustomizer> fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
@@ -28,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
 SELECT COUNT(*)
 FROM [Customers] AS [c]
-WHERE ([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)) OR (@__ef_filter__TenantPrefix_0 = N'')");
+WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (([c].[CompanyName] LIKE [c].[CompanyName] + N'%') AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL)))))");
         }
 
         public override void Client_eval()
@@ -49,7 +48,7 @@ FROM [Products] AS [p]");
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)) OR (@__ef_filter__TenantPrefix_0 = N'')");
+WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (([c].[CompanyName] LIKE [c].[CompanyName] + N'%') AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL)))))");
         }
 
         public override void Find()
@@ -62,7 +61,7 @@ WHERE ([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].
 
 SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)) OR (@__ef_filter__TenantPrefix_0 = N'')) AND ([c].[CustomerID] = @__p_0)");
+WHERE (((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (([c].[CompanyName] LIKE [c].[CompanyName] + N'%') AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL)))))) AND (([c].[CustomerID] = @__p_0) AND @__p_0 IS NOT NULL)");
         }
 
         public override void Materialized_query_parameter()
@@ -74,7 +73,7 @@ WHERE (([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c]
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)) OR (@__ef_filter__TenantPrefix_0 = N'')");
+WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (([c].[CompanyName] LIKE [c].[CompanyName] + N'%') AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL)))))");
         }
 
         public override void Materialized_query_parameter_new_context()
@@ -86,13 +85,13 @@ WHERE ([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)) OR (@__ef_filter__TenantPrefix_0 = N'')",
+WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (([c].[CompanyName] LIKE [c].[CompanyName] + N'%') AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL)))))",
                 //
                 @"@__ef_filter__TenantPrefix_0='T' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)) OR (@__ef_filter__TenantPrefix_0 = N'')");
+WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (([c].[CompanyName] LIKE [c].[CompanyName] + N'%') AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL)))))");
         }
 
         public override void Projection_query_parameter()
@@ -104,7 +103,7 @@ WHERE ([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE ([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)) OR (@__ef_filter__TenantPrefix_0 = N'')");
+WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (([c].[CompanyName] LIKE [c].[CompanyName] + N'%') AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL)))))");
         }
 
         public override void Projection_query()
@@ -116,7 +115,7 @@ WHERE ([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE ([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)) OR (@__ef_filter__TenantPrefix_0 = N'')");
+WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (([c].[CompanyName] LIKE [c].[CompanyName] + N'%') AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL)))))");
         }
 
         public override void Include_query()
@@ -126,23 +125,11 @@ WHERE ([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].
             AssertSql(
                 @"@__ef_filter__TenantPrefix_0='B' (Size = 4000)
 
-SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Customers] AS [c]
-WHERE ([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)) OR (@__ef_filter__TenantPrefix_0 = N'')
-ORDER BY [c].[CustomerID]",
-                //
-                @"@__ef_filter__TenantPrefix_1='B' (Size = 4000)
-
-SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]
-LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
-INNER JOIN (
-    SELECT [c0].[CustomerID]
-    FROM [Customers] AS [c0]
-    WHERE ([c0].[CompanyName] LIKE @__ef_filter__TenantPrefix_1 + N'%' AND (LEFT([c0].[CompanyName], LEN(@__ef_filter__TenantPrefix_1)) = @__ef_filter__TenantPrefix_1)) OR (@__ef_filter__TenantPrefix_1 = N'')
-) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
-WHERE [o.Customer].[CompanyName] IS NOT NULL
-ORDER BY [t].[CustomerID]");
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (([c].[CompanyName] LIKE [c].[CompanyName] + N'%') AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL)))))
+ORDER BY [c].[CustomerID], [o].[OrderID]");
         }
 
         public override void Include_query_opt_out()
@@ -150,17 +137,10 @@ ORDER BY [t].[CustomerID]");
             base.Include_query_opt_out();
 
             AssertSql(
-                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Customers] AS [c]
-ORDER BY [c].[CustomerID]",
-                //
-                @"SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
-FROM [Orders] AS [c.Orders]
-INNER JOIN (
-    SELECT [c0].[CustomerID]
-    FROM [Customers] AS [c0]
-) AS [t] ON [c.Orders].[CustomerID] = [t].[CustomerID]
-ORDER BY [t].[CustomerID]");
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+ORDER BY [c].[CustomerID], [o].[OrderID]");
         }
 
         public override void Included_many_to_one_query()
@@ -172,13 +152,35 @@ ORDER BY [t].[CustomerID]");
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
 FROM [Orders] AS [o]
-LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
 LEFT JOIN (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
-    WHERE ([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)) OR (@__ef_filter__TenantPrefix_0 = N'')
+    WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (([c].[CompanyName] LIKE [c].[CompanyName] + N'%') AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL)))))
 ) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
-WHERE [o.Customer].[CompanyName] IS NOT NULL");
+WHERE [t].[CompanyName] IS NOT NULL");
+        }
+
+        public override void Project_reference_that_itself_has_query_filter_with_another_reference()
+        {
+            base.Project_reference_that_itself_has_query_filter_with_another_reference();
+
+            AssertSql(
+                @"@__ef_filter__TenantPrefix_1='B' (Size = 4000)
+@__ef_filter___quantity_0='50'
+
+SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate]
+FROM [Order Details] AS [o0]
+INNER JOIN (
+    SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID] AS [CustomerID0], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
+    FROM [Orders] AS [o]
+    LEFT JOIN (
+        SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+        FROM [Customers] AS [c]
+        WHERE ((@__ef_filter__TenantPrefix_1 = N'') AND @__ef_filter__TenantPrefix_1 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_1 IS NOT NULL AND (([c].[CompanyName] LIKE [c].[CompanyName] + N'%') AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_1)) = @__ef_filter__TenantPrefix_1) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_1)) IS NOT NULL AND @__ef_filter__TenantPrefix_1 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_1)) IS NULL AND @__ef_filter__TenantPrefix_1 IS NULL)))))
+    ) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
+    WHERE [t].[CompanyName] IS NOT NULL
+) AS [t0] ON [o0].[OrderID] = [t0].[OrderID]
+WHERE [o0].[Quantity] > @__ef_filter___quantity_0");
         }
 
         public override void Included_one_to_many_query_with_client_eval()
@@ -224,7 +226,7 @@ INNER JOIN (
 WHERE (([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)) OR (@__ef_filter__TenantPrefix_0 = N'')) AND ([t0].[Discount] < CAST(10 AS real))");
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact(Skip = "issue #16326")]
         public void FromSql_is_composed()
         {
             using (var context = CreateContext())
@@ -241,7 +243,7 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM (
     select * from Customers
 ) AS [c]
-WHERE ([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)) OR (@__ef_filter__TenantPrefix_0 = N'')");
+WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (([c].[CompanyName] LIKE [c].[CompanyName] + N'%') AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL)))))");
         }
 
         public override void Compiled_query()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -4770,7 +4770,7 @@ FROM [Prices] AS [p]");
 
         #region Bug12170
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "issue #16321")]
         public virtual void Weak_entities_with_query_filter_subquery_flattening()
         {
             using (CreateDatabase12170())

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryFilterFuncletizationSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryFilterFuncletizationSqlServerTest.cs
@@ -6,8 +6,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
-    // issue #15264
-    internal class QueryFilterFuncletizationSqlServerTest
+    public class QueryFilterFuncletizationSqlServerTest
         : QueryFilterFuncletizationTestBase<QueryFilterFuncletizationSqlServerTest.QueryFilterFuncletizationSqlServerFixture>
     {
         public QueryFilterFuncletizationSqlServerTest(
@@ -27,9 +26,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 @"@__ef_filter__Field_0='False'
 @__Field_0='False'
 
-SELECT [e].[Id], [e].[IsEnabled]
-FROM [FieldFilter] AS [e]
-WHERE ([e].[IsEnabled] = @__ef_filter__Field_0) AND ([e].[IsEnabled] = @__Field_0)");
+SELECT [f].[Id], [f].[IsEnabled]
+FROM [FieldFilter] AS [f]
+WHERE (([f].[IsEnabled] = @__ef_filter__Field_0) AND @__ef_filter__Field_0 IS NOT NULL) AND (([f].[IsEnabled] = @__Field_0) AND @__Field_0 IS NOT NULL)");
         }
 
         public override void DbContext_field_is_parameterized()
@@ -39,15 +38,15 @@ WHERE ([e].[IsEnabled] = @__ef_filter__Field_0) AND ([e].[IsEnabled] = @__Field_
             AssertSql(
                 @"@__ef_filter__Field_0='False'
 
-SELECT [e].[Id], [e].[IsEnabled]
-FROM [FieldFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Field_0",
+SELECT [f].[Id], [f].[IsEnabled]
+FROM [FieldFilter] AS [f]
+WHERE ([f].[IsEnabled] = @__ef_filter__Field_0) AND @__ef_filter__Field_0 IS NOT NULL",
                 //
                 @"@__ef_filter__Field_0='True'
 
-SELECT [e].[Id], [e].[IsEnabled]
-FROM [FieldFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Field_0");
+SELECT [f].[Id], [f].[IsEnabled]
+FROM [FieldFilter] AS [f]
+WHERE ([f].[IsEnabled] = @__ef_filter__Field_0) AND @__ef_filter__Field_0 IS NOT NULL");
         }
 
         public override void DbContext_property_is_parameterized()
@@ -57,15 +56,15 @@ WHERE [e].[IsEnabled] = @__ef_filter__Field_0");
             AssertSql(
                 @"@__ef_filter__Property_0='False'
 
-SELECT [e].[Id], [e].[IsEnabled]
-FROM [PropertyFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Property_0",
+SELECT [p].[Id], [p].[IsEnabled]
+FROM [PropertyFilter] AS [p]
+WHERE ([p].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL",
                 //
                 @"@__ef_filter__Property_0='True'
 
-SELECT [e].[Id], [e].[IsEnabled]
-FROM [PropertyFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Property_0");
+SELECT [p].[Id], [p].[IsEnabled]
+FROM [PropertyFilter] AS [p]
+WHERE ([p].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL");
         }
 
         public override void DbContext_method_call_is_parameterized()
@@ -75,9 +74,9 @@ WHERE [e].[IsEnabled] = @__ef_filter__Property_0");
             AssertSql(
                 @"@__ef_filter__p_0='2'
 
-SELECT [e].[Id], [e].[Tenant]
-FROM [MethodCallFilter] AS [e]
-WHERE [e].[Tenant] = @__ef_filter__p_0");
+SELECT [m].[Id], [m].[Tenant]
+FROM [MethodCallFilter] AS [m]
+WHERE ([m].[Tenant] = @__ef_filter__p_0) AND @__ef_filter__p_0 IS NOT NULL");
         }
 
         public override void DbContext_list_is_parameterized()
@@ -85,17 +84,17 @@ WHERE [e].[Tenant] = @__ef_filter__p_0");
             base.DbContext_list_is_parameterized();
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[Tenant]
-FROM [ListFilter] AS [e]
-WHERE 0 = 1",
+                @"SELECT [l].[Id], [l].[Tenant]
+FROM [ListFilter] AS [l]
+WHERE CAST(1 AS bit) = CAST(0 AS bit)",
                 //
-                @"SELECT [e].[Id], [e].[Tenant]
-FROM [ListFilter] AS [e]
-WHERE [e].[Tenant] IN (1)",
+                @"SELECT [l].[Id], [l].[Tenant]
+FROM [ListFilter] AS [l]
+WHERE [l].[Tenant] IN (1)",
                 //
-                @"SELECT [e].[Id], [e].[Tenant]
-FROM [ListFilter] AS [e]
-WHERE [e].[Tenant] IN (2, 3)");
+                @"SELECT [l].[Id], [l].[Tenant]
+FROM [ListFilter] AS [l]
+WHERE [l].[Tenant] IN (2, 3)");
         }
 
         public override void DbContext_property_chain_is_parameterized()
@@ -105,15 +104,15 @@ WHERE [e].[Tenant] IN (2, 3)");
             AssertSql(
                 @"@__ef_filter__Enabled_0='False'
 
-SELECT [e].[Id], [e].[IsEnabled]
-FROM [PropertyChainFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Enabled_0",
+SELECT [p].[Id], [p].[IsEnabled]
+FROM [PropertyChainFilter] AS [p]
+WHERE ([p].[IsEnabled] = @__ef_filter__Enabled_0) AND @__ef_filter__Enabled_0 IS NOT NULL",
                 //
                 @"@__ef_filter__Enabled_0='True'
 
-SELECT [e].[Id], [e].[IsEnabled]
-FROM [PropertyChainFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Enabled_0");
+SELECT [p].[Id], [p].[IsEnabled]
+FROM [PropertyChainFilter] AS [p]
+WHERE ([p].[IsEnabled] = @__ef_filter__Enabled_0) AND @__ef_filter__Enabled_0 IS NOT NULL");
         }
 
         public override void DbContext_property_method_call_is_parameterized()
@@ -123,9 +122,9 @@ WHERE [e].[IsEnabled] = @__ef_filter__Enabled_0");
             AssertSql(
                 @"@__ef_filter__p_0='2'
 
-SELECT [e].[Id], [e].[Tenant]
-FROM [PropertyMethodCallFilter] AS [e]
-WHERE [e].[Tenant] = @__ef_filter__p_0");
+SELECT [p].[Id], [p].[Tenant]
+FROM [PropertyMethodCallFilter] AS [p]
+WHERE ([p].[Tenant] = @__ef_filter__p_0) AND @__ef_filter__p_0 IS NOT NULL");
         }
 
         public override void DbContext_method_call_chain_is_parameterized()
@@ -135,9 +134,9 @@ WHERE [e].[Tenant] = @__ef_filter__p_0");
             AssertSql(
                 @"@__ef_filter__p_0='2'
 
-SELECT [e].[Id], [e].[Tenant]
-FROM [MethodCallChainFilter] AS [e]
-WHERE [e].[Tenant] = @__ef_filter__p_0");
+SELECT [m].[Id], [m].[Tenant]
+FROM [MethodCallChainFilter] AS [m]
+WHERE ([m].[Tenant] = @__ef_filter__p_0) AND @__ef_filter__p_0 IS NOT NULL");
         }
 
         public override void DbContext_complex_expression_is_parameterized()
@@ -148,23 +147,23 @@ WHERE [e].[Tenant] = @__ef_filter__p_0");
                 @"@__ef_filter__Property_0='False'
 @__ef_filter__p_1='True'
 
-SELECT [x].[Id], [x].[IsEnabled]
-FROM [ComplexFilter] AS [x]
-WHERE ([x].[IsEnabled] = @__ef_filter__Property_0) AND (@__ef_filter__p_1 = CAST(1 AS bit))",
+SELECT [c].[Id], [c].[IsEnabled]
+FROM [ComplexFilter] AS [c]
+WHERE (([c].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL) AND (@__ef_filter__p_1 = CAST(1 AS bit))",
                 //
                 @"@__ef_filter__Property_0='True'
 @__ef_filter__p_1='True'
 
-SELECT [x].[Id], [x].[IsEnabled]
-FROM [ComplexFilter] AS [x]
-WHERE ([x].[IsEnabled] = @__ef_filter__Property_0) AND (@__ef_filter__p_1 = CAST(1 AS bit))",
+SELECT [c].[Id], [c].[IsEnabled]
+FROM [ComplexFilter] AS [c]
+WHERE (([c].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL) AND (@__ef_filter__p_1 = CAST(1 AS bit))",
                 //
                 @"@__ef_filter__Property_0='True'
 @__ef_filter__p_1='False'
 
-SELECT [x].[Id], [x].[IsEnabled]
-FROM [ComplexFilter] AS [x]
-WHERE ([x].[IsEnabled] = @__ef_filter__Property_0) AND (@__ef_filter__p_1 = CAST(1 AS bit))");
+SELECT [c].[Id], [c].[IsEnabled]
+FROM [ComplexFilter] AS [c]
+WHERE (([c].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL) AND (@__ef_filter__p_1 = CAST(1 AS bit))");
         }
 
         public override void DbContext_property_based_filter_does_not_short_circuit()
@@ -175,22 +174,23 @@ WHERE ([x].[IsEnabled] = @__ef_filter__Property_0) AND (@__ef_filter__p_1 = CAST
                 @"@__ef_filter__p_0='False'
 @__ef_filter__IsModerated_1='True' (Nullable = true)
 
-SELECT [x].[Id], [x].[IsDeleted], [x].[IsModerated]
-FROM [ShortCircuitFilter] AS [x]
-WHERE ([x].[IsDeleted] = CAST(0 AS bit)) AND ((@__ef_filter__p_0 = CAST(1 AS bit)) OR (@__ef_filter__IsModerated_1 = [x].[IsModerated]))",
+SELECT [s].[Id], [s].[IsDeleted], [s].[IsModerated]
+FROM [ShortCircuitFilter] AS [s]
+WHERE ([s].[IsDeleted] <> CAST(1 AS bit)) AND ((@__ef_filter__p_0 = CAST(1 AS bit)) OR ((@__ef_filter__IsModerated_1 = [s].[IsModerated]) AND @__ef_filter__IsModerated_1 IS NOT NULL))",
                 //
                 @"@__ef_filter__p_0='False'
 @__ef_filter__IsModerated_1='False' (Nullable = true)
 
-SELECT [x].[Id], [x].[IsDeleted], [x].[IsModerated]
-FROM [ShortCircuitFilter] AS [x]
-WHERE ([x].[IsDeleted] = CAST(0 AS bit)) AND ((@__ef_filter__p_0 = CAST(1 AS bit)) OR (@__ef_filter__IsModerated_1 = [x].[IsModerated]))",
+SELECT [s].[Id], [s].[IsDeleted], [s].[IsModerated]
+FROM [ShortCircuitFilter] AS [s]
+WHERE ([s].[IsDeleted] <> CAST(1 AS bit)) AND ((@__ef_filter__p_0 = CAST(1 AS bit)) OR ((@__ef_filter__IsModerated_1 = [s].[IsModerated]) AND @__ef_filter__IsModerated_1 IS NOT NULL))",
                 //
                 @"@__ef_filter__p_0='True'
+@__ef_filter__IsModerated_1=''
 
-SELECT [x].[Id], [x].[IsDeleted], [x].[IsModerated]
-FROM [ShortCircuitFilter] AS [x]
-WHERE ([x].[IsDeleted] = CAST(0 AS bit)) AND ((@__ef_filter__p_0 = CAST(1 AS bit)) OR [x].[IsModerated] IS NULL)");
+SELECT [s].[Id], [s].[IsDeleted], [s].[IsModerated]
+FROM [ShortCircuitFilter] AS [s]
+WHERE ([s].[IsDeleted] <> CAST(1 AS bit)) AND ((@__ef_filter__p_0 = CAST(1 AS bit)) OR ((@__ef_filter__IsModerated_1 = [s].[IsModerated]) AND @__ef_filter__IsModerated_1 IS NOT NULL))");
         }
 
         public override void EntityTypeConfiguration_DbContext_field_is_parameterized()
@@ -202,13 +202,13 @@ WHERE ([x].[IsDeleted] = CAST(0 AS bit)) AND ((@__ef_filter__p_0 = CAST(1 AS bit
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [EntityTypeConfigurationFieldFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Field_0",
+WHERE ([e].[IsEnabled] = @__ef_filter__Field_0) AND @__ef_filter__Field_0 IS NOT NULL",
                 //
                 @"@__ef_filter__Field_0='True'
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [EntityTypeConfigurationFieldFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Field_0");
+WHERE ([e].[IsEnabled] = @__ef_filter__Field_0) AND @__ef_filter__Field_0 IS NOT NULL");
         }
 
         public override void EntityTypeConfiguration_DbContext_property_is_parameterized()
@@ -220,13 +220,13 @@ WHERE [e].[IsEnabled] = @__ef_filter__Field_0");
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [EntityTypeConfigurationPropertyFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Property_0",
+WHERE ([e].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL",
                 //
                 @"@__ef_filter__Property_0='True'
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [EntityTypeConfigurationPropertyFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Property_0");
+WHERE ([e].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL");
         }
 
         public override void EntityTypeConfiguration_DbContext_method_call_is_parameterized()
@@ -238,7 +238,7 @@ WHERE [e].[IsEnabled] = @__ef_filter__Property_0");
 
 SELECT [e].[Id], [e].[Tenant]
 FROM [EntityTypeConfigurationMethodCallFilter] AS [e]
-WHERE [e].[Tenant] = @__ef_filter__p_0");
+WHERE ([e].[Tenant] = @__ef_filter__p_0) AND @__ef_filter__p_0 IS NOT NULL");
         }
 
         public override void EntityTypeConfiguration_DbContext_property_chain_is_parameterized()
@@ -250,13 +250,13 @@ WHERE [e].[Tenant] = @__ef_filter__p_0");
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [EntityTypeConfigurationPropertyChainFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Enabled_0",
+WHERE ([e].[IsEnabled] = @__ef_filter__Enabled_0) AND @__ef_filter__Enabled_0 IS NOT NULL",
                 //
                 @"@__ef_filter__Enabled_0='True'
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [EntityTypeConfigurationPropertyChainFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Enabled_0");
+WHERE ([e].[IsEnabled] = @__ef_filter__Enabled_0) AND @__ef_filter__Enabled_0 IS NOT NULL");
         }
 
         public override void Local_method_DbContext_field_is_parameterized()
@@ -266,15 +266,15 @@ WHERE [e].[IsEnabled] = @__ef_filter__Enabled_0");
             AssertSql(
                 @"@__ef_filter__Field_0='False'
 
-SELECT [e].[Id], [e].[IsEnabled]
-FROM [LocalMethodFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Field_0",
+SELECT [l].[Id], [l].[IsEnabled]
+FROM [LocalMethodFilter] AS [l]
+WHERE ([l].[IsEnabled] = @__ef_filter__Field_0) AND @__ef_filter__Field_0 IS NOT NULL",
                 //
                 @"@__ef_filter__Field_0='True'
 
-SELECT [e].[Id], [e].[IsEnabled]
-FROM [LocalMethodFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Field_0");
+SELECT [l].[Id], [l].[IsEnabled]
+FROM [LocalMethodFilter] AS [l]
+WHERE ([l].[IsEnabled] = @__ef_filter__Field_0) AND @__ef_filter__Field_0 IS NOT NULL");
         }
 
         public override void Local_static_method_DbContext_property_is_parameterized()
@@ -284,15 +284,15 @@ WHERE [e].[IsEnabled] = @__ef_filter__Field_0");
             AssertSql(
                 @"@__ef_filter__Property_0='False'
 
-SELECT [e].[Id], [e].[IsEnabled]
-FROM [LocalMethodParamsFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Property_0",
+SELECT [l].[Id], [l].[IsEnabled]
+FROM [LocalMethodParamsFilter] AS [l]
+WHERE ([l].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL",
                 //
                 @"@__ef_filter__Property_0='True'
 
-SELECT [e].[Id], [e].[IsEnabled]
-FROM [LocalMethodParamsFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Property_0");
+SELECT [l].[Id], [l].[IsEnabled]
+FROM [LocalMethodParamsFilter] AS [l]
+WHERE ([l].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL");
         }
 
         public override void Remote_method_DbContext_property_method_call_is_parameterized()
@@ -302,9 +302,9 @@ WHERE [e].[IsEnabled] = @__ef_filter__Property_0");
             AssertSql(
                 @"@__ef_filter__p_0='2'
 
-SELECT [e].[Id], [e].[Tenant]
-FROM [RemoteMethodParamsFilter] AS [e]
-WHERE [e].[Tenant] = @__ef_filter__p_0");
+SELECT [r].[Id], [r].[Tenant]
+FROM [RemoteMethodParamsFilter] AS [r]
+WHERE ([r].[Tenant] = @__ef_filter__p_0) AND @__ef_filter__p_0 IS NOT NULL");
         }
 
         public override void Extension_method_DbContext_field_is_parameterized()
@@ -316,13 +316,13 @@ WHERE [e].[Tenant] = @__ef_filter__p_0");
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [ExtensionBuilderFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Field_0",
+WHERE ([e].[IsEnabled] = @__ef_filter__Field_0) AND @__ef_filter__Field_0 IS NOT NULL",
                 //
                 @"@__ef_filter__Field_0='True'
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [ExtensionBuilderFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Field_0");
+WHERE ([e].[IsEnabled] = @__ef_filter__Field_0) AND @__ef_filter__Field_0 IS NOT NULL");
         }
 
         public override void Extension_method_DbContext_property_chain_is_parameterized()
@@ -334,13 +334,13 @@ WHERE [e].[IsEnabled] = @__ef_filter__Field_0");
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [ExtensionContextFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Enabled_0",
+WHERE ([e].[IsEnabled] = @__ef_filter__Enabled_0) AND @__ef_filter__Enabled_0 IS NOT NULL",
                 //
                 @"@__ef_filter__Enabled_0='True'
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [ExtensionContextFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Enabled_0");
+WHERE ([e].[IsEnabled] = @__ef_filter__Enabled_0) AND @__ef_filter__Enabled_0 IS NOT NULL");
         }
 
         public override void Using_DbSet_in_filter_works()
@@ -374,9 +374,9 @@ WHERE EXISTS (
             base.Static_member_from_dbContext_is_inlined();
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[UserId]
-FROM [DbContextStaticMemberFilter] AS [e]
-WHERE [e].[UserId] <> 1");
+                @"SELECT [d].[Id], [d].[UserId]
+FROM [DbContextStaticMemberFilter] AS [d]
+WHERE [d].[UserId] <> 1");
         }
 
         public override void Static_member_from_non_dbContext_is_inlined()
@@ -384,9 +384,9 @@ WHERE [e].[UserId] <> 1");
             base.Static_member_from_non_dbContext_is_inlined();
 
             AssertSql(
-                @"SELECT [b].[Id], [b].[IsEnabled]
-FROM [StaticMemberFilter] AS [b]
-WHERE [b].[IsEnabled] = CAST(1 AS bit)");
+                @"SELECT [s].[Id], [s].[IsEnabled]
+FROM [StaticMemberFilter] AS [s]
+WHERE [s].[IsEnabled] = CAST(1 AS bit)");
         }
 
         public override void Local_variable_from_OnModelCreating_is_inlined()
@@ -394,9 +394,9 @@ WHERE [b].[IsEnabled] = CAST(1 AS bit)");
             base.Local_variable_from_OnModelCreating_is_inlined();
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[IsEnabled]
-FROM [LocalVariableFilter] AS [e]
-WHERE [e].[IsEnabled] = CAST(1 AS bit)");
+                @"SELECT [l].[Id], [l].[IsEnabled]
+FROM [LocalVariableFilter] AS [l]
+WHERE [l].[IsEnabled] = CAST(1 AS bit)");
         }
 
         public override void Method_parameter_is_inlined()
@@ -404,9 +404,9 @@ WHERE [e].[IsEnabled] = CAST(1 AS bit)");
             base.Method_parameter_is_inlined();
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[Tenant]
-FROM [ParameterFilter] AS [e]
-WHERE [e].[Tenant] = 0");
+                @"SELECT [p].[Id], [p].[Tenant]
+FROM [ParameterFilter] AS [p]
+WHERE [p].[Tenant] = 0");
         }
 
         public override void Using_multiple_context_in_filter_parametrize_only_current_context()
@@ -416,15 +416,15 @@ WHERE [e].[Tenant] = 0");
             AssertSql(
                 @"@__ef_filter__Property_0='False'
 
-SELECT [e].[Id], [e].[BossId], [e].[IsEnabled]
-FROM [MultiContextFilter] AS [e]
-WHERE ([e].[IsEnabled] = @__ef_filter__Property_0) AND ([e].[BossId] = 1)",
+SELECT [m].[Id], [m].[BossId], [m].[IsEnabled]
+FROM [MultiContextFilter] AS [m]
+WHERE (([m].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL) AND ([m].[BossId] = 1)",
                 //
                 @"@__ef_filter__Property_0='True'
 
-SELECT [e].[Id], [e].[BossId], [e].[IsEnabled]
-FROM [MultiContextFilter] AS [e]
-WHERE ([e].[IsEnabled] = @__ef_filter__Property_0) AND ([e].[BossId] = 1)");
+SELECT [m].[Id], [m].[BossId], [m].[IsEnabled]
+FROM [MultiContextFilter] AS [m]
+WHERE (([m].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL) AND ([m].[BossId] = 1)");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerComplianceTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerComplianceTest.cs
@@ -16,10 +16,7 @@ namespace Microsoft.EntityFrameworkCore
             typeof(GraphUpdatesTestBase<>),                // issue #15318
             typeof(ProxyGraphUpdatesTestBase<>),           // issue #15318
             typeof(ComplexNavigationsWeakQueryTestBase<>), // issue #15285
-            typeof(FiltersInheritanceTestBase<>),          // issue #15264
-            typeof(FiltersTestBase<>),                     // issue #15264
             typeof(OwnedQueryTestBase<>),                  // issue #15285
-            typeof(QueryFilterFuncletizationTestBase<>),   // issue #15264
             typeof(RelationalOwnedQueryTestBase<>),        // issue #15285
             // Query pipeline
             typeof(ConcurrencyDetectorTestBase<>),

--- a/test/EFCore.Sqlite.FunctionalTests/Query/FiltersInheritanceSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/FiltersInheritanceSqliteTest.cs
@@ -3,8 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
-    // issue #15264
-    internal class FiltersInheritanceSqliteTest : FiltersInheritanceTestBase<FiltersInheritanceSqliteFixture>
+    public class FiltersInheritanceSqliteTest : FiltersInheritanceTestBase<FiltersInheritanceSqliteFixture>
     {
         public FiltersInheritanceSqliteTest(FiltersInheritanceSqliteFixture fixture)
             : base(fixture)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/FiltersSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/FiltersSqliteTest.cs
@@ -5,8 +5,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
-    // issue #15264
-    internal class FiltersSqliteTest : FiltersTestBase<NorthwindQuerySqliteFixture<NorthwindFiltersCustomizer>>
+    public class FiltersSqliteTest : FiltersTestBase<NorthwindQuerySqliteFixture<NorthwindFiltersCustomizer>>
     {
         public FiltersSqliteTest(NorthwindQuerySqliteFixture<NorthwindFiltersCustomizer> fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
@@ -18,12 +17,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         public override void Count_query()
         {
             base.Count_query();
+
             AssertSql(
                 @"@__ef_filter__TenantPrefix_0='B' (Size = 1)
 
 SELECT COUNT(*)
 FROM ""Customers"" AS ""c""
-WHERE (""c"".""CompanyName"" LIKE @__ef_filter__TenantPrefix_0 || '%' AND (substr(""c"".""CompanyName"", 1, length(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)) OR (@__ef_filter__TenantPrefix_0 = '')");
+WHERE ((@__ef_filter__TenantPrefix_0 = '') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR (""c"".""CompanyName"" IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (((""c"".""CompanyName"" LIKE ""c"".""CompanyName"" || '%') AND (((substr(""c"".""CompanyName"", 1, length(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (substr(""c"".""CompanyName"", 1, length(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (substr(""c"".""CompanyName"", 1, length(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL))) OR ((@__ef_filter__TenantPrefix_0 = '') AND @__ef_filter__TenantPrefix_0 IS NOT NULL))))");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/QueryFilterFuncletizationSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/QueryFilterFuncletizationSqliteTest.cs
@@ -6,8 +6,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
-    // issue #15264
-    internal class QueryFilterFuncletizationSqliteTest
+    public class QueryFilterFuncletizationSqliteTest
         : QueryFilterFuncletizationTestBase<QueryFilterFuncletizationSqliteTest.QueryFilterFuncletizationSqliteFixture>
     {
         public QueryFilterFuncletizationSqliteTest(

--- a/test/EFCore.Sqlite.FunctionalTests/SqliteComplianceTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/SqliteComplianceTest.cs
@@ -20,10 +20,7 @@ namespace Microsoft.EntityFrameworkCore
             typeof(GraphUpdatesTestBase<>),                // issue #15318
             typeof(ProxyGraphUpdatesTestBase<>),           // issue #15318
             typeof(ComplexNavigationsWeakQueryTestBase<>), // issue #15285
-            typeof(FiltersInheritanceTestBase<>),          // issue #15264
-            typeof(FiltersTestBase<>),                     // issue #15264
             typeof(OwnedQueryTestBase<>),                  // issue #15285
-            typeof(QueryFilterFuncletizationTestBase<>),   // issue #15264
             typeof(RelationalOwnedQueryTestBase<>),        // issue #15285
             // Query pipeline
             typeof(ConcurrencyDetectorTestBase<>),


### PR DESCRIPTION
Also, fix to #13361 - Query: QueryFilters/Defining queries are not applied recursively

When nav rewrite constructs new EntityQueryable it now looks into EntityType for any query filter annotations and applies them on top. Those predicates are parameterized and the parameters created are injected into the context as part of query execution expression.

Query filters also fundamentally change how nav expansion creates new navigations - before navigations were being added one by one, so we could easily build the NavigationTree by a new node representing given INavigation.
With query filters, the newly created navigation may contain arbitrarily complex NavigationTree structure already (if the query filter itself has some navigations).
To support that, when we create new EntityQueryable for join or collection navigation, we need to visit it (creating NavigationExpansionExpression) and merge the resulting NavigationTree with the previous navigation tree.