### PR TITLE
Full OldTable on AlterTableOperation, further comment support

### DIFF
--- a/src/EFCore.Design/Migrations/Design/CSharpMigrationOperationGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpMigrationOperationGenerator.cs
@@ -768,6 +768,14 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                         .Append(Code.Literal(operation.Comment));
                 }
 
+                if (operation.OldTable.Comment != null)
+                {
+                    builder
+                        .AppendLine(",")
+                        .Append("oldComment: ")
+                        .Append(Code.Literal(operation.OldTable.Comment));
+                }
+
                 builder.Append(")");
 
                 Annotations(operation.GetAnnotations(), builder);
@@ -1051,6 +1059,13 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                             builder
                                 .Append(", defaultValue: ")
                                 .Append(Code.UnknownLiteral(column.DefaultValue));
+                        }
+
+                        if (column.Comment != null)
+                        {
+                            builder
+                                .Append(", comment: ")
+                                .Append(Code.Literal(operation.Comment));
                         }
 
                         builder.Append(")");

--- a/src/EFCore.Relational/Migrations/MigrationBuilder.cs
+++ b/src/EFCore.Relational/Migrations/MigrationBuilder.cs
@@ -480,11 +480,13 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         /// <param name="name"> The table name. </param>
         /// <param name="schema"> The schema that contains the table, or <c>null</c> to use the default schema. </param>
         /// <param name="comment"> A comment to associate with the table. </param>
