### PR TITLE
Compare Queryable operators by MethodInfo

### DIFF
--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -316,10 +317,13 @@ namespace Microsoft.EntityFrameworkCore.Query
                     return null;
                 }
 
-                if ((methodCallExpression.Method.Name == nameof(Queryable.Any)
-                    || methodCallExpression.Method.Name == nameof(Queryable.All)
-                    || methodCallExpression.Method.Name == nameof(Queryable.Contains))
-                    && subquery.Tables.Count == 0)
+                if (subquery.Tables.Count == 0
+                    && methodCallExpression.Method.IsGenericMethod
+                    && methodCallExpression.Method.GetGenericMethodDefinition() is MethodInfo genericMethod
+                    && (genericMethod == QueryableMethodProvider.AnyWithoutPredicateMethodInfo
+                        || genericMethod == QueryableMethodProvider.AnyWithPredicateMethodInfo
+                        || genericMethod == QueryableMethodProvider.AllMethodInfo
+                        || genericMethod == QueryableMethodProvider.ContainsMethodInfo))
                 {
                     return subquery.Projection[0].Expression;
                 }

--- a/src/EFCore/Query/Internal/EntityEqualityRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/EntityEqualityRewritingExpressionVisitor.cs
@@ -188,6 +188,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
         {
             var method = methodCallExpression.Method;
+            var genericMethod = method.IsGenericMethod ? method.GetGenericMethodDefinition() : null;
             var arguments = methodCallExpression.Arguments;
             Expression newSource;
 
@@ -219,37 +220,48 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                        : newMethodCall;
             }
 
-            if (method.DeclaringType == typeof(Queryable) || method.DeclaringType == typeof(QueryableExtensions))
+            switch (method.Name)
             {
-                switch (method.Name)
-                {
-                    // These are methods that require special handling
-                    case nameof(Queryable.Contains) when arguments.Count == 2:
-                        return VisitContainsMethodCall(methodCallExpression);
+                // These are methods that require special handling
+                case nameof(Queryable.Contains)
+                when genericMethod == QueryableMethodProvider.ContainsMethodInfo:
+                    return VisitContainsMethodCall(methodCallExpression);
 
-                    case nameof(Queryable.OrderBy) when arguments.Count == 2:
-                    case nameof(Queryable.OrderByDescending) when arguments.Count == 2:
-                    case nameof(Queryable.ThenBy) when arguments.Count == 2:
-                    case nameof(Queryable.ThenByDescending) when arguments.Count == 2:
-                        return VisitOrderingMethodCall(methodCallExpression);
+                case nameof(Queryable.OrderBy)
+                when genericMethod == QueryableMethodProvider.OrderByMethodInfo:
+                case nameof(Queryable.OrderByDescending)
+                when genericMethod == QueryableMethodProvider.OrderByDescendingMethodInfo:
+                case nameof(Queryable.ThenBy)
+                when genericMethod == QueryableMethodProvider.ThenByMethodInfo:
+                case nameof(Queryable.ThenByDescending) when genericMethod == QueryableMethodProvider.ThenByDescendingMethodInfo:
+                    return VisitOrderingMethodCall(methodCallExpression);
 
-                    // The following are projecting methods, which flow the entity type from *within* the lambda outside.
-                    case nameof(Queryable.Select):
-                    case nameof(Queryable.SelectMany):
-                        return VisitSelectMethodCall(methodCallExpression);
+                // The following are projecting methods, which flow the entity type from *within* the lambda outside.
+                case nameof(Queryable.Select)
+                when genericMethod == QueryableMethodProvider.SelectMethodInfo:
+                case nameof(Queryable.SelectMany)
+                when genericMethod == QueryableMethodProvider.SelectManyWithoutCollectionSelectorMethodInfo ||
+                     genericMethod == QueryableMethodProvider.SelectManyWithCollectionSelectorMethodInfo:
+                    return VisitSelectMethodCall(methodCallExpression);
 
-                    case nameof(Queryable.GroupJoin):
-                    case nameof(Queryable.Join):
-                    case nameof(QueryableExtensions.LeftJoin):
-                        return VisitJoinMethodCall(methodCallExpression);
+                case nameof(Queryable.GroupJoin)
+                when genericMethod == QueryableMethodProvider.GroupJoinMethodInfo:
+                case nameof(Queryable.Join)
+                when genericMethod == QueryableMethodProvider.JoinMethodInfo:
+                case nameof(QueryableExtensions.LeftJoin)
+                when genericMethod == QueryableExtensions.LeftJoinMethodInfo:
+                    return VisitJoinMethodCall(methodCallExpression);
 
-                    case nameof(Queryable.GroupBy): // TODO: Implement
-                        break;
-                }
+                case nameof(Queryable.GroupBy)
+                when genericMethod == QueryableMethodProvider.GroupByWithKeySelectorMethodInfo ||
+                     genericMethod == QueryableMethodProvider.GroupByWithKeyElementSelectorMethodInfo ||
+                     genericMethod == QueryableMethodProvider.GroupByWithKeyResultSelectorMethodInfo ||
+                     genericMethod == QueryableMethodProvider.GroupByWithKeyElementResultSelectorMethodInfo:
+                    break;  // TODO: Implement
             }
 
             // We handled the Contains Queryable extension method above, but there's also IList.Contains
