### PR TITLE
Fix to #15264 - QueryRewrite: incorporate query filters into nav rewrite

### DIFF
--- a/src/EFCore/Internal/EntityFinder.cs
+++ b/src/EFCore/Internal/EntityFinder.cs
@@ -222,7 +222,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 keyValues[i] = keyValue;
             }
 
-            return _queryRoot.AsNoTracking()//.IgnoreQueryFilters()
+            return _queryRoot.AsNoTracking().IgnoreQueryFilters()
                 .Where(BuildObjectLambda(properties, new ValueBuffer(keyValues)))
                 .Select(BuildProjection(entityType));
         }

--- a/src/EFCore/Internal/IndentedStringBuilder.cs
+++ b/src/EFCore/Internal/IndentedStringBuilder.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using JetBrains.Annotations;
@@ -18,11 +17,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
     public class IndentedStringBuilder
     {
         private const byte IndentSize = 4;
-
-        private readonly string _disconnectedIndent = new string(' ', IndentSize);
-        private readonly string _suspendedIndent = "|" + new string(' ', IndentSize - 1);
-        private readonly string _connectedIndent = "|" + new string('_', IndentSize - 2) + " ";
-
         private byte _indent;
         private bool _indentPending = true;
 
@@ -158,15 +152,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
             return this;
         }
 
-        private enum NodeConnectionState
-        {
-            Disconnected = 0,
-            Connected = 1,
-            Suspended = 2
-        }
-
-        private readonly List<NodeConnectionState> _nodeConnectionStates = new List<NodeConnectionState>();
-
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -174,76 +159,10 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual IndentedStringBuilder IncrementIndent()
-            => IncrementIndent(false);
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public virtual IndentedStringBuilder IncrementIndent(bool connectNode)
         {
-            var state = connectNode ? NodeConnectionState.Connected : NodeConnectionState.Disconnected;
-            if (_indent == _nodeConnectionStates.Count)
-            {
-                _nodeConnectionStates.Add(state);
-            }
-            else
-            {
-                _nodeConnectionStates[_indent] = state;
-            }
-
             _indent++;
 
             return this;
-        }
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public virtual void DisconnectCurrentNode()
-        {
-            if (_indent > 0
-                && _nodeConnectionStates.Count >= _indent)
-            {
-                _nodeConnectionStates[_indent - 1] = NodeConnectionState.Disconnected;
-            }
-        }
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public virtual void SuspendCurrentNode()
-        {
-            if (_indent > 0
-                && _nodeConnectionStates.Count >= _indent
-                && _nodeConnectionStates[_indent - 1] == NodeConnectionState.Connected)
-            {
-                _nodeConnectionStates[_indent - 1] = NodeConnectionState.Suspended;
-            }
-        }
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public virtual void ReconnectCurrentNode()
-        {
-            if (_indent > 0
-                && _nodeConnectionStates.Count >= _indent
-                && _nodeConnectionStates[_indent - 1] == NodeConnectionState.Suspended)
-            {
-                _nodeConnectionStates[_indent - 1] = NodeConnectionState.Connected;
-            }
         }
 
         /// <summary>
@@ -257,8 +176,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
             if (_indent > 0)
             {
                 _indent--;
-
-                _nodeConnectionStates.RemoveAt(_indent);
             }
 
             return this;
@@ -284,25 +201,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         {
             if (_indentPending && (_indent > 0))
             {
-                var indentString = string.Empty;
-                for (var i = 0; i < _nodeConnectionStates.Count; i++)
-                {
-                    if (_nodeConnectionStates[i] == NodeConnectionState.Disconnected)
-                    {
-                        indentString += _disconnectedIndent;
-                    }
-                    else if (i == _nodeConnectionStates.Count - 1
-                             && _nodeConnectionStates[i] == NodeConnectionState.Connected)
-                    {
-                        indentString += _connectedIndent;
-                    }
-                    else
-                    {
-                        indentString += _suspendedIndent;
-                    }
-                }
-
-                _stringBuilder.Append(indentString);
+                _stringBuilder.Append(new string(' ', _indent * IndentSize));
             }
 
             _indentPending = false;

--- a/src/EFCore/Query/Internal/QueryMetadataExtractingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/QueryMetadataExtractingExpressionVisitor.cs
@@ -39,6 +39,15 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                     return innerQueryable;
                 }
+
+                if (genericMethodDefinition == EntityFrameworkQueryableExtensions.IgnoreQueryFiltersMethodInfo)
+                {
+                    var innerQueryable = Visit(methodCallExpression.Arguments[0]);
+
+                    _queryCompilationContext.IgnoreQueryFilters = true;
+
+                    return innerQueryable;
+                }
             }
 
             return base.VisitMethodCall(methodCallExpression);

--- a/src/EFCore/Query/QueryCompilationContext.cs
+++ b/src/EFCore/Query/QueryCompilationContext.cs
@@ -51,6 +51,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual IModel Model { get; }
         public virtual IDbContextOptions ContextOptions { get; }
         public virtual bool IsTracking { get; internal set; }
+        public virtual bool IgnoreQueryFilters { get; internal set; }
         public virtual ISet<string> Tags { get; } = new HashSet<string>();
         public virtual IDiagnosticsLogger<DbLoggerCategory.Query> Logger { get; }
         public virtual Type ContextType { get; }

--- a/src/EFCore/Query/QueryOptimizer.cs
+++ b/src/EFCore/Query/QueryOptimizer.cs
@@ -31,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             query = new NullCheckRemovingExpressionVisitor().Visit(query);
             query = new EntityEqualityRewritingExpressionVisitor(_queryCompilationContext).Rewrite(query);
             query = new SubqueryMemberPushdownExpressionVisitor().Visit(query);
-            query = new NavigationExpandingExpressionVisitor(_queryCompilationContext).Expand(query);
+            query = new NavigationExpandingExpressionVisitor(_queryCompilationContext, Dependencies.EvaluatableExpressionFilter).Expand(query);
             query = new FunctionPreprocessingVisitor().Visit(query);
             new EnumerableVerifyingExpressionVisitor().Visit(query);
 

--- a/src/EFCore/Query/QueryOptimizerDependencies.cs
+++ b/src/EFCore/Query/QueryOptimizerDependencies.cs
@@ -1,7 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -51,8 +54,25 @@ namespace Microsoft.EntityFrameworkCore.Query
         ///     </para>
         /// </summary>
         [EntityFrameworkInternal]
-        public QueryOptimizerDependencies()
+        public QueryOptimizerDependencies(
+            [NotNull] IEvaluatableExpressionFilter evaluatableExpressionFilter)
         {
+            Check.NotNull(evaluatableExpressionFilter, nameof(evaluatableExpressionFilter));
+
+            EvaluatableExpressionFilter = evaluatableExpressionFilter;
         }
+
+        /// <summary>
+        ///     Evaluatable expression filter.
+        /// </summary>
+        public IEvaluatableExpressionFilter EvaluatableExpressionFilter { get; }
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="evaluatableExpressionFilter"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public QueryOptimizerDependencies With([NotNull] IEvaluatableExpressionFilter evaluatableExpressionFilter)
+            => new QueryOptimizerDependencies(evaluatableExpressionFilter);
     }
 }

--- a/src/EFCore/Query/ReplacingExpressionVisitor.cs
+++ b/src/EFCore/Query/ReplacingExpressionVisitor.cs
@@ -89,5 +89,4 @@ namespace Microsoft.EntityFrameworkCore.Query
             return base.VisitMethodCall(methodCallExpression);
         }
     }
-
 }

--- a/test/EFCore.InMemory.FunctionalTests/InMemoryComplianceTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/InMemoryComplianceTest.cs
@@ -21,9 +21,8 @@ namespace Microsoft.EntityFrameworkCore
             typeof(GraphUpdatesTestBase<>),                // issue #15318
             typeof(ProxyGraphUpdatesTestBase<>),           // issue #15318
             typeof(ComplexNavigationsWeakQueryTestBase<>), // issue #15285
