### PR TITLE
Fix SQLite affinity type mapping to correctly find conversions

### DIFF
--- a/test/EFCore.Design.Tests/EFCore.Design.Tests.csproj
+++ b/test/EFCore.Design.Tests/EFCore.Design.Tests.csproj
@@ -18,6 +18,7 @@
     <ProjectReference Include="..\..\src\EFCore.InMemory\EFCore.InMemory.csproj" />
     <ProjectReference Include="..\..\src\EFCore.Design\EFCore.Design.csproj" />
     <ProjectReference Include="..\..\src\EFCore.SqlServer.NTS\EFCore.SqlServer.NTS.csproj" />
+    <ProjectReference Include="..\..\src\EFCore.Sqlite.Core\EFCore.Sqlite.Core.csproj" />
     <ProjectReference Include="..\EFCore.Relational.Tests\EFCore.Relational.Tests.csproj" />
     <ProjectReference Include="..\EFCore.SqlServer.FunctionalTests\EFCore.SqlServer.FunctionalTests.csproj" />
   </ItemGroup>

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/ScaffoldingTypeMapperSqliteTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/ScaffoldingTypeMapperSqliteTest.cs
@@ -1,0 +1,421 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal;
+using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public class ScaffoldingTypeMapperSqliteTest
+    {
+        // Native type cases...
+
+        [ConditionalTheory]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void Maps_text_column(bool keyOrIndex, bool rowVersion)
+        {
+            var mapping = CreateMapper().FindMapping("text", keyOrIndex, rowVersion);
+
+            AssertMapping<string>(mapping, inferred: true, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalTheory]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void Maps_integer_column(bool keyOrIndex, bool rowVersion)
+        {
+            var mapping = CreateMapper().FindMapping("integer", keyOrIndex, rowVersion);
+
+            AssertMapping<long>(mapping, inferred: true, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalTheory]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void Maps_blob_column(bool keyOrIndex, bool rowVersion)
+        {
+            var mapping = CreateMapper().FindMapping("blob", keyOrIndex, rowVersion);
+
+            AssertMapping<byte[]>(mapping, inferred: true, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalTheory]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void Maps_real_column(bool keyOrIndex, bool rowVersion)
+        {
+            var mapping = CreateMapper().FindMapping("real", keyOrIndex, rowVersion);
+
+            AssertMapping<double>(mapping, inferred: true, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        // Type affinity cases...
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Maps_int_column(bool isKeyOrIndex)
+        {
+            var mapping = CreateMapper().FindMapping("int", isKeyOrIndex, rowVersion: false);
+
+            AssertMapping<long>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Maps_bigint_column(bool isKeyOrIndex)
+        {
+            var mapping = CreateMapper().FindMapping("bigint", isKeyOrIndex, rowVersion: false);
+
+            AssertMapping<long>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalFact]
+        public void Maps_normal_varbinary_max_column()
+        {
+            var mapping = CreateMapper().FindMapping("varbinary(max)", keyOrIndex: false, rowVersion: false);
+
+            AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalFact]
+        public void Maps_normal_varbinary_sized_column()
+        {
+            var mapping = CreateMapper().FindMapping("varbinary(200)", keyOrIndex: false, rowVersion: false);
+
+            AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalFact]
+        public void Maps_normal_binary_sized_column()
+        {
+            var mapping = CreateMapper().FindMapping("binary(200)", keyOrIndex: false, rowVersion: false);
+
+            AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalFact]
+        public void Maps_key_varbinary_max_column()
+        {
+            var mapping = CreateMapper().FindMapping("varbinary(max)", keyOrIndex: true, rowVersion: false);
+
+            AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalFact]
+        public void Maps_key_varbinary_sized_column()
+        {
+            var mapping = CreateMapper().FindMapping("varbinary(200)", keyOrIndex: true, rowVersion: false);
+
+            AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalFact]
+        public void Maps_key_varbinary_default_sized_column()
+        {
+            var mapping = CreateMapper().FindMapping("varbinary(900)", keyOrIndex: true, rowVersion: false);
+
+            AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalFact]
+        public void Maps_key_binary_sized_column()
+        {
+            var mapping = CreateMapper().FindMapping("binary(200)", keyOrIndex: true, rowVersion: false);
+
+            AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalFact]
+        public void Maps_key_binary_default_sized_column()
+        {
+            var mapping = CreateMapper().FindMapping("binary(900)", keyOrIndex: true, rowVersion: false);
+
+            AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalFact]
+        public void Maps_rowversion_varbinary_max_column()
+        {
+            var mapping = CreateMapper().FindMapping("varbinary(max)", keyOrIndex: false, rowVersion: true);
+
+            AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalFact]
+        public void Maps_rowversion_varbinary_sized_column()
+        {
+            var mapping = CreateMapper().FindMapping("varbinary(200)", keyOrIndex: false, rowVersion: true);
+
+            AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalFact]
+        public void Maps_rowversion_varbinary_default_sized_column()
+        {
+            var mapping = CreateMapper().FindMapping("varbinary(8)", keyOrIndex: false, rowVersion: true);
+
+            AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalFact]
+        public void Maps_rowversion_binary_max_column()
+        {
+            var mapping = CreateMapper().FindMapping("binary(max)", keyOrIndex: false, rowVersion: true);
+
+            AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalFact]
+        public void Maps_rowversion_binary_sized_column()
+        {
+            var mapping = CreateMapper().FindMapping("binary(200)", keyOrIndex: false, rowVersion: true);
+
+            AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalFact]
+        public void Maps_rowversion_binary_default_sized_column()
+        {
+            var mapping = CreateMapper().FindMapping("binary(8)", keyOrIndex: false, rowVersion: true);
+
+            AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalFact]
+        public void Maps_normal_nvarchar_max_column()
+        {
+            var mapping = CreateMapper().FindMapping("nvarchar(max)", keyOrIndex: false, rowVersion: false);
+
+            AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalFact]
+        public void Maps_normal_nvarchar_sized_column()
+        {
+            var mapping = CreateMapper().FindMapping("nvarchar(200)", keyOrIndex: false, rowVersion: false);
+
+            AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalFact]
+        public void Maps_normal_varchar_max_column()
+        {
+            var mapping = CreateMapper().FindMapping("varchar(max)", keyOrIndex: false, rowVersion: false);
+
+            AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalFact]
+        public void Maps_normal_varchar_sized_column()
+        {
+            var mapping = CreateMapper().FindMapping("varchar(200)", keyOrIndex: false, rowVersion: false);
+
+            AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalFact]
+        public void Maps_key_nvarchar_max_column()
+        {
+            var mapping = CreateMapper().FindMapping("nvarchar(max)", keyOrIndex: true, rowVersion: false);
+
+            AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalFact]
+        public void Maps_key_nvarchar_sized_column()
+        {
+            var mapping = CreateMapper().FindMapping("nvarchar(200)", keyOrIndex: true, rowVersion: false);
+
+            AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalFact]
+        public void Maps_key_varchar_max_column()
+        {
+            var mapping = CreateMapper().FindMapping("varchar(max)", keyOrIndex: true, rowVersion: false);
+
+            AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalFact]
+        public void Maps_key_varchar_sized_column()
+        {
+            var mapping = CreateMapper().FindMapping("varchar(200)", keyOrIndex: true, rowVersion: false);
+
+            AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalFact]
+        public void Maps_key_nvarchar_default_sized_column()
+        {
+            var mapping = CreateMapper().FindMapping("nvarchar(450)", keyOrIndex: true, rowVersion: false);
+
+            AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalFact]
+        public void Maps_key_varchar_default_sized_column()
+        {
+            var mapping = CreateMapper().FindMapping("varchar(900)", keyOrIndex: true, rowVersion: false);
+
+            AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalFact]
+        public void Maps_normal_nchar_sized_column()
+        {
+            var mapping = CreateMapper().FindMapping("nchar(200)", keyOrIndex: false, rowVersion: false);
+
+            AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalFact]
+        public void Maps_normal_char_sized_column()
+        {
+            var mapping = CreateMapper().FindMapping("char(200)", keyOrIndex: false, rowVersion: false);
+
+            AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalFact]
+        public void Maps_key_nchar_max_column()
+        {
+            var mapping = CreateMapper().FindMapping("nchar(max)", keyOrIndex: true, rowVersion: false);
+
+            AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalFact]
+        public void Maps_key_nchar_sized_column()
+        {
+            var mapping = CreateMapper().FindMapping("nchar(200)", keyOrIndex: true, rowVersion: false);
+
+            AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalFact]
+        public void Maps_key_char_max_column()
+        {
+            var mapping = CreateMapper().FindMapping("char(max)", keyOrIndex: true, rowVersion: false);
+
+            AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalFact]
+        public void Maps_key_char_sized_column()
+        {
+            var mapping = CreateMapper().FindMapping("char(200)", keyOrIndex: true, rowVersion: false);
+
+            AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalFact]
+        public void Maps_key_nchar_default_sized_column()
+        {
+            var mapping = CreateMapper().FindMapping("nchar(450)", keyOrIndex: true, rowVersion: false);
+
+            AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalFact]
+        public void Maps_key_char_default_sized_column()
+        {
+            var mapping = CreateMapper().FindMapping("char(900)", keyOrIndex: true, rowVersion: false);
+
+            AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        // Unknown type cases...
+
+        [ConditionalTheory]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void Maps_empty_type_column(bool keyOrIndex, bool rowVersion)
+        {
+            var mapping = CreateMapper().FindMapping("", keyOrIndex, rowVersion);
+
+            AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalFact]
+        public void Maps_rowversion_rowversion_column()
+        {
+            var mapping = CreateMapper().FindMapping("rowversion", keyOrIndex: false, rowVersion: true);
+
+            AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Maps_decimal_column(bool isKeyOrIndex)
+        {
+            var mapping = CreateMapper().FindMapping("decimal(18, 2)", isKeyOrIndex, rowVersion: false);
+
+            AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Maps_bit_column(bool isKeyOrIndex)
+        {
+            var mapping = CreateMapper().FindMapping("bit", isKeyOrIndex, rowVersion: false);
+
+            AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Maps_datetime_column(bool isKeyOrIndex)
+        {
+            var mapping = CreateMapper().FindMapping("datetime", isKeyOrIndex, rowVersion: false);
+
+            AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Maps_datetime2_column(bool isKeyOrIndex)
+        {
+            var mapping = CreateMapper().FindMapping("datetime2", isKeyOrIndex, rowVersion: false);
+
+            AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        private static void AssertMapping<T>(TypeScaffoldingInfo mapping, bool inferred, int? maxLength, bool? unicode, bool? fixedLength)
+        {
+            Assert.Same(typeof(T), mapping.ClrType);
+            Assert.Equal(inferred, mapping.IsInferred);
+            Assert.Equal(maxLength, mapping.ScaffoldMaxLength);
+            Assert.Equal(unicode, mapping.ScaffoldUnicode);
+            Assert.Equal(fixedLength, mapping.ScaffoldFixedLength);
+        }
+
+        private static ScaffoldingTypeMapper CreateMapper()
+            => new ScaffoldingTypeMapper(
+                new SqliteTypeMappingSource(
+                    TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
+                    TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>()));
+    }
+}

--- a/test/EFCore.Sqlite.Tests/Storage/SqliteTypeMappingTest.cs
+++ b/test/EFCore.Sqlite.Tests/Storage/SqliteTypeMappingTest.cs
@@ -2,8 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Data;
 using System.Data.Common;
+using System.Linq;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -14,6 +17,65 @@ namespace Microsoft.EntityFrameworkCore.Storage
 {
     public class SqliteTypeMappingTest : RelationalTypeMappingTest
     {
+        private class YouNoTinyContext : DbContext
+        {
+            private readonly SqliteConnection _connection;
+
+            public YouNoTinyContext(SqliteConnection connection)
+                => _connection = connection;
+
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder.UseSqlite(_connection);
+
+            public DbSet<NoTiny> NoTinnies { get; set; }
+        }
+
+        private enum TinyState : byte
+        {
+            One,
+            Two,
+            Three
+        }
+
+        private class NoTiny
+        {
+            [Key]
+            public int Id { get; set; }
+
+            [Required]
+            [Column(TypeName = "tinyint")]
+            public TinyState TinyState { get; set; }
+        }
+
+        [ConditionalFact]
+        public void SQLite_type_mapping_works_even_when_using_non_SQLite_store_type()
+        {
+            using (var connection = new SqliteConnection("DataSource=:memory:"))
+            {
+                connection.Open();
+
+                using (var context = new YouNoTinyContext(connection))
+                {
+                    context.Database.EnsureCreated();
+
+                    context.Add(
+                        new NoTiny
+                        {
+                            TinyState = TinyState.Two
+                        });
+                    context.SaveChanges();
+                }
+
+                using (var context = new YouNoTinyContext(connection))
+                {
+                    var tiny = context.NoTinnies.Single();
+                    Assert.Equal(TinyState.Two, tiny.TinyState);
+                }
+
+                connection.Close();
+            }
+        }
+
         protected override DbCommand CreateTestCommand()
             => new SqliteCommand();
 
@@ -49,7 +111,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         [InlineData("", typeof(byte[]))]
         public void It_maps_strings_to_not_null_types(string typeName, Type clrType)
         {
-            Assert.Equal(clrType, CreateTypeMapper().FindMapping(typeName).ClrType);
+            Assert.Equal(clrType, CreateTypeMapper().FindMapping(typeName)?.ClrType);
         }
 
         private static IRelationalTypeMappingSource CreateTypeMapper()


### PR DESCRIPTION
Fixes #16111

The issue was that when finding a type mapping based on type name affinity we were not checking that it was compatible with the CLR type. This resulted in short-circuiting of the conversion selection and hence the wrong mapping.