-            if (method.IsGenericMethod && method.GetGenericMethodDefinition().Equals(_enumerableContainsMethodInfo)
+            if (genericMethod == _enumerableContainsMethodInfo
                 || method.DeclaringType.GetInterfaces().Contains(typeof(IList)) && string.Equals(method.Name, nameof(IList.Contains)))
             {
                 return VisitContainsMethodCall(methodCallExpression);
@@ -293,8 +305,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     if (methodCallExpression.Method.ReturnType.TryGetSequenceType() is Type returnElementType
                         && (returnElementType == sourceElementType || sourceElementType == null))
                     {
-                        return newSourceWrapper.Update(
-                            methodCallExpression.Update(null, newArguments));
+                        return newSourceWrapper.Update(methodCallExpression.Update(null, newArguments));
                     }
 
                     // If the source type is an IQueryable over the return type, this is a cardinality-reducing method (e.g. First).

--- a/src/EFCore/Query/QueryableMethodProvider.cs
+++ b/src/EFCore/Query/QueryableMethodProvider.cs
@@ -40,7 +40,6 @@ namespace Microsoft.EntityFrameworkCore.Query
         public static MethodInfo MaxWithSelectorMethodInfo { get; }
         public static MethodInfo MaxWithoutSelectorMethodInfo { get; }
 
-
         public static MethodInfo ElementAtMethodInfo { get; }
         public static MethodInfo ElementAtOrDefaultMethodInfo { get; }
         public static MethodInfo FirstWithoutPredicateMethodInfo { get; }
@@ -85,6 +84,22 @@ namespace Microsoft.EntityFrameworkCore.Query
         public static IDictionary<Type, MethodInfo> SumWithSelectorMethodInfos { get; }
         public static IDictionary<Type, MethodInfo> AverageWithoutSelectorMethodInfos { get; }
         public static IDictionary<Type, MethodInfo> AverageWithSelectorMethodInfos { get; }
+
+        public static bool IsSumWithoutSelectorMethodInfo(MethodInfo methodInfo)
+            => SumWithoutSelectorMethodInfos.Values.Contains(methodInfo);
+        public static bool IsSumWithSelectorMethodInfo(MethodInfo methodInfo)
+            => methodInfo.IsGenericMethod
+               && SumWithSelectorMethodInfos.Values.Contains(methodInfo.GetGenericMethodDefinition());
+        public static bool IsSumMethodInfo(MethodInfo methodInfo)
+            => IsSumWithoutSelectorMethodInfo(methodInfo) || IsSumWithSelectorMethodInfo(methodInfo);
+
+        public static bool IsAverageWithoutSelectorMethodInfo(MethodInfo methodInfo)
+            => AverageWithoutSelectorMethodInfos.Values.Contains(methodInfo);
+        public static bool IsAverageWithSelectorMethodInfo(MethodInfo methodInfo)
+            => methodInfo.IsGenericMethod
+               && AverageWithSelectorMethodInfos.Values.Contains(methodInfo.GetGenericMethodDefinition());
+        public static bool IsAverageMethodInfo(MethodInfo methodInfo)
+            => IsAverageWithoutSelectorMethodInfo(methodInfo) || IsAverageWithSelectorMethodInfo(methodInfo);
 
         static QueryableMethodProvider()
         {


### PR DESCRIPTION
Part of #16300, not exhaustive

Takes care of the big dispatching switches in QueryableMethodTranslatingEV, NavigationExpandingEV, EntityEqualityRewritingEV.

Some work should still be done to make QueryableMethodProvider itself more future-proof, and also to compare Enumerable operators by MethodInfo.