### PR TITLE
Query: Don't track materialized keyless entity instances

### DIFF
--- a/src/EFCore.InMemory/Query/Internal/CustomShaperCompilingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/CustomShaperCompilingExpressionVisitor.cs
@@ -45,7 +45,8 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
             {
                 if (entity is TIncludingEntity includingEntity)
                 {
-                    if (trackingQuery)
+                    if (trackingQuery
+                        && navigation.DeclaringEntityType.FindPrimaryKey() != null)
                     {
                         // For non-null relatedEntity StateManager will set the flag
                         if (relatedEntity == null)

--- a/src/EFCore.Relational/Query/IncludeCompilingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/IncludeCompilingExpressionVisitor.cs
@@ -48,7 +48,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             {
                 if (entity is TIncludingEntity includingEntity)
                 {
-                    if (trackingQuery)
+                    if (trackingQuery
+                        && navigation.DeclaringEntityType.FindPrimaryKey() != null)
                     {
                         // For non-null relatedEntity StateManager will set the flag
                         if (relatedEntity == null)

--- a/src/EFCore/Internal/InternalDbSet.cs
+++ b/src/EFCore/Internal/InternalDbSet.cs
@@ -111,18 +111,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         private EntityQueryable<TEntity> CreateEntityQueryable()
-        {
-            var queryable = new EntityQueryable<TEntity>(_context.GetDependencies().QueryProvider);
-
-#pragma warning disable 618
-            if (_entityType.FindPrimaryKey() == null)
-#pragma warning restore 618
-            {
-                queryable = (EntityQueryable<TEntity>)queryable.AsNoTracking();
-            }
-
-            return queryable;
-        }
+            => new EntityQueryable<TEntity>(_context.GetDependencies().QueryProvider);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
@@ -40,7 +40,6 @@ namespace Microsoft.EntityFrameworkCore.Query
             QueryCompilationContext queryCompilationContext)
         {
             Dependencies = dependencies;
-
             IsTracking = queryCompilationContext.IsTracking;
 
             _entityMaterializerInjectingExpressionVisitor =
@@ -283,11 +282,6 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 var primaryKey = entityType.FindPrimaryKey();
 
-                if (_trackQueryResults && primaryKey == null)
-                {
-                    throw new InvalidOperationException("A tracking query contains entityType without key in final result.");
-                }
-
                 var concreteEntityTypeVariable = Expression.Variable(typeof(IEntityType),
                     "entityType" + _currentEntityIndex);
                 variables.Add(concreteEntityTypeVariable);
@@ -298,7 +292,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                                     instanceVariable,
                                     Expression.Constant(null, entityType.ClrType)));
 
-                if (_trackQueryResults)
+                if (_trackQueryResults
+                    && primaryKey != null)
                 {
                     var entryVariable = Expression.Variable(typeof(InternalEntityEntry), "entry" + _currentEntityIndex);
                     var hasNullKeyVariable = Expression.Variable(typeof(bool), "hasNullKey" + _currentEntityIndex);
@@ -439,7 +434,8 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 expressions.Add(Expression.Assign(instanceVariable, materializationExpression));
 
-                if (_trackQueryResults)
+                if (_trackQueryResults
+                    && entityType.FindPrimaryKey() != null)
                 {
                     _visitedEntityTypes.Add(entityType);
 

--- a/test/EFCore.Specification.Tests/LazyLoadProxyTestBase.cs
+++ b/test/EFCore.Specification.Tests/LazyLoadProxyTestBase.cs
@@ -756,12 +756,15 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalTheory]
+        [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges)]
+        [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges)]
+        [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges)]
         [InlineData(EntityState.Unchanged, CascadeTiming.Immediate)]
         [InlineData(EntityState.Modified, CascadeTiming.Immediate)]
         [InlineData(EntityState.Deleted, CascadeTiming.Immediate)]
-        [InlineData(EntityState.Unchanged, CascadeTiming.Immediate)]
-        [InlineData(EntityState.Modified, CascadeTiming.Immediate)]
-        [InlineData(EntityState.Deleted, CascadeTiming.Immediate)]
+        [InlineData(EntityState.Unchanged, CascadeTiming.Never)]
+        [InlineData(EntityState.Modified, CascadeTiming.Never)]
+        [InlineData(EntityState.Deleted, CascadeTiming.Never)]
         public virtual void Lazy_load_collection_already_loaded(EntityState state, CascadeTiming cascadeDeleteTiming)
         {
             using (var context = CreateContext(lazyLoadingEnabled: true))

--- a/test/EFCore.Specification.Tests/Query/InheritanceTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/InheritanceTestBase.cs
@@ -222,7 +222,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using (var context = CreateContext())
             {
-                var animalQueries = context.Set<AnimalQuery>().AsNoTracking().OrderBy(av => av.CountryId).ToList();
+                var animalQueries = context.Set<AnimalQuery>().OrderBy(av => av.CountryId).ToList();
 
                 Assert.Equal(2, animalQueries.Count);
                 Assert.IsType<KiwiQuery>(animalQueries[0]);

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.KeylessEntities.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.KeylessEntities.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery<CustomerView>(
                 isAsync,
-                cvs => cvs.AsNoTracking());
+                cvs => cvs);
         }
 
         [ConditionalTheory]
@@ -31,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery<CustomerView>(
                 isAsync,
-                cvs => cvs.AsNoTracking().Where(c => c.City == "London"));
+                cvs => cvs.Where(c => c.City == "London"));
         }
 
         [ConditionalFact]
