### PR TITLE
Query: Skip constants in GROUP BY

### DIFF
--- a/src/EFCore.Relational/Query/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/QuerySqlGenerator.cs
@@ -173,7 +173,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             {
                 _relationalCommandBuilder.AppendLine().Append("GROUP BY ");
 
-                GenerateList(selectExpression.GroupBy, e => Visit(e),  skipCondition: e => e is SqlConstantExpression);
+                GenerateList(selectExpression.GroupBy, e => Visit(e));
             }
 
             if (selectExpression.Having != null)
@@ -683,24 +683,16 @@ namespace Microsoft.EntityFrameworkCore.Query
         private void GenerateList<T>(
             IReadOnlyList<T> items,
             Action<T> generationAction,
-            Action<IRelationalCommandBuilder> joinAction = null,
-            Func<T, bool> skipCondition = null)
+            Action<IRelationalCommandBuilder> joinAction = null)
         {
             joinAction ??= (isb => isb.Append(", "));
-            bool first = true;
 
             for (var i = 0; i < items.Count; i++)
             {
-                if (skipCondition?.Invoke(items[i])?? false)
-                {
-                    continue;
-                }
-
-                if (!first)
+                if (i > 0)
                 {
                     joinAction(_relationalCommandBuilder);
                 }
-                first = false;
 
                 generationAction(items[i]);
             }

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -285,7 +285,10 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             switch (keySelector)
             {
                 case SqlExpression sqlExpression:
-                    _groupBy.Add(sqlExpression);
+                    if (!(sqlExpression is SqlConstantExpression))
+                    {
+                        _groupBy.Add(sqlExpression);
+                    }
                     break;
 
                 case NewExpression newExpression:
@@ -1102,7 +1105,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
 
                 var groupBy = _groupBy.ToList();
                 _groupBy.Clear();
-                _groupBy.AddRange(GroupBy.Select(e => (SqlExpression)visitor.Visit(e)));
+                _groupBy.AddRange(GroupBy.Select(e => (SqlExpression)visitor.Visit(e)).Where(e => !(e is SqlConstantExpression)));
 
                 Having = (SqlExpression)visitor.Visit(Having);
 

--- a/test/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
@@ -260,6 +261,22 @@ namespace Microsoft.EntityFrameworkCore.Query
                             Sum = g.Sum(o => o.OrderID)
                         }),
                 e => e.Key1);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task GroupBy_Property_Select_Key_with_constant(bool isAsync)
+        {
+            return AssertQuery<Order>(
+                isAsync,
+                os => os.GroupBy(o => new { Name = "CustomerID", Value = o.CustomerID }).Select(
+                    g =>
+                        new
+                        {
+                            g.Key,
+                            Count = g.Count()
+                        }),
+                e => e.Key.Value);
         }
 
         [ConditionalTheory]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
@@ -192,6 +192,16 @@ FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]");
         }
 
+        public override async Task GroupBy_Property_Select_Key_with_constant(bool isAsync)
+        {
+            await base.GroupBy_Property_Select_Key_with_constant(isAsync);
+
+            AssertSql(
+                @"SELECT N'CustomerID' AS [Name], [o].[CustomerID] AS [Value], COUNT(*) AS [Count]
+FROM [Orders] AS [o]
+GROUP BY [o].[CustomerID]");
+        }
+
         public override async Task GroupBy_aggregate_projecting_conditional_expression_based_on_group_key(bool isAsync)
         {
             await base.GroupBy_aggregate_projecting_conditional_expression_based_on_group_key(isAsync);


### PR DESCRIPTION
- [x] The code builds and tests pass (verified by our automated build checks)
- [x] Commit messages follow this format

If Linq expression uses constants in GroupBy skip these constants in SQL GROUP BY to avoid "Each GROUP BY expression must contain at least one column that is not an outer reference" SQL exception.

Fixes #14152

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code meets the expectations our engineering guidelines. https://github.com/aspnet/Home/wiki/Engineering-guidelines.
