### PR TITLE
MigrationsSqlGenerator: DefaultValue formats default value properly

### DIFF
--- a/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
+++ b/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
@@ -1224,12 +1224,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         /// </summary>
         /// <param name="defaultValue"> The default value for the column. </param>
         /// <param name="defaultValueSql"> The SQL expression to use for the column's default constraint. </param>
-        /// <param name="type"> Store/database type of the column. </param>
+        /// <param name="columnType"> Store/database type of the column. </param>
         /// <param name="builder"> The command builder to use to add the SQL fragment. </param>
         protected virtual void DefaultValue(
             [CanBeNull] object defaultValue,
             [CanBeNull] string defaultValueSql,
-            [CanBeNull] string type,
+            [CanBeNull] string columnType,
             [NotNull] MigrationCommandListBuilder builder)
         {
             Check.NotNull(builder, nameof(builder));
@@ -1243,7 +1243,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             }
             else if (defaultValue != null)
             {
-                var typeMapping = type != null ? Dependencies.TypeMappingSource.FindMapping(defaultValue.GetType(), type) : null;
+                var typeMapping = columnType != null ? Dependencies.TypeMappingSource.FindMapping(defaultValue.GetType(), columnType) : null;
                 if (typeMapping == null)
                 {
                     typeMapping = Dependencies.TypeMappingSource.GetMappingForValue(defaultValue);

--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -334,7 +334,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     .Append("ALTER TABLE ")
                     .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Table, operation.Schema))
                     .Append(" ADD");
-                DefaultValue(operation.DefaultValue, operation.DefaultValueSql, builder);
+                DefaultValue(operation.DefaultValue, operation.DefaultValueSql, operation.ColumnType, builder);
                 builder
                     .Append(" FOR ")
                     .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Name))

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerMigrationSqlGeneratorTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerMigrationSqlGeneratorTest.cs
@@ -268,6 +268,44 @@ EXEC sp_addextendedproperty @name = N'Comment', @value = N'My Comment 2', @level
 ");
         }
 
+        [ConditionalFact]
+        public virtual void AddColumnOperation_datetime_with_defaultValue()
+        {
+            Generate(
+                new AddColumnOperation
+                {
+                    Table = "People",
+                    Schema = "dbo",
+                    Name = "Birthday",
+                    ClrType = typeof(DateTime),
+                    ColumnType = "datetime",
+                    IsNullable = false,
+                    DefaultValue = new DateTime(2019, 1, 1)
+                });
+
+            AssertSql(@"ALTER TABLE [dbo].[People] ADD [Birthday] datetime NOT NULL DEFAULT '2019-01-01T00:00:00.000';
+");
+        }
+
+        [ConditionalFact]
+        public virtual void AddColumnOperation_smalldatetime_with_defaultValue()
+        {
+            Generate(
+                new AddColumnOperation
+                {
+                    Table = "People",
+                    Schema = "dbo",
+                    Name = "Birthday",
+                    ClrType = typeof(DateTime),
+                    ColumnType = "smalldatetime",
+                    IsNullable = false,
+                    DefaultValue = new DateTime(2019, 1, 1)
+                });
+
+            AssertSql(@"ALTER TABLE [dbo].[People] ADD [Birthday] smalldatetime NOT NULL DEFAULT '2019-01-01T00:00:00';
+");
+        }
+
         public override void AddColumnOperation_with_maxLength_overridden()
         {
             base.AddColumnOperation_with_maxLength_overridden();


### PR DESCRIPTION
Fix for issue #14457. Contains breaking change in MigrationsSqlGenerator (changed signature of DefaultValue method).