### PR TITLE
Further merge query types into entity types

### DIFF
--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -76,7 +76,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 stringBuilder.AppendLine(";");
             }
 
-            GenerateEntityTypes(builderName, Sort(model.GetEntityTypes().Where(et => et.FindPrimaryKey() != null).ToList()), stringBuilder);
+            GenerateEntityTypes(builderName, Sort(model.GetEntityTypes().Where(et => !et.MigrationsIgnored()).ToList()), stringBuilder);
         }
 
         private static IReadOnlyList<IEntityType> Sort(IReadOnlyList<IEntityType> entityTypes)

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
@@ -360,8 +360,10 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             RemoveAnnotation(ref annotations, RelationalAnnotationNames.Comment);
             RemoveAnnotation(ref annotations, RelationalAnnotationNames.Schema);
             RemoveAnnotation(ref annotations, ScaffoldingAnnotationNames.DbSetName);
+            RemoveAnnotation(ref annotations, RelationalAnnotationNames.ViewDefinition);
 
-            if (!useDataAnnotations)
+            var isView = entityType.FindAnnotation(RelationalAnnotationNames.ViewDefinition) != null;
+            if (!useDataAnnotations || isView)
             {
                 GenerateTableName(entityType);
             }
@@ -526,7 +528,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             var explicitSchema = schema != null && schema != defaultSchema;
             var explicitTable = explicitSchema || tableName != null && tableName != entityType.GetDbSetName();
 
