### PR TITLE
Return the correct type mapping for enum properties.

### DIFF
--- a/src/EFCore.Cosmos/Storage/Internal/CosmosTypeMappingSource.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosTypeMappingSource.cs
@@ -52,7 +52,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
                 return mapping;
             }
 
-            if (clrType.IsValueType
+            if ((clrType.IsValueType
+                 && !clrType.IsEnum)
                 || clrType == typeof(string))
             {
                 return new CosmosTypeMapping(clrType);

--- a/src/EFCore.Cosmos/Update/Internal/DocumentSource.cs
+++ b/src/EFCore.Cosmos/Update/Internal/DocumentSource.cs
@@ -211,12 +211,9 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Update.Internal
         }
 
         public virtual JObject GetCurrentDocument(IUpdateEntry entry)
-        {
-            var document = _jObjectProperty != null
+            => _jObjectProperty != null
                 ? (JObject)(entry.SharedIdentityEntry ?? entry).GetCurrentValue(_jObjectProperty)
                 : null;
-            return document;
-        }
 
         private static JToken ConvertPropertyValue(IProperty property, object value)
         {

--- a/src/EFCore/Query/Internal/QueryCompiler.cs
+++ b/src/EFCore/Query/Internal/QueryCompiler.cs
@@ -103,9 +103,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             Expression query,
             IModel model,
             bool async)
-        {
-            return database.CompileQuery<TResult>(query, async);
-        }
+            => database.CompileQuery<TResult>(query, async);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Storage/Database.cs
+++ b/src/EFCore/Storage/Database.cs
@@ -68,10 +68,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
             CancellationToken cancellationToken = default);
 
         public virtual Func<QueryContext, TResult> CompileQuery<TResult>(Expression query, bool async)
-        {
-            return Dependencies.QueryCompilationContextFactory
+            => Dependencies.QueryCompilationContextFactory
                 .Create(async)
                 .CreateQueryExecutor<TResult>(query);
-        }
     }
 }

