### PR TITLE
Stop using similar-looking owned entity in deeply nested case

### DIFF
--- a/src/EFCore/Metadata/Internal/InternalRelationshipBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalRelationshipBuilder.cs
@@ -3154,7 +3154,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                             principalEntityType = model.FindEntityType(
                                 Metadata.PrincipalEntityType.Name,
                                 Metadata.PrincipalEntityType.DefiningNavigationName,
-                                Metadata.PrincipalEntityType.DefiningEntityType.Name);
+                                Metadata.PrincipalEntityType.DefiningEntityType);
                             if (principalEntityType == null)
                             {
                                 return null;
@@ -3209,7 +3209,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                                     dependentEntityType = model.FindEntityType(
                                         Metadata.DeclaringEntityType.Name,
                                         Metadata.DeclaringEntityType.DefiningNavigationName,
-                                        Metadata.DeclaringEntityType.DefiningEntityType.Name);
+                                        Metadata.DeclaringEntityType.DefiningEntityType);
                                 }
 
                                 if (dependentEntityType == null)

--- a/src/EFCore/Metadata/Internal/Model.cs
+++ b/src/EFCore/Metadata/Internal/Model.cs
@@ -462,25 +462,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual EntityType FindEntityType(
             [NotNull] string name,
             [NotNull] string definingNavigationName,
-            [NotNull] string definingEntityTypeName)
-        {
-            return !_entityTypesWithDefiningNavigation.TryGetValue(name, out var entityTypesWithSameType)
-                ? null
-                : entityTypesWithSameType
-                    .FirstOrDefault(
-                        e => e.DefiningNavigationName == definingNavigationName
-                             && e.DefiningEntityType.Name == definingEntityTypeName);
-        }
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public virtual EntityType FindEntityType(
-            [NotNull] string name,
-            [NotNull] string definingNavigationName,
             [NotNull] EntityType definingEntityType)
             => !_entityTypesWithDefiningNavigation.TryGetValue(name, out var entityTypesWithSameType)
                 ? null


### PR DESCRIPTION
Fixes #15839

The issue was that both the immediate owner for `Rejection.FirstTest#FirstTest.Tester#SpecialistStaff` and `Attitude.FirstTest#FirstTest.Tester#SpecialistStaff` are the same resulting in the former being mistaken for the latter. The fix is to use the type rather than its name.