-            if (explicitTable)
+            var isView = entityType.FindAnnotation(RelationalAnnotationNames.ViewDefinition) != null;
+            if (explicitTable || isView)
             {
                 var parameterString = _code.Literal(tableName);
                 if (explicitSchema)
@@ -536,7 +539,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
                 var lines = new List<string>
                 {
-                    $".{nameof(RelationalEntityTypeBuilderExtensions.ToTable)}({parameterString})"
+                    $".{(isView ? nameof(RelationalEntityTypeBuilderExtensions.ToView) : nameof(RelationalEntityTypeBuilderExtensions.ToTable))}({parameterString})"
                 };
 
                 AppendMultiLineFluentApi(entityType, lines);

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
@@ -140,7 +140,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             var defaultSchema = entityType.Model.GetDefaultSchema();
 
             var schemaParameterNeeded = schema != null && schema != defaultSchema;
-            var tableAttributeNeeded = schemaParameterNeeded || tableName != null && tableName != entityType.GetDbSetName();
+            var isView = entityType.FindAnnotation(RelationalAnnotationNames.ViewDefinition) != null;
+            var tableAttributeNeeded = !isView && (schemaParameterNeeded || tableName != null && tableName != entityType.GetDbSetName());
 
             if (tableAttributeNeeded)
             {

--- a/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
@@ -324,7 +324,14 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             var dbSetName = GetDbSetName(table);
             builder.Metadata.SetDbSetName(dbSetName);
 
-            builder.ToTable(table.Name, table.Schema);
+            if (table is DatabaseView)
+            {
+                builder.ToView(table.Name, table.Schema);
+            }
+            else
+            {
+                builder.ToTable(table.Name, table.Schema);
+            }
 
             if (table.Comment != null)
             {

--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeBuilderExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeBuilderExtensions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -17,10 +16,10 @@ namespace Microsoft.EntityFrameworkCore
     public static class RelationalEntityTypeBuilderExtensions
     {
         /// <summary>
-        ///     Configures the view or table that the entity type maps to when targeting a relational database.
+        ///     Configures the table that the entity type maps to when targeting a relational database.
         /// </summary>
         /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
-        /// <param name="name"> The name of the view or table. </param>
+        /// <param name="name"> The name of the table. </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
         public static EntityTypeBuilder ToTable(
             [NotNull] this EntityTypeBuilder entityTypeBuilder,
@@ -30,16 +29,17 @@ namespace Microsoft.EntityFrameworkCore
             Check.NullButNotEmpty(name, nameof(name));
 
             entityTypeBuilder.Metadata.SetTableName(name);
+            entityTypeBuilder.Metadata.RemoveAnnotation(RelationalAnnotationNames.ViewDefinition);
 
             return entityTypeBuilder;
         }
 
         /// <summary>
-        ///     Configures the view or table that the entity type maps to when targeting a relational database.
+        ///     Configures the table that the entity type maps to when targeting a relational database.
         /// </summary>
         /// <typeparam name="TEntity"> The entity type being configured. </typeparam>
         /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
-        /// <param name="name"> The name of the view or table. </param>
+        /// <param name="name"> The name of the table. </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
         public static EntityTypeBuilder<TEntity> ToTable<TEntity>(
             [NotNull] this EntityTypeBuilder<TEntity> entityTypeBuilder,
@@ -48,11 +48,11 @@ namespace Microsoft.EntityFrameworkCore
             => (EntityTypeBuilder<TEntity>)ToTable((EntityTypeBuilder)entityTypeBuilder, name);
 
         /// <summary>
-        ///     Configures the view or table that the entity type maps to when targeting a relational database.
+        ///     Configures the table that the entity type maps to when targeting a relational database.
         /// </summary>
         /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
-        /// <param name="name"> The name of the view or table. </param>
-        /// <param name="schema"> The schema of the view or table. </param>
+        /// <param name="name"> The name of the table. </param>
+        /// <param name="schema"> The schema of the table. </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
         public static EntityTypeBuilder ToTable(
             [NotNull] this EntityTypeBuilder entityTypeBuilder,
@@ -65,17 +65,18 @@ namespace Microsoft.EntityFrameworkCore
 
             entityTypeBuilder.Metadata.SetTableName(name);
             entityTypeBuilder.Metadata.SetSchema(schema);
+            entityTypeBuilder.Metadata.RemoveAnnotation(RelationalAnnotationNames.ViewDefinition);
 
             return entityTypeBuilder;
         }
 
         /// <summary>
-        ///     Configures the view or table that the entity type maps to when targeting a relational database.
+        ///     Configures the table that the entity type maps to when targeting a relational database.
         /// </summary>
         /// <typeparam name="TEntity"> The entity type being configured. </typeparam>
         /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
-        /// <param name="name"> The name of the view or table. </param>
-        /// <param name="schema"> The schema of the view or table. </param>
+        /// <param name="name"> The name of the table. </param>
+        /// <param name="schema"> The schema of the table. </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
         public static EntityTypeBuilder<TEntity> ToTable<TEntity>(
             [NotNull] this EntityTypeBuilder<TEntity> entityTypeBuilder,
@@ -85,10 +86,10 @@ namespace Microsoft.EntityFrameworkCore
             => (EntityTypeBuilder<TEntity>)ToTable((EntityTypeBuilder)entityTypeBuilder, name, schema);
 
         /// <summary>
-        ///     Configures the view or table that the entity type maps to when targeting a relational database.
+        ///     Configures the table that the entity type maps to when targeting a relational database.
         /// </summary>
         /// <param name="referenceOwnershipBuilder"> The builder for the entity type being configured. </param>
-        /// <param name="name"> The name of the view or table. </param>
+        /// <param name="name"> The name of the table. </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
         public static OwnedNavigationBuilder ToTable(
             [NotNull] this OwnedNavigationBuilder referenceOwnershipBuilder,
@@ -103,12 +104,12 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         /// <summary>
-        ///     Configures the view or table that the entity type maps to when targeting a relational database.
+        ///     Configures the table that the entity type maps to when targeting a relational database.
         /// </summary>
         /// <typeparam name="TEntity"> The entity type being configured. </typeparam>
         /// <typeparam name="TRelatedEntity"> The entity type that this relationship targets. </typeparam>
         /// <param name="referenceOwnershipBuilder"> The builder for the entity type being configured. </param>
-        /// <param name="name"> The name of the view or table. </param>
+        /// <param name="name"> The name of the table. </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
         public static OwnedNavigationBuilder<TEntity, TRelatedEntity> ToTable<TEntity, TRelatedEntity>(
             [NotNull] this OwnedNavigationBuilder<TEntity, TRelatedEntity> referenceOwnershipBuilder,
@@ -118,11 +119,11 @@ namespace Microsoft.EntityFrameworkCore
             => (OwnedNavigationBuilder<TEntity, TRelatedEntity>)ToTable((OwnedNavigationBuilder)referenceOwnershipBuilder, name);
 
         /// <summary>
-        ///     Configures the view or table that the entity type maps to when targeting a relational database.
+        ///     Configures the table that the entity type maps to when targeting a relational database.
         /// </summary>
         /// <param name="referenceOwnershipBuilder"> The builder for the entity type being configured. </param>
-        /// <param name="name"> The name of the view or table. </param>
-        /// <param name="schema"> The schema of the view or table. </param>
+        /// <param name="name"> The name of the table. </param>
+        /// <param name="schema"> The schema of the table. </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
         public static OwnedNavigationBuilder ToTable(
             [NotNull] this OwnedNavigationBuilder referenceOwnershipBuilder,
@@ -140,13 +141,13 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         /// <summary>
-        ///     Configures the view or table that the entity type maps to when targeting a relational database.
+        ///     Configures the table that the entity type maps to when targeting a relational database.
         /// </summary>
         /// <typeparam name="TEntity"> The entity type being configured. </typeparam>
         /// <typeparam name="TRelatedEntity"> The entity type that this relationship targets. </typeparam>
         /// <param name="referenceOwnershipBuilder"> The builder for the entity type being configured. </param>
-        /// <param name="name"> The name of the view or table. </param>
-        /// <param name="schema"> The schema of the view or table. </param>
+        /// <param name="name"> The name of the table. </param>
+        /// <param name="schema"> The schema of the table. </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
         public static OwnedNavigationBuilder<TEntity, TRelatedEntity> ToTable<TEntity, TRelatedEntity>(
             [NotNull] this OwnedNavigationBuilder<TEntity, TRelatedEntity> referenceOwnershipBuilder,
@@ -157,10 +158,10 @@ namespace Microsoft.EntityFrameworkCore
             => (OwnedNavigationBuilder<TEntity, TRelatedEntity>)ToTable((OwnedNavigationBuilder)referenceOwnershipBuilder, name, schema);
 
         /// <summary>
-        ///     Configures the view or table that the entity type maps to when targeting a relational database.
+        ///     Configures the table that the entity type maps to when targeting a relational database.
         /// </summary>
         /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
-        /// <param name="name"> The name of the view or table. </param>
+        /// <param name="name"> The name of the table. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns>
         ///     The same builder instance if the configuration was applied,
@@ -179,11 +180,11 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         /// <summary>
-        ///     Configures the view or table that the entity type maps to when targeting a relational database.
+        ///     Configures the table that the entity type maps to when targeting a relational database.
         /// </summary>
         /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
-        /// <param name="name"> The name of the view or table. </param>
-        /// <param name="schema"> The schema of the view or table. </param>
+        /// <param name="name"> The name of the table. </param>
+        /// <param name="schema"> The schema of the table. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns>
         ///     The same builder instance if the configuration was applied,
@@ -264,12 +265,11 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         /// <summary>
-        ///     Configures the view or table that the view maps to when targeting a relational database.
+        ///     Configures the view that the entity type maps to when targeting a relational database.
         /// </summary>
-        /// <param name="entityTypeBuilder"> The builder for the query type being configured. </param>
-        /// <param name="name"> The name of the view or table. </param>
+        /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
+        /// <param name="name"> The name of the view. </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
-        [Obsolete("Use ToTable() instead")]
         public static EntityTypeBuilder ToView(
             [NotNull] this EntityTypeBuilder entityTypeBuilder,
             [CanBeNull] string name)
@@ -278,18 +278,18 @@ namespace Microsoft.EntityFrameworkCore
             Check.NullButNotEmpty(name, nameof(name));
 
             entityTypeBuilder.Metadata.SetTableName(name);
+            entityTypeBuilder.Metadata.SetAnnotation(RelationalAnnotationNames.ViewDefinition, null);
 
             return entityTypeBuilder;
         }
 
         /// <summary>
-        ///     Configures the view or table that the view maps to when targeting a relational database.
+        ///     Configures the view that the entity type maps to when targeting a relational database.
         /// </summary>
-        /// <typeparam name="TEntity"> The query type being configured. </typeparam>
-        /// <param name="entityTypeBuilder"> The builder for the query type being configured. </param>
-        /// <param name="name"> The name of the view or table. </param>
+        /// <typeparam name="TEntity"> The entity type being configured. </typeparam>
+        /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
+        /// <param name="name"> The name of the view. </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
-        [Obsolete("Use ToTable() instead")]
         public static EntityTypeBuilder<TEntity> ToView<TEntity>(
             [NotNull] this EntityTypeBuilder<TEntity> entityTypeBuilder,
             [CanBeNull] string name)
@@ -297,13 +297,12 @@ namespace Microsoft.EntityFrameworkCore
             => (EntityTypeBuilder<TEntity>)ToView((EntityTypeBuilder)entityTypeBuilder, name);
 
         /// <summary>
-        ///     Configures the view or table that the view maps to when targeting a relational database.
+        ///     Configures the view that the entity type maps to when targeting a relational database.
         /// </summary>
-        /// <param name="entityTypeBuilder"> The builder for the query type being configured. </param>
-        /// <param name="name"> The name of the view or table. </param>
-        /// <param name="schema"> The schema of the view or table. </param>
+        /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
+        /// <param name="name"> The name of the view. </param>
+        /// <param name="schema"> The schema of the view. </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
-        [Obsolete("Use ToTable() instead")]
         public static EntityTypeBuilder ToView(
             [NotNull] this EntityTypeBuilder entityTypeBuilder,
             [CanBeNull] string name,
@@ -315,19 +314,19 @@ namespace Microsoft.EntityFrameworkCore
 
             entityTypeBuilder.Metadata.SetTableName(name);
             entityTypeBuilder.Metadata.SetSchema(schema);
+            entityTypeBuilder.Metadata.SetAnnotation(RelationalAnnotationNames.ViewDefinition, null);
 
             return entityTypeBuilder;
         }
 
         /// <summary>
-        ///     Configures the view or table that the view maps to when targeting a relational database.
+        ///     Configures the view that the entity type maps to when targeting a relational database.
         /// </summary>
-        /// <typeparam name="TEntity"> The query type being configured. </typeparam>
-        /// <param name="entityTypeBuilder"> The builder for the query type being configured. </param>
-        /// <param name="name"> The name of the view or table. </param>
-        /// <param name="schema"> The schema of the view or table. </param>
+        /// <typeparam name="TEntity"> The entity type being configured. </typeparam>
+        /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
+        /// <param name="name"> The name of the view. </param>
+        /// <param name="schema"> The schema of the view. </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
-        [Obsolete("Use ToTable() instead")]
         public static EntityTypeBuilder<TEntity> ToView<TEntity>(
             [NotNull] this EntityTypeBuilder<TEntity> entityTypeBuilder,
             [CanBeNull] string name,
@@ -415,8 +414,8 @@ namespace Microsoft.EntityFrameworkCore
             {
                 if (constraint.Sql == sql)
                 {
-                   ((CheckConstraint)constraint).UpdateConfigurationSource(
-                        fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+                    ((CheckConstraint)constraint).UpdateConfigurationSource(
+                         fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
                     return entityTypeBuilder;
                 }
 

--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
@@ -277,5 +277,22 @@ namespace Microsoft.EntityFrameworkCore
             [NotNull] this IConventionEntityType entityType, [CanBeNull] string comment, bool fromDataAnnotation = false)
             => entityType.SetOrRemoveAnnotation(RelationalAnnotationNames.Comment, comment, fromDataAnnotation);
 
+        /// <summary>
+        ///     Gets a value indicating whether the entity type is ignored by Migrations.
+        /// </summary>
+        /// <param name="entityType">The entity type.</param>
+        /// <returns>A value indicating whether the entity type is ignored by Migrations.</returns>
+        public static bool MigrationsIgnored([NotNull] this IEntityType entityType)
+        {
+            if (entityType.BaseType != null)
+            {
+                return entityType.BaseType.MigrationsIgnored();
+            }
+
+            var viewDefinition = entityType.FindAnnotation(RelationalAnnotationNames.ViewDefinition);
+
+            return (viewDefinition != null && viewDefinition.Value == null)
+                || entityType.GetDefiningQuery() != null;
+        }
     }
 }

--- a/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
@@ -90,7 +90,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
                 foreach (var parameter in dbFunction.Parameters)
                 {
-                    if(parameter.TypeMapping == null)
+                    if (parameter.TypeMapping == null)
                     {
                         throw new InvalidOperationException(
                             RelationalStrings.DbFunctionInvalidParameterType(
@@ -152,7 +152,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             [NotNull] IDiagnosticsLogger<DbLoggerCategory.Model.Validation> logger)
         {
             var tables = new Dictionary<string, List<IEntityType>>();
-            foreach (var entityType in model.GetEntityTypes().Where(et => et.FindPrimaryKey() != null))
+            foreach (var entityType in model.GetEntityTypes())
             {
                 var tableName = Format(entityType.GetSchema(), entityType.GetTableName());
 
@@ -196,11 +196,11 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             foreach (var mappedType in mappedTypes)
             {
                 if (mappedType.BaseType != null
-                    || mappedType.FindForeignKeys(mappedType.FindPrimaryKey().Properties)
+                    || (mappedType.FindPrimaryKey() != null && mappedType.FindForeignKeys(mappedType.FindPrimaryKey().Properties)
                         .Any(
                             fk => fk.PrincipalKey.IsPrimaryKey()
                                   && fk.PrincipalEntityType.RootType() != mappedType
-                                  && unvalidatedTypes.Contains(fk.PrincipalEntityType)))
+                                  && unvalidatedTypes.Contains(fk.PrincipalEntityType))))
                 {
                     continue;
                 }
@@ -235,17 +235,17 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 {
                     var key = entityType.FindPrimaryKey();
                     var otherKey = nextEntityType.FindPrimaryKey();
-                    if (key.GetName() != otherKey.GetName())
+                    if (key?.GetName() != otherKey?.GetName())
                     {
                         throw new InvalidOperationException(
                             RelationalStrings.IncompatibleTableKeyNameMismatch(
                                 tableName,
                                 entityType.DisplayName(),
                                 nextEntityType.DisplayName(),
-                                key.GetName(),
-                                key.Properties.Format(),
-                                otherKey.GetName(),
-                                otherKey.Properties.Format()));
+                                key?.GetName(),
+                                key?.Properties.Format(),
+                                otherKey?.GetName(),
+                                otherKey?.Properties.Format()));
                     }
 
                     var nextComment = nextEntityType.GetComment();

--- a/src/EFCore.Relational/Metadata/Conventions/SharedTableConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/SharedTableConvention.cs
@@ -72,11 +72,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         {
             foreach (var entityType in model.GetEntityTypes())
             {
-                if (entityType.FindPrimaryKey() == null)
-                {
-                    continue;
-                }
-
                 var tableName = (Schema: entityType.GetSchema(), TableName: entityType.GetTableName());
                 if (!tables.TryGetValue(tableName, out var entityTypes))
                 {
@@ -131,8 +126,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         private static bool ShouldUniquify(IConventionEntityType entityType, ICollection<IConventionEntityType> entityTypes)
         {
             var rootType = entityType.RootType();
-            var pkProperty = entityType.FindPrimaryKey().Properties[0];
-            var rootSharedTableType = pkProperty.FindSharedTableRootPrimaryKeyProperty()?.DeclaringEntityType;
+            var pkProperty = entityType.FindPrimaryKey()?.Properties[0];
+            var rootSharedTableType = pkProperty?.FindSharedTableRootPrimaryKeyProperty()?.DeclaringEntityType;
 
             foreach (var otherEntityType in entityTypes)
             {
@@ -142,8 +137,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                     return false;
                 }
 
-                var otherPkProperty = otherEntityType.FindPrimaryKey().Properties[0];
-                var otherRootSharedTableType = otherPkProperty.FindSharedTableRootPrimaryKeyProperty()?.DeclaringEntityType;
+                var otherPkProperty = otherEntityType.FindPrimaryKey()?.Properties[0];
+                var otherRootSharedTableType = otherPkProperty?.FindSharedTableRootPrimaryKeyProperty()?.DeclaringEntityType;
                 if (otherRootSharedTableType == entityType
                     || (otherRootSharedTableType == rootSharedTableType
                         && otherRootSharedTableType != null))

--- a/src/EFCore.Relational/Metadata/RelationalAnnotationNames.cs
+++ b/src/EFCore.Relational/Metadata/RelationalAnnotationNames.cs
@@ -93,5 +93,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     A flag indicating whether the property is constrained to fixed length values.
         /// </summary>
         public const string IsFixedLength = Prefix + "IsFixedLength";
+
+        /// <summary>
+        ///     The definition of a database view.
+        /// </summary>
+        public const string ViewDefinition = Prefix + "ViewDefinition";
     }
 }

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -617,7 +617,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             createTableOperation.Columns.AddRange(
                 GetSortedProperties(target).SelectMany(p => Add(p, diffContext, inline: true)).Cast<AddColumnOperation>());
             var primaryKey = target.EntityTypes[0].FindPrimaryKey();
-            createTableOperation.PrimaryKey = Add(primaryKey, diffContext).Cast<AddPrimaryKeyOperation>().Single();
+            if (primaryKey != null)
+            {
+                createTableOperation.PrimaryKey = Add(primaryKey, diffContext).Cast<AddPrimaryKeyOperation>().Single();
+            }
             createTableOperation.UniqueConstraints.AddRange(
                 target.GetKeys().Where(k => !k.IsPrimaryKey()).SelectMany(k => Add(k, diffContext))
                     .Cast<AddUniqueConstraintOperation>());
@@ -2147,7 +2150,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         protected virtual IEnumerable<string> GetSchemas([NotNull] IModel model)
-            => model.GetRootEntityTypes().Select(t => t.GetSchema())
+            => model.GetRootEntityTypes().Where(t => !t.MigrationsIgnored()).Select(t => t.GetSchema())
                 .Concat(model.GetSequences().Select(s => s.Schema))
                 .Where(s => !string.IsNullOrEmpty(s))
                 .Distinct();

--- a/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
+++ b/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
@@ -11,7 +11,6 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Update;
@@ -1580,7 +1579,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             [CanBeNull] string schema,
             [NotNull] string tableName)
             => model?.GetEntityTypes().Where(
-                t => t.GetTableName() == tableName && t.GetSchema() == schema && t.FindPrimaryKey() != null);
+                t => t.GetTableName() == tableName && t.GetSchema() == schema && !t.MigrationsIgnored());
 
         /// <summary>
         ///     <para>

--- a/src/EFCore.Relational/Scaffolding/Metadata/DatabaseView.cs
+++ b/src/EFCore.Relational/Scaffolding/Metadata/DatabaseView.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Scaffolding.Metadata
+{
+    /// <summary>
+    ///     A simple model for a database view used when reverse engineering an existing database.
+    /// </summary>
+    public class DatabaseView : DatabaseTable
+    {
+    }
+}

--- a/src/EFCore.Relational/Update/Internal/SharedTableEntryMap.cs
+++ b/src/EFCore.Relational/Update/Internal/SharedTableEntryMap.cs
@@ -106,7 +106,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
         {
             var principals = new Dictionary<IEntityType, IReadOnlyList<IEntityType>>(entityTypes.Count);
             var dependents = new Dictionary<IEntityType, IReadOnlyList<IEntityType>>(entityTypes.Count);
-            foreach (var entityType in entityTypes)
+            foreach (var entityType in entityTypes.Where(t => t.FindPrimaryKey() != null))
             {
                 var principalList = new List<IEntityType>();
                 foreach (var foreignKey in entityType.FindForeignKeys(entityType.FindPrimaryKey().Properties))

--- a/src/EFCore.Sqlite.Core/Scaffolding/Internal/SqliteDatabaseModelFactory.cs
+++ b/src/EFCore.Sqlite.Core/Scaffolding/Internal/SqliteDatabaseModelFactory.cs
@@ -153,7 +153,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Scaffolding.Internal
             using (var command = connection.CreateCommand())
             {
                 command.CommandText = new StringBuilder()
-                    .AppendLine("SELECT \"name\"")
+                    .AppendLine("SELECT \"name\", \"type\"")
                     .AppendLine("FROM \"sqlite_master\"")
                     .Append("WHERE \"type\" IN ('table', 'view') AND instr(\"name\", 'sqlite_') <> 1 AND \"name\" NOT IN ('")
                     .Append(HistoryRepository.DefaultTableName)
@@ -179,10 +179,12 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Scaffolding.Internal
 
                         _logger.TableFound(name);
 
-                        var table = new DatabaseTable
-                        {
-                            Name = name
-                        };
+                        var type = reader.GetString(1);
+                        var table = type == "table"
+                            ? new DatabaseTable()
+                            : new DatabaseView();
+
+                        table.Name = name;
 
                         foreach (var column in GetColumns(connection, name))
                         {

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Design.Internal;
 using Microsoft.Extensions.DependencyInjection;
@@ -183,6 +184,16 @@ namespace TestNamespace
                 model => Assert.Equal(
                     "An entity comment",
                     model.FindEntityType("TestNamespace.Entity").GetComment()));
+        }
+
+        [ConditionalFact]
+        public void Views_work()
+        {
+            Test(
+                modelBuilder => modelBuilder.Entity("Vista").ToView("Vista"),
+                new ModelCodeGenerationOptions { UseDataAnnotations = true },
+                code => Assert.Contains(".ToView(\"Vista\")", code.ContextFile.Code),
+                model => Assert.NotNull(model.FindEntityType("TestNamespace.Vista").FindAnnotation(RelationalAnnotationNames.ViewDefinition)));
         }
 
         private class TestCodeGeneratorPlugin : ProviderCodeGeneratorPlugin

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityTypeGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityTypeGeneratorTest.cs
@@ -176,5 +176,22 @@ namespace TestNamespace
                     Assert.NotNull(postType.FindPrimaryKey());
                 });
         }
+
+        [ConditionalFact]
+        public void Views_dont_generate_TableAttribute()
+        {
+            Test(
+                modelBuilder => modelBuilder.Entity("Vista").ToView("Vistas", "dbo"),
+                new ModelCodeGenerationOptions { UseDataAnnotations = true },
+                code => Assert.DoesNotContain(
+                    "[Table(",
+                    code.AdditionalFiles.First(f => f.Path == "Vista.cs").Code),
+                model =>
+                {
+                    var entityType = model.FindEntityType("TestNamespace.Vista");
+                    Assert.Equal("Vistas", entityType.GetTableName());
+                    Assert.Equal("dbo", entityType.GetSchema());
+                });
+        }
     }
 }

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
@@ -79,6 +79,10 @@ namespace Microsoft.EntityFrameworkCore.Internal
                     new DatabaseTable
                     {
                         Name = "noPrimaryKey"
+                    },
+                    new DatabaseView
+                    {
+                        Name = "view"
                     }
                 }
             };
@@ -99,6 +103,11 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 {
                     Assert.Equal("tableWithSchema", pgtable.GetTableName());
                     Assert.Equal("public", pgtable.GetSchema());
+                },
+                view =>
+                {
+                    Assert.Equal("view", view.GetTableName());
+                    Assert.NotNull(view.FindAnnotation(RelationalAnnotationNames.ViewDefinition));
                 }
             );
             Assert.Empty(model.GetEntityTypeErrors().Values);

--- a/test/EFCore.Relational.Specification.Tests/MigrationSqlGeneratorTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/MigrationSqlGeneratorTestBase.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Metadata;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -537,6 +536,24 @@ namespace Microsoft.EntityFrameworkCore
                         }
                     },
                     Comment = "Table comment"
+                });
+
+        [ConditionalFact]
+        public virtual void CreateTableOperation_no_key()
+            => Generate(
+                new CreateTableOperation
+                {
+                    Name = "Anonymous",
+                    Columns =
+                    {
+                        new AddColumnOperation
+                        {
+                            Name = "Value",
+                            Table = "Anonymous",
+                            ClrType = typeof(int),
+                            IsNullable = false
+                        }
+                    }
                 });
 
         [ConditionalFact]

--- a/test/EFCore.Relational.Specification.Tests/Query/InheritanceRelationalFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/InheritanceRelationalFixture.cs
@@ -30,7 +30,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             modelBuilder.Entity<Lilt>().Property(e => e.SugarGrams).HasColumnName("SugarGrams");
             modelBuilder.Entity<Tea>().Property(e => e.CaffeineGrams).HasColumnName("CaffeineGrams");
 
-            modelBuilder.Entity<AnimalQuery>().HasNoKey().ToTable("Animal");
+            modelBuilder.Entity<AnimalQuery>().HasNoKey().ToQuery(
+                () => context.Set<AnimalQuery>().FromSqlRaw("SELECT * FROM Animal"));
             modelBuilder.Entity<KiwiQuery>().HasDiscriminator().HasValue("Kiwi");
             modelBuilder.Entity<EagleQuery>().HasDiscriminator().HasValue("Eagle");
         }

--- a/test/EFCore.Relational.Specification.Tests/Query/InheritanceRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/InheritanceRelationalTestBase.cs
@@ -36,6 +36,10 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
+        [ConditionalFact(Skip = "Issue #16323")]
+        public override void Can_query_all_animal_views()
+            => base.Can_query_all_animal_views();
+
         private string NormalizeDelimetersInRawString(string sql)
             => ((RelationalTestStore)Fixture.TestStore).NormalizeDelimetersInRawString(sql);
 

--- a/test/EFCore.Relational.Specification.Tests/TestModels/Northwind/NorthwindRelationalContext.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/Northwind/NorthwindRelationalContext.cs
@@ -26,7 +26,8 @@ namespace Microsoft.EntityFrameworkCore.TestModels.Northwind
             modelBuilder.Entity<MostExpensiveProduct>().HasKey(mep => mep.TenMostExpensiveProducts);
 
 #pragma warning disable CS0618 // Type or member is obsolete
-            modelBuilder.Query<CustomerView>().HasNoKey().ToView("Customers");
+            modelBuilder.Query<CustomerView>().HasNoKey().ToQuery(
+                () => CustomerQueries.FromSqlRaw("SELECT * FROM Customers"));
 
             modelBuilder
                 .Query<OrderQuery>()

--- a/test/EFCore.Relational.Tests/Migrations/MigrationSqlGeneratorTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/MigrationSqlGeneratorTest.cs
@@ -202,6 +202,17 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 ");
         }
 
+        public override void CreateTableOperation_no_key()
+        {
+            base.CreateTableOperation_no_key();
+
+            AssertSql(
+                @"CREATE TABLE ""Anonymous"" (
+    ""Value"" default_int_mapping NOT NULL
+);
+");
+        }
+
         public override void DropColumnOperation()
         {
             base.DropColumnOperation();

--- a/test/EFCore.SqlServer.FunctionalTests/Query/CompiledQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/CompiledQuerySqlServerTest.cs
@@ -1,7 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -147,6 +149,22 @@ WHERE [c].[CustomerID] = N'ALFKI'",
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] = N'ALFKI'");
         }
