### PR TITLE
Add pragma warning disable 1591 for generated migrations for XMLDOC c…

### DIFF
--- a/src/EFCore.Design/Migrations/Design/CSharpMigrationsGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpMigrationsGenerator.cs
@@ -197,7 +197,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                         .AppendLine("{")
                         .DecrementIndent()
                         .DecrementIndent()
-                        .AppendLine("#pragma warning disable 612, 618")
+                        .AppendLine("#pragma warning disable 612, 618, 1591")
                         .IncrementIndent()
                         .IncrementIndent();
                     using (builder.Indent())
@@ -209,7 +209,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     builder
                         .DecrementIndent()
                         .DecrementIndent()
-                        .AppendLine("#pragma warning restore 612, 618")
+                        .AppendLine("#pragma warning restore 612, 618, 1591")
                         .IncrementIndent()
                         .IncrementIndent()
                         .AppendLine("}");
@@ -281,7 +281,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                         .AppendLine("{")
                         .DecrementIndent()
                         .DecrementIndent()
-                        .AppendLine("#pragma warning disable 612, 618")
+                        .AppendLine("#pragma warning disable 612, 618, 1591")
                         .IncrementIndent()
                         .IncrementIndent();
                     using (builder.Indent())
@@ -292,7 +292,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     builder
                         .DecrementIndent()
                         .DecrementIndent()
-                        .AppendLine("#pragma warning restore 612, 618")
+                        .AppendLine("#pragma warning restore 612, 618, 1591")
                         .IncrementIndent()
                         .IncrementIndent()
                         .AppendLine("}");

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
@@ -466,10 +466,10 @@ namespace MyNamespace
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
-#pragma warning disable 612, 618
+#pragma warning disable 612, 618, 1591
             modelBuilder
                 .HasAnnotation(""Some:EnumValue"", RegexOptions.Multiline);
-#pragma warning restore 612, 618
+#pragma warning restore 612, 618, 1591
         }
     }
 }
@@ -583,7 +583,7 @@ namespace MyNamespace
     {
         protected override void BuildModel(ModelBuilder modelBuilder)
         {
-#pragma warning disable 612, 618
+#pragma warning disable 612, 618, 1591
             modelBuilder
                 .HasAnnotation(""Some:EnumValue"", RegexOptions.Multiline);
 
@@ -613,7 +613,7 @@ namespace MyNamespace
 
                     b.ToTable(""EntityWithConstructorBinding"");
                 });
-#pragma warning restore 612, 618
+#pragma warning restore 612, 618, 1591
         }
     }
 }

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -3133,7 +3133,7 @@ namespace RootNamespace
     {
         protected override void BuildModel(ModelBuilder modelBuilder)
         {
-#pragma warning disable 612, 618
+#pragma warning disable 612, 618, 1591
             modelBuilder
                 .HasAnnotation(""Relational:MaxIdentifierLength"", 128)
                 .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
@@ -3349,7 +3349,7 @@ namespace RootNamespace
                             UnsignedInt64 = 58m
                         });
                 });
-#pragma warning restore 612, 618
+#pragma warning restore 612, 618, 1591
         }
     }
 }
@@ -3515,8 +3515,8 @@ namespace RootNamespace
     {{
         protected override void BuildModel(ModelBuilder modelBuilder)
         {{
-#pragma warning disable 612, 618{code}
-#pragma warning restore 612, 618
+#pragma warning disable 612, 618, 1591{code}
+#pragma warning restore 612, 618, 1591
         }}
     }}
 }}

--- a/test/EFCore.SqlServer.FunctionalTests/MigrationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/MigrationsSqlServerTest.cs
@@ -510,7 +510,7 @@ Foos
         {
             protected override void BuildModel(ModelBuilder modelBuilder)
             {
-#pragma warning disable 612, 618
+#pragma warning disable 612, 618, 1591
                 modelBuilder
                     .HasAnnotation("ProductVersion", "2.2.4-servicing-10062")
                     .HasAnnotation("Relational:MaxIdentifierLength", 128)
@@ -559,7 +559,7 @@ Foos
                             .WithMany("Posts")
                             .HasForeignKey("BlogId");
                     });
-#pragma warning restore 612, 618
+#pragma warning restore 612, 618, 1591
             }
         }
 
