### PR TITLE
Remove references to an entity when it is detached

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
@@ -513,8 +513,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 {
                     InitialFixup(entry, null, fromQuery: false);
                 }
-                else if (entry.EntityState == EntityState.Detached
-                         && oldState == EntityState.Deleted)
+                else if (entry.EntityState == EntityState.Detached)
                 {
                     DeleteFixup(entry);
                 }

--- a/test/EFCore.Specification.Tests/GraphUpdatesFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdatesFixtureBase.cs
@@ -413,6 +413,9 @@ namespace Microsoft.EntityFrameworkCore
                 modelBuilder.Entity<TaskChoice>();
                 modelBuilder.Entity<ParentAsAChild>();
                 modelBuilder.Entity<ChildAsAParent>();
+
+                modelBuilder.Entity<Poost>();
+                modelBuilder.Entity<Bloog>();
             }
 
             protected virtual object CreateFullGraph()
@@ -688,6 +691,18 @@ namespace Microsoft.EntityFrameworkCore
                     new ParentAsAChild
                     {
                         ChildAsAParent = new ChildAsAParent()
+                    });
+
+                var bloog = new Bloog { Id = 515 };
+
+                context.AddRange(
+                    new Poost
+                    {
+                        Id = 516, Bloog = bloog
+                    },
+                    new Poost
+                    {
+                        Id = 517, Bloog = bloog
                     });
 
                 context.SaveChanges();
@@ -2841,6 +2856,52 @@ namespace Microsoft.EntityFrameworkCore
             {
                 get => _choices;
                 set => SetWithNotify(value, ref _choices);
+            }
+        }
+
+        protected class Bloog : NotifyingEntity
+        {
+            private int _id;
+            private IEnumerable<Poost> _poosts = new ObservableHashSet<Poost>(ReferenceEqualityComparer.Instance);
+
+            [DatabaseGenerated(DatabaseGeneratedOption.None)]
+            public int Id
+            {
+                get => _id;
+                set => SetWithNotify(value, ref _id);
+            }
+
+            public IEnumerable<Poost> Poosts
+            {
+                get => _poosts;
+                set => SetWithNotify(value, ref _poosts);
+            }
+        }
+
+        protected class Poost : NotifyingEntity
+        {
+            private int _id;
+            private int? _bloogId;
+            private Bloog _bloog;
+
+            [DatabaseGenerated(DatabaseGeneratedOption.None)]
+            public int Id
+            {
+                get => _id;
+                set => SetWithNotify(value, ref _id);
+            }
+
+
+            public int? BloogId
+            {
+                get => _bloogId;
+                set => SetWithNotify(value, ref _bloogId);
+            }
+
+            public Bloog Bloog
+            {
+                get => _bloog;
+                set => SetWithNotify(value, ref _bloog);
             }
         }
 

--- a/test/EFCore.Specification.Tests/ProxyGraphUpdatesTestBase.cs
+++ b/test/EFCore.Specification.Tests/ProxyGraphUpdatesTestBase.cs
@@ -680,8 +680,8 @@ namespace Microsoft.EntityFrameworkCore
                     Assert.Same(root, new1.Root);
                     Assert.Same(new1, new2.Back);
 
-                    Assert.Same(oldRoot, old1.Root);
-                    Assert.Same(old1, old2.Back);
+                    Assert.Null(old1.Root);
+                    Assert.Null(old2.Back);
                     Assert.Equal(old1.Id, old2.Id);
                 });
         }


### PR DESCRIPTION
Fixes #15645
Fixes #13110 (was already working in 3.0, but added a test)
Fixes #15500 (was already working in 3.0, but added a test)

See also #16454