-            typeof(FiltersInheritanceTestBase<>),          // issue #15264
-            typeof(FiltersTestBase<>),                     // issue #15264
             typeof(OwnedQueryTestBase<>),                  // issue #15285
+            typeof(FiltersInheritanceTestBase<>),          // issue #17047
             // Query pipeline
             typeof(SimpleQueryTestBase<>),
             typeof(GroupByQueryTestBase<>),

--- a/test/EFCore.InMemory.FunctionalTests/Query/FiltersInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/FiltersInMemoryTest.cs
@@ -1,17 +1,35 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
-    //issue #15264
-    internal class FiltersInMemoryTest : FiltersTestBase<NorthwindQueryInMemoryFixture<NorthwindFiltersCustomizer>>
+    public class FiltersInMemoryTest : FiltersTestBase<NorthwindQueryInMemoryFixture<NorthwindFiltersCustomizer>>
     {
         public FiltersInMemoryTest(NorthwindQueryInMemoryFixture<NorthwindFiltersCustomizer> fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
             //TestLoggerFactory.TestOutputHelper = testOutputHelper;
+        }
+
+        [ConditionalFact(Skip = "issue #16963")]
+        public override void Include_query()
+        {
+            base.Include_query();
+        }
+
+        [ConditionalFact(Skip = "issue #16963")]
+        public override void Include_query_opt_out()
+        {
+            base.Include_query_opt_out();
+        }
+
+        [ConditionalFact(Skip = "issue #16963")]
+        public override void Included_many_to_one_query()
+        {
+            base.Included_many_to_one_query();
         }
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/Query/FiltersInheritanceInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/FiltersInheritanceInMemoryTest.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
-    // issue #15264
+    // issue #17047
     internal class FiltersInheritanceInMemoryTest : FiltersInheritanceTestBase<FiltersInheritanceInMemoryFixture>
     {
         public FiltersInheritanceInMemoryTest(FiltersInheritanceInMemoryFixture fixture)

--- a/test/EFCore.InMemory.FunctionalTests/Query/SimpleQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/SimpleQueryInMemoryTest.cs
@@ -264,5 +264,17 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return base.Project_single_element_from_collection_with_OrderBy_Distinct_and_FirstOrDefault_followed_by_projecting_length(isAsync);
         }
+
+        [ConditionalTheory(Skip = "Issue#16963")]
+        public override Task QueryType_with_included_nav(bool isAsync)
+        {
+            return base.QueryType_with_included_nav(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "Issue#16963")]
+        public override Task QueryType_with_included_navs_multi_level(bool isAsync)
+        {
+            return base.QueryType_with_included_navs_multi_level(isAsync);
+        }
     }
 }

