### PR TITLE
Add feeds from Versions.props to NuGet.config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -3,5 +3,6 @@
   <packageSources>
     <clear />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <add key="aspnet-extensions" value="https://dotnetfeed.blob.core.windows.net/aspnet-extensions/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
We need all restore sources to be located in NuGet.config since internal feeds can only be restored from there. More details including next steps [here](https://github.com/dotnet/arcade/blob/master/Documentation/RestoreSourcesUpdateStatus.md)

/cc @riarenas @jcagme