### PR TITLE
Query: Add support for SQL GROUP BY

### DIFF
--- a/src/EFCore.Relational/Query/Pipeline/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Pipeline/QuerySqlGenerator.cs
@@ -167,6 +167,20 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                 Visit(selectExpression.Predicate);
             }
 
+            if (selectExpression.GroupBy.Count > 0)
+            {
+                _relationalCommandBuilder.AppendLine().Append("GROUP BY ");
+
+                GenerateList(selectExpression.GroupBy, e => Visit(e));
+            }
+
+            if (selectExpression.HavingExpression != null)
+            {
+                _relationalCommandBuilder.AppendLine().Append("HAVING ");
+
+                Visit(selectExpression.HavingExpression);
+            }
+
             GenerateOrderings(selectExpression);
             GenerateLimitOffset(selectExpression);
         }

--- a/src/EFCore.Relational/Query/Pipeline/RelationalProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Pipeline/RelationalProjectionBindingExpressionVisitor.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.NavigationExpansion;
 using Microsoft.EntityFrameworkCore.Query.Pipeline;

--- a/src/EFCore.Relational/Query/Pipeline/RelationalShapedQueryOptimizingExpressionVisitors.cs
+++ b/src/EFCore.Relational/Query/Pipeline/RelationalShapedQueryOptimizingExpressionVisitors.cs
@@ -51,7 +51,10 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                 var collectionId = _collectionId++;
                 var selectExpression = (SelectExpression)collectionShaperExpression.Projection.QueryExpression;
                 // Do pushdown beforehand so it updates all pending collections first
-                if (selectExpression.IsDistinct || selectExpression.Limit != null || selectExpression.Offset != null)
+                if (selectExpression.IsDistinct
+                    || selectExpression.Limit != null
+                    || selectExpression.Offset != null
+                    || selectExpression.GroupBy.Count > 1)
                 {
                     selectExpression.PushdownIntoSubquery();
                 }

--- a/src/EFCore.Relational/Query/Pipeline/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Pipeline/RelationalSqlTranslatingExpressionVisitor.cs
@@ -56,6 +56,13 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 
                 translation = _sqlExpressionFactory.ApplyDefaultTypeMapping(translation);
 
+                if (translation is SqlConstantExpression
+                    && translation.TypeMapping == null)
+                {
+                    // Non-mappable constant
+                    return null;
+                }
+
                 _sqlVerifyingExpressionVisitor.Visit(translation);
 
                 return translation;
@@ -246,13 +253,66 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
             return null;
         }
 
+        private Expression GetSelector(MethodCallExpression methodCallExpression, GroupByShaperExpression groupByShaperExpression)
+        {
+            if (methodCallExpression.Arguments.Count == 1)
+            {
+                return groupByShaperExpression.ElementSelector;
+            }
+
+            if (methodCallExpression.Arguments.Count == 2)
+            {
+                var selectorLambda = methodCallExpression.Arguments[1].UnwrapLambdaFromQuote();
+                return ReplacingExpressionVisitor.Replace(
+                    selectorLambda.Parameters[0],
+                    groupByShaperExpression.ElementSelector,
+                    selectorLambda.Body);
+            }
+
+            throw new InvalidOperationException();
+        }
+
         protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
         {
+            // EF.Property case
             if (methodCallExpression.TryGetEFPropertyArguments(out var source, out var propertyName))
             {
                 return BindProperty(source, propertyName);
             }
 
+            // GroupBy Aggregate case
+            if (methodCallExpression.Object == null
+                && methodCallExpression.Method.DeclaringType == typeof(Enumerable)
+                && methodCallExpression.Arguments.Count > 0
+                && methodCallExpression.Arguments[0] is GroupByShaperExpression groupByShaperExpression)
+            {
+                switch (methodCallExpression.Method.Name)
+                {
+                    case nameof(Enumerable.Average):
+                        return TranslateAverage(GetSelector(methodCallExpression, groupByShaperExpression));
+
+                    case nameof(Enumerable.Count):
+                        return TranslateCount();
+
+                    case nameof(Enumerable.LongCount):
+                        return TranslateLongCount();
+
+                    case nameof(Enumerable.Max):
+                        return TranslateMax(GetSelector(methodCallExpression, groupByShaperExpression));
+
+                    case nameof(Enumerable.Min):
+                        return TranslateMin(GetSelector(methodCallExpression, groupByShaperExpression));
+
+                    case nameof(Enumerable.Sum):
+                        return TranslateSum(GetSelector(methodCallExpression, groupByShaperExpression));
+
+                    default:
+                        throw new InvalidOperationException("Unknown aggregate operator encountered.");
+                }
+
+            }
+
+            // Subquery case
             var subqueryTranslation = _queryableMethodTranslatingExpressionVisitor.TranslateSubquery(methodCallExpression);
             if (subqueryTranslation != null)
             {
@@ -280,6 +340,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                 return new SubSelectExpression(subquery);
             }
 
+            // MethodCall translators
             var @object = Visit(methodCallExpression.Object);
             if (TranslationFailed(methodCallExpression.Object, @object))
             {
@@ -413,29 +474,25 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 
         protected override Expression VisitExtension(Expression extensionExpression)
         {
-            if (extensionExpression is EntityShaperExpression)
+            switch (extensionExpression)
             {
-                return extensionExpression;
+                case EntityShaperExpression _:
+                case SqlExpression _:
+                    return extensionExpression;
+
+                case NullConditionalExpression nullConditionalExpression:
+                    return Visit(nullConditionalExpression.AccessOperation);
+
+                case CorrelationPredicateExpression correlationPredicateExpression:
+                    return Visit(correlationPredicateExpression.EqualExpression);
+
+                case ProjectionBindingExpression projectionBindingExpression:
+                    var selectExpression = (SelectExpression)projectionBindingExpression.QueryExpression;
+                    return selectExpression.GetMappedProjection(projectionBindingExpression.ProjectionMember);
+
+                default:
+                    return null;
             }
-
-            if (extensionExpression is ProjectionBindingExpression projectionBindingExpression)
-            {
-                var selectExpression = (SelectExpression)projectionBindingExpression.QueryExpression;
-
-                return selectExpression.GetMappedProjection(projectionBindingExpression.ProjectionMember);
-            }
-
-            if (extensionExpression is NullConditionalExpression nullConditionalExpression)
-            {
-                return Visit(nullConditionalExpression.AccessOperation);
-            }
-
-            if (extensionExpression is CorrelationPredicateExpression correlationPredicateExpression)
-            {
-                return Visit(correlationPredicateExpression.EqualExpression);
-            }
-
-            return base.VisitExtension(extensionExpression);
         }
 
         protected override Expression VisitConditional(ConditionalExpression conditionalExpression)

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressionFactory.cs
@@ -505,6 +505,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                 alias: null,
                 new List<ProjectionExpression>(),
                 new List<TableExpressionBase>(),
+                new List<SqlExpression>(),
                 new List<OrderingExpression>());
 
             if (projection != null)

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SelectExpression.cs
@@ -22,6 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             = new Dictionary<EntityProjectionExpression, IDictionary<IProperty, int>>();
 
         private readonly List<TableExpressionBase> _tables = new List<TableExpressionBase>();
+        private readonly List<SqlExpression> _groupBy = new List<SqlExpression>();
         private readonly List<OrderingExpression> _orderings = new List<OrderingExpression>();
 
         private readonly List<SqlExpression> _identifier = new List<SqlExpression>();
@@ -30,9 +31,11 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
 
         public IReadOnlyList<ProjectionExpression> Projection => _projection;
         public IReadOnlyList<TableExpressionBase> Tables => _tables;
+        public IReadOnlyList<SqlExpression> GroupBy => _groupBy;
         public IReadOnlyList<OrderingExpression> Orderings => _orderings;
         public ISet<string> Tags { get; private set; } = new HashSet<string>();
         public SqlExpression Predicate { get; private set; }
+        public SqlExpression HavingExpression { get; private set; }
         public SqlExpression Limit { get; private set; }
         public SqlExpression Offset { get; private set; }
         public bool IsDistinct { get; private set; }
@@ -57,11 +60,13 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             string alias,
             List<ProjectionExpression> projections,
             List<TableExpressionBase> tables,
+            List<SqlExpression> groupBy,
             List<OrderingExpression> orderings)
             : base(alias)
         {
             _projection = projections;
             _tables = tables;
+            _groupBy = groupBy;
             _orderings = orderings;
         }
 