@@ -39,7 +39,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using (var context = CreateContext())
             {
-                var results = context.Set<ProductQuery>().AsNoTracking().ToArray();
+                var results = context.Set<ProductQuery>().ToArray();
 
                 Assert.Equal(69, results.Length);
             }
@@ -50,7 +50,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using (var context = CreateContext())
             {
-                var results = context.CustomerQueries.AsNoTracking().ToArray();
+                var results = context.CustomerQueries.ToArray();
 
                 Assert.Equal(91, results.Length);
             }
@@ -62,7 +62,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var context = CreateContext())
             {
                 var results
-                    = context.Set<CustomerQuery>().AsNoTracking()
+                    = context.Set<CustomerQuery>()
                         .Where(cq => cq.OrderCount > 0)
                         .ToArray();
 
@@ -76,7 +76,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery<OrderQuery>(
                 isAsync,
-                ovs => ovs.AsNoTracking().Where(ov => ov.CustomerID == "ALFKI"));
+                ovs => ovs.Where(ov => ov.CustomerID == "ALFKI"));
         }
 
         // also issue 12873
@@ -86,7 +86,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery<OrderQuery>(
                 isAsync,
-                ovs => ovs.AsNoTracking().Where(ov => ov.CustomerID == "ALFKI").Select(ov => ov.Customer)
+                ovs => ovs.Where(ov => ov.CustomerID == "ALFKI").Select(ov => ov.Customer)
                     .Select(cv => cv.Orders.Where(cc => true).ToList()));
         }
 
@@ -98,7 +98,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 (cs, ovs)
                     => from c in cs
-                       from o in ovs.AsNoTracking().Where(ov => ov.CustomerID == c.CustomerID)
+                       from o in ovs.Where(ov => ov.CustomerID == c.CustomerID)
                        select new
                        {
                            c,
@@ -113,7 +113,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertIncludeQuery<OrderQuery>(
                 isAsync,
-                ovs => from ov in ovs.AsNoTracking().Include(ov => ov.Customer)
+                ovs => from ov in ovs.Include(ov => ov.Customer)
                        where ov.CustomerID == "ALFKI"
                        select ov,
                 new List<IExpectedInclude>
@@ -128,7 +128,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertIncludeQuery<OrderQuery>(
                 isAsync,
-                ovs => from ov in ovs.AsNoTracking().Include(ov => ov.Customer.Orders)
+                ovs => from ov in ovs.Include(ov => ov.Customer.Orders)
                        where ov.CustomerID == "ALFKI"
                        select ov,
                 new List<IExpectedInclude>
@@ -144,7 +144,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery<OrderQuery>(
                 isAsync,
-                ovs => from ov in ovs.AsNoTracking()
+                ovs => from ov in ovs
                        where ov.Customer.City == "Seattle"
                        select ov);
         }
@@ -155,7 +155,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery<OrderQuery>(
                 isAsync,
-                ovs => from ov in ovs.AsNoTracking()
+                ovs => from ov in ovs
                        where ov.Customer.Orders.Any()
                        select ov);
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -4874,8 +4874,6 @@ WHERE (
     WHERE (([c].[CustomerID] = [o].[CustomerID]) AND [o].[CustomerID] IS NOT NULL) AND (([c].[CustomerID] = [o].[CustomerID]) AND [o].[CustomerID] IS NOT NULL)) > 0");
         }
 
-        [ConditionalTheory]
-        [MemberData(nameof(IsAsyncData))]
         public override async Task Convert_to_nullable_on_nullable_value_is_ignored(bool isAsync)
         {
             await base.Convert_to_nullable_on_nullable_value_is_ignored(isAsync);


### PR DESCRIPTION
Rather than requiring AsNoTracking in the query.

Resolves #17102