### PR TITLE
Handle binary keys of different lengths in update pipeline

### DIFF
--- a/src/EFCore.Relational/Update/Internal/ModificationCommandComparer.cs
+++ b/src/EFCore.Relational/Update/Internal/ModificationCommandComparer.cs
@@ -151,6 +151,16 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
         private static readonly MethodInfo _structuralCompareMethod
             = typeof(ModificationCommandComparer).GetTypeInfo().GetDeclaredMethod(nameof(CompareStructureValue));
 
-        private static int CompareStructureValue<T>(T x, T y) => StructuralComparisons.StructuralComparer.Compare(x, y);
+        private static int CompareStructureValue<T>(T x, T y)
+        {
+            if (x is Array array1
+                && y is Array array2
+                && array1.Length != array2.Length)
+            {
+                return array1.Length - array2.Length;
+            }
+
+            return StructuralComparisons.StructuralComparer.Compare(x, y);
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
@@ -2498,6 +2498,7 @@ WHERE (DATEDIFF(NANOSECOND, [m].[TimeSpanAsTime], @__timeSpan_1) = 0) AND DATEDI
 
             const string expected = @"BinaryForeignKeyDataType.BinaryKeyDataTypeId ---> [nullable varbinary] [MaxLength = 900]
 BinaryForeignKeyDataType.Id ---> [int] [Precision = 10 Scale = 0]
+BinaryKeyDataType.Ex ---> [nullable nvarchar] [MaxLength = -1]
 BinaryKeyDataType.Id ---> [varbinary] [MaxLength = 900]
 BuiltInDataTypes.Enum16 ---> [smallint] [Precision = 5 Scale = 0]
 BuiltInDataTypes.Enum32 ---> [int] [Precision = 10 Scale = 0]

--- a/test/EFCore.SqlServer.FunctionalTests/ConvertToProviderTypesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ConvertToProviderTypesSqlServerTest.cs
@@ -32,6 +32,7 @@ namespace Microsoft.EntityFrameworkCore
 
             const string expected = @"BinaryForeignKeyDataType.BinaryKeyDataTypeId ---> [nullable nvarchar] [MaxLength = 450]
 BinaryForeignKeyDataType.Id ---> [int] [Precision = 10 Scale = 0]
+BinaryKeyDataType.Ex ---> [nullable nvarchar] [MaxLength = -1]
 BinaryKeyDataType.Id ---> [nvarchar] [MaxLength = 450]
 BuiltInDataTypes.Enum16 ---> [bigint] [Precision = 19 Scale = 0]
 BuiltInDataTypes.Enum32 ---> [bigint] [Precision = 19 Scale = 0]

--- a/test/EFCore.SqlServer.FunctionalTests/CustomConvertersSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/CustomConvertersSqlServerTest.cs
@@ -27,6 +27,7 @@ namespace Microsoft.EntityFrameworkCore
 
             const string expected = @"BinaryForeignKeyDataType.BinaryKeyDataTypeId ---> [nullable varbinary] [MaxLength = 900]
 BinaryForeignKeyDataType.Id ---> [int] [Precision = 10 Scale = 0]
+BinaryKeyDataType.Ex ---> [nullable nvarchar] [MaxLength = -1]
 BinaryKeyDataType.Id ---> [varbinary] [MaxLength = 900]
 BuiltInDataTypes.Enum16 ---> [bigint] [Precision = 19 Scale = 0]
 BuiltInDataTypes.Enum32 ---> [bigint] [Precision = 19 Scale = 0]

--- a/test/EFCore.SqlServer.FunctionalTests/EverythingIsBytesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/EverythingIsBytesSqlServerTest.cs
@@ -31,6 +31,7 @@ namespace Microsoft.EntityFrameworkCore
 
             const string expected = @"BinaryForeignKeyDataType.BinaryKeyDataTypeId ---> [nullable varbinary] [MaxLength = 900]
 BinaryForeignKeyDataType.Id ---> [varbinary] [MaxLength = 4]
+BinaryKeyDataType.Ex ---> [nullable varbinary] [MaxLength = -1]
 BinaryKeyDataType.Id ---> [varbinary] [MaxLength = 900]
 BuiltInDataTypes.Enum16 ---> [varbinary] [MaxLength = 2]
 BuiltInDataTypes.Enum32 ---> [varbinary] [MaxLength = 4]

--- a/test/EFCore.SqlServer.FunctionalTests/EverythingIsStringsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/EverythingIsStringsSqlServerTest.cs
@@ -32,6 +32,7 @@ namespace Microsoft.EntityFrameworkCore
 
             const string expected = @"BinaryForeignKeyDataType.BinaryKeyDataTypeId ---> [nullable nvarchar] [MaxLength = 450]
 BinaryForeignKeyDataType.Id ---> [nvarchar] [MaxLength = 64]
+BinaryKeyDataType.Ex ---> [nullable nvarchar] [MaxLength = -1]
 BinaryKeyDataType.Id ---> [nvarchar] [MaxLength = 450]
 BuiltInDataTypes.Enum16 ---> [nvarchar] [MaxLength = -1]
 BuiltInDataTypes.Enum32 ---> [nvarchar] [MaxLength = -1]


### PR DESCRIPTION
Fixes #16888

Note that `StructuralEqualityComparer.Equals` does not suffer from this problem.
