### PR TITLE
Add type mapping to SqlFragmentExpression

### DIFF
--- a/src/EFCore.Relational/Query/Pipeline/ISqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/Pipeline/ISqlExpressionFactory.cs
@@ -67,7 +67,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
         InExpression In(SqlExpression item, SelectExpression subquery, bool negated);
         LikeExpression Like(SqlExpression match, SqlExpression pattern, SqlExpression escapeChar = null);
         SqlConstantExpression Constant(object value, RelationalTypeMapping typeMapping = null);
-        SqlFragmentExpression Fragment(string sql);
+        SqlFragmentExpression Fragment(string sql, RelationalTypeMapping typeMapping = null);
 
         SelectExpression Select(SqlExpression projection);
         SelectExpression Select(IEntityType entityType);

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressionFactory.cs
@@ -401,8 +401,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline
         public LikeExpression Like(SqlExpression match, SqlExpression pattern, SqlExpression escapeChar = null)
             => (LikeExpression)ApplyDefaultTypeMapping(new LikeExpression(match, pattern, escapeChar, null));
 
-        public SqlFragmentExpression Fragment(string sql)
-            => new SqlFragmentExpression(sql);
+        public SqlFragmentExpression Fragment(string sql, RelationalTypeMapping typeMapping = null)
+            => new SqlFragmentExpression(sql, typeMapping);
 
         public SqlConstantExpression Constant(object value, RelationalTypeMapping typeMapping = null)
             => new SqlConstantExpression(Expression.Constant(value), typeMapping);

--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SqlFragmentExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SqlFragmentExpression.cs
@@ -4,13 +4,14 @@
 using System;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Query.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
 {
     public class SqlFragmentExpression : SqlExpression
     {
-        internal SqlFragmentExpression(string sql)
-            : base(typeof(string), null)
+        internal SqlFragmentExpression(string sql, RelationalTypeMapping typeMapping)
+            : base(typeof(string), typeMapping)
         {
             Sql = sql;
         }


### PR DESCRIPTION
To allow fragments to participate in type inference.

The concrete PostgreSQL case is to generate a [`NOW AT TIME ZONE UTC`](https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-ZONECONVERT) literal as a fragment, and to mark that with the appropriate type mapping. This way it can influence type inference when participating in other expressions.