### PR TITLE
Query: Wrap up collection materialization code path for relational

### DIFF
--- a/src/EFCore.Relational/Query/Pipeline/RelationalCollectionShaperExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/RelationalCollectionShaperExpression.cs
@@ -18,7 +18,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
             Expression outerIdentifier,
             Expression selfIdentifier,
             Expression innerShaper,
-            INavigation navigation)
+            INavigation navigation,
+            Type elementType)
         {
             CollectionId = collectionId;
             ParentIdentifier = parentIdentifier;
@@ -26,6 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
             SelfIdentifier = selfIdentifier;
             InnerShaper = innerShaper;
             Navigation = navigation;
+            ElementType = elementType;
         }
 
         public int CollectionId { get; }
@@ -34,8 +36,9 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
         public Expression SelfIdentifier { get; }
         public Expression InnerShaper { get; }
         public INavigation Navigation { get; }
+        public Type ElementType { get; }
 
-        public override Type Type => Navigation?.ClrType ?? typeof(List<>).MakeGenericType(InnerShaper.Type);
+        public override Type Type => Navigation?.ClrType ?? typeof(List<>).MakeGenericType(ElementType);
         public override ExpressionType NodeType => ExpressionType.Extension;
 
         protected override Expression VisitChildren(ExpressionVisitor visitor)
@@ -56,7 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                 || selfIdentifier != SelfIdentifier
                 || innerShaper != InnerShaper
                 ? new RelationalCollectionShaperExpression(
-                    CollectionId, parentIdentifier, outerIdentifier, selfIdentifier, innerShaper, Navigation)
+                    CollectionId, parentIdentifier, outerIdentifier, selfIdentifier, innerShaper, Navigation, ElementType)
                 : this;
         }
 

--- a/src/EFCore.Relational/Query/Pipeline/RelationalShapedQueryOptimizingExpressionVisitors.cs
+++ b/src/EFCore.Relational/Query/Pipeline/RelationalShapedQueryOptimizingExpressionVisitors.cs
@@ -62,7 +62,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                     collectionShaperExpression.Projection.Index.Value,
                     collectionId,
                     innerShaper,
-                    collectionShaperExpression.Navigation);
+                    collectionShaperExpression.Navigation,
+                    collectionShaperExpression.ElementType);
             }
 
             if (extensionExpression is ShapedQueryExpression shapedQueryExpression)

--- a/src/EFCore/Query/Pipeline/CollectionShaperExpression.cs
+++ b/src/EFCore/Query/Pipeline/CollectionShaperExpression.cs
@@ -15,11 +15,13 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
         public CollectionShaperExpression(
             ProjectionBindingExpression projection,
             Expression innerShaper,
-            INavigation navigation)
+            INavigation navigation,
+            Type elementType)
         {
             Projection = projection;
             InnerShaper = innerShaper;
             Navigation = navigation;
+            ElementType = elementType;
         }
 
         protected override Expression VisitChildren(ExpressionVisitor visitor)
@@ -33,17 +35,18 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
         public CollectionShaperExpression Update(ProjectionBindingExpression projection, Expression innerShaper)
         {
             return projection != Projection || innerShaper != InnerShaper
-                ? new CollectionShaperExpression(projection, innerShaper, Navigation)
+                ? new CollectionShaperExpression(projection, innerShaper, Navigation, ElementType)
                 : this;
         }
 
         public override ExpressionType NodeType => ExpressionType.Extension;
 
-        public override Type Type => Navigation?.ClrType ?? typeof(List<>).MakeGenericType(InnerShaper.Type);
+        public override Type Type => Navigation?.ClrType ?? typeof(List<>).MakeGenericType(ElementType);
 
         public ProjectionBindingExpression Projection { get; }
         public Expression InnerShaper { get; }
         public INavigation Navigation { get; }
+        public Type ElementType { get; }
 
         public virtual void Print(ExpressionPrinter expressionPrinter)
         {

--- a/src/EFCore/Query/Pipeline/EnumerableToQueryableReMappingExpressionVisitor.cs
+++ b/src/EFCore/Query/Pipeline/EnumerableToQueryableReMappingExpressionVisitor.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -113,6 +114,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
 
         private static bool CanConvertEnumerableToQueryable(Type enumerableType, Type queryableType, Type argumentType)
         {
+            if (enumerableType == typeof(IEnumerable)
+                && queryableType == typeof(IQueryable))
+            {
+                return true;
+            }
+
             if (!enumerableType.IsGenericType
                 || !queryableType.IsGenericType
                 || argumentType.TryGetElementType(typeof(IQueryable<>)) == null

--- a/src/EFCore/Query/Pipeline/QueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore/Query/Pipeline/QueryableMethodTranslatingExpressionVisitor.cs
@@ -55,8 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
                                 : null);
 
                         case nameof(Queryable.AsQueryable):
-                            // Don't know
-                            break;
+                            return source;
 
                         case nameof(Queryable.Average):
                             shapedQueryExpression.ResultType = ResultType.Single;

--- a/src/EFCore/Query/Pipeline/ShapedQueryExpressionVisitor.cs
+++ b/src/EFCore/Query/Pipeline/ShapedQueryExpressionVisitor.cs
@@ -420,7 +420,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
                         {
                             var accessorExpression = Expression.Constant(new ClrCollectionAccessorFactory().Create(navigation));
                             navigationExpression = Expression.Call(accessorExpression, _accessorAddRangeMethodInfo,
-                                convertedInstanceVariable, new CollectionShaperExpression(null, nestedShaper, navigation));
+                                convertedInstanceVariable, new CollectionShaperExpression(null, nestedShaper, navigation, null));
                         }
                         else
                         {

--- a/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.ResultOperators.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.ResultOperators.cs
@@ -192,6 +192,24 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10250))");
             base.Max_no_data();
         }
 
+        [ConditionalFact(Skip = "Issue#16146")]
+        public override void Average_no_data_subquery()
+        {
+            base.Average_no_data_subquery();
+        }
+
+        [ConditionalFact(Skip = "Issue#16146")]
+        public override void Max_no_data_subquery()
+        {
+            base.Max_no_data_subquery();
+        }
+
+        [ConditionalFact(Skip = "Issue#16146")]
+        public override void Min_no_data_subquery()
+        {
+            base.Min_no_data_subquery();
+        }
+
         [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Average_with_no_arg(bool isAsync)
         {

--- a/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.Select.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.Select.cs
@@ -267,6 +267,7 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))");
         }
 
+        [ConditionalTheory(Skip = "Issue #14935")]
         public override void Select_nested_collection_multi_level()
         {
             base.Select_nested_collection_multi_level();
@@ -535,6 +536,7 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10300))");
         }
 
+        [ConditionalTheory(Skip = "Issue #14935")]
         public override async Task Project_single_element_from_collection_with_OrderBy_Take_and_FirstOrDefault(bool isAsync)
         {
             await AssertQuery<Customer>(
@@ -548,6 +550,7 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
         }
 
+        [ConditionalTheory(Skip = "Issue #14935")]
         public override async Task Project_single_element_from_collection_with_OrderBy_Skip_and_FirstOrDefault(bool isAsync)
         {
             await AssertQuery<Customer>(
@@ -561,6 +564,7 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
         }
 
+        [ConditionalTheory(Skip = "Issue #14935")]
         public override async Task Project_single_element_from_collection_with_OrderBy_Distinct_and_FirstOrDefault(bool isAsync)
         {
             await AssertQuery<Customer>(
@@ -584,6 +588,7 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
         }
 
+        [ConditionalTheory(Skip = "Issue #14935")]
         public override async Task Project_single_element_from_collection_with_OrderBy_Take_and_FirstOrDefault_with_parameter(bool isAsync)
         {
             await AssertQuery<Customer>(
@@ -647,6 +652,7 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
         }
 
+        [ConditionalTheory(Skip = "Issue #14935")]
         public override async Task Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault(bool isAsync)
         {
             await AssertQueryScalar<Order>(
@@ -803,6 +809,7 @@ WHERE (c[""Discriminator""] = ""Customer"")
 ORDER BY c[""CustomerID""]");
         }
 
+        [ConditionalTheory(Skip = "Issue #14935")]
         public override async Task Anonymous_projection_with_repeated_property_being_ordered_2(bool isAsync)
         {
             await base.Anonymous_projection_with_repeated_property_being_ordered_2(isAsync);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.Where.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.Where.cs
@@ -367,6 +367,7 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))");
 
         private static readonly Expression<Func<Order, bool>> _filter = o => o.CustomerID == "ALFKI";
 
+        [ConditionalTheory(Skip = "Issue #14935")]
         public override async Task Where_as_queryable_expression(bool isAsync)
         {
             await AssertQuery<Customer>(
@@ -904,6 +905,7 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
+        [ConditionalTheory(Skip = "Issue #14935")]
         public override async Task Where_string_indexof(bool isAsync)
         {
             await base.Where_string_indexof(isAsync);
@@ -1179,6 +1181,7 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = c[""City""]))");
         }
 
+        [ConditionalTheory(Skip = "Issue #14935")]
         public override async Task Where_in_optimization_multiple(bool isAsync)
         {
             await base.Where_in_optimization_multiple(isAsync);
@@ -1189,6 +1192,7 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
+        [ConditionalTheory(Skip = "Issue #14935")]
         public override async Task Where_not_in_optimization1(bool isAsync)
         {
             await base.Where_not_in_optimization1(isAsync);
@@ -1199,6 +1203,7 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
+        [ConditionalTheory(Skip = "Issue #14935")]
         public override async Task Where_not_in_optimization2(bool isAsync)
         {
             await base.Where_not_in_optimization2(isAsync);
@@ -1209,6 +1214,7 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
+        [ConditionalTheory(Skip = "Issue #14935")]
         public override async Task Where_not_in_optimization3(bool isAsync)
         {
             await base.Where_not_in_optimization3(isAsync);
@@ -1219,6 +1225,7 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
+        [ConditionalTheory(Skip = "Issue #14935")]
         public override async Task Where_not_in_optimization4(bool isAsync)
         {
             await base.Where_not_in_optimization4(isAsync);
@@ -1229,6 +1236,7 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
+        [ConditionalTheory(Skip = "Issue #14935")]
         public override async Task Where_select_many_and(bool isAsync)
         {
             await base.Where_select_many_and(isAsync);
@@ -1708,6 +1716,7 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""City""] = null) AND (c[""Country""] = ""UK"")))");
         }
 
+        [ConditionalTheory(Skip = "Issue #14935")]
         public override async Task Where_Is_on_same_type(bool isAsync)
         {
             await base.Where_Is_on_same_type(isAsync);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.cs
@@ -1001,6 +1001,7 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
+        [ConditionalTheory(Skip = "Issue #14935")]
         public override async Task Where_select_many_or(bool isAsync)
         {
             await base.Where_select_many_or(isAsync);
@@ -1011,6 +1012,7 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
+        [ConditionalTheory(Skip = "Issue #14935")]
         public override async Task Where_select_many_or2(bool isAsync)
         {
             await base.Where_select_many_or2(isAsync);
@@ -1021,6 +1023,7 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
+        [ConditionalTheory(Skip = "Issue #14935")]
         public override async Task Where_select_many_or3(bool isAsync)
         {
             await base.Where_select_many_or3(isAsync);
@@ -1031,6 +1034,7 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
+        [ConditionalTheory(Skip = "Issue #14935")]
         public override async Task Where_select_many_or4(bool isAsync)
         {
             await base.Where_select_many_or4(isAsync);
@@ -1041,6 +1045,7 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
+        [ConditionalTheory(Skip = "Issue #14935")]
         public override async Task Where_select_many_or_with_parameter(bool isAsync)
         {
             await base.Where_select_many_or_with_parameter(isAsync);
@@ -2886,6 +2891,7 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
+        [ConditionalTheory(Skip = "Issue #14935")]
         public override async Task Anonymous_subquery_orderby(bool isAsync)
         {
             await AssertQuery<Customer>(
@@ -2999,6 +3005,7 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
         }
 
+        [ConditionalTheory(Skip = "Issue #14935")]
         public override async Task Include_with_orderby_skip_preserves_ordering(bool isAsync)
         {
             await base.Include_with_orderby_skip_preserves_ordering(isAsync);

--- a/test/EFCore.InMemory.FunctionalTests/Query/AsyncSimpleQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/AsyncSimpleQueryInMemoryTest.cs
@@ -14,6 +14,24 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
         }
 
+        [ConditionalFact(Skip = "See issue#15711")]
+        public override Task ToList_context_subquery_deadlock_issue()
+        {
+            return base.ToList_context_subquery_deadlock_issue();
+        }
+
+        [ConditionalFact(Skip = "See issue#15711")]
+        public override Task ToList_on_nav_subquery_in_projection()
+        {
+            return base.ToList_on_nav_subquery_in_projection();
+        }
+
+        [ConditionalFact(Skip = "See issue#15711")]
+        public override Task ToList_on_nav_subquery_with_predicate_in_projection()
+        {
+            return base.ToList_on_nav_subquery_with_predicate_in_projection();
+        }
+
         [ConditionalFact(Skip = "See issue#13857")]
         public override Task Query_backed_by_database_view()
         {

--- a/test/EFCore.Specification.Tests/Query/AsyncSimpleQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AsyncSimpleQueryTestBase.cs
@@ -56,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "Issue#15611")]
+        [ConditionalFact]
         public virtual async Task ToList_context_subquery_deadlock_issue()
         {
             using (var context = CreateContext())
@@ -78,7 +78,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #16076")]
+        [ConditionalFact(Skip = "Issue#16076")]
         public virtual async Task ToArray_on_nav_subquery_in_projection()
         {
             using (var context = CreateContext())
@@ -95,7 +95,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "Issue#15611")]
+        [ConditionalFact(Skip = "Issue#16076")]
         public virtual async Task ToArray_on_nav_subquery_in_projection_nested()
         {
             using (var context = CreateContext())
@@ -117,7 +117,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "Issue#15611")]
+        [ConditionalFact]
         public virtual async Task ToList_on_nav_subquery_in_projection()
         {
             using (var context = CreateContext())
@@ -134,7 +134,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "Issue#15611")]
+        [ConditionalFact]
         public virtual async Task ToList_on_nav_subquery_with_predicate_in_projection()
         {
             using (var context = CreateContext())

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -301,7 +301,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "Issue#15611")]
+        [ConditionalFact]
         public virtual void Multi_level_include_with_short_circuiting()
         {
             using (var context = CreateContext())
@@ -1013,7 +1013,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Id4 + " " + e.Name4 + " " + e.Id1 + " " + e.Name1);
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multiple_complex_includes(bool isAsync)
         {
@@ -1036,7 +1036,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.Id);
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multiple_complex_includes_self_ref(bool isAsync)
         {
@@ -1061,7 +1061,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.Id);
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multiple_complex_include_select(bool isAsync)
         {
@@ -1086,7 +1086,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.Id);
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_nav_prop_collection_one_to_many_required(bool isAsync)
         {
@@ -2177,7 +2177,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 (e, a) => Assert.Equal(e.Id, a.Id));
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Complex_multi_include_with_order_by_and_paging(bool isAsync)
         {
@@ -2199,7 +2199,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.Id);
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Complex_multi_include_with_order_by_and_paging_joins_on_correct_key(bool isAsync)
         {
@@ -2242,7 +2242,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 expectedIncludes);
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multiple_include_with_multiple_optional_navigations(bool isAsync)
         {
@@ -5281,7 +5281,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 expectedIncludes);
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task String_include_multiple_derived_collection_navigation_with_same_name_and_same_type(bool isAsync)
         {
@@ -5297,7 +5297,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 expectedIncludes);
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task String_include_multiple_derived_collection_navigation_with_same_name_and_different_type(bool isAsync)
         {
@@ -5313,7 +5313,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 expectedIncludes);
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task String_include_multiple_derived_collection_navigation_with_same_name_and_different_type_nested_also_includes_partially_matching_navigation_chains(bool isAsync)
         {
@@ -5330,7 +5330,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 expectedIncludes);
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task String_include_multiple_derived_navigations_complex(bool isAsync)
         {
@@ -6015,7 +6015,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "Issue#15611")]
+        [ConditionalFact]
         public virtual void IncludeCollection4()
         {
             using (var ctx = CreateContext())
@@ -6025,7 +6025,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "Issue#15611")]
+        [ConditionalFact]
         public virtual void IncludeCollection5()
         {
             using (var ctx = CreateContext())
@@ -6035,7 +6035,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "Issue#15611")]
+        [ConditionalFact]
         public virtual void IncludeCollection6()
         {
             using (var ctx = CreateContext())
@@ -6056,7 +6056,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "Issue#15611")]
+        [ConditionalFact]
         public virtual void IncludeCollection6_2()
         {
             using (var ctx = CreateContext())
@@ -6080,7 +6080,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "Issue#15611")]
+        [ConditionalFact]
         public virtual void IncludeCollection6_4()
         {
             using (var ctx = CreateContext())
@@ -6092,7 +6092,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "Issue#15611")]
+        [ConditionalFact]
         public virtual void IncludeCollection7()
         {
             using (var ctx = CreateContext())

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -2554,7 +2554,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 (ts, gs) => ts.Where(t => t.Note != "K.I.A." && gs.Select(g => g.SquadId).Contains(t.Gear.SquadId)));
         }
 
-        [ConditionalTheory(Skip = "issue 15043")]
+        [ConditionalTheory(Skip = "Issue#16313")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Optional_navigation_type_compensation_works_with_skip(bool isAsync)
         {
@@ -2566,7 +2566,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: CollectionAsserter<Gear>(e => e.Nickname, (e, a) => Assert.Equal(e.Nickname, a.Nickname)));
         }
 
-        [ConditionalTheory(Skip = "issue 15043")]
+        [ConditionalTheory(Skip = "Issue#16313")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Optional_navigation_type_compensation_works_with_take(bool isAsync)
         {
@@ -2578,7 +2578,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: CollectionAsserter<Gear>(e => e.Nickname, (e, a) => Assert.Equal(e.Nickname, a.Nickname)));
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_correlated_filtered_collection(bool isAsync)
         {
@@ -2592,7 +2592,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: CollectionAsserter<Weapon>(e => e.Id, (e, a) => Assert.Equal(e.Id, a.Id)));
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_correlated_filtered_collection_with_composite_key(bool isAsync)
         {
@@ -2603,7 +2603,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: CollectionAsserter<Gear>(e => e.Nickname, (e, a) => Assert.Equal(e.Nickname, a.Nickname)));
         }
 
-        [ConditionalTheory(Skip = "issue #15043")]
+        [ConditionalTheory(Skip = "Issue#16314")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_correlated_filtered_collection_works_with_caching(bool isAsync)
         {
@@ -4038,7 +4038,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15043")]
+        [ConditionalFact]
         public virtual void Optional_navigation_with_collection_composite_key()
         {
             using (var context = CreateContext())
@@ -4083,7 +4083,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "Issue #15043")]
+        [ConditionalFact]
         public virtual void Project_collection_navigation_with_inheritance1()
         {
             using (var context = CreateContext())
@@ -4103,7 +4103,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "Issue #15043")]
+        [ConditionalFact]
         public virtual void Project_collection_navigation_with_inheritance2()
         {
             using (var context = CreateContext())
@@ -4123,7 +4123,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "Issue #15043")]
+        [ConditionalFact]
         public virtual void Project_collection_navigation_with_inheritance3()
         {
             using (var context = CreateContext())
@@ -4230,7 +4230,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 7);
         }
 
