### PR TITLE
Add targeting pack override back for NETStandard.Library

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -19,6 +19,11 @@
         RuntimeFrameworkVersion="$(MicrosoftNETCoreAppRuntimeVersion)"
         TargetingPackVersion="$(MicrosoftNETCoreAppRefPackageVersion)" />
 
+    <!-- HACK: Use the latest version instead of the one bundled with the SDK -->
+    <KnownFrameworkReference Update="NETStandard.Library">
+      <TargetingPackVersion Condition="'%(TargetFramework)' == 'netstandard2.1'">$(NETStandardLibraryRefPackageVersion)</TargetingPackVersion>
+    </KnownFrameworkReference>
+
     <!-- Workaround for netstandard2.1 projects until we can get a 5.0 SDK containing https://github.com/dotnet/sdk/pull/3463 fix. -->
     <KnownFrameworkReference Update="NETStandard.Library">
       <RuntimeFrameworkName>NETStandard.Library</RuntimeFrameworkName>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -19,10 +19,10 @@
         RuntimeFrameworkVersion="$(MicrosoftNETCoreAppRuntimeVersion)"
         TargetingPackVersion="$(MicrosoftNETCoreAppRefPackageVersion)" />
 
-    <!-- HACK: Use the latest version instead of the one bundled with the SDK -->
-    <KnownFrameworkReference Update="NETStandard.Library">
-      <TargetingPackVersion Condition="'%(TargetFramework)' == 'netstandard2.1'">$(NETStandardLibraryRefPackageVersion)</TargetingPackVersion>
-    </KnownFrameworkReference>
+    <!-- Reference netstandard library at incoming dependency flow version, not bundled sdk version. -->
+    <FrameworkReference Update="NETStandard.Library"
+        Condition="'$(TargetFramework)' == 'netstandard2.1'"
+        TargetingPackVersion="$(NETStandardLibraryRefPackageVersion)" />
 
     <!-- Workaround for netstandard2.1 projects until we can get a 5.0 SDK containing https://github.com/dotnet/sdk/pull/3463 fix. -->
     <KnownFrameworkReference Update="NETStandard.Library">


### PR DESCRIPTION
This addresses the missing types error in master. It turns out that the root cause was that a hack was removed when we converted to targeting netcoreapp5.0 that was still needed for netstandard2.1: https://github.com/aspnet/EntityFrameworkCore/commit/3ce0877474e3e5efcb0b1123b68ded52ec644532#r34638627.

This should fix master.