### PR TITLE
Query: Add regression test for nav expansion inside interpolated string

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.cs
@@ -4043,6 +4043,12 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             return base.Inner_parameter_in_nested_lambdas_gets_preserved(isAsync);
         }
 
+        [ConditionalTheory(Skip = "Issue #14935")]
+        public override Task Navigation_inside_interpolated_string_is_expanded(bool isAsync)
+        {
+            return base.Navigation_inside_interpolated_string_is_expanded(isAsync);
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -7474,6 +7474,15 @@ namespace Microsoft.EntityFrameworkCore.Query
                                     dates.Contains(m.Timeline)));
         }
 
+        [ConditionalTheory]  // issue #16724
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Navigation_inside_interpolated_string_expanded(bool isAsync)
+        {
+            return AssertQuery<Weapon>(
+                isAsync,
+                ws => ws.Select(w => w.SynergyWithId.HasValue ? $"SynergyWithOwner: {w.SynergyWith.OwnerFullName}" : string.Empty));
+        }
+
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext();
 
         protected virtual void ClearLog()

--- a/test/EFCore.Specification.Tests/Query/QueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/QueryTestBase.cs
@@ -27,40 +27,40 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #region AssertAny
 
-        protected virtual Task AssertAny<TItem1>(
+        protected Task AssertAny<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<object>> query)
             where TItem1 : class
             => AssertAny(isAsync, query, query);
 
-        protected virtual Task AssertAny<TItem1>(
+        protected Task AssertAny<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<object>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<object>> expectedQuery)
             where TItem1 : class
             => Fixture.QueryAsserter.AssertAny(actualQuery, expectedQuery, isAsync);
 
-        protected virtual Task AssertAny<TItem1, TResult>(
+        protected Task AssertAny<TItem1, TResult>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TResult>> query)
             where TItem1 : class
             => AssertAny(isAsync, query, query);
 
-        protected virtual Task AssertAny<TItem1, TResult>(
+        protected Task AssertAny<TItem1, TResult>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TResult>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TResult>> expectedQuery)
             where TItem1 : class
             => Fixture.QueryAsserter.AssertAny(actualQuery, expectedQuery, isAsync);
 
-        protected virtual Task AssertAny<TItem1, TItem2>(
+        protected Task AssertAny<TItem1, TItem2>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> query)
             where TItem1 : class
             where TItem2 : class
             => AssertAny(isAsync, query, query);
 
-        protected virtual Task AssertAny<TItem1, TItem2>(
+        protected Task AssertAny<TItem1, TItem2>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> expectedQuery)
@@ -68,7 +68,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem2 : class
             => Fixture.QueryAsserter.AssertAny(actualQuery, expectedQuery, isAsync);
 
-        protected virtual Task AssertAny<TItem1, TItem2, TItem3>(
+        protected Task AssertAny<TItem1, TItem2, TItem3>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<object>> query)
             where TItem1 : class
@@ -76,7 +76,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem3 : class
             => AssertAny(isAsync, query, query);
 
-        protected virtual Task AssertAny<TItem1, TItem2, TItem3>(
+        protected Task AssertAny<TItem1, TItem2, TItem3>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<object>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<object>> expectedQuery)
@@ -85,14 +85,14 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem3 : class
             => Fixture.QueryAsserter.AssertAny(actualQuery, expectedQuery, isAsync);
 
-        protected virtual Task AssertAny<TItem1, TPredicate>(
+        protected Task AssertAny<TItem1, TPredicate>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TPredicate>> query,
             Expression<Func<TPredicate, bool>> predicate)
             where TItem1 : class
             => AssertAny(isAsync, query, query, predicate, predicate);
 
