### PR TITLE
Explicitly reference Roslyn compiler version that's currently in the '.NET Core 3 Release' channel

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -16,6 +16,12 @@
     <KnownFrameworkReference Update="NETStandard.Library">
       <TargetingPackVersion Condition="'%(TargetFramework)' == 'netstandard2.1'">$(NETStandardLibraryRefPackageVersion)</TargetingPackVersion>
     </KnownFrameworkReference>
+
+    <!-- Track compiler separately from Arcade.-->
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset"
+        Version="$(MicrosoftNetCompilersToolsetVersion)"
+        PrivateAssets="all"
+        IsImplicitlyDefined="true" />
   </ItemGroup>
 
 </Project>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -41,10 +41,6 @@
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>b5e1724093107d2133b3dab14197b8ff5dbff8ef</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Compilers" Version="3.1.1-beta4-19281-06">
-      <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>58a4b1e79aea28115e66b06f850c83a3f1fcb6d3</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.NETCore.Platforms" Version="3.0.0-preview7.19329.3" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>9e3278936912fc413891926f3789689cb05fd3c3</Sha>
@@ -78,6 +74,10 @@
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19323.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>9946534da4f73e6242ca105f6798ab58119c9ab0</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.3.0-beta1-19351-01">
+      <Uri>https://github.com/dotnet/roslyn</Uri>
+      <Sha>c91adff42c488aef2c2c532a7b053fb55e0c16ea</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -41,6 +41,10 @@
       <Uri>https://github.com/aspnet/Extensions</Uri>
       <Sha>b5e1724093107d2133b3dab14197b8ff5dbff8ef</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.NETCore.Compilers" Version="3.1.1-beta4-19281-06">
+      <Uri>https://github.com/dotnet/roslyn</Uri>
+      <Sha>58a4b1e79aea28115e66b06f850c83a3f1fcb6d3</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.NETCore.Platforms" Version="3.0.0-preview7.19329.3" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>9e3278936912fc413891926f3789689cb05fd3c3</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -50,7 +50,7 @@
     <NETStandardLibraryRefPackageVersion>2.1.0-preview7-27901-06</NETStandardLibraryRefPackageVersion>
   </PropertyGroup>
   <PropertyGroup Label="Dependencies from dotnet/roslyn">
-    <MicrosoftNetCompilersToolsetVersion>3.1.1-beta4-19281-06</MicrosoftNetCompilersToolsetVersion>
+    <MicrosoftNetCompilersToolsetVersion>3.3.0-beta1-19351-01</MicrosoftNetCompilersToolsetVersion>
   </PropertyGroup>
   <PropertyGroup Label="Dependency version settings">
     <!--

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,8 +5,7 @@
     <IncludeSourceRevisionInInformationalVersion>False</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
   <PropertyGroup Label="Arcade settings">
-    <!-- Opt-in to using the version of the Roslyn compiler bundled with Arcade. -->
-    <UsingToolMicrosoftNetCompilers>true</UsingToolMicrosoftNetCompilers>
+    <!-- Opt-in to using the ref assembly version bundled with Arcade. -->
     <UsingToolNetFrameworkReferenceAssemblies>True</UsingToolNetFrameworkReferenceAssemblies>
     <UsingToolXliff>False</UsingToolXliff>
   </PropertyGroup>
@@ -50,6 +49,9 @@
     <MicrosoftNETCoreAppRuntimewinx64PackageVersion>3.0.0-preview7-27901-06</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
     <NETStandardLibraryRefPackageVersion>2.1.0-preview7-27901-06</NETStandardLibraryRefPackageVersion>
   </PropertyGroup>
+  <PropertyGroup Label="Dependencies from dotnet/roslyn">
+    <MicrosoftNetCompilersToolsetVersion>3.1.1-beta4-19281-06</MicrosoftNetCompilersToolsetVersion>
+  </PropertyGroup>
   <PropertyGroup Label="Dependency version settings">
     <!--
       Win-x64 is used here because we have picked an arbitrary runtime identifier to flow the version of the latest NETCore.App runtime.
