### PR TITLE
Query: Move Property/Navigation binding to EntityProjection directly

### DIFF
--- a/src/EFCore.Cosmos/Query/Pipeline/SelectExpression.cs
+++ b/src/EFCore.Cosmos/Query/Pipeline/SelectExpression.cs
@@ -208,14 +208,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Pipeline
             }
         }
 
-        public SqlExpression BindProperty(IProperty property, ProjectionBindingExpression projectionBindingExpression)
-            => ((EntityProjectionExpression)_projectionMapping[projectionBindingExpression.ProjectionMember])
-                .GetProperty(property);
-
-        public SqlExpression BindNavigation(INavigation navigation, ProjectionBindingExpression projectionBindingExpression)
-            => ((EntityProjectionExpression)_projectionMapping[projectionBindingExpression.ProjectionMember])
-                .GetNavigation(navigation);
-
         public override Type Type => typeof(JObject);
         public override ExpressionType NodeType => ExpressionType.Extension;
 

--- a/src/EFCore.Cosmos/Query/Pipeline/SqlExpressionFactory.cs
+++ b/src/EFCore.Cosmos/Query/Pipeline/SqlExpressionFactory.cs
@@ -368,7 +368,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Pipeline
                 if (concreteEntityType.GetDiscriminatorProperty() != null)
                 {
                     var discriminatorColumn = ((EntityProjectionExpression)selectExpression.GetMappedProjection(new ProjectionMember()))
-                    .GetProperty(concreteEntityType.GetDiscriminatorProperty());
+                    .BindProperty(concreteEntityType.GetDiscriminatorProperty());
 
                     selectExpression.ApplyPredicate(
                         Equal(discriminatorColumn, Constant(concreteEntityType.GetDiscriminatorValue())));
@@ -377,7 +377,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Pipeline
             else
             {
                 var discriminatorColumn = ((EntityProjectionExpression)selectExpression.GetMappedProjection(new ProjectionMember()))
-                    .GetProperty(concreteEntityTypes[0].GetDiscriminatorProperty());
+                    .BindProperty(concreteEntityTypes[0].GetDiscriminatorProperty());
 
                 selectExpression.ApplyPredicate(
                     In(discriminatorColumn, Constant(concreteEntityTypes.Select(et => et.GetDiscriminatorValue()).ToList()), negated: false));

--- a/src/EFCore.Relational/Query/Pipeline/EntityProjectionExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/EntityProjectionExpression.cs
@@ -91,7 +91,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
         public override ExpressionType NodeType => ExpressionType.Extension;
         public override Type Type => EntityType.ClrType;
 
-        public ColumnExpression GetProperty(IProperty property)
+        public ColumnExpression BindProperty(IProperty property)
         {
             if (!EntityType.GetTypesInHierarchy().Contains(property.DeclaringEntityType))
             {

--- a/src/EFCore.Relational/Query/Pipeline/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Pipeline/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -622,8 +622,9 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                     var selectExpression = (SelectExpression)source.QueryExpression;
                     var concreteEntityTypes = derivedType.GetConcreteDerivedTypesInclusive().ToList();
                     var projectionBindingExpression = (ProjectionBindingExpression)entityShaperExpression.ValueBufferExpression;
-                    var discriminatorColumn = selectExpression
-                        .BindProperty(projectionBindingExpression, entityType.GetDiscriminatorProperty());
+                    var entityProjectionExpression = (EntityProjectionExpression)selectExpression.GetMappedProjection(
+                        projectionBindingExpression.ProjectionMember);
+                    var discriminatorColumn = entityProjectionExpression.BindProperty(entityType.GetDiscriminatorProperty());
 
                     var predicate = concreteEntityTypes.Count == 1
                         ? _sqlExpressionFactory.Equal(discriminatorColumn,

--- a/src/EFCore.Relational/Query/Pipeline/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Pipeline/RelationalSqlTranslatingExpressionVisitor.cs
@@ -167,15 +167,15 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 
         protected override Expression VisitMember(MemberExpression memberExpression)
         {
-            if (memberExpression.Expression is EntityShaperExpression
-                || (memberExpression.Expression is UnaryExpression innerUnaryExpression
-                    && innerUnaryExpression.NodeType == ExpressionType.Convert
-                    && innerUnaryExpression.Operand is EntityShaperExpression))
-            {
-                return BindProperty(memberExpression.Expression, memberExpression.Member.GetSimpleMemberName());
-            }
-
             var innerExpression = Visit(memberExpression.Expression);
+
+            if (innerExpression is EntityProjectionExpression
+                || (innerExpression is UnaryExpression innerUnaryExpression
+                    && innerUnaryExpression.NodeType == ExpressionType.Convert
+                    && innerUnaryExpression.Operand is EntityProjectionExpression))
+            {
+                return BindProperty(innerExpression, memberExpression.Member.GetSimpleMemberName());
+            }
 
             return TranslationFailed(memberExpression.Expression, innerExpression)
                 ? null
@@ -195,9 +195,9 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                 }
             }
 
-            if (source is EntityShaperExpression entityShaper)
+            if (source is EntityProjectionExpression entityProjection)
             {
-                var entityType = entityShaper.EntityType;
+                var entityType = entityProjection.EntityType;
                 if (convertedType != null)
                 {
                     entityType = entityType.RootType().GetDerivedTypesInclusive()
@@ -209,25 +209,23 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                     }
                 }
 
-                return BindProperty(entityShaper, entityType.FindProperty(propertyName));
+                return BindProperty(entityProjection, entityType.FindProperty(propertyName));
             }
 
             throw new InvalidOperationException();
         }
 
-        private SqlExpression BindProperty(EntityShaperExpression entityShaperExpression, IProperty property)
+        private SqlExpression BindProperty(EntityProjectionExpression entityProjectionExpression, IProperty property)
         {
-            var projectionBindingExpression = (ProjectionBindingExpression)entityShaperExpression.ValueBufferExpression;
-            return ((SelectExpression)projectionBindingExpression.QueryExpression)
-                .BindProperty(projectionBindingExpression, property);
+            return entityProjectionExpression.BindProperty(property);
         }
 
         protected override Expression VisitTypeBinary(TypeBinaryExpression typeBinaryExpression)
         {
             if (typeBinaryExpression.NodeType == ExpressionType.TypeIs
-                && typeBinaryExpression.Expression is EntityShaperExpression entityShaperExpression)
+                && Visit(typeBinaryExpression.Expression) is EntityProjectionExpression entityProjectionExpression)
             {
-                var entityType = entityShaperExpression.EntityType;
+                var entityType = entityProjectionExpression.EntityType;
                 if (entityType.GetAllBaseTypesInclusive().Any(et => et.ClrType == typeBinaryExpression.TypeOperand))
                 {
                     return _sqlExpressionFactory.Constant(true);
@@ -237,7 +235,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                 if (derivedType != null)
                 {
                     var concreteEntityTypes = derivedType.GetConcreteDerivedTypesInclusive().ToList();
-                    var discriminatorColumn = BindProperty(entityShaperExpression, entityType.GetDiscriminatorProperty());
+                    var discriminatorColumn = BindProperty(entityProjectionExpression, entityType.GetDiscriminatorProperty());
 
                     return concreteEntityTypes.Count == 1
                         ? _sqlExpressionFactory.Equal(discriminatorColumn,
@@ -277,7 +275,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
             // EF.Property case
             if (methodCallExpression.TryGetEFPropertyArguments(out var source, out var propertyName))
             {
-                return BindProperty(source, propertyName);
+                return BindProperty(Visit(source), propertyName);
             }
 
             // GroupBy Aggregate case
@@ -459,15 +457,30 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
             => new SqlParameterExpression(parameterExpression, null);
 
         protected override Expression VisitExtension(Expression extensionExpression)
-            => extensionExpression switch
+        {
+            switch (extensionExpression)
             {
-                EntityShaperExpression e         => e,
-                SqlExpression e                  => e,
-                NullConditionalExpression e      => Visit(e.AccessOperation),
-                CorrelationPredicateExpression e => Visit(e.EqualExpression),
-                ProjectionBindingExpression e    => ((SelectExpression)e.QueryExpression).GetMappedProjection(e.ProjectionMember),
-                _ => null
-            };
+                case EntityProjectionExpression _:
+                case SqlExpression _:
+                    return extensionExpression;
+
+                case NullConditionalExpression nullConditionalExpression:
+                    return Visit(nullConditionalExpression.AccessOperation);
+
+                case EntityShaperExpression entityShaperExpression:
+                    return Visit(entityShaperExpression.ValueBufferExpression);
+
+                case CorrelationPredicateExpression correlationPredicateExpression:
+                    return Visit(correlationPredicateExpression.EqualExpression);
+
+                case ProjectionBindingExpression projectionBindingExpression:
+                    var selectExpression = (SelectExpression)projectionBindingExpression.QueryExpression;
+                    return selectExpression.GetMappedProjection(projectionBindingExpression.ProjectionMember);
+
+                default:
+                    return null;
+            }
+        }
 
         protected override Expression VisitConditional(ConditionalExpression conditionalExpression)
         {
@@ -494,16 +507,19 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
         {
             var operand = Visit(unaryExpression.Operand);
 
+            if (operand is EntityProjectionExpression)
+            {
+                return unaryExpression.Update(operand);
+            }
+
             if (TranslationFailed(unaryExpression.Operand, operand))
             {
                 return null;
             }
 
             var sqlOperand = (SqlExpression)operand;
-
             switch (unaryExpression.NodeType)
             {
-
                 case ExpressionType.Not:
                     return _sqlExpressionFactory.Not(sqlOperand);
 

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressionFactory.cs
@@ -549,7 +549,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
                 }
 
                 var discriminatorColumn = ((EntityProjectionExpression)selectExpression.GetMappedProjection(new ProjectionMember()))
-                    .GetProperty(concreteEntityType.GetDiscriminatorProperty());
+                    .BindProperty(concreteEntityType.GetDiscriminatorProperty());
 
                 selectExpression.ApplyPredicate(
                     Equal(discriminatorColumn, Constant(concreteEntityType.GetDiscriminatorValue())));
@@ -558,7 +558,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
             else
             {
                 var discriminatorColumn = ((EntityProjectionExpression)selectExpression.GetMappedProjection(new ProjectionMember()))
-                    .GetProperty(concreteEntityTypes[0].GetDiscriminatorProperty());
+                    .BindProperty(concreteEntityTypes[0].GetDiscriminatorProperty());
 
                 selectExpression.ApplyPredicate(
                     In(discriminatorColumn, Constant(concreteEntityTypes.Select(et => et.GetDiscriminatorValue()).ToList()), negated: false));

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SelectExpression.cs
@@ -87,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             {
                 foreach (var property in entityType.FindPrimaryKey().Properties)
                 {
-                    _identifier.Add(entityProjection.GetProperty(property));
+                    _identifier.Add(entityProjection.BindProperty(property));
                 }
             }
         }
@@ -109,7 +109,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
             {
                 foreach (var property in entityType.FindPrimaryKey().Properties)
                 {
-                    _identifier.Add(entityProjection.GetProperty(property));
+                    _identifier.Add(entityProjection.BindProperty(property));
                 }
             }
         }
@@ -128,12 +128,6 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
                 && Projection.All(pe => pe.Expression is ColumnExpression column ? ReferenceEquals(column.Table, fromSql) : false);
         }
 
-        public SqlExpression BindProperty(ProjectionBindingExpression projectionBindingExpression, IProperty property)
-        {
-            return ((EntityProjectionExpression)_projectionMapping[projectionBindingExpression.ProjectionMember])
-                .GetProperty(property);
-        }
-
         public void ApplyProjection()
         {
             if (Projection.Any())
@@ -150,7 +144,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
 
                     foreach (var property in GetAllPropertiesInHierarchy(entityProjection.EntityType))
                     {
-                        map[property] = AddToProjection(entityProjection.GetProperty(property));
+                        map[property] = AddToProjection(entityProjection.BindProperty(property));
                     }
                     result[keyValuePair.Key] = Constant(map);
                 }
@@ -219,7 +213,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
                 dictionary = new Dictionary<IProperty, int>();
                 foreach (var property in GetAllPropertiesInHierarchy(entityProjection.EntityType))
                 {
-                    dictionary[property] = AddToProjection(entityProjection.GetProperty(property));
+                    dictionary[property] = AddToProjection(entityProjection.BindProperty(property));
                 }
 
                 _entityProjectionCache[entityProjection] = dictionary;
@@ -506,8 +500,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
                     {
                         propertyExpressions[property] = AddSetOperationColumnProjections(
                             property,
-                            select1, projection1.GetProperty(property),
-                            select2, projection2.GetProperty(property));
+                            select1, projection1.BindProperty(property),
+                            select2, projection2.BindProperty(property));
                     }
 
                     _projectionMapping[projectionMember] = new EntityProjectionExpression(projection1.EntityType, propertyExpressions);
@@ -589,7 +583,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
                         var propertyExpressions = new Dictionary<IProperty, ColumnExpression>();
                         foreach (var property in GetAllPropertiesInHierarchy(entityProjection.EntityType))
                         {
-                            var innerColumn = entityProjection.GetProperty(property);
+                            var innerColumn = entityProjection.BindProperty(property);
                             var index = subquery.AddToProjection(innerColumn);
                             var projectionExpression = subquery._projection[index];
                             var outerColumn = new ColumnExpression(projectionExpression, subquery, IsNullableProjection(projectionExpression));

--- a/src/EFCore.Sqlite.Core/Query/Pipeline/SqliteSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Sqlite.Core/Query/Pipeline/SqliteSqlTranslatingExpressionVisitor.cs
@@ -90,8 +90,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Pipeline
 
         protected override Expression VisitUnary(UnaryExpression unaryExpression)
         {
-            var visitedExpression = (SqlExpression)base.VisitUnary(unaryExpression);
-
+            var visitedExpression = base.VisitUnary(unaryExpression);
             if (visitedExpression == null)
             {
                 return null;

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
@@ -977,6 +977,81 @@ FROM ""Products"" AS ""p""
 WHERE CAST(""p"".""UnitPrice"" AS REAL) > 100.0");
         }
 
+        public override async Task Select_distinct_long_count(bool isAsync)
+        {
+            await base.Select_distinct_long_count(isAsync);
+
+            AssertSql(
+                @"SELECT COUNT(*)
+FROM (
+    SELECT DISTINCT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
+    FROM ""Customers"" AS ""c""
+) AS ""t""");
+        }
+
+        public override async Task Select_orderBy_skip_long_count(bool isAsync)
+        {
+            await base.Select_orderBy_skip_long_count(isAsync);
+
+            AssertSql(
+                @"@__p_0='7' (DbType = String)
+
+SELECT COUNT(*)
+FROM (
+    SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
+    FROM ""Customers"" AS ""c""
+    ORDER BY ""c"".""Country""
+    LIMIT -1 OFFSET @__p_0
+) AS ""t""");
+        }
+
+        public override async Task Select_orderBy_take_long_count(bool isAsync)
+        {
+            await base.Select_orderBy_take_long_count(isAsync);
+
+            AssertSql(
+                @"@__p_0='7' (DbType = String)
+
+SELECT COUNT(*)
+FROM (
+    SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
+    FROM ""Customers"" AS ""c""
+    ORDER BY ""c"".""Country""
+    LIMIT @__p_0
+) AS ""t""");
+        }
+
+        public override async Task Select_skip_long_count(bool isAsync)
+        {
+            await base.Select_skip_long_count(isAsync);
+
+            AssertSql(
+                @"@__p_0='7' (DbType = String)
+
+SELECT COUNT(*)
+FROM (
+    SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
+    FROM ""Customers"" AS ""c""
+    ORDER BY (SELECT 1)
+    LIMIT -1 OFFSET @__p_0
+) AS ""t""");
+        }
+
+        public override async Task Select_take_long_count(bool isAsync)
+        {
+            await base.Select_take_long_count(isAsync);
+
+            AssertSql(
+                @"@__p_0='7' (DbType = String)
+
+SELECT COUNT(*)
+FROM (
+    SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
+    FROM ""Customers"" AS ""c""
+    LIMIT @__p_0
+) AS ""t""");
+        }
+
         [ConditionalTheory(Skip = "SQLite bug")]
         public override Task Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault_2(bool isAsync)
             => base.Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault_2(isAsync);


### PR DESCRIPTION
Support for Owned entities
Part of #15285

Also added SQL Assertion on Sqlite for LongCount