### PR TITLE
Pull down relationship to the derived type when setting a navigation targeting the derived type.

### DIFF
--- a/src/EFCore/Extensions/ConventionEntityTypeExtensions.cs
+++ b/src/EFCore/Extensions/ConventionEntityTypeExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
@@ -51,6 +52,30 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns> The derived types. </returns>
         public static IEnumerable<IConventionEntityType> GetDirectlyDerivedTypes([NotNull] this IConventionEntityType entityType)
             => ((EntityType)entityType).GetDirectlyDerivedTypes();
+
+        /// <summary>
+        ///     Returns all base types of the given <see cref="IEntityType" />, including the type itself, top to bottom.
+        /// </summary>
+        /// <param name="entityType"> The entity type. </param>
+        /// <returns> Base types. </returns>
+        public static IEnumerable<IConventionEntityType> GetAllBaseTypesInclusive([NotNull] this IConventionEntityType entityType)
+            => GetAllBaseTypesInclusiveAscending(entityType).Reverse();
+
+        /// <summary>
+        ///     Returns all base types of the given <see cref="IEntityType" />, including the type itself, bottom to top.
+        /// </summary>
+        /// <param name="entityType"> The entity type. </param>
+        /// <returns> Base types. </returns>
+        public static IEnumerable<IConventionEntityType> GetAllBaseTypesInclusiveAscending([NotNull] this IConventionEntityType entityType)
+        {
+            Check.NotNull(entityType, nameof(entityType));
+
+            while (entityType != null)
+            {
+                yield return entityType;
+                entityType = entityType.BaseType;
+            }
+        }
 
         /// <summary>
         ///     <para>

--- a/src/EFCore/Metadata/Builders/ReferenceNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/ReferenceNavigationBuilder.cs
@@ -178,23 +178,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 ThrowForConflictingNavigation(foreignKey, collectionName, false);
             }
 
-            return RelatedEntityType != foreignKey.PrincipalEntityType
-                ? collection.MemberInfo == null && ReferenceMember == null
+            return collection.MemberInfo == null || ReferenceMember == null
                     ? builder.HasNavigations(
                         ReferenceName, collection.Name,
                         (EntityType)RelatedEntityType, (EntityType)DeclaringEntityType, ConfigurationSource.Explicit)
                     : builder.HasNavigations(
                         ReferenceMember, collection.MemberInfo,
-                        (EntityType)RelatedEntityType, (EntityType)DeclaringEntityType, ConfigurationSource.Explicit)
-                : collection.MemberInfo != null
-                    ? builder.HasNavigation(
-                        collection.MemberInfo,
-                        pointsToPrincipal: false,
-                        ConfigurationSource.Explicit)
-                    : builder.HasNavigation(
-                        collection.Name,
-                        pointsToPrincipal: false,
-                        ConfigurationSource.Explicit);
+                        (EntityType)RelatedEntityType, (EntityType)DeclaringEntityType, ConfigurationSource.Explicit);
         }
 
         /// <summary>

--- a/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
@@ -74,6 +74,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             conventionSet.EntityTypeAddedConventions.Add(new DerivedTypeDiscoveryConvention(Dependencies));
 
             conventionSet.EntityTypeIgnoredConventions.Add(inversePropertyAttributeConvention);
+            conventionSet.EntityTypeIgnoredConventions.Add(relationshipDiscoveryConvention);
 
             var discriminatorConvention = new DiscriminatorConvention(Dependencies);
             conventionSet.EntityTypeRemovedConventions.Add(new OwnedTypesConvention(Dependencies));