@@ -87,7 +92,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             }
         }
 
-        public SelectExpression(IEntityType entityType, string sql, Expression arguments)
+        internal SelectExpression(IEntityType entityType, string sql, Expression arguments)
             : base(null)
         {
             var fromSqlExpression = new FromSqlExpression(
@@ -115,6 +120,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
                 && Offset == null
                 && !IsDistinct
                 && Predicate == null
+                && GroupBy.Count == 0
+                && HavingExpression == null
                 && Orderings.Count == 0
                 && Tables.Count == 1
                 && Tables[0] is FromSqlExpression fromSql
@@ -223,7 +230,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
 
         public void PrepareForAggregate()
         {
-            if (IsDistinct || Limit != null || Offset != null || IsSetOperation)
+            if (IsDistinct || Limit != null || Offset != null || IsSetOperation || GroupBy.Count > 0)
             {
                 PushdownIntoSubquery();
             }
@@ -243,22 +250,88 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
                 expression = new SqlRemappingVisitor(mappings).Remap(expression);
             }
 
-            if (Predicate == null)
+            if (_groupBy.Count > 0)
             {
-                Predicate = expression;
+                if (HavingExpression == null)
+                {
+                    HavingExpression = expression;
+                }
+                else
+                {
+                    HavingExpression = new SqlBinaryExpression(
+                        ExpressionType.AndAlso,
+                        HavingExpression,
+                        expression,
+                        typeof(bool),
+                        expression.TypeMapping);
+                }
             }
             else
             {
-                Predicate = new SqlBinaryExpression(
-                    ExpressionType.AndAlso,
-                    Predicate,
-                    expression,
-                    typeof(bool),
-                    expression.TypeMapping);
+                if (Predicate == null)
+                {
+                    Predicate = expression;
+                }
+                else
+                {
+                    Predicate = new SqlBinaryExpression(
+                        ExpressionType.AndAlso,
+                        Predicate,
+                        expression,
+                        typeof(bool),
+                        expression.TypeMapping);
+                }
             }
         }
 
         public override ExpressionType NodeType => ExpressionType.Extension;
+
+        public Expression ApplyGrouping(Expression keySelector)
+        {
+            ClearOrdering();
+
+            if (keySelector is SqlConstantExpression
+                || keySelector is SqlParameterExpression)
+            {
+                PushdownIntoSubquery();
+                var subquery = (SelectExpression)_tables[0];
+                var projectionIndex = subquery.AddToProjection((SqlExpression)keySelector, nameof(IGrouping<int, int>.Key));
+
+                keySelector = new ColumnExpression(subquery.Projection[projectionIndex], subquery, false);
+            }
+
+            AppendGroupBy(keySelector);
+
+            return keySelector;
+        }
+
+        private void AppendGroupBy(Expression keySelector)
+        {
+            switch (keySelector)
+            {
+                case SqlExpression sqlExpression:
+                    _groupBy.Add(sqlExpression);
+                    break;
+
+                case NewExpression newExpression:
+                    foreach (var argument in newExpression.Arguments)
+                    {
+                        AppendGroupBy(argument);
+                    }
+                    break;
+
+                case MemberInitExpression memberInitExpression:
+                    AppendGroupBy(memberInitExpression.NewExpression);
+                    foreach (var argument in memberInitExpression.Bindings)
+                    {
+                        AppendGroupBy(((MemberAssignment)argument).Expression);
+                    }
+                    break;
+
+                default:
+                    throw new InvalidOperationException("Invalid keySelector for Group By");
+            }
+        }
 
 
         public void ApplyOrdering(OrderingExpression orderingExpression)
@@ -342,7 +415,6 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             _orderings.Clear();
         }
 
-
         /// <summary>
         ///     Applies a set operation (e.g. Union, Intersect) on this query, pushing it down and <paramref name="otherSelectExpression"/>
         ///     down to be the set operands.