--- a/test/EFCore.Specification.Tests/Query/FiltersInheritanceTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/FiltersInheritanceTestBase.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         protected TFixture Fixture { get; }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Can_use_of_type_animal()
         {
             using (var context = CreateContext())
@@ -31,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Can_use_is_kiwi()
         {
             using (var context = CreateContext())
@@ -42,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Can_use_is_kiwi_with_other_predicate()
         {
             using (var context = CreateContext())
@@ -53,7 +53,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Can_use_is_kiwi_in_projection()
         {
             using (var context = CreateContext())
@@ -66,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Can_use_of_type_bird()
         {
             using (var context = CreateContext())
@@ -79,7 +79,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Can_use_of_type_bird_predicate()
         {
             using (var context = CreateContext())
@@ -97,7 +97,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Can_use_of_type_bird_with_projection()
         {
             using (var context = CreateContext())
@@ -117,7 +117,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Can_use_of_type_bird_first()
         {
             using (var context = CreateContext())
@@ -130,7 +130,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Can_use_of_type_kiwi()
         {
             using (var context = CreateContext())
@@ -143,7 +143,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Can_use_derived_set()
         {
             using (var context = CreateContext())
@@ -155,7 +155,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Can_use_IgnoreQueryFilters_and_GetDatabaseValues()
         {
             using (var context = CreateContext())

--- a/test/EFCore.Specification.Tests/Query/FiltersTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/FiltersTestBase.cs
@@ -5,7 +5,6 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
-using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 using Xunit;
 
 // ReSharper disable StaticMemberInGenericType
@@ -29,38 +28,37 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         protected TFixture Fixture { get; }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Count_query()
         {
             Assert.Equal(7, _context.Customers.Count());
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Materialized_query()
         {
             Assert.Equal(7, _context.Customers.ToList().Count);
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Find()
         {
             Assert.Null(_context.Find<Customer>("ALFKI"));
         }
 
-        // also issue #15264
         [ConditionalFact(Skip = "Issue #14935. Cannot eval 'where ClientMethod([p])'")] 
         public virtual void Client_eval()
         {
             Assert.Equal(69, _context.Products.ToList().Count);
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual async Task Materialized_query_async()
         {
             Assert.Equal(7, (await _context.Customers.ToListAsync()).Count);
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Materialized_query_parameter()
         {
             _context.TenantPrefix = "F";
@@ -68,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Assert.Equal(8, _context.Customers.ToList().Count);
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Materialized_query_parameter_new_context()
         {
             Assert.Equal(7, _context.Customers.ToList().Count);
@@ -81,13 +79,13 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Projection_query()
         {
             Assert.Equal(7, _context.Customers.Select(c => c.CustomerID).ToList().Count);
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Projection_query_parameter()
         {
             _context.TenantPrefix = "F";
@@ -95,7 +93,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Assert.Equal(8, _context.Customers.Select(c => c.CustomerID).ToList().Count);
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Include_query()
         {
             var results = _context.Customers.Include(c => c.Orders).ToList();
@@ -103,7 +101,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Assert.Equal(7, results.Count);
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Include_query_opt_out()
         {
             var results = _context.Customers.Include(c => c.Orders).IgnoreQueryFilters().ToList();
@@ -111,16 +109,24 @@ namespace Microsoft.EntityFrameworkCore.Query
             Assert.Equal(91, results.Count);
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Included_many_to_one_query()
         {
             var results = _context.Orders.Include(o => o.Customer).ToList();
 
-            Assert.Equal(830, results.Count);
+            Assert.Equal(80, results.Count);
             Assert.True(results.All(o => o.Customer == null || o.CustomerID.StartsWith("B")));
         }
 
-        // also issue #15264
+        [ConditionalFact]
+        public virtual void Project_reference_that_itself_has_query_filter_with_another_reference()
+        {
+            var results = _context.OrderDetails.Select(od => od.Order).ToList();
+
+            Assert.Equal(5, results.Count);
+            Assert.True(results.All(o => o.Customer == null || o.CustomerID.StartsWith("B")));
+        }
+
         [ConditionalFact(Skip = "Issue #14935. Cannot eval 'where ClientMethod([p])'")]
         public virtual void Included_one_to_many_query_with_client_eval()
         {
@@ -133,7 +139,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                          || p.OrderDetails.All(od => od.Quantity > 50)));
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact(Skip = "issue #15081")]
         public virtual void Navs_query()
         {
             var results
@@ -146,7 +152,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Assert.Equal(5, results.Count);
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Compiled_query()
         {
             var query = EF.CompileQuery(

--- a/test/EFCore.Specification.Tests/Query/QueryFilterFuncletizationTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/QueryFilterFuncletizationTestBase.cs
@@ -21,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         protected QueryFilterFuncletizationContext CreateContext() => Fixture.CreateContext();
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void DbContext_property_parameter_does_not_clash_with_closure_parameter_name()
         {
             using (var context = CreateContext())
@@ -31,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void DbContext_field_is_parameterized()
         {
             using (var context = CreateContext())
@@ -46,7 +46,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void DbContext_property_is_parameterized()
         {
             using (var context = CreateContext())
@@ -61,7 +61,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void DbContext_method_call_is_parameterized()
         {
             using (var context = CreateContext())
@@ -71,14 +71,13 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void DbContext_list_is_parameterized()
         {
             using (var context = CreateContext())
             {
                 // This throws because the default value of TenantIds is null which is NRE
-                var exception = Record.Exception(() => context.Set<ListFilter>().ToList());
-                Assert.True(exception is InvalidOperationException || exception is ArgumentNullException);
+                Assert.Throws<NullReferenceException>(() => context.Set<ListFilter>().ToList());
 
                 context.TenantIds = new List<int>();
                 var query = context.Set<ListFilter>().ToList();
@@ -101,7 +100,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void DbContext_property_chain_is_parameterized()
         {
             using (var context = CreateContext())
@@ -125,7 +124,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void DbContext_property_method_call_is_parameterized()
         {
             using (var context = CreateContext())
@@ -139,7 +138,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void DbContext_method_call_chain_is_parameterized()
         {
             using (var context = CreateContext())
@@ -149,7 +148,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void DbContext_complex_expression_is_parameterized()
         {
             using (var context = CreateContext())
@@ -167,7 +166,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void DbContext_property_based_filter_does_not_short_circuit()
         {
             using (var context = CreateContext())
@@ -184,7 +183,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void EntityTypeConfiguration_DbContext_field_is_parameterized()
         {
             using (var context = CreateContext())
@@ -199,7 +198,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void EntityTypeConfiguration_DbContext_property_is_parameterized()
         {
             using (var context = CreateContext())
@@ -214,7 +213,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void EntityTypeConfiguration_DbContext_method_call_is_parameterized()
         {
             using (var context = CreateContext())
@@ -224,7 +223,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void EntityTypeConfiguration_DbContext_property_chain_is_parameterized()
         {
             using (var context = CreateContext())
@@ -248,7 +247,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Local_method_DbContext_field_is_parameterized()
         {
             using (var context = CreateContext())
@@ -263,7 +262,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Local_static_method_DbContext_property_is_parameterized()
         {
             using (var context = CreateContext())
@@ -278,7 +277,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Remote_method_DbContext_property_method_call_is_parameterized()
         {
             using (var context = CreateContext())
@@ -292,7 +291,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Extension_method_DbContext_field_is_parameterized()
         {
             using (var context = CreateContext())
@@ -307,7 +306,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Extension_method_DbContext_property_chain_is_parameterized()
         {
             using (var context = CreateContext())
@@ -351,7 +350,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Static_member_from_dbContext_is_inlined()
         {
             using (var context = CreateContext())
@@ -362,7 +361,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Static_member_from_non_dbContext_is_inlined()
         {
             using (var context = CreateContext())
@@ -373,7 +372,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Local_variable_from_OnModelCreating_is_inlined()
         {
             using (var context = CreateContext())
@@ -384,7 +383,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Local_variable_from_OnModelCreating_can_throw_exception()
         {
             using (var context = CreateContext())
@@ -397,7 +396,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Method_parameter_is_inlined()
         {
             using (var context = CreateContext())
@@ -406,7 +405,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public virtual void Using_multiple_context_in_filter_parametrize_only_current_context()
         {
             using (var context = CreateContext())

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.QueryTypes.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.QueryTypes.cs
@@ -56,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "Issue#15264")]
+        [ConditionalFact(Skip = "issue #16323")]
         public virtual void QueryType_with_nav_defining_query()
         {
             using (var context = CreateContext())
@@ -70,7 +70,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory(Skip = "Issue#15264")]
+        [ConditionalTheory(Skip = "issue #16323")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task QueryType_with_defining_query(bool isAsync)
         {
@@ -79,9 +79,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ovs => ovs.AsNoTracking().Where(ov => ov.CustomerID == "ALFKI"));
         }
 
-        // #issue 12873
-        //[ConditionalTheory]
-        //[MemberData(nameof(IsAsyncData))]
+        // also issue 12873
+        [ConditionalTheory(Skip = "issue #16323")]
+        [MemberData(nameof(IsAsyncData))]
         public virtual Task QueryType_with_defining_query_and_correlated_collection(bool isAsync)
         {
             return AssertQuery<OrderQuery>(
@@ -90,7 +90,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Select(cv => cv.Orders.Where(cc => true).ToList()));
         }
 
-        [ConditionalTheory(Skip = "Issue#15264")]
+        [ConditionalTheory(Skip = "issue #15081")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task QueryType_with_mixed_tracking(bool isAsync)
         {
@@ -107,7 +107,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.c.CustomerID);
         }
 
-        [ConditionalTheory(Skip = "Issue#15264")]
+        [ConditionalTheory(Skip = "issue #16323")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task QueryType_with_included_nav(bool isAsync)
         {
@@ -122,7 +122,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "Issue#15264")]
+        [ConditionalTheory(Skip = "issue #16323")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task QueryType_with_included_navs_multi_level(bool isAsync)
         {
@@ -138,7 +138,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "Issue#15264")]
+        [ConditionalTheory(Skip = "issue #16323")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task QueryType_select_where_navigation(bool isAsync)
         {
@@ -149,7 +149,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                        select ov);
         }
 
-        [ConditionalTheory(Skip = "Issue#15264")]
+        [ConditionalTheory(Skip = "issue #16323")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task QueryType_select_where_navigation_multi_level(bool isAsync)
         {

--- a/test/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/ProceduralQueryExpressionGenerator.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/ProceduralQueryExpressionGenerator.cs
@@ -480,7 +480,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities.QueryTestGeneration
             }
 
             // printed just for debugging purposes
-            var queryString = new ExpressionPrinter().Print(newExpression, printConnections: false);
+            var queryString = new ExpressionPrinter().Print(newExpression);
 
             try
             {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FiltersInheritanceSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FiltersInheritanceSqlServerTest.cs
@@ -5,8 +5,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
-    // issue #15264
-    internal class FiltersInheritanceSqlServerTest : FiltersInheritanceTestBase<FiltersInheritanceSqlServerFixture>
+    public class FiltersInheritanceSqlServerTest : FiltersInheritanceTestBase<FiltersInheritanceSqlServerFixture>
     {
         public FiltersInheritanceSqlServerTest(FiltersInheritanceSqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
@@ -22,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             AssertSql(
                 @"SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
 FROM [Animal] AS [a]
-WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a].[CountryId] = 1)
+WHERE [a].[Discriminator] IN (N'Eagle', N'Kiwi') AND ([a].[CountryId] = 1)
 ORDER BY [a].[Species]");
         }
 
@@ -33,7 +32,7 @@ ORDER BY [a].[Species]");
             AssertSql(
                 @"SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
 FROM [Animal] AS [a]
-WHERE ([a].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a].[CountryId] = 1)) AND ([a].[Discriminator] = N'Kiwi')");
+WHERE ([a].[Discriminator] IN (N'Eagle', N'Kiwi') AND ([a].[CountryId] = 1)) AND ([a].[Discriminator] = N'Kiwi')");
         }
 
         public override void Can_use_is_kiwi_with_other_predicate()
@@ -43,7 +42,7 @@ WHERE ([a].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a].[CountryId] = 1)) AND
             AssertSql(
                 @"SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
 FROM [Animal] AS [a]
-WHERE ([a].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a].[CountryId] = 1)) AND (([a].[Discriminator] = N'Kiwi') AND ([a].[CountryId] = 1))");
+WHERE ([a].[Discriminator] IN (N'Eagle', N'Kiwi') AND ([a].[CountryId] = 1)) AND (([a].[Discriminator] = N'Kiwi') AND ([a].[CountryId] = 1))");
         }
 
         public override void Can_use_is_kiwi_in_projection()
@@ -52,11 +51,11 @@ WHERE ([a].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a].[CountryId] = 1)) AND
 
             AssertSql(
                 @"SELECT CASE
-    WHEN [a].[Discriminator] = N'Kiwi'
-    THEN CAST(1 AS bit) ELSE CAST(0 AS bit)
+    WHEN [a].[Discriminator] = N'Kiwi' THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
 END
 FROM [Animal] AS [a]
-WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a].[CountryId] = 1)");
+WHERE [a].[Discriminator] IN (N'Eagle', N'Kiwi') AND ([a].[CountryId] = 1)");
         }
 
         public override void Can_use_of_type_bird()
@@ -66,7 +65,7 @@ WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a].[CountryId] = 1)");
             AssertSql(
                 @"SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
 FROM [Animal] AS [a]
-WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a].[CountryId] = 1)
+WHERE ([a].[Discriminator] IN (N'Eagle', N'Kiwi') AND ([a].[CountryId] = 1)) AND [a].[Discriminator] IN (N'Eagle', N'Kiwi')
 ORDER BY [a].[Species]");
         }
 
@@ -77,7 +76,7 @@ ORDER BY [a].[Species]");
             AssertSql(
                 @"SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
 FROM [Animal] AS [a]
-WHERE ([a].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a].[CountryId] = 1)) AND ([a].[CountryId] = 1)
+WHERE (([a].[Discriminator] IN (N'Eagle', N'Kiwi') AND ([a].[CountryId] = 1)) AND ([a].[CountryId] = 1)) AND [a].[Discriminator] IN (N'Eagle', N'Kiwi')
 ORDER BY [a].[Species]");
         }
 
@@ -88,7 +87,7 @@ ORDER BY [a].[Species]");
             AssertSql(
                 @"SELECT [a].[EagleId]
 FROM [Animal] AS [a]
-WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a].[CountryId] = 1)");
+WHERE ([a].[Discriminator] IN (N'Eagle', N'Kiwi') AND ([a].[CountryId] = 1)) AND [a].[Discriminator] IN (N'Eagle', N'Kiwi')");
         }
 
         public override void Can_use_of_type_bird_first()
@@ -98,7 +97,7 @@ WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a].[CountryId] = 1)");
             AssertSql(
                 @"SELECT TOP(1) [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
 FROM [Animal] AS [a]
-WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a].[CountryId] = 1)
+WHERE ([a].[Discriminator] IN (N'Eagle', N'Kiwi') AND ([a].[CountryId] = 1)) AND [a].[Discriminator] IN (N'Eagle', N'Kiwi')
 ORDER BY [a].[Species]");
         }
 
@@ -109,7 +108,7 @@ ORDER BY [a].[Species]");
             AssertSql(
                 @"SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[FoundOn]
 FROM [Animal] AS [a]
-WHERE ([a].[Discriminator] = N'Kiwi') AND ([a].[CountryId] = 1)");
+WHERE ([a].[Discriminator] IN (N'Eagle', N'Kiwi') AND ([a].[CountryId] = 1)) AND ([a].[Discriminator] = N'Kiwi')");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FiltersSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FiltersSqlServerTest.cs
@@ -2,15 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
-using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 using Xunit;
 using Xunit.Abstractions;
 
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Query
 {
-    //issue #15264
-    internal class FiltersSqlServerTest : FiltersTestBase<NorthwindQuerySqlServerFixture<NorthwindFiltersCustomizer>>
+    public class FiltersSqlServerTest : FiltersTestBase<NorthwindQuerySqlServerFixture<NorthwindFiltersCustomizer>>
     {
         public FiltersSqlServerTest(NorthwindQuerySqlServerFixture<NorthwindFiltersCustomizer> fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
@@ -28,7 +26,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
 SELECT COUNT(*)
 FROM [Customers] AS [c]
-WHERE ([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)) OR (@__ef_filter__TenantPrefix_0 = N'')");
+WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (([c].[CompanyName] LIKE [c].[CompanyName] + N'%') AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL)))))");
         }
 
         public override void Client_eval()
@@ -49,7 +47,7 @@ FROM [Products] AS [p]");
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)) OR (@__ef_filter__TenantPrefix_0 = N'')");
+WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (([c].[CompanyName] LIKE [c].[CompanyName] + N'%') AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL)))))");
         }
 
         public override void Find()
@@ -62,7 +60,7 @@ WHERE ([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].
 
 SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)) OR (@__ef_filter__TenantPrefix_0 = N'')) AND ([c].[CustomerID] = @__p_0)");
+WHERE (((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (([c].[CompanyName] LIKE [c].[CompanyName] + N'%') AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL)))))) AND (([c].[CustomerID] = @__p_0) AND @__p_0 IS NOT NULL)");
         }
 
         public override void Materialized_query_parameter()
@@ -74,7 +72,7 @@ WHERE (([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c]
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)) OR (@__ef_filter__TenantPrefix_0 = N'')");
+WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (([c].[CompanyName] LIKE [c].[CompanyName] + N'%') AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL)))))");
         }
 
         public override void Materialized_query_parameter_new_context()
@@ -86,13 +84,13 @@ WHERE ([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)) OR (@__ef_filter__TenantPrefix_0 = N'')",
+WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (([c].[CompanyName] LIKE [c].[CompanyName] + N'%') AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL)))))",
                 //
                 @"@__ef_filter__TenantPrefix_0='T' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)) OR (@__ef_filter__TenantPrefix_0 = N'')");
+WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (([c].[CompanyName] LIKE [c].[CompanyName] + N'%') AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL)))))");
         }
 
         public override void Projection_query_parameter()
