### PR TITLE
Use unique database names for Cosmos tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,8 @@ variables:
     value: ENTITYFRAMEWORKCORE
   - name: _CosmosConnectionUrl
     value: https://ef-nightly-test.documents.azure.com:443/
+  - name: _CosmosToken
+    value: C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==
 
 trigger:
   - master

--- a/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
@@ -19,6 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.TestUtilities
         private readonly TestStoreContext _storeContext;
         private readonly string _dataFilePath;
         private readonly Action<CosmosDbContextOptionsBuilder> _configureCosmos;
+        private static readonly Guid _runId = Guid.NewGuid();
 
         public static CosmosTestStore Create(string name, Action<CosmosDbContextOptionsBuilder> extensionConfiguration = null)
             => new CosmosTestStore(name, shared: false, extensionConfiguration: extensionConfiguration);
@@ -33,7 +34,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.TestUtilities
 
         private CosmosTestStore(
             string name, bool shared = true, string dataFilePath = null, Action<CosmosDbContextOptionsBuilder> extensionConfiguration = null)
-            : base(name, shared)
+            : base(name + _runId.ToString(), shared)
         {
             ConnectionUri = TestEnvironment.DefaultConnection;
             AuthToken = TestEnvironment.AuthToken;


### PR DESCRIPTION
Use a dummy token to skip the tests, as they fail if no token is set