@@ -360,10 +432,12 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             Expression shaperExpression)
         {
             // TODO: throw if there are pending collection joins
-            var select1 = new SelectExpression(null, new List<ProjectionExpression>(), _tables.ToList(), _orderings.ToList())
+            // TODO: What happens when applying set operations on 2 queries with one of them being grouping
+            var select1 = new SelectExpression(null, new List<ProjectionExpression>(), _tables.ToList(), _groupBy.ToList(), _orderings.ToList())
             {
                 IsDistinct = IsDistinct,
                 Predicate = Predicate,
+                HavingExpression = HavingExpression,
                 Offset = Offset,
                 Limit = Limit,
                 SetOperationType = SetOperationType
@@ -420,6 +494,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             Limit = null;
             IsDistinct = false;
             Predicate = null;
+            HavingExpression = null;
             _orderings.Clear();
             _tables.Clear();
             _tables.Add(select1);
@@ -433,23 +508,23 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
                 SelectExpression select1, EntityProjectionExpression projection1,
                 SelectExpression select2, EntityProjectionExpression projection2)
             {
-                 var propertyExpressions = new Dictionary<IProperty, ColumnExpression>();
+                var propertyExpressions = new Dictionary<IProperty, ColumnExpression>();
 
-                 if (projection1.EntityType == projection2.EntityType)
-                 {
-                     foreach (var property in GetAllPropertiesInHierarchy(projection1.EntityType))
-                     {
-                         propertyExpressions[property] = AddSetOperationColumnProjections(
-                             property,
-                             select1, projection1.GetProperty(property),
-                             select2, projection2.GetProperty(property));
-                     }
+                if (projection1.EntityType == projection2.EntityType)
+                {
+                    foreach (var property in GetAllPropertiesInHierarchy(projection1.EntityType))
+                    {
+                        propertyExpressions[property] = AddSetOperationColumnProjections(
+                            property,
+                            select1, projection1.GetProperty(property),
+                            select2, projection2.GetProperty(property));
+                    }
 
-                     _projectionMapping[projectionMember] = new EntityProjectionExpression(projection1.EntityType, propertyExpressions);
-                     return;
-                 }
+                    _projectionMapping[projectionMember] = new EntityProjectionExpression(projection1.EntityType, propertyExpressions);
+                    return;
+                }
 
-                 throw new InvalidOperationException("Set operations over different entity types are currently unsupported (see #16298)");
+                throw new InvalidOperationException("Set operations over different entity types are currently unsupported (see #16298)");
             }
 
             ColumnExpression AddSetOperationColumnProjections(
@@ -486,10 +561,11 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
 
         public IDictionary<SqlExpression, ColumnExpression> PushdownIntoSubquery()
         {
-            var subquery = new SelectExpression("t", new List<ProjectionExpression>(), _tables.ToList(), _orderings.ToList())
+            var subquery = new SelectExpression("t", new List<ProjectionExpression>(), _tables.ToList(), _groupBy.ToList(), _orderings.ToList())
             {
                 IsDistinct = IsDistinct,
                 Predicate = Predicate,
+                HavingExpression = HavingExpression,
                 Offset = Offset,
                 Limit = Limit,
                 SetOperationType = SetOperationType
@@ -554,7 +630,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
                 {
                     _identifier.Add(outerColumn);
                 }
-                else if (!IsDistinct)
+                else if (!IsDistinct && GroupBy.Count == 0)
                 {
                     var index = subquery.AddToProjection(identifier);
                     var projectionExpression = subquery._projection[index];
@@ -572,7 +648,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
                 {
                     _childIdentifiers.Add(outerColumn);
                 }
-                else if (!IsDistinct)
+                else if (!IsDistinct && GroupBy.Count == 0)
                 {
                     var index = subquery.AddToProjection(identifier);
                     var projectionExpression = subquery._projection[index];
@@ -602,9 +678,11 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             Limit = null;
             IsDistinct = false;
             Predicate = null;
+            HavingExpression = null;
             SetOperationType = SetOperationType.None;
             _tables.Clear();
             _tables.Add(subquery);
+            _groupBy.Clear();
 
             return projectionMap;
         }
@@ -652,7 +730,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
                     || innerSelectExpression.Limit != null
                     || innerSelectExpression.IsDistinct
                     || innerSelectExpression.Predicate != null
-                    || innerSelectExpression.Tables.Count > 1)
+                    || innerSelectExpression.Tables.Count > 1
+                    || innerSelectExpression.GroupBy.Count > 1)
                 {
                     var orderings = innerSelectExpression.Orderings.ToList();
                     var sqlRemappingVisitor = new SqlRemappingVisitor(innerSelectExpression.PushdownIntoSubquery());
@@ -849,6 +928,12 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
 
         public void AddInnerJoin(SelectExpression innerSelectExpression, SqlExpression joinPredicate, Type transparentIdentifierType)
         {
+            if (Limit != null || Offset != null || IsDistinct || IsSetOperation || GroupBy.Count > 1)
+            {
+                joinPredicate = new SqlRemappingVisitor(PushdownIntoSubquery())
+                    .Remap(joinPredicate);
+            }
+
             // TODO: write a test which has distinct on outer so that we can verify pushdown
             if (innerSelectExpression.Orderings.Any()
                 || innerSelectExpression.Limit != null
@@ -856,7 +941,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
                 || innerSelectExpression.IsDistinct
                 // TODO: Predicate can be lifted in inner join
                 || innerSelectExpression.Predicate != null
-                || innerSelectExpression.Tables.Count > 1)
+                || innerSelectExpression.Tables.Count > 1
+                || innerSelectExpression.GroupBy.Count > 1)
             {
                 joinPredicate = new SqlRemappingVisitor(innerSelectExpression.PushdownIntoSubquery())
                     .Remap(joinPredicate);
@@ -884,7 +970,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
 
         public void AddLeftJoin(SelectExpression innerSelectExpression, SqlExpression joinPredicate, Type transparentIdentifierType)
         {
-            if (Limit != null || Offset != null || IsDistinct || IsSetOperation)
+            if (Limit != null || Offset != null || IsDistinct || IsSetOperation || GroupBy.Count > 1)
             {
                 joinPredicate = new SqlRemappingVisitor(PushdownIntoSubquery())
                     .Remap(joinPredicate);
@@ -895,7 +981,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
                 || innerSelectExpression.Offset != null
                 || innerSelectExpression.IsDistinct
                 || innerSelectExpression.Predicate != null
-                || innerSelectExpression.Tables.Count > 1)
+                || innerSelectExpression.Tables.Count > 1
+                || innerSelectExpression.GroupBy.Count > 1)
             {
                 joinPredicate = new SqlRemappingVisitor(innerSelectExpression.PushdownIntoSubquery())
                     .Remap(joinPredicate);
@@ -932,7 +1019,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
 
         public void AddCrossJoin(SelectExpression innerSelectExpression, Type transparentIdentifierType)
         {
-            if (Limit != null || Offset != null || IsDistinct || Predicate != null || IsSetOperation)
+            if (Limit != null || Offset != null || IsDistinct || Predicate != null || IsSetOperation || GroupBy.Count > 1)
             {
                 PushdownIntoSubquery();
             }
@@ -941,7 +1028,9 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
                 || innerSelectExpression.Limit != null
                 || innerSelectExpression.Offset != null
                 || innerSelectExpression.IsDistinct
-                || innerSelectExpression.Predicate != null)
+                || innerSelectExpression.Predicate != null
+                || innerSelectExpression.Tables.Count > 1
+                || innerSelectExpression.GroupBy.Count > 1)
             {
                 innerSelectExpression.PushdownIntoSubquery();
             }
@@ -1021,6 +1110,12 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
 
                 Predicate = (SqlExpression)visitor.Visit(Predicate);
 
+                var groupBy = _groupBy.ToList();
+                _groupBy.Clear();
+                _groupBy.AddRange(GroupBy.Select(e => (SqlExpression)visitor.Visit(e)));
+
+                HavingExpression = (SqlExpression)visitor.Visit(HavingExpression);
+
                 var orderings = _orderings.ToList();
                 _orderings.Clear();
                 _orderings.AddRange(orderings.Select(e => e.Update((SqlExpression)visitor.Visit(e.Expression))));
@@ -1070,6 +1165,17 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
                 var predicate = (SqlExpression)visitor.Visit(Predicate);
                 changed |= predicate != Predicate;
 
+                var groupBy = new List<SqlExpression>();
+                foreach (var groupingKey in _groupBy)
+                {
+                    var newGroupingKey = (SqlExpression)visitor.Visit(groupingKey);
+                    changed |= newGroupingKey != groupingKey;
+                    groupBy.Add(newGroupingKey);
+                }
+
+                var havingExpression = (SqlExpression)visitor.Visit(HavingExpression);
+                changed |= havingExpression != HavingExpression;
+
                 var orderings = new List<OrderingExpression>();
                 foreach (var ordering in _orderings)
                 {
@@ -1086,10 +1192,11 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
 
                 if (changed)
                 {
-                    var newSelectExpression = new SelectExpression(Alias, projections, tables, orderings)
+                    var newSelectExpression = new SelectExpression(Alias, projections, tables, groupBy, orderings)
                     {
                         _projectionMapping = projectionMapping,
                         Predicate = predicate,
+                        HavingExpression = havingExpression,
                         Offset = offset,
                         Limit = limit,
                         IsDistinct = IsDistinct,
@@ -1158,6 +1265,17 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
                 return false;
             }
 
+            if (!_groupBy.SequenceEqual(selectExpression._groupBy))
+            {
+                return false;
+            }
+
+            if (!(HavingExpression == null && selectExpression.HavingExpression == null
+                || HavingExpression != null && Predicate.Equals(selectExpression.HavingExpression)))
+            {
+                return false;
+            }
+
             if (!_orderings.SequenceEqual(selectExpression._orderings))
             {
                 return false;
@@ -1183,6 +1301,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             List<ProjectionExpression> projections,
             List<TableExpressionBase> tables,
             SqlExpression predicate,
+            List<SqlExpression> groupBy,
+            SqlExpression havingExpression,
             List<OrderingExpression> orderings,
             SqlExpression limit,
             SqlExpression offset,
@@ -1195,10 +1315,11 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
                 projectionMapping[kvp.Key] = kvp.Value;
             }
 
-            return new SelectExpression(alias, projections, tables, orderings)
+            return new SelectExpression(alias, projections, tables, groupBy, orderings)
             {
                 _projectionMapping = projectionMapping,
                 Predicate = predicate,
+                HavingExpression = havingExpression,
                 Offset = offset,
                 Limit = limit,
                 IsDistinct = distinct,
@@ -1225,6 +1346,13 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             }
 
             hash.Add(Predicate);
+
+            foreach (var groupingKey in _groupBy)
+            {
+                hash.Add(groupingKey);
+            }
+
+            hash.Add(HavingExpression);
 
             foreach (var ordering in _orderings)
             {
@@ -1305,16 +1433,24 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
                     expressionPrinter.StringBuilder.AppendLine().Append("WHERE ");
                     expressionPrinter.Visit(Predicate);
                 }
+
+                if (GroupBy.Any())
+                {
+                    expressionPrinter.StringBuilder.AppendLine().Append("GROUP BY ");
+                    expressionPrinter.VisitList(GroupBy);
+                }
+
+                if (HavingExpression != null)
+                {
+                    expressionPrinter.StringBuilder.AppendLine().Append("HAVING ");
+                    expressionPrinter.Visit(HavingExpression);
+                }
             }
 
             if (Orderings.Any())
             {
-                var orderings = Orderings.ToList();
-                if (orderings.Count > 0)
-                {
-                    expressionPrinter.StringBuilder.AppendLine().Append("ORDER BY ");
-                    expressionPrinter.VisitList(orderings);
-                }
+                expressionPrinter.StringBuilder.AppendLine().Append("ORDER BY ");
+                expressionPrinter.VisitList(Orderings);
             }
             else if (Offset != null)
             {

--- a/src/EFCore/Query/Pipeline/GroupByShaperExpression.cs
+++ b/src/EFCore/Query/Pipeline/GroupByShaperExpression.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query.Expressions.Internal;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Query.Pipeline
+{
+    public class GroupByShaperExpression : Expression, IPrintable
+    {
+        public GroupByShaperExpression(Expression keySelector, Expression elementSelector)
+        {
+            KeySelector = keySelector;
+            ElementSelector = elementSelector;
+        }
+
+        public Expression KeySelector { get; }
+        public Expression ElementSelector { get; }
+
+        public override Type Type => typeof(IGrouping<,>).MakeGenericType(KeySelector.Type, ElementSelector.Type);
+        public override ExpressionType NodeType => ExpressionType.Extension;
+
+        public void Print(ExpressionPrinter expressionPrinter)
+        {
+            expressionPrinter.StringBuilder.AppendLine("GroupBy(");
+            expressionPrinter.StringBuilder.Append("KeySelector: ");
+            expressionPrinter.Visit(KeySelector);
+            expressionPrinter.StringBuilder.AppendLine(", ");
+            expressionPrinter.StringBuilder.Append("ElementSelector:");
+            expressionPrinter.Visit(ElementSelector);
+            expressionPrinter.StringBuilder.AppendLine(")");
+        }
+
+        protected override Expression VisitChildren(ExpressionVisitor visitor)
+        {
+            var keySelector = visitor.Visit(KeySelector);
+            var elementSelector = visitor.Visit(ElementSelector);
+
+            return Update(keySelector, elementSelector);
+        }
+
+        public GroupByShaperExpression Update(Expression keySelector, Expression elementSelector)
+            => keySelector != KeySelector || elementSelector != ElementSelector
+                ? new GroupByShaperExpression(keySelector, elementSelector)
+                : this;
+    }
+}

--- a/src/EFCore/Query/Pipeline/ReplacingExpressionVisitor.cs
+++ b/src/EFCore/Query/Pipeline/ReplacingExpressionVisitor.cs
@@ -52,6 +52,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Pipeline
         {
             var innerExpression = Visit(memberExpression.Expression);
 
+            if (innerExpression is GroupByShaperExpression groupByShaperExpression
+                && memberExpression.Member.Name == nameof(IGrouping<int, int>.Key))
+            {
+                return groupByShaperExpression.KeySelector;
+            }
+
             if (innerExpression is NewExpression newExpression)
             {
                 var index = newExpression.Members.IndexOf(memberExpression.Member);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
@@ -21,6 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query
             //TestLoggerFactory.TestOutputHelper = testOutputHelper;
         }
 
+        [ConditionalFact(Skip = "#16392")]
         public override void Navigation_rewrite_on_owned_collection()
         {
             base.Navigation_rewrite_on_owned_collection();
@@ -28,6 +29,18 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query
                 @"SELECT c
 FROM root c
 WHERE ((c[""Discriminator""] = ""LeafB"") OR ((c[""Discriminator""] = ""LeafA"") OR ((c[""Discriminator""] = ""Branch"") OR (c[""Discriminator""] = ""OwnedPerson""))))");
+        }
+
+        [ConditionalFact(Skip = "#16392")]
+        public override void Navigation_rewrite_on_owned_collection_with_composition()
+        {
+            base.Navigation_rewrite_on_owned_collection_with_composition();
+        }
+
+        [ConditionalFact(Skip = "#16392")]
+        public override void Navigation_rewrite_on_owned_collection_with_composition_complex()
+        {
+            base.Navigation_rewrite_on_owned_collection_with_composition_complex();
         }
 
         [ConditionalFact(Skip = "Owned collection #12086")]

--- a/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.Where.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.Where.cs
@@ -1864,5 +1864,11 @@ SELECT c
 FROM root c
 WHERE ((c[""Discriminator""] = ""Order"") AND @__p_0)");
         }
+
+        [ConditionalTheory(Skip = "Issue#16391")]
+        public override Task Where_is_conditional(bool isAsync)
+        {
+            return base.Where_is_conditional(isAsync);
+        }
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/InMemoryComplianceTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/InMemoryComplianceTest.cs
@@ -24,6 +24,7 @@ namespace Microsoft.EntityFrameworkCore
             typeof(OwnedQueryTestBase<>),                  // issue #15285
             // Query pipeline
             typeof(SimpleQueryTestBase<>),
+            typeof(GroupByQueryTestBase<>),
             typeof(ConcurrencyDetectorTestBase<>),
             typeof(AsNoTrackingTestBase<>),
             typeof(AsTrackingTestBase<>),

--- a/test/EFCore.InMemory.FunctionalTests/Query/GroupByQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/GroupByQueryInMemoryTest.cs
@@ -8,7 +8,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
-    public class GroupByQueryInMemoryTest : GroupByQueryTestBase<NorthwindQueryInMemoryFixture<NoopModelCustomizer>>
+    internal class GroupByQueryInMemoryTest : GroupByQueryTestBase<NorthwindQueryInMemoryFixture<NoopModelCustomizer>>
     {
         public GroupByQueryInMemoryTest(
             NorthwindQueryInMemoryFixture<NoopModelCustomizer> fixture,

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -3658,7 +3658,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true);
         }
 
-        [ConditionalTheory(Skip = "Issue #15249")]
+        [ConditionalTheory(Skip = "Issue #15799")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Can_group_by_indexed_property_on_query(bool isAsync)
         {
@@ -3667,7 +3667,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 cs => cs.GroupBy(c => c[City.NationPropertyName]).Select(g => g.Count()));
         }
 
-        [ConditionalTheory(Skip = "Issue #15249")]
+        [ConditionalTheory(Skip = "Issue #15799")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Can_group_by_converted_indexed_property_on_query(bool isAsync)
         {
@@ -7041,7 +7041,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 gs => gs.Include(g => g.CityOfBirth).GroupBy(g => g.Rank).Select(g => g.Count()));
         }
 
-        [ConditionalTheory(Skip = "issue #150249")]
+        [ConditionalTheory(Skip = "issue #15249")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_Include_Select_LongCount(bool isAsync)
         {
@@ -7050,7 +7050,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 gs => gs.Include(g => g.CityOfBirth).GroupBy(g => g.Rank).Select(g => g.LongCount()));
         }
 
-        [ConditionalTheory(Skip = "issue #150249")]
+        [ConditionalTheory(Skip = "issue #15249")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_Include_Select_Max(bool isAsync)
         {

--- a/test/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #region GroupByProperty
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_Select_Average(bool isAsync)
         {
@@ -47,7 +47,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 os => os.Where(o => o.Customer.City != "London").GroupBy(o => o.CustomerID, (k, es) => new { k, es }).Select(g => g.es.Average(o => o.OrderID)));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_Select_Count(bool isAsync)
         {
@@ -56,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 os => os.GroupBy(o => o.CustomerID).Select(g => g.Count()));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_Select_LongCount(bool isAsync)
         {
@@ -65,7 +65,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 os => os.GroupBy(o => o.CustomerID).Select(g => g.LongCount()));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_Select_Max(bool isAsync)
         {
@@ -74,7 +74,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 os => os.GroupBy(o => o.CustomerID).Select(g => g.Max(o => o.OrderID)));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_Select_Min(bool isAsync)
         {
@@ -83,7 +83,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 os => os.GroupBy(o => o.CustomerID).Select(g => g.Min(o => o.OrderID)));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_Select_Sum(bool isAsync)
         {
@@ -93,7 +93,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     o => EF.Property<string>(o, "CustomerID")).Select(g => g.Sum(o => o.OrderID)));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_Select_Sum_Min_Max_Avg(bool isAsync)
         {
@@ -111,7 +111,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Min + " " + e.Max);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_Select_Key_Average(bool isAsync)
         {
@@ -127,7 +127,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Key);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_Select_Key_Count(bool isAsync)
         {
@@ -143,7 +143,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Key);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_Select_Key_LongCount(bool isAsync)
         {
@@ -159,7 +159,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Key);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_Select_Key_Max(bool isAsync)
         {
@@ -175,7 +175,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Key);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_Select_Key_Min(bool isAsync)
         {
@@ -191,7 +191,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Key);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_Select_Key_Sum(bool isAsync)
         {
@@ -207,7 +207,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Key);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_Select_Key_Sum_Min_Max_Avg(bool isAsync)
         {
@@ -226,7 +226,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Min + " " + e.Max);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_Select_Sum_Min_Key_Max_Avg(bool isAsync)
         {
@@ -245,7 +245,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Min + " " + e.Max);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_Select_key_multiple_times_and_aggregate(bool isAsync)
         {
@@ -262,8 +262,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Key1);
         }
 
-        // also #15249
-        [ConditionalTheory(Skip = "issue #12826")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_aggregate_projecting_conditional_expression_based_on_group_key(bool isAsync)
         {
@@ -283,7 +282,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #region GroupByAnonymousAggregate
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_anonymous_Select_Average(bool isAsync)
         {
@@ -296,7 +295,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     }).Select(g => g.Average(o => o.OrderID)));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_anonymous_Select_Count(bool isAsync)
         {
@@ -309,7 +308,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     }).Select(g => g.Count()));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_anonymous_Select_LongCount(bool isAsync)
         {
@@ -322,7 +321,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     }).Select(g => g.LongCount()));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_anonymous_Select_Max(bool isAsync)
         {
@@ -335,7 +334,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     }).Select(g => g.Max(o => o.OrderID)));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_anonymous_Select_Min(bool isAsync)
         {
@@ -348,7 +347,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     }).Select(g => g.Min(o => o.OrderID)));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_anonymous_Select_Sum(bool isAsync)
         {
@@ -361,7 +360,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     }).Select(g => g.Sum(o => o.OrderID)));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_anonymous_Select_Sum_Min_Max_Avg(bool isAsync)
         {
@@ -383,7 +382,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Min + " " + e.Max);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_anonymous_with_alias_Select_Key_Sum(bool isAsync)
         {
@@ -402,7 +401,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         }));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Composite_Select_Average(bool isAsync)
         {
@@ -416,7 +415,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     }).Select(g => g.Average(o => o.OrderID)));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Composite_Select_Count(bool isAsync)
         {
@@ -430,7 +429,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     }).Select(g => g.Count()));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Composite_Select_LongCount(bool isAsync)
         {
@@ -444,7 +443,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     }).Select(g => g.LongCount()));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Composite_Select_Max(bool isAsync)
         {
@@ -458,7 +457,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     }).Select(g => g.Max(o => o.OrderID)));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Composite_Select_Min(bool isAsync)
         {
@@ -472,7 +471,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     }).Select(g => g.Min(o => o.OrderID)));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Composite_Select_Sum(bool isAsync)
         {
@@ -486,7 +485,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     }).Select(g => g.Sum(o => o.OrderID)));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Composite_Select_Sum_Min_Max_Avg(bool isAsync)
         {
@@ -509,7 +508,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Min + " " + e.Max);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Composite_Select_Key_Average(bool isAsync)
         {
@@ -530,7 +529,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Key.CustomerID + " " + e.Key.EmployeeID);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Composite_Select_Key_Count(bool isAsync)
         {
@@ -551,7 +550,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Key.CustomerID + " " + e.Key.EmployeeID);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Composite_Select_Key_LongCount(bool isAsync)
         {
@@ -572,7 +571,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Key.CustomerID + " " + e.Key.EmployeeID);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Composite_Select_Key_Max(bool isAsync)
         {
@@ -593,7 +592,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Key.CustomerID + " " + e.Key.EmployeeID);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Composite_Select_Key_Min(bool isAsync)
         {
@@ -614,7 +613,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Key.CustomerID + " " + e.Key.EmployeeID);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Composite_Select_Key_Sum(bool isAsync)
         {
@@ -635,7 +634,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Key.CustomerID + " " + e.Key.EmployeeID);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Composite_Select_Key_Sum_Min_Max_Avg(bool isAsync)
         {
@@ -659,7 +658,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Min + " " + e.Max);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Composite_Select_Sum_Min_Key_Max_Avg(bool isAsync)
         {
@@ -683,7 +682,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Min + " " + e.Max);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Composite_Select_Sum_Min_Key_flattened_Max_Avg(bool isAsync)
         {
@@ -708,8 +707,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Min + " " + e.Max);
         }
 