@@ -104,7 +102,7 @@ WHERE ([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE ([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)) OR (@__ef_filter__TenantPrefix_0 = N'')");
+WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (([c].[CompanyName] LIKE [c].[CompanyName] + N'%') AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL)))))");
         }
 
         public override void Projection_query()
@@ -116,7 +114,7 @@ WHERE ([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE ([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)) OR (@__ef_filter__TenantPrefix_0 = N'')");
+WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (([c].[CompanyName] LIKE [c].[CompanyName] + N'%') AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL)))))");
         }
 
         public override void Include_query()
@@ -126,23 +124,20 @@ WHERE ([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].
             AssertSql(
                 @"@__ef_filter__TenantPrefix_0='B' (Size = 4000)
 
-SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate]
 FROM [Customers] AS [c]
-WHERE ([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)) OR (@__ef_filter__TenantPrefix_0 = N'')
-ORDER BY [c].[CustomerID]",
-                //
-                @"@__ef_filter__TenantPrefix_1='B' (Size = 4000)
-
-SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]
-LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
-INNER JOIN (
-    SELECT [c0].[CustomerID]
-    FROM [Customers] AS [c0]
-    WHERE ([c0].[CompanyName] LIKE @__ef_filter__TenantPrefix_1 + N'%' AND (LEFT([c0].[CompanyName], LEN(@__ef_filter__TenantPrefix_1)) = @__ef_filter__TenantPrefix_1)) OR (@__ef_filter__TenantPrefix_1 = N'')
-) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
-WHERE [o.Customer].[CompanyName] IS NOT NULL
-ORDER BY [t].[CustomerID]");
+LEFT JOIN (
+    SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    FROM [Orders] AS [o]
+    LEFT JOIN (
+        SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+        FROM [Customers] AS [c0]
+        WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c0].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (([c0].[CompanyName] LIKE [c0].[CompanyName] + N'%') AND (((LEFT([c0].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c0].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c0].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL)))))
+    ) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
+    WHERE [t].[CompanyName] IS NOT NULL
+) AS [t0] ON [c].[CustomerID] = [t0].[CustomerID]
+WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (([c].[CompanyName] LIKE [c].[CompanyName] + N'%') AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL)))))
+ORDER BY [c].[CustomerID], [t0].[OrderID]");
         }
 
         public override void Include_query_opt_out()
