### PR TITLE
The magical query pipeline

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/QuerySqlGenerator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/QuerySqlGenerator.cs
@@ -179,7 +179,14 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 _sqlBuilder.Append("DISTINCT ");
             }
 
-            GenerateList(selectExpression.Projection, t => Visit(t));
+            if (selectExpression.Projection.Any())
+            {
+                GenerateList(selectExpression.Projection, e => Visit(e));
+            }
+            else
+            {
+                _sqlBuilder.Append("1");
+            }
             _sqlBuilder.AppendLine();
 
             _sqlBuilder.Append("FROM root ");

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -302,7 +302,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             var remappedKeySelector = RemapLambdaBody(source, keySelector);
 
             var translatedKey = TranslateGroupingKey(remappedKeySelector)
-                ?? (remappedKeySelector is ConstantExpression ? remappedKeySelector : null);
+                ?? (remappedKeySelector as ConstantExpression);
             if (translatedKey != null)
             {
                 if (elementSelector != null)

--- a/src/EFCore/Query/Internal/EnumerableToQueryableMethodConvertingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/EnumerableToQueryableMethodConvertingExpressionVisitor.cs
@@ -25,8 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 }
 
                 if (methodCallExpression.Arguments.Count > 0
-                    && (methodCallExpression.Arguments[0] is ParameterExpression
-                        || methodCallExpression.Arguments[0] is ConstantExpression))
+                    && ClientSource(methodCallExpression.Arguments[0]))
                 {
                     // this is methodCall over closure variable or constant
                     return base.VisitMethodCall(methodCallExpression);
@@ -137,8 +136,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 && methodCallExpression.Method.DeclaringType.GetGenericTypeDefinition() == typeof(List<>)
                 && string.Equals(nameof(List<int>.Contains), methodCallExpression.Method.Name))
             {
-                if (methodCallExpression.Object is ParameterExpression
-                    || methodCallExpression.Object is ConstantExpression)
+                if (ClientSource(methodCallExpression.Object))
                 {
                     // this is methodCall over closure variable or constant
                     return base.VisitMethodCall(methodCallExpression);
@@ -156,6 +154,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             return base.VisitMethodCall(methodCallExpression);
         }
+
+        private static bool ClientSource(Expression expression)
+            => expression is ConstantExpression
+                || expression is MemberInitExpression
+                || expression is NewExpression
+                || expression is ParameterExpression;
 
         private static bool CanConvertEnumerableToQueryable(Type enumerableType, Type queryableType)
         {

--- a/src/EFCore/Query/Internal/ParameterExtractingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/ParameterExtractingExpressionVisitor.cs
@@ -100,6 +100,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
 
             if (_evaluatableExpressions.TryGetValue(expression, out var generateParameter)
+                && !PreserveInitializationConstant(expression, generateParameter)
                 && !PreserveConvertNode(expression))
             {
                 return Evaluate(expression, _parameterize && generateParameter);
@@ -108,13 +109,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             return base.Visit(expression);
         }
 
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        protected virtual bool PreserveConvertNode(Expression expression)
+        private bool PreserveInitializationConstant(Expression expression, bool generateParameter)
+            => !generateParameter && (expression is NewExpression || expression is MemberInitExpression);
+
+        private bool PreserveConvertNode(Expression expression)
         {
             if (expression is UnaryExpression unaryExpression
                 && (unaryExpression.NodeType == ExpressionType.Convert

--- a/src/EFCore/Query/ReplacingExpressionVisitor.cs
+++ b/src/EFCore/Query/ReplacingExpressionVisitor.cs
@@ -72,15 +72,20 @@ namespace Microsoft.EntityFrameworkCore.Query
                 var newEntityExpression = Visit(entityExpression);
                 if (newEntityExpression is NewExpression newExpression)
                 {
-                    var index = newExpression.Members.Select(m => m.Name).IndexOf(propertyName);
-
-                    return newExpression.Arguments[index];
+                    var index = newExpression.Members?.Select(m => m.Name).IndexOf(propertyName);
+                    if (index > 0)
+                    {
+                        return newExpression.Arguments[index.Value];
+                    }
                 }
 
                 if (newEntityExpression is MemberInitExpression memberInitExpression)
                 {
-                    return ((MemberAssignment)memberInitExpression.Bindings
-                        .Single(mb => mb.Member.Name == propertyName)).Expression;
+                    if (memberInitExpression.Bindings.SingleOrDefault(
+                        mb => mb.Member.Name == propertyName) is MemberAssignment memberAssignment)
+                    {
+                        return memberAssignment.Expression;
+                    }
                 }
 
                 return methodCallExpression.Update(null, new[] { newEntityExpression, methodCallExpression.Arguments[1] });

--- a/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.Select.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.Select.cs
@@ -364,6 +364,7 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
+        [ConditionalTheory(Skip = "Issue#14935")]
         public override async Task New_date_time_in_anonymous_type_works(bool isAsync)
         {
             await base.New_date_time_in_anonymous_type_works(isAsync);

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -6259,7 +6259,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     }));
         }
 
-        [ConditionalTheory(Skip = "issue #15712")]
+        [ConditionalTheory(Skip = "Issue#10001")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_subquery_projecting_single_constant_inside_anonymous(bool isAsync)
         {
@@ -6277,7 +6277,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     }));
         }
 
