### PR TITLE
Entity equality support for non-anonymous DTOs

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosProjectionBindingExpressionVisitor.cs
@@ -331,37 +331,55 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         /// </summary>
         protected override Expression VisitMemberInit(MemberInitExpression memberInitExpression)
         {
-            var newExpression = (NewExpression)Visit(memberInitExpression.NewExpression);
+            var newExpression = VisitAndConvert(memberInitExpression.NewExpression, nameof(VisitMemberInit));
             if (newExpression == null)
             {
                 return null;
             }
 
-            var newBindings = new MemberAssignment[memberInitExpression.Bindings.Count];
+            var newBindings = new MemberBinding[memberInitExpression.Bindings.Count];
             for (var i = 0; i < newBindings.Length; i++)
             {
-                var memberAssignment = (MemberAssignment)memberInitExpression.Bindings[i];
-                if (_clientEval)
+                if (memberInitExpression.Bindings[i].BindingType != MemberBindingType.Assignment)
                 {
-                    newBindings[i] = memberAssignment.Update(Visit(memberAssignment.Expression));
+                    return null;
                 }
-                else
+
+                newBindings[i] = VisitMemberBinding(memberInitExpression.Bindings[i]);
+
+                if (newBindings[i] == null)
                 {
-                    var projectionMember = _projectionMembers.Peek().Append(memberAssignment.Member);
-                    _projectionMembers.Push(projectionMember);
-
-                    var visitedExpression = Visit(memberAssignment.Expression);
-                    if (visitedExpression == null)
-                    {
-                        return null;
-                    }
-
-                    newBindings[i] = memberAssignment.Update(visitedExpression);
-                    _projectionMembers.Pop();
+                    return null;
                 }
             }
 
             return memberInitExpression.Update(newExpression, newBindings);
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        protected override MemberAssignment VisitMemberAssignment(MemberAssignment memberAssignment)
+        {
+            if (_clientEval)
+            {
+                return memberAssignment.Update(Visit(memberAssignment.Expression));
+            }
+
+            var projectionMember = _projectionMembers.Peek().Append(memberAssignment.Member);
+            _projectionMembers.Push(projectionMember);
+
+            var visitedExpression = Visit(memberAssignment.Expression);
+            if (visitedExpression == null)
+            {
+                return null;
+            }
+
+            _projectionMembers.Pop();
+            return memberAssignment.Update(visitedExpression);
         }
 
         // TODO: Debugging

--- a/src/EFCore.InMemory/Query/Internal/InMemoryProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryProjectionBindingExpressionVisitor.cs
@@ -209,37 +209,49 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
 
         protected override Expression VisitMemberInit(MemberInitExpression memberInitExpression)
         {
-            var newExpression = (NewExpression)Visit(memberInitExpression.NewExpression);
+            var newExpression = VisitAndConvert(memberInitExpression.NewExpression, nameof(VisitMemberInit));
             if (newExpression == null)
             {
                 return null;
             }
 
-            var newBindings = new MemberAssignment[memberInitExpression.Bindings.Count];
+            var newBindings = new MemberBinding[memberInitExpression.Bindings.Count];
             for (var i = 0; i < newBindings.Length; i++)
             {
-                var memberAssignment = (MemberAssignment)memberInitExpression.Bindings[i];
-                if (_clientEval)
+                if (memberInitExpression.Bindings[i].BindingType != MemberBindingType.Assignment)
                 {
-                    newBindings[i] = memberAssignment.Update(Visit(memberAssignment.Expression));
+                    return null;
                 }
-                else
+
+                newBindings[i] = VisitMemberBinding(memberInitExpression.Bindings[i]);
+
+                if (newBindings[i] == null)
                 {
-                    var projectionMember = _projectionMembers.Peek().Append(memberAssignment.Member);
-                    _projectionMembers.Push(projectionMember);
-
-                    var visitedExpression = Visit(memberAssignment.Expression);
-                    if (visitedExpression == null)
-                    {
-                        return null;
-                    }
-
-                    newBindings[i] = memberAssignment.Update(visitedExpression);
-                    _projectionMembers.Pop();
+                    return null;
                 }
             }
 
             return memberInitExpression.Update(newExpression, newBindings);
+        }
+
+        protected override MemberAssignment VisitMemberAssignment(MemberAssignment memberAssignment)
+        {
+            if (_clientEval)
+            {
+                return memberAssignment.Update(Visit(memberAssignment.Expression));
+            }
+
+            var projectionMember = _projectionMembers.Peek().Append(memberAssignment.Member);
+            _projectionMembers.Push(projectionMember);
+
+            var visitedExpression = Visit(memberAssignment.Expression);
+            if (visitedExpression == null)
+            {
+                return null;
+            }
+
+            _projectionMembers.Pop();
+            return memberAssignment.Update(visitedExpression);
         }
 
         // TODO: Debugging

--- a/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
@@ -232,37 +232,49 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
         protected override Expression VisitMemberInit(MemberInitExpression memberInitExpression)
         {
-            var newExpression = (NewExpression)Visit(memberInitExpression.NewExpression);
+            var newExpression = VisitAndConvert(memberInitExpression.NewExpression, nameof(VisitMemberInit));
             if (newExpression == null)
             {
                 return null;
             }
 
-            var newBindings = new MemberAssignment[memberInitExpression.Bindings.Count];
+            var newBindings = new MemberBinding[memberInitExpression.Bindings.Count];
             for (var i = 0; i < newBindings.Length; i++)
             {
-                var memberAssignment = (MemberAssignment)memberInitExpression.Bindings[i];
-                if (_clientEval)
+                if (memberInitExpression.Bindings[i].BindingType != MemberBindingType.Assignment)
                 {
-                    newBindings[i] = memberAssignment.Update(Visit(memberAssignment.Expression));
+                    return null;
                 }
-                else
+
+                newBindings[i] = VisitMemberBinding(memberInitExpression.Bindings[i]);
+
+                if (newBindings[i] == null)
                 {
-                    var projectionMember = _projectionMembers.Peek().Append(memberAssignment.Member);
-                    _projectionMembers.Push(projectionMember);
-
-                    var visitedExpression = Visit(memberAssignment.Expression);
-                    if (visitedExpression == null)
-                    {
-                        return null;
-                    }
-
-                    newBindings[i] = memberAssignment.Update(visitedExpression);
-                    _projectionMembers.Pop();
+                    return null;
                 }
             }
 
             return memberInitExpression.Update(newExpression, newBindings);
+        }
+
+        protected override MemberAssignment VisitMemberAssignment(MemberAssignment memberAssignment)
+        {
+            if (_clientEval)
+            {
+                return memberAssignment.Update(Visit(memberAssignment.Expression));
+            }
+
+            var projectionMember = _projectionMembers.Peek().Append(memberAssignment.Member);
+            _projectionMembers.Push(projectionMember);
+
+            var visitedExpression = Visit(memberAssignment.Expression);
+            if (visitedExpression == null)
+            {
+                return null;
+            }
+
+            _projectionMembers.Pop();
+            return memberAssignment.Update(visitedExpression);
         }
 
         // TODO: Debugging

--- a/src/EFCore/Query/Internal/ExpressionEqualityComparer.cs
+++ b/src/EFCore/Query/Internal/ExpressionEqualityComparer.cs
@@ -711,7 +711,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     case MemberBindingType.MemberBinding:
                         return CompareMemberMemberBinding((MemberMemberBinding)a, (MemberMemberBinding)b);
                     default:
-                        throw new NotImplementedException();
+                        throw new InvalidOperationException("Unhandled member binding type: " + a.BindingType);
                 }
             }
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.cs
@@ -3828,6 +3828,12 @@ WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
         [ConditionalTheory(Skip = "Issue#14935")]