--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -445,7 +445,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             ConfigurationSource? typeConfigurationSource,
             ConfigurationSource? configurationSource)
         {
-            IEnumerable<Property> propertiesToDetach = null;
+            List<Property> propertiesToDetach = null;
             var existingProperty = Metadata.FindProperty(propertyName);
             if (existingProperty != null)
             {
@@ -456,7 +456,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     {
                         if (configurationSource.Overrides(existingProperty.GetConfigurationSource()))
                         {
-                            propertiesToDetach = new[]
+                            propertiesToDetach = new List<Property>
                             {
                                 existingProperty
                             };
@@ -527,7 +527,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
                 Metadata.RemoveIgnored(propertyName);
 
-                propertiesToDetach = Metadata.FindDerivedProperties(propertyName);
+                foreach (var derivedType in Metadata.GetDerivedTypes())
+                {
+                    var derivedProperty = derivedType.FindDeclaredProperty(propertyName);
+                    if (derivedProperty != null)
+                    {
+                        if (propertiesToDetach == null)
+                        {
+                            propertiesToDetach = new List<Property>();
+                        }
+
+                        propertiesToDetach.Add(derivedProperty);
+                    }
+                }
             }
 
             InternalPropertyBuilder builder;

--- a/src/EFCore/Metadata/Internal/Property.cs
+++ b/src/EFCore/Metadata/Internal/Property.cs
@@ -117,8 +117,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual void UpdateConfigurationSource(ConfigurationSource configurationSource)
-            => _configurationSource = _configurationSource.Max(configurationSource);
+        public virtual bool UpdateConfigurationSource(ConfigurationSource configurationSource)
+        {
+            var oldConfigurationSource = _configurationSource;
+            _configurationSource = _configurationSource.Max(configurationSource);
+            return _configurationSource != oldConfigurationSource;
+        }
 
         // Needed for a workaround before reference counting is implemented
         // Issue #214

--- a/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
@@ -1689,14 +1689,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             ConfigurationSource addConfigurationSource,
             bool ignoredFirst,
             bool setBaseFirst)
-        {
-            VerifyIgnoreMember(
+            => VerifyIgnoreMember(
                 ignoredOnType, ignoreConfigurationSource, addConfigurationSource, ignoredFirst, setBaseFirst,
                 et => et.Metadata.FindProperty(OrderMinimal.CustomerIdProperty.Name) != null,
                 et => et.Property(OrderMinimal.CustomerIdProperty, addConfigurationSource) != null,
                 et => et.Property(OrderMinimal.CustomerIdProperty, ignoreConfigurationSource) != null,
                 OrderMinimal.CustomerIdProperty.Name);
-        }
 
         private void VerifyIgnoreMember(
             Type ignoredOnType,
@@ -1784,11 +1782,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 Assert.True(unignoreMember(ignoredEntityTypeBuilder));
             }
 
+            Assert.Equal(expectedAdded, findMember(addedEntityTypeBuilder));
             Assert.Equal(
                 expectedIgnored,
                 ignoredEntityTypeBuilder.Metadata.FindDeclaredIgnoredConfigurationSource(memberToIgnore)
                 == ignoreConfigurationSource);
-            Assert.Equal(expectedAdded, findMember(addedEntityTypeBuilder));
         }
 
         private void ConfigureOrdersHierarchy(InternalModelBuilder modelBuilder)

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilder.Other.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilder.Other.cs
@@ -66,13 +66,29 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
         }
 
         [ConditionalFact]
+        public virtual void HasMany_with_a_collection_navigation_CLR_property_to_derived_type_throws()
+        {
+            using (var context = new CustomModelBuildingContext(
+                Configure(),
+                b =>
+                {
+                    b.Entity<Dr>().HasMany<Dre>(d => d.Jrs);
+                }))
+            {
+                Assert.Equal(
+                    CoreStrings.NavigationCollectionWrongClrType(nameof(Dr.Jrs), nameof(Dr), "ICollection<DreJr>", nameof(Dre)),
+                    Assert.Throws<InvalidOperationException>(() => context.Model).Message);
+            }
+        }
+
+        [ConditionalFact]
         public virtual void OwnsOne_HasOne_with_just_string_navigation_for_non_CLR_property_throws()
         {
             using (var context = new CustomModelBuildingContext(
                 Configure(),
                 b =>
                 {
-                    b.Entity<Dr>().OwnsOne(e =>e.Dre).HasOne("Snoop");
+                    b.Entity<Dr>().OwnsOne(e => e.Dre).HasOne("Snoop");
                 }))
             {
                 Assert.Equal(
@@ -86,9 +102,15 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public int Id { get; set; }
 
             public Dre Dre { get; set; }
+
+            public ICollection<DreJr> Jrs { get; set; }
         }
 
         protected class Dre
+        {
+        }
+
+        protected class DreJr : Dre
         {
         }
 

--- a/test/EFCore.Tests/ModelBuilding/TestModel.cs
+++ b/test/EFCore.Tests/ModelBuilding/TestModel.cs
@@ -94,6 +94,9 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public IEnumerable<Order> Orders { get; set; }
 
+            [NotMapped]
+            public ICollection<SpecialOrder> SomeOrders { get; set; }
+
             public CustomerDetails Details { get; set; }
         }
 


### PR DESCRIPTION
Remove ambiguous navigations when the target type is ignored or a base type is set that has the navigation ignored.
Throw correct exception when the collection navigation type doesn't match the dependent entity type.

Fixes #16762