-        [ConditionalTheory(Skip = "#15611")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_on_derived_type_using_string(bool isAsync)
         {
@@ -4429,7 +4429,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         .Select(g => g.Rank.ToString()));
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_naked_navigation_with_ToList(bool isAsync)
         {
@@ -4457,7 +4457,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true);
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory(Skip = "Issue#16318")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_naked_navigation_with_ToArray(bool isAsync)
         {
@@ -4471,7 +4471,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: CollectionAsserter<Weapon>(e => e.Id, (e, a) => Assert.Equal(e.Id, a.Id)));
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_basic_projection(bool isAsync)
         {
@@ -4487,7 +4487,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: CollectionAsserter<Weapon>(e => e.Id, (e, a) => Assert.Equal(e.Id, a.Id)));
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_basic_projection_explicit_to_list(bool isAsync)
         {
@@ -4503,7 +4503,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: CollectionAsserter<Weapon>(e => e.Id, (e, a) => Assert.Equal(e.Id, a.Id)));
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory(Skip = "Issue#16318")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_basic_projection_explicit_to_array(bool isAsync)
         {
@@ -4519,7 +4519,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: CollectionAsserter<Weapon>(e => e.Id, (e, a) => Assert.Equal(e.Id, a.Id)));
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_basic_projection_ordered(bool isAsync)
         {
@@ -4536,7 +4536,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: CollectionAsserter<Weapon>(elementAsserter: (e, a) => Assert.Equal(e.Id, a.Id)));
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory(Skip = "Issue#16318")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_basic_projection_composite_key(bool isAsync)
         {
@@ -4564,7 +4564,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_basic_projecting_single_property(bool isAsync)
         {
@@ -4580,7 +4580,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: CollectionAsserter<string>(e => e));
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_basic_projecting_constant(bool isAsync)
         {
@@ -4596,7 +4596,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: CollectionAsserter<string>());
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_basic_projecting_constant_bool(bool isAsync)
         {
@@ -4612,7 +4612,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: CollectionAsserter<bool>());
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_projection_of_collection_thru_navigation(bool isAsync)
         {
@@ -4632,7 +4632,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     }));
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_project_anonymous_collection_result(bool isAsync)
         {
@@ -4658,7 +4658,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_nested(bool isAsync)
         {
@@ -4685,7 +4685,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_nested_mixed_streaming_with_buffer1(bool isAsync)
         {
@@ -4712,7 +4712,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "Issue 15043")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_nested_mixed_streaming_with_buffer2(bool isAsync)
         {
@@ -4739,7 +4739,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory(Skip = "Issue#16226")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_nested_with_custom_ordering(bool isAsync)
         {
@@ -4780,7 +4780,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_same_collection_projected_multiple_times(bool isAsync)
         {
@@ -4803,7 +4803,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory(Skip = "Issue#16318")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_similar_collection_projected_multiple_times(bool isAsync)
         {
@@ -4827,7 +4827,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory(Skip = "Issue#16226")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_different_collections_projected(bool isAsync)
         {
@@ -4861,7 +4861,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multiple_orderby_with_navigation_expansion_on_one_of_the_order_bys(bool isAsync)
         {
@@ -4875,7 +4875,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true);
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory(Skip = "Issue#16226")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multiple_orderby_with_navigation_expansion_on_one_of_the_order_bys_inside_subquery(bool isAsync)
         {
@@ -4903,7 +4903,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory(Skip = "Issue#16226")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multiple_orderby_with_navigation_expansion_on_one_of_the_order_bys_inside_subquery_duplicated_orderings(bool isAsync)
         {
@@ -4933,7 +4933,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory(Skip = "Issue#16226")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multiple_orderby_with_navigation_expansion_on_one_of_the_order_bys_inside_subquery_complex_orderings(bool isAsync)
         {
@@ -4961,7 +4961,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory(Skip = "Issue#16226")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_multiple_nested_complex_collections(bool isAsync)
         {
@@ -5030,7 +5030,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory(Skip = "Issue#16311")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_inner_subquery_selector_references_outer_qsre(bool isAsync)
         {
@@ -5056,7 +5056,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory(Skip = "Issue#16311")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_inner_subquery_predicate_references_outer_qsre(bool isAsync)
         {
@@ -5082,7 +5082,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory(Skip = "Issue#16311")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_nested_inner_subquery_references_outer_qsre_one_level_up(bool isAsync)
         {
@@ -5121,7 +5121,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory(Skip = "Issue#16311")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_nested_inner_subquery_references_outer_qsre_two_levels_up(bool isAsync)
         {
@@ -5160,7 +5160,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_on_select_many(bool isAsync)
         {
@@ -5194,7 +5194,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory(Skip = "Issue#16313")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_with_Skip(bool isAsync)
         {
@@ -5206,7 +5206,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     CollectionAsserter<Gear>(elementAsserter: (ee, aa) => Assert.Equal(ee.Nickname, aa.Nickname))(e, a));
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory(Skip = "Issue#16313")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_with_Take(bool isAsync)
         {
@@ -5218,7 +5218,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     CollectionAsserter<Gear>(elementAsserter: (ee, aa) => Assert.Equal(ee.Nickname, aa.Nickname))(e, a));
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_with_Distinct(bool isAsync)
         {
@@ -5241,7 +5241,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) => CollectionAsserter<Gear>(elementAsserter: (ee, aa) => Assert.Equal(ee.Nickname, aa.Nickname)));
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory(Skip = "Issue#16088")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_on_left_join_with_predicate(bool isAsync)
         {
@@ -5275,7 +5275,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory(Skip = "Issue#16088")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_on_left_join_with_null_value(bool isAsync)
         {
@@ -5297,7 +5297,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) => CollectionAsserter<string>(ee => ee));
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory(Skip = "Issue#16088")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_left_join_with_self_reference(bool isAsync)
         {
@@ -5329,7 +5329,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory(Skip = "Issue#16088")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_deeply_nested_left_join(bool isAsync)
         {
@@ -5362,7 +5362,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                             eee => eee.Id, (eee, aaa) => Assert.Equal(eee.Id, aaa.Id))));
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory(Skip = "Issue#16226")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_from_left_join_with_additional_elements_projected_of_that_join(bool isAsync)
         {
@@ -5394,7 +5394,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_complex_scenario1(bool isAsync)
         {
@@ -5432,7 +5432,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_complex_scenario2(bool isAsync)
         {
@@ -5481,7 +5481,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_with_funky_orderby_complex_scenario1(bool isAsync)
         {
@@ -5520,7 +5520,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory(Skip = "Issue#16226")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_with_funky_orderby_complex_scenario2(bool isAsync)
         {
@@ -5573,7 +5573,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalFact(Skip = "Issue #15043")]
+        [ConditionalFact(Skip = "Issue#16330")]
         public virtual void Correlated_collection_with_top_level_FirstOrDefault()
         {
             using (var ctx = CreateContext())
@@ -5602,7 +5602,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 gs => gs.Select(g => g.Weapons));
         }
 
-        [ConditionalFact(Skip = "Issue #15043")]
+        [ConditionalFact(Skip = "Issue#16330")]
         public virtual void Correlated_collection_with_top_level_Last_with_orderby_on_outer()
         {
             using (var ctx = CreateContext())
@@ -5623,7 +5623,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "Issue #15043")]
+        [ConditionalFact(Skip = "Issue#16330")]
         public virtual void Correlated_collection_with_top_level_Last_with_order_by_on_inner()
         {
             using (var ctx = CreateContext())
@@ -5866,7 +5866,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 lls => lls.Where(ll => ll is LocustCommander ? ((LocustCommander)ll).HighCommand.IsOperational : false));
         }
 
-        [ConditionalTheory(Skip = "issue #15043")]
+        [ConditionalTheory(Skip = "Issue#16311")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Outer_parameter_in_join_key(bool isAsync)
         {
@@ -5885,7 +5885,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) => CollectionAsserter<string>(elementSorter: ee => ee)(e.Collection, a.Collection));
         }
 
-        [ConditionalTheory(Skip = "issue #15043")]
+        [ConditionalTheory(Skip = "Issue#16311")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Outer_parameter_in_join_key_inner_and_outer(bool isAsync)
         {
@@ -5904,7 +5904,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) => CollectionAsserter<string>(elementSorter: ee => ee)(e.Collection, a.Collection));
         }
 
-        [ConditionalTheory(Skip = "issue #15043")]
+        [ConditionalTheory(Skip = "Issue#15711")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Outer_parameter_in_group_join_key(bool isAsync)
         {
@@ -5923,7 +5923,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) => CollectionAsserter<string>(elementSorter: ee => ee)(e.Collection, a.Collection));
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory(Skip = "Issue#16311")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Outer_parameter_in_group_join_with_DefaultIfEmpty(bool isAsync)
         {
@@ -6293,7 +6293,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15043")]
+        [ConditionalFact(Skip = "Issue#16330")]
         public virtual void Streaming_correlated_collection_issue_11403()
         {
             Weapon[] expected;
@@ -6463,7 +6463,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collection_order_by_constant(bool isAsync)
         {
@@ -6624,7 +6624,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true);
         }
 
-        [ConditionalTheory(Skip = "Issue: #15611")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_with_complex_OrderBy3(bool isAsync)
         {
@@ -6640,7 +6640,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true);
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collection_with_complex_OrderBy(bool isAsync)
         {
@@ -6653,7 +6653,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: CollectionAsserter<Gear>(ee => ee.FullName, (ee, aa) => Assert.Equal(ee.FullName, aa.FullName)));
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collection_with_very_complex_order_by(bool isAsync)
         {
@@ -6826,7 +6826,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true);
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Cast_subquery_to_base_type_using_typed_ToList(bool isAsync)
         {
@@ -6849,7 +6849,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: CollectionAsserter<Gear>(e => e.Nickname, (e, a) => Assert.Equal(e.Nickname, a.Nickname)));
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory(Skip = "Issue#16318")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Cast_ordered_subquery_to_base_type_using_typed_ToArray(bool isAsync)
         {
@@ -6872,7 +6872,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: CollectionAsserter<Gear>(e => e.Nickname, (e, a) => Assert.Equal(e.Nickname, a.Nickname)));
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory(Skip = "Issue#15713")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collection_with_complex_order_by_funcletized_to_constant_bool(bool isAsync)
         {
@@ -7466,7 +7466,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_contains_on_navigation_with_composite_keys(bool isAsync)
         {

--- a/test/EFCore.Specification.Tests/Query/InheritanceRelationshipsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/InheritanceRelationshipsQueryTestBase.cs
@@ -15,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         protected TFixture Fixture { get; }
 
-        [ConditionalFact(Skip = "issue #15611")]
+        [ConditionalFact]
         public virtual void Changes_in_derived_related_entities_are_detected()
         {
             using (var context = CreateContext())
@@ -197,7 +197,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15611")]
+        [ConditionalFact]
         public virtual void Include_collection_with_inheritance1()
         {
             using (var context = CreateContext())
@@ -223,7 +223,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15611")]
+        [ConditionalFact]
         public virtual void Include_collection_with_inheritance_with_filter1()
         {
             using (var context = CreateContext())
@@ -249,7 +249,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15611")]
+        [ConditionalFact]
         public virtual void Include_collection_without_inheritance()
         {
             using (var context = CreateContext())
@@ -273,7 +273,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15611")]
+        [ConditionalFact]
         public virtual void Include_collection_without_inheritance_with_filter()
         {
             using (var context = CreateContext())
@@ -429,7 +429,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15611")]
+        [ConditionalFact]
         public virtual void Include_collection_with_inheritance_on_derived1()
         {
             using (var context = CreateContext())
@@ -443,7 +443,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15611")]
+        [ConditionalFact]
         public virtual void Include_collection_with_inheritance_on_derived2()
         {
             using (var context = CreateContext())
@@ -455,7 +455,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15611")]
+        [ConditionalFact]
         public virtual void Include_collection_with_inheritance_on_derived3()
         {
             using (var context = CreateContext())
@@ -515,7 +515,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15611")]
+        [ConditionalFact]
         public virtual void Nested_include_with_inheritance_reference_collection1()
         {
             using (var context = CreateContext())
@@ -527,7 +527,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15611")]
+        [ConditionalFact]
         public virtual void Nested_include_with_inheritance_reference_collection3()
         {
             using (var context = CreateContext())
@@ -551,7 +551,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15611")]
+        [ConditionalFact]
         public virtual void Nested_include_with_inheritance_collection_reference1()
         {
             using (var context = CreateContext())
@@ -577,7 +577,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15611")]
+        [ConditionalFact]
         public virtual void Nested_include_with_inheritance_collection_collection1()
         {
             using (var context = CreateContext())
@@ -603,7 +603,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15611")]
+        [ConditionalFact]
         public virtual void Nested_include_collection_reference_on_non_entity_base()
         {
             using (var context = CreateContext())

--- a/test/EFCore.Specification.Tests/Query/InheritanceTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/InheritanceTestBase.cs
@@ -294,7 +294,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15611")]
+        [ConditionalFact]
         public virtual void Can_include_animals()
         {
             using (var context = CreateContext())
@@ -311,7 +311,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15611")]
+        [ConditionalFact]
         public virtual void Can_include_prey()
         {
             using (var context = CreateContext())

--- a/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
@@ -194,7 +194,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15043")]
+        [ConditionalFact]
         public virtual void Navigation_rewrite_on_owned_collection()
         {
             using (var ctx = CreateContext())
@@ -207,7 +207,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15043")]
+        [ConditionalFact]
         public virtual void Navigation_rewrite_on_owned_collection_with_composition()
         {
             using (var ctx = CreateContext())
@@ -221,7 +221,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
 
-        [ConditionalFact(Skip = "issue #15043")]
+        [ConditionalFact]
         public virtual void Navigation_rewrite_on_owned_collection_with_composition_complex()
         {
             using (var ctx = CreateContext())

--- a/test/EFCore.Specification.Tests/Query/QueryNavigationsTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/QueryNavigationsTestBase.cs
@@ -526,7 +526,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 1);
         }
 
-        [ConditionalTheory(Skip = "issue #15043")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_collection_navigation_simple(bool isAsync)
         {
@@ -571,7 +571,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "issue #15043")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_collection_navigation_simple_followed_by_ordering_by_scalar(bool isAsync)
         {
@@ -594,7 +594,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 30);
         }
 
-        [ConditionalTheory(Skip = "issue #15043")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_collection_navigation_multi_part(bool isAsync)
         {
@@ -616,7 +616,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 6);
         }
 
-        [ConditionalTheory(Skip = "issue #12922, #15043")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_collection_navigation_multi_part2(bool isAsync)
         {
@@ -958,7 +958,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true);
         }
 
-        [ConditionalTheory(Skip = "issue #15043")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Collection_select_nav_prop_first_or_default_then_nav_prop(bool isAsync)
         {
@@ -1485,7 +1485,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15611")]
+        [ConditionalFact]
         public virtual void Include_on_inner_projecting_groupjoin_complex()
         {
             using (var ctx = CreateContext())

--- a/test/EFCore.Specification.Tests/Query/QueryTaggingTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/QueryTaggingTestBase.cs
@@ -79,7 +79,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15611")]
+        [ConditionalFact]
         public virtual void Tag_on_include_query()
         {
             using (var context = CreateContext())

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.JoinGroupJoin.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.JoinGroupJoin.cs
@@ -421,7 +421,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 830);
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory(Skip = "Issue#15711")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_customers_orders(bool isAsync)
         {
@@ -588,7 +588,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.OrderID);
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory(Skip = "Issue#15711")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_tracking_groups(bool isAsync)
         {
@@ -603,7 +603,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 830);
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory(Skip = "Issue#15711")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_tracking_groups2(bool isAsync)
         {
@@ -673,7 +673,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 919);
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory(Skip = "Issue#15711")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_outer_projection(bool isAsync)
         {
@@ -694,7 +694,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 830);
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory(Skip = "Issue#15711")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_outer_projection2(bool isAsync)
         {
@@ -714,7 +714,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory(Skip = "Issue#15711")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_outer_projection3(bool isAsync)
         {
@@ -729,7 +729,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) => CollectionAsserter<string>(s => s)(e.g, a.g));
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory(Skip = "Issue#15711")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_outer_projection4(bool isAsync)
         {
@@ -740,7 +740,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: CollectionAsserter<string>(s => s));
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory(Skip = "Issue#15711")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_outer_projection_reverse(bool isAsync)
         {
@@ -761,7 +761,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 89);
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory(Skip = "Issue#15711")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_outer_projection_reverse2(bool isAsync)
         {

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
@@ -410,14 +410,13 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "TaskList#24")]
+        [ConditionalFact]
         public virtual void Min_no_data_subquery()
         {
             using (var context = CreateContext())
             {
-                Assert.Throws<InvalidOperationException>(
-                    () =>
-                        context.Customers.Select(c => c.Orders.Where(o => o.OrderID == -1).Min(o => o.OrderID)).ToList());
+                // Verify that it does not throw
+                context.Customers.Select(c => c.Orders.Where(o => o.OrderID == -1).Min(o => o.OrderID)).ToList();
             }
         }
 
@@ -430,14 +429,13 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "TaskList#24")]
+        [ConditionalFact]
         public virtual void Max_no_data_subquery()
         {
             using (var context = CreateContext())
             {
-                Assert.Throws<InvalidOperationException>(
-                    () =>
-                        context.Customers.Select(c => c.Orders.Where(o => o.OrderID == -1).Max(o => o.OrderID)).ToList());
+                // Verify that it does not throw
+                context.Customers.Select(c => c.Orders.Where(o => o.OrderID == -1).Max(o => o.OrderID)).ToList();
             }
         }
 
@@ -450,14 +448,13 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "TaskList#24")]
+        [ConditionalFact]
         public virtual void Average_no_data_subquery()
         {
             using (var context = CreateContext())
             {
-                Assert.Throws<InvalidOperationException>(
-                    () =>
-                        context.Customers.Select(c => c.Orders.Where(o => o.OrderID == -1).Average(o => o.OrderID)).ToList());
+                // Verify that it does not throw
+                context.Customers.Select(c => c.Orders.Where(o => o.OrderID == -1).Average(o => o.OrderID)).ToList();
             }
         }
 
@@ -939,7 +936,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 1);
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory(Skip = "Issue#16314")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multiple_collection_navigation_with_FirstOrDefault_chained(bool isAsync)
         {

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
@@ -55,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 cs => cs.Select(c => c.Region));
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory(Skip = "Issue#16318")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Projection_when_client_evald_subquery(bool isAsync)
         {
@@ -408,7 +408,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select c.City);
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory(Skip = "Issue#16314")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_nested_collection(bool isAsync)
         {
@@ -428,7 +428,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) => CollectionAsserter<int>(i => i));
         }
 
-        [ConditionalFact(Skip = "Issue#15611")]
+        [ConditionalFact]
         public virtual void Select_nested_collection_multi_level()
         {
             using (var context = CreateContext())
@@ -592,7 +592,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Count);
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory(Skip = "Issue#16311")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_nested_collection_deep(bool isAsync)
         {
@@ -816,7 +816,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Select(o => o.OrderDate.Value - new DateTime(1997, 1, 1)));
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Project_single_element_from_collection_with_OrderBy_Take_and_FirstOrDefault(bool isAsync)
         {
@@ -826,7 +826,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     c => c.Orders.OrderBy(o => o.OrderID).Select(o => o.CustomerID).Take(1).FirstOrDefault()));
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Project_single_element_from_collection_with_OrderBy_Skip_and_FirstOrDefault(bool isAsync)
         {
@@ -836,7 +836,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     c => c.Orders.OrderBy(o => o.OrderID).Select(o => o.CustomerID).Skip(1).FirstOrDefault()));
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Project_single_element_from_collection_with_OrderBy_Distinct_and_FirstOrDefault(bool isAsync)
         {
@@ -869,7 +869,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Select(c => c.Orders.OrderBy(o => o.OrderID).Select(o => o.CustomerID).Take(1).SingleOrDefault()));
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Project_single_element_from_collection_with_OrderBy_Take_and_FirstOrDefault_with_parameter(bool isAsync)
         {
@@ -924,7 +924,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         .FirstOrDefault()));
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault(bool isAsync)
         {
@@ -935,7 +935,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         o => o.OrderDetails.OrderBy(od => od.Product.ProductName).Select(od => od.OrderID).Take(1).FirstOrDefault()));
         }
 
-        [ConditionalTheory(Skip = "Issue #15043")]
+        [ConditionalTheory(Skip = "Issue#10001")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault_2(bool isAsync)
         {
@@ -1103,7 +1103,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       });
         }
 
-        [ConditionalTheory(Skip = "TaskList#6")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Anonymous_projection_with_repeated_property_being_ordered_2(bool isAsync)
         {

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         private static readonly Expression<Func<Order, bool>> _filter = o => o.CustomerID == "ALFKI";
 
-        [ConditionalTheory(Skip = "TaskItem#6")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_as_queryable_expression(bool isAsync)
         {
@@ -856,7 +856,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 20);
         }
 
-        [ConditionalTheory(Skip = "TaskList#1")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_string_indexof(bool isAsync)
         {
@@ -1119,7 +1119,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 91);
         }
 
-        [ConditionalTheory(Skip = "TaskList#10")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_in_optimization_multiple(bool isAsync)
         {
@@ -1141,7 +1141,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 16);
         }
 
-        [ConditionalTheory(Skip = "TaskList#10")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_not_in_optimization1(bool isAsync)
         {
@@ -1161,7 +1161,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 90);
         }
 
-        [ConditionalTheory(Skip = "TaskList#10")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_not_in_optimization2(bool isAsync)
         {
@@ -1181,7 +1181,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 93);
         }
 
-        [ConditionalTheory(Skip = "TaskList#10")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_not_in_optimization3(bool isAsync)
         {
@@ -1202,7 +1202,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 92);
         }
 
-        [ConditionalTheory(Skip = "TaskList#10")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_not_in_optimization4(bool isAsync)
         {
@@ -1224,7 +1224,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 90);
         }
 
-        [ConditionalTheory(Skip = "TaskList#10")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_select_many_and(bool isAsync)
         {
@@ -1561,7 +1561,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 22);
         }
 
-        [ConditionalTheory(Skip = "TaskList#9")]
+        [ConditionalTheory(Skip = "Issue#14572")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_expression_invoke(bool isAsync)
         {
@@ -1877,7 +1877,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 cs => cs.Where(c => c.City == "London").Select(c => c.CompanyName));
         }
 
-        [ConditionalTheory(Skip = "TaskItem#5")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_Is_on_same_type(bool isAsync)
         {
@@ -1950,7 +1950,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 5);
         }
 
-        [ConditionalTheory(Skip = "TaskList#6")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_contains_on_navigation(bool isAsync)
         {
@@ -1960,7 +1960,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 830);
         }
 
-        [ConditionalTheory(Skip = "TaskList#6")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_subquery_FirstOrDefault_is_null(bool isAsync)
         {
@@ -1970,7 +1970,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 2);
         }
 
-        [ConditionalTheory(Skip = "TaskList#6")]
+        [ConditionalTheory(Skip = "Issue#15855")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_subquery_FirstOrDefault_compared_to_entity(bool isAsync)
         {

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -1145,7 +1145,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 85);
         }
 
-        [ConditionalFact(Skip = "TaskList#6")]
+        [ConditionalFact]
         public virtual void Any_with_multiple_conditions_still_uses_exists()
         {
             using (var context = CreateContext())
@@ -1353,7 +1353,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 1);
         }
 
-        [ConditionalTheory(Skip = "TaskList#10")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_select_many_or(bool isAsync)
         {
@@ -1373,7 +1373,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 100);
         }
 
-        [ConditionalTheory(Skip = "TaskList#10")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_select_many_or2(bool isAsync)
         {
@@ -1393,7 +1393,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 16);
         }
 
-        [ConditionalTheory(Skip = "TaskList#10")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_select_many_or3(bool isAsync)
         {
@@ -1414,7 +1414,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 17);
         }
 
-        [ConditionalTheory(Skip = "TaskList#10")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_select_many_or4(bool isAsync)
         {
@@ -1436,7 +1436,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 19);
         }
 
-        [ConditionalTheory(Skip = "TaskList#10")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_select_many_or_with_parameter(bool isAsync)
         {
@@ -1791,7 +1791,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             public override int GetHashCode() => HashCode.Combine(Id, Count);
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory(Skip = "Issue#16314")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_correlated_subquery_projection(bool isAsync)
         {
@@ -1804,7 +1804,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: CollectionAsserter<Order>(o => o.OrderID));
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory(Skip = "Issue#16314")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_correlated_subquery_filtered(bool isAsync)
         {
@@ -1841,7 +1841,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         //         assertOrder: true);
         // }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory(Skip = "Issue#16314")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_nested_collection_in_anonymous_type(bool isAsync)
         {
@@ -1870,7 +1870,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 1);
         }
 
-        [ConditionalTheory(Skip = "Issue#15611")]
+        [ConditionalTheory(Skip = "Issue#16311")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_subquery_recursive_trivial(bool isAsync)
         {
@@ -2598,7 +2598,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 88);
         }
 
-        [ConditionalTheory(Skip = "TaskList#10")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_select_many(bool isAsync)
         {
@@ -2612,7 +2612,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 1);
         }
 
-        [ConditionalTheory(Skip = "TaskList#10")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_orderby_select_many(bool isAsync)
         {
@@ -4906,7 +4906,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true);
         }
 
-        [ConditionalTheory(Skip = "TaskList#6")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Anonymous_subquery_orderby(bool isAsync)
         {
@@ -5071,13 +5071,17 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) => Assert.Equal(e.Property, a.Property));
         }
 
-        [ConditionalTheory(Skip = "Issue #15611")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_with_orderby_skip_preserves_ordering(bool isAsync)
         {
             return AssertQuery<Customer>(
                 isAsync,
-                cs => cs.Include(c => c.Orders).Where(c => c.CustomerID != "VAFFE" && c.CustomerID != "DRACD").OrderBy(c => c.City).Skip(40)
+                cs => cs.Include(c => c.Orders)
+                    .Where(c => c.CustomerID != "VAFFE" && c.CustomerID != "DRACD")
+                    .OrderBy(c => c.City)
+                    .ThenBy(c => c.CustomerID)
+                    .Skip(40)
                     .Take(5),
                 entryCount: 48,
                 assertOrder: true);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -1310,7 +1310,7 @@ INNER JOIN [LevelTwo] AS [l1.OneToMany_Optional1] ON [l1].[Id] = [l1.OneToMany_O
 LEFT JOIN [LevelThree] AS [l1.OneToMany_Optional1.OneToOne_Optional_FK2] ON [l1.OneToMany_Optional1].[Id] = [l1.OneToMany_Optional1.OneToOne_Optional_FK2].[Level2_Optional_Id]");
         }
 
-        [ConditionalFact(Skip = "Issue#15611")]
+        [ConditionalFact]
         public void Multiple_complex_includes_from_sql()
         {
             using (var context = CreateContext())

--- a/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceRelationshipsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceRelationshipsQuerySqlServerTest.cs
@@ -161,20 +161,15 @@ WHERE ([r].[Name] <> N'Bar') OR [r].[Name] IS NULL");
             base.Include_collection_with_inheritance1();
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[BaseId]
-FROM [BaseEntities] AS [e]
-WHERE [e].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity')
-ORDER BY [e].[Id]",
-                //
-                @"SELECT [e.BaseCollectionOnBase].[Id], [e.BaseCollectionOnBase].[BaseParentId], [e.BaseCollectionOnBase].[Discriminator], [e.BaseCollectionOnBase].[Name], [e.BaseCollectionOnBase].[DerivedProperty]
-FROM [BaseCollectionsOnBase] AS [e.BaseCollectionOnBase]
-INNER JOIN (
-    SELECT [e0].[Id]
-    FROM [BaseEntities] AS [e0]
-    WHERE [e0].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity')
-) AS [t] ON [e.BaseCollectionOnBase].[BaseParentId] = [t].[Id]
-WHERE [e.BaseCollectionOnBase].[Discriminator] IN (N'DerivedCollectionOnBase', N'BaseCollectionOnBase')
-ORDER BY [t].[Id]");
+                @"SELECT [b].[Id], [b].[Discriminator], [b].[Name], [b].[BaseId], [t].[Id], [t].[BaseParentId], [t].[Discriminator], [t].[Name], [t].[DerivedProperty]
+FROM [BaseEntities] AS [b]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Discriminator], [b0].[Name], [b0].[DerivedProperty]
+    FROM [BaseCollectionsOnBase] AS [b0]
+    WHERE [b0].[Discriminator] IN (N'BaseCollectionOnBase', N'DerivedCollectionOnBase')
+) AS [t] ON [b].[Id] = [t].[BaseParentId]
+WHERE [b].[Discriminator] IN (N'BaseInheritanceRelationshipEntity', N'DerivedInheritanceRelationshipEntity')
+ORDER BY [b].[Id], [t].[Id]");
         }
 
         public override void Include_collection_with_inheritance_reverse()
@@ -197,20 +192,15 @@ WHERE [b].[Discriminator] IN (N'BaseCollectionOnBase', N'DerivedCollectionOnBase
             base.Include_collection_with_inheritance_with_filter1();
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[BaseId]
-FROM [BaseEntities] AS [e]
-WHERE [e].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity') AND (([e].[Name] <> N'Bar') OR [e].[Name] IS NULL)
-ORDER BY [e].[Id]",
-                //
-                @"SELECT [e.BaseCollectionOnBase].[Id], [e.BaseCollectionOnBase].[BaseParentId], [e.BaseCollectionOnBase].[Discriminator], [e.BaseCollectionOnBase].[Name], [e.BaseCollectionOnBase].[DerivedProperty]
-FROM [BaseCollectionsOnBase] AS [e.BaseCollectionOnBase]
-INNER JOIN (
-    SELECT [e0].[Id]
-    FROM [BaseEntities] AS [e0]
-    WHERE [e0].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity') AND (([e0].[Name] <> N'Bar') OR [e0].[Name] IS NULL)
-) AS [t] ON [e.BaseCollectionOnBase].[BaseParentId] = [t].[Id]
-WHERE [e.BaseCollectionOnBase].[Discriminator] IN (N'DerivedCollectionOnBase', N'BaseCollectionOnBase')
-ORDER BY [t].[Id]");
+                @"SELECT [b].[Id], [b].[Discriminator], [b].[Name], [b].[BaseId], [t].[Id], [t].[BaseParentId], [t].[Discriminator], [t].[Name], [t].[DerivedProperty]
+FROM [BaseEntities] AS [b]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Discriminator], [b0].[Name], [b0].[DerivedProperty]
+    FROM [BaseCollectionsOnBase] AS [b0]
+    WHERE [b0].[Discriminator] IN (N'BaseCollectionOnBase', N'DerivedCollectionOnBase')
+) AS [t] ON [b].[Id] = [t].[BaseParentId]
+WHERE [b].[Discriminator] IN (N'BaseInheritanceRelationshipEntity', N'DerivedInheritanceRelationshipEntity') AND (([b].[Name] <> N'Bar') OR [b].[Name] IS NULL)
+ORDER BY [b].[Id], [t].[Id]");
         }
 
         public override void Include_collection_with_inheritance_with_filter_reverse()
@@ -233,19 +223,11 @@ WHERE [b].[Discriminator] IN (N'BaseCollectionOnBase', N'DerivedCollectionOnBase
             base.Include_collection_without_inheritance();
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[BaseId]
-FROM [BaseEntities] AS [e]
-WHERE [e].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity')
-ORDER BY [e].[Id]",
-                //
-                @"SELECT [e.CollectionOnBase].[Id], [e.CollectionOnBase].[Name], [e.CollectionOnBase].[ParentId]
-FROM [CollectionsOnBase] AS [e.CollectionOnBase]
-INNER JOIN (
-    SELECT [e0].[Id]
-    FROM [BaseEntities] AS [e0]
-    WHERE [e0].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity')
-) AS [t] ON [e.CollectionOnBase].[ParentId] = [t].[Id]
-ORDER BY [t].[Id]");
+                @"SELECT [b].[Id], [b].[Discriminator], [b].[Name], [b].[BaseId], [c].[Id], [c].[Name], [c].[ParentId]
+FROM [BaseEntities] AS [b]
+LEFT JOIN [CollectionsOnBase] AS [c] ON [b].[Id] = [c].[ParentId]
+WHERE [b].[Discriminator] IN (N'BaseInheritanceRelationshipEntity', N'DerivedInheritanceRelationshipEntity')
+ORDER BY [b].[Id], [c].[Id]");
         }
 
         public override void Include_collection_without_inheritance_reverse()
@@ -267,19 +249,11 @@ LEFT JOIN (
             base.Include_collection_without_inheritance_with_filter();
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[BaseId]
-FROM [BaseEntities] AS [e]
-WHERE [e].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity') AND (([e].[Name] <> N'Bar') OR [e].[Name] IS NULL)
-ORDER BY [e].[Id]",
-                //
-                @"SELECT [e.CollectionOnBase].[Id], [e.CollectionOnBase].[Name], [e.CollectionOnBase].[ParentId]
-FROM [CollectionsOnBase] AS [e.CollectionOnBase]
-INNER JOIN (
-    SELECT [e0].[Id]
-    FROM [BaseEntities] AS [e0]
-    WHERE [e0].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity') AND (([e0].[Name] <> N'Bar') OR [e0].[Name] IS NULL)
-) AS [t] ON [e.CollectionOnBase].[ParentId] = [t].[Id]
-ORDER BY [t].[Id]");
+                @"SELECT [b].[Id], [b].[Discriminator], [b].[Name], [b].[BaseId], [c].[Id], [c].[Name], [c].[ParentId]
+FROM [BaseEntities] AS [b]
+LEFT JOIN [CollectionsOnBase] AS [c] ON [b].[Id] = [c].[ParentId]
+WHERE [b].[Discriminator] IN (N'BaseInheritanceRelationshipEntity', N'DerivedInheritanceRelationshipEntity') AND (([b].[Name] <> N'Bar') OR [b].[Name] IS NULL)
+ORDER BY [b].[Id], [c].[Id]");
         }
 
         public override void Include_collection_without_inheritance_with_filter_reverse()
@@ -458,20 +432,15 @@ LEFT JOIN (
             base.Include_collection_with_inheritance_on_derived1();
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[BaseId]
-FROM [BaseEntities] AS [e]
-WHERE [e].[Discriminator] = N'DerivedInheritanceRelationshipEntity'
-ORDER BY [e].[Id]",
-                //
-                @"SELECT [e.BaseCollectionOnBase].[Id], [e.BaseCollectionOnBase].[BaseParentId], [e.BaseCollectionOnBase].[Discriminator], [e.BaseCollectionOnBase].[Name], [e.BaseCollectionOnBase].[DerivedProperty]
-FROM [BaseCollectionsOnBase] AS [e.BaseCollectionOnBase]
-INNER JOIN (
-    SELECT [e0].[Id]
-    FROM [BaseEntities] AS [e0]
-    WHERE [e0].[Discriminator] = N'DerivedInheritanceRelationshipEntity'
-) AS [t] ON [e.BaseCollectionOnBase].[BaseParentId] = [t].[Id]
-WHERE [e.BaseCollectionOnBase].[Discriminator] IN (N'DerivedCollectionOnBase', N'BaseCollectionOnBase')
-ORDER BY [t].[Id]");
+                @"SELECT [b].[Id], [b].[Discriminator], [b].[Name], [b].[BaseId], [t].[Id], [t].[BaseParentId], [t].[Discriminator], [t].[Name], [t].[DerivedProperty]
+FROM [BaseEntities] AS [b]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Discriminator], [b0].[Name], [b0].[DerivedProperty]
+    FROM [BaseCollectionsOnBase] AS [b0]
+    WHERE [b0].[Discriminator] IN (N'BaseCollectionOnBase', N'DerivedCollectionOnBase')
+) AS [t] ON [b].[Id] = [t].[BaseParentId]
+WHERE [b].[Discriminator] = N'DerivedInheritanceRelationshipEntity'
+ORDER BY [b].[Id], [t].[Id]");
         }
 
         public override void Include_collection_with_inheritance_on_derived2()
@@ -479,20 +448,15 @@ ORDER BY [t].[Id]");
             base.Include_collection_with_inheritance_on_derived2();
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[BaseId]
-FROM [BaseEntities] AS [e]
-WHERE [e].[Discriminator] = N'DerivedInheritanceRelationshipEntity'
-ORDER BY [e].[Id]",
-                //
-                @"SELECT [e.BaseCollectionOnDerived].[Id], [e.BaseCollectionOnDerived].[Discriminator], [e.BaseCollectionOnDerived].[Name], [e.BaseCollectionOnDerived].[ParentId], [e.BaseCollectionOnDerived].[DerivedInheritanceRelationshipEntityId]
-FROM [BaseCollectionsOnDerived] AS [e.BaseCollectionOnDerived]
-INNER JOIN (
-    SELECT [e0].[Id]
-    FROM [BaseEntities] AS [e0]
-    WHERE [e0].[Discriminator] = N'DerivedInheritanceRelationshipEntity'
-) AS [t] ON [e.BaseCollectionOnDerived].[ParentId] = [t].[Id]
-WHERE [e.BaseCollectionOnDerived].[Discriminator] IN (N'DerivedCollectionOnDerived', N'BaseCollectionOnDerived')
-ORDER BY [t].[Id]");
+                @"SELECT [b].[Id], [b].[Discriminator], [b].[Name], [b].[BaseId], [t].[Id], [t].[Discriminator], [t].[Name], [t].[ParentId], [t].[DerivedInheritanceRelationshipEntityId]
+FROM [BaseEntities] AS [b]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[Discriminator], [b0].[Name], [b0].[ParentId], [b0].[DerivedInheritanceRelationshipEntityId]
+    FROM [BaseCollectionsOnDerived] AS [b0]
+    WHERE [b0].[Discriminator] IN (N'BaseCollectionOnDerived', N'DerivedCollectionOnDerived')
+) AS [t] ON [b].[Id] = [t].[ParentId]
+WHERE [b].[Discriminator] = N'DerivedInheritanceRelationshipEntity'
+ORDER BY [b].[Id], [t].[Id]");
         }
 
         public override void Include_collection_with_inheritance_on_derived3()
@@ -500,20 +464,15 @@ ORDER BY [t].[Id]");
             base.Include_collection_with_inheritance_on_derived3();
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[BaseId]
-FROM [BaseEntities] AS [e]
-WHERE [e].[Discriminator] = N'DerivedInheritanceRelationshipEntity'
-ORDER BY [e].[Id]",
-                //
-                @"SELECT [e.DerivedCollectionOnDerived].[Id], [e.DerivedCollectionOnDerived].[Discriminator], [e.DerivedCollectionOnDerived].[Name], [e.DerivedCollectionOnDerived].[ParentId], [e.DerivedCollectionOnDerived].[DerivedInheritanceRelationshipEntityId]
-FROM [BaseCollectionsOnDerived] AS [e.DerivedCollectionOnDerived]
-INNER JOIN (
-    SELECT [e0].[Id]
-    FROM [BaseEntities] AS [e0]
-    WHERE [e0].[Discriminator] = N'DerivedInheritanceRelationshipEntity'
-) AS [t] ON [e.DerivedCollectionOnDerived].[DerivedInheritanceRelationshipEntityId] = [t].[Id]
-WHERE [e.DerivedCollectionOnDerived].[Discriminator] = N'DerivedCollectionOnDerived'
-ORDER BY [t].[Id]");
+                @"SELECT [b].[Id], [b].[Discriminator], [b].[Name], [b].[BaseId], [t].[Id], [t].[Discriminator], [t].[Name], [t].[ParentId], [t].[DerivedInheritanceRelationshipEntityId]
+FROM [BaseEntities] AS [b]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[Discriminator], [b0].[Name], [b0].[ParentId], [b0].[DerivedInheritanceRelationshipEntityId]
+    FROM [BaseCollectionsOnDerived] AS [b0]
+    WHERE [b0].[Discriminator] = N'DerivedCollectionOnDerived'
+) AS [t] ON [b].[Id] = [t].[DerivedInheritanceRelationshipEntityId]
+WHERE [b].[Discriminator] = N'DerivedInheritanceRelationshipEntity'
+ORDER BY [b].[Id], [t].[Id]");
         }
 
         public override void Include_collection_with_inheritance_on_derived_reverse()
@@ -596,30 +555,20 @@ WHERE [n].[Discriminator] IN (N'NestedReferenceBase', N'NestedReferenceDerived')
             base.Nested_include_with_inheritance_reference_collection1();
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[BaseId], [t].[Id], [t].[BaseParentId], [t].[Discriminator], [t].[Name]
-FROM [BaseEntities] AS [e]
+                @"SELECT [b].[Id], [b].[Discriminator], [b].[Name], [b].[BaseId], [t].[Id], [t].[BaseParentId], [t].[Discriminator], [t].[Name], [t0].[Id], [t0].[Discriminator], [t0].[Name], [t0].[ParentCollectionId], [t0].[ParentReferenceId]
+FROM [BaseEntities] AS [b]
 LEFT JOIN (
-    SELECT [e.BaseReferenceOnBase].*
-    FROM [BaseReferencesOnBase] AS [e.BaseReferenceOnBase]
-    WHERE [e.BaseReferenceOnBase].[Discriminator] IN (N'DerivedReferenceOnBase', N'BaseReferenceOnBase')
-) AS [t] ON [e].[Id] = [t].[BaseParentId]
-WHERE [e].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity')
-ORDER BY [t].[Id]",
-                //
-                @"SELECT [e.BaseReferenceOnBase.NestedCollection].[Id], [e.BaseReferenceOnBase.NestedCollection].[Discriminator], [e.BaseReferenceOnBase.NestedCollection].[Name], [e.BaseReferenceOnBase.NestedCollection].[ParentCollectionId], [e.BaseReferenceOnBase.NestedCollection].[ParentReferenceId]
-FROM [NestedCollections] AS [e.BaseReferenceOnBase.NestedCollection]
-INNER JOIN (
-    SELECT DISTINCT [t0].[Id]
-    FROM [BaseEntities] AS [e0]
-    LEFT JOIN (
-        SELECT [e.BaseReferenceOnBase0].*
-        FROM [BaseReferencesOnBase] AS [e.BaseReferenceOnBase0]
-        WHERE [e.BaseReferenceOnBase0].[Discriminator] IN (N'DerivedReferenceOnBase', N'BaseReferenceOnBase')
-    ) AS [t0] ON [e0].[Id] = [t0].[BaseParentId]
-    WHERE [e0].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity')
-) AS [t1] ON [e.BaseReferenceOnBase.NestedCollection].[ParentReferenceId] = [t1].[Id]
-WHERE [e.BaseReferenceOnBase.NestedCollection].[Discriminator] IN (N'NestedCollectionDerived', N'NestedCollectionBase')
-ORDER BY [t1].[Id]");
+    SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Discriminator], [b0].[Name]
+    FROM [BaseReferencesOnBase] AS [b0]
+    WHERE [b0].[Discriminator] IN (N'BaseReferenceOnBase', N'DerivedReferenceOnBase')
+) AS [t] ON [b].[Id] = [t].[BaseParentId]
+LEFT JOIN (
+    SELECT [n].[Id], [n].[Discriminator], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId]
+    FROM [NestedCollections] AS [n]
+    WHERE [n].[Discriminator] IN (N'NestedCollectionBase', N'NestedCollectionDerived')
+) AS [t0] ON [t].[Id] = [t0].[ParentReferenceId]
+WHERE [b].[Discriminator] IN (N'BaseInheritanceRelationshipEntity', N'DerivedInheritanceRelationshipEntity')
+ORDER BY [b].[Id], [t0].[Id]");
         }
 
         public override void Nested_include_with_inheritance_reference_collection3()
@@ -627,30 +576,20 @@ ORDER BY [t1].[Id]");
             base.Nested_include_with_inheritance_reference_collection3();
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[BaseId], [t].[Id], [t].[BaseParentId], [t].[Discriminator], [t].[Name]
-FROM [BaseEntities] AS [e]
+                @"SELECT [b].[Id], [b].[Discriminator], [b].[Name], [b].[BaseId], [t].[Id], [t].[BaseParentId], [t].[Discriminator], [t].[Name], [t0].[Id], [t0].[Discriminator], [t0].[Name], [t0].[ParentCollectionId], [t0].[ParentReferenceId]
+FROM [BaseEntities] AS [b]
 LEFT JOIN (
-    SELECT [e.BaseReferenceOnBase].*
-    FROM [BaseReferencesOnBase] AS [e.BaseReferenceOnBase]
-    WHERE [e.BaseReferenceOnBase].[Discriminator] IN (N'DerivedReferenceOnBase', N'BaseReferenceOnBase')
-) AS [t] ON [e].[Id] = [t].[BaseParentId]
-WHERE [e].[Discriminator] = N'DerivedInheritanceRelationshipEntity'
-ORDER BY [t].[Id]",
-                //
-                @"SELECT [e.BaseReferenceOnBase.NestedCollection].[Id], [e.BaseReferenceOnBase.NestedCollection].[Discriminator], [e.BaseReferenceOnBase.NestedCollection].[Name], [e.BaseReferenceOnBase.NestedCollection].[ParentCollectionId], [e.BaseReferenceOnBase.NestedCollection].[ParentReferenceId]
-FROM [NestedCollections] AS [e.BaseReferenceOnBase.NestedCollection]
-INNER JOIN (
-    SELECT DISTINCT [t0].[Id]
-    FROM [BaseEntities] AS [e0]
-    LEFT JOIN (
-        SELECT [e.BaseReferenceOnBase0].*
-        FROM [BaseReferencesOnBase] AS [e.BaseReferenceOnBase0]
-        WHERE [e.BaseReferenceOnBase0].[Discriminator] IN (N'DerivedReferenceOnBase', N'BaseReferenceOnBase')
-    ) AS [t0] ON [e0].[Id] = [t0].[BaseParentId]
-    WHERE [e0].[Discriminator] = N'DerivedInheritanceRelationshipEntity'
-) AS [t1] ON [e.BaseReferenceOnBase.NestedCollection].[ParentReferenceId] = [t1].[Id]
-WHERE [e.BaseReferenceOnBase.NestedCollection].[Discriminator] IN (N'NestedCollectionDerived', N'NestedCollectionBase')
-ORDER BY [t1].[Id]");
+    SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Discriminator], [b0].[Name]
+    FROM [BaseReferencesOnBase] AS [b0]
+    WHERE [b0].[Discriminator] IN (N'BaseReferenceOnBase', N'DerivedReferenceOnBase')
+) AS [t] ON [b].[Id] = [t].[BaseParentId]
+LEFT JOIN (
+    SELECT [n].[Id], [n].[Discriminator], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId]
+    FROM [NestedCollections] AS [n]
+    WHERE [n].[Discriminator] IN (N'NestedCollectionBase', N'NestedCollectionDerived')
+) AS [t0] ON [t].[Id] = [t0].[ParentReferenceId]
+WHERE [b].[Discriminator] = N'DerivedInheritanceRelationshipEntity'
+ORDER BY [b].[Id], [t0].[Id]");
         }
 
         public override void Nested_include_with_inheritance_reference_collection_reverse()
@@ -678,25 +617,20 @@ WHERE [n].[Discriminator] IN (N'NestedCollectionBase', N'NestedCollectionDerived
             base.Nested_include_with_inheritance_collection_reference1();
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[BaseId]
-FROM [BaseEntities] AS [e]
-WHERE [e].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity')
-ORDER BY [e].[Id]",
-                //
-                @"SELECT [e.BaseCollectionOnBase].[Id], [e.BaseCollectionOnBase].[BaseParentId], [e.BaseCollectionOnBase].[Discriminator], [e.BaseCollectionOnBase].[Name], [e.BaseCollectionOnBase].[DerivedProperty], [t].[Id], [t].[Discriminator], [t].[Name], [t].[ParentCollectionId], [t].[ParentReferenceId]
-FROM [BaseCollectionsOnBase] AS [e.BaseCollectionOnBase]
+                @"SELECT [b].[Id], [b].[Discriminator], [b].[Name], [b].[BaseId], [t0].[Id], [t0].[BaseParentId], [t0].[Discriminator], [t0].[Name], [t0].[DerivedProperty], [t0].[Id0], [t0].[Discriminator0], [t0].[Name0], [t0].[ParentCollectionId], [t0].[ParentReferenceId]
+FROM [BaseEntities] AS [b]
 LEFT JOIN (
-    SELECT [b.NestedReference].*
-    FROM [NestedReferences] AS [b.NestedReference]
-    WHERE [b.NestedReference].[Discriminator] IN (N'NestedReferenceDerived', N'NestedReferenceBase')
-) AS [t] ON [e.BaseCollectionOnBase].[Id] = [t].[ParentCollectionId]
-INNER JOIN (
-    SELECT [e0].[Id]
-    FROM [BaseEntities] AS [e0]
-    WHERE [e0].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity')
-) AS [t0] ON [e.BaseCollectionOnBase].[BaseParentId] = [t0].[Id]
-WHERE [e.BaseCollectionOnBase].[Discriminator] IN (N'DerivedCollectionOnBase', N'BaseCollectionOnBase')
-ORDER BY [t0].[Id]");
+    SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Discriminator], [b0].[Name], [b0].[DerivedProperty], [t].[Id] AS [Id0], [t].[Discriminator] AS [Discriminator0], [t].[Name] AS [Name0], [t].[ParentCollectionId], [t].[ParentReferenceId]
+    FROM [BaseCollectionsOnBase] AS [b0]
+    LEFT JOIN (
+        SELECT [n].[Id], [n].[Discriminator], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId]
+        FROM [NestedReferences] AS [n]
+        WHERE [n].[Discriminator] IN (N'NestedReferenceBase', N'NestedReferenceDerived')
+    ) AS [t] ON [b0].[Id] = [t].[ParentCollectionId]
+    WHERE [b0].[Discriminator] IN (N'BaseCollectionOnBase', N'DerivedCollectionOnBase')
+) AS [t0] ON [b].[Id] = [t0].[BaseParentId]
+WHERE [b].[Discriminator] IN (N'BaseInheritanceRelationshipEntity', N'DerivedInheritanceRelationshipEntity')
+ORDER BY [b].[Id], [t0].[Id]");
         }
 
         public override void Nested_include_with_inheritance_collection_reference_reverse()
@@ -724,35 +658,20 @@ WHERE [n].[Discriminator] IN (N'NestedReferenceBase', N'NestedReferenceDerived')
             base.Nested_include_with_inheritance_collection_collection1();
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[BaseId]
-FROM [BaseEntities] AS [e]
-WHERE [e].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity')
-ORDER BY [e].[Id]",
-                //
-                @"SELECT [e.BaseCollectionOnBase].[Id], [e.BaseCollectionOnBase].[BaseParentId], [e.BaseCollectionOnBase].[Discriminator], [e.BaseCollectionOnBase].[Name], [e.BaseCollectionOnBase].[DerivedProperty]
-FROM [BaseCollectionsOnBase] AS [e.BaseCollectionOnBase]
-INNER JOIN (
-    SELECT [e0].[Id]
-    FROM [BaseEntities] AS [e0]
-    WHERE [e0].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity')
-) AS [t] ON [e.BaseCollectionOnBase].[BaseParentId] = [t].[Id]
-WHERE [e.BaseCollectionOnBase].[Discriminator] IN (N'DerivedCollectionOnBase', N'BaseCollectionOnBase')
-ORDER BY [t].[Id], [e.BaseCollectionOnBase].[Id]",
-                //
-                @"SELECT [e.BaseCollectionOnBase.NestedCollection].[Id], [e.BaseCollectionOnBase.NestedCollection].[Discriminator], [e.BaseCollectionOnBase.NestedCollection].[Name], [e.BaseCollectionOnBase.NestedCollection].[ParentCollectionId], [e.BaseCollectionOnBase.NestedCollection].[ParentReferenceId]
-FROM [NestedCollections] AS [e.BaseCollectionOnBase.NestedCollection]
-INNER JOIN (
-    SELECT DISTINCT [e.BaseCollectionOnBase0].[Id], [t0].[Id] AS [Id0]
-    FROM [BaseCollectionsOnBase] AS [e.BaseCollectionOnBase0]
-    INNER JOIN (
-        SELECT [e1].[Id]
-        FROM [BaseEntities] AS [e1]
-        WHERE [e1].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity')
-    ) AS [t0] ON [e.BaseCollectionOnBase0].[BaseParentId] = [t0].[Id]
-    WHERE [e.BaseCollectionOnBase0].[Discriminator] IN (N'DerivedCollectionOnBase', N'BaseCollectionOnBase')
-) AS [t1] ON [e.BaseCollectionOnBase.NestedCollection].[ParentCollectionId] = [t1].[Id]
-WHERE [e.BaseCollectionOnBase.NestedCollection].[Discriminator] IN (N'NestedCollectionDerived', N'NestedCollectionBase')
-ORDER BY [t1].[Id0], [t1].[Id]");
+                @"SELECT [b].[Id], [b].[Discriminator], [b].[Name], [b].[BaseId], [t0].[Id], [t0].[BaseParentId], [t0].[Discriminator], [t0].[Name], [t0].[DerivedProperty], [t0].[Id0], [t0].[Discriminator0], [t0].[Name0], [t0].[ParentCollectionId], [t0].[ParentReferenceId]
+FROM [BaseEntities] AS [b]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Discriminator], [b0].[Name], [b0].[DerivedProperty], [t].[Id] AS [Id0], [t].[Discriminator] AS [Discriminator0], [t].[Name] AS [Name0], [t].[ParentCollectionId], [t].[ParentReferenceId]
+    FROM [BaseCollectionsOnBase] AS [b0]
+    LEFT JOIN (
+        SELECT [n].[Id], [n].[Discriminator], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId]
+        FROM [NestedCollections] AS [n]
+        WHERE [n].[Discriminator] IN (N'NestedCollectionBase', N'NestedCollectionDerived')
+    ) AS [t] ON [b0].[Id] = [t].[ParentCollectionId]
+    WHERE [b0].[Discriminator] IN (N'BaseCollectionOnBase', N'DerivedCollectionOnBase')
+) AS [t0] ON [b].[Id] = [t0].[BaseParentId]
+WHERE [b].[Discriminator] IN (N'BaseInheritanceRelationshipEntity', N'DerivedInheritanceRelationshipEntity')
+ORDER BY [b].[Id], [t0].[Id], [t0].[Id0]");
         }
 
         public override void Nested_include_with_inheritance_collection_collection_reverse()
@@ -780,18 +699,14 @@ WHERE [n].[Discriminator] IN (N'NestedCollectionBase', N'NestedCollectionDerived
             base.Nested_include_collection_reference_on_non_entity_base();
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[Name]
-FROM [ReferencedEntities] AS [e]
-ORDER BY [e].[Id]",
-                //
-                @"SELECT [e.Principals].[Id], [e.Principals].[Name], [e.Principals].[ReferenceId], [e.Principals].[ReferencedEntityId], [p.Reference].[Id], [p.Reference].[Name]
-FROM [PrincipalEntities] AS [e.Principals]
-LEFT JOIN [ReferencedEntities] AS [p.Reference] ON [e.Principals].[ReferenceId] = [p.Reference].[Id]
-INNER JOIN (
-    SELECT [e0].[Id]
-    FROM [ReferencedEntities] AS [e0]
-) AS [t] ON [e.Principals].[ReferencedEntityId] = [t].[Id]
-ORDER BY [t].[Id]");
+                @"SELECT [r].[Id], [r].[Name], [t].[Id], [t].[Name], [t].[ReferenceId], [t].[ReferencedEntityId], [t].[Id0], [t].[Name0]
+FROM [ReferencedEntities] AS [r]
+LEFT JOIN (
+    SELECT [p].[Id], [p].[Name], [p].[ReferenceId], [p].[ReferencedEntityId], [r0].[Id] AS [Id0], [r0].[Name] AS [Name0]
+    FROM [PrincipalEntities] AS [p]
+    LEFT JOIN [ReferencedEntities] AS [r0] ON [p].[ReferenceId] = [r0].[Id]
+) AS [t] ON [r].[Id] = [t].[ReferencedEntityId]
+ORDER BY [r].[Id], [t].[Id]");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceSqlServerTest.cs
@@ -282,21 +282,18 @@ WHERE [p].[Genus] = 0"
             base.Can_include_prey();
 
             AssertSql(
-                @"SELECT TOP(2) [e].[Species], [e].[CountryId], [e].[Discriminator], [e].[Name], [e].[EagleId], [e].[IsFlightless], [e].[Group]
-FROM [Animal] AS [e]
-WHERE [e].[Discriminator] = N'Eagle'
-ORDER BY [e].[Species]",
-                //
-                @"SELECT [e.Prey].[Species], [e.Prey].[CountryId], [e.Prey].[Discriminator], [e.Prey].[Name], [e.Prey].[EagleId], [e.Prey].[IsFlightless], [e.Prey].[Group], [e.Prey].[FoundOn]
-FROM [Animal] AS [e.Prey]
-INNER JOIN (
-    SELECT TOP(1) [e0].[Species]
-    FROM [Animal] AS [e0]
-    WHERE [e0].[Discriminator] = N'Eagle'
-    ORDER BY [e0].[Species]
-) AS [t] ON [e.Prey].[EagleId] = [t].[Species]
-WHERE [e.Prey].[Discriminator] IN (N'Eagle', N'Kiwi')
-ORDER BY [t].[Species]");
+                @"SELECT [t].[Species], [t].[CountryId], [t].[Discriminator], [t].[Name], [t].[EagleId], [t].[IsFlightless], [t].[Group], [t0].[Species], [t0].[CountryId], [t0].[Discriminator], [t0].[Name], [t0].[EagleId], [t0].[IsFlightless], [t0].[Group], [t0].[FoundOn]
+FROM (
+    SELECT TOP(2) [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group]
+    FROM [Animal] AS [a]
+    WHERE [a].[Discriminator] = N'Eagle'
+) AS [t]
+LEFT JOIN (
+    SELECT [a0].[Species], [a0].[CountryId], [a0].[Discriminator], [a0].[Name], [a0].[EagleId], [a0].[IsFlightless], [a0].[Group], [a0].[FoundOn]
+    FROM [Animal] AS [a0]
+    WHERE [a0].[Discriminator] IN (N'Eagle', N'Kiwi')
+) AS [t0] ON [t].[Species] = [t0].[EagleId]
+ORDER BY [t].[Species], [t0].[Species]");
         }
 
         public override void Can_include_animals()
@@ -304,18 +301,14 @@ ORDER BY [t].[Species]");
             base.Can_include_animals();
 
             AssertSql(
-                @"SELECT [c].[Id], [c].[Name]
+                @"SELECT [c].[Id], [c].[Name], [t].[Species], [t].[CountryId], [t].[Discriminator], [t].[Name], [t].[EagleId], [t].[IsFlightless], [t].[Group], [t].[FoundOn]
 FROM [Country] AS [c]
-ORDER BY [c].[Name], [c].[Id]",
-                //
-                @"SELECT [c.Animals].[Species], [c.Animals].[CountryId], [c.Animals].[Discriminator], [c.Animals].[Name], [c.Animals].[EagleId], [c.Animals].[IsFlightless], [c.Animals].[Group], [c.Animals].[FoundOn]
-FROM [Animal] AS [c.Animals]
-INNER JOIN (
-    SELECT [c0].[Id], [c0].[Name]
-    FROM [Country] AS [c0]
-) AS [t] ON [c.Animals].[CountryId] = [t].[Id]
-WHERE [c.Animals].[Discriminator] IN (N'Eagle', N'Kiwi')
-ORDER BY [t].[Name], [t].[Id]");
+LEFT JOIN (
+    SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
+    FROM [Animal] AS [a]
+    WHERE [a].[Discriminator] IN (N'Eagle', N'Kiwi')
+) AS [t] ON [c].[Id] = [t].[CountryId]
+ORDER BY [c].[Name], [c].[Id], [t].[Species]");
         }
 
         public override void Can_use_of_type_kiwi_where_north_on_derived_property()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -47,7 +47,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #region Bug6901
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public void Left_outer_join_bug_6091()
         {
             using (var testStore = SqlServerTestStore.CreateInitialized("QueryBugsTest"))
@@ -134,7 +134,7 @@ INSERT [dbo].[Postcodes] ([PostcodeID], [PostcodeValue], [TownName]) VALUES (5, 
 
         #region Bug5481
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public async Task Multiple_optional_navs_should_not_deadlock_bug_5481()
         {
             using (var testStore = SqlServerTestStore.CreateInitialized("QueryBugsTest"))
@@ -238,7 +238,7 @@ INSERT [dbo].[Postcodes] ([PostcodeID], [PostcodeValue], [TownName]) VALUES (5, 
 
         #endregion
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact(Skip = "Issue#15751")]
         public void Query_when_null_key_in_database_should_throw()
         {
             using (var testStore = SqlServerTestStore.CreateInitialized("QueryBugsTest"))
@@ -652,7 +652,7 @@ LEFT JOIN [Customer] AS [c] ON (([o].[CustomerFirstName] = [c].[FirstName]) AND 
 
         #region Bug963
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public void Include_on_optional_navigation_One_To_Many_963()
         {
             using (CreateDatabase963())
@@ -664,7 +664,7 @@ LEFT JOIN [Customer] AS [c] ON (([o].[CustomerFirstName] = [c].[FirstName]) AND 
             }
         }
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public void Include_on_optional_navigation_Many_To_One_963()
         {
             using (CreateDatabase963())
@@ -676,7 +676,7 @@ LEFT JOIN [Customer] AS [c] ON (([o].[CustomerFirstName] = [c].[FirstName]) AND 
             }
         }
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public void Include_on_optional_navigation_One_To_One_principal_963()
         {
             using (CreateDatabase963())
@@ -688,7 +688,7 @@ LEFT JOIN [Customer] AS [c] ON (([o].[CustomerFirstName] = [c].[FirstName]) AND 
             }
         }
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public void Include_on_optional_navigation_One_To_One_dependent_963()
         {
             using (CreateDatabase963())
@@ -867,7 +867,7 @@ Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Gra
 
         #region Bug3758
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public void Customer_collections_materialize_properly_3758()
         {
             using (CreateDatabase3758())
@@ -1082,7 +1082,7 @@ Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Gra
 
         #region Bug3409
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public void ThenInclude_with_interface_navigations_3409()
         {
             using (CreateDatabase3409())
@@ -1242,7 +1242,7 @@ Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Gra
 
         #region Bug3101
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact(Skip = "Issue#16229")]
         public virtual void Repro3101_simple_coalesce1()
         {
             using (CreateDatabase3101())
@@ -1262,7 +1262,7 @@ Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Gra
             }
         }
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact(Skip = "Issue#16229")]
         public virtual void Repro3101_simple_coalesce2()
         {
             using (CreateDatabase3101())
@@ -1282,7 +1282,7 @@ Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Gra
             }
         }
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact(Skip = "Issue#16229")]
         public virtual void Repro3101_simple_coalesce3()
         {
             using (CreateDatabase3101())
@@ -1302,7 +1302,7 @@ Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Gra
             }
         }
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact(Skip = "Issue#16229")]
         public virtual void Repro3101_complex_coalesce1()
         {
             using (CreateDatabase3101())
@@ -1326,7 +1326,7 @@ Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Gra
             }
         }
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact(Skip = "Issue#16229")]
         public virtual void Repro3101_complex_coalesce2()
         {
             using (CreateDatabase3101())
@@ -1350,7 +1350,7 @@ Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Gra
             }
         }
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact(Skip = "Issue#16229")]
         public virtual void Repro3101_nested_coalesce1()
         {
             using (CreateDatabase3101())
@@ -1375,7 +1375,7 @@ Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Gra
             }
         }
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact(Skip = "Issue#16229")]
         public virtual void Repro3101_nested_coalesce2()
         {
             using (CreateDatabase3101())
@@ -1401,7 +1401,7 @@ Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Gra
             }
         }
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact(Skip = "Issue#16229")]
         public virtual void Repro3101_conditional()
         {
             using (CreateDatabase3101())
@@ -1424,7 +1424,7 @@ Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Gra
             }
         }
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public virtual void Repro3101_coalesce_tracking()
         {
             using (CreateDatabase3101())
@@ -1552,7 +1552,7 @@ Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Gra
 
         #region Bug6986
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public virtual void Repro6986_can_query_base_type_when_derived_types_contain_shadow_properties()
         {
             using (CreateDatabase6986())
@@ -1568,7 +1568,7 @@ Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Gra
             }
         }
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public virtual void Repro6986_can_include_dependent_to_principal_navigation_of_derived_type_with_shadow_fk()
         {
             using (CreateDatabase6986())
@@ -1583,7 +1583,7 @@ Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Gra
             }
         }
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public virtual void Repro6986_can_project_shadow_property_using_ef_property()
         {
             using (CreateDatabase6986())
@@ -1696,7 +1696,7 @@ Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Gra
 
         #region Bug5456
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public virtual void Repro5456_include_group_join_is_per_query_context()
         {
             using (CreateDatabase5456())
@@ -1714,7 +1714,7 @@ Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Gra
             }
         }
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public virtual async Task Repro5456_include_group_join_is_per_query_context_async()
         {
             using (CreateDatabase5456())
@@ -1734,7 +1734,7 @@ Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Gra
             }
         }
 
