### PR TITLE
Query: Throw when capturing unknown type constants in shaper

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.cs
@@ -42,11 +42,11 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public CosmosShapedQueryCompilingExpressionVisitor(
-            QueryCompilationContext queryCompilationContext,
             ShapedQueryCompilingExpressionVisitorDependencies dependencies,
+            QueryCompilationContext queryCompilationContext,
             ISqlExpressionFactory sqlExpressionFactory,
             IQuerySqlGeneratorFactory querySqlGeneratorFactory)
-            : base(queryCompilationContext, dependencies)
+            : base(dependencies, queryCompilationContext)
         {
             _sqlExpressionFactory = sqlExpressionFactory;
             _querySqlGeneratorFactory = querySqlGeneratorFactory;

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitorFactory.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitorFactory.cs
@@ -41,8 +41,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         /// </summary>
         public virtual ShapedQueryCompilingExpressionVisitor Create(QueryCompilationContext queryCompilationContext)
             => new CosmosShapedQueryCompilingExpressionVisitor(
-                queryCompilationContext,
                 _dependencies,
+                queryCompilationContext,
                 _sqlExpressionFactory,
                 _querySqlGeneratorFactory);
     }

--- a/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryExpressionVisitor.cs
@@ -23,9 +23,9 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
         private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
 
         public InMemoryShapedQueryCompilingExpressionVisitor(
-            QueryCompilationContext queryCompilationContext,
-            ShapedQueryCompilingExpressionVisitorDependencies dependencies)
-            : base(queryCompilationContext, dependencies)
+            ShapedQueryCompilingExpressionVisitorDependencies dependencies,
+            QueryCompilationContext queryCompilationContext)
+            : base(dependencies, queryCompilationContext)
         {
             _contextType = queryCompilationContext.ContextType;
             _logger = queryCompilationContext.Logger;

--- a/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryExpressionVisitorFactory.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryExpressionVisitorFactory.cs
@@ -15,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
         }
 
         public virtual ShapedQueryCompilingExpressionVisitor Create(QueryCompilationContext queryCompilationContext)
-            => new InMemoryShapedQueryCompilingExpressionVisitor(queryCompilationContext, _dependencies);
+            => new InMemoryShapedQueryCompilingExpressionVisitor(_dependencies, queryCompilationContext);
     }
 
 }

--- a/src/EFCore.Relational/Query/Internal/RelationalShapedQueryExpressionVisitorFactory.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalShapedQueryExpressionVisitorFactory.cs
@@ -19,9 +19,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         public virtual ShapedQueryCompilingExpressionVisitor Create(QueryCompilationContext queryCompilationContext)
         {
             return new RelationalShapedQueryCompilingExpressionVisitor(
-                queryCompilationContext,
                 _dependencies,
-                _relationalDependencies);
+                _relationalDependencies,
+                queryCompilationContext);
         }
     }
 }

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.cs
@@ -18,10 +18,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         private readonly ISet<string> _tags;
 
         public RelationalShapedQueryCompilingExpressionVisitor(
-            QueryCompilationContext queryCompilationContext,
             ShapedQueryCompilingExpressionVisitorDependencies dependencies,
-            RelationalShapedQueryCompilingExpressionVisitorDependencies relationalDependencies)
-            : base(queryCompilationContext, dependencies)
+            RelationalShapedQueryCompilingExpressionVisitorDependencies relationalDependencies,
+            QueryCompilationContext queryCompilationContext)
+            : base(dependencies, queryCompilationContext)
         {
             RelationalDependencies = relationalDependencies;
 

--- a/src/EFCore/Query/ShapedQueryCompilingExpressionVisitorDependencies.cs
+++ b/src/EFCore/Query/ShapedQueryCompilingExpressionVisitorDependencies.cs
@@ -3,6 +3,7 @@
 
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -54,11 +55,14 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// </summary>
         [EntityFrameworkInternal]
         public ShapedQueryCompilingExpressionVisitorDependencies(
-            [NotNull] IEntityMaterializerSource entityMaterializerSource)
+            [NotNull] IEntityMaterializerSource entityMaterializerSource,
+            [NotNull] ITypeMappingSource typeMappingSource)
         {
             Check.NotNull(entityMaterializerSource, nameof(entityMaterializerSource));
+            Check.NotNull(typeMappingSource, nameof(typeMappingSource));
 
             EntityMaterializerSource = entityMaterializerSource;
+            TypeMappingSource = typeMappingSource;
         }
 
         /// <summary>
