### PR TITLE
CI: Use an older version of SpatiaLite on macOS

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -106,14 +106,14 @@ jobs:
           pool:
             vmImage: macOS-10.13
           steps:
-            - bash: brew install libspatialite
+            # HACK: Use an older version to work around #16667
+            - bash: brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/835ae521c065524abdf66578e68032fa24bce514/Formula/libspatialite.rb
               displayName: Install SpatiaLite
               continueOnError: true
             - script: eng/common/cibuild.sh --configuration $(_BuildConfig) --binaryLog --prepareMachine
               env:
                 Test__Cosmos__DefaultConnection: $(_CosmosConnectionUrl)
               name: Build
-              continueOnError: true
             - task: PublishBuildArtifacts@1
               displayName: Upload TestResults
               condition: always()

--- a/test/ef.Tests/ef.Tests.csproj
+++ b/test/ef.Tests/ef.Tests.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelPackageVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Part of #16667