-        [ConditionalFact(Skip = "issue #15611")]
+        [ConditionalFact]
         public virtual void Repro5456_multiple_include_group_join_is_per_query_context()
         {
             using (CreateDatabase5456())
@@ -1752,7 +1752,7 @@ Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Gra
             }
         }
 
-        [ConditionalFact(Skip = "issue #15611")]
+        [ConditionalFact]
         public virtual async Task Repro5456_multiple_include_group_join_is_per_query_context_async()
         {
             using (CreateDatabase5456())
@@ -1773,7 +1773,7 @@ Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Gra
             }
         }
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public virtual void Repro5456_multi_level_include_group_join_is_per_query_context()
         {
             using (CreateDatabase5456())
@@ -1791,7 +1791,7 @@ Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Gra
             }
         }
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public virtual async Task Repro5456_multi_level_include_group_join_is_per_query_context_async()
         {
             using (CreateDatabase5456())
@@ -1886,7 +1886,7 @@ Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Gra
 
         #region Bug7359
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public virtual void Discriminator_type_is_handled_correctly_in_materialization_bug_7359()
         {
             using (CreateDatabase7359())
@@ -1900,7 +1900,7 @@ Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Gra
             }
         }
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public virtual void Discriminator_type_is_handled_correctly_with_is_operator_bug_7359()
         {
             using (CreateDatabase7359())
@@ -1961,7 +1961,7 @@ Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Gra
 
         #region Bug7312
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public virtual void Reference_include_on_derived_type_with_sibling_works_bug_7312()
         {
             using (CreateDatabase7312())
@@ -2035,7 +2035,7 @@ Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Gra
 
         #region Bug8282
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public virtual void Entity_passed_to_DTO_constructor_works()
         {
             using (CreateDatabase8282())
@@ -2321,7 +2321,7 @@ WHERE ([e].[Id] = @__id_0) AND @__id_0 IS NOT NULL");
             }
         }
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public virtual void Variable_from_multi_level_nested_closure_is_parametrized()
         {
             using (CreateDatabase8909())
@@ -2347,22 +2347,22 @@ WHERE ([e].[Id] = @__id_0) AND @__id_0 IS NOT NULL");
                     AssertSql(
                         @"@__id_0='1'
 
-SELECT [c].[Id], [c].[Name]
-FROM [Entities] AS [c]
-WHERE [c].[Id] IN (
-    SELECT [c0].[Id]
-    FROM [Entities] AS [c0]
-    WHERE [c0].[Id] = @__id_0
+SELECT [e].[Id], [e].[Name]
+FROM [Entities] AS [e]
+WHERE [e].[Id] IN (
+    SELECT [e0].[Id]
+    FROM [Entities] AS [e0]
+    WHERE ([e0].[Id] = @__id_0) AND @__id_0 IS NOT NULL
 )",
                         //
                         @"@__id_0='2'
 
-SELECT [c].[Id], [c].[Name]
-FROM [Entities] AS [c]
-WHERE [c].[Id] IN (
-    SELECT [c0].[Id]
-    FROM [Entities] AS [c0]
-    WHERE [c0].[Id] = @__id_0
+SELECT [e].[Id], [e].[Name]
+FROM [Entities] AS [e]
+WHERE [e].[Id] IN (
+    SELECT [e0].[Id]
+    FROM [Entities] AS [e0]
+    WHERE ([e0].[Id] = @__id_0) AND @__id_0 IS NOT NULL
 )");
                 }
             }
@@ -2719,7 +2719,7 @@ WHERE [w].[Val] = 1");
 
         #region Bug9277
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public virtual void From_sql_gets_value_of_out_parameter_in_stored_procedure()
         {
             using (CreateDatabase9277())
@@ -2815,7 +2815,7 @@ BEGIN
 
         #region Bug9038
 
-        [ConditionalFact(Skip = "issue #15611")]
+        [ConditionalFact]
         public virtual async Task Include_collection_optional_reference_collection_9038()
         {
             using (CreateDatabase9038())
@@ -2834,7 +2834,7 @@ BEGIN
             }
         }
 
-        [ConditionalFact(Skip = "issue #15611")]
+        [ConditionalFact]
         public async Task Include_optional_reference_collection_another_collection()
         {
             using (CreateDatabase9038())
@@ -2977,7 +2977,7 @@ BEGIN
 
         #region Bug9735
 
-        [ConditionalFact(Skip = "issue #15611")]
+        [ConditionalFact]
         // TODO: Convert to test in IncludeTestBase once issue #9742 is fixed
         public virtual void Repro9735()
         {
@@ -2997,37 +2997,28 @@ BEGIN
                     AssertSql(
                         @"@__p_0='2'
 
-SELECT TOP(@__p_0) [b].[Id], [b].[AddressId], [b].[CustomerDetailsId], [b].[Name]
-FROM [Customers] AS [b]
-LEFT JOIN [CustomerDetails9735] AS [b.CustomerDetails] ON [b].[CustomerDetailsId] = [b.CustomerDetails].[Id]
-ORDER BY CASE
-    WHEN [b].[AddressId] > 0
-    THEN CAST(1 AS bit) ELSE CAST(0 AS bit)
-END, CASE
-    WHEN [b].[CustomerDetailsId] IS NOT NULL
-    THEN [b.CustomerDetails].[Name] ELSE N''
-END, [b].[Id]",
-                        //
-                        @"@__p_0='2'
-
-SELECT [b.Orders].[Id], [b.Orders].[CustomerId], [b.Orders].[Name]
-FROM [Order9735] AS [b.Orders]
-INNER JOIN (
-    SELECT DISTINCT [t].*
-    FROM (
-        SELECT TOP(@__p_0) [b0].[Id], CASE
-            WHEN [b0].[AddressId] > 0
-            THEN CAST(1 AS bit) ELSE CAST(0 AS bit)
-        END AS [c], CASE
-            WHEN [b0].[CustomerDetailsId] IS NOT NULL
-            THEN [b.CustomerDetails0].[Name] ELSE N''
-        END AS [c0]
-        FROM [Customers] AS [b0]
-        LEFT JOIN [CustomerDetails9735] AS [b.CustomerDetails0] ON [b0].[CustomerDetailsId] = [b.CustomerDetails0].[Id]
-        ORDER BY [c], [c0], [b0].[Id]
-    ) AS [t]
-) AS [t0] ON [b.Orders].[CustomerId] = [t0].[Id]
-ORDER BY [t0].[c], [t0].[c0], [t0].[Id]");
+SELECT [t].[Id], [t].[AddressId], [t].[CustomerDetailsId], [t].[Name], [t].[Id0], [o].[Id], [o].[CustomerId], [o].[Name]
+FROM (
+    SELECT TOP(@__p_0) [c].[Id], [c].[AddressId], [c].[CustomerDetailsId], [c].[Name], [a].[Id] AS [Id0], CASE
+        WHEN [a].[Id] > 0 THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END AS [c], CASE
+        WHEN [c0].[Id] IS NOT NULL THEN [c0].[Name]
+        ELSE N''
+    END AS [c0]
+    FROM [Customers] AS [c]
+    INNER JOIN [Address9735] AS [a] ON [c].[AddressId] = [a].[Id]
+    LEFT JOIN [CustomerDetails9735] AS [c0] ON [c].[CustomerDetailsId] = [c0].[Id]
+    ORDER BY CASE
+        WHEN [a].[Id] > 0 THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END, CASE
+        WHEN [c0].[Id] IS NOT NULL THEN [c0].[Name]
+        ELSE N''
+    END
+) AS [t]
+LEFT JOIN [Order9735] AS [o] ON [t].[Id] = [o].[CustomerId]
+ORDER BY [t].[c], [t].[c0], [t].[Id], [t].[Id0], [o].[Id]");
                 }
             }
         }
@@ -3233,7 +3224,7 @@ ORDER BY [t0].[c], [t0].[c0], [t0].[Id]");
 
         #region Bug9468
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public virtual void Conditional_expression_with_conditions_does_not_collapse_if_nullable_bool()
         {
             using (CreateDatabase9468())
@@ -3252,14 +3243,14 @@ ORDER BY [t0].[c], [t0].[c0], [t0].[Id]");
 
                     AssertSql(
                         @"SELECT CASE
-    WHEN [t.Configuration].[Id] IS NOT NULL
-    THEN CASE
-        WHEN [t.Configuration].[Processed] = CAST(0 AS bit)
-        THEN CAST(1 AS bit) ELSE CAST(0 AS bit)
-    END ELSE NULL
+    WHEN [c].[Id] IS NOT NULL THEN CASE
+        WHEN [c].[Processed] <> CAST(1 AS bit) THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END
+    ELSE NULL
 END AS [Processing]
-FROM [Carts] AS [t]
-LEFT JOIN [Configuration9468] AS [t.Configuration] ON [t].[ConfigurationId] = [t.Configuration].[Id]");
+FROM [Carts] AS [c0]
+LEFT JOIN [Configuration9468] AS [c] ON [c0].[ConfigurationId] = [c].[Id]");
                 }
             }
         }
@@ -3674,7 +3665,7 @@ WHERE [e].[SomeValue] = @__ef_filter__Tenant_0");
 
         #region Bug11104
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public virtual void QueryBuffer_requirement_is_computed_when_querying_base_type_while_derived_type_has_shadow_prop()
         {
             using (CreateDatabase11104())
@@ -3689,7 +3680,7 @@ WHERE [e].[SomeValue] = @__ef_filter__Tenant_0");
                     AssertSql(
                         @"SELECT [b].[Id], [b].[IsTwo], [b].[MoreStuffId]
 FROM [Bases] AS [b]
-WHERE [b].[IsTwo] IN (CAST(1 AS bit), CAST(0 AS bit))");
+WHERE [b].[IsTwo] IN (CAST(0 AS bit), CAST(1 AS bit))");
                 }
             }
         }
@@ -4538,7 +4529,7 @@ FROM [Prices] AS [p]");
             }
         }
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public virtual void Correlated_collection_with_OfType_base()
         {
             using (CreateDatabase12582())
@@ -4614,7 +4605,7 @@ FROM [Prices] AS [p]");
 
         #region Bug12748
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact(Skip = "Issue#16318")]
         public virtual void Correlated_collection_correctly_associates_entities_with_byte_array_keys()
         {
             using (CreateDatabase12748())
@@ -4847,7 +4838,7 @@ FROM [Prices] AS [p]");
 
         #region Bug11944
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public virtual void Include_collection_works_when_defined_on_intermediate_type()
         {
             using (CreateDatabase11944())
@@ -4863,7 +4854,7 @@ FROM [Prices] AS [p]");
             }
         }
 
