### PR TITLE
Test to verify owned references in project load automatically

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
@@ -20,6 +20,11 @@ namespace Microsoft.EntityFrameworkCore.Query
             //TestLoggerFactory.TestOutputHelper = testOutputHelper;
         }
 
+        [ConditionalFact(Skip = "Issue#12086")]
+        public override void Query_loads_reference_nav_automatically_in_projection()
+        {
+        }
+
         [ConditionalFact(Skip = "Issue#15711")]
         public override void Query_with_owned_entity_equality_operator()
         {
@@ -475,6 +480,31 @@ WHERE (c[""Discriminator""] = ""LeafA"")");
                                     new { Id = "H", Name = "Hydrogen", StarId = 1 },
                                     new { Id = "He", Name = "Helium", StarId = 1 });
                             });
+                    });
+
+                modelBuilder.Entity<Barton>(
+                    b =>
+                    {
+                        b.OwnsOne(
+                            e => e.Throned, b => b.HasData(
+                                new
+                                {
+                                    BartonId = 1,
+                                    Property = "Property"
+                                }));
+                        b.HasData(
+                            new Barton
+                            {
+                                Id = 1, Simple = "Simple"
+                            });
+
+                    });
+
+                modelBuilder.Entity<Fink>().HasData(
+                    new
+                    {
+                        Id = 1,
+                        BartonId = 1
                     });
             }
         }

--- a/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
@@ -442,6 +442,20 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
+
+        [ConditionalFact]
+        public virtual void Query_loads_reference_nav_automatically_in_projection()
+        {
+            using (var context = CreateContext())
+            {
+                var barton = context.Set<Fink>().Select(e => e.Barton).Single();
+
+                Assert.Equal(1, barton.Id);
+                Assert.Equal("Simple", barton.Simple);
+                Assert.Equal("Property", barton.Throned.Property);
+            }
+        }
+
         protected virtual DbContext CreateContext() => Fixture.CreateContext();
 
         public abstract class OwnedQueryFixtureBase : SharedStoreFixtureBase<PoolableDbContext>
@@ -672,6 +686,31 @@ namespace Microsoft.EntityFrameworkCore.Query
                         //            new { Id = "He", Name = "Helium", StarId = 1 });
                         //    });
                     });
+
+                modelBuilder.Entity<Barton>(
+                    b =>
+                    {
+                        b.OwnsOne(
+                            e => e.Throned, b => b.HasData(
+                                new
+                                {
+                                    BartonId = 1,
+                                    Property = "Property"
+                                }));
+                        b.HasData(
+                            new Barton
+                            {
+                                Id = 1, Simple = "Simple"
+                            });
+
+                    });
+
+                modelBuilder.Entity<Fink>().HasData(
+                    new
+                    {
+                        Id = 1,
+                        BartonId = 1
+                    });
             }
 
             public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
@@ -761,6 +800,27 @@ namespace Microsoft.EntityFrameworkCore.Query
             public string Name { get; set; }
 
             public int StarId { get; set; }
+        }
+
+        protected class Barton
+        {
+            public int Id { get; set; }
+
+            public Throned Throned { get; set; }
+
+            public string Simple { get; set; }
+        }
+
+        protected class Fink
+        {
+            public Barton Barton { get; set; }
+
+            public int Id { get; set; }
+        }
+
+        protected class Throned
+        {
+            public string Property { get; set; }
         }
     }
 }


### PR DESCRIPTION
Fixes #13546

Still fails on Cosmos, but due to failed left-join translation.