-        // also #15249
-        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy(new NominalType() {CustomerID = [o].CustomerID, EmployeeID = [o].EmployeeID}, [o])'")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Dto_as_key_Select_Sum(bool isAsync)
         {
@@ -729,8 +727,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         }));
         }
 
-        // also #15249
-        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([o].CustomerID, new NominalType() {CustomerID = [o].CustomerID, EmployeeID = [o].EmployeeID})'")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Dto_as_element_selector_Select_Sum(bool isAsync)
         {
@@ -771,7 +768,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                    && EmployeeID == other.EmployeeID;
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Composite_Select_Dto_Sum_Min_Key_flattened_Max_Avg(bool isAsync)
         {
@@ -826,7 +823,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                    && string.Equals(CustomerId, other.CustomerId);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Composite_Select_Sum_Min_part_Key_flattened_Max_Avg(bool isAsync)
         {
@@ -850,7 +847,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Min + " " + e.Max);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Constant_Select_Sum_Min_Key_Max_Avg(bool isAsync)
         {
@@ -869,7 +866,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Min + " " + e.Max);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Constant_with_element_selector_Select_Sum(bool isAsync)
         {
@@ -884,7 +881,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Sum);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Constant_with_element_selector_Select_Sum2(bool isAsync)
         {
@@ -899,7 +896,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Sum);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Constant_with_element_selector_Select_Sum3(bool isAsync)
         {
@@ -914,7 +911,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Sum);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_after_predicate_Constant_Select_Sum_Min_Key_Max_Avg(bool isAsync)
         {
@@ -933,7 +930,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Min + " " + e.Max);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Constant_with_element_selector_Select_Sum_Min_Key_Max_Avg(bool isAsync)
         {
@@ -949,7 +946,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Sum);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_param_Select_Sum_Min_Key_Max_Avg(bool isAsync)
         {
@@ -970,7 +967,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Min + " " + e.Max);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_param_with_element_selector_Select_Sum(bool isAsync)
         {
@@ -987,7 +984,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Sum);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_param_with_element_selector_Select_Sum2(bool isAsync)
         {
@@ -1004,7 +1001,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Sum);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_param_with_element_selector_Select_Sum3(bool isAsync)
         {
@@ -1021,7 +1018,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Sum);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_param_with_element_selector_Select_Sum_Min_Key_Max_Avg(bool isAsync)
         {
@@ -1043,7 +1040,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #region GroupByWithElementSelectorAggregate
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_scalar_element_selector_Average(bool isAsync)
         {
@@ -1052,7 +1049,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 os => os.GroupBy(o => o.CustomerID, o => o.OrderID).Select(g => g.Average()));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_scalar_element_selector_Count(bool isAsync)
         {
@@ -1061,7 +1058,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 os => os.GroupBy(o => o.CustomerID, o => o.OrderID).Select(g => g.Count()));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_scalar_element_selector_LongCount(bool isAsync)
         {
@@ -1070,7 +1067,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 os => os.GroupBy(o => o.CustomerID, o => o.OrderID).Select(g => g.LongCount()));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_scalar_element_selector_Max(bool isAsync)
         {
@@ -1079,7 +1076,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 os => os.GroupBy(o => o.CustomerID, o => o.OrderID).Select(g => g.Max()));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_scalar_element_selector_Min(bool isAsync)
         {
@@ -1088,7 +1085,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 os => os.GroupBy(o => o.CustomerID, o => o.OrderID).Select(g => g.Min()));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_scalar_element_selector_Sum(bool isAsync)
         {
@@ -1097,7 +1094,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 os => os.GroupBy(o => o.CustomerID, o => o.OrderID).Select(g => g.Sum()));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_scalar_element_selector_Sum_Min_Max_Avg(bool isAsync)
         {
@@ -1115,7 +1112,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Min + " " + e.Max);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_anonymous_element_selector_Average(bool isAsync)
         {
@@ -1129,7 +1126,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     }).Select(g => g.Average(o => o.OrderID)));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_anonymous_element_selector_Count(bool isAsync)
         {
@@ -1143,7 +1140,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     }).Select(g => g.Count()));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_anonymous_element_selector_LongCount(bool isAsync)
         {
@@ -1157,7 +1154,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     }).Select(g => g.LongCount()));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_anonymous_element_selector_Max(bool isAsync)
         {
@@ -1171,7 +1168,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     }).Select(g => g.Max(o => o.OrderID)));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_anonymous_element_selector_Min(bool isAsync)
         {
@@ -1185,7 +1182,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     }).Select(g => g.Min(o => o.OrderID)));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_anonymous_element_selector_Sum(bool isAsync)
         {
@@ -1199,7 +1196,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     }).Select(g => g.Sum(o => o.OrderID)));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_anonymous_element_selector_Sum_Min_Max_Avg(bool isAsync)
         {
@@ -1222,7 +1219,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Sum + " " + e.Avg);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_element_selector_complex_aggregate(bool isAsync)
         {
@@ -1232,7 +1229,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Select(g => g.Sum(e => e.OrderID + 1)));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_element_selector_complex_aggregate2(bool isAsync)
         {
@@ -1242,8 +1239,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Select(g => g.Sum(e => e.OrderID + 1)));
         }
 