-        [ConditionalFact(Skip = "QueryIssue")]
+        [ConditionalFact]
         public virtual void Correlated_collection_works_when_defined_on_intermediate_type()
         {
             using (CreateDatabase11944())
@@ -5080,7 +5071,7 @@ END IN ('0a47bcb7-a1cb-4345-8944-c58f82d6aac7', '5f221fb9-66f4-442a-92c9-d97ed59
 
         #region Bug13157
 
-        [ConditionalFact(Skip = "issue #15043")]
+        [ConditionalFact(Skip = "Issue#16321")]
         public virtual void Correlated_subquery_with_owned_navigation_being_compared_to_null_works()
         {
             using (CreateDatabase13157())

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -1394,10 +1394,10 @@ WHERE EXISTS (
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ([c].[City] = N'London') AND EXISTS (
+WHERE (([c].[City] = N'London') AND [c].[City] IS NOT NULL) AND EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE ([c].[CustomerID] = [o].[CustomerID]) AND ([o].[EmployeeID] = 1))");
+    WHERE (([c].[CustomerID] = [o].[CustomerID]) AND [o].[CustomerID] IS NOT NULL) AND (([o].[EmployeeID] = 1) AND [o].[EmployeeID] IS NOT NULL))");
         }
 
         public override async Task All_top_level(bool isAsync)
@@ -1487,7 +1487,7 @@ ORDER BY [c].[CustomerID]");
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Customers] AS [c]
 CROSS JOIN [Employees] AS [e]
-WHERE ([c].[City] = N'London') OR ([e].[City] = N'London')");
+WHERE (([c].[City] = N'London') AND [c].[City] IS NOT NULL) OR (([e].[City] = N'London') AND [e].[City] IS NOT NULL)");
         }
 
         public override async Task Where_select_many_or2(bool isAsync)
