### PR TITLE
Query: Merge processing of eager loaded include with normal include

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
@@ -221,9 +221,6 @@ WHERE (c[""Discriminator""] = ""LeafA"")");
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 
-        private void AssertContainsSql(params string[] expected)
-            => Fixture.TestSqlLoggerFactory.AssertBaseline(expected, assertOrder: false);
-
         private void ClearLog()
             => Fixture.TestSqlLoggerFactory.Clear();
 

--- a/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
@@ -92,7 +92,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "Issue#16619")]
+        [ConditionalFact]
         public virtual void No_ignored_include_warning_when_implicit_load()
         {
             using (var context = CreateContext())


### PR DESCRIPTION
Resolves #16619

This avoids issue of adding includes when includes are not part of projection.
Fixed in new nav rewrite