-        // issue #15249
-        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([o].CustomerID, [o].OrderID)' could not be translated and will be evaluated locally.'")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_element_selector_complex_aggregate3(bool isAsync)
         {
@@ -1253,7 +1249,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Select(g => g.Sum(e => e + 1)));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_element_selector_complex_aggregate4(bool isAsync)
         {
@@ -1267,7 +1263,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #region GroupByAfterComposition
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_empty_key_Aggregate(bool isAsync)
         {
@@ -1281,7 +1277,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         .Select(g => g.Sum(o => o.OrderID)));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_empty_key_Aggregate_Key(bool isAsync)
         {
@@ -1300,7 +1296,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                             }));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task OrderBy_GroupBy_Aggregate(bool isAsync)
         {
@@ -1312,7 +1308,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         .Select(g => g.Sum(o => o.OrderID)));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task OrderBy_Skip_GroupBy_Aggregate(bool isAsync)
         {
@@ -1325,7 +1321,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         .Select(g => g.Average(o => o.OrderID)));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task OrderBy_Take_GroupBy_Aggregate(bool isAsync)
         {
@@ -1338,7 +1334,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         .Select(g => g.Min(o => o.OrderID)));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task OrderBy_Skip_Take_GroupBy_Aggregate(bool isAsync)
         {
@@ -1352,7 +1348,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         .Select(g => g.Max(o => o.OrderID)));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Distinct_GroupBy_Aggregate(bool isAsync)
         {
@@ -1370,7 +1366,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Key);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Anonymous_projection_Distinct_GroupBy_Aggregate(bool isAsync)
         {
@@ -1394,7 +1390,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Key);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory(Skip = "Issue#15711")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task SelectMany_GroupBy_Aggregate(bool isAsync)
         {
@@ -1412,7 +1408,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Key);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_GroupBy_Aggregate(bool isAsync)
         {
@@ -1432,7 +1428,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Key);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory(Skip = "Issue#15249")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_required_navigation_member_Aggregate(bool isAsync)
         {
@@ -1450,7 +1446,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.CustomerId);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_complex_GroupBy_Aggregate(bool isAsync)
         {
@@ -1471,7 +1467,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Key);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_GroupBy_Aggregate(bool isAsync)
         {
@@ -1494,7 +1490,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Key);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_GroupBy_Aggregate_2(bool isAsync)
         {
@@ -1516,7 +1512,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Key);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_GroupBy_Aggregate_3(bool isAsync)
         {
@@ -1538,7 +1534,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Key);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_GroupBy_Aggregate_4(bool isAsync)
         {
@@ -1560,7 +1556,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Value);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_GroupBy_Aggregate_5(bool isAsync)
         {
@@ -1582,7 +1578,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Value);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory(Skip = "Issue#15249")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_optional_navigation_member_Aggregate(bool isAsync)
         {
@@ -1600,7 +1596,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Country);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_complex_GroupBy_Aggregate(bool isAsync)
         {
@@ -1624,7 +1620,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Key);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Self_join_GroupBy_Aggregate(bool isAsync)
         {
@@ -1644,7 +1640,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Key);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory(Skip = "Issue#15249")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_multi_navigation_members_Aggregate(bool isAsync)
         {
@@ -1667,8 +1663,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.CompositeKey.CustomerID + " " + e.CompositeKey.ProductName);
         }
 