@@ -1498,7 +1498,7 @@ WHERE ([c].[City] = N'London') OR ([e].[City] = N'London')");
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Customers] AS [c]
 CROSS JOIN [Employees] AS [e]
-WHERE [c].[City] IN (N'London', N'Berlin')");
+WHERE (([c].[City] = N'London') AND [c].[City] IS NOT NULL) OR (([c].[City] = N'Berlin') AND [c].[City] IS NOT NULL)");
         }
 
         public override async Task Where_select_many_or3(bool isAsync)
@@ -1509,7 +1509,7 @@ WHERE [c].[City] IN (N'London', N'Berlin')");
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Customers] AS [c]
 CROSS JOIN [Employees] AS [e]
-WHERE [c].[City] IN (N'London', N'Berlin', N'Seattle')");
+WHERE ((([c].[City] = N'London') AND [c].[City] IS NOT NULL) OR (([c].[City] = N'Berlin') AND [c].[City] IS NOT NULL)) OR (([c].[City] = N'Seattle') AND [c].[City] IS NOT NULL)");
         }
 
         public override async Task Where_select_many_or4(bool isAsync)
@@ -1520,7 +1520,7 @@ WHERE [c].[City] IN (N'London', N'Berlin', N'Seattle')");
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Customers] AS [c]
 CROSS JOIN [Employees] AS [e]
