### PR TITLE
Avoid deadlock in tests

### DIFF
--- a/test/EFCore.Specification.Tests/Query/AsyncSimpleQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AsyncSimpleQueryTestBase.cs
@@ -274,13 +274,22 @@ namespace Microsoft.EntityFrameworkCore.Query
                     {
                         var blockingTask = Task.Run(
                             () =>
-                                context.Customers.Select(
-                                    c => Process(c, synchronizationEvent, blockingSemaphore)).ToList());
+                            {
+                                try
+                                {
+                                    context.Customers.Select(
+                                        c => Process(c, synchronizationEvent, blockingSemaphore)).ToList();
+                                }
+                                finally
+                                {
+                                    synchronizationEvent.Set();
+                                }
+                            });
 
                         var throwingTask = Task.Run(
                             async () =>
                             {
-                                synchronizationEvent.Wait();
+                                synchronizationEvent.Wait(TimeSpan.FromMinutes(5));
 
                                 Assert.Equal(
                                     CoreStrings.ConcurrentMethodInvocation,
@@ -309,13 +318,22 @@ namespace Microsoft.EntityFrameworkCore.Query
                     {
                         var blockingTask = Task.Run(
                             () =>
-                                context.Customers.Select(
-                                    c => Process(c, synchronizationEvent, blockingSemaphore)).ToList());
+                            {
+                                try
+                                {
+                                    context.Customers.Select(
+                                        c => Process(c, synchronizationEvent, blockingSemaphore)).ToList();
+                                }
+                                finally
+                                {
+                                    synchronizationEvent.Set();
+                                }
+                            });
 
                         var throwingTask = Task.Run(
                             async () =>
                             {
-                                synchronizationEvent.Wait();
+                                synchronizationEvent.Wait(TimeSpan.FromMinutes(5));
 
                                 Assert.Equal(
                                     CoreStrings.ConcurrentMethodInvocation,
@@ -336,7 +354,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         private static Customer Process(Customer c, ManualResetEventSlim e, SemaphoreSlim s)
         {
             e.Set();
-            s.Wait();
+            s.Wait(TimeSpan.FromMinutes(5));
             s.Release(1);
             return c;
         }


### PR DESCRIPTION
Instead throw an exception

Part of #17019