-        protected virtual Task AssertAny<TItem1, TPredicate>(
+        protected Task AssertAny<TItem1, TPredicate>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TPredicate>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TPredicate>> expectedQuery,
@@ -105,14 +105,14 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #region AssertAll
 
-        protected virtual Task AssertAll<TItem1, TPredicate>(
+        protected Task AssertAll<TItem1, TPredicate>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TPredicate>> query,
             Expression<Func<TPredicate, bool>> predicate)
             where TItem1 : class
             => AssertAll(isAsync, query, query, predicate, predicate);
 
-        protected virtual Task AssertAll<TItem1, TPredicate>(
+        protected Task AssertAll<TItem1, TPredicate>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TPredicate>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TPredicate>> expectedQuery,
@@ -125,7 +125,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #region AssertFirst
 
-        protected virtual Task AssertFirst<TItem1>(
+        protected Task AssertFirst<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<object>> query,
             Action<object, object> asserter = null,
@@ -133,7 +133,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => AssertFirst(isAsync, query, query, asserter, entryCount);
 
-        protected virtual Task AssertFirst<TItem1>(
+        protected Task AssertFirst<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<object>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<object>> expectedQuery,
@@ -142,7 +142,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => Fixture.QueryAsserter.AssertFirst(actualQuery, expectedQuery, asserter, entryCount, isAsync);
 
-        protected virtual Task AssertFirst<TItem1, TPredicate>(
+        protected Task AssertFirst<TItem1, TPredicate>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TPredicate>> query,
             Expression<Func<TPredicate, bool>> predicate,
@@ -151,7 +151,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => AssertFirst(isAsync, query, query, predicate, predicate, asserter, entryCount);
 
-        protected virtual Task AssertFirst<TItem1, TPredicate>(
+        protected Task AssertFirst<TItem1, TPredicate>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TPredicate>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TPredicate>> expectedQuery,
@@ -167,7 +167,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #region AssertFirstOrDefault
 
-        protected virtual Task AssertFirstOrDefault<TItem1>(
+        protected Task AssertFirstOrDefault<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<object>> query,
             Action<object, object> asserter = null,
@@ -175,7 +175,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => AssertFirstOrDefault(isAsync, query, query, asserter, entryCount);
 
-        protected virtual Task AssertFirstOrDefault<TItem1>(
+        protected Task AssertFirstOrDefault<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<object>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<object>> expectedQuery,
@@ -184,7 +184,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => Fixture.QueryAsserter.AssertFirstOrDefault(actualQuery, expectedQuery, asserter, entryCount, isAsync);
 
-        protected virtual Task AssertFirstOrDefault<TItem1, TItem2>(
+        protected Task AssertFirstOrDefault<TItem1, TItem2>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> query,
             Action<object, object> asserter = null,
@@ -193,7 +193,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem2 : class
             => AssertFirstOrDefault(isAsync, query, query, asserter, entryCount);
 
-        protected virtual Task AssertFirstOrDefault<TItem1, TItem2>(
+        protected Task AssertFirstOrDefault<TItem1, TItem2>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> expectedQuery,
@@ -203,7 +203,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem2 : class
             => Fixture.QueryAsserter.AssertFirstOrDefault(actualQuery, expectedQuery, asserter, entryCount, isAsync);
 
-        protected virtual Task AssertFirstOrDefault<TItem1, TItem2, TItem3>(
+        protected Task AssertFirstOrDefault<TItem1, TItem2, TItem3>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<object>> query,
             Action<object, object> asserter = null,
@@ -213,7 +213,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem3 : class
             => AssertFirstOrDefault(isAsync, query, query, asserter, entryCount);
 
-        protected virtual Task AssertFirstOrDefault<TItem1, TItem2, TItem3>(
+        protected Task AssertFirstOrDefault<TItem1, TItem2, TItem3>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<object>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<object>> expectedQuery,
@@ -224,7 +224,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem3 : class
             => Fixture.QueryAsserter.AssertFirstOrDefault(actualQuery, expectedQuery, asserter, entryCount, isAsync);
 
-        protected virtual Task AssertFirstOrDefault<TItem1, TPredicate>(
+        protected Task AssertFirstOrDefault<TItem1, TPredicate>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TPredicate>> query,
             Expression<Func<TPredicate, bool>> predicate,
@@ -233,7 +233,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => AssertFirstOrDefault(isAsync, query, query, predicate, predicate, asserter, entryCount);
 
-        protected virtual Task AssertFirstOrDefault<TItem1, TPredicate>(
+        protected Task AssertFirstOrDefault<TItem1, TPredicate>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TPredicate>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TPredicate>> expectedQuery,
@@ -249,7 +249,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #region AssertSingle
 
-        protected virtual Task AssertSingle<TItem1>(
+        protected Task AssertSingle<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<object>> query,
             Action<object, object> asserter = null,
@@ -257,7 +257,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => AssertSingle(isAsync, query, query, asserter, entryCount);
 
-        protected virtual Task AssertSingle<TItem1>(
+        protected Task AssertSingle<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<object>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<object>> expectedQuery,
@@ -266,7 +266,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => Fixture.QueryAsserter.AssertSingle(actualQuery, expectedQuery, asserter, entryCount, isAsync);
 
-        protected virtual Task AssertSingle<TItem1, TItem2>(
+        protected Task AssertSingle<TItem1, TItem2>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> query,
             Action<object, object> asserter = null,
@@ -275,7 +275,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem2 : class
             => AssertSingle(isAsync, query, query, asserter, entryCount);
 
-        protected virtual Task AssertSingle<TItem1, TItem2>(
+        protected Task AssertSingle<TItem1, TItem2>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> expectedQuery,
@@ -285,7 +285,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem2 : class
             => Fixture.QueryAsserter.AssertSingle(actualQuery, expectedQuery, asserter, entryCount, isAsync);
 
-        protected virtual Task AssertSingle<TItem1, TPredicate>(
+        protected Task AssertSingle<TItem1, TPredicate>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TPredicate>> query,
             Expression<Func<TPredicate, bool>> predicate,
@@ -294,7 +294,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => AssertSingle(isAsync, query, query, predicate, predicate, asserter, entryCount);
 
-        protected virtual Task AssertSingle<TItem1, TPredicate>(
+        protected Task AssertSingle<TItem1, TPredicate>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TPredicate>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TPredicate>> expectedQuery,
@@ -310,7 +310,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #region AssertSingleOrDefault
 
-        protected virtual Task AssertSingleOrDefault<TItem1>(
+        protected Task AssertSingleOrDefault<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<object>> query,
             Action<object, object> asserter = null,
@@ -318,7 +318,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => AssertSingleOrDefault(isAsync, query, query, asserter, entryCount);
 
-        protected virtual Task AssertSingleOrDefault<TItem1>(
+        protected Task AssertSingleOrDefault<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<object>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<object>> expectedQuery,
@@ -327,7 +327,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => Fixture.QueryAsserter.AssertSingleOrDefault(actualQuery, expectedQuery, asserter, entryCount, isAsync);
 
-        protected virtual Task AssertSingleOrDefault<TItem1, TPredicate>(
+        protected Task AssertSingleOrDefault<TItem1, TPredicate>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TPredicate>> query,
             Expression<Func<TPredicate, bool>> predicate,
@@ -336,7 +336,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => AssertSingleOrDefault(isAsync, query, query, predicate, predicate, asserter, entryCount);
 
-        protected virtual Task AssertSingleOrDefault<TItem1, TPredicate>(
+        protected Task AssertSingleOrDefault<TItem1, TPredicate>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TPredicate>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TPredicate>> expectedQuery,
@@ -352,7 +352,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #region AssertLast
 
-        protected virtual Task AssertLast<TItem1>(
+        protected Task AssertLast<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<object>> query,
             Action<object, object> asserter = null,
@@ -360,7 +360,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => AssertLast(isAsync, query, query, asserter, entryCount);
 
-        protected virtual Task AssertLast<TItem1>(
+        protected Task AssertLast<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<object>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<object>> expectedQuery,
@@ -369,7 +369,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => Fixture.QueryAsserter.AssertLast(actualQuery, expectedQuery, asserter, entryCount, isAsync);
 
-        protected virtual Task AssertLast<TItem1, TPredicate>(
+        protected Task AssertLast<TItem1, TPredicate>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TPredicate>> query,
             Expression<Func<TPredicate, bool>> predicate,
@@ -378,7 +378,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => AssertLast(isAsync, query, query, predicate, predicate, asserter, entryCount);
 
-        protected virtual Task AssertLast<TItem1, TPredicate>(
+        protected Task AssertLast<TItem1, TPredicate>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TPredicate>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TPredicate>> expectedQuery,
@@ -394,7 +394,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #region AssertLastOrDefault
 
-        protected virtual Task AssertLastOrDefault<TItem1>(
+        protected Task AssertLastOrDefault<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<object>> query,
             Action<object, object> asserter = null,
@@ -402,7 +402,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => AssertLastOrDefault(isAsync, query, query, asserter, entryCount);
 
-        protected virtual Task AssertLastOrDefault<TItem1>(
+        protected Task AssertLastOrDefault<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<object>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<object>> expectedQuery,
@@ -411,7 +411,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => Fixture.QueryAsserter.AssertLastOrDefault(actualQuery, expectedQuery, asserter, entryCount, isAsync);
 
-        protected virtual Task AssertLastOrDefault<TItem1, TPredicate>(
+        protected Task AssertLastOrDefault<TItem1, TPredicate>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TPredicate>> query,
             Expression<Func<TPredicate, bool>> predicate,
@@ -420,7 +420,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => AssertLastOrDefault(isAsync, query, query, predicate, predicate, asserter, entryCount);
 
-        protected virtual Task AssertLastOrDefault<TItem1, TPredicate>(
+        protected Task AssertLastOrDefault<TItem1, TPredicate>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TPredicate>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TPredicate>> expectedQuery,
@@ -436,40 +436,40 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #region AssertCount
 
-        protected virtual Task AssertCount<TItem1>(
+        protected Task AssertCount<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<object>> query)
             where TItem1 : class
             => AssertCount(isAsync, query, query);
 
-        protected virtual Task AssertCount<TItem1>(
+        protected Task AssertCount<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<object>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<object>> expectedQuery)
             where TItem1 : class
             => Fixture.QueryAsserter.AssertCount(actualQuery, expectedQuery, isAsync);
 
-        protected virtual Task AssertCount<TItem1>(
+        protected Task AssertCount<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<bool>> query)
             where TItem1 : class
             => AssertCount(isAsync, query, query);
 
-        protected virtual Task AssertCount<TItem1>(
+        protected Task AssertCount<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<bool>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<bool>> expectedQuery)
             where TItem1 : class
             => Fixture.QueryAsserter.AssertCount(actualQuery, expectedQuery, isAsync);
 
-        protected virtual Task AssertCount<TItem1, TPredicate>(
+        protected Task AssertCount<TItem1, TPredicate>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TPredicate>> query,
             Expression<Func<TPredicate, bool>> predicate)
             where TItem1 : class
             => AssertCount(isAsync, query, query, predicate, predicate);
 
-        protected virtual Task AssertCount<TItem1, TPredicate>(
+        protected Task AssertCount<TItem1, TPredicate>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TPredicate>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TPredicate>> expectedQuery,
@@ -478,14 +478,14 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => Fixture.QueryAsserter.AssertCount(actualQuery, expectedQuery, actualPredicate, expectedPredicate, isAsync);
 
-        protected virtual Task AssertCount<TItem1, TItem2>(
+        protected Task AssertCount<TItem1, TItem2>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> query)
             where TItem1 : class
             where TItem2 : class
             => AssertCount(isAsync, query, query);
 
-        protected virtual Task AssertCount<TItem1, TItem2>(
+        protected Task AssertCount<TItem1, TItem2>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> expectedQuery)
@@ -497,27 +497,27 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #region AssertLongCount
 
-        protected virtual Task AssertLongCount<TItem1>(
+        protected Task AssertLongCount<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<object>> query)
             where TItem1 : class
             => AssertLongCount(isAsync, query, query);
 
-        protected virtual Task AssertLongCount<TItem1>(
+        protected Task AssertLongCount<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<object>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<object>> expectedQuery)
             where TItem1 : class
             => Fixture.QueryAsserter.AssertLongCount(actualQuery, expectedQuery, isAsync);
 
-        protected virtual Task AssertLongCount<TItem1, TItem2>(
+        protected Task AssertLongCount<TItem1, TItem2>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> query)
             where TItem1 : class
             where TItem2 : class
             => AssertLongCount(isAsync, query, query);
 
-        protected virtual Task AssertLongCount<TItem1, TItem2>(
+        protected Task AssertLongCount<TItem1, TItem2>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> expectedQuery)
@@ -529,7 +529,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #region AssertMin
 
-        protected virtual Task AssertMin<TItem1>(
+        protected Task AssertMin<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<object>> query,
             Action<object, object> asserter = null,
@@ -537,7 +537,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => AssertMin(isAsync, query, query, asserter, entryCount);
 
-        protected virtual Task AssertMin<TItem1>(
+        protected Task AssertMin<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<object>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<object>> expectedQuery,
@@ -546,7 +546,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => Fixture.QueryAsserter.AssertMin(actualQuery, expectedQuery, asserter, entryCount, isAsync);
 
-        protected virtual Task AssertMin<TItem1>(
+        protected Task AssertMin<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<int>> query,
             Action<object, object> asserter = null,
@@ -554,7 +554,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => AssertMin(isAsync, query, query, asserter, entryCount);
 
-        protected virtual Task AssertMin<TItem1>(
+        protected Task AssertMin<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<int>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<int>> expectedQuery,
@@ -563,7 +563,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => Fixture.QueryAsserter.AssertMin(actualQuery, expectedQuery, asserter, entryCount, isAsync);
 
-        protected virtual Task AssertMin<TItem1>(
+        protected Task AssertMin<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<long>> query,
             Action<object, object> asserter = null,
@@ -571,7 +571,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => AssertMin(isAsync, query, query, asserter, entryCount);
 
-        protected virtual Task AssertMin<TItem1>(
+        protected Task AssertMin<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<long>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<long>> expectedQuery,
@@ -580,7 +580,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => Fixture.QueryAsserter.AssertMin(actualQuery, expectedQuery, asserter, entryCount, isAsync);
 
-        protected virtual Task AssertMin<TItem1, TSelector>(
+        protected Task AssertMin<TItem1, TSelector>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> query,
             Expression<Func<TSelector, int>> selector,
@@ -589,7 +589,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => AssertMin(isAsync, query, query, selector, selector, asserter, entryCount);
 
-        protected virtual Task AssertMin<TItem1, TSelector>(
+        protected Task AssertMin<TItem1, TSelector>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> expectedQuery,
@@ -600,7 +600,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => Fixture.QueryAsserter.AssertMin(actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, entryCount, isAsync);
 
-        protected virtual Task AssertMin<TItem1, TSelector>(
+        protected Task AssertMin<TItem1, TSelector>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> query,
             Expression<Func<TSelector, int?>> selector,
@@ -609,7 +609,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => AssertMin(isAsync, query, query, selector, selector, asserter, entryCount);
 
-        protected virtual Task AssertMin<TItem1, TSelector>(
+        protected Task AssertMin<TItem1, TSelector>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> expectedQuery,
@@ -620,7 +620,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => Fixture.QueryAsserter.AssertMin(actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, entryCount, isAsync);
 
-        protected virtual Task AssertMin<TItem1, TSelector>(
+        protected Task AssertMin<TItem1, TSelector>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> query,
             Expression<Func<TSelector, decimal>> selector,
@@ -629,7 +629,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => AssertMin(isAsync, query, query, selector, selector, asserter, entryCount);
 
-        protected virtual Task AssertMin<TItem1, TSelector>(
+        protected Task AssertMin<TItem1, TSelector>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> expectedQuery,
@@ -644,7 +644,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #region AssertMax
 
-        protected virtual Task AssertMax<TItem1>(
+        protected Task AssertMax<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<object>> query,
             Action<object, object> asserter = null,
@@ -652,7 +652,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => AssertMax(isAsync, query, query, asserter, entryCount);
 
-        protected virtual Task AssertMax<TItem1>(
+        protected Task AssertMax<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<object>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<object>> expectedQuery,
@@ -661,7 +661,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => Fixture.QueryAsserter.AssertMax(actualQuery, expectedQuery, asserter, entryCount, isAsync);
 
-        protected virtual Task AssertMax<TItem1>(
+        protected Task AssertMax<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<int>> query,
             Action<object, object> asserter = null,
@@ -669,7 +669,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => AssertMax(isAsync, query, query, asserter, entryCount);
 
-        protected virtual Task AssertMax<TItem1>(
+        protected Task AssertMax<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<int>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<int>> expectedQuery,
@@ -678,7 +678,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => Fixture.QueryAsserter.AssertMax(actualQuery, expectedQuery, asserter, entryCount, isAsync);
 
-        protected virtual Task AssertMax<TItem1>(
+        protected Task AssertMax<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<long>> query,
             Action<object, object> asserter = null,
@@ -686,7 +686,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => AssertMax(isAsync, query, query, asserter, entryCount);
 
-        protected virtual Task AssertMax<TItem1>(
+        protected Task AssertMax<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<long>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<long>> expectedQuery,
@@ -695,7 +695,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => Fixture.QueryAsserter.AssertMax(actualQuery, expectedQuery, asserter, entryCount, isAsync);
 
-        protected virtual Task AssertMax<TItem1, TSelector>(
+        protected Task AssertMax<TItem1, TSelector>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> query,
             Expression<Func<TSelector, int>> selector,
@@ -704,7 +704,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => AssertMax(isAsync, query, query, selector, selector, asserter, entryCount);
 
-        protected virtual Task AssertMax<TItem1, TSelector>(
+        protected Task AssertMax<TItem1, TSelector>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> expectedQuery,
@@ -715,7 +715,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => Fixture.QueryAsserter.AssertMax(actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, entryCount, isAsync);
 
-        protected virtual Task AssertMax<TItem1, TSelector>(
+        protected Task AssertMax<TItem1, TSelector>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> query,
             Expression<Func<TSelector, int?>> selector,
@@ -724,7 +724,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => AssertMax(isAsync, query, query, selector, selector, asserter, entryCount);
 
-        protected virtual Task AssertMax<TItem1, TSelector>(
+        protected Task AssertMax<TItem1, TSelector>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> expectedQuery,
@@ -735,7 +735,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => Fixture.QueryAsserter.AssertMax(actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, entryCount, isAsync);
 
-        protected virtual Task AssertMax<TItem1, TSelector>(
+        protected Task AssertMax<TItem1, TSelector>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> query,
             Expression<Func<TSelector, decimal>> selector,
@@ -744,7 +744,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => AssertMax(isAsync, query, query, selector, selector, asserter, entryCount);
 
-        protected virtual Task AssertMax<TItem1, TSelector>(
+        protected Task AssertMax<TItem1, TSelector>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> expectedQuery,
@@ -759,14 +759,14 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #region AssertSum
 
-        protected virtual Task AssertSum<TItem1>(
+        protected Task AssertSum<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<int>> query,
             Action<object, object> asserter = null)
             where TItem1 : class
             => AssertSum(isAsync, query, query, asserter);
 
-        protected virtual Task AssertSum<TItem1>(
+        protected Task AssertSum<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<int>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<int>> expectedQuery,
@@ -774,14 +774,14 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => Fixture.QueryAsserter.AssertSum(actualQuery, expectedQuery, asserter, isAsync);
 
-        protected virtual Task AssertSum<TItem1>(
+        protected Task AssertSum<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<int?>> query,
             Action<object, object> asserter = null)
             where TItem1 : class
             => AssertSum(isAsync, query, query, asserter);
 
-        protected virtual Task AssertSum<TItem1>(
+        protected Task AssertSum<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<int?>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<int?>> expectedQuery,
@@ -789,7 +789,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => Fixture.QueryAsserter.AssertSum(actualQuery, expectedQuery, asserter, isAsync);
 
-        protected virtual Task AssertSum<TItem1, TSelector>(
+        protected Task AssertSum<TItem1, TSelector>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> query,
             Expression<Func<TSelector, int>> selector,
@@ -797,7 +797,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => Fixture.QueryAsserter.AssertSum(query, query, selector, selector, asserter, isAsync);
 
-        protected virtual Task AssertSum<TItem1, TSelector>(
+        protected Task AssertSum<TItem1, TSelector>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> expectedQuery,
@@ -807,7 +807,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => Fixture.QueryAsserter.AssertSum(actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
 
-        protected virtual Task AssertSum<TItem1, TSelector>(
+        protected Task AssertSum<TItem1, TSelector>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> query,
             Expression<Func<TSelector, int?>> selector,
@@ -815,7 +815,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => Fixture.QueryAsserter.AssertSum(query, query, selector, selector, asserter, isAsync);
 
-        protected virtual Task AssertSum<TItem1, TSelector>(
+        protected Task AssertSum<TItem1, TSelector>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> expectedQuery,
@@ -825,7 +825,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => Fixture.QueryAsserter.AssertSum(actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
 
-        protected virtual Task AssertSum<TItem1, TSelector>(
+        protected Task AssertSum<TItem1, TSelector>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> query,
             Expression<Func<TSelector, decimal>> selector,
@@ -833,7 +833,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => Fixture.QueryAsserter.AssertSum(query, query, selector, selector, asserter, isAsync);
 
-        protected virtual Task AssertSum<TItem1, TSelector>(
+        protected Task AssertSum<TItem1, TSelector>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> expectedQuery,
@@ -843,7 +843,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => Fixture.QueryAsserter.AssertSum(actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
 
-        protected virtual Task AssertSum<TItem1, TSelector>(
+        protected Task AssertSum<TItem1, TSelector>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> query,
             Expression<Func<TSelector, float>> selector,
@@ -851,7 +851,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => Fixture.QueryAsserter.AssertSum(query, query, selector, selector, asserter, isAsync);
 
-        protected virtual Task AssertSum<TItem1, TSelector>(
+        protected Task AssertSum<TItem1, TSelector>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> expectedQuery,
@@ -861,7 +861,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => Fixture.QueryAsserter.AssertSum(actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
 
-        protected virtual Task AssertSum<TItem1, TItem2, TSelector>(
+        protected Task AssertSum<TItem1, TItem2, TSelector>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TSelector>> query,
             Expression<Func<TSelector, int>> selector,
@@ -870,7 +870,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem2 : class
             => Fixture.QueryAsserter.AssertSum(query, query, selector, selector, asserter, isAsync);
 
-        protected virtual Task AssertSum<TItem1, TItem2, TSelector>(
+        protected Task AssertSum<TItem1, TItem2, TSelector>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TSelector>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TSelector>> expectedQuery,
@@ -885,14 +885,14 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #region AssertAverage
 
-        protected virtual Task AssertAverage<TItem1>(
+        protected Task AssertAverage<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<int>> query,
             Action<object, object> asserter = null)
             where TItem1 : class
             => AssertAverage(isAsync, query, query);
 
-        protected virtual Task AssertAverage<TItem1>(
+        protected Task AssertAverage<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<int>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<int>> expectedQuery,
@@ -900,7 +900,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => Fixture.QueryAsserter.AssertAverage(actualQuery, expectedQuery, asserter, isAsync);
 
-        protected virtual Task AssertAverage<TItem1>(
+        protected Task AssertAverage<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<int?>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<int?>> expectedQuery,
@@ -908,14 +908,14 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => Fixture.QueryAsserter.AssertAverage(actualQuery, expectedQuery, asserter, isAsync);
 
-        protected virtual Task AssertAverage<TItem1>(
+        protected Task AssertAverage<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<long>> query,
             Action<object, object> asserter = null)
             where TItem1 : class
             => AssertAverage(isAsync, query, query);
 
-        protected virtual Task AssertAverage<TItem1>(
+        protected Task AssertAverage<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<long>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<long>> expectedQuery,
@@ -923,7 +923,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => Fixture.QueryAsserter.AssertAverage(actualQuery, expectedQuery, asserter, isAsync);
 
-        protected virtual Task AssertAverage<TItem1, TSelector>(
+        protected Task AssertAverage<TItem1, TSelector>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> query,
             Expression<Func<TSelector, int>> selector,
@@ -931,7 +931,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => AssertAverage(isAsync, query, query, selector, selector, asserter);
 
-        protected virtual Task AssertAverage<TItem1, TSelector>(
+        protected Task AssertAverage<TItem1, TSelector>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> expectedQuery,
@@ -941,7 +941,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => Fixture.QueryAsserter.AssertAverage(actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
 
-        protected virtual Task AssertAverage<TItem1, TSelector>(
+        protected Task AssertAverage<TItem1, TSelector>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> query,
             Expression<Func<TSelector, int?>> selector,
@@ -949,7 +949,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => AssertAverage(isAsync, query, query, selector, selector, asserter);
 
-        protected virtual Task AssertAverage<TItem1, TSelector>(
+        protected Task AssertAverage<TItem1, TSelector>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> expectedQuery,
@@ -959,7 +959,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => Fixture.QueryAsserter.AssertAverage(actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
 
-        protected virtual Task AssertAverage<TItem1, TSelector>(
+        protected Task AssertAverage<TItem1, TSelector>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> query,
             Expression<Func<TSelector, decimal>> selector,
@@ -967,7 +967,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => AssertAverage(isAsync, query, query, selector, selector, asserter);
 
-        protected virtual Task AssertAverage<TItem1, TSelector>(
+        protected Task AssertAverage<TItem1, TSelector>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> expectedQuery,
@@ -977,7 +977,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => Fixture.QueryAsserter.AssertAverage(actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
 
-        protected virtual Task AssertAverage<TItem1, TSelector>(
+        protected Task AssertAverage<TItem1, TSelector>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> query,
             Expression<Func<TSelector, float>> selector,
@@ -985,7 +985,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => AssertAverage(isAsync, query, query, selector, selector, asserter);
 
-        protected virtual Task AssertAverage<TItem1, TSelector>(
+        protected Task AssertAverage<TItem1, TSelector>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TSelector>> expectedQuery,

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -6012,5 +6012,14 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 os => os.Select(o => new Order { OrderDate = o.OrderDate.Value }));
         }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Navigation_inside_interpolated_string_is_expanded(bool isAsync)
+        {
+            return AssertQuery<Order>(
+                isAsync,
+                os => os.Select(o => $"CustomerCity:{o.Customer.City}"));
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -1023,10 +1023,10 @@ WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND (([g].[LeaderNickname] = 
             await base.Null_propagation_optimization2(isAsync);
 
             // issue #16050
-//            AssertSql(
-//                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
-//FROM [Gears] AS [g]
-//WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND [g].[LeaderNickname] LIKE N'%us'");
+            //            AssertSql(
+            //                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+            //FROM [Gears] AS [g]
+            //WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND [g].[LeaderNickname] LIKE N'%us'");
         }
 
         public override async Task Null_propagation_optimization3(bool isAsync)
@@ -1034,10 +1034,10 @@ WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND (([g].[LeaderNickname] = 
             await base.Null_propagation_optimization3(isAsync);
 
             // issue #16050
-//            AssertSql(
-//                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
-//FROM [Gears] AS [g]
-//WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND [g].[LeaderNickname] LIKE N'%us'");
+            //            AssertSql(
+            //                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+            //FROM [Gears] AS [g]
+            //WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND [g].[LeaderNickname] LIKE N'%us'");
         }
 
         public override async Task Null_propagation_optimization4(bool isAsync)
@@ -1045,10 +1045,10 @@ WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND (([g].[LeaderNickname] = 
             await base.Null_propagation_optimization4(isAsync);
 
             // issue #16050
-//            AssertSql(
-//                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
-//FROM [Gears] AS [g]
-//WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND (CAST(LEN([g].[LeaderNickname]) AS int) = 5)");
+            //            AssertSql(
+            //                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+            //FROM [Gears] AS [g]
+            //WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND (CAST(LEN([g].[LeaderNickname]) AS int) = 5)");
         }
 
         public override async Task Null_propagation_optimization5(bool isAsync)
@@ -1056,10 +1056,10 @@ WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND (([g].[LeaderNickname] = 
             await base.Null_propagation_optimization5(isAsync);
 
             // issue #16050
-//            AssertSql(
-//                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
-//FROM [Gears] AS [g]
-//WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND (CAST(LEN([g].[LeaderNickname]) AS int) = 5)");
+            //            AssertSql(
+            //                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+            //FROM [Gears] AS [g]
+            //WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND (CAST(LEN([g].[LeaderNickname]) AS int) = 5)");
         }
 
         public override async Task Null_propagation_optimization6(bool isAsync)
@@ -1067,10 +1067,10 @@ WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND (([g].[LeaderNickname] = 
             await base.Null_propagation_optimization6(isAsync);
 
             // issue #16050
-//            AssertSql(
-//                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
-//FROM [Gears] AS [g]
-//WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND (CAST(LEN([g].[LeaderNickname]) AS int) = 5)");
+            //            AssertSql(
+            //                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+            //FROM [Gears] AS [g]
+            //WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND (CAST(LEN([g].[LeaderNickname]) AS int) = 5)");
         }
 
         public override async Task Select_null_propagation_optimization7(bool isAsync)
@@ -1078,10 +1078,10 @@ WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND (([g].[LeaderNickname] = 
             await base.Select_null_propagation_optimization7(isAsync);
 
             // issue #16050
-//            AssertSql(
-//                @"SELECT [g].[LeaderNickname] + [g].[LeaderNickname]
-//FROM [Gears] AS [g]
-//WHERE [g].[Discriminator] IN (N'Officer', N'Gear')");
+            //            AssertSql(
+            //                @"SELECT [g].[LeaderNickname] + [g].[LeaderNickname]
+            //FROM [Gears] AS [g]
+            //WHERE [g].[Discriminator] IN (N'Officer', N'Gear')");
         }
 
         public override async Task Select_null_propagation_optimization8(bool isAsync)
@@ -1125,14 +1125,14 @@ WHERE [g].[Discriminator] IN (N'Gear', N'Officer')");
             await base.Select_null_propagation_negative2(isAsync);
 
             // issue #16081
-//            AssertSql(
-//                @"SELECT CASE
-//    WHEN [g1].[LeaderNickname] IS NOT NULL
-//    THEN [g2].[LeaderNickname] ELSE NULL
-//END
-//FROM [Gears] AS [g1]
-//CROSS JOIN [Gears] AS [g2]
-//WHERE [g1].[Discriminator] IN (N'Officer', N'Gear')");
+            //            AssertSql(
+            //                @"SELECT CASE
+            //    WHEN [g1].[LeaderNickname] IS NOT NULL
+            //    THEN [g2].[LeaderNickname] ELSE NULL
+            //END
+            //FROM [Gears] AS [g1]
+            //CROSS JOIN [Gears] AS [g2]
+            //WHERE [g1].[Discriminator] IN (N'Officer', N'Gear')");
         }
 
         public override async Task Select_null_propagation_negative3(bool isAsync)
@@ -2081,16 +2081,16 @@ WHERE [g].[Discriminator] IN (N'Gear', N'Officer')");
             await base.Join_with_order_by_without_skip_or_take(isAsync);
 
             // issue #16086
-//            AssertSql(
-//                @"SELECT [t].[Name], [g].[FullName]
-//FROM [Gears] AS [g]
-//INNER JOIN (
-//    SELECT [ww].*
-//    FROM [Weapons] AS [ww]
-//    ORDER BY [ww].[Name]
-//    OFFSET 0 ROWS
-//) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
-//WHERE [g].[Discriminator] IN (N'Officer', N'Gear')");
+            //            AssertSql(
+            //                @"SELECT [t].[Name], [g].[FullName]
+            //FROM [Gears] AS [g]
+            //INNER JOIN (
+            //    SELECT [ww].*
+            //    FROM [Weapons] AS [ww]
+            //    ORDER BY [ww].[Name]
+            //    OFFSET 0 ROWS
+            //) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
+            //WHERE [g].[Discriminator] IN (N'Officer', N'Gear')");
         }
 
         public override async Task Collection_with_inheritance_and_join_include_joined(bool isAsync)
@@ -3076,10 +3076,10 @@ WHERE [m].[Timeline] <> CAST(SYSUTCDATETIME() AS datetimeoffset)");
             await base.Where_datetimeoffset_date_component(isAsync);
 
             // issue #16057
-//            AssertSql(
-//                @"SELECT [m].[Id], [m].[CodeName], [m].[Rating], [m].[Timeline]
-//FROM [Missions] AS [m]
-//WHERE CONVERT(date, [m].[Timeline]) > '0001-01-01T00:00:00.0000000-08:00'");
+            //            AssertSql(
+            //                @"SELECT [m].[Id], [m].[CodeName], [m].[Rating], [m].[Timeline]
+            //FROM [Missions] AS [m]
+            //WHERE CONVERT(date, [m].[Timeline]) > '0001-01-01T00:00:00.0000000-08:00'");
         }
 
         public override async Task Where_datetimeoffset_year_component(bool isAsync)
@@ -3450,12 +3450,12 @@ ORDER BY [g].[FullName]");
             base.Subquery_is_lifted_from_main_from_clause_of_SelectMany();
 
             // issue #16081
-//            AssertSql(
-//                @"SELECT [g].[FullName] AS [Name1], [g2].[FullName] AS [Name2]
-//FROM [Gears] AS [g]
-//CROSS JOIN [Gears] AS [g2]
-//WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND (([g].[HasSoulPatch] = CAST(1 AS bit)) AND ([g2].[HasSoulPatch] = CAST(0 AS bit)))
-//ORDER BY [Name1], [g].[Rank]");
+            //            AssertSql(
+            //                @"SELECT [g].[FullName] AS [Name1], [g2].[FullName] AS [Name2]
+            //FROM [Gears] AS [g]
+            //CROSS JOIN [Gears] AS [g2]
+            //WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND (([g].[HasSoulPatch] = CAST(1 AS bit)) AND ([g2].[HasSoulPatch] = CAST(0 AS bit)))
+            //ORDER BY [Name1], [g].[Rank]");
         }
 
         public override async Task Subquery_containing_SelectMany_projecting_main_from_clause_gets_lifted(bool isAsync)
@@ -3463,12 +3463,12 @@ ORDER BY [g].[FullName]");
             await base.Subquery_containing_SelectMany_projecting_main_from_clause_gets_lifted(isAsync);
 
             // issue #16081
-//            AssertSql(
-//                @"SELECT [gear].[FullName]
-//FROM [Gears] AS [gear]
-//CROSS JOIN [Tags] AS [tag]
-//WHERE [gear].[Discriminator] IN (N'Officer', N'Gear') AND ([gear].[HasSoulPatch] = CAST(1 AS bit))
-//ORDER BY [gear].[FullName], [tag].[Note]");
+            //            AssertSql(
+            //                @"SELECT [gear].[FullName]
+            //FROM [Gears] AS [gear]
+            //CROSS JOIN [Tags] AS [tag]
+            //WHERE [gear].[Discriminator] IN (N'Officer', N'Gear') AND ([gear].[HasSoulPatch] = CAST(1 AS bit))
+            //ORDER BY [gear].[FullName], [tag].[Note]");
         }
 
         public override async Task Subquery_containing_join_projecting_main_from_clause_gets_lifted(bool isAsync)
@@ -3528,18 +3528,18 @@ ORDER BY [g].[Nickname]");
             await base.Subquery_is_lifted_from_additional_from_clause(isAsync);
 
             // issue #16081
-//            AssertSql(
-//                @"SELECT [g1].[FullName] AS [Name1], [t].[FullName] AS [Name2]
-//FROM [Gears] AS [g1]
-//CROSS JOIN (
-//    SELECT [g].*
-//    FROM [Gears] AS [g]
-//    WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
-//    ORDER BY [g].[Rank]
-//    OFFSET 0 ROWS
-//) AS [t]
-//WHERE [g1].[Discriminator] IN (N'Officer', N'Gear') AND (([g1].[HasSoulPatch] = CAST(1 AS bit)) AND ([t].[HasSoulPatch] = CAST(0 AS bit)))
-//ORDER BY [Name1]");
+            //            AssertSql(
+            //                @"SELECT [g1].[FullName] AS [Name1], [t].[FullName] AS [Name2]
+            //FROM [Gears] AS [g1]
+            //CROSS JOIN (
+            //    SELECT [g].*
+            //    FROM [Gears] AS [g]
+            //    WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+            //    ORDER BY [g].[Rank]
+            //    OFFSET 0 ROWS
+            //) AS [t]
+            //WHERE [g1].[Discriminator] IN (N'Officer', N'Gear') AND (([g1].[HasSoulPatch] = CAST(1 AS bit)) AND ([t].[HasSoulPatch] = CAST(0 AS bit)))
+            //ORDER BY [Name1]");
         }
 
         public override async Task Subquery_with_result_operator_is_not_lifted(bool isAsync)
@@ -3841,16 +3841,16 @@ ORDER BY [f].[Name]");
             base.Navigation_access_on_derived_entity_using_cast();
 
             // issue #15944
-//            AssertSql(
-//                @"SELECT [f].[Name], [t].[ThreatLevel] AS [Threat]
-//FROM [ConditionalFactions] AS [f]
-//LEFT JOIN (
-//    SELECT [f.Commander].*
-//    FROM [LocustLeaders] AS [f.Commander]
-//    WHERE [f.Commander].[Discriminator] = N'LocustCommander'
-//) AS [t] ON ([f].[Discriminator] = N'LocustHorde') AND ([f].[CommanderName] = [t].[Name])
-//WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')
-//ORDER BY [f].[Name]");
+            //            AssertSql(
+            //                @"SELECT [f].[Name], [t].[ThreatLevel] AS [Threat]
+            //FROM [ConditionalFactions] AS [f]
+            //LEFT JOIN (
+            //    SELECT [f.Commander].*
+            //    FROM [LocustLeaders] AS [f.Commander]
+            //    WHERE [f.Commander].[Discriminator] = N'LocustCommander'
+            //) AS [t] ON ([f].[Discriminator] = N'LocustHorde') AND ([f].[CommanderName] = [t].[Name])
+            //WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')
+            //ORDER BY [f].[Name]");
         }
 
         public override void Navigation_access_on_derived_materialized_entity_using_cast()
@@ -3858,16 +3858,16 @@ ORDER BY [f].[Name]");
             base.Navigation_access_on_derived_materialized_entity_using_cast();
 
             // issue #15944
-//            AssertSql(
-//                @"SELECT [f].[Id], [f].[CapitalName], [f].[Discriminator], [f].[Name], [f].[CommanderName], [f].[Eradicated], [t].[ThreatLevel]
-//FROM [ConditionalFactions] AS [f]
-//LEFT JOIN (
-//    SELECT [f.Commander].*
-//    FROM [LocustLeaders] AS [f.Commander]
-//    WHERE [f.Commander].[Discriminator] = N'LocustCommander'
-//) AS [t] ON ([f].[Discriminator] = N'LocustHorde') AND ([f].[CommanderName] = [t].[Name])
-//WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')
-//ORDER BY [f].[Name]");
+            //            AssertSql(
+            //                @"SELECT [f].[Id], [f].[CapitalName], [f].[Discriminator], [f].[Name], [f].[CommanderName], [f].[Eradicated], [t].[ThreatLevel]
+            //FROM [ConditionalFactions] AS [f]
+            //LEFT JOIN (
+            //    SELECT [f.Commander].*
+            //    FROM [LocustLeaders] AS [f.Commander]
+            //    WHERE [f.Commander].[Discriminator] = N'LocustCommander'
+            //) AS [t] ON ([f].[Discriminator] = N'LocustHorde') AND ([f].[CommanderName] = [t].[Name])
+            //WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')
+            //ORDER BY [f].[Name]");
         }
 
         public override void Navigation_access_via_EFProperty_on_derived_entity_using_cast()
@@ -3890,16 +3890,16 @@ ORDER BY [f].[Name]");
         {
             base.Navigation_access_fk_on_derived_entity_using_cast();
 
-//            AssertSql(
-//                @"SELECT [f].[Name] AS [Name0], [t].[Name] AS [CommanderName]
-//FROM [ConditionalFactions] AS [f]
-//LEFT JOIN (
-//    SELECT [f.Commander].*
-//    FROM [LocustLeaders] AS [f.Commander]
-//    WHERE [f.Commander].[Discriminator] = N'LocustCommander'
-//) AS [t] ON ([f].[Discriminator] = N'LocustHorde') AND ([f].[CommanderName] = [t].[Name])
-//WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')
-//ORDER BY [Name0]");
+            //            AssertSql(
+            //                @"SELECT [f].[Name] AS [Name0], [t].[Name] AS [CommanderName]
+            //FROM [ConditionalFactions] AS [f]
+            //LEFT JOIN (
+            //    SELECT [f.Commander].*
+            //    FROM [LocustLeaders] AS [f.Commander]
+            //    WHERE [f.Commander].[Discriminator] = N'LocustCommander'
+            //) AS [t] ON ([f].[Discriminator] = N'LocustHorde') AND ([f].[CommanderName] = [t].[Name])
+            //WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')
+            //ORDER BY [Name0]");
         }
 
         public override void Collection_navigation_access_on_derived_entity_using_cast()
@@ -3922,12 +3922,12 @@ ORDER BY [f].[Name]");
             base.Collection_navigation_access_on_derived_entity_using_cast_in_SelectMany();
 
             // TODO: this will later be translated to INNER JOIN
-//            AssertSql(
-//                @"SELECT [f].[Name] AS [Name0], [f.Leaders].[Name] AS [LeaderName]
-//FROM [ConditionalFactions] AS [f]
-//INNER JOIN [LocustLeaders] AS [f.Leaders] ON [f].[Id] = [f.Leaders].[LocustHordeId]
-//WHERE (([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')) AND [f.Leaders].[Discriminator] IN (N'LocustCommander', N'LocustLeader')
-//ORDER BY [LeaderName]");
+            //            AssertSql(
+            //                @"SELECT [f].[Name] AS [Name0], [f.Leaders].[Name] AS [LeaderName]
+            //FROM [ConditionalFactions] AS [f]
+            //INNER JOIN [LocustLeaders] AS [f.Leaders] ON [f].[Id] = [f.Leaders].[LocustHordeId]
+            //WHERE (([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')) AND [f.Leaders].[Discriminator] IN (N'LocustCommander', N'LocustLeader')
+            //ORDER BY [LeaderName]");
 
             AssertSql(
                 @"SELECT [f].[Name] AS [Name0], [ll].[Name] AS [LeaderName]
@@ -4152,10 +4152,10 @@ WHERE (([t0].[Discriminator] = N'Officer') AND [t0].[Discriminator] IS NOT NULL)
         {
             base.Select_null_conditional_with_inheritance();
 
-//            AssertSql(
-//                @"SELECT [f].[CommanderName]
-//FROM [ConditionalFactions] AS [f]
-//WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')");
+            //            AssertSql(
+            //                @"SELECT [f].[CommanderName]
+            //FROM [ConditionalFactions] AS [f]
+            //WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')");
         }
 
         public override void Select_null_conditional_with_inheritance_negative()
@@ -5869,11 +5869,11 @@ ORDER BY [t1].[Note], [t1].[Name], [w].[Id]");
         {
             await base.Select_required_navigation_on_derived_type(isAsync);
 
-//            AssertSql(
-//                @"SELECT [ll.HighCommand].[Name]
-//FROM [LocustLeaders] AS [ll]
-//LEFT JOIN [LocustHighCommands] AS [ll.HighCommand] ON ([ll].[Discriminator] = N'LocustCommander') AND ([ll].[HighCommandId] = [ll.HighCommand].[Id])
-//WHERE [ll].[Discriminator] IN (N'LocustCommander', N'LocustLeader')");
+            //            AssertSql(
+            //                @"SELECT [ll.HighCommand].[Name]
+            //FROM [LocustLeaders] AS [ll]
+            //LEFT JOIN [LocustHighCommands] AS [ll.HighCommand] ON ([ll].[Discriminator] = N'LocustCommander') AND ([ll].[HighCommandId] = [ll.HighCommand].[Id])
+            //WHERE [ll].[Discriminator] IN (N'LocustCommander', N'LocustLeader')");
         }
 
         public override async Task Select_required_navigation_on_the_same_type_with_cast(bool isAsync)
@@ -5891,11 +5891,11 @@ WHERE [g].[Discriminator] IN (N'Gear', N'Officer')");
         {
             await base.Where_required_navigation_on_derived_type(isAsync);
 
-//            AssertSql(
-//                @"SELECT [ll].[Name], [ll].[Discriminator], [ll].[LocustHordeId], [ll].[ThreatLevel], [ll].[DefeatedByNickname], [ll].[DefeatedBySquadId], [ll].[HighCommandId]
-//FROM [LocustLeaders] AS [ll]
-//LEFT JOIN [LocustHighCommands] AS [ll.HighCommand] ON ([ll].[Discriminator] = N'LocustCommander') AND ([ll].[HighCommandId] = [ll.HighCommand].[Id])
-//WHERE [ll].[Discriminator] IN (N'LocustCommander', N'LocustLeader') AND ([ll.HighCommand].[IsOperational] = CAST(1 AS bit))");
+            //            AssertSql(
+            //                @"SELECT [ll].[Name], [ll].[Discriminator], [ll].[LocustHordeId], [ll].[ThreatLevel], [ll].[DefeatedByNickname], [ll].[DefeatedBySquadId], [ll].[HighCommandId]
+            //FROM [LocustLeaders] AS [ll]
+            //LEFT JOIN [LocustHighCommands] AS [ll.HighCommand] ON ([ll].[Discriminator] = N'LocustCommander') AND ([ll].[HighCommandId] = [ll.HighCommand].[Id])
+            //WHERE [ll].[Discriminator] IN (N'LocustCommander', N'LocustLeader') AND ([ll.HighCommand].[IsOperational] = CAST(1 AS bit))");
         }
 
         public override async Task Outer_parameter_in_join_key(bool isAsync)
@@ -6078,12 +6078,12 @@ FROM [LocustLeaders] AS [lc]
 INNER JOIN [LocustHighCommands] AS [lc.HighCommand] ON [lc].[HighCommandId] = [lc.HighCommand].[Id]
 WHERE [lc].[Discriminator] = N'LocustCommander'
 ORDER BY [lc.HighCommand].[Id], [lc].[Name]");
-//            AssertSql(
-//                @"SELECT [lc].[Name]
-//FROM [LocustLeaders] AS [lc]
-//INNER JOIN [LocustHighCommands] AS [lc.HighCommand] ON [lc].[HighCommandId] = [lc.HighCommand].[Id]
-//WHERE [lc].[Discriminator] = N'LocustCommander'
-//ORDER BY [lc.HighCommand].[Id], [lc].[Name]");
+            //            AssertSql(
+            //                @"SELECT [lc].[Name]
+            //FROM [LocustLeaders] AS [lc]
+            //INNER JOIN [LocustHighCommands] AS [lc.HighCommand] ON [lc].[HighCommandId] = [lc.HighCommand].[Id]
+            //WHERE [lc].[Discriminator] = N'LocustCommander'
+            //ORDER BY [lc.HighCommand].[Id], [lc].[Name]");
         }
 
         public override async Task Order_by_entity_qsre_composite_key(bool isAsync)
@@ -6132,11 +6132,11 @@ INNER JOIN [Weapons] AS [w0] ON [w].[Id] = [w0].[Id]");
             await base.Join_on_entity_qsre_keys_composite_key(isAsync);
 
             // issue #16081
-//            AssertSql(
-//                @"SELECT [g1].[FullName] AS [GearName1], [g2].[FullName] AS [GearName2]
-//FROM [Gears] AS [g1]
-//INNER JOIN [Gears] AS [g2] ON ([g1].[Nickname] = [g2].[Nickname]) AND ([g1].[SquadId] = [g2].[SquadId])
-//WHERE [g1].[Discriminator] IN (N'Officer', N'Gear') AND [g2].[Discriminator] IN (N'Officer', N'Gear')");
+            //            AssertSql(
+            //                @"SELECT [g1].[FullName] AS [GearName1], [g2].[FullName] AS [GearName2]
+            //FROM [Gears] AS [g1]
+            //INNER JOIN [Gears] AS [g2] ON ([g1].[Nickname] = [g2].[Nickname]) AND ([g1].[SquadId] = [g2].[SquadId])
+            //WHERE [g1].[Discriminator] IN (N'Officer', N'Gear') AND [g2].[Discriminator] IN (N'Officer', N'Gear')");
         }
 
         public override async Task Join_on_entity_qsre_keys_inheritance(bool isAsync)
@@ -6144,11 +6144,11 @@ INNER JOIN [Weapons] AS [w0] ON [w].[Id] = [w0].[Id]");
             await base.Join_on_entity_qsre_keys_inheritance(isAsync);
 
             // issue #16081
-//            AssertSql(
-//                @"SELECT [g].[FullName] AS [GearName], [o].[FullName] AS [OfficerName]
-//FROM [Gears] AS [g]
-//INNER JOIN [Gears] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
-//WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([o].[Discriminator] = N'Officer')");
+            //            AssertSql(
+            //                @"SELECT [g].[FullName] AS [GearName], [o].[FullName] AS [OfficerName]
+            //FROM [Gears] AS [g]
+            //INNER JOIN [Gears] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
+            //WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([o].[Discriminator] = N'Officer')");
         }
 
         public override async Task Join_on_entity_qsre_keys_outer_key_is_navigation(bool isAsync)
@@ -6402,14 +6402,14 @@ ORDER BY [w].[Id]");
             await base.Project_one_value_type_from_empty_collection(isAsync);
 
             // issue #15864
-//            AssertSql(
-//                @"SELECT [s].[Name], COALESCE((
-//    SELECT TOP(1) [g].[SquadId]
-//    FROM [Gears] AS [g]
-//    WHERE ([g].[Discriminator] IN (N'Officer', N'Gear') AND ([s].[Id] = [g].[SquadId])) AND ([g].[HasSoulPatch] = CAST(1 AS bit))
-//), 0) AS [SquadId]
-//FROM [Squads] AS [s]
-//WHERE [s].[Name] = N'Kilo'");
+            //            AssertSql(
+            //                @"SELECT [s].[Name], COALESCE((
+            //    SELECT TOP(1) [g].[SquadId]
+            //    FROM [Gears] AS [g]
+            //    WHERE ([g].[Discriminator] IN (N'Officer', N'Gear') AND ([s].[Id] = [g].[SquadId])) AND ([g].[HasSoulPatch] = CAST(1 AS bit))
+            //), 0) AS [SquadId]
+            //FROM [Squads] AS [s]
+            //WHERE [s].[Name] = N'Kilo'");
         }
 
         public override async Task Filter_on_subquery_projecting_one_value_type_from_empty_collection(bool isAsync)
@@ -6431,13 +6431,13 @@ WHERE ([s].[Name] = N'Kilo') AND (COALESCE((
             await base.Select_subquery_projecting_single_constant_int(isAsync);
 
             // issue #15864
-//            AssertSql(
-//                @"SELECT [s].[Name], COALESCE((
-//    SELECT TOP(1) 42
-//    FROM [Gears] AS [g]
-//    WHERE ([g].[Discriminator] IN (N'Officer', N'Gear') AND ([s].[Id] = [g].[SquadId])) AND ([g].[HasSoulPatch] = CAST(1 AS bit))
-//), 0) AS [Gear]
-//FROM [Squads] AS [s]");
+            //            AssertSql(
+            //                @"SELECT [s].[Name], COALESCE((
+            //    SELECT TOP(1) 42
+            //    FROM [Gears] AS [g]
+            //    WHERE ([g].[Discriminator] IN (N'Officer', N'Gear') AND ([s].[Id] = [g].[SquadId])) AND ([g].[HasSoulPatch] = CAST(1 AS bit))
+            //), 0) AS [Gear]
+            //FROM [Squads] AS [s]");
         }
 
         public override async Task Select_subquery_projecting_single_constant_string(bool isAsync)
@@ -6457,13 +6457,13 @@ FROM [Squads] AS [s]");
             await base.Select_subquery_projecting_single_constant_bool(isAsync);
 
             // issue #15864
-//            AssertSql(
-//                @"SELECT [s].[Name], COALESCE((
-//    SELECT TOP(1) CAST(1 AS bit)
-//    FROM [Gears] AS [g]
-//    WHERE ([g].[Discriminator] IN (N'Officer', N'Gear') AND ([s].[Id] = [g].[SquadId])) AND ([g].[HasSoulPatch] = CAST(1 AS bit))
-//), CAST(0 AS bit)) AS [Gear]
-//FROM [Squads] AS [s]");
+            //            AssertSql(
+            //                @"SELECT [s].[Name], COALESCE((
+            //    SELECT TOP(1) CAST(1 AS bit)
+            //    FROM [Gears] AS [g]
+            //    WHERE ([g].[Discriminator] IN (N'Officer', N'Gear') AND ([s].[Id] = [g].[SquadId])) AND ([g].[HasSoulPatch] = CAST(1 AS bit))
+            //), CAST(0 AS bit)) AS [Gear]
+            //FROM [Squads] AS [s]");
         }
 
         public override async Task Select_subquery_projecting_single_constant_inside_anonymous(bool isAsync)
@@ -6790,15 +6790,15 @@ WHERE [g].[Discriminator] = N'Officer'");
             await base.Select_subquery_boolean(isAsync);
 
             // issue #15864
-//            AssertSql(
-//                @"SELECT COALESCE((
-//    SELECT TOP(1) [w].[IsAutomatic]
-//    FROM [Weapons] AS [w]
-//    WHERE [g].[FullName] = [w].[OwnerFullName]
-//    ORDER BY [w].[Id]
-//), CAST(0 AS bit))
-//FROM [Gears] AS [g]
-//WHERE [g].[Discriminator] IN (N'Officer', N'Gear')");
+            //            AssertSql(
+            //                @"SELECT COALESCE((
+            //    SELECT TOP(1) [w].[IsAutomatic]
+            //    FROM [Weapons] AS [w]
+            //    WHERE [g].[FullName] = [w].[OwnerFullName]
+            //    ORDER BY [w].[Id]
+            //), CAST(0 AS bit))
+            //FROM [Gears] AS [g]
+            //WHERE [g].[Discriminator] IN (N'Officer', N'Gear')");
         }
 
         public override async Task Select_subquery_boolean_with_pushdown(bool isAsync)
@@ -6880,15 +6880,15 @@ WHERE [g].[Discriminator] IN (N'Gear', N'Officer')");
             await base.Select_subquery_boolean_empty(isAsync);
 
             // issue #15864
-//            AssertSql(
-//                @"SELECT COALESCE((
-//    SELECT TOP(1) [w].[IsAutomatic]
-//    FROM [Weapons] AS [w]
-//    WHERE ([g].[FullName] = [w].[OwnerFullName]) AND ([w].[Name] = N'BFG')
-//    ORDER BY [w].[Id]
-//), CAST(0 AS bit))
-//FROM [Gears] AS [g]
-//WHERE [g].[Discriminator] IN (N'Officer', N'Gear')");
+            //            AssertSql(
+            //                @"SELECT COALESCE((
+            //    SELECT TOP(1) [w].[IsAutomatic]
+            //    FROM [Weapons] AS [w]
+            //    WHERE ([g].[FullName] = [w].[OwnerFullName]) AND ([w].[Name] = N'BFG')
+            //    ORDER BY [w].[Id]
+            //), CAST(0 AS bit))
+            //FROM [Gears] AS [g]
+            //WHERE [g].[Discriminator] IN (N'Officer', N'Gear')");
         }
 
         public override async Task Select_subquery_boolean_empty_with_pushdown(bool isAsync)
@@ -7162,13 +7162,13 @@ END");
             await base.Double_order_by_on_string_compare(isAsync);
 
             // issue #16092
-//            AssertSql(
-//                @"SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
-//FROM [Weapons] AS [w]
-//ORDER BY CASE
-//    WHEN [w].[Name] = N'Marcus'' Lancer'
-//    THEN CAST(1 AS bit) ELSE CAST(0 AS bit)
-//END, [w].[Id]");
+            //            AssertSql(
+            //                @"SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+            //FROM [Weapons] AS [w]
+            //ORDER BY CASE
+            //    WHEN [w].[Name] = N'Marcus'' Lancer'
+            //    THEN CAST(1 AS bit) ELSE CAST(0 AS bit)
+            //END, [w].[Id]");
         }
 
         public override async Task Double_order_by_binary_expression(bool isAsync)
@@ -7186,14 +7186,14 @@ ORDER BY [w].[Id] + 2");
             await base.String_compare_with_null_conditional_argument(isAsync);
 
             // issue #16092
-//            AssertSql(
-//                @"SELECT [w.SynergyWith].[Id], [w.SynergyWith].[AmmunitionType], [w.SynergyWith].[IsAutomatic], [w.SynergyWith].[Name], [w.SynergyWith].[OwnerFullName], [w.SynergyWith].[SynergyWithId]
-//FROM [Weapons] AS [w]
-//LEFT JOIN [Weapons] AS [w.SynergyWith] ON [w].[SynergyWithId] = [w.SynergyWith].[Id]
-//ORDER BY CASE
-//    WHEN [w.SynergyWith].[Name] = N'Marcus'' Lancer'
-//    THEN CAST(1 AS bit) ELSE CAST(0 AS bit)
-//END");
+            //            AssertSql(
+            //                @"SELECT [w.SynergyWith].[Id], [w.SynergyWith].[AmmunitionType], [w.SynergyWith].[IsAutomatic], [w.SynergyWith].[Name], [w.SynergyWith].[OwnerFullName], [w.SynergyWith].[SynergyWithId]
+            //FROM [Weapons] AS [w]
+            //LEFT JOIN [Weapons] AS [w.SynergyWith] ON [w].[SynergyWithId] = [w.SynergyWith].[Id]
+            //ORDER BY CASE
+            //    WHEN [w.SynergyWith].[Name] = N'Marcus'' Lancer'
+            //    THEN CAST(1 AS bit) ELSE CAST(0 AS bit)
+            //END");
         }
 
         public override async Task String_compare_with_null_conditional_argument2(bool isAsync)
@@ -7201,14 +7201,14 @@ ORDER BY [w].[Id] + 2");
             await base.String_compare_with_null_conditional_argument2(isAsync);
 
             // issue #16092
-//            AssertSql(
-//                @"SELECT [w.SynergyWith].[Id], [w.SynergyWith].[AmmunitionType], [w.SynergyWith].[IsAutomatic], [w.SynergyWith].[Name], [w.SynergyWith].[OwnerFullName], [w.SynergyWith].[SynergyWithId]
-//FROM [Weapons] AS [w]
-//LEFT JOIN [Weapons] AS [w.SynergyWith] ON [w].[SynergyWithId] = [w.SynergyWith].[Id]
-//ORDER BY CASE
-//    WHEN N'Marcus'' Lancer' = [w.SynergyWith].[Name]
-//    THEN CAST(1 AS bit) ELSE CAST(0 AS bit)
-//END");
+            //            AssertSql(
+            //                @"SELECT [w.SynergyWith].[Id], [w.SynergyWith].[AmmunitionType], [w.SynergyWith].[IsAutomatic], [w.SynergyWith].[Name], [w.SynergyWith].[OwnerFullName], [w.SynergyWith].[SynergyWithId]
+            //FROM [Weapons] AS [w]
+            //LEFT JOIN [Weapons] AS [w.SynergyWith] ON [w].[SynergyWithId] = [w.SynergyWith].[Id]
+            //ORDER BY CASE
+            //    WHEN N'Marcus'' Lancer' = [w.SynergyWith].[Name]
+            //    THEN CAST(1 AS bit) ELSE CAST(0 AS bit)
+            //END");
         }
 
         public override async Task String_concat_with_null_conditional_argument(bool isAsync)
@@ -7600,12 +7600,12 @@ WHERE [t].[Id] = @__p_0");
             base.OfTypeNav1();
 
             // issue #16094
-//            AssertSql(
-//                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
-//FROM [Gears] AS [g]
-//LEFT JOIN [Tags] AS [g.Tag] ON ([g].[Nickname] = [g.Tag].[GearNickName]) AND ([g].[SquadId] = [g.Tag].[GearSquadId])
-//LEFT JOIN [Tags] AS [o.Tag] ON ([g].[Nickname] = [o.Tag].[GearNickName]) AND ([g].[SquadId] = [o.Tag].[GearSquadId])
-//WHERE (([g].[Discriminator] = N'Officer') AND (([g.Tag].[Note] <> N'Foo') OR [g.Tag].[Note] IS NULL)) AND (([o.Tag].[Note] <> N'Bar') OR [o.Tag].[Note] IS NULL)");
+            //            AssertSql(
+            //                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+            //FROM [Gears] AS [g]
+            //LEFT JOIN [Tags] AS [g.Tag] ON ([g].[Nickname] = [g.Tag].[GearNickName]) AND ([g].[SquadId] = [g.Tag].[GearSquadId])
+            //LEFT JOIN [Tags] AS [o.Tag] ON ([g].[Nickname] = [o.Tag].[GearNickName]) AND ([g].[SquadId] = [o.Tag].[GearSquadId])
+            //WHERE (([g].[Discriminator] = N'Officer') AND (([g.Tag].[Note] <> N'Foo') OR [g.Tag].[Note] IS NULL)) AND (([o.Tag].[Note] <> N'Bar') OR [o.Tag].[Note] IS NULL)");
         }
 
         public override void OfTypeNav2()
@@ -7613,12 +7613,12 @@ WHERE [t].[Id] = @__p_0");
             base.OfTypeNav2();
 
             // issue #16094
-//            AssertSql(
-//                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
-//FROM [Gears] AS [g]
-//LEFT JOIN [Tags] AS [g.Tag] ON ([g].[Nickname] = [g.Tag].[GearNickName]) AND ([g].[SquadId] = [g.Tag].[GearSquadId])
-//LEFT JOIN [Cities] AS [o.AssignedCity] ON [g].[AssignedCityName] = [o.AssignedCity].[Name]
-//WHERE (([g].[Discriminator] = N'Officer') AND (([g.Tag].[Note] <> N'Foo') OR [g.Tag].[Note] IS NULL)) AND (([o.AssignedCity].[Location] <> 'Bar') OR [o.AssignedCity].[Location] IS NULL)");
+            //            AssertSql(
+            //                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+            //FROM [Gears] AS [g]
+            //LEFT JOIN [Tags] AS [g.Tag] ON ([g].[Nickname] = [g.Tag].[GearNickName]) AND ([g].[SquadId] = [g.Tag].[GearSquadId])
+            //LEFT JOIN [Cities] AS [o.AssignedCity] ON [g].[AssignedCityName] = [o.AssignedCity].[Name]
+            //WHERE (([g].[Discriminator] = N'Officer') AND (([g.Tag].[Note] <> N'Foo') OR [g.Tag].[Note] IS NULL)) AND (([o.AssignedCity].[Location] <> 'Bar') OR [o.AssignedCity].[Location] IS NULL)");
         }
 
         public override void OfTypeNav3()
@@ -7626,13 +7626,13 @@ WHERE [t].[Id] = @__p_0");
             base.OfTypeNav3();
 
             // issue #16094
-//            AssertSql(
-//                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
-//FROM [Gears] AS [g]
-//LEFT JOIN [Tags] AS [g.Tag] ON ([g].[Nickname] = [g.Tag].[GearNickName]) AND ([g].[SquadId] = [g.Tag].[GearSquadId])
-//INNER JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
-//LEFT JOIN [Tags] AS [o.Tag] ON ([g].[Nickname] = [o.Tag].[GearNickName]) AND ([g].[SquadId] = [o.Tag].[GearSquadId])
-//WHERE (([g].[Discriminator] = N'Officer') AND (([g.Tag].[Note] <> N'Foo') OR [g.Tag].[Note] IS NULL)) AND (([o.Tag].[Note] <> N'Bar') OR [o.Tag].[Note] IS NULL)");
+            //            AssertSql(
+            //                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+            //FROM [Gears] AS [g]
+            //LEFT JOIN [Tags] AS [g.Tag] ON ([g].[Nickname] = [g.Tag].[GearNickName]) AND ([g].[SquadId] = [g.Tag].[GearSquadId])
+            //INNER JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
+            //LEFT JOIN [Tags] AS [o.Tag] ON ([g].[Nickname] = [o.Tag].[GearNickName]) AND ([g].[SquadId] = [o.Tag].[GearSquadId])
+            //WHERE (([g].[Discriminator] = N'Officer') AND (([g.Tag].[Note] <> N'Foo') OR [g.Tag].[Note] IS NULL)) AND (([o.Tag].[Note] <> N'Bar') OR [o.Tag].[Note] IS NULL)");
         }
 
         public override void Nav_rewrite_Distinct_with_convert()
@@ -7656,16 +7656,16 @@ WHERE [t].[Id] = @__p_0");
             base.Nav_rewrite_with_convert1();
 
             // issue #15994
-//            AssertSql(
-//                @"SELECT [t].[Name], [t].[Discriminator], [t].[LocustHordeId], [t].[ThreatLevel], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId]
-//FROM [ConditionalFactions] AS [f]
-//LEFT JOIN [Cities] AS [f.Capital] ON [f].[CapitalName] = [f.Capital].[Name]
-//LEFT JOIN (
-//    SELECT [f.Capital.Commander].*
-//    FROM [LocustLeaders] AS [f.Capital.Commander]
-//    WHERE [f.Capital.Commander].[Discriminator] = N'LocustCommander'
-//) AS [t] ON ([f].[Discriminator] = N'LocustHorde') AND ([f].[CommanderName] = [t].[Name])
-//WHERE ([f].[Discriminator] = N'LocustHorde') AND (([f.Capital].[Name] <> N'Foo') OR [f.Capital].[Name] IS NULL)");
+            //            AssertSql(
+            //                @"SELECT [t].[Name], [t].[Discriminator], [t].[LocustHordeId], [t].[ThreatLevel], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId]
+            //FROM [ConditionalFactions] AS [f]
+            //LEFT JOIN [Cities] AS [f.Capital] ON [f].[CapitalName] = [f.Capital].[Name]
+            //LEFT JOIN (
+            //    SELECT [f.Capital.Commander].*
+            //    FROM [LocustLeaders] AS [f.Capital.Commander]
+            //    WHERE [f.Capital.Commander].[Discriminator] = N'LocustCommander'
+            //) AS [t] ON ([f].[Discriminator] = N'LocustHorde') AND ([f].[CommanderName] = [t].[Name])
+            //WHERE ([f].[Discriminator] = N'LocustHorde') AND (([f.Capital].[Name] <> N'Foo') OR [f.Capital].[Name] IS NULL)");
         }
 
         public override void Nav_rewrite_with_convert2()
@@ -7673,16 +7673,16 @@ WHERE [t].[Id] = @__p_0");
             base.Nav_rewrite_with_convert2();
 
             // issue #15994
-//            AssertSql(
-//                @"SELECT [f].[Id], [f].[CapitalName], [f].[Discriminator], [f].[Name], [f].[CommanderName], [f].[Eradicated]
-//FROM [ConditionalFactions] AS [f]
-//LEFT JOIN [Cities] AS [f.Capital] ON [f].[CapitalName] = [f.Capital].[Name]
-//LEFT JOIN (
-//    SELECT [f.Capital.Commander].*
-//    FROM [LocustLeaders] AS [f.Capital.Commander]
-//    WHERE [f.Capital.Commander].[Discriminator] = N'LocustCommander'
-//) AS [t] ON ([f].[Discriminator] = N'LocustHorde') AND ([f].[CommanderName] = [t].[Name])
-//WHERE (([f].[Discriminator] = N'LocustHorde') AND (([f.Capital].[Name] <> N'Foo') OR [f.Capital].[Name] IS NULL)) AND (([t].[Name] <> N'Bar') OR [t].[Name] IS NULL)");
+            //            AssertSql(
+            //                @"SELECT [f].[Id], [f].[CapitalName], [f].[Discriminator], [f].[Name], [f].[CommanderName], [f].[Eradicated]
+            //FROM [ConditionalFactions] AS [f]
+            //LEFT JOIN [Cities] AS [f.Capital] ON [f].[CapitalName] = [f.Capital].[Name]
+            //LEFT JOIN (
+            //    SELECT [f.Capital.Commander].*
+            //    FROM [LocustLeaders] AS [f.Capital.Commander]
+            //    WHERE [f.Capital.Commander].[Discriminator] = N'LocustCommander'
+            //) AS [t] ON ([f].[Discriminator] = N'LocustHorde') AND ([f].[CommanderName] = [t].[Name])
+            //WHERE (([f].[Discriminator] = N'LocustHorde') AND (([f.Capital].[Name] <> N'Foo') OR [f.Capital].[Name] IS NULL)) AND (([t].[Name] <> N'Bar') OR [t].[Name] IS NULL)");
         }
 
         public override void Nav_rewrite_with_convert3()
@@ -7690,16 +7690,16 @@ WHERE [t].[Id] = @__p_0");
             base.Nav_rewrite_with_convert3();
 
             // issue #15994
-//            AssertSql(
-//                @"SELECT [f].[Id], [f].[CapitalName], [f].[Discriminator], [f].[Name], [f].[CommanderName], [f].[Eradicated]
-//FROM [ConditionalFactions] AS [f]
-//LEFT JOIN [Cities] AS [f.Capital] ON [f].[CapitalName] = [f.Capital].[Name]
-//LEFT JOIN (
-//    SELECT [f.Capital.Commander].*
-//    FROM [LocustLeaders] AS [f.Capital.Commander]
-//    WHERE [f.Capital.Commander].[Discriminator] = N'LocustCommander'
-//) AS [t] ON ([f].[Discriminator] = N'LocustHorde') AND ([f].[CommanderName] = [t].[Name])
-//WHERE (([f].[Discriminator] = N'LocustHorde') AND (([f.Capital].[Name] <> N'Foo') OR [f.Capital].[Name] IS NULL)) AND (([t].[Name] <> N'Bar') OR [t].[Name] IS NULL)");
+            //            AssertSql(
+            //                @"SELECT [f].[Id], [f].[CapitalName], [f].[Discriminator], [f].[Name], [f].[CommanderName], [f].[Eradicated]
+            //FROM [ConditionalFactions] AS [f]
+            //LEFT JOIN [Cities] AS [f.Capital] ON [f].[CapitalName] = [f.Capital].[Name]
+            //LEFT JOIN (
+            //    SELECT [f.Capital.Commander].*
+            //    FROM [LocustLeaders] AS [f.Capital.Commander]
+            //    WHERE [f.Capital.Commander].[Discriminator] = N'LocustCommander'
+            //) AS [t] ON ([f].[Discriminator] = N'LocustHorde') AND ([f].[CommanderName] = [t].[Name])
+            //WHERE (([f].[Discriminator] = N'LocustHorde') AND (([f.Capital].[Name] <> N'Foo') OR [f.Capital].[Name] IS NULL)) AND (([t].[Name] <> N'Bar') OR [t].[Name] IS NULL)");
         }
 
         public override async Task Where_contains_on_navigation_with_composite_keys(bool isAsync)
@@ -7765,7 +7765,21 @@ WHERE (
 
 SELECT [m].[Id], [m].[CodeName], [m].[Rating], [m].[Timeline]
 FROM [Missions] AS [m]
-WHERE ((@__start_0 <= CAST(CONVERT(date, [m].[Timeline]) AS datetimeoffset)) AND ([m].[Timeline] < @__end_1)) AND [m].[Timeline] IN ('1902-01-02T10:00:00.1234567+01:30')");        }
+WHERE ((@__start_0 <= CAST(CONVERT(date, [m].[Timeline]) AS datetimeoffset)) AND ([m].[Timeline] < @__end_1)) AND [m].[Timeline] IN ('1902-01-02T10:00:00.1234567+01:30')");
+        }
+
+        public override async Task Navigation_inside_interpolated_string_expanded(bool isAsync)
+        {
+            await base.Navigation_inside_interpolated_string_expanded(isAsync);
+
+            AssertSql(
+                @"SELECT CASE
+    WHEN [w].[SynergyWithId] IS NOT NULL THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END, [w0].[OwnerFullName]
+FROM [Weapons] AS [w]
+LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]");
+        }
 
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -4899,6 +4899,16 @@ WHERE (
 FROM [Orders] AS [o]");
         }
 
+        public override async Task Navigation_inside_interpolated_string_is_expanded(bool isAsync)
+        {
+            await base.Navigation_inside_interpolated_string_is_expanded(isAsync);
+
+            AssertSql(
+                @"SELECT [c].[City]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Resolves #16724