@@ -150,17 +145,10 @@ ORDER BY [t].[CustomerID]");
             base.Include_query_opt_out();
 
             AssertSql(
-                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Customers] AS [c]
-ORDER BY [c].[CustomerID]",
-                //
-                @"SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
-FROM [Orders] AS [c.Orders]
-INNER JOIN (
-    SELECT [c0].[CustomerID]
-    FROM [Customers] AS [c0]
-) AS [t] ON [c.Orders].[CustomerID] = [t].[CustomerID]
-ORDER BY [t].[CustomerID]");
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+ORDER BY [c].[CustomerID], [o].[OrderID]");
         }
 
         public override void Included_many_to_one_query()
@@ -172,13 +160,35 @@ ORDER BY [t].[CustomerID]");
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
 FROM [Orders] AS [o]
-LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
 LEFT JOIN (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
-    WHERE ([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)) OR (@__ef_filter__TenantPrefix_0 = N'')
+    WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (([c].[CompanyName] LIKE [c].[CompanyName] + N'%') AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL)))))
 ) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
-WHERE [o.Customer].[CompanyName] IS NOT NULL");
+WHERE [t].[CompanyName] IS NOT NULL");
+        }
+
+        public override void Project_reference_that_itself_has_query_filter_with_another_reference()
+        {
+            base.Project_reference_that_itself_has_query_filter_with_another_reference();
+
+            AssertSql(
+                @"@__ef_filter__TenantPrefix_1='B' (Size = 4000)
+@__ef_filter___quantity_0='50'
+
+SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate]
+FROM [Order Details] AS [o0]
+INNER JOIN (
+    SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID] AS [CustomerID0], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
+    FROM [Orders] AS [o]
+    LEFT JOIN (
+        SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+        FROM [Customers] AS [c]
+        WHERE ((@__ef_filter__TenantPrefix_1 = N'') AND @__ef_filter__TenantPrefix_1 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_1 IS NOT NULL AND (([c].[CompanyName] LIKE [c].[CompanyName] + N'%') AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_1)) = @__ef_filter__TenantPrefix_1) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_1)) IS NOT NULL AND @__ef_filter__TenantPrefix_1 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_1)) IS NULL AND @__ef_filter__TenantPrefix_1 IS NULL)))))
+    ) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
+    WHERE [t].[CompanyName] IS NOT NULL
+) AS [t0] ON [o0].[OrderID] = [t0].[OrderID]
+WHERE [o0].[Quantity] > @__ef_filter___quantity_0");
         }
 
         public override void Included_one_to_many_query_with_client_eval()
@@ -224,7 +234,7 @@ INNER JOIN (
 WHERE (([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)) OR (@__ef_filter__TenantPrefix_0 = N'')) AND ([t0].[Discount] < CAST(10 AS real))");
         }
 
-        [ConditionalFact(Skip = "issue #15264")]
+        [ConditionalFact]
         public void FromSql_is_composed()
         {
             using (var context = CreateContext())
@@ -241,7 +251,32 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM (
     select * from Customers
 ) AS [c]
-WHERE ([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)) OR (@__ef_filter__TenantPrefix_0 = N'')");
+WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (([c].[CompanyName] LIKE [c].[CompanyName] + N'%') AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL)))))");
+        }
+
+        [ConditionalFact]
+        public void FromSql_is_composed_when_filter_has_navigation()
+        {
+            using (var context = CreateContext())
+            {
+                var results = context.Orders.FromSqlRaw("select * from Orders").ToList();
+
+                Assert.Equal(80, results.Count);
+            }
+
+            AssertSql(
+                @"@__ef_filter__TenantPrefix_0='B' (Size = 4000)
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    select * from Orders
+) AS [o]
+LEFT JOIN (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (([c].[CompanyName] LIKE [c].[CompanyName] + N'%') AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL)))))
+) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
+WHERE [t].[CompanyName] IS NOT NULL");
         }
 
         public override void Compiled_query()
@@ -254,14 +289,14 @@ WHERE ([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)) OR (@__ef_filter__TenantPrefix_0 = N'')) AND ([c].[CustomerID] = @__customerID)",
+WHERE (((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (([c].[CompanyName] LIKE [c].[CompanyName] + N'%') AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL)))))) AND (([c].[CustomerID] = @__customerID) AND @__customerID IS NOT NULL)",
                 //
                 @"@__ef_filter__TenantPrefix_0='B' (Size = 4000)
 @__customerID='BLAUS' (Size = 5)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)) OR (@__ef_filter__TenantPrefix_0 = N'')) AND ([c].[CustomerID] = @__customerID)");