+        /// <param name="oldComment"> The previous comment to associate with the table. </param>
         /// <returns> A builder to allow annotations to be added to the operation. </returns>
         public virtual AlterOperationBuilder<AlterTableOperation> AlterTable(
             [NotNull] string name,
             [CanBeNull] string schema = null,
-            [CanBeNull] string comment = null)
+            [CanBeNull] string comment = null,
+            [CanBeNull] string oldComment = null)
         {
             Check.NotEmpty(name, nameof(name));
 
@@ -492,7 +494,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             {
                 Schema = schema,
                 Name = name,
-                Comment = comment
+                Comment = comment,
+                OldTable = new TableOperation
+                {
+                    Comment = oldComment
+                }
             };
             Operations.Add(operation);
 
@@ -679,7 +685,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         /// <param name="constraints">
         ///     A delegate allowing constraints to be applied over the columns configured by the 'columns' delegate above.
         /// </param>
-        /// <param name="comment"> A comment to been applied to the table. </param>
+        /// <param name="comment"> A comment to be applied to the table. </param>
         /// <returns> A <see cref="CreateTableBuilder{TColumns}" /> to allow further configuration to be chained. </returns>
         public virtual CreateTableBuilder<TColumns> CreateTable<TColumns>(
             [NotNull] string name,

--- a/src/EFCore.Relational/Migrations/Operations/AlterTableOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/AlterTableOperation.cs
@@ -10,7 +10,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
     /// <summary>
     ///     A <see cref="MigrationOperation" /> to alter an existing table.
     /// </summary>
-    public class AlterTableOperation : MigrationOperation, IAlterMigrationOperation
+    public class AlterTableOperation : TableOperation, IAlterMigrationOperation
     {
         /// <summary>
         ///     The name of the table.
@@ -23,14 +23,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
         public virtual string Schema { get; [param: CanBeNull] set; }
 
         /// <summary>
-        ///     Comment for this table
-        /// </summary>
-        public virtual string Comment { get; [param: CanBeNull] set; }
-
-        /// <summary>
         ///     An operation representing the table as it was before being altered.
         /// </summary>
-        public virtual Annotatable OldTable { get; [param: NotNull] set; } = new Annotatable();
+        public virtual TableOperation OldTable { get; [param: NotNull] set; } = new TableOperation();
 
         /// <inheritdoc />
         IMutableAnnotatable IAlterMigrationOperation.OldAnnotations => OldTable;

--- a/src/EFCore.Relational/Migrations/Operations/Builders/ColumnsBuilder.cs
+++ b/src/EFCore.Relational/Migrations/Operations/Builders/ColumnsBuilder.cs
@@ -44,6 +44,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations.Builders
         /// <param name="defaultValueSql"> The SQL expression to use for the column's default constraint. </param>
         /// <param name="computedColumnSql"> The SQL expression to use to compute the column value. </param>
         /// <param name="fixedLength"> Indicates whether or not the column is constrained to fixed-length data. </param>
+        /// <param name="comment"> A comment to be applied to the table. </param>
         /// <returns> The same builder so that multiple calls can be chained. </returns>
         public virtual OperationBuilder<AddColumnOperation> Column<T>(
             [CanBeNull] string type = null,
@@ -55,7 +56,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations.Builders
             [CanBeNull] object defaultValue = null,
             [CanBeNull] string defaultValueSql = null,
             [CanBeNull] string computedColumnSql = null,
-            bool? fixedLength = null)
+            bool? fixedLength = null,
+            [CanBeNull] string comment = null)
         {
             var operation = new AddColumnOperation
             {
@@ -71,7 +73,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations.Builders
                 DefaultValue = defaultValue,
                 DefaultValueSql = defaultValueSql,
                 ComputedColumnSql = computedColumnSql,
-                IsFixedLength = fixedLength
+                IsFixedLength = fixedLength,
+                Comment = comment
             };
             _createTableOperation.Columns.Add(operation);
 

--- a/src/EFCore.Relational/Migrations/Operations/CreateTableOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/CreateTableOperation.cs
@@ -9,7 +9,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
     /// <summary>
     ///     A <see cref="MigrationOperation" /> for creating a new table.
     /// </summary>
-    public class CreateTableOperation : MigrationOperation
+    public class CreateTableOperation : TableOperation
     {
         /// <summary>
         ///     The name of the table.
@@ -20,11 +20,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
         ///     The schema that contains the table, or <c>null</c> if the default schema should be used.
         /// </summary>
         public virtual string Schema { get; [param: CanBeNull] set; }
-
-        /// <summary>
-        ///     Comment for this table
-        /// </summary>
-        public virtual string Comment { get; [param: CanBeNull] set; }
 
         /// <summary>
         ///     The <see cref="AddPrimaryKeyOperation" /> representing the creation of the primary key for the table.

--- a/src/EFCore.Relational/Migrations/Operations/TableOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/TableOperation.cs
@@ -1,0 +1,19 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Migrations.Operations
+{
+    /// <summary>
+    ///     A <see cref="MigrationOperation" /> for operations on tables.
+    ///     See also <see cref="CreateTableOperation" /> and <see cref="AlterTableOperation" />.
+    /// </summary>
+    public class TableOperation : MigrationOperation
+    {
+        /// <summary>
+        ///     Comment for this table
+        /// </summary>
+        public virtual string Comment { get; [param: CanBeNull] set; }
+    }
+}

--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -137,7 +138,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
                 if (operation.Comment != null)
                 {
-                    AddDropComment(builder, operation.Comment, null, operation.Schema, operation.Table, operation.Name);
+                    GenerateComment(builder, model, operation.Comment, null,
+                        operation.Schema,
+                        "Table", operation.Table,
+                        "Column", operation.Name);
                 }
 
                 builder.EndCommand(suppressTransaction: IsMemoryOptimized(operation, model, operation.Schema, operation.Table));
@@ -339,7 +343,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
             if (operation.OldColumn.Comment != operation.Comment)
             {
-                AddDropComment(builder, operation.Comment, operation.OldColumn.Comment, operation.Schema, operation.Table, operation.Name);
+                GenerateComment(builder, model, operation.Comment, operation.OldColumn.Comment,
+                    operation.Schema,
+                    "Table", operation.Table,
+                    "Column", operation.Name);
             }
 
             if (narrowed)
@@ -478,12 +485,16 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
             if (operation.Comment != null)
             {
-                AddDropComment(builder, operation.Comment, null, operation.Schema, operation.Name);
+                GenerateComment(builder, model, operation.Comment, null, operation.Schema, "Table", operation.Name);
             }
 
             foreach (var column in operation.Columns.Where(c => c.Comment != null))
             {
-                AddDropComment(builder, column.Comment, null, operation.Schema, operation.Name, column.Name);
+                GenerateComment(builder, model, column.Comment, null,
+                    operation.Schema,
+                    "Table", operation.Name,
+                    "Column", column.Name,
+                    firstComment: false);
             }
 
             builder.EndCommand(suppressTransaction: memoryOptimized);
@@ -671,7 +682,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             Check.NotNull(operation, nameof(operation));
             Check.NotNull(builder, nameof(builder));
 
-            if (string.Equals(operation.Name, "DBO", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(operation.Name, "dbo", StringComparison.OrdinalIgnoreCase))
             {
                 return;
             }
@@ -965,7 +976,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 throw new InvalidOperationException(SqlServerStrings.AlterMemoryOptimizedTable);
             }
 
-            base.Generate(operation, model, builder);
+            if (operation.OldTable.Comment != operation.Comment)
+            {
+                GenerateComment(builder, model, operation.Comment, operation.OldTable.Comment, operation.Schema, "Table", operation.Name);
+            }
+
+            builder.EndCommand(suppressTransaction: IsMemoryOptimized(operation, model, operation.Schema, operation.Name));
         }
 
         /// <summary>
@@ -1640,41 +1656,76 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         ///     </para>
         /// </summary>
         /// <param name="builder"> The command builder to use to build the commands. </param>
+        /// <param name="model"> The target model which may be <c>null</c> if the operations exist without a model. </param>
         /// <param name="comment"> The new comment to be applied. </param>
         /// <param name="oldComment"> The previous comment. </param>
         /// <param name="schema"> The schema of the table. </param>
-        /// <param name="table"> The name of the table. </param>
-        /// <param name="columnName"> The column name if comment is being applied to a column. </param>
-        protected virtual void AddDropComment(
+        /// <param name="level1Type"> The type of the level1 object (Table, Index). </param>
+        /// <param name="level1Name"> The name of the table or index. </param>
+        /// <param name="level2Type"> The type of the level2 object (Column). </param>
+        /// <param name="level2Name"> The name of the column. </param>
+        /// <param name="firstComment">
+        ///     Indicates whether this is the first comment operation being generated in this batch.
+        ///     Only the first operation will cause the @schema variable to be declared and set.
+        /// </param>
+        protected virtual void GenerateComment(
             [NotNull] MigrationCommandListBuilder builder,
+            [CanBeNull] IModel model,
             [CanBeNull] string comment,
             [CanBeNull] string oldComment,
-            [NotNull] string schema,
-            [NotNull] string table,
-            [CanBeNull] string columnName = null)
+            [CanBeNull] string schema,
+            [NotNull] string level1Type,
+            [NotNull] string level1Name,
+            [CanBeNull] string level2Type = null,
+            [CanBeNull] string level2Name = null,
+            bool firstComment = true)
         {
             if (comment == oldComment)
             {
                 return;
             }
 
+            var stringTypeMapping = Dependencies.TypeMappingSource.GetMapping(typeof(string));
+
+            schema ??= model?.GetDefaultSchema();
+            if (schema == null)
+            {
+                if (firstComment)
+                {
+                    builder.Append("DECLARE @schema AS nvarchar(max)")
+                        .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator);
+                    builder.Append("SET @schema = SCHEMA_NAME()")
+                        .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator);
+                }
+                schema = "@schema";
+            }
+            else
+            {
+                schema = Literal(schema);
+            }
+
             if (oldComment != null)
             {
-                GenerateDropExtendedProperty(builder,
-                    "Comment",
-                    "Schema", schema,
-                    "Table", table,
-                    columnName == null ? null : "Column", columnName);
+                GenerateDropExtendedProperty(
+                    builder,
+                    Literal("Comment"),
+                    Literal("Schema"), schema,
+                    Literal(level1Type), Literal(level1Name),
+                    level2Type == null ? null : Literal(level2Type),
+                    level2Type == null ? null : Literal(level2Name));
             }
 
             if (comment != null)
             {
                 GenerateAddExtendedProperty(builder,
-                    "Comment", comment,
-                    "Schema", schema,
-                    "Table", table,
-                    columnName == null ? null : "Column", columnName);
+                    Literal("Comment"), Literal(comment),
+                    Literal("Schema"), schema,
+                    Literal(level1Type), Literal(level1Name),
+                    level2Type == null ? null : Literal(level2Type),
+                    level2Type == null ? null : Literal(level2Name));
             }
+
+            string Literal(string s) => stringTypeMapping.GenerateSqlLiteral(s);
         }
 
         /// <summary>
