### PR TITLE
Set operations: include/nav support

### DIFF
--- a/src/EFCore.Relational/Query/Pipeline/RelationalShapedQueryOptimizingExpressionVisitors.cs
+++ b/src/EFCore.Relational/Query/Pipeline/RelationalShapedQueryOptimizingExpressionVisitors.cs
@@ -51,7 +51,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                 var collectionId = _collectionId++;
                 var selectExpression = (SelectExpression)collectionShaperExpression.Projection.QueryExpression;
                 // Do pushdown beforehand so it updates all pending collections first
-                if (selectExpression.IsDistinct || selectExpression.Limit != null || selectExpression.Offset != null)
+                if (selectExpression.IsDistinct || selectExpression.Limit != null || selectExpression.Offset != null || selectExpression.IsSetOperation)
                 {
                     selectExpression.PushdownIntoSubquery();
                 }

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SelectExpression.cs
@@ -842,10 +842,12 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             return null;
         }
 
+        // We treat a set operation as a transparent wrapper over its left operand (the ColumnExpression projection mappings
+        // found on a set operation SelectExpression are actually those of its left operand).
         private bool ContainsTableReference(TableExpressionBase table)
-        {
-            return _tables.Any(te => ReferenceEquals(te is JoinExpressionBase jeb ? jeb.Table : te, table));
-        }
+            => IsSetOperation
+                ? ((SelectExpression)Tables[0]).ContainsTableReference(table)
+                : Tables.Any(te => ReferenceEquals(te is JoinExpressionBase jeb ? jeb.Table : te, table));
 
         public void AddInnerJoin(SelectExpression innerSelectExpression, SqlExpression joinPredicate, Type transparentIdentifierType)
         {

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2148,6 +2148,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 GetString("UnableToDiscriminate", nameof(entityType), nameof(discriminator)),
                 entityType, discriminator);
 
+        /// <summary>
+        ///     When performing a set operation, both operands must have the same Include operations.
+        /// </summary>
+        public static string SetOperationWithDifferentIncludesInOperands
+            => GetString("SetOperationWithDifferentIncludesInOperands");
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1186,4 +1186,7 @@
   <data name="UnableToDiscriminate" xml:space="preserve">
     <value>Unable to materialize entity of type '{entityType}'. No discriminators matched '{discriminator}'.</value>
   </data>
+  <data name="SetOperationWithDifferentIncludesInOperands" xml:space="preserve">
+    <value>When performing a set operation, both operands must have the same Include operations.</value>
+  </data>
 </root>

--- a/src/EFCore/Query/NavigationExpansion/Visitors/NavigationExpansionReducingVisitor.cs
+++ b/src/EFCore/Query/NavigationExpansion/Visitors/NavigationExpansionReducingVisitor.cs
@@ -120,8 +120,8 @@ namespace Microsoft.EntityFrameworkCore.Query.NavigationExpansion.Visitors
                     result = NavigationExpansionHelpers.AddNavigationJoin(
                         result.source,
                         result.parameter,
-                        pendingIncludeNode.Value,
-                        pendingIncludeNode.Key,
+                        pendingIncludeNode.SourceMapping,
+                        pendingIncludeNode.NavTreeNode,
                         navigationExpansionExpression.State,
                         new List<INavigation>(),
                         include: true);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.SetOperations.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.SetOperations.cs
@@ -33,7 +33,11 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query
         public override Task Union_with_anonymous_type_projection(bool isAsync) => Task.CompletedTask;
         public override Task Select_Union_unrelated(bool isAsync) => Task.CompletedTask;
         public override Task Select_Union_different_fields_in_anonymous_with_subquery(bool isAsync) => Task.CompletedTask;
+        public override Task Union_Include(bool isAsync) => Task.CompletedTask;
+        public override Task Include_Union(bool isAsync) => Task.CompletedTask;
         public override Task Select_Except_reference_projection(bool isAsync) => Task.CompletedTask;
+        public override void Include_Union_only_on_one_side_throws() {}
+        public override void Include_Union_different_includes_throws() {}
         public override Task SubSelect_Union(bool isAsync) => Task.CompletedTask;
         public override Task Client_eval_Union_FirstOrDefault(bool isAsync) => Task.CompletedTask;
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.SetOperations.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.SetOperations.cs
@@ -264,6 +264,44 @@ WHERE ([t0].[Foo] = N'Berlin') AND [t0].[Foo] IS NOT NULL
 ORDER BY [t0].[Foo]");
         }
 
+        public override async Task Union_Include(bool isAsync)
+        {
+            await base.Union_Include(isAsync);
+
+            AssertSql(
+                @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE ([c].[City] = N'Berlin') AND [c].[City] IS NOT NULL
+    UNION
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    WHERE ([c0].[City] = N'London') AND [c0].[City] IS NOT NULL
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID], [o].[OrderID]");
+        }
+
+        public override async Task Include_Union(bool isAsync)
+        {
+            await base.Include_Union(isAsync);
+
+            AssertSql(
+                @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE ([c].[City] = N'Berlin') AND [c].[City] IS NOT NULL
+    UNION
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    WHERE ([c0].[City] = N'London') AND [c0].[City] IS NOT NULL
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID], [o].[OrderID]");
+        }
+
         public override async Task Select_Except_reference_projection(bool isAsync)
         {
             await base.Select_Except_reference_projection(isAsync);


### PR DESCRIPTION
This was split off from #16249 and now only contains include/nav features.

Continues #6812
Fixes #13196
Fixes #16065
Fixes #16165

