### PR TITLE
Query: Add support for custom EntityQueryables

### DIFF
--- a/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
+++ b/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
@@ -167,6 +167,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             TryAdd<IMethodCallTranslatorProvider, RelationalMethodCallTranslatorProvider>();
             TryAdd<IMemberTranslatorProvider, RelationalMemberTranslatorProvider>();
             TryAdd<IShapedQueryOptimizerFactory, RelationalShapedQueryOptimizerFactory>();
+            TryAdd<IQueryOptimizerFactory, RelationalQueryOptimizerFactory>();
             TryAdd<IRelationalSqlTranslatingExpressionVisitorFactory, RelationalSqlTranslatingExpressionVisitorFactory>();
             TryAdd<ISqlExpressionFactory, SqlExpressionFactory>();
 
@@ -188,6 +189,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 .AddDependencySingleton<QuerySqlGeneratorDependencies>()
                 .AddDependencySingleton<RelationalShapedQueryCompilingExpressionVisitorDependencies>()
                 .AddDependencySingleton<RelationalShapedQueryOptimizerDependencies>()
+                .AddDependencySingleton<RelationalQueryOptimizerDependencies>()
                 .AddDependencyScoped<MigrationsSqlGeneratorDependencies>()
                 .AddDependencyScoped<RelationalConventionSetBuilderDependencies>()
                 .AddDependencyScoped<ModificationCommandBatchFactoryDependencies>()

--- a/src/EFCore.Relational/Query/Internal/FromSqlEntityQueryable.cs
+++ b/src/EFCore.Relational/Query/Internal/FromSqlEntityQueryable.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public class FromSqlEntityQueryable<TResult> : EntityQueryable<TResult>
+    {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public FromSqlEntityQueryable(IAsyncQueryProvider queryProvider, string sql, Expression arguments)
+            : base(queryProvider)
+        {
+            Sql = sql;
+            Arguments = arguments;
+            Expression = Expression.Constant(this);
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual string Sql { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual Expression Arguments { get; }
+    }
+}

--- a/src/EFCore.Relational/Query/Internal/FromSqlEntityQueryableInjectingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/FromSqlEntityQueryableInjectingExpressionVisitor.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal
+{
+    public class FromSqlEntityQueryableInjectingExpressionVisitor : ExpressionVisitor
+    {
+        protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
+        {
+            if (methodCallExpression.Method.DeclaringType == typeof(RelationalQueryableExtensions)
+                && methodCallExpression.Method.Name == nameof(RelationalQueryableExtensions.FromSqlOnQueryable))
+            {
+                var sql = (string)((ConstantExpression)methodCallExpression.Arguments[1]).Value;
+                var queryable = (IQueryable)((ConstantExpression)methodCallExpression.Arguments[0]).Value;
+
+                return Expression.Constant(
+                    _createFromSqlEntityQueryableMethod
+                        .MakeGenericMethod(queryable.ElementType)
+                        .Invoke(null, new object[] { queryable.Provider, sql, methodCallExpression.Arguments[2] }));
+            }
+
+            return base.VisitMethodCall(methodCallExpression);
+        }
+
+        private static readonly MethodInfo _createFromSqlEntityQueryableMethod
+            = typeof(FromSqlEntityQueryableInjectingExpressionVisitor)
+                .GetTypeInfo().GetDeclaredMethod(nameof(_CreateFromSqlEntityQueryable));
+
+        [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
+        private static FromSqlEntityQueryable<TResult> _CreateFromSqlEntityQueryable<TResult>(
+            IAsyncQueryProvider entityQueryProvider,
+            string sql,
+            Expression arguments)
+            => new FromSqlEntityQueryable<TResult>(entityQueryProvider, sql, arguments);
+    }
+}

--- a/src/EFCore.Relational/Query/Internal/RelationalQueryOptimizerFactory.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalQueryOptimizerFactory.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal
+{
+    public class RelationalQueryOptimizerFactory : IQueryOptimizerFactory
+    {
+        private readonly QueryOptimizerDependencies _dependencies;
+        private readonly RelationalQueryOptimizerDependencies _relationalDependencies;
+
+        public RelationalQueryOptimizerFactory(
+            QueryOptimizerDependencies dependencies,
+            RelationalQueryOptimizerDependencies relationalDependencies)
+        {
+            _dependencies = dependencies;
+            _relationalDependencies = relationalDependencies;
+        }
+
+        public virtual QueryOptimizer Create(QueryCompilationContext queryCompilationContext)
+        {
+            return new RelationalQueryOptimizer(
+                _dependencies,
+                _relationalDependencies,
+                queryCompilationContext);
+        }
+    }
+}

--- a/src/EFCore.Relational/Query/RelationalQueryOptimizer.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryOptimizer.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public class RelationalQueryOptimizer : QueryOptimizer
+    {
+        public RelationalQueryOptimizer(
+            QueryOptimizerDependencies dependencies,
+            RelationalQueryOptimizerDependencies relationalDependencies,
+            QueryCompilationContext queryCompilationContext)
+            : base(dependencies, queryCompilationContext)
+        {
+            RelationalDependencies = relationalDependencies;
+        }
+
+        protected virtual RelationalQueryOptimizerDependencies RelationalDependencies { get; }
+
+        public override Expression Visit(Expression query)
+        {
+            query = new FromSqlEntityQueryableInjectingExpressionVisitor().Visit(query);
+
+            return base.Visit(query);
+        }
+    }
+}

--- a/src/EFCore.Relational/Query/RelationalQueryOptimizerDependencies.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryOptimizerDependencies.cs
@@ -1,9 +1,7 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -31,11 +29,11 @@ namespace Microsoft.EntityFrameworkCore.Query
     ///         The implementation does not need to be thread-safe.
     ///     </para>
     /// </summary>
-    public sealed class RelationalShapedQueryOptimizerDependencies
+    public sealed class RelationalQueryOptimizerDependencies
     {
         /// <summary>
         ///     <para>
-        ///         Creates the service dependencies parameter object for a <see cref="RelationalShapedQueryOptimizer" />.
+        ///         Creates the service dependencies parameter object for a <see cref="RelationalQueryOptimizer" />.
         ///     </para>
         ///     <para>
         ///         Do not call this constructor directly from either provider or application code as it may change
@@ -53,25 +51,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         ///     </para>
         /// </summary>
         [EntityFrameworkInternal]
-        public RelationalShapedQueryOptimizerDependencies(
-            [NotNull] ISqlExpressionFactory sqlExpressionFactory)
+        public RelationalQueryOptimizerDependencies()
         {
-            Check.NotNull(sqlExpressionFactory, nameof(sqlExpressionFactory));
-
-            SqlExpressionFactory = sqlExpressionFactory;
         }
-
-        /// <summary>
-        ///    The SQL expression factory.
-        /// </summary>
-        public ISqlExpressionFactory SqlExpressionFactory { get; }
-
-        /// <summary>
-        ///     Clones this dependency parameter object with one service replaced.
-        /// </summary>
-        /// <param name="sqlExpressionFactory"> A replacement for the current dependency of this type. </param>
-        /// <returns> A new parameter object with the given service replaced. </returns>
-        public RelationalShapedQueryOptimizerDependencies With([NotNull] ISqlExpressionFactory sqlExpressionFactory)
-            => new RelationalShapedQueryOptimizerDependencies(sqlExpressionFactory);
     }
 }