@@ -1717,37 +1768,38 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             Check.NotNull(builder, nameof(builder));
             Check.NotNull(name, nameof(name));
 
-            var stringTypeMapping = Dependencies.TypeMappingSource.GetMapping(typeof(string));
-
-            builder.Append("EXEC sp_addextendedproperty @name = ").Append(stringTypeMapping.GenerateSqlLiteral(name));
+            builder.Append("EXEC sp_addextendedproperty @name = ").Append(name);
             if (value != null)
             {
-                builder.Append(", @value = ").Append(stringTypeMapping.GenerateSqlLiteral(value));
+                builder.Append(", @value = ").Append(value);
             }
 
             if (level0Type != null)
             {
+                Debug.Assert(level0Name != null);
                 builder
                     .Append(", @level0type = ")
-                    .Append(stringTypeMapping.GenerateSqlLiteral(level0Type))
+                    .Append(level0Type)
                     .Append(", @level0name = ")
-                    .Append(stringTypeMapping.GenerateSqlLiteral(level0Name));
+                    .Append(level0Name);
 
                 if (level1Type != null)
                 {
+                    Debug.Assert(level1Name != null);
                     builder
                         .Append(", @level1type = ")
-                        .Append(stringTypeMapping.GenerateSqlLiteral(level1Type))
+                        .Append(level1Type)
                         .Append(", @level1name = ")
-                        .Append(stringTypeMapping.GenerateSqlLiteral(level1Name));
+                        .Append(level1Name);
 
                     if (level2Type != null)
                     {
+                        Debug.Assert(level2Name != null);
                         builder
                             .Append(", @level2type = ")
-                            .Append(stringTypeMapping.GenerateSqlLiteral(level2Type))
+                            .Append(level2Type)
                             .Append(", @level2name = ")
-                            .Append(stringTypeMapping.GenerateSqlLiteral(level2Name));
+                            .Append(level2Name);
                     }
                 }
             }