-        // also #15249
-        [ConditionalTheory(Skip = "Unable to bind group by. See Issue#6658")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Union_simple_groupby(bool isAsync)
         {
@@ -1682,11 +1677,10 @@ namespace Microsoft.EntityFrameworkCore.Query
                         {
                             g.Key,
                             Total = g.Count()
-                        }),
-                entryCount: 19);
+                        }));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_anonymous_GroupBy_Aggregate(bool isAsync)
         {
@@ -1711,7 +1705,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         }));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory(Skip = "Issue#15249")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_principal_key_property_optimization(bool isAsync)
         {
@@ -1730,7 +1724,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #region GroupByAggregateComposition
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_OrderBy_key(bool isAsync)
         {
@@ -1748,7 +1742,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_OrderBy_count(bool isAsync)
         {
@@ -1767,7 +1761,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_OrderBy_count_Select_sum(bool isAsync)
         {
@@ -1786,7 +1780,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_aggregate_Contains(bool isAsync)
         {
@@ -1800,7 +1794,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 31);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_aggregate_Pushdown(bool isAsync)
         {
@@ -1814,9 +1808,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Skip(4));
         }
 
-        // issue #12577
-        //[ConditionalTheory]
-        //[MemberData(nameof(IsAsyncData))]
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_aggregate_Pushdown_followed_by_projecting_Length(bool isAsync)
         {
             return AssertQueryScalar<Order>(
@@ -1830,9 +1823,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Select(e => e.Length));
         }
 
-        // issue #12600
-        //[ConditionalTheory]
-        //[MemberData(nameof(IsAsyncData))]
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_aggregate_Pushdown_followed_by_projecting_constant(bool isAsync)
         {
             return AssertQueryScalar<Order>(
@@ -1843,7 +1835,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .OrderBy(t => t)
                     .Take(20)
                     .Skip(4)
-                    .Select(e => 1));
+                    .Select(e => 5));
         }
 
         [ConditionalFact(Skip = "Issue #14935. Cannot eval 'GroupBy([o].CustomerID, [o])'")]
@@ -1866,7 +1858,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_filter_key(bool isAsync)
         {
@@ -1883,7 +1875,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                             }));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_filter_count(bool isAsync)
         {
@@ -1900,7 +1892,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                             }));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_filter_count_OrderBy_count_Select_sum(bool isAsync)
         {
@@ -1920,7 +1912,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                             }));
         }
 