+        public override async Task Entity_equality_through_DTO_projection(bool isAsync)
+        {
+            await base.Entity_equality_through_DTO_projection(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "Issue#14935")]
         public override Task GroupJoin_customers_employees_shadow(bool isAsync)
         {
             return base.GroupJoin_customers_employees_shadow(isAsync);

--- a/test/EFCore.Specification.Tests/Query/QueryNavigationsTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/QueryNavigationsTestBase.cs
@@ -1537,5 +1537,10 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Where(od => od.Order.Customer.City == "London"),
                 entryCount: 221);
         }
+
+        private class OrderDTO
+        {
+            public Customer Customer { get; set; }
+        }
     }
 }

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -526,6 +526,23 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
+        public virtual Task Entity_equality_through_DTO_projection(bool isAsync)
+            => AssertQuery<Order>(
+                isAsync,
+                o => o
+                    .Select(o => new CustomerWrapper { Customer = o.Customer })
+                    .Where(x => x.Customer != null),
+                entryCount: 89);
+
+        private class CustomerWrapper
+        {
+            public Customer Customer { get; set; }
+            public override bool Equals(object obj) => obj is CustomerWrapper other && other.Customer.Equals(Customer);
+            public override int GetHashCode() => Customer.GetHashCode();
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual Task Entity_equality_through_subquery(bool isAsync)
             => AssertQuery<Customer>(
                 isAsync,

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -297,6 +297,17 @@ LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 WHERE [c].[CustomerID] IS NOT NULL");
         }
 
+        public override async Task Entity_equality_through_DTO_projection(bool isAsync)
+        {
+            await base.Entity_equality_through_DTO_projection(isAsync);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+WHERE [c].[CustomerID] IS NOT NULL");
+        }
+
         public override async Task Entity_equality_through_subquery(bool isAsync)
         {
             await base.Entity_equality_through_subquery(isAsync);


### PR DESCRIPTION
Also various modifications to support MemberMemberBinding better (RelationalProjectionBindingExpressionVisitor, ReplacingExpressionVisitor, ExpressionEqualityComparer)

Fixes #16789

There's probably some specific support for MemberMemberBinding missing from RelationalProjectionBindingExpressionVisitor but I think we can take care of that later.

Note that we still don't support MemberListBinding.