### PR TITLE
Add tests for FromSql with DbParameter without name prefix

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/Query/FromSqlQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/FromSqlQueryTestBase.cs
@@ -733,6 +733,21 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
             }
         }
 
+        [Fact]
+        public virtual void FromSqlRaw_with_dbParameter_without_name_prefix()
+        {
+            using (var context = CreateContext())
+            {
+                var parameter = CreateDbParameter("city", "London");
+
+                var actual = context.Customers.FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [City] = @city"), parameter)
+                    .ToArray();
+
+                Assert.Equal(6, actual.Length);
+                Assert.True(actual.All(c => c.City == "London"));
+            }
+        }
+
         [ConditionalFact]
         public virtual void FromSqlRaw_with_dbParameter_mixed()
         {
@@ -904,9 +919,28 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
             {
                 var parameter = CreateDbParameter("@somename", "ALFKI");
 
-                var query = context.Customers
+                var actual = context.Customers
                     .FromSqlInterpolated(NormalizeDelimetersInInterpolatedString($"SELECT * FROM [Customers] WHERE [CustomerID] = {parameter}"))
                     .ToList();
+
+                Assert.Equal(1, actual.Count);
+                Assert.True(actual.All(c => c.City == "Berlin"));
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void FromSqlInterpolated_with_inlined_db_parameter_without_name_prefix()
+        {
+            using (var context = CreateContext())
+            {
+                var parameter = CreateDbParameter("somename", "ALFKI");
+
+                var actual = context.Customers
+                    .FromSqlInterpolated(NormalizeDelimetersInInterpolatedString($"SELECT * FROM [Customers] WHERE [CustomerID] = {parameter}"))
+                    .ToList();
+
+                Assert.Equal(1, actual.Count);
+                Assert.True(actual.All(c => c.City == "Berlin"));
             }
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlQuerySqlServerTest.cs
@@ -412,6 +412,15 @@ WHERE (([c].[ContactName] = [c].[CompanyName]) AND ([c].[ContactName] IS NOT NUL
 SELECT * FROM ""Customers"" WHERE ""City"" = @city");
         }
 
+        public override void FromSqlRaw_with_dbParameter_without_name_prefix()
+        {
+            base.FromSqlRaw_with_dbParameter_without_name_prefix();
+            AssertSql(
+                @"city='London' (Nullable = false) (Size = 6)
+
+SELECT * FROM ""Customers"" WHERE ""City"" = @city");
+        }
+
         public override void FromSqlRaw_with_dbParameter_mixed()
         {
             base.FromSqlRaw_with_dbParameter_mixed();
@@ -480,6 +489,16 @@ ORDER BY [c].[CustomerID], [o].[OrderID], [o0].[OrderID], [o0].[ProductID]");
 
             AssertSql(
                 @"@somename='ALFKI' (Nullable = false) (Size = 5)
+
+SELECT * FROM ""Customers"" WHERE ""CustomerID"" = @somename");
+        }
+
+        public override void FromSqlInterpolated_with_inlined_db_parameter_without_name_prefix()
+        {
+            base.FromSqlInterpolated_with_inlined_db_parameter_without_name_prefix();
+
+            AssertSql(
+    @"somename='ALFKI' (Nullable = false) (Size = 5)
 
 SELECT * FROM ""Customers"" WHERE ""CustomerID"" = @somename");
         }


### PR DESCRIPTION
New variations of FromSqlRaw and FromSqlInterpolated specification tests take DbParameter without using a prefix in the name. E.g. "city" instead of "@city" and verify that the prefix is added automatically when the parameter name is added in-line in the SQL.

Also added SQL Server ~~and SQLite~~ overrides that assert the SQL.

Closes #14173