### PR TITLE
Add a convention that configures default value for a property

### DIFF
--- a/src/EFCore.Relational/Metadata/Conventions/Infrastructure/RelationalConventionSetBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Infrastructure/RelationalConventionSetBuilder.cs
@@ -67,8 +67,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             ReplaceConvention(conventionSet.ForeignKeyRemovedConventions, valueGenerationConvention);
 
             var relationalColumnAttributeConvention = new RelationalColumnAttributeConvention(Dependencies, RelationalDependencies);
+            var relationalDefaultValueAttributeConvention = new RelationalDefaultValueAttributeConvention(Dependencies, RelationalDependencies);
 
             conventionSet.PropertyAddedConventions.Add(relationalColumnAttributeConvention);
+            conventionSet.PropertyAddedConventions.Add(relationalDefaultValueAttributeConvention);
 
             var tableNameFromDbSetConvention = new TableNameFromDbSetConvention(Dependencies, RelationalDependencies);
             conventionSet.EntityTypeAddedConventions.Add(new RelationalTableAttributeConvention(Dependencies, RelationalDependencies));
@@ -77,6 +79,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             conventionSet.EntityTypeBaseTypeChangedConventions.Add(tableNameFromDbSetConvention);
 
             conventionSet.PropertyFieldChangedConventions.Add(relationalColumnAttributeConvention);
+            conventionSet.PropertyFieldChangedConventions.Add(relationalDefaultValueAttributeConvention);
 
             var storeGenerationConvention = new StoreGenerationConvention(Dependencies, RelationalDependencies);
             conventionSet.PropertyAnnotationChangedConventions.Add(storeGenerationConvention);

--- a/src/EFCore.Relational/Metadata/Conventions/RelationalDefaultValueAttributeConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/RelationalDefaultValueAttributeConvention.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
+{
+    /// <summary>
+    ///     A convention that configures default value for a property based on the applied <see cref="DefaultValueAttribute"/>.
+    /// </summary>
+    public class RelationalDefaultValueAttributeConvention : PropertyAttributeConventionBase<DefaultValueAttribute>
+    {
+        /// <summary>
+        ///     Creates a new instance of <see cref="RelationalDefaultValueAttributeConvention" />.
+        /// </summary>
+        /// <param name="dependencies"> Parameter object containing dependencies for this convention. </param>
+        /// <param name="relationalDependencies">  Parameter object containing relational dependencies for this convention. </param>
+        public RelationalDefaultValueAttributeConvention(
+            [NotNull] ProviderConventionSetBuilderDependencies dependencies,
+            [NotNull] RelationalConventionSetBuilderDependencies relationalDependencies)
+            : base(dependencies)
+        {
+        }
+
+        /// <summary>
+        ///     Called after a property is added to the entity type with an attribute on the associated CLR property or field.
+        /// </summary>
+        /// <param name="propertyBuilder"> The builder for the property. </param>
+        /// <param name="attribute"> The attribute. </param>
+        /// <param name="clrMember"> The member that has the attribute. </param>
+        /// <param name="context"> Additional information associated with convention execution. </param>
+        protected override void ProcessPropertyAdded(
+            IConventionPropertyBuilder propertyBuilder,
+            DefaultValueAttribute attribute,
+            MemberInfo clrMember,
+            IConventionContext context)
+        {
+            if (attribute.Value != null)
+            {
+                propertyBuilder.HasDefaultValue(attribute.Value, fromDataAnnotation: true);
+            }
+        }
+    }
+}

--- a/test/EFCore.Relational.Tests/Metadata/RelationalPropertyAttributeConventionTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/RelationalPropertyAttributeConventionTest.cs
@@ -126,6 +126,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
             new RelationalColumnAttributeConvention(CreateDependencies(), CreateRelationalDependencies())
                 .ProcessPropertyAdded(propertyBuilder, context);
+
+            new RelationalDefaultValueAttributeConvention(CreateDependencies(), CreateRelationalDependencies())
+                .ProcessPropertyAdded(propertyBuilder, context);
         }
 
         private InternalEntityTypeBuilder CreateInternalEntityTypeBuilder<T>()


### PR DESCRIPTION
Summary of the changes
    - Add a convention that configures default value for a property based on the applied `DefaultValueAttribute`