### PR TITLE
Add test for ambiguous self-reference case

### DIFF
--- a/test/EFCore.Tests/ModelBuilding/OneToOneTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OneToOneTestBase.cs
@@ -4459,6 +4459,18 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 }
             }
 
+            [ConditionalFact]
+            public virtual void Multiple_self_referencing_navigations_throw_as_ambiguous()
+            {
+                var modelBuilder = CreateModelBuilder();
+
+                modelBuilder.Entity<User>();
+
+                Assert.Equal(
+                    CoreStrings.AmbiguousOneToOneRelationship("User.CreatedBy", "User.UpdatedBy"),
+                    Assert.Throws<InvalidOperationException>(() => modelBuilder.FinalizeModel()).Message);
+            }
+
             private static void AssertGraph(Node node1, Node node2, Node node3)
             {
                 Assert.Null(node1.PreviousNode);

--- a/test/EFCore.Tests/ModelBuilding/TestModel.cs
+++ b/test/EFCore.Tests/ModelBuilding/TestModel.cs
@@ -280,6 +280,21 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public int SelfRefId { get; set; }
         }
 
+        protected class User
+        {
+            [Required]
+            public Guid Id { get; set; }
+            [Required]
+            [MaxLength(150)]
+            public string Name { get; set; }
+            [Required]
+            public User CreatedBy { get; set; }
+            public User UpdatedBy { get; set; }
+            [Required]
+            public Guid CreatedById { get; set; }
+            public Guid? UpdatedById { get; set; }
+        }
+
         protected class SelfRefManyToOneDerived : SelfRefManyToOne
         {
         }


### PR DESCRIPTION
Verified that this is already fixed in 3.0. (Also verified that it did throw in 2.2, so this is a 3.0 fix.)

Issue #13573