@@ -63,6 +65,10 @@
       $(RestoreSources);
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
       https://dotnetfeed.blob.core.windows.net/aspnet-extensions/index.json;
+    </RestoreSources>
+    <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true' AND $(MicrosoftNetCompilersToolsetVersion.Contains('-')) ">
+      $(RestoreSources);
+      https://dotnet.myget.org/F/roslyn/api/v3/index.json;
     </RestoreSources>
   </PropertyGroup>
 </Project>

--- a/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
@@ -104,6 +104,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             var databaseGeneratedAttributeConvention = new DatabaseGeneratedAttributeConvention(Dependencies);
             var requiredPropertyAttributeConvention = new RequiredPropertyAttributeConvention(Dependencies);
             var nonNullableReferencePropertyConvention = new NonNullableReferencePropertyConvention(Dependencies);
+            var nonNullableNavigationConvention = new NonNullableNavigationConvention(Dependencies);
             var maxLengthAttributeConvention = new MaxLengthAttributeConvention(Dependencies);
             var stringLengthAttributeConvention = new StringLengthAttributeConvention(Dependencies);
             var timestampAttributeConvention = new TimestampAttributeConvention(Dependencies);
@@ -171,11 +172,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             conventionSet.ModelFinalizedConventions.Add(foreignKeyIndexConvention);
             conventionSet.ModelFinalizedConventions.Add(foreignKeyPropertyDiscoveryConvention);
             conventionSet.ModelFinalizedConventions.Add(servicePropertyDiscoveryConvention);
+            conventionSet.ModelFinalizedConventions.Add(nonNullableReferencePropertyConvention);
+            conventionSet.ModelFinalizedConventions.Add(nonNullableNavigationConvention);
             conventionSet.ModelFinalizedConventions.Add(new ValidatingConvention(Dependencies));
+            // Don't add any more conventions to ModelFinalizedConventions after ValidatingConvention
 
             conventionSet.NavigationAddedConventions.Add(backingFieldConvention);
             conventionSet.NavigationAddedConventions.Add(new RequiredNavigationAttributeConvention(Dependencies));
-            conventionSet.NavigationAddedConventions.Add(new NonNullableNavigationConvention(Dependencies));
+            conventionSet.NavigationAddedConventions.Add(nonNullableNavigationConvention);
             conventionSet.NavigationAddedConventions.Add(inversePropertyAttributeConvention);
             conventionSet.NavigationAddedConventions.Add(foreignKeyPropertyDiscoveryConvention);
             conventionSet.NavigationAddedConventions.Add(relationshipDiscoveryConvention);

--- a/src/EFCore/Metadata/Conventions/NonNullableConventionBase.cs
+++ b/src/EFCore/Metadata/Conventions/NonNullableConventionBase.cs
@@ -2,9 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
@@ -13,11 +15,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
     ///     A base type for conventions that configure model aspects based on whether the member type
     ///     is a non-nullable reference type.
     /// </summary>