+
+        [ConditionalFact(Skip = "Issue #16323")]
+        public override Task DbQuery_query_async()
+            => base.DbQuery_query_async();
+
+        [ConditionalFact(Skip = "Issue #16323")]
+        public override void DbQuery_query_first()
+            => base.DbQuery_query_first();
+
+        [ConditionalFact(Skip = "Issue #16323")]
+        public override Task DbQuery_query_first_async()
+            => base.DbQuery_query_first_async();
+
+        [ConditionalFact(Skip = "Issue #16323")]
+        public override void DbQuery_query()
+            => base.DbQuery_query();
 
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.KeylessEntities.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.KeylessEntities.cs
@@ -2,11 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
     public partial class SimpleQuerySqlServerTest
     {
+        [ConditionalTheory(Skip = "Issue #16323")]
         public override async Task KeylessEntity_simple(bool isAsync)
         {
             await base.KeylessEntity_simple(isAsync);
@@ -16,6 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 FROM [Customers] AS [c]");
         }
 
+        [ConditionalTheory(Skip = "Issue #16323")]
         public override async Task KeylessEntity_where_simple(bool isAsync)
         {
             await base.KeylessEntity_where_simple(isAsync);
@@ -176,5 +179,9 @@ WHERE EXISTS (
     FROM [Orders] AS [o0]
     WHERE [ov.Customer].[CustomerID] = [o0].[CustomerID])");
         }
+
+        [ConditionalFact(Skip = "Issue #16323")]
+        public override void Auto_initialized_view_set()
+            => base.Auto_initialized_view_set();
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Scaffolding/SqlServerDatabaseModelFactoryTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Scaffolding/SqlServerDatabaseModelFactoryTest.cs
@@ -16,7 +16,6 @@ using Microsoft.EntityFrameworkCore.SqlServer.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Scaffolding.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
-using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 using Microsoft.Extensions.Logging;
 using Xunit;
 
@@ -641,11 +640,11 @@ CREATE TABLE [dbo].[Blogs] (
 EXECUTE sys.sp_addextendedproperty @name = N'MS_Description', @value = N'Blog table comment.
 On multiple lines.',
     @level0type = N'SCHEMA', @level0name = 'dbo', 
-	@level1type = N'TABLE', @level1name = 'Blogs';
+    @level1type = N'TABLE', @level1name = 'Blogs';
 EXECUTE sys.sp_addextendedproperty @name = N'MS_Description', @value = N'Blog.Id column comment.',
     @level0type = N'SCHEMA', @level0name = 'dbo', 
-	@level1type = N'TABLE', @level1name = 'Blogs',
-	@level2type = N'COLUMN', @level2name = 'Id';
+    @level1type = N'TABLE', @level1name = 'Blogs',
+    @level2type = N'COLUMN', @level2name = 'Id';
 ",
                 Enumerable.Empty<string>(),
                 Enumerable.Empty<string>(),
@@ -685,7 +684,7 @@ SELECT
                 Enumerable.Empty<string>(),
                 dbModel =>
                 {
-                    var table = dbModel.Tables.Single();
+                    var table = Assert.IsType<DatabaseView>(dbModel.Tables.Single());
 
                     Assert.Equal(2, table.Columns.Count);
                     Assert.Equal(null, table.PrimaryKey);

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerMigrationSqlGeneratorTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerMigrationSqlGeneratorTest.cs
@@ -67,6 +67,17 @@ EXEC sp_addextendedproperty @name = N'Comment', @value = N'ID comment', @level0t
 ");
         }
 
+        public override void CreateTableOperation_no_key()
+        {
+            base.CreateTableOperation_no_key();
+
+            AssertSql(
+                @"CREATE TABLE [Anonymous] (
+    [Value] int NOT NULL
+);
+");
+        }
+
         public override void CreateIndexOperation_with_filter_where_clause()
         {
             base.CreateIndexOperation_with_filter_where_clause();

--- a/test/EFCore.SqlServer.FunctionalTests/WithConstructorsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/WithConstructorsSqlServerTest.cs
@@ -4,6 +4,7 @@
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
 
 namespace Microsoft.EntityFrameworkCore
 {
@@ -13,6 +14,10 @@ namespace Microsoft.EntityFrameworkCore
             : base(fixture)
         {
         }
+
+        [ConditionalFact(Skip = "Issue #16323")]
+        public override void Query_with_keyless_type()
+            => base.Query_with_keyless_type();
 
         protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
             => facade.UseTransaction(transaction.GetDbTransaction());
@@ -25,7 +30,8 @@ namespace Microsoft.EntityFrameworkCore
             {
                 base.OnModelCreating(modelBuilder, context);
 
-                modelBuilder.Entity<BlogQuery>().HasNoKey().ToTable("Blog");
+                modelBuilder.Entity<BlogQuery>().HasNoKey().ToQuery(
+                    () => context.Set<BlogQuery>().FromSqlRaw("SELECT * FROM Blog"));
             }
         }
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/CompiledQueryInMemoryTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/CompiledQueryInMemoryTest.cs
@@ -1,7 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
@@ -11,5 +13,21 @@ namespace Microsoft.EntityFrameworkCore.Query
             : base(fixture)
         {
         }
+
+        [ConditionalFact(Skip = "Issue #16323")]
+        public override Task DbQuery_query_async()
+            => base.DbQuery_query_async();
+
+        [ConditionalFact(Skip = "Issue #16323")]
+        public override void DbQuery_query_first()
+            => base.DbQuery_query_first();
+
+        [ConditionalFact(Skip = "Issue #16323")]
+        public override Task DbQuery_query_first_async()
+            => base.DbQuery_query_first_async();
+
+        [ConditionalFact(Skip = "Issue #16323")]
+        public override void DbQuery_query()
+            => base.DbQuery_query();
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
-using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -1055,6 +1054,18 @@ FROM (
         [ConditionalTheory(Skip = "SQLite bug")]
         public override Task Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault_2(bool isAsync)
             => base.Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault_2(isAsync);
+
+        [ConditionalFact(Skip = "Issue #16323")]
+        public override void Auto_initialized_view_set()
+            => base.Auto_initialized_view_set();
+
+        [ConditionalTheory(Skip = "Issue #16323")]
+        public override Task KeylessEntity_simple(bool isAsync)
+            => base.KeylessEntity_simple(isAsync);
+
+        [ConditionalTheory(Skip = "Issue #16323")]
+        public override Task KeylessEntity_where_simple(bool isAsync)
+            => base.KeylessEntity_where_simple(isAsync);
 
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);

--- a/test/EFCore.Sqlite.FunctionalTests/Scaffolding/SqliteDatabaseModelFactoryTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Scaffolding/SqliteDatabaseModelFactoryTest.cs
@@ -178,7 +178,7 @@ SELECT
                 Enumerable.Empty<string>(),
                 dbModel =>
                 {
-                    var table = dbModel.Tables.Single();
+                    var table = Assert.IsType<DatabaseView>(dbModel.Tables.Single());
 
                     Assert.Equal(2, table.Columns.Count);
                     Assert.Equal(null, table.PrimaryKey);

--- a/test/EFCore.Sqlite.FunctionalTests/WithConstructorsSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/WithConstructorsSqliteTest.cs
@@ -4,6 +4,7 @@
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
 
 namespace Microsoft.EntityFrameworkCore
 {
@@ -13,6 +14,10 @@ namespace Microsoft.EntityFrameworkCore
             : base(fixture)
         {
         }
+
+        [ConditionalFact(Skip = "Issue #16323")]
+        public override void Query_with_keyless_type()
+            => base.Query_with_keyless_type();
 
         protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
             => facade.UseTransaction(transaction.GetDbTransaction());
@@ -25,7 +30,8 @@ namespace Microsoft.EntityFrameworkCore
             {
                 base.OnModelCreating(modelBuilder, context);
 
-                modelBuilder.Entity<BlogQuery>().HasNoKey().ToTable("Blog");
+                modelBuilder.Entity<BlogQuery>().HasNoKey().ToQuery(
+                    () => context.Set<BlogQuery>().FromSqlRaw("SELECT * FROM Blog"));
             }
         }
     }


### PR DESCRIPTION
Changes:
- Un-obsolete ToView
- Differentiate between views and keyless tables in RevEng
- Ignore ToView and ToQuery in Migrations; handle HasNoKey
- Handle duplicate table names when HasNoKey

Resolves #14787, fixes #14195