-WHERE [c].[City] IN (N'London', N'Berlin', N'Seattle', N'Lisboa')");
+WHERE (((([c].[City] = N'London') AND [c].[City] IS NOT NULL) OR (([c].[City] = N'Berlin') AND [c].[City] IS NOT NULL)) OR (([c].[City] = N'Seattle') AND [c].[City] IS NOT NULL)) OR (([c].[City] = N'Lisboa') AND [c].[City] IS NOT NULL)");
         }
 
         public override async Task Where_select_many_or_with_parameter(bool isAsync)
@@ -1534,7 +1534,7 @@ WHERE [c].[City] IN (N'London', N'Berlin', N'Seattle', N'Lisboa')");
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Customers] AS [c]
 CROSS JOIN [Employees] AS [e]
-WHERE [c].[City] IN (@__london_0, N'Berlin', N'Seattle', @__lisboa_1)");
+WHERE ((((([c].[City] = @__london_0) AND ([c].[City] IS NOT NULL AND @__london_0 IS NOT NULL)) OR ([c].[City] IS NULL AND @__london_0 IS NULL)) OR (([c].[City] = N'Berlin') AND [c].[City] IS NOT NULL)) OR (([c].[City] = N'Seattle') AND [c].[City] IS NOT NULL)) OR ((([c].[City] = @__lisboa_1) AND ([c].[City] IS NOT NULL AND @__lisboa_1 IS NOT NULL)) OR ([c].[City] IS NULL AND @__lisboa_1 IS NULL))");
         }
 
         public override async Task SelectMany_mixed(bool isAsync)