-    public abstract class NonNullableConventionBase
+    public abstract class NonNullableConventionBase : IModelFinalizedConvention
     {
+        // For the interpretation of nullability metadata, see
+        // https://github.com/dotnet/roslyn/blob/master/docs/features/nullable-metadata.md
+
+        private const string StateAnnotationName = "NonNullableConventionState";
         private const string NullableAttributeFullName = "System.Runtime.CompilerServices.NullableAttribute";
-        private Type _nullableAttrType;
-        private FieldInfo _nullableFlagsFieldInfo;
+        private const string NullableContextAttributeFullName = "System.Runtime.CompilerServices.NullableContextAttribute";
 
         /// <summary>
         ///     Creates a new instance of <see cref="NonNullableConventionBase" />.
@@ -33,40 +38,118 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         /// </summary>
         protected virtual ProviderConventionSetBuilderDependencies Dependencies { get; }
 
+        private byte? GetNullabilityContextFlag(NonNullabilityConventionState state, Attribute[] attributes)
+        {
+            if (attributes.FirstOrDefault(a => a.GetType().FullName == NullableContextAttributeFullName) is Attribute attribute)
+            {
+                var attributeType = attribute.GetType();
+
+                if (attributeType != state.NullableContextAttrType)
+                {
+                    state.NullableContextFlagFieldInfo = attributeType.GetField("Flag");
+                    state.NullableContextAttrType = attributeType;
+                }
+
+                if (state.NullableContextFlagFieldInfo?.GetValue(attribute) is byte flag)
+                {
+                    return flag;
+                }
+            }
+
+            return null;
+        }
+
         /// <summary>
         ///     Returns a value indicating whether the member type is a non-nullable reference type.
         /// </summary>
+        /// <param name="modelBuilder"> The model builder used to build the model. </param>
         /// <param name="memberInfo"> The member info. </param>
         /// <returns> <c>true</c> if the member type is a non-nullable reference type. </returns>
-        protected virtual bool IsNonNullable([NotNull] MemberInfo memberInfo)
+        protected virtual bool IsNonNullable(
+            [NotNull] IConventionModelBuilder modelBuilder,
+            [NotNull] MemberInfo memberInfo)
         {
+            var state = GetOrInitializeState(modelBuilder);
+
             // For C# 8.0 nullable types, the C# currently synthesizes a NullableAttribute that expresses nullability into assemblies
             // it produces. If the model is spread across more than one assembly, there will be multiple versions of this attribute,
             // so look for it by name, caching to avoid reflection on every check.
             // Note that this may change - if https://github.com/dotnet/corefx/issues/36222 is done we can remove all of this.
-            if (!(Attribute.GetCustomAttributes(memberInfo, true)
-                    .FirstOrDefault(a => a.GetType().FullName == NullableAttributeFullName)
-                is { } attribute))
+
+            // First look for NullableAttribute on the member itself
+            if (Attribute.GetCustomAttributes(memberInfo, true)
+                    .FirstOrDefault(a => a.GetType().FullName == NullableAttributeFullName) is Attribute attribute)
             {
-                return false;
+                var attributeType = attribute.GetType();
+
+                if (attributeType != state.NullableAttrType)
+                {
+                    state.NullableFlagsFieldInfo = attributeType.GetField("NullableFlags");
+                    state.NullableAttrType = attributeType;
+                }
+
+                if (state.NullableFlagsFieldInfo?.GetValue(attribute) is byte[] flags
+                    && flags.FirstOrDefault() == 1)
+                {
+                    return true;
+                }
             }
 
-            var attributeType = attribute.GetType();
-            if (attributeType != _nullableAttrType)
+            // No attribute on the member, try to find a NullableContextAttribute on the declaring type
+            var type = memberInfo.DeclaringType;
+            if (type != null)
             {
-                _nullableFlagsFieldInfo = attributeType.GetField("NullableFlags");
-                _nullableAttrType = attributeType;
+                if (state.TypeNonNullabilityContextCache.TryGetValue(type, out var cachedTypeNonNullable))
+                {
+                    return cachedTypeNonNullable;
+                }
+
+                var typeContextFlag = GetNullabilityContextFlag(state, Attribute.GetCustomAttributes(type));
+                if (typeContextFlag.HasValue)
+                {
+                    return state.TypeNonNullabilityContextCache[type] = typeContextFlag.Value == 1;
+                }
             }
 
-            // For the interpretation of NullableFlags, see
-            // https://github.com/dotnet/roslyn/blob/master/docs/features/nullable-reference-types.md#annotations
-            if (_nullableFlagsFieldInfo?.GetValue(attribute) is byte[] flags
-                && flags.FirstOrDefault() == 1)
+            // Not found at the type level, try at the module level
+            var module = memberInfo.Module;
+            if (!state.ModuleNonNullabilityContextCache.TryGetValue(module, out var moduleNonNullable))
             {
-                return true;
+                var moduleContextFlag = GetNullabilityContextFlag(state, Attribute.GetCustomAttributes(memberInfo.Module));
+                moduleNonNullable = state.ModuleNonNullabilityContextCache[module] =
+                    moduleContextFlag.HasValue && moduleContextFlag == 1;
             }
 
-            return false;
+            if (type != null)
+            {
+                state.TypeNonNullabilityContextCache[type] = moduleNonNullable;
+            }
+
+            return moduleNonNullable;
+        }
+
+        private NonNullabilityConventionState GetOrInitializeState(IConventionModelBuilder modelBuilder)
+            => (NonNullabilityConventionState)(
+                modelBuilder.Metadata.FindAnnotation(StateAnnotationName) ??
+                modelBuilder.Metadata.AddAnnotation(StateAnnotationName, new NonNullabilityConventionState())
+            ).Value;
+
+        /// <summary>
+        ///     Called after a model is finalized. Removes the cached state annotation used by this convention.
+        /// </summary>
+        /// <param name="modelBuilder"> The builder for the model. </param>
+        /// <param name="context"> Additional information associated with convention execution. </param>
+        public virtual void ProcessModelFinalized(IConventionModelBuilder modelBuilder, IConventionContext<IConventionModelBuilder> context)
+            => modelBuilder.Metadata.RemoveAnnotation(StateAnnotationName);
+
+        private class NonNullabilityConventionState
+        {
+            public Type NullableAttrType;
+            public Type NullableContextAttrType;
+            public FieldInfo NullableFlagsFieldInfo;
+            public FieldInfo NullableContextFlagFieldInfo;
+            public Dictionary<Type, bool> TypeNonNullabilityContextCache { get; } = new Dictionary<Type, bool>();
+            public Dictionary<Module, bool> ModuleNonNullabilityContextCache { get; } = new Dictionary<Module, bool>();
         }
     }
 }