@@ -1790,33 +1842,34 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             Check.NotNull(builder, nameof(builder));
             Check.NotNull(name, nameof(name));
 
-            var stringTypeMapping = Dependencies.TypeMappingSource.GetMapping(typeof(string));
-
-            builder.Append("EXEC sp_dropextendedproperty @name = ").Append(stringTypeMapping.GenerateSqlLiteral(name));
+            builder.Append("EXEC sp_dropextendedproperty @name = ").Append(name);
 
             if (level0Type != null)
             {
+                Debug.Assert(level0Name != null);
                 builder
                     .Append(", @level0type = ")
-                    .Append(stringTypeMapping.GenerateSqlLiteral(level0Type))
+                    .Append(level0Type)
                     .Append(", @level0name = ")
-                    .Append(stringTypeMapping.GenerateSqlLiteral(level0Name));
+                    .Append(level0Name);
 
                 if (level1Type != null)
                 {
+                    Debug.Assert(level1Name != null);
                     builder
                         .Append(", @level1type = ")
-                        .Append(stringTypeMapping.GenerateSqlLiteral(level1Type))
+                        .Append(level1Type)
                         .Append(", @level1name = ")
-                        .Append(stringTypeMapping.GenerateSqlLiteral(level1Name));
+                        .Append(level1Name);
 
                     if (level2Type != null)
                     {
+                        Debug.Assert(level2Name != null);
                         builder
                             .Append(", @level2type = ")
-                            .Append(stringTypeMapping.GenerateSqlLiteral(level2Type))
+                            .Append(level2Type)
                             .Append(", @level2name = ")
-                            .Append(stringTypeMapping.GenerateSqlLiteral(level2Name));
+                            .Append(level2Name);
                     }
                 }
             }

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationOperationGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationOperationGeneratorTest.cs
@@ -778,17 +778,23 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 {
                     Name = "Customer",
                     Schema = "dbo",
-                    Comment = "My Comment"
+                    Comment = "My Comment 2",
+                    OldTable =
+                    {
+                        Comment = "My Comment"
+                    }
                 },
                 "mb.AlterTable(" + _eol +
                 "    name: \"Customer\"," + _eol +
                 "    schema: \"dbo\"," + _eol +
-                "    comment: \"My Comment\");",
+                "    comment: \"My Comment 2\"," + _eol +
+                "    oldComment: \"My Comment\");",
                 o =>
                 {
                     Assert.Equal("Customer", o.Name);
                     Assert.Equal("dbo", o.Schema);
-                    Assert.Equal("My Comment", o.Comment);
+                    Assert.Equal("My Comment 2", o.Comment);
+                    Assert.Equal("My Comment", o.OldTable.Comment);
                 });
         }
 

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -621,6 +621,38 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         }
 
         [ConditionalFact]
+        public void Alter_table_comment()
+        {
+            Execute(
+                source => source.Entity(
+                    "MountainLion",
+                    x =>
+                    {
+                        x.ToTable("MountainLion", "dbo");
+                        x.Property<int>("Id");
+                        x.HasComment("Old comment");
+                    }),
+                target => target.Entity(
+                    "MountainLion",
+                    x =>
+                    {
+                        x.ToTable("MountainLion", "dbo");
+                        x.Property<int>("Id");
+                        x.HasComment("New comment");
+                    }),
+                operations =>
+                {
+                    Assert.Equal(1, operations.Count);
+
+                    var operation = Assert.IsType<AlterTableOperation>(operations[0]);
+                    Assert.Equal("dbo", operation.Schema);
+                    Assert.Equal("MountainLion", operation.Name);
+                    Assert.Equal("New comment", operation.Comment);
+                    Assert.Equal("Old comment", operation.OldTable.Comment);
+                });
+        }
+
+        [ConditionalFact]
         public void Rename_table()
         {
             Execute(


### PR DESCRIPTION
Changed AlterTableOperation.OldTable from Annotatable to TableOperation,
and did various fixes throughout to support comment alteration on tables.

Some comment fixes and refactoring.

Fixes #16819
Fixes #16798 

* The extended property functions (e.g. sp_addextendedproperty) don't accept NULL for schema - it must always be passed. Am defaulting to the model default and after that to dbo, hopefully that's right.
* Trying to call sp_addextendedproperty or sp_dropextendedproperty twice results in an error (property is already defined), meaning that this comment implementation isn't idempotent. Does it need to be?