@@ -575,7 +575,7 @@ Foos
         {
             protected override void BuildModel(ModelBuilder modelBuilder)
             {
-#pragma warning disable 612, 618
+#pragma warning disable 612, 618, 1591
                 modelBuilder
                     .HasAnnotation("ProductVersion", "2.1.0")
                     .HasAnnotation("Relational:MaxIdentifierLength", 128)
@@ -802,7 +802,7 @@ Foos
                             .HasForeignKey("UserId")
                             .OnDelete(DeleteBehavior.Cascade);
                     });
-#pragma warning restore 612, 618
+#pragma warning restore 612, 618, 1591
             }
         }
 
@@ -818,7 +818,7 @@ Foos
         {
             protected override void BuildModel(ModelBuilder modelBuilder)
             {
-#pragma warning disable 612, 618
+#pragma warning disable 612, 618, 1591
                 modelBuilder
                     .HasAnnotation("ProductVersion", "2.2.0-preview1")
                     .HasAnnotation("Relational:MaxIdentifierLength", 128)
@@ -1045,7 +1045,7 @@ Foos
                             .HasForeignKey("UserId")
                             .OnDelete(DeleteBehavior.Cascade);
                     });
-#pragma warning restore 612, 618
+#pragma warning restore 612, 618, 1591
             }
         }
 
@@ -1061,7 +1061,7 @@ Foos
         {
             protected override void BuildModel(ModelBuilder modelBuilder)
             {
-#pragma warning disable 612, 618
+#pragma warning disable 612, 618, 1591
             modelBuilder
                 .HasAnnotation("ProductVersion", "3.0.0")
                 .HasAnnotation("Relational:MaxIdentifierLength", 128)
@@ -1317,7 +1317,7 @@ Foos
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
-#pragma warning restore 612, 618
+#pragma warning restore 612, 618, 1591
             }
         }
     }

--- a/test/EFCore.Sqlite.FunctionalTests/MigrationsSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/MigrationsSqliteTest.cs
@@ -315,7 +315,7 @@ sqlite_sequence
         {
             protected override void BuildModel(ModelBuilder modelBuilder)
             {
-#pragma warning disable 612, 618
+#pragma warning disable 612, 618, 1591
                 modelBuilder
                     .HasAnnotation("ProductVersion", "2.2.4-servicing-10062");
 
@@ -360,7 +360,7 @@ sqlite_sequence
                             .WithMany("Posts")
                             .HasForeignKey("BlogId");
                     });
-#pragma warning restore 612, 618
+#pragma warning restore 612, 618, 1591
             }
         }
 
@@ -368,7 +368,7 @@ sqlite_sequence
     {
         protected override void BuildModel(ModelBuilder modelBuilder)
         {
-#pragma warning disable 612, 618
+#pragma warning disable 612, 618, 1591
             modelBuilder
                 .HasAnnotation("ProductVersion", "2.1.0");
 
@@ -577,7 +577,7 @@ sqlite_sequence
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade);
                 });
-#pragma warning restore 612, 618
+#pragma warning restore 612, 618, 1591
         }
     }
 
@@ -593,7 +593,7 @@ sqlite_sequence
     {
         protected override void BuildModel(ModelBuilder modelBuilder)
         {
-#pragma warning disable 612, 618
+#pragma warning disable 612, 618, 1591
             modelBuilder
                 .HasAnnotation("ProductVersion", "2.2.0-preview1");
 
@@ -802,7 +802,7 @@ sqlite_sequence
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade);
                 });
-#pragma warning restore 612, 618
+#pragma warning restore 612, 618, 1591
         }
     }
 
@@ -818,7 +818,7 @@ sqlite_sequence
     {
         protected override void BuildModel(ModelBuilder modelBuilder)
         {
-#pragma warning disable 612, 618
+#pragma warning disable 612, 618, 1591
             modelBuilder
                 .HasAnnotation("ProductVersion", "3.0.0");
 
@@ -1068,7 +1068,7 @@ sqlite_sequence
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
-#pragma warning restore 612, 618
+#pragma warning restore 612, 618, 1591
         }
     }
 


### PR DESCRIPTION
Summary of the changes
    - Updated migration sharp code generator to disable/restore pragma warning 1591 for projects              that is compiled with XMLDOC and WarningAsError flags not to trigger compilation errors by migrations
    - Updated corresponding tests and stuff

Fixes https://github.com/aspnet/EntityFrameworkCore/issues/13955