### PR TITLE
Query: Allow tracking of weak entities when not projecting defining e…

### DIFF
--- a/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
@@ -199,10 +199,8 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                     foreach (var entityType in _visitedEntityTypes)
                     {
-                        if ((entityType.HasDefiningNavigation()
-                            && !containsOwner(entityType.DefiningEntityType))
-                            || (entityType.FindOwnership() is IForeignKey ownership
-                                && !containsOwner(ownership.PrincipalEntityType)))
+                        if (entityType.FindOwnership() is IForeignKey ownership
+                            && !containsOwner(ownership.PrincipalEntityType))
                         {
                             throw new InvalidOperationException("A tracking query projects owned entity without corresponding owner in result. " +
                                 "Owned entities cannot be tracked without their owner. " +

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsWeakQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsWeakQueryTestBase.cs
@@ -180,10 +180,5 @@ namespace Microsoft.EntityFrameworkCore.Query
         public override void Member_pushdown_with_collection_navigation_in_the_middle()
         {
         }
-
-        // Invalid test due to projecting owned entity without owner in tracking query
-        public override void Entries_for_detached_entities_are_removed()
-        {
-        }
     }
 }


### PR DESCRIPTION
…ntity

Resolves #16999