### PR TITLE
Query: Translation of LambdaExpression is null

### DIFF
--- a/src/EFCore.Cosmos/Query/Pipeline/CosmosSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Pipeline/CosmosSqlTranslatingExpressionVisitor.cs
@@ -313,6 +313,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Pipeline
 
         protected override Expression VisitInvocation(InvocationExpression node) => null;
 
+        protected override Expression VisitLambda<T>(Expression<T> node) => null;
+
         protected override Expression VisitConstant(ConstantExpression constantExpression)
             => new SqlConstantExpression(constantExpression, null);
 

--- a/src/EFCore.InMemory/Query/Pipeline/InMemoryExpressionTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Pipeline/InMemoryExpressionTranslatingExpressionVisitor.cs
@@ -253,6 +253,12 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Pipeline
             }
         }
 
+        protected override Expression VisitListInit(ListInitExpression node) => null;
+
+        protected override Expression VisitInvocation(InvocationExpression node) => null;
+
+        protected override Expression VisitLambda<T>(Expression<T> node) => null;
+
         protected override Expression VisitParameter(ParameterExpression parameterExpression)
         {
             if (parameterExpression.Name.StartsWith(CompiledQueryCache.CompiledQueryParameterPrefix))

--- a/src/EFCore.Relational/Query/Pipeline/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Pipeline/RelationalSqlTranslatingExpressionVisitor.cs
@@ -449,6 +449,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
 
         protected override Expression VisitInvocation(InvocationExpression node) => null;
 
+        protected override Expression VisitLambda<T>(Expression<T> node) => null;
+
         protected override Expression VisitConstant(ConstantExpression constantExpression)
             => new SqlConstantExpression(constantExpression, null);
 


### PR DESCRIPTION
Resolves #16597

If we visit lambda then the parameter would be translated to server equivalent which cannot be used anymore to reconstruct the lambda expression so it threw weird exception.
LambdaExpression cannot be server represented hence return null