-        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'GroupBy([o].CustomerID, [o])'")]
+        [ConditionalTheory(Skip = "Issue#15249")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Aggregate_Join(bool isAsync)
         {
@@ -1945,7 +1937,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 126);
         }
 
-        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'join Order o in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Order]) on [a].LastOrderID equals [o].OrderID'")]
+        [ConditionalTheory(Skip = "Issue#15249")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_GroupBy_Aggregate_multijoins(bool isAsync)
         {
@@ -1971,7 +1963,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 126);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory(Skip = "Issue#15249")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_GroupBy_Aggregate_single_join(bool isAsync)
         {
@@ -1996,7 +1988,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 63);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory(Skip = "Issue#15249")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_GroupBy_Aggregate_with_another_join(bool isAsync)
         {
@@ -2024,7 +2016,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 63);
         }
 
-        [ConditionalTheory(Skip = "Issue #14935. Cannot eval 'join <>f__AnonymousType264`2 i in {from Customer c in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Customer]) join <>f__AnonymousType261`2 a in {from IGrouping`2 g in {value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.TestModels.Northwind.Order]) => GroupBy([o].CustomerID, [o])} where ({[g] => Count()} > 5) select new <>f__AnonymousType261`2(CustomerID = [g].Key, LastOrderID = {from Order o in [g] select [o].OrderID => Max()})} on [c].CustomerID equals [a].CustomerID select new <>f__AnonymousType264`2(c = [c], LastOrderID = [a].LastOrderID)} on [o].CustomerID equals [i].c.CustomerID'")]
+        [ConditionalTheory(Skip = "Issue#15249")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_GroupBy_Aggregate_in_subquery(bool isAsync)
         {
@@ -2057,7 +2049,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 133);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory(Skip = "Issue#15249")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_GroupBy_Aggregate_on_key(bool isAsync)
         {
@@ -2083,7 +2075,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 63);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_with_result_selector(bool isAsync)
         {
@@ -2105,7 +2097,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Min + " " + e.Max);
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Sum_constant(bool isAsync)
         {
@@ -2114,7 +2106,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 os => os.GroupBy(o => o.CustomerID).Select(g => g.Sum(e => 1)));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Sum_constant_cast(bool isAsync)
         {
@@ -2123,7 +2115,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 os => os.GroupBy(o => o.CustomerID).Select(g => g.Sum(e => 1L)));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Distinct_GroupBy_OrderBy_key(bool isAsync)
         {
@@ -2227,7 +2219,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       select g.Where(e => e.OrderID < 10300).Count());
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Key_as_part_of_element_selector(bool isAsync)
         {
@@ -2248,7 +2240,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         }));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_composite_Key_as_part_of_element_selector(bool isAsync)
         {
@@ -2948,7 +2940,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #region ResultOperatorsAfterGroupBy
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Count_after_GroupBy_aggregate(bool isAsync)
         {
@@ -2974,7 +2966,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                        select g.Where(e => e.OrderID < 10300).Count()).LongCountAsync());
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual async Task MinMax_after_GroupBy_aggregate(bool isAsync)
         {
@@ -2987,15 +2979,30 @@ namespace Microsoft.EntityFrameworkCore.Query
                 os => os.GroupBy(o => o.CustomerID).Select(g => g.Sum(gg => gg.OrderID)));
         }
 
-        [ConditionalTheory(Skip = "issue #15249")]
+        [ConditionalTheory(Skip = "Issue#16389")]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task AllAny_after_GroupBy_aggregate(bool isAsync)
+        public virtual async Task All_after_GroupBy_aggregate(bool isAsync)
         {
             await AssertAll<Order, int>(
                 isAsync,
                 os => os.GroupBy(o => o.CustomerID).Select(g => g.Sum(gg => gg.OrderID)),
                 predicate: ee => true);
+        }
 
