### PR TITLE
Try match FK properties with the exact name as principal key if they are a proper subset of the dependent PK and don't contain the Id property.

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/ChangeDetector.cs
+++ b/src/EFCore/ChangeTracking/Internal/ChangeDetector.cs
@@ -144,7 +144,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             _logger.DetectChangesStarting(stateManager.Context);
 
             foreach (var entry in stateManager.ToList()) // Might be too big, but usually _all_ entities are using Snapshot tracking
-
             {
                 if (entry.EntityType.GetChangeTrackingStrategy() == ChangeTrackingStrategy.Snapshot
                     && entry.EntityState != EntityState.Detached)
@@ -299,7 +298,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 }
 
                 var added = new HashSet<object>(ReferenceEqualityComparer.Instance);
-
                 if (currentCollection != null)
                 {
                     foreach (var entity in currentCollection)

--- a/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
@@ -258,7 +258,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             foreach (var newValue in added)
             {
                 var newTargetEntry = stateManager.GetOrCreateEntry(newValue, targetEntityType);
-
                 if (newTargetEntry.EntityState != EntityState.Detached)
                 {
                     try


### PR DESCRIPTION
Fixes #15250