@@ -1826,10 +1826,13 @@ ORDER BY [c].[CustomerID]");
             await base.Where_select_many(isAsync);
 
             AssertSql(
-                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-CROSS JOIN [Orders] AS [o]
-WHERE [c].[CustomerID] = N'ALFKI'");
+                @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] = N'ALFKI'
+) AS [t]
+CROSS JOIN [Orders] AS [o]");
         }
 
         public override async Task Where_orderby_select_many(bool isAsync)
@@ -1837,11 +1840,13 @@ WHERE [c].[CustomerID] = N'ALFKI'");
             await base.Where_orderby_select_many(isAsync);
 
             AssertSql(
-                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-CROSS JOIN [Orders] AS [o]
-WHERE [c].[CustomerID] = N'ALFKI'
-ORDER BY [c].[CustomerID]");
+                @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] = N'ALFKI'
+) AS [t]
+CROSS JOIN [Orders] AS [o]");
         }
 
         public override async Task SelectMany_cartesian_product_with_ordering(bool isAsync)
@@ -3886,23 +3891,20 @@ ORDER BY [c].[CustomerID] + [c].[City]");
 
             AssertSql(
                 @"SELECT (
-    SELECT TOP(1) [o1].[OrderDate]
-    FROM [Orders] AS [o1]
-    WHERE [c].[CustomerID] = [o1].[CustomerID]
-    ORDER BY [o1].[OrderID] DESC
-) AS [A]
+    SELECT TOP(1) [o].[OrderDate]
+    FROM [Orders] AS [o]
+    WHERE ([c].[CustomerID] = [o].[CustomerID]) AND [o].[CustomerID] IS NOT NULL
+    ORDER BY [o].[OrderID] DESC) AS [A]
 FROM [Customers] AS [c]
 WHERE (
     SELECT COUNT(*)
-    FROM [Orders] AS [o]
-    WHERE [c].[CustomerID] = [o].[CustomerID]
-) > 1
-ORDER BY (
-    SELECT TOP(1) [o0].[OrderDate]
     FROM [Orders] AS [o0]
-    WHERE [c].[CustomerID] = [o0].[CustomerID]
-    ORDER BY [o0].[OrderID] DESC
-)");
+    WHERE ([c].[CustomerID] = [o0].[CustomerID]) AND [o0].[CustomerID] IS NOT NULL) > 1
+ORDER BY (
+    SELECT TOP(1) [o1].[OrderDate]
+    FROM [Orders] AS [o1]
+    WHERE ([c].[CustomerID] = [o1].[CustomerID]) AND [o1].[CustomerID] IS NOT NULL
+    ORDER BY [o1].[OrderID] DESC)");
         }
 
         public override async Task DTO_member_distinct_where(bool isAsync)