-        [ConditionalTheory(Skip = "issue #15712")]
+        [ConditionalTheory(Skip = "Issue#10001")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_subquery_projecting_multiple_constants_inside_anonymous(bool isAsync)
         {

--- a/test/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
@@ -1277,7 +1277,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         .Select(g => g.Sum(o => o.OrderID)));
         }
 
-        [ConditionalTheory(Skip = "Issue#17048")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_empty_key_Aggregate_Key(bool isAsync)
         {

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
@@ -101,7 +101,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory(Skip = "Issue #15712")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual async Task Select_bool_closure(bool isAsync)
         {
@@ -309,7 +309,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.City);
         }
 
-        [ConditionalTheory(Skip = "Issue#15712")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_anonymous_empty(bool isAsync)
         {
@@ -322,7 +322,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => 1);
         }
 
-        [ConditionalTheory(Skip = "Issue#15712")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_anonymous_literal(bool isAsync)
         {
@@ -620,7 +620,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "Issue#15712")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task New_date_time_in_anonymous_type_works(bool isAsync)
         {

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -4308,7 +4308,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.ShipName);
         }
 
-        [ConditionalTheory(Skip = "Issue#17048")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual async Task ToString_with_formatter_is_evaluated_on_the_client(bool isAsync)
         {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
@@ -824,12 +824,8 @@ GROUP BY [o].[CustomerID]");
             await base.GroupBy_empty_key_Aggregate(isAsync);
 
             AssertSql(
-                @"SELECT SUM([t].[OrderID])
-FROM (
-    SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], 1 AS [Key]
-    FROM [Orders] AS [o]
-) AS [t]
-GROUP BY [t].[Key]");
+                @"SELECT SUM([o].[OrderID])
+FROM [Orders] AS [o]");
         }
 
         public override async Task GroupBy_empty_key_Aggregate_Key(bool isAsync)
@@ -837,12 +833,8 @@ GROUP BY [t].[Key]");
             await base.GroupBy_empty_key_Aggregate_Key(isAsync);
 
             AssertSql(
-                @"SELECT SUM([t].[OrderID])
-FROM (
-    SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], 1 AS [Key]
-    FROM [Orders] AS [o]
-) AS [t]
-GROUP BY [t].[Key]");
+                @"SELECT SUM([o].[OrderID]) AS [Sum]
+FROM [Orders] AS [o]");
         }
 
         public override async Task OrderBy_GroupBy_Aggregate(bool isAsync)


### PR DESCRIPTION
This puts some of the processing (evaluating the expression to the corresponding constant) inside translation pipeline.
- When applying EntityEquality, assumption here is that property is always going to be mapped on server side so we can generate constant.
- When translating newExpression. If the generated constant can be mapped, it would work. (like new Datetime()) else translation would null out.

Resolves #15712
Resolves #17048
Resolves #7983
