### PR TITLE
Query: Update EntityProjection when filtering on derived type

### DIFF
--- a/src/EFCore.Relational/Query/EntityProjectionExpression.cs
+++ b/src/EFCore.Relational/Query/EntityProjectionExpression.cs
@@ -80,8 +80,21 @@ namespace Microsoft.EntityFrameworkCore.Query
             {
                 return new EntityProjectionExpression(derivedType, _innerTable, _nullable);
             }
+            else
+            {
+                var propertyExpressionCache = new Dictionary<IProperty, ColumnExpression>();
+                foreach (var kvp in _propertyExpressionsCache)
+                {
+                    var property = kvp.Key;
+                    if (derivedType.IsAssignableFrom(property.DeclaringEntityType)
+                        || property.DeclaringEntityType.IsAssignableFrom(derivedType))
+                    {
+                        propertyExpressionCache[property] = kvp.Value;
+                    }
+                }
 
-            throw new InvalidOperationException("EntityProjectionExpression: Cannot update EntityType when _innerTable is null");
+                return new EntityProjectionExpression(derivedType, propertyExpressionCache);
+            }
         }
 
         public virtual IEntityType EntityType { get; }

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
@@ -655,8 +655,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             if (outer is EntityReference outerEntityReference
                 && inner is EntityReference innerEntityReference)
             {
-                return outerEntityReference.EntityType == innerEntityReference.EntityType
-                    && outerEntityReference.IncludePaths.Equals(innerEntityReference.IncludePaths);
+                return outerEntityReference.IncludePaths.Equals(innerEntityReference.IncludePaths);
             }
 
             if (outer is NewExpression outerNewExpression

--- a/test/EFCore.Specification.Tests/Query/InheritanceTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/InheritanceTestBase.cs
@@ -512,7 +512,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "#16217")]
+        [ConditionalFact(Skip = "#16298")]
         public virtual void OfType_Union_OfType()
         {
             using (var context = CreateContext())
@@ -520,6 +520,19 @@ namespace Microsoft.EntityFrameworkCore.Query
                 context.Set<Bird>()
                     .OfType<Kiwi>()
                     .Union(context.Set<Bird>())
+                    .OfType<Kiwi>()
+                    .ToList();
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Subquery_OfType()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<Bird>()
+                    .Take(5)
+                    .Distinct()  // Causes pushdown
                     .OfType<Kiwi>()
                     .ToList();
             }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceSqlServerTest.cs
@@ -459,6 +459,29 @@ FROM (
 WHERE ([t].[FoundOn] = CAST(0 AS tinyint)) AND [t].[FoundOn] IS NOT NULL");
         }
 
+        public override void OfType_Union_OfType()
+        {
+            base.OfType_Union_OfType();
+
+            AssertSql(" ");
+        }
+
+        public override void Subquery_OfType()
+        {
+            base.Subquery_OfType();
+
+            AssertSql(
+                @"@__p_0='5'
+
+SELECT DISTINCT [t].[Species], [t].[CountryId], [t].[Discriminator], [t].[Name], [t].[EagleId], [t].[IsFlightless], [t].[FoundOn]
+FROM (
+    SELECT TOP(@__p_0) [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
+    FROM [Animal] AS [a]
+    WHERE [a].[Discriminator] IN (N'Eagle', N'Kiwi')
+) AS [t]
+WHERE [t].[Discriminator] = N'Kiwi'");
+        }
+
         public override void Union_entity_equality()
         {
             base.Union_entity_equality();


### PR DESCRIPTION
Resolves #16217