@@ -4018,25 +4020,16 @@ ORDER BY (
                 @"@__p_0='40'
 @__p_1='5'
 
-SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-WHERE [c].[CustomerID] NOT IN (N'VAFFE', N'DRACD')
-ORDER BY [c].[City], [c].[CustomerID]
-OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY",
-                //
-                @"@__p_0='40'
-@__p_1='5'
-
-SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
-FROM [Orders] AS [c.Orders]
-INNER JOIN (
-    SELECT [c0].[CustomerID], [c0].[City]
-    FROM [Customers] AS [c0]
-    WHERE [c0].[CustomerID] NOT IN (N'VAFFE', N'DRACD')
-    ORDER BY [c0].[City], [c0].[CustomerID]
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE ([c].[CustomerID] <> N'VAFFE') AND ([c].[CustomerID] <> N'DRACD')
+    ORDER BY [c].[City], [c].[CustomerID]
     OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
-) AS [t] ON [c.Orders].[CustomerID] = [t].[CustomerID]
-ORDER BY [t].[City], [t].[CustomerID]");
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[City], [t].[CustomerID], [o].[OrderID]");
         }
 
         public override async Task Int16_parameter_can_be_used_for_int_column(bool isAsync)
@@ -4668,7 +4661,7 @@ WHERE [o].[CustomerID] = @_outer_CustomerID");
 
 SELECT COUNT(*)
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID] AS [CustomerID0]
     FROM [Orders] AS [o]
     INNER JOIN (
         SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
@@ -469,7 +469,7 @@ WHERE (length(""c"".""City"") = 6) AND length(""c"".""City"") IS NOT NULL");
             AssertSql(
                 @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
 FROM ""Customers"" AS ""c""
-WHERE ((instr(""c"".""City"", 'Sea') - 1) <> -1) OR ""c"".""City"" IS NULL");
+WHERE ((instr(""c"".""City"", 'Sea') - 1) <> -1) OR instr(""c"".""City"", 'Sea') - 1 IS NULL");
         }
 
         public override async Task Indexof_with_emptystring(bool isAsync)


### PR DESCRIPTION
Bugs fixed
- Allow ToList on collection projection to be called with less derived type
- Project out necessary identifiers for collection join when pushing down. (Except distinct case)
- Lift ordering from inner collection to generated ordered result (This would be improved further by #16226)
- Map Cast from Enumerable to Queryable
- Translate AsQueryable as no-op

Resolves #12098
Resolves #15043
Resolves #15611
Part of #15711
