### PR TITLE
Apply column comments when creating tables

### DIFF
--- a/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
+++ b/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
@@ -573,6 +573,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 GenerateComment(operation, model, builder, operation.Comment, operation.Schema, operation.Name);
             }
 
+            foreach (var column in operation.Columns.Where(c => c.Comment != null))
+            {
+                GenerateComment(operation, model, builder, column.Comment, operation.Schema, operation.Name, column.Name);
+            }
+
             if (terminate)
             {
                 builder.AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator);

--- a/test/EFCore.Relational.Specification.Tests/MigrationSqlGeneratorTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/MigrationSqlGeneratorTestBase.cs
@@ -497,7 +497,8 @@ namespace Microsoft.EntityFrameworkCore
                             Name = "EmployerId",
                             Table = "People",
                             ClrType = typeof(int),
-                            IsNullable = true
+                            IsNullable = true,
+                            Comment = "Employer ID comment"
                         },
                         new AddColumnOperation
                         {
@@ -534,7 +535,8 @@ namespace Microsoft.EntityFrameworkCore
                             PrincipalTable = "Companies",
                             PrincipalColumns = new[] { "Id" }
                         }
-                    }
+                    },
+                    Comment = "Table comment"
                 });
 
         [ConditionalFact]

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerMigrationSqlGeneratorTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerMigrationSqlGeneratorTest.cs
@@ -17,6 +17,28 @@ namespace Microsoft.EntityFrameworkCore
 {
     public class SqlServerMigrationSqlGeneratorTest : MigrationSqlGeneratorTestBase
     {
+        public override void CreateTableOperation()
+        {
+            base.CreateTableOperation();
+
+            Assert.Equal(
+                @"CREATE TABLE [dbo].[People] (
+    [Id] int NOT NULL,
+    [EmployerId] int NULL,
+    [SSN] char(11) NULL,
+    PRIMARY KEY ([Id]),
+    UNIQUE ([SSN]),
+    CHECK (SSN > 0),
+    FOREIGN KEY ([EmployerId]) REFERENCES [Companies] ([Id])
+)GO
+
+EXEC sp_addextendedproperty @name = N'Comment', @value = N'Table comment', @level0type = N'Schema', @level0name = N'dbo', @level1type = N'Table', @level1name = N'People'GO
+
+EXEC sp_addextendedproperty @name = N'Comment', @value = N'Employer ID comment', @level0type = N'Schema', @level0name = N'dbo', @level1type = N'Table', @level1name = N'People', @level2type = N'Column', @level2name = N'EmployerId';
+",
+                Sql, ignoreLineEndingDifferences: true);
+        }
+
         public override void CreateIndexOperation_with_filter_where_clause()
         {
             base.CreateIndexOperation_with_filter_where_clause();


### PR DESCRIPTION
In our current comment support (#15037), when creating a table only the table's comment is applied, and not the table's columns' comments.