@@ -67,11 +71,24 @@ namespace Microsoft.EntityFrameworkCore.Query
         public IEntityMaterializerSource EntityMaterializerSource { get; }
 
         /// <summary>
+        ///     The type mapping source.
+        /// </summary>
+        public ITypeMappingSource TypeMappingSource { get; }
+
+        /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
         /// </summary>
         /// <param name="entityMaterializerSource"> A replacement for the current dependency of this type. </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
         public ShapedQueryCompilingExpressionVisitorDependencies With([NotNull] IEntityMaterializerSource entityMaterializerSource)
-            => new ShapedQueryCompilingExpressionVisitorDependencies(entityMaterializerSource);
+            => new ShapedQueryCompilingExpressionVisitorDependencies(entityMaterializerSource, TypeMappingSource);
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="typeMappingSource"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public ShapedQueryCompilingExpressionVisitorDependencies With([NotNull] ITypeMappingSource typeMappingSource)
+            => new ShapedQueryCompilingExpressionVisitorDependencies(EntityMaterializerSource, typeMappingSource);
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/Query/SimpleQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/SimpleQueryInMemoryTest.cs
@@ -276,5 +276,23 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return base.QueryType_with_included_navs_multi_level(isAsync);
         }
+
+        [ConditionalTheory(Skip = "Issue#17050")]
+        public override void Client_code_using_instance_in_static_method()
+        {
+            base.Client_code_using_instance_in_static_method();
+        }
+
+        [ConditionalTheory(Skip = "Issue#17050")]
+        public override void Client_code_using_instance_method_throws()
+        {
+            base.Client_code_using_instance_method_throws();
+        }
+
+        [ConditionalTheory(Skip = "Issue#17050")]
+        public override void Client_code_using_instance_in_anonymous_type()
+        {
+            base.Client_code_using_instance_in_anonymous_type();
+        }
     }
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/SqlExecutorTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/SqlExecutorTestBase.cs
@@ -52,7 +52,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue#17019")]
         public virtual void Throws_on_concurrent_command()
         {
             using (var context = CreateContext())
@@ -221,7 +221,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue#17019")]
         public virtual async Task Throws_on_concurrent_command_async()
         {
             using (var context = CreateContext())

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -7092,7 +7092,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return Task.CompletedTask;
         }
 
-        public TEntity Client<TEntity>(TEntity entity) => entity;
+        public static TEntity Client<TEntity>(TEntity entity) => entity;
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
@@ -1277,7 +1277,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         .Select(g => g.Sum(o => o.OrderID)));
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue#17048")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_empty_key_Aggregate_Key(bool isAsync)
         {

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -3683,7 +3683,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "Deadlock")]
+        [ConditionalFact(Skip = "Issue#17019")]
         public virtual void Throws_on_concurrent_query_list()
         {
             using (var context = CreateContext())
@@ -3719,7 +3719,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "Deadlock")]
+        [ConditionalFact(Skip = "Issue#17019")]
         public virtual void Throws_on_concurrent_query_first()
         {
             using (var context = CreateContext())
@@ -4290,7 +4290,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.ShipName);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue#17048")]
         [MemberData(nameof(IsAsyncData))]
         public virtual async Task ToString_with_formatter_is_evaluated_on_the_client(bool isAsync)
         {
@@ -5999,6 +5999,40 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery<Order>(
                 isAsync,
                 os => os.Select(o => $"CustomerCity:{o.Customer.City}"));
+        }
+
+        [ConditionalFact]
+        public virtual void Client_code_using_instance_method_throws()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Throws<InvalidOperationException>(
+                    () => context.Customers.Select(c => InstanceMethod(c)).ToList());
+            }
+        }
+
+        private string InstanceMethod(Customer c) => c.City;
+
+        [ConditionalFact]
+        public virtual void Client_code_using_instance_in_static_method()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Throws<InvalidOperationException>(
+                    () => context.Customers.Select(c => StaticMethod(this, c)).ToList());
+            }
+        }
+
+        private static string StaticMethod(SimpleQueryTestBase<TFixture> containingClass, Customer c) => c.City;
+
+        [ConditionalFact]
+        public virtual void Client_code_using_instance_in_anonymous_type()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Throws<InvalidOperationException>(
+                    () => context.Customers.Select(c => new { A = this }).ToList());
+            }
         }
     }
 }


### PR DESCRIPTION
3.0 work for #13048