--- a/src/EFCore/Storage/ValueConversion/ValueConverterSelector.cs
+++ b/src/EFCore/Storage/ValueConversion/ValueConverterSelector.cs
@@ -69,176 +69,173 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         {
             Check.NotNull(modelClrType, nameof(modelClrType));
 
-            var underlyingModelType = modelClrType.UnwrapNullableType();
-            var underlyingProviderType = providerClrType?.UnwrapNullableType();
-
-            if (underlyingModelType.IsEnum)
+            if (modelClrType.IsEnum)
             {
                 foreach (var converterInfo in FindNumericConventions(
-                    underlyingModelType,
-                    underlyingProviderType,
+                    modelClrType,
+                    providerClrType,
                     typeof(EnumToNumberConverter<,>),
                     EnumToStringOrBytes))
                 {
                     yield return converterInfo;
                 }
             }
-            else if (underlyingModelType == typeof(bool))
+            else if (modelClrType == typeof(bool))
             {
                 foreach (var converterInfo in FindNumericConventions(
                     typeof(bool),
-                    underlyingProviderType,
+                    providerClrType,
                     typeof(BoolToZeroOneConverter<>),
                     null))
                 {
                     yield return converterInfo;
                 }
 
-                if (underlyingProviderType == null
-                    || underlyingProviderType == typeof(string))
+                if (providerClrType == null
+                    || providerClrType == typeof(string))
                 {
                     yield return BoolToStringConverter.DefaultInfo;
                 }
 
-                if (underlyingProviderType == null
-                    || underlyingProviderType == typeof(byte[]))
+                if (providerClrType == null
+                    || providerClrType == typeof(byte[]))
                 {
                     yield return _converters.GetOrAdd(
-                        (underlyingModelType, typeof(byte[])),
+                        (modelClrType, typeof(byte[])),
                         k => new ValueConverterInfo(
-                            underlyingModelType,
+                            modelClrType,
                             typeof(byte[]),
                             info => new BoolToZeroOneConverter<byte>().ComposeWith(
                                 NumberToBytesConverter<byte>.DefaultInfo.Create()),
                             new ConverterMappingHints(size: 1)));
                 }
             }
-            else if (underlyingModelType == typeof(char))
+            else if (modelClrType == typeof(char))
             {
-                foreach (var valueConverterInfo in ForChar(typeof(char), underlyingProviderType))
+                foreach (var valueConverterInfo in ForChar(typeof(char), providerClrType))
                 {
                     yield return valueConverterInfo;
                 }
             }
-            else if (underlyingModelType == typeof(Guid))
+            else if (modelClrType == typeof(Guid))
             {
-                if (underlyingProviderType == null
-                    || underlyingProviderType == typeof(byte[]))
+                if (providerClrType == null
+                    || providerClrType == typeof(byte[]))
                 {
                     yield return _converters.GetOrAdd(
-                        (underlyingModelType, typeof(byte[])),
+                        (modelClrType, typeof(byte[])),
                         k => GuidToBytesConverter.DefaultInfo);
                 }
 
-                if (underlyingProviderType == null
-                    || underlyingProviderType == typeof(string))
+                if (providerClrType == null
+                    || providerClrType == typeof(string))
                 {
                     yield return _converters.GetOrAdd(
-                        (underlyingModelType, typeof(string)),
+                        (modelClrType, typeof(string)),
                         k => GuidToStringConverter.DefaultInfo);
                 }
             }
-            else if (underlyingModelType == typeof(byte[]))
+            else if (modelClrType == typeof(byte[]))
             {
-                if (underlyingProviderType == null
-                    || underlyingProviderType == typeof(string))
+                if (providerClrType == null
+                    || providerClrType == typeof(string))
                 {
                     yield return _converters.GetOrAdd(
-                        (underlyingModelType, typeof(string)),
+                        (modelClrType, typeof(string)),
                         k => BytesToStringConverter.DefaultInfo);
                 }
             }
-            else if (underlyingModelType == typeof(Uri))
+            else if (modelClrType == typeof(Uri))
             {
-                if (underlyingProviderType == null
-                    || underlyingProviderType == typeof(string))
+                if (providerClrType == null
+                    || providerClrType == typeof(string))
                 {
                     yield return _converters.GetOrAdd(
-                        (underlyingModelType, typeof(string)),
+                        (modelClrType, typeof(string)),
                         k => UriToStringConverter.DefaultInfo);
                 }
             }
-            else if (underlyingModelType == typeof(string))
+            else if (modelClrType == typeof(string))
             {
-                if (underlyingProviderType == null
-                    || underlyingProviderType == typeof(byte[]))
+                if (providerClrType == null
+                    || providerClrType == typeof(byte[]))
                 {
                     yield return _converters.GetOrAdd(
-                        (underlyingModelType, typeof(byte[])),
+                        (modelClrType, typeof(byte[])),
                         k => StringToBytesConverter.DefaultInfo);
                 }
-                else if (underlyingProviderType.IsEnum)
+                else if (providerClrType.IsEnum)
                 {
                     yield return _converters.GetOrAdd(
-                        (typeof(string), underlyingProviderType),
+                        (typeof(string), providerClrType),
                         k => (ValueConverterInfo)typeof(StringToEnumConverter<>)
                             .MakeGenericType(k.ProviderClrType)
                             .GetAnyProperty("DefaultInfo")
                             .GetValue(null));
                 }
-                else if (_numerics.Contains(underlyingProviderType))
+                else if (_numerics.Contains(providerClrType))
                 {
                     foreach (var converterInfo in FindNumericConventions(
                         typeof(string),
-                        underlyingProviderType,
+                        providerClrType,
                         typeof(StringToNumberConverter<>),
                         null))
                     {
                         yield return converterInfo;
                     }
                 }
-                else if (underlyingProviderType == typeof(DateTime))
+                else if (providerClrType == typeof(DateTime))
                 {
                     yield return _converters.GetOrAdd(
-                        (underlyingModelType, typeof(DateTime)),
+                        (modelClrType, typeof(DateTime)),
                         k => StringToDateTimeConverter.DefaultInfo);
                 }
-                else if (underlyingProviderType == typeof(DateTimeOffset))
+                else if (providerClrType == typeof(DateTimeOffset))
                 {
                     yield return _converters.GetOrAdd(
-                        (underlyingModelType, typeof(DateTimeOffset)),
+                        (modelClrType, typeof(DateTimeOffset)),
                         k => StringToDateTimeOffsetConverter.DefaultInfo);
                 }
-                else if (underlyingProviderType == typeof(TimeSpan))
+                else if (providerClrType == typeof(TimeSpan))
                 {
                     yield return _converters.GetOrAdd(
-                        (underlyingModelType, typeof(TimeSpan)),
+                        (modelClrType, typeof(TimeSpan)),
                         k => StringToTimeSpanConverter.DefaultInfo);
                 }
-                else if (underlyingProviderType == typeof(Guid))
+                else if (providerClrType == typeof(Guid))
                 {
                     yield return _converters.GetOrAdd(
-                        (underlyingModelType, typeof(Guid)),
+                        (modelClrType, typeof(Guid)),
                         k => StringToGuidConverter.DefaultInfo);
                 }
-                else if (underlyingProviderType == typeof(bool))
+                else if (providerClrType == typeof(bool))
                 {
                     yield return _converters.GetOrAdd(
-                        (underlyingModelType, typeof(bool)),
+                        (modelClrType, typeof(bool)),
                         k => StringToBoolConverter.DefaultInfo);
                 }
-                else if (underlyingProviderType == typeof(char))
+                else if (providerClrType == typeof(char))
                 {
                     yield return _converters.GetOrAdd(
-                        (underlyingModelType, typeof(char)),
+                        (modelClrType, typeof(char)),
                         k => StringToCharConverter.DefaultInfo);
                 }
-                else if (underlyingProviderType == typeof(Uri))
+                else if (providerClrType == typeof(Uri))
                 {
                     yield return _converters.GetOrAdd(
-                        (underlyingModelType, typeof(Uri)),
+                        (modelClrType, typeof(Uri)),
                         k => StringToUriConverter.DefaultInfo);
                 }
             }
-            else if (underlyingModelType == typeof(DateTime)
-                     || underlyingModelType == typeof(DateTimeOffset)
-                     || underlyingModelType == typeof(TimeSpan))
+            else if (modelClrType == typeof(DateTime)
+                     || modelClrType == typeof(DateTimeOffset)
+                     || modelClrType == typeof(TimeSpan))
             {
-                if (underlyingProviderType == null
-                    || underlyingProviderType == typeof(string))
+                if (providerClrType == null
+                    || providerClrType == typeof(string))
                 {
                     yield return _converters.GetOrAdd(
-                        (underlyingModelType, typeof(string)),
+                        (modelClrType, typeof(string)),
                         k => k.ModelClrType == typeof(DateTime)
                             ? DateTimeToStringConverter.DefaultInfo
                             : k.ModelClrType == typeof(DateTimeOffset)
@@ -246,11 +243,11 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
                                 : TimeSpanToStringConverter.DefaultInfo);
                 }
 
-                if (underlyingProviderType == null
-                    || underlyingProviderType == typeof(long))
+                if (providerClrType == null
+                    || providerClrType == typeof(long))
                 {
                     yield return _converters.GetOrAdd(
-                        (underlyingModelType, typeof(long)),
+                        (modelClrType, typeof(long)),
                         k => k.ModelClrType == typeof(DateTime)
                             ? DateTimeToBinaryConverter.DefaultInfo
                             : k.ModelClrType == typeof(DateTimeOffset)
@@ -258,17 +255,17 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
                                 : TimeSpanToTicksConverter.DefaultInfo);
                 }
 
-                if (underlyingProviderType == null
-                    || underlyingProviderType == typeof(byte[]))
+                if (providerClrType == null
+                    || providerClrType == typeof(byte[]))
                 {
-                    yield return underlyingModelType == typeof(DateTimeOffset)
+                    yield return modelClrType == typeof(DateTimeOffset)
                         ? _converters.GetOrAdd(
-                            (underlyingModelType, typeof(byte[])),
+                            (modelClrType, typeof(byte[])),
                             k => DateTimeOffsetToBytesConverter.DefaultInfo)
                         : _converters.GetOrAdd(
-                            (underlyingModelType, typeof(byte[])),
+                            (modelClrType, typeof(byte[])),
                             k => new ValueConverterInfo(
-                                underlyingModelType,
+                                modelClrType,
                                 typeof(byte[]),
                                 i => (i.ModelClrType == typeof(DateTime)
                                         ? DateTimeToBinaryConverter.DefaultInfo.Create()
@@ -278,15 +275,15 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
                                 NumberToBytesConverter<long>.DefaultInfo.MappingHints));
                 }
             }
-            else if (_numerics.Contains(underlyingModelType)
-                     && (underlyingProviderType == null
-                         || underlyingProviderType == typeof(byte[])
-                         || underlyingProviderType == typeof(string)
-                         || _numerics.Contains(underlyingProviderType)))
+            else if (_numerics.Contains(modelClrType)
+                     && (providerClrType == null
+                         || providerClrType == typeof(byte[])
+                         || providerClrType == typeof(string)
+                         || _numerics.Contains(providerClrType)))
             {
                 foreach (var converterInfo in FindNumericConventions(
-                    underlyingModelType,
-                    underlyingProviderType,
+                    modelClrType,
+                    providerClrType,
                     typeof(CastingConverter<,>),
                     NumberToStringOrBytes))
                 {

--- a/test/EFCore.Cosmos.FunctionalTests/BuiltInDataTypesCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/BuiltInDataTypesCosmosTest.cs
@@ -2,29 +2,80 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Cosmos.TestUtilities;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Cosmos
 {
-    // TODO: Issue #12086
-    internal class BuiltInDataTypesCosmosTest : BuiltInDataTypesTestBase<BuiltInDataTypesCosmosTest.BuiltInDataTypesCosmosFixture>
+    public class BuiltInDataTypesCosmosTest : BuiltInDataTypesTestBase<BuiltInDataTypesCosmosTest.BuiltInDataTypesCosmosFixture>
     {
         public BuiltInDataTypesCosmosTest(BuiltInDataTypesCosmosFixture fixture)
             : base(fixture)
         {
         }
 
-        public override void Can_query_using_any_nullable_data_type_as_literal()
+        [ConditionalTheory(Skip = "Issue #16919")]
+        public override Task Can_filter_projection_with_inline_enum_variable(bool async)
         {
-            // TODO: Requires ReLinq to be removed
+            return base.Can_filter_projection_with_inline_enum_variable(async);
         }
 
+        [ConditionalTheory(Skip = "Issue #16919")]
+        public override Task Can_filter_projection_with_captured_enum_variable(bool async)
+        {
+            return base.Can_filter_projection_with_captured_enum_variable(async);
+        }
+
+        [ConditionalFact(Skip = "Issue #16919")]
+        public override void Can_query_using_any_data_type()
+        {
+            base.Can_query_using_any_data_type();
+        }
+
+        [ConditionalFact(Skip = "Issue #16919")]
+        public override void Can_query_using_any_data_type_nullable_shadow()
+        {
+            base.Can_query_using_any_data_type_nullable_shadow();
+        }
+
+        [ConditionalFact(Skip = "Issue #16919")]
+        public override void Can_query_using_any_data_type_shadow()
+        {
+            base.Can_query_using_any_data_type_shadow();
+        }
+
+        [ConditionalFact(Skip = "Issue #16919")]
+        public override void Can_query_using_any_nullable_data_type()
+        {
+            base.Can_query_using_any_nullable_data_type();
+        }
+
+        [ConditionalFact(Skip = "Issue #16919")]
+        public override void Can_query_using_any_nullable_data_type_as_literal()
+        {
+            base.Can_query_using_any_nullable_data_type_as_literal();
+        }
+
+        [ConditionalFact(Skip = "Issue #16919")]
+        public override void Can_query_with_null_parameters_using_any_nullable_data_type()
+        {
+            base.Can_query_with_null_parameters_using_any_nullable_data_type();
+        }
+
+        [ConditionalFact(Skip = "Issue #16919")]
+        public override void Can_insert_and_read_back_with_string_key()
+        {
+            base.Can_insert_and_read_back_with_string_key();
+        }
+
+        [ConditionalFact(Skip = "Issue #16920")]
         public override void Can_insert_and_read_back_with_binary_key()
         {
-            // TODO: For this to work Join needs to be translated or compiled as a Join with custom equality comparer
+            base.Can_insert_and_read_back_with_binary_key();
         }
 
         public override void Can_perform_query_with_max_length()
@@ -37,6 +88,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
             protected override ITestStoreFactory TestStoreFactory => CosmosTestStoreFactory.Instance;
 
             public override bool StrictEquality => true;
+
+            public override int IntegerPrecision => 53;
 
             public override bool SupportsAnsi => false;
 

--- a/test/EFCore.Cosmos.FunctionalTests/CustomConvertersCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/CustomConvertersCosmosTest.cs
@@ -2,15 +2,16 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Cosmos.TestUtilities;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Cosmos
 {
-    // TODO: Issue #12086
-    internal class CustomConvertersCosmosTest : CustomConvertersTestBase<CustomConvertersCosmosTest.CustomConvertersCosmosFixture>
+    public class CustomConvertersCosmosTest : CustomConvertersTestBase<CustomConvertersCosmosTest.CustomConvertersCosmosFixture>
     {
         public CustomConvertersCosmosTest(CustomConvertersCosmosFixture fixture)
             : base(fixture)
@@ -22,13 +23,88 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
             // Over the 2Mb document limit
         }
 
-        // TODO: For these to work Join needs to be translated or compiled as a Join with custom equality comparer
-        public override void Can_insert_and_read_back_with_binary_key()
+        [ConditionalTheory(Skip = "Issue #16919")]
+        public override Task Can_filter_projection_with_inline_enum_variable(bool async)
         {
+            return base.Can_filter_projection_with_inline_enum_variable(async);
         }
 
+        [ConditionalTheory(Skip = "Issue #16919")]
+        public override Task Can_filter_projection_with_captured_enum_variable(bool async)
+        {
+            return base.Can_filter_projection_with_captured_enum_variable(async);
+        }
+
+        [ConditionalFact(Skip = "Issue #16919")]
+        public override void Can_query_using_any_data_type()
+        {
+            base.Can_query_using_any_data_type();
+        }
+
+        [ConditionalFact(Skip = "Issue #16919")]
+        public override void Can_query_using_any_data_type_nullable_shadow()
+        {
+            base.Can_query_using_any_data_type_nullable_shadow();
+        }
+
+        [ConditionalFact(Skip = "Issue #16919")]
+        public override void Can_query_using_any_data_type_shadow()
+        {
+            base.Can_query_using_any_data_type_shadow();
+        }
+
+        [ConditionalFact(Skip = "Issue #16919")]
+        public override void Can_query_using_any_nullable_data_type()
+        {
+            base.Can_query_using_any_nullable_data_type();
+        }
+
+        [ConditionalFact(Skip = "Issue #16919")]
+        public override void Can_query_using_any_nullable_data_type_as_literal()
+        {
+            base.Can_query_using_any_nullable_data_type_as_literal();
+        }
+
+        [ConditionalFact(Skip = "Issue #16919")]
+        public override void Can_query_with_null_parameters_using_any_nullable_data_type()
+        {
+            base.Can_query_with_null_parameters_using_any_nullable_data_type();
+        }
+
+        [ConditionalFact(Skip = "Issue #16919")]
+        public override void Can_insert_and_read_back_with_string_key()
+        {
+            base.Can_insert_and_read_back_with_string_key();
+        }
+
+        [ConditionalFact(Skip = "Issue #16919")]
+        public override void Can_query_and_update_with_conversion_for_custom_struct()
+        {
+            base.Can_query_and_update_with_conversion_for_custom_struct();
+        }
+
+        [ConditionalFact(Skip = "Issue #16919")]
+        public override void Can_query_and_update_with_conversion_for_custom_type()
+        {
+            base.Can_query_and_update_with_conversion_for_custom_type();
+        }
+
+        [ConditionalFact(Skip = "Issue #16920")]
+        public override void Can_query_and_update_with_nullable_converter_on_primary_key()
+        {
+            base.Can_query_and_update_with_nullable_converter_on_primary_key();
+        }
+
+        [ConditionalFact(Skip = "Issue #16920")]
+        public override void Can_insert_and_read_back_with_binary_key()
+        {
+            base.Can_insert_and_read_back_with_binary_key();
+        }
+
+        [ConditionalFact(Skip = "Issue #16920")]
         public override void Can_insert_and_read_back_with_case_insensitive_string_key()
         {
+            base.Can_insert_and_read_back_with_case_insensitive_string_key();
         }
 
         public class CustomConvertersCosmosFixture : CustomConvertersFixtureBase
@@ -36,6 +112,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
             protected override ITestStoreFactory TestStoreFactory => CosmosTestStoreFactory.Instance;
 
             public override bool StrictEquality => true;
+
+            public override int IntegerPrecision => 53;
 
             public override bool SupportsAnsi => false;
 

--- a/test/EFCore.Cosmos.FunctionalTests/EmbeddedDocumentsTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/EmbeddedDocumentsTest.cs
@@ -192,7 +192,22 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
             {
                 using (var context = CreateContext())
                 {
-                    context.Add(new Person { Id = 3, Addresses = new[] { new Address { Street = "First", City = "City" }, new Address { Street = "Second", City = "City" } } });
+                    context.Add(
+                        new Person
+                        {
+                            Id = 3,
+                            Addresses = new[]
+                            {
+                                new Address
+                                {
+                                    Street = "First", City = "City"
+                                },
+                                new Address
+                                {
+                                    Street = "Second", City = "City"
+                                }
+                            }
+                        });
 
                     context.SaveChanges();
                 }


### PR DESCRIPTION
Move the null check outside of the value convertor to avoid turning null into 0.
Take integer precision into account in the type mapping tests.

Fixes #13164