### PR TITLE
Query: Remove serialization of async query code

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.cs
@@ -990,7 +990,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 {
                     try
                     {
-                        using (await _cosmosQueryContext.ConcurrencyDetector.EnterCriticalSectionAsync(_cancellationToken))
+                        using (_cosmosQueryContext.ConcurrencyDetector.EnterCriticalSection())
                         {
                             if (_enumerator == null)
                             {

--- a/src/EFCore.Relational/Extensions/RelationalDatabaseFacadeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalDatabaseFacadeExtensions.cs
@@ -377,7 +377,7 @@ namespace Microsoft.EntityFrameworkCore
             var concurrencyDetector = facadeDependencies.ConcurrencyDetector;
             var logger = facadeDependencies.CommandLogger;
 
-            using (await concurrencyDetector.EnterCriticalSectionAsync(cancellationToken))
+            using (concurrencyDetector.EnterCriticalSection())
             {
                 var rawSqlCommand = GetFacadeDependencies(databaseFacade).RawSqlCommandBuilder
                     .Build(sql.Format, parameters);
@@ -645,7 +645,7 @@ namespace Microsoft.EntityFrameworkCore
             var concurrencyDetector = facadeDependencies.ConcurrencyDetector;
             var logger = facadeDependencies.CommandLogger;
 
-            using (await concurrencyDetector.EnterCriticalSectionAsync(cancellationToken))
+            using (concurrencyDetector.EnterCriticalSection())
             {
                 var rawSqlCommand = GetFacadeDependencies(databaseFacade).RawSqlCommandBuilder
                     .Build(sql, parameters);

--- a/src/EFCore.Relational/Query/AsyncQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/AsyncQueryingEnumerable.cs
@@ -85,7 +85,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 {
                     try
                     {
-                        using (await _relationalQueryContext.ConcurrencyDetector.EnterCriticalSectionAsync(_cancellationToken))
+                        using (_relationalQueryContext.ConcurrencyDetector.EnterCriticalSection())
                         {
                             if (_dataReader == null)
                             {

--- a/src/EFCore/Internal/IConcurrencyDetector.cs
+++ b/src/EFCore/Internal/IConcurrencyDetector.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.Internal
@@ -31,13 +29,5 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         IDisposable EnterCriticalSection();
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        Task<IDisposable> EnterCriticalSectionAsync(CancellationToken cancellationToken);
     }
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/SqlExecutorTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/SqlExecutorTestBase.cs
@@ -221,7 +221,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "#12138")]
+        [ConditionalFact]
         public virtual async Task Throws_on_concurrent_command_async()
         {
             using (var context = CreateContext())

--- a/test/EFCore.Specification.Tests/ConcurrencyDetectorTestBase.cs
+++ b/test/EFCore.Specification.Tests/ConcurrencyDetectorTestBase.cs
@@ -51,7 +51,7 @@ namespace Microsoft.EntityFrameworkCore
                 });
         }
 
-        [ConditionalFact(Skip = "#12138")]
+        [ConditionalFact]
         public virtual Task Find_logs_concurrent_access_async()
         {
             return ConcurrencyDetectorTest(c => c.Products.FindAsync(1).AsTask());
@@ -68,7 +68,7 @@ namespace Microsoft.EntityFrameworkCore
                 });
         }
 
-        [ConditionalFact(Skip = "#12138")]
+        [ConditionalFact]
         public virtual Task Count_logs_concurrent_access_async()
         {
             return ConcurrencyDetectorTest(c => c.Products.CountAsync());
@@ -85,7 +85,7 @@ namespace Microsoft.EntityFrameworkCore
                 });
         }
 
-        [ConditionalFact(Skip = "#12138")]
+        [ConditionalFact]
         public virtual Task First_logs_concurrent_access_async()
         {
             return ConcurrencyDetectorTest(c => c.Products.FirstAsync());
@@ -102,7 +102,7 @@ namespace Microsoft.EntityFrameworkCore
                 });
         }
 
-        [ConditionalFact(Skip = "#12138")]
+        [ConditionalFact]
         public virtual Task Last_logs_concurrent_access_async()
         {
             return ConcurrencyDetectorTest(c => c.Products.LastAsync());
@@ -119,7 +119,7 @@ namespace Microsoft.EntityFrameworkCore
                 });
         }
 
-        [ConditionalFact(Skip = "#12138")]
+        [ConditionalFact]
         public virtual Task Single_logs_concurrent_access_async()
         {
             return ConcurrencyDetectorTest(c => c.Products.SingleAsync(p => p.ProductID == 1));
@@ -136,7 +136,7 @@ namespace Microsoft.EntityFrameworkCore
                 });
         }
 
-        [ConditionalFact(Skip = "#12138")]
+        [ConditionalFact]
         public virtual Task Any_logs_concurrent_access_async()
         {
             return ConcurrencyDetectorTest(c => c.Products.AnyAsync(p => p.ProductID < 10));
@@ -153,7 +153,7 @@ namespace Microsoft.EntityFrameworkCore
                 });
         }
 
-        [ConditionalFact(Skip = "#12138")]
+        [ConditionalFact]
         public virtual Task ToList_logs_concurrent_access_async()
         {
             return ConcurrencyDetectorTest(c => c.Products.ToListAsync());

--- a/test/EFCore.Specification.Tests/Query/AsyncSimpleQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AsyncSimpleQueryTestBase.cs
@@ -263,7 +263,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "#12138")]
+        [ConditionalFact(Skip = "Issue#17019")]
         public virtual async Task Throws_on_concurrent_query_list()
         {
             using (var context = CreateContext())
@@ -298,7 +298,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "#12138")]
+        [ConditionalFact(Skip = "Issue#17019")]
         public virtual async Task Throws_on_concurrent_query_first()
         {
             using (var context = CreateContext())
@@ -316,6 +316,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                             async () =>
                             {
                                 synchronizationEvent.Wait();
+
                                 Assert.Equal(
                                     CoreStrings.ConcurrentMethodInvocation,
                                     (await Assert.ThrowsAsync<InvalidOperationException>(


### PR DESCRIPTION
This was causing deadlock issue in product because after concurrency exception the context is unusuable and in pooling scenario it caused forever wait in async queries

Resolves #10914
Resolves #12138