+        [ConditionalTheory(Skip = "Issue#16389")]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task All_after_GroupBy_aggregate2(bool isAsync)
+        {
+            await AssertAll<Order, int>(
+                isAsync,
+                os => os.GroupBy(o => o.CustomerID).Select(g => g.Sum(gg => gg.OrderID)),
+                predicate: ee => ee >= 0);
+        }
+
+        [ConditionalTheory(Skip = "Issue#16389")]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Any_after_GroupBy_aggregate(bool isAsync)
+        {
             await AssertAny<Order, int>(
                 isAsync,
                 os => os.GroupBy(o => o.CustomerID).Select(g => g.Sum(gg => gg.OrderID)));

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.SetOperations.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.SetOperations.cs
@@ -119,7 +119,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Union(cs.Where(e => e.City == "London")),
                 entryCount: 25);
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue#16365")]
         [MemberData(nameof(IsAsyncData))]
         public virtual void Union_non_entity(bool isAsync)
             => AssertQuery<Customer>(isAsync, cs => cs

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -2749,7 +2749,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select c.CustomerID);
         }
 
-        [ConditionalTheory(Skip = "Issue#15718")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task SelectMany_LongCount(bool isAsync)
         {
@@ -5197,7 +5197,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 cs => cs.OrderBy(c => c.Country).Take(7));
         }
 
-        [ConditionalTheory(Skip = "Issue#15718")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_take_long_count(bool isAsync)
         {
@@ -5206,7 +5206,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 cs => cs.Take(7));
         }
 
-        [ConditionalTheory(Skip = "Issue#15718")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_orderBy_take_long_count(bool isAsync)
         {
@@ -5269,7 +5269,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 cs => cs.OrderBy(c => c.Country).Skip(7));
         }
 
-        [ConditionalTheory(Skip = "Issue#15718")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_skip_long_count(bool isAsync)
         {
@@ -5278,7 +5278,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 cs => cs.Skip(7));
         }
 
-        [ConditionalTheory(Skip = "Issue#15718")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_orderBy_skip_long_count(bool isAsync)
         {
@@ -5332,7 +5332,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 cs => cs.Distinct());
         }
 
-        [ConditionalTheory(Skip = "Issue#15718")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_distinct_long_count(bool isAsync)
         {
@@ -5428,7 +5428,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       select c.CustomerID);
         }
 
-        [ConditionalTheory(Skip = "Issue#16365")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Comparing_navigations_using_Equals(bool isAsync)
         {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/IncludeSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/IncludeSqlServerTest.cs
@@ -712,11 +712,15 @@ ORDER BY [t].[CustomerID]");
 @__p_1='2'
 
 SELECT [o].[CustomerID]
-FROM [Order Details] AS [o0]
-INNER JOIN [Orders] AS [o] ON [o0].[OrderID] = [o].[OrderID]
-WHERE [o0].[Quantity] = CAST(10 AS smallint)
-ORDER BY [o0].[OrderID], [o0].[ProductID]
-OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY");
+FROM (
+    SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+    FROM [Order Details] AS [o0]
+    WHERE [o0].[Quantity] = CAST(10 AS smallint)
+    ORDER BY [o0].[OrderID], [o0].[ProductID]
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [Orders] AS [o] ON [t].[OrderID] = [o].[OrderID]
+ORDER BY [t].[OrderID], [t].[ProductID]");
             }
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -3746,7 +3746,7 @@ WHERE [b].[IsTwo] IN (CAST(0 AS bit), CAST(1 AS bit))");
 
         #region Bug11818_11831
 
-        [ConditionalFact(Skip = "issue #15249")]
+        [ConditionalFact]
         public virtual void GroupJoin_Anonymous_projection_GroupBy_Aggregate_join_elimination()
         {
             using (CreateDatabase11818())
@@ -3772,19 +3772,15 @@ WHERE [b].[IsTwo] IN (CAST(0 AS bit), CAST(1 AS bit))");
                         .ToList();
 
                     AssertSql(
-                @"SELECT [t].[Name] AS [Key], COUNT(*) + 5 AS [cnt]
-FROM [Table] AS [e]
-LEFT JOIN (
-    SELECT [a].*
-    FROM [Table] AS [a]
-    WHERE [a].[Name] IS NOT NULL
-) AS [t] ON [e].[Id] = [t].[Id]
+                        @"SELECT [t].[Name] AS [Key], COUNT(*) + 5 AS [cnt]
+FROM [Table] AS [t0]
+LEFT JOIN [Table] AS [t] ON [t0].[Id] = [t].[Id]
 GROUP BY [t].[Name]");
                 }
             }
         }
 
-        [ConditionalFact(Skip = "issue #15249")]
+        [ConditionalFact]
         public virtual void GroupJoin_Anonymous_projection_GroupBy_Aggregate_join_elimination_2()
         {
             using (CreateDatabase11818())
@@ -3817,20 +3813,12 @@ GROUP BY [t].[Name]");
                             })
                         .ToList();
 
-                    AssertSql(
+            AssertSql(
                 @"SELECT [t].[Name] AS [MyKey], COUNT(*) + 5 AS [cnt]
-FROM [Table] AS [e]
-LEFT JOIN (
-    SELECT [a].*
-    FROM [Table] AS [a]
-    WHERE [a].[Name] IS NOT NULL
-) AS [t] ON [e].[Id] = [t].[Id]
-LEFT JOIN (
-    SELECT [m].*
-    FROM [Table] AS [m]
-    WHERE [m].[MaumarEntity11818_Name] IS NOT NULL
-) AS [t0] ON [e].[Id] = [t0].[Id]
-GROUP BY [t].[Name], [t0].[MaumarEntity11818_Name]");
+FROM [Table] AS [t0]
+LEFT JOIN [Table] AS [t] ON [t0].[Id] = [t].[Id]
+LEFT JOIN [Table] AS [t1] ON [t0].[Id] = [t1].[Id]
+GROUP BY [t].[Name], [t1].[MaumarEntity11818_Name]");
                 }
             }
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -4123,7 +4123,7 @@ FROM (
 
 SELECT COUNT_BIG(*)
 FROM (
-    SELECT TOP(@__p_0) [c].*
+    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
 ) AS [t]");
         }
@@ -4137,7 +4137,7 @@ FROM (
 
 SELECT COUNT_BIG(*)
 FROM (
-    SELECT TOP(@__p_0) [c].*
+    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[Country]
 ) AS [t]");
@@ -4245,7 +4245,7 @@ FROM (
 
 SELECT COUNT_BIG(*)
 FROM (
-    SELECT [c].*
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY (SELECT 1)
     OFFSET @__p_0 ROWS
@@ -4261,7 +4261,7 @@ FROM (
 
 SELECT COUNT_BIG(*)
 FROM (
-    SELECT [c].*
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[Country]
     OFFSET @__p_0 ROWS
@@ -4347,7 +4347,7 @@ FROM (
             AssertSql(
                 @"SELECT COUNT_BIG(*)
 FROM (
-    SELECT DISTINCT [c].*
+    SELECT DISTINCT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
 ) AS [t]");
         }


### PR DESCRIPTION
This allows us to use those methods to translate aggregates after GroupBy

Resolves #15718
Query: Translate to SQL GROUP BY when aggregate operator is applied after GroupBy

Resolves #12826
Resolves #6658
Part of #15711
Resolves #15853
Resolves #12799
Resolves #12476
Resolves #11976