--- a/src/EFCore/Metadata/Conventions/NonNullableNavigationConvention.cs
+++ b/src/EFCore/Metadata/Conventions/NonNullableNavigationConvention.cs
@@ -40,8 +40,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             Check.NotNull(relationshipBuilder, nameof(relationshipBuilder));
             Check.NotNull(navigation, nameof(navigation));
 
-            if (!IsNonNullable(navigation)
-                || navigation.IsCollection())
+            var modelBuilder = relationshipBuilder.ModelBuilder;
+
+            if (!IsNonNullable(modelBuilder, navigation) || navigation.IsCollection())
             {
                 return;
             }
@@ -51,7 +52,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 var inverse = navigation.FindInverse();
                 if (inverse != null)
                 {
-                    if (IsNonNullable(inverse))
+                    if (IsNonNullable(modelBuilder, inverse))
                     {
                         Dependencies.Logger.NonNullableReferenceOnBothNavigations(navigation, inverse);
                         return;
@@ -82,9 +83,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             context.StopProcessingIfChanged(relationshipBuilder.Metadata.DependentToPrincipal);
         }
 
-        private bool IsNonNullable(IConventionNavigation navigation)
+        private bool IsNonNullable(IConventionModelBuilder modelBuilder, IConventionNavigation navigation)
             => navigation.DeclaringEntityType.HasClrType()
                && navigation.DeclaringEntityType.GetRuntimeProperties().Find(navigation.Name) is PropertyInfo propertyInfo
-               && IsNonNullable(propertyInfo);
+               && IsNonNullable(modelBuilder, propertyInfo);
     }
 }

--- a/src/EFCore/Metadata/Conventions/NonNullableReferencePropertyConvention.cs
+++ b/src/EFCore/Metadata/Conventions/NonNullableReferencePropertyConvention.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             // If the model is spread across multiple assemblies, it may contain different NullableAttribute types as
             // the compiler synthesizes them for each assembly.
             if (propertyBuilder.Metadata.GetIdentifyingMemberInfo() is MemberInfo memberInfo
-                && IsNonNullable(memberInfo))
+                && IsNonNullable(propertyBuilder.ModelBuilder, memberInfo))
             {
                 propertyBuilder.IsRequired(true);
             }


### PR DESCRIPTION
- bit surprised this isn't pulling in '3.2.0-beta4-19326-12' but that may come once dotnet/roslyn branches
- see also #16370 and #16385 discussions

If we decide to take this (with QB approval), I'll also add a subscription to auto-update the toolset.