+WHERE (((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (([c].[CompanyName] LIKE [c].[CompanyName] + N'%') AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL)))))) AND (([c].[CustomerID] = @__customerID) AND @__customerID IS NOT NULL)");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryFilterFuncletizationSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryFilterFuncletizationSqlServerTest.cs
@@ -6,8 +6,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
-    // issue #15264
-    internal class QueryFilterFuncletizationSqlServerTest
+    public class QueryFilterFuncletizationSqlServerTest
         : QueryFilterFuncletizationTestBase<QueryFilterFuncletizationSqlServerTest.QueryFilterFuncletizationSqlServerFixture>
     {
         public QueryFilterFuncletizationSqlServerTest(
@@ -27,9 +26,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 @"@__ef_filter__Field_0='False'
 @__Field_0='False'
 
-SELECT [e].[Id], [e].[IsEnabled]
-FROM [FieldFilter] AS [e]
-WHERE ([e].[IsEnabled] = @__ef_filter__Field_0) AND ([e].[IsEnabled] = @__Field_0)");
+SELECT [f].[Id], [f].[IsEnabled]
+FROM [FieldFilter] AS [f]
+WHERE (([f].[IsEnabled] = @__ef_filter__Field_0) AND @__ef_filter__Field_0 IS NOT NULL) AND (([f].[IsEnabled] = @__Field_0) AND @__Field_0 IS NOT NULL)");
         }
 
         public override void DbContext_field_is_parameterized()
@@ -39,15 +38,15 @@ WHERE ([e].[IsEnabled] = @__ef_filter__Field_0) AND ([e].[IsEnabled] = @__Field_
             AssertSql(
                 @"@__ef_filter__Field_0='False'
 
-SELECT [e].[Id], [e].[IsEnabled]
-FROM [FieldFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Field_0",
+SELECT [f].[Id], [f].[IsEnabled]
+FROM [FieldFilter] AS [f]
+WHERE ([f].[IsEnabled] = @__ef_filter__Field_0) AND @__ef_filter__Field_0 IS NOT NULL",
                 //
                 @"@__ef_filter__Field_0='True'
 
-SELECT [e].[Id], [e].[IsEnabled]
-FROM [FieldFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Field_0");
+SELECT [f].[Id], [f].[IsEnabled]
+FROM [FieldFilter] AS [f]
+WHERE ([f].[IsEnabled] = @__ef_filter__Field_0) AND @__ef_filter__Field_0 IS NOT NULL");
         }
 
         public override void DbContext_property_is_parameterized()
@@ -57,15 +56,15 @@ WHERE [e].[IsEnabled] = @__ef_filter__Field_0");
             AssertSql(
                 @"@__ef_filter__Property_0='False'
 
-SELECT [e].[Id], [e].[IsEnabled]
-FROM [PropertyFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Property_0",
+SELECT [p].[Id], [p].[IsEnabled]
+FROM [PropertyFilter] AS [p]
+WHERE ([p].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL",
                 //
                 @"@__ef_filter__Property_0='True'
 
-SELECT [e].[Id], [e].[IsEnabled]
-FROM [PropertyFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Property_0");
+SELECT [p].[Id], [p].[IsEnabled]
+FROM [PropertyFilter] AS [p]
+WHERE ([p].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL");
         }
 
         public override void DbContext_method_call_is_parameterized()
@@ -75,9 +74,9 @@ WHERE [e].[IsEnabled] = @__ef_filter__Property_0");
             AssertSql(
                 @"@__ef_filter__p_0='2'
 
-SELECT [e].[Id], [e].[Tenant]
-FROM [MethodCallFilter] AS [e]
-WHERE [e].[Tenant] = @__ef_filter__p_0");
+SELECT [m].[Id], [m].[Tenant]
+FROM [MethodCallFilter] AS [m]
+WHERE ([m].[Tenant] = @__ef_filter__p_0) AND @__ef_filter__p_0 IS NOT NULL");
         }
 
         public override void DbContext_list_is_parameterized()
@@ -85,17 +84,17 @@ WHERE [e].[Tenant] = @__ef_filter__p_0");
             base.DbContext_list_is_parameterized();
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[Tenant]
-FROM [ListFilter] AS [e]
-WHERE 0 = 1",
+                @"SELECT [l].[Id], [l].[Tenant]
+FROM [ListFilter] AS [l]
+WHERE CAST(1 AS bit) = CAST(0 AS bit)",
                 //
-                @"SELECT [e].[Id], [e].[Tenant]
-FROM [ListFilter] AS [e]
-WHERE [e].[Tenant] IN (1)",
+                @"SELECT [l].[Id], [l].[Tenant]
+FROM [ListFilter] AS [l]
+WHERE [l].[Tenant] IN (1)",
                 //
-                @"SELECT [e].[Id], [e].[Tenant]
-FROM [ListFilter] AS [e]
-WHERE [e].[Tenant] IN (2, 3)");
+                @"SELECT [l].[Id], [l].[Tenant]
+FROM [ListFilter] AS [l]
+WHERE [l].[Tenant] IN (2, 3)");
         }
 
         public override void DbContext_property_chain_is_parameterized()
@@ -105,15 +104,15 @@ WHERE [e].[Tenant] IN (2, 3)");
             AssertSql(
                 @"@__ef_filter__Enabled_0='False'
 
-SELECT [e].[Id], [e].[IsEnabled]
-FROM [PropertyChainFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Enabled_0",
+SELECT [p].[Id], [p].[IsEnabled]
+FROM [PropertyChainFilter] AS [p]
+WHERE ([p].[IsEnabled] = @__ef_filter__Enabled_0) AND @__ef_filter__Enabled_0 IS NOT NULL",
                 //
                 @"@__ef_filter__Enabled_0='True'
 
-SELECT [e].[Id], [e].[IsEnabled]
-FROM [PropertyChainFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Enabled_0");
+SELECT [p].[Id], [p].[IsEnabled]
+FROM [PropertyChainFilter] AS [p]
+WHERE ([p].[IsEnabled] = @__ef_filter__Enabled_0) AND @__ef_filter__Enabled_0 IS NOT NULL");
         }
 
         public override void DbContext_property_method_call_is_parameterized()
@@ -123,9 +122,9 @@ WHERE [e].[IsEnabled] = @__ef_filter__Enabled_0");
             AssertSql(
                 @"@__ef_filter__p_0='2'
 
-SELECT [e].[Id], [e].[Tenant]
-FROM [PropertyMethodCallFilter] AS [e]
-WHERE [e].[Tenant] = @__ef_filter__p_0");
+SELECT [p].[Id], [p].[Tenant]
+FROM [PropertyMethodCallFilter] AS [p]
+WHERE ([p].[Tenant] = @__ef_filter__p_0) AND @__ef_filter__p_0 IS NOT NULL");
         }
 
         public override void DbContext_method_call_chain_is_parameterized()
@@ -135,9 +134,9 @@ WHERE [e].[Tenant] = @__ef_filter__p_0");
             AssertSql(
                 @"@__ef_filter__p_0='2'
 
-SELECT [e].[Id], [e].[Tenant]
-FROM [MethodCallChainFilter] AS [e]
-WHERE [e].[Tenant] = @__ef_filter__p_0");
+SELECT [m].[Id], [m].[Tenant]
+FROM [MethodCallChainFilter] AS [m]
+WHERE ([m].[Tenant] = @__ef_filter__p_0) AND @__ef_filter__p_0 IS NOT NULL");
         }
 
         public override void DbContext_complex_expression_is_parameterized()
@@ -148,23 +147,23 @@ WHERE [e].[Tenant] = @__ef_filter__p_0");
                 @"@__ef_filter__Property_0='False'
 @__ef_filter__p_1='True'
 
-SELECT [x].[Id], [x].[IsEnabled]
-FROM [ComplexFilter] AS [x]
-WHERE ([x].[IsEnabled] = @__ef_filter__Property_0) AND (@__ef_filter__p_1 = CAST(1 AS bit))",
+SELECT [c].[Id], [c].[IsEnabled]
+FROM [ComplexFilter] AS [c]
+WHERE (([c].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL) AND (@__ef_filter__p_1 = CAST(1 AS bit))",
                 //
                 @"@__ef_filter__Property_0='True'
 @__ef_filter__p_1='True'
 
-SELECT [x].[Id], [x].[IsEnabled]
-FROM [ComplexFilter] AS [x]
-WHERE ([x].[IsEnabled] = @__ef_filter__Property_0) AND (@__ef_filter__p_1 = CAST(1 AS bit))",
+SELECT [c].[Id], [c].[IsEnabled]
+FROM [ComplexFilter] AS [c]
+WHERE (([c].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL) AND (@__ef_filter__p_1 = CAST(1 AS bit))",
                 //
                 @"@__ef_filter__Property_0='True'
 @__ef_filter__p_1='False'
 
-SELECT [x].[Id], [x].[IsEnabled]
-FROM [ComplexFilter] AS [x]
-WHERE ([x].[IsEnabled] = @__ef_filter__Property_0) AND (@__ef_filter__p_1 = CAST(1 AS bit))");
+SELECT [c].[Id], [c].[IsEnabled]
+FROM [ComplexFilter] AS [c]
+WHERE (([c].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL) AND (@__ef_filter__p_1 = CAST(1 AS bit))");
         }
 
         public override void DbContext_property_based_filter_does_not_short_circuit()
@@ -175,22 +174,23 @@ WHERE ([x].[IsEnabled] = @__ef_filter__Property_0) AND (@__ef_filter__p_1 = CAST
                 @"@__ef_filter__p_0='False'
 @__ef_filter__IsModerated_1='True' (Nullable = true)
 
-SELECT [x].[Id], [x].[IsDeleted], [x].[IsModerated]
-FROM [ShortCircuitFilter] AS [x]
-WHERE ([x].[IsDeleted] = CAST(0 AS bit)) AND ((@__ef_filter__p_0 = CAST(1 AS bit)) OR (@__ef_filter__IsModerated_1 = [x].[IsModerated]))",
+SELECT [s].[Id], [s].[IsDeleted], [s].[IsModerated]
+FROM [ShortCircuitFilter] AS [s]
+WHERE ([s].[IsDeleted] <> CAST(1 AS bit)) AND ((@__ef_filter__p_0 = CAST(1 AS bit)) OR ((@__ef_filter__IsModerated_1 = [s].[IsModerated]) AND @__ef_filter__IsModerated_1 IS NOT NULL))",
                 //
                 @"@__ef_filter__p_0='False'
 @__ef_filter__IsModerated_1='False' (Nullable = true)
 
-SELECT [x].[Id], [x].[IsDeleted], [x].[IsModerated]
-FROM [ShortCircuitFilter] AS [x]
-WHERE ([x].[IsDeleted] = CAST(0 AS bit)) AND ((@__ef_filter__p_0 = CAST(1 AS bit)) OR (@__ef_filter__IsModerated_1 = [x].[IsModerated]))",
+SELECT [s].[Id], [s].[IsDeleted], [s].[IsModerated]
+FROM [ShortCircuitFilter] AS [s]
+WHERE ([s].[IsDeleted] <> CAST(1 AS bit)) AND ((@__ef_filter__p_0 = CAST(1 AS bit)) OR ((@__ef_filter__IsModerated_1 = [s].[IsModerated]) AND @__ef_filter__IsModerated_1 IS NOT NULL))",
                 //
                 @"@__ef_filter__p_0='True'
+@__ef_filter__IsModerated_1=''
 
-SELECT [x].[Id], [x].[IsDeleted], [x].[IsModerated]
-FROM [ShortCircuitFilter] AS [x]
-WHERE ([x].[IsDeleted] = CAST(0 AS bit)) AND ((@__ef_filter__p_0 = CAST(1 AS bit)) OR [x].[IsModerated] IS NULL)");
+SELECT [s].[Id], [s].[IsDeleted], [s].[IsModerated]
+FROM [ShortCircuitFilter] AS [s]
+WHERE ([s].[IsDeleted] <> CAST(1 AS bit)) AND ((@__ef_filter__p_0 = CAST(1 AS bit)) OR ((@__ef_filter__IsModerated_1 = [s].[IsModerated]) AND @__ef_filter__IsModerated_1 IS NOT NULL))");
         }
 
         public override void EntityTypeConfiguration_DbContext_field_is_parameterized()
@@ -202,13 +202,13 @@ WHERE ([x].[IsDeleted] = CAST(0 AS bit)) AND ((@__ef_filter__p_0 = CAST(1 AS bit
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [EntityTypeConfigurationFieldFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Field_0",
+WHERE ([e].[IsEnabled] = @__ef_filter__Field_0) AND @__ef_filter__Field_0 IS NOT NULL",
                 //
                 @"@__ef_filter__Field_0='True'
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [EntityTypeConfigurationFieldFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Field_0");
+WHERE ([e].[IsEnabled] = @__ef_filter__Field_0) AND @__ef_filter__Field_0 IS NOT NULL");
         }
 
         public override void EntityTypeConfiguration_DbContext_property_is_parameterized()
@@ -220,13 +220,13 @@ WHERE [e].[IsEnabled] = @__ef_filter__Field_0");
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [EntityTypeConfigurationPropertyFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Property_0",
+WHERE ([e].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL",
                 //
                 @"@__ef_filter__Property_0='True'
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [EntityTypeConfigurationPropertyFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Property_0");
+WHERE ([e].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL");
         }
 
         public override void EntityTypeConfiguration_DbContext_method_call_is_parameterized()
@@ -238,7 +238,7 @@ WHERE [e].[IsEnabled] = @__ef_filter__Property_0");
 
 SELECT [e].[Id], [e].[Tenant]
 FROM [EntityTypeConfigurationMethodCallFilter] AS [e]
-WHERE [e].[Tenant] = @__ef_filter__p_0");
+WHERE ([e].[Tenant] = @__ef_filter__p_0) AND @__ef_filter__p_0 IS NOT NULL");
         }
 
         public override void EntityTypeConfiguration_DbContext_property_chain_is_parameterized()
@@ -250,13 +250,13 @@ WHERE [e].[Tenant] = @__ef_filter__p_0");
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [EntityTypeConfigurationPropertyChainFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Enabled_0",
+WHERE ([e].[IsEnabled] = @__ef_filter__Enabled_0) AND @__ef_filter__Enabled_0 IS NOT NULL",
                 //
                 @"@__ef_filter__Enabled_0='True'
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [EntityTypeConfigurationPropertyChainFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Enabled_0");
+WHERE ([e].[IsEnabled] = @__ef_filter__Enabled_0) AND @__ef_filter__Enabled_0 IS NOT NULL");
         }
 
         public override void Local_method_DbContext_field_is_parameterized()
@@ -266,15 +266,15 @@ WHERE [e].[IsEnabled] = @__ef_filter__Enabled_0");
             AssertSql(
                 @"@__ef_filter__Field_0='False'
 
-SELECT [e].[Id], [e].[IsEnabled]
-FROM [LocalMethodFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Field_0",
+SELECT [l].[Id], [l].[IsEnabled]
+FROM [LocalMethodFilter] AS [l]
+WHERE ([l].[IsEnabled] = @__ef_filter__Field_0) AND @__ef_filter__Field_0 IS NOT NULL",
                 //
                 @"@__ef_filter__Field_0='True'
 
-SELECT [e].[Id], [e].[IsEnabled]
-FROM [LocalMethodFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Field_0");
+SELECT [l].[Id], [l].[IsEnabled]
+FROM [LocalMethodFilter] AS [l]
+WHERE ([l].[IsEnabled] = @__ef_filter__Field_0) AND @__ef_filter__Field_0 IS NOT NULL");
         }
 
         public override void Local_static_method_DbContext_property_is_parameterized()
@@ -284,15 +284,15 @@ WHERE [e].[IsEnabled] = @__ef_filter__Field_0");
             AssertSql(
                 @"@__ef_filter__Property_0='False'
 
-SELECT [e].[Id], [e].[IsEnabled]
-FROM [LocalMethodParamsFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Property_0",
+SELECT [l].[Id], [l].[IsEnabled]
+FROM [LocalMethodParamsFilter] AS [l]
+WHERE ([l].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL",
                 //
                 @"@__ef_filter__Property_0='True'
 
-SELECT [e].[Id], [e].[IsEnabled]
-FROM [LocalMethodParamsFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Property_0");
+SELECT [l].[Id], [l].[IsEnabled]
+FROM [LocalMethodParamsFilter] AS [l]
+WHERE ([l].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL");
         }
 
         public override void Remote_method_DbContext_property_method_call_is_parameterized()
@@ -302,9 +302,9 @@ WHERE [e].[IsEnabled] = @__ef_filter__Property_0");
             AssertSql(
                 @"@__ef_filter__p_0='2'
 
-SELECT [e].[Id], [e].[Tenant]
-FROM [RemoteMethodParamsFilter] AS [e]
-WHERE [e].[Tenant] = @__ef_filter__p_0");
+SELECT [r].[Id], [r].[Tenant]
+FROM [RemoteMethodParamsFilter] AS [r]
+WHERE ([r].[Tenant] = @__ef_filter__p_0) AND @__ef_filter__p_0 IS NOT NULL");
         }
 
         public override void Extension_method_DbContext_field_is_parameterized()
@@ -316,13 +316,13 @@ WHERE [e].[Tenant] = @__ef_filter__p_0");
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [ExtensionBuilderFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Field_0",
+WHERE ([e].[IsEnabled] = @__ef_filter__Field_0) AND @__ef_filter__Field_0 IS NOT NULL",
                 //
                 @"@__ef_filter__Field_0='True'
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [ExtensionBuilderFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Field_0");
+WHERE ([e].[IsEnabled] = @__ef_filter__Field_0) AND @__ef_filter__Field_0 IS NOT NULL");
         }
 
         public override void Extension_method_DbContext_property_chain_is_parameterized()
@@ -334,13 +334,13 @@ WHERE [e].[IsEnabled] = @__ef_filter__Field_0");
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [ExtensionContextFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Enabled_0",
+WHERE ([e].[IsEnabled] = @__ef_filter__Enabled_0) AND @__ef_filter__Enabled_0 IS NOT NULL",
                 //
                 @"@__ef_filter__Enabled_0='True'
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [ExtensionContextFilter] AS [e]
-WHERE [e].[IsEnabled] = @__ef_filter__Enabled_0");
+WHERE ([e].[IsEnabled] = @__ef_filter__Enabled_0) AND @__ef_filter__Enabled_0 IS NOT NULL");
         }
 
         public override void Using_DbSet_in_filter_works()
@@ -374,9 +374,9 @@ WHERE EXISTS (
             base.Static_member_from_dbContext_is_inlined();
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[UserId]
-FROM [DbContextStaticMemberFilter] AS [e]
-WHERE [e].[UserId] <> 1");
+                @"SELECT [d].[Id], [d].[UserId]
+FROM [DbContextStaticMemberFilter] AS [d]
+WHERE [d].[UserId] <> 1");
         }
 
         public override void Static_member_from_non_dbContext_is_inlined()
@@ -384,9 +384,9 @@ WHERE [e].[UserId] <> 1");
             base.Static_member_from_non_dbContext_is_inlined();
 
             AssertSql(
-                @"SELECT [b].[Id], [b].[IsEnabled]
-FROM [StaticMemberFilter] AS [b]
-WHERE [b].[IsEnabled] = CAST(1 AS bit)");
+                @"SELECT [s].[Id], [s].[IsEnabled]
+FROM [StaticMemberFilter] AS [s]
+WHERE [s].[IsEnabled] = CAST(1 AS bit)");
         }
 
         public override void Local_variable_from_OnModelCreating_is_inlined()
@@ -394,9 +394,9 @@ WHERE [b].[IsEnabled] = CAST(1 AS bit)");
             base.Local_variable_from_OnModelCreating_is_inlined();
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[IsEnabled]
-FROM [LocalVariableFilter] AS [e]
-WHERE [e].[IsEnabled] = CAST(1 AS bit)");
+                @"SELECT [l].[Id], [l].[IsEnabled]
+FROM [LocalVariableFilter] AS [l]
+WHERE [l].[IsEnabled] = CAST(1 AS bit)");
         }
 
         public override void Method_parameter_is_inlined()
@@ -404,9 +404,9 @@ WHERE [e].[IsEnabled] = CAST(1 AS bit)");
             base.Method_parameter_is_inlined();
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[Tenant]
-FROM [ParameterFilter] AS [e]
-WHERE [e].[Tenant] = 0");
+                @"SELECT [p].[Id], [p].[Tenant]
+FROM [ParameterFilter] AS [p]
+WHERE [p].[Tenant] = 0");
         }
 
         public override void Using_multiple_context_in_filter_parametrize_only_current_context()
@@ -416,15 +416,15 @@ WHERE [e].[Tenant] = 0");
             AssertSql(
                 @"@__ef_filter__Property_0='False'
 
-SELECT [e].[Id], [e].[BossId], [e].[IsEnabled]
-FROM [MultiContextFilter] AS [e]
-WHERE ([e].[IsEnabled] = @__ef_filter__Property_0) AND ([e].[BossId] = 1)",
+SELECT [m].[Id], [m].[BossId], [m].[IsEnabled]
+FROM [MultiContextFilter] AS [m]
+WHERE (([m].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL) AND ([m].[BossId] = 1)",
                 //
                 @"@__ef_filter__Property_0='True'
 
-SELECT [e].[Id], [e].[BossId], [e].[IsEnabled]
-FROM [MultiContextFilter] AS [e]
-WHERE ([e].[IsEnabled] = @__ef_filter__Property_0) AND ([e].[BossId] = 1)");
+SELECT [m].[Id], [m].[BossId], [m].[IsEnabled]
+FROM [MultiContextFilter] AS [m]
+WHERE (([m].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL) AND ([m].[BossId] = 1)");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerComplianceTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerComplianceTest.cs
@@ -12,9 +12,6 @@ namespace Microsoft.EntityFrameworkCore
     {
         protected override ICollection<Type> IgnoredTestBases { get; } = new HashSet<Type>
         {
-            typeof(FiltersInheritanceTestBase<>),          // issue #15264
-            typeof(FiltersTestBase<>),                     // issue #15264
-            typeof(QueryFilterFuncletizationTestBase<>),   // issue #15264
             // Query pipeline
             typeof(ConcurrencyDetectorTestBase<>),
             typeof(ConcurrencyDetectorRelationalTestBase<>),

--- a/test/EFCore.Sqlite.FunctionalTests/Query/FiltersInheritanceSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/FiltersInheritanceSqliteTest.cs
@@ -3,8 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
-    // issue #15264
-    internal class FiltersInheritanceSqliteTest : FiltersInheritanceTestBase<FiltersInheritanceSqliteFixture>
+    public class FiltersInheritanceSqliteTest : FiltersInheritanceTestBase<FiltersInheritanceSqliteFixture>
     {
         public FiltersInheritanceSqliteTest(FiltersInheritanceSqliteFixture fixture)
             : base(fixture)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/FiltersSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/FiltersSqliteTest.cs
@@ -5,8 +5,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
-    // issue #15264
-    internal class FiltersSqliteTest : FiltersTestBase<NorthwindQuerySqliteFixture<NorthwindFiltersCustomizer>>
+    public class FiltersSqliteTest : FiltersTestBase<NorthwindQuerySqliteFixture<NorthwindFiltersCustomizer>>
     {
         public FiltersSqliteTest(NorthwindQuerySqliteFixture<NorthwindFiltersCustomizer> fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
@@ -18,12 +17,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         public override void Count_query()
         {
             base.Count_query();
+
             AssertSql(
                 @"@__ef_filter__TenantPrefix_0='B' (Size = 1)
 
 SELECT COUNT(*)
 FROM ""Customers"" AS ""c""
-WHERE (""c"".""CompanyName"" LIKE @__ef_filter__TenantPrefix_0 || '%' AND (substr(""c"".""CompanyName"", 1, length(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)) OR (@__ef_filter__TenantPrefix_0 = '')");
+WHERE ((@__ef_filter__TenantPrefix_0 = '') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR (""c"".""CompanyName"" IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (((""c"".""CompanyName"" LIKE ""c"".""CompanyName"" || '%') AND (((substr(""c"".""CompanyName"", 1, length(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (substr(""c"".""CompanyName"", 1, length(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (substr(""c"".""CompanyName"", 1, length(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL))) OR ((@__ef_filter__TenantPrefix_0 = '') AND @__ef_filter__TenantPrefix_0 IS NOT NULL))))");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/QueryFilterFuncletizationSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/QueryFilterFuncletizationSqliteTest.cs
@@ -6,9 +6,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
-    // issue #15264
-    internal class QueryFilterFuncletizationSqliteTest
-        : QueryFilterFuncletizationTestBase<QueryFilterFuncletizationSqliteTest.QueryFilterFuncletizationSqliteFixture>
+    public class QueryFilterFuncletizationSqliteTest : QueryFilterFuncletizationTestBase<QueryFilterFuncletizationSqliteTest.QueryFilterFuncletizationSqliteFixture>
     {
         public QueryFilterFuncletizationSqliteTest(
             QueryFilterFuncletizationSqliteFixture fixture, ITestOutputHelper testOutputHelper)

--- a/test/EFCore.Sqlite.FunctionalTests/SqliteComplianceTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/SqliteComplianceTest.cs
@@ -15,9 +15,6 @@ namespace Microsoft.EntityFrameworkCore
             typeof(FromSqlSprocQueryTestBase<>),
             typeof(SqlExecutorTestBase<>),
             typeof(UdfDbFunctionTestBase<>),
-            typeof(FiltersInheritanceTestBase<>),          // issue #15264
-            typeof(FiltersTestBase<>),                     // issue #15264
-            typeof(QueryFilterFuncletizationTestBase<>),   // issue #15264
             // Query pipeline
             typeof(ConcurrencyDetectorTestBase<>),
             typeof(ConcurrencyDetectorRelationalTestBase<>),


### PR DESCRIPTION
When nav rewrite constructs new EntityQueryable it now looks into EntityType for any query filter annotations and applies them on top. Those predicates are parameterized and the parameters created are injected into the context as part of query execution expression.
Generated predicate expression is re-visited by nav expansion to recursively handle filters (expand potential navigation expansions that were introduced in them).

This adds some complexity to the way navigations are expanded - before the newly constructed join always was guaranteed to be an entity. Now it can be a complex structure with multiple navigations already expanded.