### PR TITLE
Fix ExpressionPrinter logic for InExpression arrays

### DIFF
--- a/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SqlConstantExpression.cs
+++ b/src/EFCore.Relational/Query/Pipeline/SqlExpressions/SqlConstantExpression.cs
@@ -26,31 +26,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Query.Pipeline.SqlExpressions
         protected override Expression VisitChildren(ExpressionVisitor visitor) => this;
         public override void Print(ExpressionPrinter expressionPrinter) => Print(Value, expressionPrinter);
 
-        private void Print(
-            object value,
-            ExpressionPrinter expressionPrinter)
-        {
-            if (value is IEnumerable enumerable
-                && !(value is string)
-                && !(value is byte[]))
-            {
-                bool first = true;
-                foreach (var item in enumerable)
-                {
-                    if (!first)
-                    {
-                        expressionPrinter.StringBuilder.Append(", ");
-                    }
-
-                    first = false;
-                    Print(item, expressionPrinter);
-                }
-            }
-            else
-            {
-                expressionPrinter.StringBuilder.Append(TypeMapping?.GenerateSqlLiteral(value) ?? Value?.ToString() ?? "NULL");
-            }
-        }
+        private void Print(object value, ExpressionPrinter expressionPrinter)
+            => expressionPrinter.StringBuilder.Append(TypeMapping?.GenerateSqlLiteral(value) ?? Value?.ToString() ?? "NULL");
 
         public override bool Equals(object obj)
             => obj != null


### PR DESCRIPTION
InExpression can hold an SqlConstantExpression with an array value, but with its elements' type mapping (i.e. string[] value but SqlServerStringMapping type mapping, which don't correspond). As a result SqlConstantExpression contained special logic for printing its values when the value is Enumerable, but this logic breaks for PostgreSQL where array constants are an actual thing.

Move array printing logic from SqlConstantExpression to InExpression to unblock native PostgreSQL arrays.