### PR TITLE
Allow set operations over other mapping types

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -452,17 +452,24 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                         continue;
                     }
 
-                    if (joinedMapping.Value1 is ColumnExpression && joinedMapping.Value2 is ColumnExpression
-                        || joinedMapping.Value1 is ScalarSubqueryExpression && joinedMapping.Value2 is ScalarSubqueryExpression)
+                    if (joinedMapping.Value1 is SqlExpression innerColumn1
+                        && joinedMapping.Value2 is SqlExpression innerColumn2)
                     {
-                        handleColumnMapping(
-                            joinedMapping.Key,
-                            select1, (SqlExpression)joinedMapping.Value1,
-                            select2, (SqlExpression)joinedMapping.Value2);
+                        // For now, make sure that both sides output the same store type, otherwise the query may fail.
+                        // TODO: with #15586 we'll be able to also allow different store types which are implicitly convertible to one another.
+                        if (innerColumn1.TypeMapping.StoreType != innerColumn2.TypeMapping.StoreType)
+                        {
+                            throw new InvalidOperationException("Set operations over different store types are currently unsupported");
+                        }
+
+                        var alias = joinedMapping.Key.Last?.Name;
+                        select1.AddToProjection(innerColumn1, alias);
+                        select2.AddToProjection(innerColumn2, alias);
+                        _projectionMapping[joinedMapping.Key] = innerColumn1;
                         continue;
                     }
 
-                    throw new InvalidOperationException("Non-matching or unknown projection mapping type in set operation");
+                    throw new InvalidOperationException($"Non-matching or unknown projection mapping type in set operation ({joinedMapping.Value1.GetType().Name} and {joinedMapping.Value2.GetType().Name})");
                 }
             }
 
@@ -519,19 +526,6 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                 }
 
                 return column1;
-            }
-
-            void handleColumnMapping(
-                ProjectionMember projectionMember,
-                SelectExpression select1, SqlExpression innerColumn1,
-                SelectExpression select2, SqlExpression innerColumn2)
-            {
-                // The actual columns may actually be different, but we don't care as long as the type and alias
-                // coming out of the two operands are the same
-                var alias = projectionMember.Last?.Name;
-                select1.AddToProjection(innerColumn1, alias);
-                select2.AddToProjection(innerColumn2, alias);
-                _projectionMapping[projectionMember] = innerColumn1;
             }
         }
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.SetOperations.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.SetOperations.cs
@@ -40,5 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         public override void Include_Union_different_includes_throws() {}
         public override Task SubSelect_Union(bool isAsync) => Task.CompletedTask;
         public override Task Client_eval_Union_FirstOrDefault(bool isAsync) => Task.CompletedTask;
+        public override Task GroupBy_Select_Union(bool isAsync) => Task.CompletedTask;
+        public override Task Union_over_different_projection_types(bool isAsync, string leftType, string rightType) => Task.CompletedTask;
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/Query/SimpleQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/SimpleQueryInMemoryTest.cs
@@ -217,6 +217,16 @@ namespace Microsoft.EntityFrameworkCore.Query
             return Task.CompletedTask; //base.Select_Except_reference_projection(isAsync);
         }
 
+        public override Task GroupBy_Select_Union(bool isAsync)
+        {
+            return Task.CompletedTask; //base.GroupBy_Select_Union(isAsync);
+        }
+
+        public override Task Union_over_different_projection_types(bool isAsync, string leftType, string rightType)
+        {
+            return Task.CompletedTask; //base.Union_over_different_projection_types(isAsync);
+        }
+
         #endregion
 
         [ConditionalFact(Skip = "Issue#16564")]

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.SetOperations.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.SetOperations.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
@@ -339,5 +340,60 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .Union(cs));
 
         private static Customer ClientSideMethod(Customer c) => c;
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task GroupBy_Select_Union(bool isAsync)
+            => AssertQuery<Customer>(isAsync, cs => cs
+                    .Where(c => c.City == "Berlin")
+                    .GroupBy(c => c.CustomerID)
+                    .Select(g => new { CustomerID = g.Key, Count = g.Count() })
+                    .Union(cs
+                        .Where(c => c.City == "London")
+                        .GroupBy(c => c.CustomerID)
+                        .Select(g => new { CustomerID = g.Key, Count = g.Count() })));
+
+        [ConditionalTheory]
+        [MemberData(nameof(GetSetOperandTestCases))]
+        public virtual Task Union_over_different_projection_types(bool isAsync, string leftType, string rightType)
+        {
+            var (left, right) = (ExpressionGenerator(leftType), ExpressionGenerator(rightType));
+            return AssertQuery<Order>(isAsync, os => left(os).Union(right(os)));
+
+            static Func<IQueryable<Order>, IQueryable<object>> ExpressionGenerator(string expressionType)
+            {
+                switch (expressionType)
+                {
+                    case "Column":
+                        return os => os.Select(o => (object)o.OrderID);
+                    case "Function":
+                        return os => os
+                            .GroupBy(o => o.OrderID)
+                            .Select(g => (object)g.Count());
+                    case "Constant":
+                        return os => os.Select(o => (object)8);
+                    case "Unary":
+                        return os => os.Select(o => (object)-o.OrderID);
+                    case "Binary":
+                        return os => os.Select(o => (object)(o.OrderID + 1));
+                    case "ScalarSubquery":
+                        return os => os.Select(o => (object)o.OrderDetails.Count());
+                    default:
+                        throw new NotSupportedException();
+                }
+            }
+        }
+
+        private static IEnumerable<object[]> GetSetOperandTestCases()
+            => from async in new[] { true, false }
+               from leftType in SupportedOperandExpressionType
+               from rightType in SupportedOperandExpressionType
+               select new object[] { async, leftType, rightType };
+
+        // ReSharper disable once StaticMemberInGenericType
+        private static readonly string[] SupportedOperandExpressionType =
+        {
+            "Column", "Function", "Constant", "Unary", "Binary", "ScalarSubquery"
+        };
     }
 }


### PR DESCRIPTION
Including different mapping types on the two sides, as long as the result is compatible.

Fixes #16725