### PR TITLE
Make ConnectionMode for CosmosDB editable by consumer

### DIFF
--- a/src/EFCore.Cosmos/Infrastructure/CosmosDbContextOptionsBuilder.cs
+++ b/src/EFCore.Cosmos/Infrastructure/CosmosDbContextOptionsBuilder.cs
@@ -4,6 +4,7 @@
 using System;
 using System.ComponentModel;
 using JetBrains.Annotations;
+using Microsoft.Azure.Cosmos;
 using Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -49,6 +50,13 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <param name="region">CosmosDB region name</param>
         public virtual CosmosDbContextOptionsBuilder Region([NotNull] string region)
             => WithOption(e => e.WithRegion(Check.NotNull(region, nameof(region))));
+
+        /// <summary>
+        /// Configures the context to use the provide connection mode.
+        /// </summary>
+        /// <param name="connectionMode">CosmosDB connection mode</param>
+        public virtual CosmosDbContextOptionsBuilder ConnectionMode(ConnectionMode connectionMode)
+            => WithOption(e => e.WithConnectionMode(Check.NotNull(connectionMode, nameof(connectionMode))));
 
         /// <summary>
         ///     Sets an option by cloning the extension used to store the settings. This ensures the builder

--- a/src/EFCore.Cosmos/Infrastructure/CosmosDbContextOptionsBuilder.cs
+++ b/src/EFCore.Cosmos/Infrastructure/CosmosDbContextOptionsBuilder.cs
@@ -52,7 +52,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             => WithOption(e => e.WithRegion(Check.NotNull(region, nameof(region))));
 
         /// <summary>
-        /// Configures the context to use the provide connection mode.
+        /// Configures the context to use the provided connection mode.
         /// </summary>
         /// <param name="connectionMode">CosmosDB connection mode</param>
         public virtual CosmosDbContextOptionsBuilder ConnectionMode(ConnectionMode connectionMode)

--- a/src/EFCore.Cosmos/Infrastructure/Internal/CosmosDbOptionExtension.cs
+++ b/src/EFCore.Cosmos/Infrastructure/Internal/CosmosDbOptionExtension.cs
@@ -250,6 +250,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal
                     var hashCode = Extension._accountEndpoint.GetHashCode();
                     hashCode = (hashCode * 397) ^ Extension._accountKey.GetHashCode();
                     hashCode = (hashCode * 397) ^ (Extension._region?.GetHashCode() ?? 0);
+                    hashCode = (hashCode * 397) ^ (Extension._connectionMode?.GetHashCode() ?? 0);
 
                     _serviceProviderHash = hashCode;
                 }

--- a/src/EFCore.Cosmos/Infrastructure/Internal/CosmosDbOptionExtension.cs
+++ b/src/EFCore.Cosmos/Infrastructure/Internal/CosmosDbOptionExtension.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
 using JetBrains.Annotations;
+using Microsoft.Azure.Cosmos;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -24,6 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal
         private string _accountEndpoint;
         private string _accountKey;
         private string _region;
+        private ConnectionMode? _connectionMode;
         private string _databaseName;
         private Func<ExecutionStrategyDependencies, IExecutionStrategy> _executionStrategyFactory;
         private DbContextOptionsExtensionInfo _info;
@@ -51,6 +53,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal
             _databaseName = copyFrom._databaseName;
             _executionStrategyFactory = copyFrom._executionStrategyFactory;
             _region = copyFrom._region;
+            _connectionMode = copyFrom._connectionMode;
         }
 
         /// <summary>
@@ -150,6 +153,34 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal
             var clone = Clone();
 
             clone._region = region;
+
+            return clone;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual ConnectionMode? ConnectionMode => _connectionMode;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual CosmosOptionsExtension WithConnectionMode(ConnectionMode connectionMode)
+        {
+            if (!Enum.IsDefined(typeof(ConnectionMode), connectionMode))
+            {
+                throw new ArgumentOutOfRangeException(nameof(connectionMode));
+            }
+
+            var clone = Clone();
+
+            clone._connectionMode = connectionMode;
 
             return clone;
         }

