### PR TITLE
SqlServer Migrations: Consolidate IDENTITY annotations

### DIFF
--- a/src/EFCore.SqlServer/Metadata/Internal/SqlServerAnnotationNames.cs
+++ b/src/EFCore.SqlServer/Metadata/Internal/SqlServerAnnotationNames.cs
@@ -81,6 +81,14 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public const string Identity = Prefix + "Identity";
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public const string IdentitySeed = Prefix + "IdentitySeed";
 
         /// <summary>

--- a/src/EFCore.SqlServer/Migrations/Internal/SqlServerMigrationsAnnotationProvider.cs
+++ b/src/EFCore.SqlServer/Migrations/Internal/SqlServerMigrationsAnnotationProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -112,25 +113,12 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Migrations.Internal
         {
             if (property.GetValueGenerationStrategy() == SqlServerValueGenerationStrategy.IdentityColumn)
             {
-                yield return new Annotation(
-                    SqlServerAnnotationNames.ValueGenerationStrategy,
-                    SqlServerValueGenerationStrategy.IdentityColumn);
-
                 var seed = property.GetIdentitySeed();
-                if (seed.HasValue)
-                {
-                    yield return new Annotation(
-                        SqlServerAnnotationNames.IdentitySeed,
-                        seed.Value);
-                }
-
                 var increment = property.GetIdentityIncrement();
-                if (increment.HasValue)
-                {
-                    yield return new Annotation(
-                        SqlServerAnnotationNames.IdentityIncrement,
-                        increment.Value);
-                }
+
+                yield return new Annotation(
+                    SqlServerAnnotationNames.Identity,
+                    string.Format(CultureInfo.InvariantCulture, "{0}, {1}", seed ?? 1, increment ?? 1));
             }
 
         }

--- a/test/EFCore.SqlServer.Tests/Migrations/SqlServerMigrationsAnnotationProviderTest.cs
+++ b/test/EFCore.SqlServer.Tests/Migrations/SqlServerMigrationsAnnotationProviderTest.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.SqlServer.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.Migrations.Internal
+{
+    public class SqlServerMigrationsAnnotationProviderTest
+    {
+        private readonly ModelBuilder _modelBuilder;
+        private readonly SqlServerMigrationsAnnotationProvider _annotations;
+
+        public SqlServerMigrationsAnnotationProviderTest()
+        {
+            _modelBuilder = SqlServerTestHelpers.Instance.CreateConventionBuilder(/*skipValidation: true*/);
+            _annotations = new SqlServerMigrationsAnnotationProvider(new MigrationsAnnotationProviderDependencies());
+        }
+
+        [Fact]
+        public void For_property_handles_identity_annotations()
+        {
+            var property = _modelBuilder.Entity("Entity")
+                .Property<int>("Id").UseIdentityColumn(2, 3)
+                .Metadata;
+
+            var migrationAnnotations = _annotations.For(property).ToList();
+
+            var identity = Assert.Single(migrationAnnotations, a => a.Name == SqlServerAnnotationNames.Identity);
+            Assert.Equal("2, 3", identity.Value);
+        }
+    }
+}

--- a/test/EFCore.SqlServer.Tests/Migrations/SqlServerModelDifferTest.cs
+++ b/test/EFCore.SqlServer.Tests/Migrations/SqlServerModelDifferTest.cs
@@ -136,7 +136,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     Assert.Equal("bah", operation.Schema);
                     Assert.Equal("Lamb", operation.Table);
                     Assert.Equal("Id", operation.Name);
-                    Assert.Equal(SqlServerValueGenerationStrategy.IdentityColumn, operation["SqlServer:ValueGenerationStrategy"]);
+                    Assert.Equal("1, 1", operation["SqlServer:Identity"]);
                 });
         }
 
@@ -168,7 +168,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     Assert.Equal("bah", operation.Schema);
                     Assert.Equal("Lamb", operation.Table);
                     Assert.Equal("Num", operation.Name);
-                    Assert.Equal(SqlServerValueGenerationStrategy.IdentityColumn, operation["SqlServer:ValueGenerationStrategy"]);
+                    Assert.Equal("1, 1", operation["SqlServer:Identity"]);
                 });
         }
 
@@ -334,7 +334,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     Assert.Equal(2, createTableOperation.Columns.Count);
                     var idColumn = createTableOperation.Columns[0];
                     Assert.Equal("Id", idColumn.Name);
-                    Assert.Equal(SqlServerValueGenerationStrategy.IdentityColumn, idColumn["SqlServer:ValueGenerationStrategy"]);
+                    Assert.Equal("1, 1", idColumn["SqlServer:Identity"]);
                     var timeColumn = createTableOperation.Columns[1];
                     Assert.Equal("Time", timeColumn.Name);
                     Assert.True(timeColumn.IsNullable);


### PR DESCRIPTION
Note, this introduces a **breaking change** from 3.0.0-preview7. Migrations with the following...
``` csharp
.Annotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn)
.Annotation("SqlServer:IdentitySeed", 2)
.Annotation("SqlServer:IdentityIncrement", 3)
```
...will need to be manually updated to this.
``` csharp
.Annotation("SqlServer:Identity", "2, 3")
```

Fixes #13352