### PR TITLE
Don't set constructor binding by convention if already set

### DIFF
--- a/src/EFCore/Metadata/Conventions/ConstructorBindingConvention.cs
+++ b/src/EFCore/Metadata/Conventions/ConstructorBindingConvention.cs
@@ -48,7 +48,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         {
             foreach (var entityType in modelBuilder.Metadata.GetEntityTypes())
             {
-                if (entityType.ClrType?.IsAbstract == false)
+                if (entityType.ClrType?.IsAbstract == false
+                    && entityType.Builder.CanSetAnnotation(CoreAnnotationNames.ConstructorBinding, null))
                 {
                     var maxServiceParams = 0;
                     var minPropertyParams = int.MaxValue;


### PR DESCRIPTION
Fixes #13891