--- a/src/EFCore.Cosmos/Infrastructure/Internal/CosmosSingletonOptions.cs
+++ b/src/EFCore.Cosmos/Infrastructure/Internal/CosmosSingletonOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Azure.Cosmos;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
@@ -53,6 +54,15 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public virtual ConnectionMode? ConnectionMode { get; private set; }
+
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public virtual void Initialize(IDbContextOptions options)
         {
             var cosmosOptions = options.FindExtension<CosmosOptionsExtension>();
@@ -61,6 +71,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal
                 AccountEndpoint = cosmosOptions.AccountEndpoint;
                 AccountKey = cosmosOptions.AccountKey;
                 Region = cosmosOptions.Region;
+                ConnectionMode = cosmosOptions.ConnectionMode;
             }
         }
 
@@ -77,7 +88,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal
             if (cosmosOptions != null
                 && (AccountEndpoint != cosmosOptions.AccountEndpoint
                     || AccountKey != cosmosOptions.AccountKey
-                    || Region != cosmosOptions.Region))
+                    || Region != cosmosOptions.Region
+                    || ConnectionMode != cosmosOptions.ConnectionMode))
             {
                 throw new InvalidOperationException(
                     CoreStrings.SingletonOptionChanged(

--- a/src/EFCore.Cosmos/Infrastructure/Internal/ICosmosSingletonOptions.cs
+++ b/src/EFCore.Cosmos/Infrastructure/Internal/ICosmosSingletonOptions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.Azure.Cosmos;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -45,5 +46,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         string Region { get; }
+
+        ConnectionMode? ConnectionMode { get; }
     }
 }

--- a/src/EFCore.Cosmos/Storage/Internal/SingletonCosmosClientWrapper.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/SingletonCosmosClientWrapper.cs
@@ -45,7 +45,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
             var configuration = new CosmosClientOptions
             {
                 ApplicationName = _userAgent,
-                ConnectionMode = ConnectionMode.Direct
+                ConnectionMode = options.ConnectionMode ?? ConnectionMode.Direct
             };
 
             if (options.Region != null)

--- a/test/EFCore.Cosmos.Tests/Extensions/CosmosDbContextOptionsExtensionsTests.cs
+++ b/test/EFCore.Cosmos.Tests/Extensions/CosmosDbContextOptionsExtensionsTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Azure.Cosmos;
+﻿using System;
+using Microsoft.Azure.Cosmos;
 using Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal;
 using Xunit;
 
@@ -38,6 +39,33 @@ namespace Microsoft.EntityFrameworkCore
 
             // The region will be validated by the Cosmos SDK, because the region list is not constant
             Assert.Equal(regionName, extension.Region);
+        }
+
+        [ConditionalFact]
+        public void Can_create_options_with_correct_connection_mode()
+        {
+            var connectionMode = ConnectionMode.Direct;
+            var options = new DbContextOptionsBuilder().UseCosmos(
+                "serviceEndPoint",
+                "authKeyOrResourceToken",
+                "databaseName",
+                o => { o.ConnectionMode(connectionMode); });
+
+            var extension = options.Options.FindExtension<CosmosOptionsExtension>();
+
+            Assert.Equal(connectionMode, extension.ConnectionMode);
+        }
+
+        [ConditionalFact]
+        public void Throws_if_wrong_connection_mode()
+        {
+            var connectionMode = (ConnectionMode) 958410610;
+            var options = Assert.Throws<ArgumentOutOfRangeException>(() =>
+                new DbContextOptionsBuilder().UseCosmos(
+                    "serviceEndPoint",
+                    "authKeyOrResourceToken",
+                    "databaseName",
+                    o => { o.ConnectionMode(connectionMode); }));
         }
     }
 }


### PR DESCRIPTION
- Expose CosmosDB connection mode to the library consumer as a CosmosOptions propriety.

Fixes #16842 