--- a/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
+++ b/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
@@ -142,8 +142,24 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public static bool IsEntityQueryable([NotNull] this ConstantExpression constantExpression)
-            => constantExpression.Type.GetTypeInfo().IsGenericType
-               && constantExpression.Type.GetGenericTypeDefinition() == typeof(EntityQueryable<>);
+        {
+            if (constantExpression.Type.GetTypeInfo().IsGenericType)
+            {
+                if (constantExpression.Type.GetTypeInfo().GetGenericTypeDefinition() == typeof(EntityQueryable<>))
+                {
+                    return true;
+                }
+
+                var genericArguments = constantExpression.Type.GetTypeInfo().GetGenericArguments();
+                if (genericArguments.Length == 1)
+                {
+                    return typeof(EntityQueryable<>).MakeGenericType(genericArguments[0])
+                        .GetTypeInfo().IsAssignableFrom(constantExpression.Type);
+                }
+            }
+
+            return false;
+        }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Query/Internal/EntityQueryable`.cs
+++ b/src/EFCore/Query/Internal/EntityQueryable`.cs
@@ -74,7 +74,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual Expression Expression { get; }
+        public virtual Expression Expression { get; protected set; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to


### PR DESCRIPTION
This makes look up for EntityQueryable in query tree bit more complex but it adds support for providers to add custom EntityQueryable to carry more metadata as needs to and allow rest of the pipeline to be transparent about it.
Current FromSql has be to converted during compilation phase since, we want to parameterize the arguments array in the methodCall.
If there is nothing to parameterize then providers can directly create custom Queryable.

Resolves #16326
