### PR TITLE
[preview9] Add non-owned table splitting support to query

### DIFF
--- a/src/EFCore.Cosmos/Extensions/CosmosEntityTypeExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosEntityTypeExtensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns> The name of the container to which the entity type is mapped. </returns>
         public static string GetCosmosContainer([NotNull] this IEntityType entityType) =>
             entityType.BaseType != null
-                ? entityType.RootType().GetCosmosContainer()
+                ? entityType.GetRootType().GetCosmosContainer()
                 : (string)entityType[CosmosAnnotationNames.ContainerName]
                   ?? GetCosmosDefaultContainer(entityType);
 

--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -719,7 +719,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 if (discriminatorValueAnnotation?.Value != null)
                 {
                     var value = discriminatorValueAnnotation.Value;
-                    var discriminatorProperty = entityType.RootType().GetDiscriminatorProperty();
+                    var discriminatorProperty = entityType.GetRootType().GetDiscriminatorProperty();
                     if (discriminatorProperty != null)
                     {
                         var valueConverter = FindValueConverter(discriminatorProperty);

--- a/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
@@ -99,7 +99,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                 var entityType = entityProjection.EntityType;
                 if (convertedType != null)
                 {
-                    entityType = entityType.RootType().GetDerivedTypesInclusive()
+                    entityType = entityType.GetRootType().GetDerivedTypesInclusive()
                         .FirstOrDefault(et => et.ClrType == convertedType);
 
                     if (entityType == null)

--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns> The name of the table to which the entity type is mapped. </returns>
         public static string GetTableName([NotNull] this IEntityType entityType) =>
             entityType.BaseType != null
-                ? entityType.RootType().GetTableName()
+                ? entityType.GetRootType().GetTableName()
                 : (string)entityType[RelationalAnnotationNames.TableName]
                   ?? GetDefaultTableName(entityType);
 
@@ -87,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns> The database schema that contains the mapped table. </returns>
         public static string GetSchema([NotNull] this IEntityType entityType) =>
             entityType.BaseType != null
-                ? entityType.RootType().GetSchema()
+                ? entityType.GetRootType().GetSchema()
                 : (string)entityType[RelationalAnnotationNames.Schema]
                   ?? GetDefaultSchema(entityType);
 

--- a/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
@@ -199,7 +199,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                     || (mappedType.FindPrimaryKey() != null && mappedType.FindForeignKeys(mappedType.FindPrimaryKey().Properties)
                         .Any(
                             fk => fk.PrincipalKey.IsPrimaryKey()
-                                  && fk.PrincipalEntityType.RootType() != mappedType
+                                  && fk.PrincipalEntityType.GetRootType() != mappedType
                                   && unvalidatedTypes.Contains(fk.PrincipalEntityType))))
                 {
                     continue;

--- a/src/EFCore.Relational/Metadata/Internal/TableMapping.cs
+++ b/src/EFCore.Relational/Metadata/Internal/TableMapping.cs
@@ -69,7 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                      && (t.FindDeclaredPrimaryKey() == null || t.FindForeignKeys(t.FindDeclaredPrimaryKey().Properties)
                          .All(
                              fk => !fk.PrincipalKey.IsPrimaryKey()
-                                   || fk.PrincipalEntityType.RootType() == t
+                                   || fk.PrincipalEntityType.GetRootType() == t
                                    || t.GetTableName() != fk.PrincipalEntityType.GetTableName()
                                    || t.GetSchema() != fk.PrincipalEntityType.GetSchema())));
 

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -730,7 +730,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
 
             foreach (var definingForeignKey in entityType.GetDeclaredReferencingForeignKeys()
                 .Where(
-                    fk => fk.DeclaringEntityType.RootType() != entityType.RootType()
+                    fk => fk.DeclaringEntityType.GetRootType() != entityType.GetRootType()
                           && fk.DeclaringEntityType.GetTableName() == entityType.GetTableName()
                           && fk == fk.DeclaringEntityType
                               .FindForeignKey(
@@ -913,7 +913,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         /// </summary>
         protected virtual IEnumerable<MigrationOperation> Diff([NotNull] IProperty source, [NotNull] IProperty target, [NotNull] DiffContext diffContext)
         {
-            var targetEntityType = target.DeclaringEntityType.RootType();
+            var targetEntityType = target.DeclaringEntityType.GetRootType();
 
             if (source.GetColumnName() != target.GetColumnName())
             {
@@ -985,7 +985,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             [NotNull] DiffContext diffContext,
             bool inline = false)
         {
-            var targetEntityType = target.DeclaringEntityType.RootType();
+            var targetEntityType = target.DeclaringEntityType.GetRootType();
 
             var operation = new AddColumnOperation
             {
@@ -1009,7 +1009,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         /// </summary>
         protected virtual IEnumerable<MigrationOperation> Remove([NotNull] IProperty source, [NotNull] DiffContext diffContext)
         {
-            var sourceEntityType = source.DeclaringEntityType.RootType();
+            var sourceEntityType = source.DeclaringEntityType.GetRootType();
 
             var operation = new DropColumnOperation
             {
@@ -1102,7 +1102,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         /// </summary>
         protected virtual IEnumerable<MigrationOperation> Add([NotNull] IKey target, [NotNull] DiffContext diffContext)
         {
-            var targetEntityType = target.DeclaringEntityType.RootType();
+            var targetEntityType = target.DeclaringEntityType.GetRootType();
             var columns = GetColumns(target.Properties);
 
             MigrationOperation operation;
@@ -1142,7 +1142,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             [NotNull] IKey source,
             [NotNull] DiffContext diffContext)
         {
-            var sourceEntityType = source.DeclaringEntityType.RootType();
+            var sourceEntityType = source.DeclaringEntityType.GetRootType();
 
             MigrationOperation operation;
             if (source.IsPrimaryKey())
@@ -1218,8 +1218,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         /// </summary>
         protected virtual IEnumerable<MigrationOperation> Add([NotNull] IForeignKey target, [NotNull] DiffContext diffContext)
         {
-            var targetEntityType = target.DeclaringEntityType.RootType();
-            var targetPrincipalEntityType = target.PrincipalEntityType.RootType();
+            var targetEntityType = target.DeclaringEntityType.GetRootType();
+            var targetPrincipalEntityType = target.PrincipalEntityType.GetRootType();
 
             var operation = new AddForeignKeyOperation
             {
@@ -1253,7 +1253,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         /// </summary>
         protected virtual IEnumerable<MigrationOperation> Remove([NotNull] IForeignKey source, [NotNull] DiffContext diffContext)
         {
-            var declaringRootEntityType = source.DeclaringEntityType.RootType();
+            var declaringRootEntityType = source.DeclaringEntityType.GetRootType();
 
             var dropTableOperation = diffContext.FindDrop(declaringRootEntityType);
             if (dropTableOperation == null)
@@ -1316,7 +1316,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             [NotNull] IIndex target,
             [NotNull] DiffContext diffContext)
         {
-            var targetEntityType = target.DeclaringEntityType.RootType();
+            var targetEntityType = target.DeclaringEntityType.GetRootType();
             var sourceName = source.GetName();
             var targetName = target.GetName();
 
@@ -1342,7 +1342,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             [NotNull] IIndex target,
             [NotNull] DiffContext diffContext)
         {
-            var targetEntityType = target.DeclaringEntityType.RootType();
+            var targetEntityType = target.DeclaringEntityType.GetRootType();
 
             var operation = new CreateIndexOperation
             {
@@ -1366,7 +1366,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         /// </summary>
         protected virtual IEnumerable<MigrationOperation> Remove([NotNull] IIndex source, [NotNull] DiffContext diffContext)
         {
-            var sourceEntityType = source.DeclaringEntityType.RootType();
+            var sourceEntityType = source.DeclaringEntityType.GetRootType();
 
             var operation = new DropIndexOperation
             {
@@ -1422,7 +1422,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         /// </summary>
         protected virtual IEnumerable<MigrationOperation> Add([NotNull] ICheckConstraint target, [NotNull] DiffContext diffContext)
         {
-            var targetEntityType = target.EntityType.RootType();
+            var targetEntityType = target.EntityType.GetRootType();
 
             var operation = new CreateCheckConstraintOperation
             {
@@ -1446,7 +1446,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         /// </summary>
         protected virtual IEnumerable<MigrationOperation> Remove([NotNull] ICheckConstraint source, [NotNull] DiffContext diffContext)
         {
-            var sourceEntityType = source.EntityType.RootType();
+            var sourceEntityType = source.EntityType.GetRootType();
 
             var operation = new DropCheckConstraintOperation
             {
@@ -2011,7 +2011,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                                 batchInsertOperation = null;
                             }
 
-                            if (c.Entries.All(e => diffContext.FindDrop(e.EntityType.RootType()) == null))
+                            if (c.Entries.All(e => diffContext.FindDrop(e.EntityType.GetRootType()) == null))
                             {
                                 yield return new DeleteDataOperation
                                 {

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.RelationalProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.RelationalProjectionBindingRemovingExpressionVisitor.cs
@@ -107,13 +107,11 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
 
             private object GetProjectionIndex(ProjectionBindingExpression projectionBindingExpression)
-            {
-                return projectionBindingExpression.ProjectionMember != null
+                => projectionBindingExpression.ProjectionMember != null
                     ? ((ConstantExpression)_selectExpression.GetMappedProjection(projectionBindingExpression.ProjectionMember)).Value
                     : (projectionBindingExpression.Index != null
                         ? (object)projectionBindingExpression.Index
                         : projectionBindingExpression.IndexMap);
-            }
 
             private static bool IsNullableProjection(ProjectionExpression projection)
                 => !(projection.Expression is ColumnExpression column) || column.IsNullable;

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -209,7 +209,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 var entityType = entityProjectionExpression.EntityType;
                 if (convertedType != null)
                 {
-                    entityType = entityType.RootType().GetDerivedTypesInclusive()
+                    entityType = entityType.GetRootType().GetDerivedTypesInclusive()
                         .FirstOrDefault(et => et.ClrType == convertedType);
 
                     if (entityType == null)

--- a/src/EFCore.Relational/Query/SqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/SqlExpressionFactory.cs
@@ -5,9 +5,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Storage;
 
@@ -437,7 +440,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual SelectExpression Select(IEntityType entityType)
         {
             var selectExpression = new SelectExpression(entityType);
-            AddDiscriminator(selectExpression, entityType);
+            AddConditions(selectExpression, entityType);
 
             return selectExpression;
         }
@@ -445,39 +448,195 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual SelectExpression Select(IEntityType entityType, string sql, Expression sqlArguments)
         {
             var selectExpression = new SelectExpression(entityType, sql, sqlArguments);
-            AddDiscriminator(selectExpression, entityType);
+            AddConditions(selectExpression, entityType);
 
             return selectExpression;
         }
 
-        private void AddDiscriminator(SelectExpression selectExpression, IEntityType entityType)
+        private void AddConditions(
+            SelectExpression selectExpression,
+            IEntityType entityType,
+            ICollection<IEntityType> sharingTypes = null,
+            bool skipJoins = false)
         {
-            var concreteEntityTypes = entityType.GetConcreteDerivedTypesInclusive().ToList();
-
-            if (concreteEntityTypes.Count == 1)
+            if (entityType.FindPrimaryKey() == null)
             {
-                var concreteEntityType = concreteEntityTypes[0];
-                // If not a derived type
-                if (concreteEntityType.RootType() == concreteEntityType)
-                {
-                    return;
-                }
-
-                var discriminatorColumn = ((EntityProjectionExpression)selectExpression.GetMappedProjection(new ProjectionMember()))
-                    .BindProperty(concreteEntityType.GetDiscriminatorProperty());
-
-                selectExpression.ApplyPredicate(
-                    Equal(discriminatorColumn, Constant(concreteEntityType.GetDiscriminatorValue())));
-
+                AddDiscriminatorCondition(selectExpression, entityType);
             }
             else
             {
-                var discriminatorColumn = ((EntityProjectionExpression)selectExpression.GetMappedProjection(new ProjectionMember()))
-                    .BindProperty(concreteEntityTypes[0].GetDiscriminatorProperty());
+                sharingTypes ??= new HashSet<IEntityType>(
+                        entityType.Model.GetEntityTypes()
+                            .Where(et => et.FindPrimaryKey() != null
+                                      && et.GetTableName() == entityType.GetTableName()
+                                      && et.GetSchema() == entityType.GetSchema()));
 
-                selectExpression.ApplyPredicate(
-                    In(discriminatorColumn, Constant(concreteEntityTypes.Select(et => et.GetDiscriminatorValue()).ToList()), negated: false));
+                if (sharingTypes.Count > 0)
+                {
+                    bool discriminatorAdded = AddDiscriminatorCondition(selectExpression, entityType);
+
+                    var linkingFks = entityType.GetRootType().FindForeignKeys(entityType.FindPrimaryKey().Properties)
+                                        .Where(
+                                            fk => fk.PrincipalKey.IsPrimaryKey()
+                                                  && fk.PrincipalEntityType != entityType
+                                                  && sharingTypes.Contains(fk.PrincipalEntityType))
+                                        .ToList();
+
+                    if (linkingFks.Count > 0)
+                    {
+                        if (!discriminatorAdded)
+                        {
+                            AddOptionalDependentConditions(selectExpression, entityType, sharingTypes);
+                        }
+
+                        if (!skipJoins)
+                        {
+                            AddInnerJoin(selectExpression, linkingFks[0], sharingTypes, skipInnerJoins: false);
+
+                            foreach (var otherFk in linkingFks.Skip(1))
+                            {
+                                var otherSelectExpression = new SelectExpression(entityType);
+
+                                AddInnerJoin(otherSelectExpression, otherFk, sharingTypes, skipInnerJoins: false);
+                                selectExpression.ApplySetOperation(SetOperationType.Union, otherSelectExpression, null);
+                            }
+                        }
+                    }
+                }
             }
         }
+
+        private void AddInnerJoin(
+            SelectExpression selectExpression, IForeignKey foreignKey, ICollection<IEntityType> sharingTypes, bool skipInnerJoins)
+        {
+            var joinPredicate = GenerateJoinPredicate(selectExpression, foreignKey, sharingTypes, skipInnerJoins, out var innerSelect);
+
+            selectExpression.AddInnerJoin(innerSelect, joinPredicate, null);
+        }
+
+        private SqlExpression GenerateJoinPredicate(
+            SelectExpression selectExpression,
+            IForeignKey foreignKey,
+            ICollection<IEntityType> sharingTypes,
+            bool skipInnerJoins,
+            out SelectExpression innerSelect)
+        {
+            var outerEntityProjection = GetMappedEntityProjectionExpression(selectExpression);
+            var outerIsPrincipal = foreignKey.PrincipalEntityType.IsAssignableFrom(outerEntityProjection.EntityType);
+
+            innerSelect = outerIsPrincipal
+                ? new SelectExpression(foreignKey.DeclaringEntityType)
+                : new SelectExpression(foreignKey.PrincipalEntityType);
+            AddConditions(
+                innerSelect,
+                outerIsPrincipal ? foreignKey.DeclaringEntityType : foreignKey.PrincipalEntityType,
+                sharingTypes,
+                skipInnerJoins);
+
+            var innerEntityProjection = GetMappedEntityProjectionExpression(innerSelect);
+
+            var outerKey = (outerIsPrincipal ? foreignKey.PrincipalKey.Properties : foreignKey.Properties)
+                .Select(p => outerEntityProjection.BindProperty(p));
+            var innerKey = (outerIsPrincipal ? foreignKey.Properties : foreignKey.PrincipalKey.Properties)
+                .Select(p => innerEntityProjection.BindProperty(p));
+
+            return outerKey.Zip<SqlExpression, SqlExpression, SqlExpression>(innerKey, Equal)
+                .Aggregate(AndAlso);
+        }
+
+        private bool AddDiscriminatorCondition(SelectExpression selectExpression, IEntityType entityType)
+        {
+            SqlExpression predicate;
+            var concreteEntityTypes = entityType.GetConcreteDerivedTypesInclusive().ToList();
+            if (concreteEntityTypes.Count == 1)
+            {
+                var concreteEntityType = concreteEntityTypes[0];
+                if (concreteEntityType.BaseType == null)
+                {
+                    return false;
+                }
+
+                var discriminatorColumn = GetMappedEntityProjectionExpression(selectExpression)
+                    .BindProperty(concreteEntityType.GetDiscriminatorProperty());
+
+                predicate = Equal(discriminatorColumn, Constant(concreteEntityType.GetDiscriminatorValue()));
+            }
+            else
+            {
+                var discriminatorColumn = GetMappedEntityProjectionExpression(selectExpression)
+                    .BindProperty(concreteEntityTypes[0].GetDiscriminatorProperty());
+
+                predicate = In(discriminatorColumn, Constant(concreteEntityTypes.Select(et => et.GetDiscriminatorValue()).ToList()), negated: false);
+            }
+
+            selectExpression.ApplyPredicate(predicate);
+
+            return true;
+        }
+
+        private void AddOptionalDependentConditions(
+            SelectExpression selectExpression, IEntityType entityType, ICollection<IEntityType> sharingTypes)
+        {
+            SqlExpression predicate = null;
+            var requiredNonPkProperties = entityType.GetProperties().Where(p => !p.IsNullable && !p.IsPrimaryKey()).ToList();
+            if (requiredNonPkProperties.Count > 0)
+            {
+                var entityProjectionExpression = GetMappedEntityProjectionExpression(selectExpression);
+                predicate = IsNotNull(requiredNonPkProperties[0], entityProjectionExpression);
+
+                if (requiredNonPkProperties.Count > 1)
+                {
+                    predicate
+                        = requiredNonPkProperties
+                            .Skip(1)
+                            .Aggregate(
+                                predicate, (current, property) =>
+                                    AndAlso(
+                                        IsNotNull(property, entityProjectionExpression),
+                                        current));
+                }
+
+                selectExpression.ApplyPredicate(predicate);
+            }
+            else
+            {
+                var allNonPkProperties = entityType.GetProperties().Where(p => !p.IsPrimaryKey()).ToList();
+                if (allNonPkProperties.Count > 0)
+                {
+                    var entityProjectionExpression = GetMappedEntityProjectionExpression(selectExpression);
+                    predicate = IsNotNull(allNonPkProperties[0], entityProjectionExpression);
+
+                    if (allNonPkProperties.Count > 1)
+                    {
+                        predicate
+                            = allNonPkProperties
+                                .Skip(1)
+                                .Aggregate(
+                                    predicate, (current, property) =>
+                                        OrElse(
+                                            IsNotNull(property, entityProjectionExpression),
+                                            current));
+                    }
+                    selectExpression.ApplyPredicate(predicate);
+
+                    foreach (var referencingFk in entityType.GetReferencingForeignKeys())
+                    {
+                        var otherSelectExpression = new SelectExpression(entityType);
+
+                        var sameTable = sharingTypes.Contains(referencingFk.DeclaringEntityType);
+                        AddInnerJoin(otherSelectExpression, referencingFk,
+                                        sameTable ? sharingTypes : null,
+                                        skipInnerJoins: sameTable);
+                        selectExpression.ApplySetOperation(SetOperationType.Union, otherSelectExpression, null);
+                    }
+                }
+            }
+        }
+
+        private EntityProjectionExpression GetMappedEntityProjectionExpression(SelectExpression selectExpression)
+            => (EntityProjectionExpression)selectExpression.GetMappedProjection(new ProjectionMember());
+
+        private SqlExpression IsNotNull(IProperty property, EntityProjectionExpression entityProjection)
+            => IsNotNull(entityProjection.BindProperty(property));
     }
 }

--- a/src/EFCore.Relational/Query/SqlExpressions/SqlFunctionExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlFunctionExpression.cs
@@ -15,27 +15,21 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             string name,
             Type type,
             RelationalTypeMapping typeMapping)
-        {
-            return new SqlFunctionExpression(instance: null, schema: null, name, niladic: true, arguments: null, builtIn: true, type, typeMapping);
-        }
+            => new SqlFunctionExpression(instance: null, schema: null, name, niladic: true, arguments: null, builtIn: true, type, typeMapping);
 
         public static SqlFunctionExpression CreateNiladic(
             string schema,
             string name,
             Type type,
             RelationalTypeMapping typeMapping)
-        {
-            return new SqlFunctionExpression(instance: null, schema, name, niladic: true, arguments: null, builtIn: true, type, typeMapping);
-        }
+            => new SqlFunctionExpression(instance: null, schema, name, niladic: true, arguments: null, builtIn: true, type, typeMapping);
 
         public static SqlFunctionExpression CreateNiladic(
             SqlExpression instance,
             string name,
             Type type,
             RelationalTypeMapping typeMapping)
-        {
-            return new SqlFunctionExpression(instance, schema: null, name, niladic: true, arguments: null, builtIn: true, type, typeMapping);
-        }
+            => new SqlFunctionExpression(instance, schema: null, name, niladic: true, arguments: null, builtIn: true, type, typeMapping);
 
         public static SqlFunctionExpression Create(
             SqlExpression instance,
@@ -43,18 +37,14 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             IEnumerable<SqlExpression> arguments,
             Type type,
             RelationalTypeMapping typeMapping)
-        {
-            return new SqlFunctionExpression(instance, schema: null, name, niladic: false, arguments, builtIn: true, type, typeMapping);
-        }
+            => new SqlFunctionExpression(instance, schema: null, name, niladic: false, arguments, builtIn: true, type, typeMapping);
 
         public static SqlFunctionExpression Create(
             string name,
             IEnumerable<SqlExpression> arguments,
             Type type,
             RelationalTypeMapping typeMapping)
-        {
-            return new SqlFunctionExpression(instance: null, schema: null, name, niladic: false, arguments, builtIn: true, type, typeMapping);
-        }
+            => new SqlFunctionExpression(instance: null, schema: null, name, niladic: false, arguments, builtIn: true, type, typeMapping);
 
         public static SqlFunctionExpression Create(
             string schema,
@@ -62,9 +52,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             IEnumerable<SqlExpression> arguments,
             Type type,
             RelationalTypeMapping typeMapping)
-        {
-            return new SqlFunctionExpression(instance: null, schema, name, niladic: false, arguments, builtIn: false, type, typeMapping);
-        }
+            => new SqlFunctionExpression(instance: null, schema, name, niladic: false, arguments, builtIn: false, type, typeMapping);
 
         public SqlFunctionExpression(
             Expression instance,

--- a/src/EFCore.Relational/Update/Internal/SharedTableEntryMap.cs
+++ b/src/EFCore.Relational/Update/Internal/SharedTableEntryMap.cs
@@ -192,7 +192,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
 
         private IUpdateEntry GetMainEntry(IUpdateEntry entry)
         {
-            var entityType = entry.EntityType.RootType();
+            var entityType = entry.EntityType.GetRootType();
             if (_principals[entityType].Count == 0)
             {
                 return entry;

--- a/src/EFCore/Extensions/ConventionEntityTypeExtensions.cs
+++ b/src/EFCore/Extensions/ConventionEntityTypeExtensions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     The root base type. If the given entity type is not a derived type, then the same entity type is returned.
         /// </returns>
         public static IConventionEntityType RootType([NotNull] this IConventionEntityType entityType)
-            => (IConventionEntityType)((IEntityType)entityType).RootType();
+            => (IConventionEntityType)((IEntityType)entityType).GetRootType();
 
         /// <summary>
         ///     Gets all types in the model that derive from a given entity type.

--- a/src/EFCore/Extensions/EntityTypeExtensions.cs
+++ b/src/EFCore/Extensions/EntityTypeExtensions.cs
@@ -41,12 +41,23 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns>
         ///     The root base type. If the given entity type is not a derived type, then the same entity type is returned.
         /// </returns>
-        public static IEntityType RootType([NotNull] this IEntityType entityType)
+        public static IEntityType GetRootType([NotNull] this IEntityType entityType)
         {
             Check.NotNull(entityType, nameof(entityType));
 
-            return entityType.BaseType?.RootType() ?? entityType;
+            return entityType.BaseType?.GetRootType() ?? entityType;
         }
+
+        /// <summary>
+        ///     Gets the root base type for a given entity type.
+        /// </summary>
+        /// <param name="entityType"> The type to find the root of. </param>
+        /// <returns>
+        ///     The root base type. If the given entity type is not a derived type, then the same entity type is returned.
+        /// </returns>
+        [Obsolete("Use GetRootType")]
+        public static IEntityType RootType([NotNull] this IEntityType entityType)
+            => entityType.GetRootType();
 
         /// <summary>
         ///     Gets all types in the model that derive from a given entity type.
@@ -636,6 +647,7 @@ namespace Microsoft.EntityFrameworkCore
 
             return (LambdaExpression)entityType[CoreAnnotationNames.DefiningQuery];
         }
+
         /// <summary>
         ///     Returns the <see cref="IProperty" /> that will be used for storing a discriminator value.
         /// </summary>
@@ -644,7 +656,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             if (entityType.BaseType != null)
             {
-                return entityType.RootType().GetDiscriminatorProperty();
+                return entityType.GetRootType().GetDiscriminatorProperty();
             }
 
             var propertyName = (string)entityType[CoreAnnotationNames.DiscriminatorProperty];

--- a/src/EFCore/Extensions/Internal/EFPropertyExtensions.cs
+++ b/src/EFCore/Extensions/Internal/EFPropertyExtensions.cs
@@ -2,12 +2,14 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Query.Internal;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore.Internal
@@ -66,6 +68,27 @@ namespace Microsoft.EntityFrameworkCore.Internal
                && typeof(object) == methodInfo.ReturnType
                && methodInfo.GetParameters()?.Count() == 1
                && typeof(string) == methodInfo.GetParameters().First().ParameterType;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public static Expression CreateKeyAccessExpression(
+            [NotNull] this Expression target,
+            [NotNull] IReadOnlyList<IProperty> properties,
+            bool makeNullable = false)
+            => properties.Count == 1
+                ? target.CreateEFPropertyExpression(properties[0], makeNullable)
+                : Expression.New(
+                    AnonymousObject.AnonymousObjectCtor,
+                    Expression.NewArrayInit(
+                        typeof(object),
+                        properties
+                            .Select(p => Expression.Convert(target.CreateEFPropertyExpression(p, makeNullable), typeof(object)))
+                            .Cast<Expression>()
+                            .ToArray()));
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Extensions/KeyExtensions.cs
+++ b/src/EFCore/Extensions/KeyExtensions.cs
@@ -23,5 +23,13 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns> The foreign keys that reference the given key. </returns>
         public static IEnumerable<IForeignKey> GetReferencingForeignKeys([NotNull] this IKey key)
             => Check.NotNull(key, nameof(key)).AsKey().ReferencingForeignKeys ?? Enumerable.Empty<IForeignKey>();
+
+        /// <summary>
+        ///     Returns a value indicating whether the key is the primary key.
+        /// </summary>
+        /// <param name="key"> The key to find whether it is primary. </param>
+        /// <returns> <c>true</c> if the key is the primary key. </returns>
+        public static bool IsPrimaryKey([NotNull] this IKey key)
+            => key == key.DeclaringEntityType.FindPrimaryKey();
     }
 }

--- a/src/EFCore/Extensions/MutableEntityTypeExtensions.cs
+++ b/src/EFCore/Extensions/MutableEntityTypeExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     The root base type. If the given entity type is not a derived type, then the same entity type is returned.
         /// </returns>
         public static IMutableEntityType RootType([NotNull] this IMutableEntityType entityType)
-            => (IMutableEntityType)((IEntityType)entityType).RootType();
+            => (IMutableEntityType)((IEntityType)entityType).GetRootType();
 
         /// <summary>
         ///     Gets all types in the model that derive from a given entity type.

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -457,7 +457,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         [DebuggerStepThrough]
-        public virtual EntityType RootType() => (EntityType)((IEntityType)this).RootType();
+        public virtual EntityType RootType() => (EntityType)((IEntityType)this).GetRootType();
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -2532,7 +2532,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 && entityType.GetDiscriminatorProperty() == null)
             {
                 throw new InvalidOperationException(
-                    CoreStrings.NoDiscriminatorForValue(entityType.DisplayName(), entityType.RootType().DisplayName()));
+                    CoreStrings.NoDiscriminatorForValue(entityType.DisplayName(), entityType.GetRootType().DisplayName()));
             }
 
             if (value != null

--- a/src/EFCore/Metadata/Internal/KeyExtensions.cs
+++ b/src/EFCore/Metadata/Internal/KeyExtensions.cs
@@ -43,15 +43,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static bool IsPrimaryKey([NotNull] this IKey key)
-            => key == key.DeclaringEntityType.FindPrimaryKey();
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
         public static int IndexOf([NotNull] this IKey key, [NotNull] IProperty property)
         {
             var index = 0;

--- a/src/EFCore/Query/Internal/EntityEqualityRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/EntityEqualityRewritingExpressionVisitor.cs
@@ -370,7 +370,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
 
             if (sourceEntityType != null && itemEntityType != null
-                && sourceEntityType.RootType() != itemEntityType.RootType())
+                && sourceEntityType.GetRootType() != itemEntityType.GetRootType())
             {
                 return Expression.Constant(false);
             }
@@ -599,7 +599,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             if (newOuterKeySelector.Body is EntityReferenceExpression outerKeySelectorWrapper
                 && newInnerKeySelector.Body is EntityReferenceExpression innerKeySelectorWrapper
                 && outerKeySelectorWrapper.IsEntityType && innerKeySelectorWrapper.IsEntityType
-                && outerKeySelectorWrapper.EntityType.RootType() == innerKeySelectorWrapper.EntityType.RootType())
+                && outerKeySelectorWrapper.EntityType.GetRootType() == innerKeySelectorWrapper.EntityType.GetRootType())
             {
                 var entityType = outerKeySelectorWrapper.EntityType;
                 var keyProperties = entityType.FindPrimaryKey()?.Properties;
@@ -761,7 +761,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             if (leftTypeWrapper != null
                 && rightTypeWrapper != null
-                && leftTypeWrapper.EntityType.RootType() != rightTypeWrapper.EntityType.RootType())
+                && leftTypeWrapper.EntityType.GetRootType() != rightTypeWrapper.EntityType.GetRootType())
             {
                 return Expression.Constant(!equality);
             }
@@ -878,16 +878,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 : visitedExpression;
         }
 
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        // TODO: DRY with NavigationExpansionHelpers
-        protected virtual Expression CreateKeyAccessExpression(
-            [NotNull] Expression target,
-            [NotNull] IReadOnlyList<IProperty> properties)
+        private Expression CreateKeyAccessExpression(
+            Expression target,
+            IReadOnlyList<IProperty> properties)
             => properties.Count == 1
                 ? CreatePropertyAccessExpression(target, properties[0])
                 : Expression.New(
@@ -895,11 +888,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     Expression.NewArrayInit(
                         typeof(object),
                         properties
-                            .Select(
-                                p =>
-                                    Expression.Convert(
-                                        CreatePropertyAccessExpression(target, p),
-                                        typeof(object)))
+                            .Select(p => Expression.Convert(CreatePropertyAccessExpression(target, p), typeof(object)))
                             .Cast<Expression>()
                             .ToArray()));
 

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
@@ -131,7 +131,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             if (!_queryCompilationContext.IgnoreQueryFilters)
             {
                 var entityType = _queryCompilationContext.Model.FindEntityType(navigationExpansionExpression.Type.GetSequenceType());
-                var rootEntityType = entityType.RootType();
+                var rootEntityType = entityType.GetRootType();
                 var queryFilterAnnotation = rootEntityType.FindAnnotation("QueryFilter");
                 if (queryFilterAnnotation != null)
                 {

--- a/src/EFCore/Query/TransparentIdentifierFactory.cs
+++ b/src/EFCore/Query/TransparentIdentifierFactory.cs
@@ -9,9 +9,7 @@ namespace Microsoft.EntityFrameworkCore.Query
     public static class TransparentIdentifierFactory
     {
         public static Type Create(Type outerType, Type innerType)
-        {
-            return typeof(TransparentIdentifier<,>).MakeGenericType(outerType, innerType);
-        }
+            => typeof(TransparentIdentifier<,>).MakeGenericType(outerType, innerType);
 
         private readonly struct TransparentIdentifier<TOuter, TInner>
         {

--- a/test/EFCore.Cosmos.FunctionalTests/EmbeddedDocumentsTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/EmbeddedDocumentsTest.cs
@@ -365,7 +365,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
                     eb =>
                     {
                         eb.HasKey(e => e.Name);
-                        eb.OwnsOne(v => v.Operator);
+                        eb.OwnsOne(v => v.Operator).OwnsOne(v => v.Details);
                     });
 
                 modelBuilder.Entity<Engine>(

--- a/test/EFCore.Relational.Specification.Tests/TableSplittingTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/TableSplittingTestBase.cs
@@ -56,7 +56,42 @@ namespace Microsoft.EntityFrameworkCore
             {
                 using (var context = CreateContext())
                 {
-                    Assert.Equal(4, context.Set<Operator>().ToList().Count);
+                    Assert.Equal(5, context.Set<Operator>().ToList().Count);
+                }
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Can_query_shared_nonhierarchy()
+        {
+            using (CreateTestStore(
+                modelBuilder =>
+                {
+                    OnModelCreating(modelBuilder);
+                    modelBuilder.Ignore<LicensedOperator>();
+                }))
+            {
+                using (var context = CreateContext())
+                {
+                    Assert.Equal(5, context.Set<Operator>().ToList().Count);
+                }
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Can_query_shared_nonhierarchy_with_nonshared_dependent()
+        {
+            using (CreateTestStore(
+                modelBuilder =>
+                {
+                    OnModelCreating(modelBuilder);
+                    modelBuilder.Ignore<LicensedOperator>();
+                    modelBuilder.Entity<OperatorDetails>().ToTable("OperatorDetails");
+                }))
+            {
+                using (var context = CreateContext())
+                {
+                    Assert.Equal(5, context.Set<Operator>().ToList().Count);
                 }
             }
         }
@@ -365,6 +400,7 @@ namespace Microsoft.EntityFrameworkCore
 
             modelBuilder.Entity<Engine>().ToTable("Vehicles");
             modelBuilder.Entity<Operator>().ToTable("Vehicles");
+            modelBuilder.Entity<OperatorDetails>().ToTable("Vehicles");
             modelBuilder.Entity<FuelTank>().ToTable("Vehicles");
         }
 

--- a/test/EFCore.Specification.Tests/ComplianceTestBase.cs
+++ b/test/EFCore.Specification.Tests/ComplianceTestBase.cs
@@ -18,7 +18,10 @@ namespace Microsoft.EntityFrameworkCore
         [ConditionalFact]
         public virtual void All_test_bases_must_be_implemented()
         {
-            var concreteTests = TargetAssembly.GetTypes().Where(c => c.BaseType != typeof(object) && !c.IsAbstract).ToList();
+            var concreteTests = TargetAssembly.GetTypes().Where(c =>
+                c.BaseType != typeof(object) && !c.IsAbstract
+                && (c.IsPublic || c.IsNestedPublic))
+                .ToList();
             var nonImplementedBases
                 = (from baseType in GetBaseTestClasses()
                    where !IgnoredTestBases.Contains(baseType)

--- a/test/EFCore.Specification.Tests/TestModels/TransportationModel/LicensedOperator.cs
+++ b/test/EFCore.Specification.Tests/TestModels/TransportationModel/LicensedOperator.cs
@@ -8,11 +8,9 @@ namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
         public string LicenseType { get; set; }
 
         public override bool Equals(object obj)
-        {
-            return obj is LicensedOperator other
+            => obj is LicensedOperator other
                    && base.Equals(other)
                    && LicenseType == other.LicenseType;
-        }
 
         public override int GetHashCode() => base.GetHashCode();
     }

--- a/test/EFCore.Specification.Tests/TestModels/TransportationModel/Operator.cs
+++ b/test/EFCore.Specification.Tests/TestModels/TransportationModel/Operator.cs
@@ -10,13 +10,15 @@ namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
         public string VehicleName { get; set; }
         public string Name { get; set; }
         public Vehicle Vehicle { get; set; }
+        public OperatorDetails Details { get; set; }        
 
         public override bool Equals(object obj)
             => obj is Operator other
                && VehicleName == other.VehicleName
-               && Name == other.Name;
+               && Name == other.Name
+               && Equals(Details, other.Details);
 
         public override int GetHashCode()
-            => HashCode.Combine(VehicleName, Name);
+            => HashCode.Combine(VehicleName, Name, Details);
     }
 }

--- a/test/EFCore.Specification.Tests/TestModels/TransportationModel/OperatorDetails.cs
+++ b/test/EFCore.Specification.Tests/TestModels/TransportationModel/OperatorDetails.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
+{
+    public class OperatorDetails
+    {
+        public string VehicleName { get; set; }
+        public string Type { get; set; }
+
+        public override bool Equals(object obj)
+            => obj is OperatorDetails other
+               && VehicleName == other.VehicleName
+               && Type == other.Type;
+
+        public override int GetHashCode()
+            => HashCode.Combine(VehicleName, Type);
+    }
+}

--- a/test/EFCore.Specification.Tests/TestModels/TransportationModel/TransportationContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/TransportationModel/TransportationContext.cs
@@ -42,6 +42,9 @@ namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
                     eb.HasOne(e => e.Vehicle)
                         .WithOne(e => e.Operator)
                         .HasForeignKey<Operator>(e => e.VehicleName);
+                    eb.HasOne(e => e.Details)
+                        .WithOne()
+                        .HasForeignKey<OperatorDetails>(e => e.VehicleName);
                 });
             modelBuilder.Entity<LicensedOperator>();
 
@@ -64,6 +67,13 @@ namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
                         .WithOne(e => e.SolidFuelTank)
                         .HasForeignKey<SolidFuelTank>(e => e.VehicleName);
                 });
+
+
+            modelBuilder.Entity<OperatorDetails>(
+                eb =>
+                {
+                    eb.HasKey(e => e.VehicleName);
+                });
         }
 
         public void Seed()
@@ -77,6 +87,7 @@ namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
             var expected = CreateVehicles().OrderBy(v => v.Name).ToList();
             var actual = Vehicles
                 .Include(v => v.Operator)
+                .ThenInclude(v => v.Details)
                 .Include(v => ((PoweredVehicle)v).Engine)
                 .ThenInclude(e => (e as CombustionEngine).FuelTank)
                 .OrderBy(v => v.Name).ToList();
@@ -157,6 +168,15 @@ namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
                             FuelType = "Reduced smoke Hydroxyl-Terminated Polybutadiene",
                             Capacity = "22 kg",
                             GrainGeometry = "Cylindrical",
+                            VehicleName = "AIM-9M Sidewinder"
+                        },
+                        VehicleName = "AIM-9M Sidewinder"
+                    },
+                    Operator = new Operator
+                    {
+                        Details = new OperatorDetails
+                        {
+                            Type = "Heat-seeking",
                             VehicleName = "AIM-9M Sidewinder"
                         },
                         VehicleName = "AIM-9M Sidewinder"

--- a/test/EFCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
@@ -147,16 +147,36 @@ namespace Microsoft.EntityFrameworkCore
             base.ConcurrencyCheckAttribute_throws_if_value_in_database_changed();
 
             AssertSql(
-                @"SELECT TOP(1) [s].[UniqueNo], [s].[MaxLengthProperty], [s].[Name], [s].[RowVersion], [s0].[UniqueNo], [s0].[AdditionalDetails_Name], [s1].[UniqueNo], [s1].[Details_Name]
+                @"SELECT TOP(1) [s].[UniqueNo], [s].[MaxLengthProperty], [s].[Name], [s].[RowVersion], [t].[UniqueNo], [t].[AdditionalDetails_Name], [t0].[UniqueNo], [t0].[Details_Name]
 FROM [Sample] AS [s]
-LEFT JOIN [Sample] AS [s0] ON [s].[UniqueNo] = [s0].[UniqueNo]
-LEFT JOIN [Sample] AS [s1] ON [s].[UniqueNo] = [s1].[UniqueNo]
+LEFT JOIN (
+    SELECT [s0].[UniqueNo], [s0].[AdditionalDetails_Name], [s1].[UniqueNo] AS [UniqueNo0]
+    FROM [Sample] AS [s0]
+    INNER JOIN [Sample] AS [s1] ON [s0].[UniqueNo] = [s1].[UniqueNo]
+    WHERE [s0].[AdditionalDetails_Name] IS NOT NULL
+) AS [t] ON [s].[UniqueNo] = [t].[UniqueNo]
+LEFT JOIN (
+    SELECT [s2].[UniqueNo], [s2].[Details_Name], [s3].[UniqueNo] AS [UniqueNo0]
+    FROM [Sample] AS [s2]
+    INNER JOIN [Sample] AS [s3] ON [s2].[UniqueNo] = [s3].[UniqueNo]
+    WHERE [s2].[Details_Name] IS NOT NULL
+) AS [t0] ON [s].[UniqueNo] = [t0].[UniqueNo]
 WHERE [s].[UniqueNo] = 1",
                 //
-                @"SELECT TOP(1) [s].[UniqueNo], [s].[MaxLengthProperty], [s].[Name], [s].[RowVersion], [s0].[UniqueNo], [s0].[AdditionalDetails_Name], [s1].[UniqueNo], [s1].[Details_Name]
+                @"SELECT TOP(1) [s].[UniqueNo], [s].[MaxLengthProperty], [s].[Name], [s].[RowVersion], [t].[UniqueNo], [t].[AdditionalDetails_Name], [t0].[UniqueNo], [t0].[Details_Name]
 FROM [Sample] AS [s]
-LEFT JOIN [Sample] AS [s0] ON [s].[UniqueNo] = [s0].[UniqueNo]
-LEFT JOIN [Sample] AS [s1] ON [s].[UniqueNo] = [s1].[UniqueNo]
+LEFT JOIN (
+    SELECT [s0].[UniqueNo], [s0].[AdditionalDetails_Name], [s1].[UniqueNo] AS [UniqueNo0]
+    FROM [Sample] AS [s0]
+    INNER JOIN [Sample] AS [s1] ON [s0].[UniqueNo] = [s1].[UniqueNo]
+    WHERE [s0].[AdditionalDetails_Name] IS NOT NULL
+) AS [t] ON [s].[UniqueNo] = [t].[UniqueNo]
+LEFT JOIN (
+    SELECT [s2].[UniqueNo], [s2].[Details_Name], [s3].[UniqueNo] AS [UniqueNo0]
+    FROM [Sample] AS [s2]
+    INNER JOIN [Sample] AS [s3] ON [s2].[UniqueNo] = [s3].[UniqueNo]
+    WHERE [s2].[Details_Name] IS NOT NULL
+) AS [t0] ON [s].[UniqueNo] = [t0].[UniqueNo]
 WHERE [s].[UniqueNo] = 1",
                 //
                 @"@p2='1'

--- a/test/EFCore.SqlServer.FunctionalTests/PropertyEntrySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/PropertyEntrySqlServerTest.cs
@@ -18,9 +18,14 @@ namespace Microsoft.EntityFrameworkCore
             base.Property_entry_original_value_is_set();
 
             AssertSql(
-                @"SELECT TOP(1) [e].[Id], [e].[EngineSupplierId], [e].[Name], [e0].[Id], [e0].[StorageLocation_Latitude], [e0].[StorageLocation_Longitude]
+                @"SELECT TOP(1) [e].[Id], [e].[EngineSupplierId], [e].[Name], [t].[Id], [t].[StorageLocation_Latitude], [t].[StorageLocation_Longitude]
 FROM [Engines] AS [e]
-LEFT JOIN [Engines] AS [e0] ON [e].[Id] = [e0].[Id]
+LEFT JOIN (
+    SELECT [e0].[Id], [e0].[StorageLocation_Latitude], [e0].[StorageLocation_Longitude], [e1].[Id] AS [Id0]
+    FROM [Engines] AS [e0]
+    INNER JOIN [Engines] AS [e1] ON [e0].[Id] = [e1].[Id]
+    WHERE [e0].[StorageLocation_Longitude] IS NOT NULL AND [e0].[StorageLocation_Latitude] IS NOT NULL
+) AS [t] ON [e].[Id] = [t].[Id]
 ORDER BY [e].[Id]",
                 //
                 @"@p1='1'

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -1124,11 +1124,27 @@ LEFT JOIN [LevelTwo] AS [l] ON [l0].[Id] = [l].[Level1_Optional_Id]");
 
             AssertSql(
                 @"SELECT SUM(CASE
-    WHEN [l].[Id] IS NULL THEN 0
-    ELSE [l].[Level1_Required_Id]
+    WHEN [t].[Id] IS NULL THEN 0
+    ELSE [t].[Level1_Required_Id]
 END)
-FROM [LevelOne] AS [l0]
-LEFT JOIN [LevelTwo] AS [l] ON [l0].[Id] = [l].[Level1_Optional_Id]");
+FROM [Level1] AS [l1]
+LEFT JOIN (
+    SELECT [l2].[Id], [l2].[Date], [l2].[Name], [t0].[Id] AS [Id0], [t0].[OneToOne_Required_PK_Date], [t0].[Level1_Optional_Id], [t0].[Level1_Required_Id], [t0].[Level2_Name], [t0].[OneToMany_Optional_Inverse2Id], [t0].[OneToMany_Required_Inverse2Id], [t0].[OneToOne_Optional_PK_Inverse2Id]
+    FROM [Level1] AS [l2]
+    LEFT JOIN (
+        SELECT [l3].[Id], [l3].[OneToOne_Required_PK_Date], [l3].[Level1_Optional_Id], [l3].[Level1_Required_Id], [l3].[Level2_Name], [l3].[OneToMany_Optional_Inverse2Id], [l3].[OneToMany_Required_Inverse2Id], [l3].[OneToOne_Optional_PK_Inverse2Id], [l4].[Id] AS [Id0]
+        FROM [Level1] AS [l3]
+        INNER JOIN [Level1] AS [l4] ON [l3].[Id] = [l4].[Id]
+        WHERE [l3].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l3].[Level1_Required_Id] IS NOT NULL AND [l3].[OneToOne_Required_PK_Date] IS NOT NULL)
+    ) AS [t0] ON [l2].[Id] = [t0].[Id]
+    WHERE [t0].[Id] IS NOT NULL
+) AS [t1] ON [l1].[Id] = [t1].[Level1_Optional_Id]
+LEFT JOIN (
+    SELECT [l].[Id], [l].[OneToOne_Required_PK_Date], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Level2_Name], [l].[OneToMany_Optional_Inverse2Id], [l].[OneToMany_Required_Inverse2Id], [l].[OneToOne_Optional_PK_Inverse2Id], [l0].[Id] AS [Id0]
+    FROM [Level1] AS [l]
+    INNER JOIN [Level1] AS [l0] ON [l].[Id] = [l0].[Id]
+    WHERE [l].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l].[Level1_Required_Id] IS NOT NULL AND [l].[OneToOne_Required_PK_Date] IS NOT NULL)
+) AS [t] ON [t1].[Id] = [t].[Id]");
         }
 
         public override async Task Include_with_optional_navigation(bool isAsync)
@@ -1856,11 +1872,26 @@ ORDER BY [l].[Id]");
             await base.SelectMany_with_Include1(isAsync);
 
             AssertSql(
-                @"SELECT [l].[Id], [l].[OneToOne_Required_PK_Date], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Level2_Name], [l].[OneToMany_Optional_Inverse2Id], [l].[OneToMany_Required_Inverse2Id], [l].[OneToOne_Optional_PK_Inverse2Id], [l0].[Id], [l1].[Id], [l1].[Level2_Optional_Id], [l1].[Level2_Required_Id], [l1].[Level3_Name], [l1].[OneToMany_Optional_Inverse3Id], [l1].[OneToMany_Required_Inverse3Id], [l1].[OneToOne_Optional_PK_Inverse3Id]
-FROM [Level1] AS [l0]
-INNER JOIN [Level1] AS [l] ON [l0].[Id] = [l].[OneToMany_Optional_Inverse2Id]
-LEFT JOIN [Level1] AS [l1] ON [l].[Id] = [l1].[OneToMany_Optional_Inverse3Id]
-ORDER BY [l0].[Id], [l].[Id], [l1].[Id]");
+                @"SELECT [t].[Id], [t].[OneToOne_Required_PK_Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Level2_Name], [t].[OneToMany_Optional_Inverse2Id], [t].[OneToMany_Required_Inverse2Id], [t].[OneToOne_Optional_PK_Inverse2Id], [l1].[Id], [t].[Id0], [t1].[Id], [t1].[Level2_Optional_Id], [t1].[Level2_Required_Id], [t1].[Level3_Name], [t1].[OneToMany_Optional_Inverse3Id], [t1].[OneToMany_Required_Inverse3Id], [t1].[OneToOne_Optional_PK_Inverse3Id], [t1].[Id0], [t1].[Id00]
+FROM [Level1] AS [l1]
+INNER JOIN (
+    SELECT [l].[Id], [l].[OneToOne_Required_PK_Date], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Level2_Name], [l].[OneToMany_Optional_Inverse2Id], [l].[OneToMany_Required_Inverse2Id], [l].[OneToOne_Optional_PK_Inverse2Id], [l0].[Id] AS [Id0]
+    FROM [Level1] AS [l]
+    INNER JOIN [Level1] AS [l0] ON [l].[Id] = [l0].[Id]
+    WHERE [l].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l].[Level1_Required_Id] IS NOT NULL AND [l].[OneToOne_Required_PK_Date] IS NOT NULL)
+) AS [t] ON [l1].[Id] = [t].[OneToMany_Optional_Inverse2Id]
+LEFT JOIN (
+    SELECT [l2].[Id], [l2].[Level2_Optional_Id], [l2].[Level2_Required_Id], [l2].[Level3_Name], [l2].[OneToMany_Optional_Inverse3Id], [l2].[OneToMany_Required_Inverse3Id], [l2].[OneToOne_Optional_PK_Inverse3Id], [t0].[Id] AS [Id0], [t0].[Id0] AS [Id00]
+    FROM [Level1] AS [l2]
+    INNER JOIN (
+        SELECT [l3].[Id], [l3].[OneToOne_Required_PK_Date], [l3].[Level1_Optional_Id], [l3].[Level1_Required_Id], [l3].[Level2_Name], [l3].[OneToMany_Optional_Inverse2Id], [l3].[OneToMany_Required_Inverse2Id], [l3].[OneToOne_Optional_PK_Inverse2Id], [l4].[Id] AS [Id0]
+        FROM [Level1] AS [l3]
+        INNER JOIN [Level1] AS [l4] ON [l3].[Id] = [l4].[Id]
+        WHERE [l3].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l3].[Level1_Required_Id] IS NOT NULL AND [l3].[OneToOne_Required_PK_Date] IS NOT NULL)
+    ) AS [t0] ON [l2].[Id] = [t0].[Id]
+    WHERE [l2].[OneToMany_Required_Inverse3Id] IS NOT NULL AND [l2].[Level2_Required_Id] IS NOT NULL
+) AS [t1] ON [t].[Id] = [t1].[OneToMany_Optional_Inverse3Id]
+ORDER BY [l1].[Id], [t].[Id], [t].[Id0], [t1].[Id], [t1].[Id0], [t1].[Id00]");
         }
 
         public override async Task Orderby_SelectMany_with_Include1(bool isAsync)
@@ -2992,13 +3023,29 @@ ORDER BY [l].[Id]");
             await base.Explicit_GroupJoin_in_subquery_with_unrelated_projection2(isAsync);
 
             AssertSql(
-                @"SELECT [t].[Id]
+                @"SELECT [t2].[Id]
 FROM (
-    SELECT DISTINCT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
-    FROM [LevelOne] AS [l]
-    LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
-    WHERE ([l0].[Name] <> N'Foo') OR [l0].[Name] IS NULL
-) AS [t]");
+    SELECT DISTINCT [l].[Id], [l].[Date], [l].[Name]
+    FROM [Level1] AS [l]
+    LEFT JOIN (
+        SELECT [l0].[Id], [l0].[Date], [l0].[Name], [t].[Id] AS [Id0], [t].[OneToOne_Required_PK_Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Level2_Name], [t].[OneToMany_Optional_Inverse2Id], [t].[OneToMany_Required_Inverse2Id], [t].[OneToOne_Optional_PK_Inverse2Id]
+        FROM [Level1] AS [l0]
+        LEFT JOIN (
+            SELECT [l1].[Id], [l1].[OneToOne_Required_PK_Date], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[Level2_Name], [l1].[OneToMany_Optional_Inverse2Id], [l1].[OneToMany_Required_Inverse2Id], [l1].[OneToOne_Optional_PK_Inverse2Id], [l2].[Id] AS [Id0]
+            FROM [Level1] AS [l1]
+            INNER JOIN [Level1] AS [l2] ON [l1].[Id] = [l2].[Id]
+            WHERE [l1].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l1].[Level1_Required_Id] IS NOT NULL AND [l1].[OneToOne_Required_PK_Date] IS NOT NULL)
+        ) AS [t] ON [l0].[Id] = [t].[Id]
+        WHERE [t].[Id] IS NOT NULL
+    ) AS [t0] ON [l].[Id] = [t0].[Level1_Optional_Id]
+    LEFT JOIN (
+        SELECT [l3].[Id], [l3].[OneToOne_Required_PK_Date], [l3].[Level1_Optional_Id], [l3].[Level1_Required_Id], [l3].[Level2_Name], [l3].[OneToMany_Optional_Inverse2Id], [l3].[OneToMany_Required_Inverse2Id], [l3].[OneToOne_Optional_PK_Inverse2Id], [l4].[Id] AS [Id0]
+        FROM [Level1] AS [l3]
+        INNER JOIN [Level1] AS [l4] ON [l3].[Id] = [l4].[Id]
+        WHERE [l3].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l3].[Level1_Required_Id] IS NOT NULL AND [l3].[OneToOne_Required_PK_Date] IS NOT NULL)
+    ) AS [t1] ON [t0].[Id] = [t1].[Id]
+    WHERE ([t1].[Level2_Name] <> N'Foo') OR [t1].[Level2_Name] IS NULL
+) AS [t2]");
         }
 
         public override async Task Explicit_GroupJoin_in_subquery_with_unrelated_projection3(bool isAsync)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsWeakQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsWeakQuerySqlServerTest.cs
@@ -21,9 +21,14 @@ namespace Microsoft.EntityFrameworkCore.Query
             await base.Simple_level1_include(isAsync);
 
             AssertSql(
-                @"SELECT [l].[Id], [l].[Date], [l].[Name], [l0].[Id], [l0].[OneToOne_Required_PK_Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Level2_Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id]
+               @"SELECT [l].[Id], [l].[Date], [l].[Name], [t].[Id], [t].[OneToOne_Required_PK_Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Level2_Name], [t].[OneToMany_Optional_Inverse2Id], [t].[OneToMany_Required_Inverse2Id], [t].[OneToOne_Optional_PK_Inverse2Id]
 FROM [Level1] AS [l]
-LEFT JOIN [Level1] AS [l0] ON [l].[Id] = [l0].[Id]");
+LEFT JOIN (
+    SELECT [l0].[Id], [l0].[OneToOne_Required_PK_Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Level2_Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l1].[Id] AS [Id0]
+    FROM [Level1] AS [l0]
+    INNER JOIN [Level1] AS [l1] ON [l0].[Id] = [l1].[Id]
+    WHERE [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l0].[Level1_Required_Id] IS NOT NULL AND [l0].[OneToOne_Required_PK_Date] IS NOT NULL)
+) AS [t] ON [l].[Id] = [t].[Id]");
         }
 
         public override async Task Simple_level1(bool isAsync)
@@ -40,10 +45,25 @@ FROM [Level1] AS [l]");
             await base.Simple_level1_level2_include(isAsync);
 
             AssertSql(
-                @"SELECT [l].[Id], [l].[Date], [l].[Name], [l0].[Id], [l0].[OneToOne_Required_PK_Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Level2_Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l1].[Id], [l1].[Level2_Optional_Id], [l1].[Level2_Required_Id], [l1].[Level3_Name], [l1].[OneToMany_Optional_Inverse3Id], [l1].[OneToMany_Required_Inverse3Id], [l1].[OneToOne_Optional_PK_Inverse3Id]
+                @"SELECT [l].[Id], [l].[Date], [l].[Name], [t].[Id], [t].[OneToOne_Required_PK_Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Level2_Name], [t].[OneToMany_Optional_Inverse2Id], [t].[OneToMany_Required_Inverse2Id], [t].[OneToOne_Optional_PK_Inverse2Id], [t1].[Id], [t1].[Level2_Optional_Id], [t1].[Level2_Required_Id], [t1].[Level3_Name], [t1].[OneToMany_Optional_Inverse3Id], [t1].[OneToMany_Required_Inverse3Id], [t1].[OneToOne_Optional_PK_Inverse3Id]
 FROM [Level1] AS [l]
-LEFT JOIN [Level1] AS [l0] ON [l].[Id] = [l0].[Id]
-LEFT JOIN [Level1] AS [l1] ON [l0].[Id] = [l1].[Id]");
+LEFT JOIN (
+    SELECT [l0].[Id], [l0].[OneToOne_Required_PK_Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Level2_Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l1].[Id] AS [Id0]
+    FROM [Level1] AS [l0]
+    INNER JOIN [Level1] AS [l1] ON [l0].[Id] = [l1].[Id]
+    WHERE [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l0].[Level1_Required_Id] IS NOT NULL AND [l0].[OneToOne_Required_PK_Date] IS NOT NULL)
+) AS [t] ON [l].[Id] = [t].[Id]
+LEFT JOIN (
+    SELECT [l2].[Id], [l2].[Level2_Optional_Id], [l2].[Level2_Required_Id], [l2].[Level3_Name], [l2].[OneToMany_Optional_Inverse3Id], [l2].[OneToMany_Required_Inverse3Id], [l2].[OneToOne_Optional_PK_Inverse3Id], [t0].[Id] AS [Id0], [t0].[Id0] AS [Id00]
+    FROM [Level1] AS [l2]
+    INNER JOIN (
+        SELECT [l3].[Id], [l3].[OneToOne_Required_PK_Date], [l3].[Level1_Optional_Id], [l3].[Level1_Required_Id], [l3].[Level2_Name], [l3].[OneToMany_Optional_Inverse2Id], [l3].[OneToMany_Required_Inverse2Id], [l3].[OneToOne_Optional_PK_Inverse2Id], [l4].[Id] AS [Id0]
+        FROM [Level1] AS [l3]
+        INNER JOIN [Level1] AS [l4] ON [l3].[Id] = [l4].[Id]
+        WHERE [l3].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l3].[Level1_Required_Id] IS NOT NULL AND [l3].[OneToOne_Required_PK_Date] IS NOT NULL)
+    ) AS [t0] ON [l2].[Id] = [t0].[Id]
+    WHERE [l2].[OneToMany_Required_Inverse3Id] IS NOT NULL AND [l2].[Level2_Required_Id] IS NOT NULL
+) AS [t1] ON [t].[Id] = [t1].[Id]");
         }
 
         public override async Task Simple_level1_level2_GroupBy_Count(bool isAsync)
@@ -92,11 +112,41 @@ HAVING MIN(COALESCE([t].[Id], 0)) > 0");
             await base.Simple_level1_level2_level3_include(isAsync);
 
             AssertSql(
-                @"SELECT [l].[Id], [l].[Date], [l].[Name], [l0].[Id], [l0].[OneToOne_Required_PK_Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Level2_Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l1].[Id], [l1].[Level2_Optional_Id], [l1].[Level2_Required_Id], [l1].[Level3_Name], [l1].[OneToMany_Optional_Inverse3Id], [l1].[OneToMany_Required_Inverse3Id], [l1].[OneToOne_Optional_PK_Inverse3Id], [l2].[Id], [l2].[Level3_Optional_Id], [l2].[Level3_Required_Id], [l2].[Level4_Name], [l2].[OneToMany_Optional_Inverse4Id], [l2].[OneToMany_Required_Inverse4Id], [l2].[OneToOne_Optional_PK_Inverse4Id]
+                @"SELECT [l].[Id], [l].[Date], [l].[Name], [t].[Id], [t].[OneToOne_Required_PK_Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Level2_Name], [t].[OneToMany_Optional_Inverse2Id], [t].[OneToMany_Required_Inverse2Id], [t].[OneToOne_Optional_PK_Inverse2Id], [t1].[Id], [t1].[Level2_Optional_Id], [t1].[Level2_Required_Id], [t1].[Level3_Name], [t1].[OneToMany_Optional_Inverse3Id], [t1].[OneToMany_Required_Inverse3Id], [t1].[OneToOne_Optional_PK_Inverse3Id], [t4].[Id], [t4].[Level3_Optional_Id], [t4].[Level3_Required_Id], [t4].[Level4_Name], [t4].[OneToMany_Optional_Inverse4Id], [t4].[OneToMany_Required_Inverse4Id], [t4].[OneToOne_Optional_PK_Inverse4Id]
 FROM [Level1] AS [l]
-LEFT JOIN [Level1] AS [l0] ON [l].[Id] = [l0].[Id]
-LEFT JOIN [Level1] AS [l1] ON [l0].[Id] = [l1].[Id]
-LEFT JOIN [Level1] AS [l2] ON [l1].[Id] = [l2].[Id]");
+LEFT JOIN (
+    SELECT [l0].[Id], [l0].[OneToOne_Required_PK_Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Level2_Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l1].[Id] AS [Id0]
+    FROM [Level1] AS [l0]
+    INNER JOIN [Level1] AS [l1] ON [l0].[Id] = [l1].[Id]
+    WHERE [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l0].[Level1_Required_Id] IS NOT NULL AND [l0].[OneToOne_Required_PK_Date] IS NOT NULL)
+) AS [t] ON [l].[Id] = [t].[Id]
+LEFT JOIN (
+    SELECT [l2].[Id], [l2].[Level2_Optional_Id], [l2].[Level2_Required_Id], [l2].[Level3_Name], [l2].[OneToMany_Optional_Inverse3Id], [l2].[OneToMany_Required_Inverse3Id], [l2].[OneToOne_Optional_PK_Inverse3Id], [t0].[Id] AS [Id0], [t0].[Id0] AS [Id00]
+    FROM [Level1] AS [l2]
+    INNER JOIN (
+        SELECT [l3].[Id], [l3].[OneToOne_Required_PK_Date], [l3].[Level1_Optional_Id], [l3].[Level1_Required_Id], [l3].[Level2_Name], [l3].[OneToMany_Optional_Inverse2Id], [l3].[OneToMany_Required_Inverse2Id], [l3].[OneToOne_Optional_PK_Inverse2Id], [l4].[Id] AS [Id0]
+        FROM [Level1] AS [l3]
+        INNER JOIN [Level1] AS [l4] ON [l3].[Id] = [l4].[Id]
+        WHERE [l3].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l3].[Level1_Required_Id] IS NOT NULL AND [l3].[OneToOne_Required_PK_Date] IS NOT NULL)
+    ) AS [t0] ON [l2].[Id] = [t0].[Id]
+    WHERE [l2].[OneToMany_Required_Inverse3Id] IS NOT NULL AND [l2].[Level2_Required_Id] IS NOT NULL
+) AS [t1] ON [t].[Id] = [t1].[Id]
+LEFT JOIN (
+    SELECT [l5].[Id], [l5].[Level3_Optional_Id], [l5].[Level3_Required_Id], [l5].[Level4_Name], [l5].[OneToMany_Optional_Inverse4Id], [l5].[OneToMany_Required_Inverse4Id], [l5].[OneToOne_Optional_PK_Inverse4Id], [t3].[Id] AS [Id0], [t3].[Id0] AS [Id00], [t3].[Id00] AS [Id000]
+    FROM [Level1] AS [l5]
+    INNER JOIN (
+        SELECT [l6].[Id], [l6].[Level2_Optional_Id], [l6].[Level2_Required_Id], [l6].[Level3_Name], [l6].[OneToMany_Optional_Inverse3Id], [l6].[OneToMany_Required_Inverse3Id], [l6].[OneToOne_Optional_PK_Inverse3Id], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
+        FROM [Level1] AS [l6]
+        INNER JOIN (
+            SELECT [l7].[Id], [l7].[OneToOne_Required_PK_Date], [l7].[Level1_Optional_Id], [l7].[Level1_Required_Id], [l7].[Level2_Name], [l7].[OneToMany_Optional_Inverse2Id], [l7].[OneToMany_Required_Inverse2Id], [l7].[OneToOne_Optional_PK_Inverse2Id], [l8].[Id] AS [Id0]
+            FROM [Level1] AS [l7]
+            INNER JOIN [Level1] AS [l8] ON [l7].[Id] = [l8].[Id]
+            WHERE [l7].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l7].[Level1_Required_Id] IS NOT NULL AND [l7].[OneToOne_Required_PK_Date] IS NOT NULL)
+        ) AS [t2] ON [l6].[Id] = [t2].[Id]
+        WHERE [l6].[OneToMany_Required_Inverse3Id] IS NOT NULL AND [l6].[Level2_Required_Id] IS NOT NULL
+    ) AS [t3] ON [l5].[Id] = [t3].[Id]
+    WHERE [l5].[OneToMany_Required_Inverse4Id] IS NOT NULL AND [l5].[Level3_Required_Id] IS NOT NULL
+) AS [t4] ON [t1].[Id] = [t4].[Id]");
         }
 
         public override async Task Nested_group_join_with_take(bool isAsync)
@@ -139,19 +189,29 @@ LEFT JOIN (
             await base.Explicit_GroupJoin_in_subquery_with_unrelated_projection2(isAsync);
 
             AssertSql(
-                @"SELECT [t0].[Id]
+                @"SELECT [t2].[Id]
 FROM (
     SELECT DISTINCT [l].[Id], [l].[Date], [l].[Name]
     FROM [Level1] AS [l]
     LEFT JOIN (
-        SELECT [l0].[Id], [l0].[Date], [l0].[Name], [l1].[Id] AS [Id0], [l1].[OneToOne_Required_PK_Date], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[Level2_Name], [l1].[OneToMany_Optional_Inverse2Id], [l1].[OneToMany_Required_Inverse2Id], [l1].[OneToOne_Optional_PK_Inverse2Id]
+        SELECT [l0].[Id], [l0].[Date], [l0].[Name], [t].[Id] AS [Id0], [t].[OneToOne_Required_PK_Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Level2_Name], [t].[OneToMany_Optional_Inverse2Id], [t].[OneToMany_Required_Inverse2Id], [t].[OneToOne_Optional_PK_Inverse2Id]
         FROM [Level1] AS [l0]
-        LEFT JOIN [Level1] AS [l1] ON [l0].[Id] = [l1].[Id]
-        WHERE [l1].[Id] IS NOT NULL
-    ) AS [t] ON [l].[Id] = [t].[Level1_Optional_Id]
-    LEFT JOIN [Level1] AS [l2] ON [t].[Id] = [l2].[Id]
-    WHERE ([l2].[Level2_Name] <> N'Foo') OR [l2].[Level2_Name] IS NULL
-) AS [t0]");
+        LEFT JOIN (
+            SELECT [l1].[Id], [l1].[OneToOne_Required_PK_Date], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[Level2_Name], [l1].[OneToMany_Optional_Inverse2Id], [l1].[OneToMany_Required_Inverse2Id], [l1].[OneToOne_Optional_PK_Inverse2Id], [l2].[Id] AS [Id0]
+            FROM [Level1] AS [l1]
+            INNER JOIN [Level1] AS [l2] ON [l1].[Id] = [l2].[Id]
+            WHERE [l1].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l1].[Level1_Required_Id] IS NOT NULL AND [l1].[OneToOne_Required_PK_Date] IS NOT NULL)
+        ) AS [t] ON [l0].[Id] = [t].[Id]
+        WHERE [t].[Id] IS NOT NULL
+    ) AS [t0] ON [l].[Id] = [t0].[Level1_Optional_Id]
+    LEFT JOIN (
+        SELECT [l3].[Id], [l3].[OneToOne_Required_PK_Date], [l3].[Level1_Optional_Id], [l3].[Level1_Required_Id], [l3].[Level2_Name], [l3].[OneToMany_Optional_Inverse2Id], [l3].[OneToMany_Required_Inverse2Id], [l3].[OneToOne_Optional_PK_Inverse2Id], [l4].[Id] AS [Id0]
+        FROM [Level1] AS [l3]
+        INNER JOIN [Level1] AS [l4] ON [l3].[Id] = [l4].[Id]
+        WHERE [l3].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l3].[Level1_Required_Id] IS NOT NULL AND [l3].[OneToOne_Required_PK_Date] IS NOT NULL)
+    ) AS [t1] ON [t0].[Id] = [t1].[Id]
+    WHERE ([t1].[Level2_Name] <> N'Foo') OR [t1].[Level2_Name] IS NULL
+) AS [t2]");
         }
 
         public override async Task Result_operator_nav_prop_reference_optional_via_DefaultIfEmpty(bool isAsync)
@@ -160,29 +220,55 @@ FROM (
 
             AssertSql(
                 @"SELECT SUM(CASE
-    WHEN [l].[Id] IS NULL THEN 0
-    ELSE [l].[Level1_Required_Id]
+    WHEN [t].[Id] IS NULL THEN 0
+    ELSE [t].[Level1_Required_Id]
 END)
-FROM [Level1] AS [l0]
+FROM [Level1] AS [l1]
 LEFT JOIN (
-    SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l2].[Id] AS [Id0], [l2].[OneToOne_Required_PK_Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Level2_Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id]
-    FROM [Level1] AS [l1]
-    LEFT JOIN [Level1] AS [l2] ON [l1].[Id] = [l2].[Id]
-    WHERE [l2].[Id] IS NOT NULL
-) AS [t] ON [l0].[Id] = [t].[Level1_Optional_Id]
-LEFT JOIN [Level1] AS [l] ON [t].[Id] = [l].[Id]");
+    SELECT [l2].[Id], [l2].[Date], [l2].[Name], [t0].[Id] AS [Id0], [t0].[OneToOne_Required_PK_Date], [t0].[Level1_Optional_Id], [t0].[Level1_Required_Id], [t0].[Level2_Name], [t0].[OneToMany_Optional_Inverse2Id], [t0].[OneToMany_Required_Inverse2Id], [t0].[OneToOne_Optional_PK_Inverse2Id]
+    FROM [Level1] AS [l2]
+    LEFT JOIN (
+        SELECT [l3].[Id], [l3].[OneToOne_Required_PK_Date], [l3].[Level1_Optional_Id], [l3].[Level1_Required_Id], [l3].[Level2_Name], [l3].[OneToMany_Optional_Inverse2Id], [l3].[OneToMany_Required_Inverse2Id], [l3].[OneToOne_Optional_PK_Inverse2Id], [l4].[Id] AS [Id0]
+        FROM [Level1] AS [l3]
+        INNER JOIN [Level1] AS [l4] ON [l3].[Id] = [l4].[Id]
+        WHERE [l3].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l3].[Level1_Required_Id] IS NOT NULL AND [l3].[OneToOne_Required_PK_Date] IS NOT NULL)
+    ) AS [t0] ON [l2].[Id] = [t0].[Id]
+    WHERE [t0].[Id] IS NOT NULL
+) AS [t1] ON [l1].[Id] = [t1].[Level1_Optional_Id]
+LEFT JOIN (
+    SELECT [l].[Id], [l].[OneToOne_Required_PK_Date], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Level2_Name], [l].[OneToMany_Optional_Inverse2Id], [l].[OneToMany_Required_Inverse2Id], [l].[OneToOne_Optional_PK_Inverse2Id], [l0].[Id] AS [Id0]
+    FROM [Level1] AS [l]
+    INNER JOIN [Level1] AS [l0] ON [l].[Id] = [l0].[Id]
+    WHERE [l].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l].[Level1_Required_Id] IS NOT NULL AND [l].[OneToOne_Required_PK_Date] IS NOT NULL)
+) AS [t] ON [t1].[Id] = [t].[Id]");
         }
+
 
         public override async Task SelectMany_with_Include1(bool isAsync)
         {
             await base.SelectMany_with_Include1(isAsync);
 
             AssertSql(
-                @"SELECT [l].[Id], [l].[OneToOne_Required_PK_Date], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Level2_Name], [l].[OneToMany_Optional_Inverse2Id], [l].[OneToMany_Required_Inverse2Id], [l].[OneToOne_Optional_PK_Inverse2Id], [l0].[Id], [l1].[Id], [l1].[Level2_Optional_Id], [l1].[Level2_Required_Id], [l1].[Level3_Name], [l1].[OneToMany_Optional_Inverse3Id], [l1].[OneToMany_Required_Inverse3Id], [l1].[OneToOne_Optional_PK_Inverse3Id]
-FROM [Level1] AS [l0]
-INNER JOIN [Level1] AS [l] ON [l0].[Id] = [l].[OneToMany_Optional_Inverse2Id]
-LEFT JOIN [Level1] AS [l1] ON [l].[Id] = [l1].[OneToMany_Optional_Inverse3Id]
-ORDER BY [l0].[Id], [l].[Id], [l1].[Id]");
+                @"SELECT [t].[Id], [t].[OneToOne_Required_PK_Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Level2_Name], [t].[OneToMany_Optional_Inverse2Id], [t].[OneToMany_Required_Inverse2Id], [t].[OneToOne_Optional_PK_Inverse2Id], [l1].[Id], [t].[Id0], [t1].[Id], [t1].[Level2_Optional_Id], [t1].[Level2_Required_Id], [t1].[Level3_Name], [t1].[OneToMany_Optional_Inverse3Id], [t1].[OneToMany_Required_Inverse3Id], [t1].[OneToOne_Optional_PK_Inverse3Id], [t1].[Id0], [t1].[Id00]
+FROM [Level1] AS [l1]
+INNER JOIN (
+    SELECT [l].[Id], [l].[OneToOne_Required_PK_Date], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Level2_Name], [l].[OneToMany_Optional_Inverse2Id], [l].[OneToMany_Required_Inverse2Id], [l].[OneToOne_Optional_PK_Inverse2Id], [l0].[Id] AS [Id0]
+    FROM [Level1] AS [l]
+    INNER JOIN [Level1] AS [l0] ON [l].[Id] = [l0].[Id]
+    WHERE [l].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l].[Level1_Required_Id] IS NOT NULL AND [l].[OneToOne_Required_PK_Date] IS NOT NULL)
+) AS [t] ON [l1].[Id] = [t].[OneToMany_Optional_Inverse2Id]
+LEFT JOIN (
+    SELECT [l2].[Id], [l2].[Level2_Optional_Id], [l2].[Level2_Required_Id], [l2].[Level3_Name], [l2].[OneToMany_Optional_Inverse3Id], [l2].[OneToMany_Required_Inverse3Id], [l2].[OneToOne_Optional_PK_Inverse3Id], [t0].[Id] AS [Id0], [t0].[Id0] AS [Id00]
+    FROM [Level1] AS [l2]
+    INNER JOIN (
+        SELECT [l3].[Id], [l3].[OneToOne_Required_PK_Date], [l3].[Level1_Optional_Id], [l3].[Level1_Required_Id], [l3].[Level2_Name], [l3].[OneToMany_Optional_Inverse2Id], [l3].[OneToMany_Required_Inverse2Id], [l3].[OneToOne_Optional_PK_Inverse2Id], [l4].[Id] AS [Id0]
+        FROM [Level1] AS [l3]
+        INNER JOIN [Level1] AS [l4] ON [l3].[Id] = [l4].[Id]
+        WHERE [l3].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l3].[Level1_Required_Id] IS NOT NULL AND [l3].[OneToOne_Required_PK_Date] IS NOT NULL)
+    ) AS [t0] ON [l2].[Id] = [t0].[Id]
+    WHERE [l2].[OneToMany_Required_Inverse3Id] IS NOT NULL AND [l2].[Level2_Required_Id] IS NOT NULL
+) AS [t1] ON [t].[Id] = [t1].[OneToMany_Optional_Inverse3Id]
+ORDER BY [l1].[Id], [t].[Id], [t].[Id0], [t1].[Id], [t1].[Id0], [t1].[Id00]");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
@@ -19,22 +19,85 @@ namespace Microsoft.EntityFrameworkCore.Query
             base.Query_with_owned_entity_equality_operator();
 
             AssertSql(
-                @"SELECT [o].[Id], [o].[Discriminator], [o0].[Id], [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId], [o2].[Id], [o3].[Id], [o3].[BranchAddress_Country_Name], [o3].[BranchAddress_Country_PlanetId], [o4].[Id], [o5].[Id], [o5].[LeafAAddress_Country_Name], [o5].[LeafAAddress_Country_PlanetId], [t].[Id], [o7].[ClientId], [o7].[Id]
+                @"SELECT [o].[Id], [o].[Discriminator], [t0].[Id], [t3].[Id], [t3].[PersonAddress_Country_Name], [t3].[PersonAddress_Country_PlanetId], [t5].[Id], [t8].[Id], [t8].[BranchAddress_Country_Name], [t8].[BranchAddress_Country_PlanetId], [t10].[Id], [t13].[Id], [t13].[LeafAAddress_Country_Name], [t13].[LeafAAddress_Country_PlanetId], [t14].[Id], [o16].[ClientId], [o16].[Id]
 FROM [OwnedPerson] AS [o]
 CROSS JOIN (
-    SELECT [o6].[Id], [o6].[Discriminator]
-    FROM [OwnedPerson] AS [o6]
-    WHERE [o6].[Discriminator] = N'LeafB'
-) AS [t]
-LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
-LEFT JOIN [OwnedPerson] AS [o1] ON [o0].[Id] = [o1].[Id]
-LEFT JOIN [OwnedPerson] AS [o2] ON [o].[Id] = [o2].[Id]
-LEFT JOIN [OwnedPerson] AS [o3] ON [o2].[Id] = [o3].[Id]
-LEFT JOIN [OwnedPerson] AS [o4] ON [o].[Id] = [o4].[Id]
-LEFT JOIN [OwnedPerson] AS [o5] ON [o4].[Id] = [o5].[Id]
-LEFT JOIN [Order] AS [o7] ON [o].[Id] = [o7].[ClientId]
+    SELECT [o15].[Id], [o15].[Discriminator]
+    FROM [OwnedPerson] AS [o15]
+    WHERE [o15].[Discriminator] = N'LeafB'
+) AS [t14]
+LEFT JOIN (
+    SELECT [o0].[Id], [t].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o0]
+    INNER JOIN (
+        SELECT [o1].[Id], [o1].[Discriminator]
+        FROM [OwnedPerson] AS [o1]
+        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+    ) AS [t] ON [o0].[Id] = [t].[Id]
+) AS [t0] ON [o].[Id] = [t0].[Id]
+LEFT JOIN (
+    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o2]
+    INNER JOIN (
+        SELECT [o3].[Id], [t1].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o3]
+        INNER JOIN (
+            SELECT [o4].[Id], [o4].[Discriminator]
+            FROM [OwnedPerson] AS [o4]
+            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+        ) AS [t1] ON [o3].[Id] = [t1].[Id]
+    ) AS [t2] ON [o2].[Id] = [t2].[Id]
+    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t3] ON [t0].[Id] = [t3].[Id]
+LEFT JOIN (
+    SELECT [o5].[Id], [t4].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o5]
+    INNER JOIN (
+        SELECT [o6].[Id], [o6].[Discriminator]
+        FROM [OwnedPerson] AS [o6]
+        WHERE [o6].[Discriminator] IN (N'Branch', N'LeafA')
+    ) AS [t4] ON [o5].[Id] = [t4].[Id]
+) AS [t5] ON [o].[Id] = [t5].[Id]
+LEFT JOIN (
+    SELECT [o7].[Id], [o7].[BranchAddress_Country_Name], [o7].[BranchAddress_Country_PlanetId], [t7].[Id] AS [Id0], [t7].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o7]
+    INNER JOIN (
+        SELECT [o8].[Id], [t6].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o8]
+        INNER JOIN (
+            SELECT [o9].[Id], [o9].[Discriminator]
+            FROM [OwnedPerson] AS [o9]
+            WHERE [o9].[Discriminator] IN (N'Branch', N'LeafA')
+        ) AS [t6] ON [o8].[Id] = [t6].[Id]
+    ) AS [t7] ON [o7].[Id] = [t7].[Id]
+    WHERE [o7].[BranchAddress_Country_PlanetId] IS NOT NULL
+) AS [t8] ON [t5].[Id] = [t8].[Id]
+LEFT JOIN (
+    SELECT [o10].[Id], [t9].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o10]
+    INNER JOIN (
+        SELECT [o11].[Id], [o11].[Discriminator]
+        FROM [OwnedPerson] AS [o11]
+        WHERE [o11].[Discriminator] = N'LeafA'
+    ) AS [t9] ON [o10].[Id] = [t9].[Id]
+) AS [t10] ON [o].[Id] = [t10].[Id]
+LEFT JOIN (
+    SELECT [o12].[Id], [o12].[LeafAAddress_Country_Name], [o12].[LeafAAddress_Country_PlanetId], [t12].[Id] AS [Id0], [t12].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o12]
+    INNER JOIN (
+        SELECT [o13].[Id], [t11].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o13]
+        INNER JOIN (
+            SELECT [o14].[Id], [o14].[Discriminator]
+            FROM [OwnedPerson] AS [o14]
+            WHERE [o14].[Discriminator] = N'LeafA'
+        ) AS [t11] ON [o13].[Id] = [t11].[Id]
+    ) AS [t12] ON [o12].[Id] = [t12].[Id]
+    WHERE [o12].[LeafAAddress_Country_PlanetId] IS NOT NULL
+) AS [t13] ON [t10].[Id] = [t13].[Id]
+LEFT JOIN [Order] AS [o16] ON [o].[Id] = [o16].[ClientId]
 WHERE CAST(0 AS bit) = CAST(1 AS bit)
-ORDER BY [o].[Id], [t].[Id], [o7].[ClientId], [o7].[Id]");
+ORDER BY [o].[Id], [t14].[Id], [o16].[ClientId], [o16].[Id]");
         }
 
         public override void Query_for_base_type_loads_all_owned_navs()
@@ -43,19 +106,103 @@ ORDER BY [o].[Id], [t].[Id], [o7].[ClientId], [o7].[Id]");
 
             // See issue #10067
             AssertSql(
-                @"SELECT [o].[Id], [o].[Discriminator], [o0].[Id], [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId], [o2].[Id], [o3].[Id], [o3].[BranchAddress_Country_Name], [o3].[BranchAddress_Country_PlanetId], [o4].[Id], [o5].[Id], [o5].[LeafBAddress_Country_Name], [o5].[LeafBAddress_Country_PlanetId], [o6].[Id], [o7].[Id], [o7].[LeafAAddress_Country_Name], [o7].[LeafAAddress_Country_PlanetId], [o8].[ClientId], [o8].[Id]
+                @"SELECT [o].[Id], [o].[Discriminator], [t0].[Id], [t3].[Id], [t3].[PersonAddress_Country_Name], [t3].[PersonAddress_Country_PlanetId], [t5].[Id], [t8].[Id], [t8].[BranchAddress_Country_Name], [t8].[BranchAddress_Country_PlanetId], [t10].[Id], [t13].[Id], [t13].[LeafBAddress_Country_Name], [t13].[LeafBAddress_Country_PlanetId], [t15].[Id], [t18].[Id], [t18].[LeafAAddress_Country_Name], [t18].[LeafAAddress_Country_PlanetId], [o20].[ClientId], [o20].[Id]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
-LEFT JOIN [OwnedPerson] AS [o1] ON [o0].[Id] = [o1].[Id]
-LEFT JOIN [OwnedPerson] AS [o2] ON [o].[Id] = [o2].[Id]
-LEFT JOIN [OwnedPerson] AS [o3] ON [o2].[Id] = [o3].[Id]
-LEFT JOIN [OwnedPerson] AS [o4] ON [o].[Id] = [o4].[Id]
-LEFT JOIN [OwnedPerson] AS [o5] ON [o4].[Id] = [o5].[Id]
-LEFT JOIN [OwnedPerson] AS [o6] ON [o].[Id] = [o6].[Id]
-LEFT JOIN [OwnedPerson] AS [o7] ON [o6].[Id] = [o7].[Id]
-LEFT JOIN [Order] AS [o8] ON [o].[Id] = [o8].[ClientId]
+LEFT JOIN (
+    SELECT [o0].[Id], [t].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o0]
+    INNER JOIN (
+        SELECT [o1].[Id], [o1].[Discriminator]
+        FROM [OwnedPerson] AS [o1]
+        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+    ) AS [t] ON [o0].[Id] = [t].[Id]
+) AS [t0] ON [o].[Id] = [t0].[Id]
+LEFT JOIN (
+    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o2]
+    INNER JOIN (
+        SELECT [o3].[Id], [t1].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o3]
+        INNER JOIN (
+            SELECT [o4].[Id], [o4].[Discriminator]
+            FROM [OwnedPerson] AS [o4]
+            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+        ) AS [t1] ON [o3].[Id] = [t1].[Id]
+    ) AS [t2] ON [o2].[Id] = [t2].[Id]
+    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t3] ON [t0].[Id] = [t3].[Id]
+LEFT JOIN (
+    SELECT [o5].[Id], [t4].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o5]
+    INNER JOIN (
+        SELECT [o6].[Id], [o6].[Discriminator]
+        FROM [OwnedPerson] AS [o6]
+        WHERE [o6].[Discriminator] IN (N'Branch', N'LeafA')
+    ) AS [t4] ON [o5].[Id] = [t4].[Id]
+) AS [t5] ON [o].[Id] = [t5].[Id]
+LEFT JOIN (
+    SELECT [o7].[Id], [o7].[BranchAddress_Country_Name], [o7].[BranchAddress_Country_PlanetId], [t7].[Id] AS [Id0], [t7].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o7]
+    INNER JOIN (
+        SELECT [o8].[Id], [t6].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o8]
+        INNER JOIN (
+            SELECT [o9].[Id], [o9].[Discriminator]
+            FROM [OwnedPerson] AS [o9]
+            WHERE [o9].[Discriminator] IN (N'Branch', N'LeafA')
+        ) AS [t6] ON [o8].[Id] = [t6].[Id]
+    ) AS [t7] ON [o7].[Id] = [t7].[Id]
+    WHERE [o7].[BranchAddress_Country_PlanetId] IS NOT NULL
+) AS [t8] ON [t5].[Id] = [t8].[Id]
+LEFT JOIN (
+    SELECT [o10].[Id], [t9].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o10]
+    INNER JOIN (
+        SELECT [o11].[Id], [o11].[Discriminator]
+        FROM [OwnedPerson] AS [o11]
+        WHERE [o11].[Discriminator] = N'LeafB'
+    ) AS [t9] ON [o10].[Id] = [t9].[Id]
+) AS [t10] ON [o].[Id] = [t10].[Id]
+LEFT JOIN (
+    SELECT [o12].[Id], [o12].[LeafBAddress_Country_Name], [o12].[LeafBAddress_Country_PlanetId], [t12].[Id] AS [Id0], [t12].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o12]
+    INNER JOIN (
+        SELECT [o13].[Id], [t11].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o13]
+        INNER JOIN (
+            SELECT [o14].[Id], [o14].[Discriminator]
+            FROM [OwnedPerson] AS [o14]
+            WHERE [o14].[Discriminator] = N'LeafB'
+        ) AS [t11] ON [o13].[Id] = [t11].[Id]
+    ) AS [t12] ON [o12].[Id] = [t12].[Id]
+    WHERE [o12].[LeafBAddress_Country_PlanetId] IS NOT NULL
+) AS [t13] ON [t10].[Id] = [t13].[Id]
+LEFT JOIN (
+    SELECT [o15].[Id], [t14].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o15]
+    INNER JOIN (
+        SELECT [o16].[Id], [o16].[Discriminator]
+        FROM [OwnedPerson] AS [o16]
+        WHERE [o16].[Discriminator] = N'LeafA'
+    ) AS [t14] ON [o15].[Id] = [t14].[Id]
+) AS [t15] ON [o].[Id] = [t15].[Id]
+LEFT JOIN (
+    SELECT [o17].[Id], [o17].[LeafAAddress_Country_Name], [o17].[LeafAAddress_Country_PlanetId], [t17].[Id] AS [Id0], [t17].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o17]
+    INNER JOIN (
+        SELECT [o18].[Id], [t16].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o18]
+        INNER JOIN (
+            SELECT [o19].[Id], [o19].[Discriminator]
+            FROM [OwnedPerson] AS [o19]
+            WHERE [o19].[Discriminator] = N'LeafA'
+        ) AS [t16] ON [o18].[Id] = [t16].[Id]
+    ) AS [t17] ON [o17].[Id] = [t17].[Id]
+    WHERE [o17].[LeafAAddress_Country_PlanetId] IS NOT NULL
+) AS [t18] ON [t15].[Id] = [t18].[Id]
+LEFT JOIN [Order] AS [o20] ON [o].[Id] = [o20].[ClientId]
 WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-ORDER BY [o].[Id], [o8].[ClientId], [o8].[Id]");
+ORDER BY [o].[Id], [o20].[ClientId], [o20].[Id]");
         }
 
         public override void No_ignored_include_warning_when_implicit_load()
@@ -73,17 +220,80 @@ WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
             base.Query_for_branch_type_loads_all_owned_navs();
 
             AssertSql(
-                @"SELECT [o].[Id], [o].[Discriminator], [o0].[Id], [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId], [o2].[Id], [o3].[Id], [o3].[BranchAddress_Country_Name], [o3].[BranchAddress_Country_PlanetId], [o4].[Id], [o5].[Id], [o5].[LeafAAddress_Country_Name], [o5].[LeafAAddress_Country_PlanetId], [o6].[ClientId], [o6].[Id]
+                @"SELECT [o].[Id], [o].[Discriminator], [t0].[Id], [t3].[Id], [t3].[PersonAddress_Country_Name], [t3].[PersonAddress_Country_PlanetId], [t5].[Id], [t8].[Id], [t8].[BranchAddress_Country_Name], [t8].[BranchAddress_Country_PlanetId], [t10].[Id], [t13].[Id], [t13].[LeafAAddress_Country_Name], [t13].[LeafAAddress_Country_PlanetId], [o15].[ClientId], [o15].[Id]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
-LEFT JOIN [OwnedPerson] AS [o1] ON [o0].[Id] = [o1].[Id]
-LEFT JOIN [OwnedPerson] AS [o2] ON [o].[Id] = [o2].[Id]
-LEFT JOIN [OwnedPerson] AS [o3] ON [o2].[Id] = [o3].[Id]
-LEFT JOIN [OwnedPerson] AS [o4] ON [o].[Id] = [o4].[Id]
-LEFT JOIN [OwnedPerson] AS [o5] ON [o4].[Id] = [o5].[Id]
-LEFT JOIN [Order] AS [o6] ON [o].[Id] = [o6].[ClientId]
+LEFT JOIN (
+    SELECT [o0].[Id], [t].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o0]
+    INNER JOIN (
+        SELECT [o1].[Id], [o1].[Discriminator]
+        FROM [OwnedPerson] AS [o1]
+        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+    ) AS [t] ON [o0].[Id] = [t].[Id]
+) AS [t0] ON [o].[Id] = [t0].[Id]
+LEFT JOIN (
+    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o2]
+    INNER JOIN (
+        SELECT [o3].[Id], [t1].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o3]
+        INNER JOIN (
+            SELECT [o4].[Id], [o4].[Discriminator]
+            FROM [OwnedPerson] AS [o4]
+            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+        ) AS [t1] ON [o3].[Id] = [t1].[Id]
+    ) AS [t2] ON [o2].[Id] = [t2].[Id]
+    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t3] ON [t0].[Id] = [t3].[Id]
+LEFT JOIN (
+    SELECT [o5].[Id], [t4].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o5]
+    INNER JOIN (
+        SELECT [o6].[Id], [o6].[Discriminator]
+        FROM [OwnedPerson] AS [o6]
+        WHERE [o6].[Discriminator] IN (N'Branch', N'LeafA')
+    ) AS [t4] ON [o5].[Id] = [t4].[Id]
+) AS [t5] ON [o].[Id] = [t5].[Id]
+LEFT JOIN (
+    SELECT [o7].[Id], [o7].[BranchAddress_Country_Name], [o7].[BranchAddress_Country_PlanetId], [t7].[Id] AS [Id0], [t7].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o7]
+    INNER JOIN (
+        SELECT [o8].[Id], [t6].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o8]
+        INNER JOIN (
+            SELECT [o9].[Id], [o9].[Discriminator]
+            FROM [OwnedPerson] AS [o9]
+            WHERE [o9].[Discriminator] IN (N'Branch', N'LeafA')
+        ) AS [t6] ON [o8].[Id] = [t6].[Id]
+    ) AS [t7] ON [o7].[Id] = [t7].[Id]
+    WHERE [o7].[BranchAddress_Country_PlanetId] IS NOT NULL
+) AS [t8] ON [t5].[Id] = [t8].[Id]
+LEFT JOIN (
+    SELECT [o10].[Id], [t9].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o10]
+    INNER JOIN (
+        SELECT [o11].[Id], [o11].[Discriminator]
+        FROM [OwnedPerson] AS [o11]
+        WHERE [o11].[Discriminator] = N'LeafA'
+    ) AS [t9] ON [o10].[Id] = [t9].[Id]
+) AS [t10] ON [o].[Id] = [t10].[Id]
+LEFT JOIN (
+    SELECT [o12].[Id], [o12].[LeafAAddress_Country_Name], [o12].[LeafAAddress_Country_PlanetId], [t12].[Id] AS [Id0], [t12].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o12]
+    INNER JOIN (
+        SELECT [o13].[Id], [t11].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o13]
+        INNER JOIN (
+            SELECT [o14].[Id], [o14].[Discriminator]
+            FROM [OwnedPerson] AS [o14]
+            WHERE [o14].[Discriminator] = N'LeafA'
+        ) AS [t11] ON [o13].[Id] = [t11].[Id]
+    ) AS [t12] ON [o12].[Id] = [t12].[Id]
+    WHERE [o12].[LeafAAddress_Country_PlanetId] IS NOT NULL
+) AS [t13] ON [t10].[Id] = [t13].[Id]
+LEFT JOIN [Order] AS [o15] ON [o].[Id] = [o15].[ClientId]
 WHERE [o].[Discriminator] IN (N'Branch', N'LeafA')
-ORDER BY [o].[Id], [o6].[ClientId], [o6].[Id]");
+ORDER BY [o].[Id], [o15].[ClientId], [o15].[Id]");
         }
 
         public override void Query_for_leaf_type_loads_all_owned_navs()
@@ -91,17 +301,80 @@ ORDER BY [o].[Id], [o6].[ClientId], [o6].[Id]");
             base.Query_for_leaf_type_loads_all_owned_navs();
 
             AssertSql(
-                @"SELECT [o].[Id], [o].[Discriminator], [o0].[Id], [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId], [o2].[Id], [o3].[Id], [o3].[BranchAddress_Country_Name], [o3].[BranchAddress_Country_PlanetId], [o4].[Id], [o5].[Id], [o5].[LeafAAddress_Country_Name], [o5].[LeafAAddress_Country_PlanetId], [o6].[ClientId], [o6].[Id]
+                @"SELECT [o].[Id], [o].[Discriminator], [t0].[Id], [t3].[Id], [t3].[PersonAddress_Country_Name], [t3].[PersonAddress_Country_PlanetId], [t5].[Id], [t8].[Id], [t8].[BranchAddress_Country_Name], [t8].[BranchAddress_Country_PlanetId], [t10].[Id], [t13].[Id], [t13].[LeafAAddress_Country_Name], [t13].[LeafAAddress_Country_PlanetId], [o15].[ClientId], [o15].[Id]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
-LEFT JOIN [OwnedPerson] AS [o1] ON [o0].[Id] = [o1].[Id]
-LEFT JOIN [OwnedPerson] AS [o2] ON [o].[Id] = [o2].[Id]
-LEFT JOIN [OwnedPerson] AS [o3] ON [o2].[Id] = [o3].[Id]
-LEFT JOIN [OwnedPerson] AS [o4] ON [o].[Id] = [o4].[Id]
-LEFT JOIN [OwnedPerson] AS [o5] ON [o4].[Id] = [o5].[Id]
-LEFT JOIN [Order] AS [o6] ON [o].[Id] = [o6].[ClientId]
+LEFT JOIN (
+    SELECT [o0].[Id], [t].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o0]
+    INNER JOIN (
+        SELECT [o1].[Id], [o1].[Discriminator]
+        FROM [OwnedPerson] AS [o1]
+        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+    ) AS [t] ON [o0].[Id] = [t].[Id]
+) AS [t0] ON [o].[Id] = [t0].[Id]
+LEFT JOIN (
+    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o2]
+    INNER JOIN (
+        SELECT [o3].[Id], [t1].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o3]
+        INNER JOIN (
+            SELECT [o4].[Id], [o4].[Discriminator]
+            FROM [OwnedPerson] AS [o4]
+            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+        ) AS [t1] ON [o3].[Id] = [t1].[Id]
+    ) AS [t2] ON [o2].[Id] = [t2].[Id]
+    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t3] ON [t0].[Id] = [t3].[Id]
+LEFT JOIN (
+    SELECT [o5].[Id], [t4].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o5]
+    INNER JOIN (
+        SELECT [o6].[Id], [o6].[Discriminator]
+        FROM [OwnedPerson] AS [o6]
+        WHERE [o6].[Discriminator] IN (N'Branch', N'LeafA')
+    ) AS [t4] ON [o5].[Id] = [t4].[Id]
+) AS [t5] ON [o].[Id] = [t5].[Id]
+LEFT JOIN (
+    SELECT [o7].[Id], [o7].[BranchAddress_Country_Name], [o7].[BranchAddress_Country_PlanetId], [t7].[Id] AS [Id0], [t7].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o7]
+    INNER JOIN (
+        SELECT [o8].[Id], [t6].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o8]
+        INNER JOIN (
+            SELECT [o9].[Id], [o9].[Discriminator]
+            FROM [OwnedPerson] AS [o9]
+            WHERE [o9].[Discriminator] IN (N'Branch', N'LeafA')
+        ) AS [t6] ON [o8].[Id] = [t6].[Id]
+    ) AS [t7] ON [o7].[Id] = [t7].[Id]
+    WHERE [o7].[BranchAddress_Country_PlanetId] IS NOT NULL
+) AS [t8] ON [t5].[Id] = [t8].[Id]
+LEFT JOIN (
+    SELECT [o10].[Id], [t9].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o10]
+    INNER JOIN (
+        SELECT [o11].[Id], [o11].[Discriminator]
+        FROM [OwnedPerson] AS [o11]
+        WHERE [o11].[Discriminator] = N'LeafA'
+    ) AS [t9] ON [o10].[Id] = [t9].[Id]
+) AS [t10] ON [o].[Id] = [t10].[Id]
+LEFT JOIN (
+    SELECT [o12].[Id], [o12].[LeafAAddress_Country_Name], [o12].[LeafAAddress_Country_PlanetId], [t12].[Id] AS [Id0], [t12].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o12]
+    INNER JOIN (
+        SELECT [o13].[Id], [t11].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o13]
+        INNER JOIN (
+            SELECT [o14].[Id], [o14].[Discriminator]
+            FROM [OwnedPerson] AS [o14]
+            WHERE [o14].[Discriminator] = N'LeafA'
+        ) AS [t11] ON [o13].[Id] = [t11].[Id]
+    ) AS [t12] ON [o12].[Id] = [t12].[Id]
+    WHERE [o12].[LeafAAddress_Country_PlanetId] IS NOT NULL
+) AS [t13] ON [t10].[Id] = [t13].[Id]
+LEFT JOIN [Order] AS [o15] ON [o].[Id] = [o15].[ClientId]
 WHERE [o].[Discriminator] = N'LeafA'
-ORDER BY [o].[Id], [o6].[ClientId], [o6].[Id]");
+ORDER BY [o].[Id], [o15].[ClientId], [o15].[Id]");
         }
 
         public override void Query_when_group_by()
@@ -211,7 +484,7 @@ ORDER BY [t15].[Id]");
             AssertSql(
                 @"@__p_0='5'
 
-SELECT [t0].[Id], [t0].[Discriminator], [o0].[Id], [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId], [o2].[Id], [o3].[Id], [o3].[BranchAddress_Country_Name], [o3].[BranchAddress_Country_PlanetId], [o4].[Id], [o5].[Id], [o5].[LeafBAddress_Country_Name], [o5].[LeafBAddress_Country_PlanetId], [o6].[Id], [o7].[Id], [o7].[LeafAAddress_Country_Name], [o7].[LeafAAddress_Country_PlanetId], [o8].[ClientId], [o8].[Id]
+SELECT [t0].[Id], [t0].[Discriminator], [t2].[Id], [t5].[Id], [t5].[PersonAddress_Country_Name], [t5].[PersonAddress_Country_PlanetId], [t7].[Id], [t10].[Id], [t10].[BranchAddress_Country_Name], [t10].[BranchAddress_Country_PlanetId], [t12].[Id], [t15].[Id], [t15].[LeafBAddress_Country_Name], [t15].[LeafBAddress_Country_PlanetId], [t17].[Id], [t20].[Id], [t20].[LeafAAddress_Country_Name], [t20].[LeafAAddress_Country_PlanetId], [o20].[ClientId], [o20].[Id]
 FROM (
     SELECT TOP(@__p_0) [t].[Id], [t].[Discriminator]
     FROM (
@@ -221,17 +494,109 @@ FROM (
     ) AS [t]
     ORDER BY [t].[Id]
 ) AS [t0]
-LEFT JOIN [OwnedPerson] AS [o9] ON [t0].[Id] = [o9].[Id]
-LEFT JOIN [OwnedPerson] AS [o0] ON [t0].[Id] = [o0].[Id]
-LEFT JOIN [OwnedPerson] AS [o1] ON [o0].[Id] = [o1].[Id]
-LEFT JOIN [OwnedPerson] AS [o2] ON [t0].[Id] = [o2].[Id]
-LEFT JOIN [OwnedPerson] AS [o3] ON [o2].[Id] = [o3].[Id]
-LEFT JOIN [OwnedPerson] AS [o4] ON [t0].[Id] = [o4].[Id]
-LEFT JOIN [OwnedPerson] AS [o5] ON [o4].[Id] = [o5].[Id]
-LEFT JOIN [OwnedPerson] AS [o6] ON [t0].[Id] = [o6].[Id]
-LEFT JOIN [OwnedPerson] AS [o7] ON [o6].[Id] = [o7].[Id]
-LEFT JOIN [Order] AS [o8] ON [t0].[Id] = [o8].[ClientId]
-ORDER BY [t0].[Id], [o8].[ClientId], [o8].[Id]");
+LEFT JOIN (
+    SELECT [o21].[Id], [t21].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o21]
+    INNER JOIN (
+        SELECT [o22].[Id], [o22].[Discriminator]
+        FROM [OwnedPerson] AS [o22]
+        WHERE [o22].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+    ) AS [t21] ON [o21].[Id] = [t21].[Id]
+) AS [t22] ON [t0].[Id] = [t22].[Id]
+LEFT JOIN (
+    SELECT [o0].[Id], [t1].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o0]
+    INNER JOIN (
+        SELECT [o1].[Id], [o1].[Discriminator]
+        FROM [OwnedPerson] AS [o1]
+        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+    ) AS [t1] ON [o0].[Id] = [t1].[Id]
+) AS [t2] ON [t0].[Id] = [t2].[Id]
+LEFT JOIN (
+    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t4].[Id] AS [Id0], [t4].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o2]
+    INNER JOIN (
+        SELECT [o3].[Id], [t3].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o3]
+        INNER JOIN (
+            SELECT [o4].[Id], [o4].[Discriminator]
+            FROM [OwnedPerson] AS [o4]
+            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+        ) AS [t3] ON [o3].[Id] = [t3].[Id]
+    ) AS [t4] ON [o2].[Id] = [t4].[Id]
+    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t5] ON [t2].[Id] = [t5].[Id]
+LEFT JOIN (
+    SELECT [o5].[Id], [t6].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o5]
+    INNER JOIN (
+        SELECT [o6].[Id], [o6].[Discriminator]
+        FROM [OwnedPerson] AS [o6]
+        WHERE [o6].[Discriminator] IN (N'Branch', N'LeafA')
+    ) AS [t6] ON [o5].[Id] = [t6].[Id]
+) AS [t7] ON [t0].[Id] = [t7].[Id]
+LEFT JOIN (
+    SELECT [o7].[Id], [o7].[BranchAddress_Country_Name], [o7].[BranchAddress_Country_PlanetId], [t9].[Id] AS [Id0], [t9].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o7]
+    INNER JOIN (
+        SELECT [o8].[Id], [t8].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o8]
+        INNER JOIN (
+            SELECT [o9].[Id], [o9].[Discriminator]
+            FROM [OwnedPerson] AS [o9]
+            WHERE [o9].[Discriminator] IN (N'Branch', N'LeafA')
+        ) AS [t8] ON [o8].[Id] = [t8].[Id]
+    ) AS [t9] ON [o7].[Id] = [t9].[Id]
+    WHERE [o7].[BranchAddress_Country_PlanetId] IS NOT NULL
+) AS [t10] ON [t7].[Id] = [t10].[Id]
+LEFT JOIN (
+    SELECT [o10].[Id], [t11].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o10]
+    INNER JOIN (
+        SELECT [o11].[Id], [o11].[Discriminator]
+        FROM [OwnedPerson] AS [o11]
+        WHERE [o11].[Discriminator] = N'LeafB'
+    ) AS [t11] ON [o10].[Id] = [t11].[Id]
+) AS [t12] ON [t0].[Id] = [t12].[Id]
+LEFT JOIN (
+    SELECT [o12].[Id], [o12].[LeafBAddress_Country_Name], [o12].[LeafBAddress_Country_PlanetId], [t14].[Id] AS [Id0], [t14].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o12]
+    INNER JOIN (
+        SELECT [o13].[Id], [t13].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o13]
+        INNER JOIN (
+            SELECT [o14].[Id], [o14].[Discriminator]
+            FROM [OwnedPerson] AS [o14]
+            WHERE [o14].[Discriminator] = N'LeafB'
+        ) AS [t13] ON [o13].[Id] = [t13].[Id]
+    ) AS [t14] ON [o12].[Id] = [t14].[Id]
+    WHERE [o12].[LeafBAddress_Country_PlanetId] IS NOT NULL
+) AS [t15] ON [t12].[Id] = [t15].[Id]
+LEFT JOIN (
+    SELECT [o15].[Id], [t16].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o15]
+    INNER JOIN (
+        SELECT [o16].[Id], [o16].[Discriminator]
+        FROM [OwnedPerson] AS [o16]
+        WHERE [o16].[Discriminator] = N'LeafA'
+    ) AS [t16] ON [o15].[Id] = [t16].[Id]
+) AS [t17] ON [t0].[Id] = [t17].[Id]
+LEFT JOIN (
+    SELECT [o17].[Id], [o17].[LeafAAddress_Country_Name], [o17].[LeafAAddress_Country_PlanetId], [t19].[Id] AS [Id0], [t19].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o17]
+    INNER JOIN (
+        SELECT [o18].[Id], [t18].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o18]
+        INNER JOIN (
+            SELECT [o19].[Id], [o19].[Discriminator]
+            FROM [OwnedPerson] AS [o19]
+            WHERE [o19].[Discriminator] = N'LeafA'
+        ) AS [t18] ON [o18].[Id] = [t18].[Id]
+    ) AS [t19] ON [o17].[Id] = [t19].[Id]
+    WHERE [o17].[LeafAAddress_Country_PlanetId] IS NOT NULL
+) AS [t20] ON [t17].[Id] = [t20].[Id]
+LEFT JOIN [Order] AS [o20] ON [t0].[Id] = [o20].[ClientId]
+ORDER BY [t0].[Id], [o20].[ClientId], [o20].[Id]");
         }
 
         public override void Navigation_rewrite_on_owned_reference_projecting_scalar()
@@ -239,11 +604,32 @@ ORDER BY [t0].[Id], [o8].[ClientId], [o8].[Id]");
             base.Navigation_rewrite_on_owned_reference_projecting_scalar();
 
             AssertSql(
-                @"SELECT [o].[PersonAddress_Country_Name]
-FROM [OwnedPerson] AS [o0]
-LEFT JOIN [OwnedPerson] AS [o1] ON [o0].[Id] = [o1].[Id]
-LEFT JOIN [OwnedPerson] AS [o] ON [o1].[Id] = [o].[Id]
-WHERE [o0].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA') AND (([o].[PersonAddress_Country_Name] = N'USA') AND [o].[PersonAddress_Country_Name] IS NOT NULL)");
+                @"SELECT [t1].[PersonAddress_Country_Name]
+FROM [OwnedPerson] AS [o2]
+LEFT JOIN (
+    SELECT [o3].[Id], [t2].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o3]
+    INNER JOIN (
+        SELECT [o4].[Id], [o4].[Discriminator]
+        FROM [OwnedPerson] AS [o4]
+        WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+    ) AS [t2] ON [o3].[Id] = [t2].[Id]
+) AS [t3] ON [o2].[Id] = [t3].[Id]
+LEFT JOIN (
+    SELECT [o].[Id], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [t0].[Id] AS [Id0], [t0].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o]
+    INNER JOIN (
+        SELECT [o0].[Id], [t].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o0]
+        INNER JOIN (
+            SELECT [o1].[Id], [o1].[Discriminator]
+            FROM [OwnedPerson] AS [o1]
+            WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+        ) AS [t] ON [o0].[Id] = [t].[Id]
+    ) AS [t0] ON [o].[Id] = [t0].[Id]
+    WHERE [o].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t1] ON [t3].[Id] = [t1].[Id]
+WHERE [o2].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA') AND (([t1].[PersonAddress_Country_Name] = N'USA') AND [t1].[PersonAddress_Country_Name] IS NOT NULL)");
         }
 
         public override void Navigation_rewrite_on_owned_reference_projecting_entity()
@@ -251,19 +637,103 @@ WHERE [o0].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA') AN
             base.Navigation_rewrite_on_owned_reference_projecting_entity();
 
             AssertSql(
-                @"SELECT [o].[Id], [o].[Discriminator], [o0].[Id], [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId], [o2].[Id], [o3].[Id], [o3].[BranchAddress_Country_Name], [o3].[BranchAddress_Country_PlanetId], [o4].[Id], [o5].[Id], [o5].[LeafBAddress_Country_Name], [o5].[LeafBAddress_Country_PlanetId], [o6].[Id], [o7].[Id], [o7].[LeafAAddress_Country_Name], [o7].[LeafAAddress_Country_PlanetId], [o8].[ClientId], [o8].[Id]
+                @"SELECT [o].[Id], [o].[Discriminator], [t0].[Id], [t3].[Id], [t3].[PersonAddress_Country_Name], [t3].[PersonAddress_Country_PlanetId], [t5].[Id], [t8].[Id], [t8].[BranchAddress_Country_Name], [t8].[BranchAddress_Country_PlanetId], [t10].[Id], [t13].[Id], [t13].[LeafBAddress_Country_Name], [t13].[LeafBAddress_Country_PlanetId], [t15].[Id], [t18].[Id], [t18].[LeafAAddress_Country_Name], [t18].[LeafAAddress_Country_PlanetId], [o20].[ClientId], [o20].[Id]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
-LEFT JOIN [OwnedPerson] AS [o1] ON [o0].[Id] = [o1].[Id]
-LEFT JOIN [OwnedPerson] AS [o2] ON [o].[Id] = [o2].[Id]
-LEFT JOIN [OwnedPerson] AS [o3] ON [o2].[Id] = [o3].[Id]
-LEFT JOIN [OwnedPerson] AS [o4] ON [o].[Id] = [o4].[Id]
-LEFT JOIN [OwnedPerson] AS [o5] ON [o4].[Id] = [o5].[Id]
-LEFT JOIN [OwnedPerson] AS [o6] ON [o].[Id] = [o6].[Id]
-LEFT JOIN [OwnedPerson] AS [o7] ON [o6].[Id] = [o7].[Id]
-LEFT JOIN [Order] AS [o8] ON [o].[Id] = [o8].[ClientId]
-WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA') AND (([o1].[PersonAddress_Country_Name] = N'USA') AND [o1].[PersonAddress_Country_Name] IS NOT NULL)
-ORDER BY [o].[Id], [o8].[ClientId], [o8].[Id]");
+LEFT JOIN (
+    SELECT [o0].[Id], [t].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o0]
+    INNER JOIN (
+        SELECT [o1].[Id], [o1].[Discriminator]
+        FROM [OwnedPerson] AS [o1]
+        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+    ) AS [t] ON [o0].[Id] = [t].[Id]
+) AS [t0] ON [o].[Id] = [t0].[Id]
+LEFT JOIN (
+    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o2]
+    INNER JOIN (
+        SELECT [o3].[Id], [t1].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o3]
+        INNER JOIN (
+            SELECT [o4].[Id], [o4].[Discriminator]
+            FROM [OwnedPerson] AS [o4]
+            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+        ) AS [t1] ON [o3].[Id] = [t1].[Id]
+    ) AS [t2] ON [o2].[Id] = [t2].[Id]
+    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t3] ON [t0].[Id] = [t3].[Id]
+LEFT JOIN (
+    SELECT [o5].[Id], [t4].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o5]
+    INNER JOIN (
+        SELECT [o6].[Id], [o6].[Discriminator]
+        FROM [OwnedPerson] AS [o6]
+        WHERE [o6].[Discriminator] IN (N'Branch', N'LeafA')
+    ) AS [t4] ON [o5].[Id] = [t4].[Id]
+) AS [t5] ON [o].[Id] = [t5].[Id]
+LEFT JOIN (
+    SELECT [o7].[Id], [o7].[BranchAddress_Country_Name], [o7].[BranchAddress_Country_PlanetId], [t7].[Id] AS [Id0], [t7].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o7]
+    INNER JOIN (
+        SELECT [o8].[Id], [t6].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o8]
+        INNER JOIN (
+            SELECT [o9].[Id], [o9].[Discriminator]
+            FROM [OwnedPerson] AS [o9]
+            WHERE [o9].[Discriminator] IN (N'Branch', N'LeafA')
+        ) AS [t6] ON [o8].[Id] = [t6].[Id]
+    ) AS [t7] ON [o7].[Id] = [t7].[Id]
+    WHERE [o7].[BranchAddress_Country_PlanetId] IS NOT NULL
+) AS [t8] ON [t5].[Id] = [t8].[Id]
+LEFT JOIN (
+    SELECT [o10].[Id], [t9].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o10]
+    INNER JOIN (
+        SELECT [o11].[Id], [o11].[Discriminator]
+        FROM [OwnedPerson] AS [o11]
+        WHERE [o11].[Discriminator] = N'LeafB'
+    ) AS [t9] ON [o10].[Id] = [t9].[Id]
+) AS [t10] ON [o].[Id] = [t10].[Id]
+LEFT JOIN (
+    SELECT [o12].[Id], [o12].[LeafBAddress_Country_Name], [o12].[LeafBAddress_Country_PlanetId], [t12].[Id] AS [Id0], [t12].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o12]
+    INNER JOIN (
+        SELECT [o13].[Id], [t11].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o13]
+        INNER JOIN (
+            SELECT [o14].[Id], [o14].[Discriminator]
+            FROM [OwnedPerson] AS [o14]
+            WHERE [o14].[Discriminator] = N'LeafB'
+        ) AS [t11] ON [o13].[Id] = [t11].[Id]
+    ) AS [t12] ON [o12].[Id] = [t12].[Id]
+    WHERE [o12].[LeafBAddress_Country_PlanetId] IS NOT NULL
+) AS [t13] ON [t10].[Id] = [t13].[Id]
+LEFT JOIN (
+    SELECT [o15].[Id], [t14].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o15]
+    INNER JOIN (
+        SELECT [o16].[Id], [o16].[Discriminator]
+        FROM [OwnedPerson] AS [o16]
+        WHERE [o16].[Discriminator] = N'LeafA'
+    ) AS [t14] ON [o15].[Id] = [t14].[Id]
+) AS [t15] ON [o].[Id] = [t15].[Id]
+LEFT JOIN (
+    SELECT [o17].[Id], [o17].[LeafAAddress_Country_Name], [o17].[LeafAAddress_Country_PlanetId], [t17].[Id] AS [Id0], [t17].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o17]
+    INNER JOIN (
+        SELECT [o18].[Id], [t16].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o18]
+        INNER JOIN (
+            SELECT [o19].[Id], [o19].[Discriminator]
+            FROM [OwnedPerson] AS [o19]
+            WHERE [o19].[Discriminator] = N'LeafA'
+        ) AS [t16] ON [o18].[Id] = [t16].[Id]
+    ) AS [t17] ON [o17].[Id] = [t17].[Id]
+    WHERE [o17].[LeafAAddress_Country_PlanetId] IS NOT NULL
+) AS [t18] ON [t15].[Id] = [t18].[Id]
+LEFT JOIN [Order] AS [o20] ON [o].[Id] = [o20].[ClientId]
+WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA') AND (([t3].[PersonAddress_Country_Name] = N'USA') AND [t3].[PersonAddress_Country_Name] IS NOT NULL)
+ORDER BY [o].[Id], [o20].[ClientId], [o20].[Id]");
         }
 
         public override void Navigation_rewrite_on_owned_collection()
@@ -303,18 +773,39 @@ WHERE [o0].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
 
             AssertSql(
                 @"SELECT (
-    SELECT TOP(1) [o].[PersonAddress_Country_Name]
-    FROM [Order] AS [o0]
+    SELECT TOP(1) [t1].[PersonAddress_Country_Name]
+    FROM [Order] AS [o2]
     LEFT JOIN (
-        SELECT [o1].[Id], [o1].[Discriminator]
-        FROM [OwnedPerson] AS [o1]
-        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-    ) AS [t] ON [o0].[ClientId] = [t].[Id]
-    LEFT JOIN [OwnedPerson] AS [o2] ON [t].[Id] = [o2].[Id]
-    LEFT JOIN [OwnedPerson] AS [o] ON [o2].[Id] = [o].[Id]
-    WHERE [o3].[Id] = [o0].[ClientId])
-FROM [OwnedPerson] AS [o3]
-WHERE [o3].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
+        SELECT [o3].[Id], [o3].[Discriminator]
+        FROM [OwnedPerson] AS [o3]
+        WHERE [o3].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+    ) AS [t2] ON [o2].[ClientId] = [t2].[Id]
+    LEFT JOIN (
+        SELECT [o4].[Id], [t3].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o4]
+        INNER JOIN (
+            SELECT [o5].[Id], [o5].[Discriminator]
+            FROM [OwnedPerson] AS [o5]
+            WHERE [o5].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+        ) AS [t3] ON [o4].[Id] = [t3].[Id]
+    ) AS [t4] ON [t2].[Id] = [t4].[Id]
+    LEFT JOIN (
+        SELECT [o].[Id], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [t0].[Id] AS [Id0], [t0].[Id0] AS [Id00]
+        FROM [OwnedPerson] AS [o]
+        INNER JOIN (
+            SELECT [o0].[Id], [t].[Id] AS [Id0]
+            FROM [OwnedPerson] AS [o0]
+            INNER JOIN (
+                SELECT [o1].[Id], [o1].[Discriminator]
+                FROM [OwnedPerson] AS [o1]
+                WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+            ) AS [t] ON [o0].[Id] = [t].[Id]
+        ) AS [t0] ON [o].[Id] = [t0].[Id]
+        WHERE [o].[PersonAddress_Country_PlanetId] IS NOT NULL
+    ) AS [t1] ON [t4].[Id] = [t1].[Id]
+    WHERE [o6].[Id] = [o2].[ClientId])
+FROM [OwnedPerson] AS [o6]
+WHERE [o6].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
         }
 
         public override void SelectMany_on_owned_collection()
@@ -333,11 +824,32 @@ WHERE [o0].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
             base.Navigation_rewrite_on_owned_reference_followed_by_regular_entity();
 
             AssertSql(
-                @"SELECT [p].[Id], [p].[StarId]
+               @"SELECT [p].[Id], [p].[StarId]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
-LEFT JOIN [OwnedPerson] AS [o1] ON [o0].[Id] = [o1].[Id]
-LEFT JOIN [Planet] AS [p] ON [o1].[PersonAddress_Country_PlanetId] = [p].[Id]
+LEFT JOIN (
+    SELECT [o0].[Id], [t].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o0]
+    INNER JOIN (
+        SELECT [o1].[Id], [o1].[Discriminator]
+        FROM [OwnedPerson] AS [o1]
+        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+    ) AS [t] ON [o0].[Id] = [t].[Id]
+) AS [t0] ON [o].[Id] = [t0].[Id]
+LEFT JOIN (
+    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o2]
+    INNER JOIN (
+        SELECT [o3].[Id], [t1].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o3]
+        INNER JOIN (
+            SELECT [o4].[Id], [o4].[Discriminator]
+            FROM [OwnedPerson] AS [o4]
+            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+        ) AS [t1] ON [o3].[Id] = [t1].[Id]
+    ) AS [t2] ON [o2].[Id] = [t2].[Id]
+    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t3] ON [t0].[Id] = [t3].[Id]
+LEFT JOIN [Planet] AS [p] ON [t3].[PersonAddress_Country_PlanetId] = [p].[Id]
 WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
         }
 
@@ -348,9 +860,30 @@ WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
             AssertSql(
                 @"SELECT [o].[Id], [o0].[ClientId], [o0].[Id]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN [OwnedPerson] AS [o1] ON [o].[Id] = [o1].[Id]
-LEFT JOIN [OwnedPerson] AS [o2] ON [o1].[Id] = [o2].[Id]
-LEFT JOIN [Planet] AS [p] ON [o2].[PersonAddress_Country_PlanetId] = [p].[Id]
+LEFT JOIN (
+    SELECT [o1].[Id], [t].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o1]
+    INNER JOIN (
+        SELECT [o2].[Id], [o2].[Discriminator]
+        FROM [OwnedPerson] AS [o2]
+        WHERE [o2].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+    ) AS [t] ON [o1].[Id] = [t].[Id]
+) AS [t0] ON [o].[Id] = [t0].[Id]
+LEFT JOIN (
+    SELECT [o3].[Id], [o3].[PersonAddress_Country_Name], [o3].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o3]
+    INNER JOIN (
+        SELECT [o4].[Id], [t1].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o4]
+        INNER JOIN (
+            SELECT [o5].[Id], [o5].[Discriminator]
+            FROM [OwnedPerson] AS [o5]
+            WHERE [o5].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+        ) AS [t1] ON [o4].[Id] = [t1].[Id]
+    ) AS [t2] ON [o3].[Id] = [t2].[Id]
+    WHERE [o3].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t3] ON [t0].[Id] = [t3].[Id]
+LEFT JOIN [Planet] AS [p] ON [t3].[PersonAddress_Country_PlanetId] = [p].[Id]
 LEFT JOIN [Order] AS [o0] ON [o].[Id] = [o0].[ClientId]
 WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA') AND (([p].[Id] <> 42) OR [p].[Id] IS NULL)
 ORDER BY [o].[Id], [o0].[ClientId], [o0].[Id]");
@@ -361,14 +894,35 @@ ORDER BY [o].[Id], [o0].[ClientId], [o0].[Id]");
             base.Project_multiple_owned_navigations();
 
             AssertSql(
-                @"SELECT [o].[Id], [o0].[Id], [o0].[PersonAddress_Country_Name], [o0].[PersonAddress_Country_PlanetId], [p].[Id], [p].[StarId], [o1].[Id], [o2].[ClientId], [o2].[Id]
-FROM [OwnedPerson] AS [o1]
-LEFT JOIN [OwnedPerson] AS [o] ON [o1].[Id] = [o].[Id]
-LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
-LEFT JOIN [Planet] AS [p] ON [o0].[PersonAddress_Country_PlanetId] = [p].[Id]
-LEFT JOIN [Order] AS [o2] ON [o1].[Id] = [o2].[ClientId]
-WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-ORDER BY [o1].[Id], [o2].[ClientId], [o2].[Id]");
+                @"SELECT [t0].[Id], [t3].[Id], [t3].[PersonAddress_Country_Name], [t3].[PersonAddress_Country_PlanetId], [p].[Id], [p].[StarId], [o4].[Id], [o5].[ClientId], [o5].[Id]
+FROM [OwnedPerson] AS [o4]
+LEFT JOIN (
+    SELECT [o].[Id], [t].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o]
+    INNER JOIN (
+        SELECT [o0].[Id], [o0].[Discriminator]
+        FROM [OwnedPerson] AS [o0]
+        WHERE [o0].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+    ) AS [t] ON [o].[Id] = [t].[Id]
+) AS [t0] ON [o4].[Id] = [t0].[Id]
+LEFT JOIN (
+    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o1]
+    INNER JOIN (
+        SELECT [o2].[Id], [t1].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o2]
+        INNER JOIN (
+            SELECT [o3].[Id], [o3].[Discriminator]
+            FROM [OwnedPerson] AS [o3]
+            WHERE [o3].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+        ) AS [t1] ON [o2].[Id] = [t1].[Id]
+    ) AS [t2] ON [o1].[Id] = [t2].[Id]
+    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t3] ON [t0].[Id] = [t3].[Id]
+LEFT JOIN [Planet] AS [p] ON [t3].[PersonAddress_Country_PlanetId] = [p].[Id]
+LEFT JOIN [Order] AS [o5] ON [o4].[Id] = [o5].[ClientId]
+WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+ORDER BY [o4].[Id], [o5].[ClientId], [o5].[Id]");
         }
 
         public override void Project_multiple_owned_navigations_with_expansion_on_owned_collections()
@@ -384,16 +938,58 @@ ORDER BY [o1].[Id], [o2].[ClientId], [o2].[Id]");
         FROM [OwnedPerson] AS [o0]
         WHERE [o0].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
     ) AS [t] ON [o].[ClientId] = [t].[Id]
-    LEFT JOIN [OwnedPerson] AS [o1] ON [t].[Id] = [o1].[Id]
-    LEFT JOIN [OwnedPerson] AS [o2] ON [o1].[Id] = [o2].[Id]
-    LEFT JOIN [Planet] AS [p] ON [o2].[PersonAddress_Country_PlanetId] = [p].[Id]
+    LEFT JOIN (
+        SELECT [o1].[Id], [t0].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o1]
+        INNER JOIN (
+            SELECT [o2].[Id], [o2].[Discriminator]
+            FROM [OwnedPerson] AS [o2]
+            WHERE [o2].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+        ) AS [t0] ON [o1].[Id] = [t0].[Id]
+    ) AS [t1] ON [t].[Id] = [t1].[Id]
+    LEFT JOIN (
+        SELECT [o3].[Id], [o3].[PersonAddress_Country_Name], [o3].[PersonAddress_Country_PlanetId], [t3].[Id] AS [Id0], [t3].[Id0] AS [Id00]
+        FROM [OwnedPerson] AS [o3]
+        INNER JOIN (
+            SELECT [o4].[Id], [t2].[Id] AS [Id0]
+            FROM [OwnedPerson] AS [o4]
+            INNER JOIN (
+                SELECT [o5].[Id], [o5].[Discriminator]
+                FROM [OwnedPerson] AS [o5]
+                WHERE [o5].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+            ) AS [t2] ON [o4].[Id] = [t2].[Id]
+        ) AS [t3] ON [o3].[Id] = [t3].[Id]
+        WHERE [o3].[PersonAddress_Country_PlanetId] IS NOT NULL
+    ) AS [t4] ON [t1].[Id] = [t4].[Id]
+    LEFT JOIN [Planet] AS [p] ON [t4].[PersonAddress_Country_PlanetId] = [p].[Id]
     LEFT JOIN [Star] AS [s] ON [p].[StarId] = [s].[Id]
-    WHERE ([o3].[Id] = [o].[ClientId]) AND (([s].[Id] <> 42) OR [s].[Id] IS NULL)) AS [Count], [p0].[Id], [p0].[StarId]
-FROM [OwnedPerson] AS [o3]
-LEFT JOIN [OwnedPerson] AS [o4] ON [o3].[Id] = [o4].[Id]
-LEFT JOIN [OwnedPerson] AS [o5] ON [o4].[Id] = [o5].[Id]
-LEFT JOIN [Planet] AS [p0] ON [o5].[PersonAddress_Country_PlanetId] = [p0].[Id]
-WHERE [o3].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
+    WHERE ([o6].[Id] = [o].[ClientId]) AND (([s].[Id] <> 42) OR [s].[Id] IS NULL)) AS [Count], [p0].[Id], [p0].[StarId]
+FROM [OwnedPerson] AS [o6]
+LEFT JOIN (
+    SELECT [o7].[Id], [t5].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o7]
+    INNER JOIN (
+        SELECT [o8].[Id], [o8].[Discriminator]
+        FROM [OwnedPerson] AS [o8]
+        WHERE [o8].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+    ) AS [t5] ON [o7].[Id] = [t5].[Id]
+) AS [t6] ON [o6].[Id] = [t6].[Id]
+LEFT JOIN (
+    SELECT [o9].[Id], [o9].[PersonAddress_Country_Name], [o9].[PersonAddress_Country_PlanetId], [t8].[Id] AS [Id0], [t8].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o9]
+    INNER JOIN (
+        SELECT [o10].[Id], [t7].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o10]
+        INNER JOIN (
+            SELECT [o11].[Id], [o11].[Discriminator]
+            FROM [OwnedPerson] AS [o11]
+            WHERE [o11].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+        ) AS [t7] ON [o10].[Id] = [t7].[Id]
+    ) AS [t8] ON [o9].[Id] = [t8].[Id]
+    WHERE [o9].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t9] ON [t6].[Id] = [t9].[Id]
+LEFT JOIN [Planet] AS [p0] ON [t9].[PersonAddress_Country_PlanetId] = [p0].[Id]
+WHERE [o6].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
         }
 
         public override void Navigation_rewrite_on_owned_reference_followed_by_regular_entity_filter()
@@ -401,20 +997,104 @@ WHERE [o3].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
             base.Navigation_rewrite_on_owned_reference_followed_by_regular_entity_filter();
 
             AssertSql(
-                @"SELECT [o].[Id], [o].[Discriminator], [o0].[Id], [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId], [o2].[Id], [o3].[Id], [o3].[BranchAddress_Country_Name], [o3].[BranchAddress_Country_PlanetId], [o4].[Id], [o5].[Id], [o5].[LeafBAddress_Country_Name], [o5].[LeafBAddress_Country_PlanetId], [o6].[Id], [o7].[Id], [o7].[LeafAAddress_Country_Name], [o7].[LeafAAddress_Country_PlanetId], [o8].[ClientId], [o8].[Id]
+                @"SELECT [o].[Id], [o].[Discriminator], [t0].[Id], [t3].[Id], [t3].[PersonAddress_Country_Name], [t3].[PersonAddress_Country_PlanetId], [t5].[Id], [t8].[Id], [t8].[BranchAddress_Country_Name], [t8].[BranchAddress_Country_PlanetId], [t10].[Id], [t13].[Id], [t13].[LeafBAddress_Country_Name], [t13].[LeafBAddress_Country_PlanetId], [t15].[Id], [t18].[Id], [t18].[LeafAAddress_Country_Name], [t18].[LeafAAddress_Country_PlanetId], [o20].[ClientId], [o20].[Id]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
-LEFT JOIN [OwnedPerson] AS [o1] ON [o0].[Id] = [o1].[Id]
-LEFT JOIN [Planet] AS [p] ON [o1].[PersonAddress_Country_PlanetId] = [p].[Id]
-LEFT JOIN [OwnedPerson] AS [o2] ON [o].[Id] = [o2].[Id]
-LEFT JOIN [OwnedPerson] AS [o3] ON [o2].[Id] = [o3].[Id]
-LEFT JOIN [OwnedPerson] AS [o4] ON [o].[Id] = [o4].[Id]
-LEFT JOIN [OwnedPerson] AS [o5] ON [o4].[Id] = [o5].[Id]
-LEFT JOIN [OwnedPerson] AS [o6] ON [o].[Id] = [o6].[Id]
-LEFT JOIN [OwnedPerson] AS [o7] ON [o6].[Id] = [o7].[Id]
-LEFT JOIN [Order] AS [o8] ON [o].[Id] = [o8].[ClientId]
+LEFT JOIN (
+    SELECT [o0].[Id], [t].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o0]
+    INNER JOIN (
+        SELECT [o1].[Id], [o1].[Discriminator]
+        FROM [OwnedPerson] AS [o1]
+        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+    ) AS [t] ON [o0].[Id] = [t].[Id]
+) AS [t0] ON [o].[Id] = [t0].[Id]
+LEFT JOIN (
+    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o2]
+    INNER JOIN (
+        SELECT [o3].[Id], [t1].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o3]
+        INNER JOIN (
+            SELECT [o4].[Id], [o4].[Discriminator]
+            FROM [OwnedPerson] AS [o4]
+            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+        ) AS [t1] ON [o3].[Id] = [t1].[Id]
+    ) AS [t2] ON [o2].[Id] = [t2].[Id]
+    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t3] ON [t0].[Id] = [t3].[Id]
+LEFT JOIN [Planet] AS [p] ON [t3].[PersonAddress_Country_PlanetId] = [p].[Id]
+LEFT JOIN (
+    SELECT [o5].[Id], [t4].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o5]
+    INNER JOIN (
+        SELECT [o6].[Id], [o6].[Discriminator]
+        FROM [OwnedPerson] AS [o6]
+        WHERE [o6].[Discriminator] IN (N'Branch', N'LeafA')
+    ) AS [t4] ON [o5].[Id] = [t4].[Id]
+) AS [t5] ON [o].[Id] = [t5].[Id]
+LEFT JOIN (
+    SELECT [o7].[Id], [o7].[BranchAddress_Country_Name], [o7].[BranchAddress_Country_PlanetId], [t7].[Id] AS [Id0], [t7].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o7]
+    INNER JOIN (
+        SELECT [o8].[Id], [t6].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o8]
+        INNER JOIN (
+            SELECT [o9].[Id], [o9].[Discriminator]
+            FROM [OwnedPerson] AS [o9]
+            WHERE [o9].[Discriminator] IN (N'Branch', N'LeafA')
+        ) AS [t6] ON [o8].[Id] = [t6].[Id]
+    ) AS [t7] ON [o7].[Id] = [t7].[Id]
+    WHERE [o7].[BranchAddress_Country_PlanetId] IS NOT NULL
+) AS [t8] ON [t5].[Id] = [t8].[Id]
+LEFT JOIN (
+    SELECT [o10].[Id], [t9].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o10]
+    INNER JOIN (
+        SELECT [o11].[Id], [o11].[Discriminator]
+        FROM [OwnedPerson] AS [o11]
+        WHERE [o11].[Discriminator] = N'LeafB'
+    ) AS [t9] ON [o10].[Id] = [t9].[Id]
+) AS [t10] ON [o].[Id] = [t10].[Id]
+LEFT JOIN (
+    SELECT [o12].[Id], [o12].[LeafBAddress_Country_Name], [o12].[LeafBAddress_Country_PlanetId], [t12].[Id] AS [Id0], [t12].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o12]
+    INNER JOIN (
+        SELECT [o13].[Id], [t11].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o13]
+        INNER JOIN (
+            SELECT [o14].[Id], [o14].[Discriminator]
+            FROM [OwnedPerson] AS [o14]
+            WHERE [o14].[Discriminator] = N'LeafB'
+        ) AS [t11] ON [o13].[Id] = [t11].[Id]
+    ) AS [t12] ON [o12].[Id] = [t12].[Id]
+    WHERE [o12].[LeafBAddress_Country_PlanetId] IS NOT NULL
+) AS [t13] ON [t10].[Id] = [t13].[Id]
+LEFT JOIN (
+    SELECT [o15].[Id], [t14].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o15]
+    INNER JOIN (
+        SELECT [o16].[Id], [o16].[Discriminator]
+        FROM [OwnedPerson] AS [o16]
+        WHERE [o16].[Discriminator] = N'LeafA'
+    ) AS [t14] ON [o15].[Id] = [t14].[Id]
+) AS [t15] ON [o].[Id] = [t15].[Id]
+LEFT JOIN (
+    SELECT [o17].[Id], [o17].[LeafAAddress_Country_Name], [o17].[LeafAAddress_Country_PlanetId], [t17].[Id] AS [Id0], [t17].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o17]
+    INNER JOIN (
+        SELECT [o18].[Id], [t16].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o18]
+        INNER JOIN (
+            SELECT [o19].[Id], [o19].[Discriminator]
+            FROM [OwnedPerson] AS [o19]
+            WHERE [o19].[Discriminator] = N'LeafA'
+        ) AS [t16] ON [o18].[Id] = [t16].[Id]
+    ) AS [t17] ON [o17].[Id] = [t17].[Id]
+    WHERE [o17].[LeafAAddress_Country_PlanetId] IS NOT NULL
+) AS [t18] ON [t15].[Id] = [t18].[Id]
+LEFT JOIN [Order] AS [o20] ON [o].[Id] = [o20].[ClientId]
 WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA') AND (([p].[Id] <> 7) OR [p].[Id] IS NULL)
-ORDER BY [o].[Id], [o8].[ClientId], [o8].[Id]");
+ORDER BY [o].[Id], [o20].[ClientId], [o20].[Id]");
         }
 
         public override void Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_property()
@@ -424,9 +1104,30 @@ ORDER BY [o].[Id], [o8].[ClientId], [o8].[Id]");
             AssertSql(
                 @"SELECT [p].[Id]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
-LEFT JOIN [OwnedPerson] AS [o1] ON [o0].[Id] = [o1].[Id]
-LEFT JOIN [Planet] AS [p] ON [o1].[PersonAddress_Country_PlanetId] = [p].[Id]
+LEFT JOIN (
+    SELECT [o0].[Id], [t].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o0]
+    INNER JOIN (
+        SELECT [o1].[Id], [o1].[Discriminator]
+        FROM [OwnedPerson] AS [o1]
+        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+    ) AS [t] ON [o0].[Id] = [t].[Id]
+) AS [t0] ON [o].[Id] = [t0].[Id]
+LEFT JOIN (
+    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o2]
+    INNER JOIN (
+        SELECT [o3].[Id], [t1].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o3]
+        INNER JOIN (
+            SELECT [o4].[Id], [o4].[Discriminator]
+            FROM [OwnedPerson] AS [o4]
+            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+        ) AS [t1] ON [o3].[Id] = [t1].[Id]
+    ) AS [t2] ON [o2].[Id] = [t2].[Id]
+    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t3] ON [t0].[Id] = [t3].[Id]
+LEFT JOIN [Planet] AS [p] ON [t3].[PersonAddress_Country_PlanetId] = [p].[Id]
 WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
         }
 
@@ -437,9 +1138,30 @@ WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
             AssertSql(
                 @"SELECT [o].[Id], [m].[Id], [m].[Diameter], [m].[PlanetId]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
-LEFT JOIN [OwnedPerson] AS [o1] ON [o0].[Id] = [o1].[Id]
-LEFT JOIN [Planet] AS [p] ON [o1].[PersonAddress_Country_PlanetId] = [p].[Id]
+LEFT JOIN (
+    SELECT [o0].[Id], [t].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o0]
+    INNER JOIN (
+        SELECT [o1].[Id], [o1].[Discriminator]
+        FROM [OwnedPerson] AS [o1]
+        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+    ) AS [t] ON [o0].[Id] = [t].[Id]
+) AS [t0] ON [o].[Id] = [t0].[Id]
+LEFT JOIN (
+    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o2]
+    INNER JOIN (
+        SELECT [o3].[Id], [t1].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o3]
+        INNER JOIN (
+            SELECT [o4].[Id], [o4].[Discriminator]
+            FROM [OwnedPerson] AS [o4]
+            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+        ) AS [t1] ON [o3].[Id] = [t1].[Id]
+    ) AS [t2] ON [o2].[Id] = [t2].[Id]
+    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t3] ON [t0].[Id] = [t3].[Id]
+LEFT JOIN [Planet] AS [p] ON [t3].[PersonAddress_Country_PlanetId] = [p].[Id]
 LEFT JOIN [Moon] AS [m] ON [p].[Id] = [m].[PlanetId]
 WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
 ORDER BY [o].[Id], [m].[Id]");
@@ -452,9 +1174,30 @@ ORDER BY [o].[Id], [m].[Id]");
             AssertSql(
                 @"SELECT [m].[Id], [m].[Diameter], [m].[PlanetId]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
-LEFT JOIN [OwnedPerson] AS [o1] ON [o0].[Id] = [o1].[Id]
-LEFT JOIN [Planet] AS [p] ON [o1].[PersonAddress_Country_PlanetId] = [p].[Id]
+LEFT JOIN (
+    SELECT [o0].[Id], [t].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o0]
+    INNER JOIN (
+        SELECT [o1].[Id], [o1].[Discriminator]
+        FROM [OwnedPerson] AS [o1]
+        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+    ) AS [t] ON [o0].[Id] = [t].[Id]
+) AS [t0] ON [o].[Id] = [t0].[Id]
+LEFT JOIN (
+    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o2]
+    INNER JOIN (
+        SELECT [o3].[Id], [t1].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o3]
+        INNER JOIN (
+            SELECT [o4].[Id], [o4].[Discriminator]
+            FROM [OwnedPerson] AS [o4]
+            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+        ) AS [t1] ON [o3].[Id] = [t1].[Id]
+    ) AS [t2] ON [o2].[Id] = [t2].[Id]
+    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t3] ON [t0].[Id] = [t3].[Id]
+LEFT JOIN [Planet] AS [p] ON [t3].[PersonAddress_Country_PlanetId] = [p].[Id]
 INNER JOIN [Moon] AS [m] ON [p].[Id] = [m].[PlanetId]
 WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
         }
@@ -466,9 +1209,30 @@ WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
             AssertSql(
                 @"SELECT [e].[Id], [e].[Name], [e].[StarId]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
-LEFT JOIN [OwnedPerson] AS [o1] ON [o0].[Id] = [o1].[Id]
-LEFT JOIN [Planet] AS [p] ON [o1].[PersonAddress_Country_PlanetId] = [p].[Id]
+LEFT JOIN (
+    SELECT [o0].[Id], [t].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o0]
+    INNER JOIN (
+        SELECT [o1].[Id], [o1].[Discriminator]
+        FROM [OwnedPerson] AS [o1]
+        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+    ) AS [t] ON [o0].[Id] = [t].[Id]
+) AS [t0] ON [o].[Id] = [t0].[Id]
+LEFT JOIN (
+    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o2]
+    INNER JOIN (
+        SELECT [o3].[Id], [t1].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o3]
+        INNER JOIN (
+            SELECT [o4].[Id], [o4].[Discriminator]
+            FROM [OwnedPerson] AS [o4]
+            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+        ) AS [t1] ON [o3].[Id] = [t1].[Id]
+    ) AS [t2] ON [o2].[Id] = [t2].[Id]
+    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t3] ON [t0].[Id] = [t3].[Id]
+LEFT JOIN [Planet] AS [p] ON [t3].[PersonAddress_Country_PlanetId] = [p].[Id]
 LEFT JOIN [Star] AS [s] ON [p].[StarId] = [s].[Id]
 INNER JOIN [Element] AS [e] ON [s].[Id] = [e].[StarId]
 WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
@@ -481,9 +1245,30 @@ WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
             AssertSql(
                 @"SELECT [s].[Id], [s].[Name], [o].[Id], [e].[Id], [e].[Name], [e].[StarId]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
-LEFT JOIN [OwnedPerson] AS [o1] ON [o0].[Id] = [o1].[Id]
-LEFT JOIN [Planet] AS [p] ON [o1].[PersonAddress_Country_PlanetId] = [p].[Id]
+LEFT JOIN (
+    SELECT [o0].[Id], [t].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o0]
+    INNER JOIN (
+        SELECT [o1].[Id], [o1].[Discriminator]
+        FROM [OwnedPerson] AS [o1]
+        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+    ) AS [t] ON [o0].[Id] = [t].[Id]
+) AS [t0] ON [o].[Id] = [t0].[Id]
+LEFT JOIN (
+    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o2]
+    INNER JOIN (
+        SELECT [o3].[Id], [t1].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o3]
+        INNER JOIN (
+            SELECT [o4].[Id], [o4].[Discriminator]
+            FROM [OwnedPerson] AS [o4]
+            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+        ) AS [t1] ON [o3].[Id] = [t1].[Id]
+    ) AS [t2] ON [o2].[Id] = [t2].[Id]
+    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t3] ON [t0].[Id] = [t3].[Id]
+LEFT JOIN [Planet] AS [p] ON [t3].[PersonAddress_Country_PlanetId] = [p].[Id]
 LEFT JOIN [Star] AS [s] ON [p].[StarId] = [s].[Id]
 LEFT JOIN [Element] AS [e] ON [s].[Id] = [e].[StarId]
 WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
@@ -497,9 +1282,30 @@ ORDER BY [o].[Id], [e].[Id]");
             AssertSql(
                 @"SELECT [s].[Name]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
-LEFT JOIN [OwnedPerson] AS [o1] ON [o0].[Id] = [o1].[Id]
-LEFT JOIN [Planet] AS [p] ON [o1].[PersonAddress_Country_PlanetId] = [p].[Id]
+LEFT JOIN (
+    SELECT [o0].[Id], [t].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o0]
+    INNER JOIN (
+        SELECT [o1].[Id], [o1].[Discriminator]
+        FROM [OwnedPerson] AS [o1]
+        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+    ) AS [t] ON [o0].[Id] = [t].[Id]
+) AS [t0] ON [o].[Id] = [t0].[Id]
+LEFT JOIN (
+    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o2]
+    INNER JOIN (
+        SELECT [o3].[Id], [t1].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o3]
+        INNER JOIN (
+            SELECT [o4].[Id], [o4].[Discriminator]
+            FROM [OwnedPerson] AS [o4]
+            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+        ) AS [t1] ON [o3].[Id] = [t1].[Id]
+    ) AS [t2] ON [o2].[Id] = [t2].[Id]
+    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t3] ON [t0].[Id] = [t3].[Id]
+LEFT JOIN [Planet] AS [p] ON [t3].[PersonAddress_Country_PlanetId] = [p].[Id]
 LEFT JOIN [Star] AS [s] ON [p].[StarId] = [s].[Id]
 WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
         }
@@ -512,14 +1318,34 @@ WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
             AssertSql(
                 @"SELECT [s].[Id], [s].[Name], [o].[Id], [e].[Id], [e].[Name], [e].[StarId]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
-LEFT JOIN [OwnedPerson] AS [o1] ON [o0].[Id] = [o1].[Id]
-LEFT JOIN [Planet] AS [p] ON [o1].[PersonAddress_Country_PlanetId] = [p].[Id]
+LEFT JOIN (
+    SELECT [o0].[Id], [t].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o0]
+    INNER JOIN (
+        SELECT [o1].[Id], [o1].[Discriminator]
+        FROM [OwnedPerson] AS [o1]
+        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+    ) AS [t] ON [o0].[Id] = [t].[Id]
+) AS [t0] ON [o].[Id] = [t0].[Id]
+LEFT JOIN (
+    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o2]
+    INNER JOIN (
+        SELECT [o3].[Id], [t1].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o3]
+        INNER JOIN (
+            SELECT [o4].[Id], [o4].[Discriminator]
+            FROM [OwnedPerson] AS [o4]
+            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+        ) AS [t1] ON [o3].[Id] = [t1].[Id]
+    ) AS [t2] ON [o2].[Id] = [t2].[Id]
+    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t3] ON [t0].[Id] = [t3].[Id]
+LEFT JOIN [Planet] AS [p] ON [t3].[PersonAddress_Country_PlanetId] = [p].[Id]
 LEFT JOIN [Star] AS [s] ON [p].[StarId] = [s].[Id]
 LEFT JOIN [Element] AS [e] ON [s].[Id] = [e].[StarId]
 WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA') AND (([s].[Name] = N'Sol') AND [s].[Name] IS NOT NULL)
 ORDER BY [o].[Id], [e].[Id]");
-
         }
 
         public override void Query_with_OfType_eagerly_loads_correct_owned_navigations()
@@ -527,17 +1353,80 @@ ORDER BY [o].[Id], [e].[Id]");
             base.Query_with_OfType_eagerly_loads_correct_owned_navigations();
 
             AssertSql(
-                @"SELECT [o].[Id], [o].[Discriminator], [o0].[Id], [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId], [o2].[Id], [o3].[Id], [o3].[BranchAddress_Country_Name], [o3].[BranchAddress_Country_PlanetId], [o4].[Id], [o5].[Id], [o5].[LeafAAddress_Country_Name], [o5].[LeafAAddress_Country_PlanetId], [o6].[ClientId], [o6].[Id]
+                @"SELECT [o].[Id], [o].[Discriminator], [t0].[Id], [t3].[Id], [t3].[PersonAddress_Country_Name], [t3].[PersonAddress_Country_PlanetId], [t5].[Id], [t8].[Id], [t8].[BranchAddress_Country_Name], [t8].[BranchAddress_Country_PlanetId], [t10].[Id], [t13].[Id], [t13].[LeafAAddress_Country_Name], [t13].[LeafAAddress_Country_PlanetId], [o15].[ClientId], [o15].[Id]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
-LEFT JOIN [OwnedPerson] AS [o1] ON [o0].[Id] = [o1].[Id]
-LEFT JOIN [OwnedPerson] AS [o2] ON [o].[Id] = [o2].[Id]
-LEFT JOIN [OwnedPerson] AS [o3] ON [o2].[Id] = [o3].[Id]
-LEFT JOIN [OwnedPerson] AS [o4] ON [o].[Id] = [o4].[Id]
-LEFT JOIN [OwnedPerson] AS [o5] ON [o4].[Id] = [o5].[Id]
-LEFT JOIN [Order] AS [o6] ON [o].[Id] = [o6].[ClientId]
+LEFT JOIN (
+    SELECT [o0].[Id], [t].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o0]
+    INNER JOIN (
+        SELECT [o1].[Id], [o1].[Discriminator]
+        FROM [OwnedPerson] AS [o1]
+        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+    ) AS [t] ON [o0].[Id] = [t].[Id]
+) AS [t0] ON [o].[Id] = [t0].[Id]
+LEFT JOIN (
+    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o2]
+    INNER JOIN (
+        SELECT [o3].[Id], [t1].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o3]
+        INNER JOIN (
+            SELECT [o4].[Id], [o4].[Discriminator]
+            FROM [OwnedPerson] AS [o4]
+            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+        ) AS [t1] ON [o3].[Id] = [t1].[Id]
+    ) AS [t2] ON [o2].[Id] = [t2].[Id]
+    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t3] ON [t0].[Id] = [t3].[Id]
+LEFT JOIN (
+    SELECT [o5].[Id], [t4].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o5]
+    INNER JOIN (
+        SELECT [o6].[Id], [o6].[Discriminator]
+        FROM [OwnedPerson] AS [o6]
+        WHERE [o6].[Discriminator] IN (N'Branch', N'LeafA')
+    ) AS [t4] ON [o5].[Id] = [t4].[Id]
+) AS [t5] ON [o].[Id] = [t5].[Id]
+LEFT JOIN (
+    SELECT [o7].[Id], [o7].[BranchAddress_Country_Name], [o7].[BranchAddress_Country_PlanetId], [t7].[Id] AS [Id0], [t7].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o7]
+    INNER JOIN (
+        SELECT [o8].[Id], [t6].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o8]
+        INNER JOIN (
+            SELECT [o9].[Id], [o9].[Discriminator]
+            FROM [OwnedPerson] AS [o9]
+            WHERE [o9].[Discriminator] IN (N'Branch', N'LeafA')
+        ) AS [t6] ON [o8].[Id] = [t6].[Id]
+    ) AS [t7] ON [o7].[Id] = [t7].[Id]
+    WHERE [o7].[BranchAddress_Country_PlanetId] IS NOT NULL
+) AS [t8] ON [t5].[Id] = [t8].[Id]
+LEFT JOIN (
+    SELECT [o10].[Id], [t9].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o10]
+    INNER JOIN (
+        SELECT [o11].[Id], [o11].[Discriminator]
+        FROM [OwnedPerson] AS [o11]
+        WHERE [o11].[Discriminator] = N'LeafA'
+    ) AS [t9] ON [o10].[Id] = [t9].[Id]
+) AS [t10] ON [o].[Id] = [t10].[Id]
+LEFT JOIN (
+    SELECT [o12].[Id], [o12].[LeafAAddress_Country_Name], [o12].[LeafAAddress_Country_PlanetId], [t12].[Id] AS [Id0], [t12].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o12]
+    INNER JOIN (
+        SELECT [o13].[Id], [t11].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o13]
+        INNER JOIN (
+            SELECT [o14].[Id], [o14].[Discriminator]
+            FROM [OwnedPerson] AS [o14]
+            WHERE [o14].[Discriminator] = N'LeafA'
+        ) AS [t11] ON [o13].[Id] = [t11].[Id]
+    ) AS [t12] ON [o12].[Id] = [t12].[Id]
+    WHERE [o12].[LeafAAddress_Country_PlanetId] IS NOT NULL
+) AS [t13] ON [t10].[Id] = [t13].[Id]
+LEFT JOIN [Order] AS [o15] ON [o].[Id] = [o15].[ClientId]
 WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA') AND ([o].[Discriminator] = N'LeafA')
-ORDER BY [o].[Id], [o6].[ClientId], [o6].[Id]");
+ORDER BY [o].[Id], [o15].[ClientId], [o15].[Id]");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -2644,15 +2644,25 @@ WHERE [e].[Id] IN (
                     Assert.True(result[0].Cast.All(a => a.Details != null));
 
                     AssertSql(
-                        @"SELECT [m].[Id], [m].[Title], [m0].[Id], [m0].[Details_Info], [t].[Id], [t].[Movie9202Id], [t].[Name], [t].[Id0], [t].[Details_Info]
+                @"SELECT [m].[Id], [m].[Title], [t].[Id], [t].[Details_Info], [t1].[Id], [t1].[Movie9202Id], [t1].[Name], [t1].[Id0], [t1].[Details_Info]
 FROM [Movies] AS [m]
-LEFT JOIN [Movies] AS [m0] ON [m].[Id] = [m0].[Id]
 LEFT JOIN (
-    SELECT [a].[Id], [a].[Movie9202Id], [a].[Name], [a0].[Id] AS [Id0], [a0].[Details_Info]
+    SELECT [m0].[Id], [m0].[Details_Info], [m1].[Id] AS [Id0]
+    FROM [Movies] AS [m0]
+    INNER JOIN [Movies] AS [m1] ON [m0].[Id] = [m1].[Id]
+    WHERE [m0].[Details_Info] IS NOT NULL
+) AS [t] ON [m].[Id] = [t].[Id]
+LEFT JOIN (
+    SELECT [a].[Id], [a].[Movie9202Id], [a].[Name], [t0].[Id] AS [Id0], [t0].[Details_Info]
     FROM [Actors] AS [a]
-    LEFT JOIN [Actors] AS [a0] ON [a].[Id] = [a0].[Id]
-) AS [t] ON [m].[Id] = [t].[Movie9202Id]
-ORDER BY [m].[Id], [t].[Id]");
+    LEFT JOIN (
+        SELECT [a0].[Id], [a0].[Details_Info], [a1].[Id] AS [Id0]
+        FROM [Actors] AS [a0]
+        INNER JOIN [Actors] AS [a1] ON [a0].[Id] = [a1].[Id]
+        WHERE [a0].[Details_Info] IS NOT NULL
+    ) AS [t0] ON [a].[Id] = [t0].[Id]
+) AS [t1] ON [m].[Id] = [t1].[Movie9202Id]
+ORDER BY [m].[Id], [t1].[Id]");
                 }
             }
         }
@@ -2673,15 +2683,25 @@ ORDER BY [m].[Id], [t].[Id]");
                     Assert.True(result[0].Cast.All(a => a.Details != null));
 
                     AssertSql(
-                        @"SELECT [m].[Id], [m].[Title], [m0].[Id], [m0].[Details_Info], [t].[Id], [t].[Movie9202Id], [t].[Name], [t].[Id0], [t].[Details_Info]
+                @"SELECT [m].[Id], [m].[Title], [t].[Id], [t].[Details_Info], [t1].[Id], [t1].[Movie9202Id], [t1].[Name], [t1].[Id0], [t1].[Details_Info]
 FROM [Movies] AS [m]
-LEFT JOIN [Movies] AS [m0] ON [m].[Id] = [m0].[Id]
 LEFT JOIN (
-    SELECT [a].[Id], [a].[Movie9202Id], [a].[Name], [a0].[Id] AS [Id0], [a0].[Details_Info]
+    SELECT [m0].[Id], [m0].[Details_Info], [m1].[Id] AS [Id0]
+    FROM [Movies] AS [m0]
+    INNER JOIN [Movies] AS [m1] ON [m0].[Id] = [m1].[Id]
+    WHERE [m0].[Details_Info] IS NOT NULL
+) AS [t] ON [m].[Id] = [t].[Id]
+LEFT JOIN (
+    SELECT [a].[Id], [a].[Movie9202Id], [a].[Name], [t0].[Id] AS [Id0], [t0].[Details_Info]
     FROM [Actors] AS [a]
-    LEFT JOIN [Actors] AS [a0] ON [a].[Id] = [a0].[Id]
-) AS [t] ON [m].[Id] = [t].[Movie9202Id]
-ORDER BY [m].[Id], [t].[Id]");
+    LEFT JOIN (
+        SELECT [a0].[Id], [a0].[Details_Info], [a1].[Id] AS [Id0]
+        FROM [Actors] AS [a0]
+        INNER JOIN [Actors] AS [a1] ON [a0].[Id] = [a1].[Id]
+        WHERE [a0].[Details_Info] IS NOT NULL
+    ) AS [t0] ON [a].[Id] = [t0].[Id]
+) AS [t1] ON [m].[Id] = [t1].[Movie9202Id]
+ORDER BY [m].[Id], [t1].[Id]");
                 }
             }
         }
@@ -3921,10 +3941,15 @@ WHERE [b].[IsTwo] IN (CAST(0 AS bit), CAST(1 AS bit))");
                         .ToList();
 
                     AssertSql(
-                        @"SELECT [t].[Name] AS [Key], COUNT(*) + 5 AS [cnt]
-FROM [Table] AS [t0]
-LEFT JOIN [Table] AS [t] ON [t0].[Id] = [t].[Id]
-GROUP BY [t].[Name]");
+                @"SELECT [t1].[Name] AS [Key], COUNT(*) + 5 AS [cnt]
+FROM [Table] AS [t2]
+LEFT JOIN (
+    SELECT [t].[Id], [t].[Name], [t0].[Id] AS [Id0]
+    FROM [Table] AS [t]
+    INNER JOIN [Table] AS [t0] ON [t].[Id] = [t0].[Id]
+    WHERE [t].[Name] IS NOT NULL
+) AS [t1] ON [t2].[Id] = [t1].[Id]
+GROUP BY [t1].[Name]");
                 }
             }
         }
@@ -3963,11 +3988,21 @@ GROUP BY [t].[Name]");
                         .ToList();
 
                     AssertSql(
-                        @"SELECT [t].[Name] AS [MyKey], COUNT(*) + 5 AS [cnt]
-FROM [Table] AS [t0]
-LEFT JOIN [Table] AS [t] ON [t0].[Id] = [t].[Id]
-LEFT JOIN [Table] AS [t1] ON [t0].[Id] = [t1].[Id]
-GROUP BY [t].[Name], [t1].[MaumarEntity11818_Name]");
+                @"SELECT [t1].[Name] AS [MyKey], COUNT(*) + 5 AS [cnt]
+FROM [Table] AS [t2]
+LEFT JOIN (
+    SELECT [t].[Id], [t].[Name], [t0].[Id] AS [Id0]
+    FROM [Table] AS [t]
+    INNER JOIN [Table] AS [t0] ON [t].[Id] = [t0].[Id]
+    WHERE [t].[Name] IS NOT NULL
+) AS [t1] ON [t2].[Id] = [t1].[Id]
+LEFT JOIN (
+    SELECT [t3].[Id], [t3].[MaumarEntity11818_Name], [t4].[Id] AS [Id0]
+    FROM [Table] AS [t3]
+    INNER JOIN [Table] AS [t4] ON [t3].[Id] = [t4].[Id]
+    WHERE [t3].[MaumarEntity11818_Name] IS NOT NULL
+) AS [t5] ON [t2].[Id] = [t5].[Id]
+GROUP BY [t1].[Name], [t5].[MaumarEntity11818_Name]");
                 }
             }
         }
@@ -5198,17 +5233,22 @@ END IN ('0a47bcb7-a1cb-4345-8944-c58f82d6aac7', '5f221fb9-66f4-442a-92c9-d97ed59
                     Assert.Equal(10, partners[0].Addresses[0].Turnovers.AmountIn);
 
                     AssertSql(
-                        @"SELECT [p].[Id], [t].[c], [t].[Turnovers_AmountIn], [t].[Id]
+                @"SELECT [p].[Id], [t0].[c], [t0].[Turnovers_AmountIn], [t0].[Id]
 FROM [Partners] AS [p]
 LEFT JOIN (
     SELECT CASE
-        WHEN [a].[Id] IS NULL THEN CAST(1 AS bit)
+        WHEN [t].[Id] IS NULL THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
-    END AS [c], [a].[Turnovers_AmountIn], [a0].[Id], [a0].[Partner13157Id]
-    FROM [Address13157] AS [a0]
-    LEFT JOIN [Address13157] AS [a] ON [a0].[Id] = [a].[Id]
-) AS [t] ON [p].[Id] = [t].[Partner13157Id]
-ORDER BY [p].[Id], [t].[Id]");
+    END AS [c], [t].[Turnovers_AmountIn], [a1].[Id], [a1].[Partner13157Id]
+    FROM [Address13157] AS [a1]
+    LEFT JOIN (
+        SELECT [a].[Id], [a].[Turnovers_AmountIn], [a0].[Id] AS [Id0]
+        FROM [Address13157] AS [a]
+        INNER JOIN [Address13157] AS [a0] ON [a].[Id] = [a0].[Id]
+        WHERE [a].[Turnovers_AmountIn] IS NOT NULL
+    ) AS [t] ON [a1].[Id] = [t].[Id]
+) AS [t0] ON [p].[Id] = [t0].[Partner13157Id]
+ORDER BY [p].[Id], [t0].[Id]");
                 }
             }
         }

--- a/test/EFCore.SqlServer.FunctionalTests/TableSplittingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TableSplittingSqlServerTest.cs
@@ -6,8 +6,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore
 {
-    // Issue #16032
-    internal class TableSplittingSqlServerTest : TableSplittingTestBase
+    public class TableSplittingSqlServerTest : TableSplittingTestBase
     {
         public TableSplittingSqlServerTest(ITestOutputHelper testOutputHelper)
             : base(testOutputHelper)
@@ -20,26 +19,69 @@ namespace Microsoft.EntityFrameworkCore
         {
             base.Can_use_with_redundant_relationships();
 
-            // TODO: [Name] shouldn't be selected multiple times and left joins are not needed
+            // TODO: [Name] shouldn't be selected multiple times and no joins are needed
             AssertSql(
-                @"SELECT [v].[Name], [v].[Discriminator], [v].[SeatingCapacity], [t].[Name], [t].[Operator_Discriminator], [t].[Operator_Name], [t].[LicenseType], [t0].[Name], [t0].[Description], [t0].[Engine_Discriminator], [t1].[Name], [t1].[Capacity], [t1].[FuelTank_Discriminator], [t1].[FuelType], [t1].[GrainGeometry]
+                @"SELECT [v].[Name], [v].[Discriminator], [v].[SeatingCapacity], [t0].[Name], [t0].[Operator_Discriminator], [t0].[Operator_Name], [t0].[LicenseType], [t3].[Name], [t3].[Type], [t5].[Name], [t5].[Description], [t5].[Engine_Discriminator], [t9].[Name], [t9].[Capacity], [t9].[FuelTank_Discriminator], [t9].[FuelType], [t9].[GrainGeometry]
 FROM [Vehicles] AS [v]
 LEFT JOIN (
-    SELECT [v.Operator].*
-    FROM [Vehicles] AS [v.Operator]
-    WHERE [v.Operator].[Discriminator] IN (N'PoweredVehicle', N'Vehicle') AND [v.Operator].[Operator_Discriminator] IN (N'LicensedOperator', N'Operator')
-) AS [t] ON [v].[Name] = [t].[Name]
-LEFT JOIN (
-    SELECT [v.Operator.Engine].*
-    FROM [Vehicles] AS [v.Operator.Engine]
-    WHERE ([v.Operator.Engine].[Discriminator] = N'PoweredVehicle') AND [v.Operator.Engine].[Engine_Discriminator] IN (N'SolidRocket', N'IntermittentCombustionEngine', N'ContinuousCombustionEngine', N'Engine')
+    SELECT [v0].[Name], [v0].[Operator_Discriminator], [v0].[Operator_Name], [v0].[LicenseType], [t].[Name] AS [Name0]
+    FROM [Vehicles] AS [v0]
+    INNER JOIN (
+        SELECT [v1].[Name], [v1].[Discriminator], [v1].[SeatingCapacity]
+        FROM [Vehicles] AS [v1]
+        WHERE [v1].[Discriminator] IN (N'Vehicle', N'PoweredVehicle')
+    ) AS [t] ON [v0].[Name] = [t].[Name]
+    WHERE [v0].[Operator_Discriminator] IN (N'Operator', N'LicensedOperator')
 ) AS [t0] ON [v].[Name] = [t0].[Name]
 LEFT JOIN (
-    SELECT [v.Operator.Engine.FuelTank].*
-    FROM [Vehicles] AS [v.Operator.Engine.FuelTank]
-    WHERE (([v.Operator.Engine.FuelTank].[Discriminator] = N'PoweredVehicle') AND [v.Operator.Engine.FuelTank].[FuelTank_Discriminator] IN (N'SolidFuelTank', N'FuelTank')) OR ((([v.Operator.Engine.FuelTank].[Discriminator] = N'PoweredVehicle') AND [v.Operator.Engine.FuelTank].[Engine_Discriminator] IN (N'SolidRocket', N'IntermittentCombustionEngine', N'ContinuousCombustionEngine')) AND [v.Operator.Engine.FuelTank].[FuelTank_Discriminator] IN (N'SolidFuelTank', N'FuelTank'))
-) AS [t1] ON [t0].[Name] = [t1].[Name]
-WHERE [v].[Discriminator] IN (N'PoweredVehicle', N'Vehicle')
+    SELECT [v2].[Name], [v2].[Type], [t2].[Name] AS [Name0], [t2].[Name0] AS [Name00]
+    FROM [Vehicles] AS [v2]
+    INNER JOIN (
+        SELECT [v3].[Name], [v3].[Operator_Discriminator], [v3].[Operator_Name], [v3].[LicenseType], [t1].[Name] AS [Name0]
+        FROM [Vehicles] AS [v3]
+        INNER JOIN (
+            SELECT [v4].[Name], [v4].[Discriminator], [v4].[SeatingCapacity]
+            FROM [Vehicles] AS [v4]
+            WHERE [v4].[Discriminator] IN (N'Vehicle', N'PoweredVehicle')
+        ) AS [t1] ON [v3].[Name] = [t1].[Name]
+        WHERE [v3].[Operator_Discriminator] IN (N'Operator', N'LicensedOperator')
+    ) AS [t2] ON [v2].[Name] = [t2].[Name]
+    WHERE [v2].[Type] IS NOT NULL
+) AS [t3] ON [t0].[Name] = [t3].[Name]
+LEFT JOIN (
+    SELECT [v5].[Name], [v5].[Description], [v5].[Engine_Discriminator], [t4].[Name] AS [Name0]
+    FROM [Vehicles] AS [v5]
+    INNER JOIN (
+        SELECT [v6].[Name], [v6].[Discriminator], [v6].[SeatingCapacity]
+        FROM [Vehicles] AS [v6]
+        WHERE [v6].[Discriminator] = N'PoweredVehicle'
+    ) AS [t4] ON [v5].[Name] = [t4].[Name]
+    WHERE [v5].[Engine_Discriminator] IN (N'Engine', N'ContinuousCombustionEngine', N'IntermittentCombustionEngine', N'SolidRocket')
+) AS [t5] ON [v].[Name] = [t5].[Name]
+LEFT JOIN (
+    SELECT [v7].[Name], [v7].[Capacity], [v7].[FuelTank_Discriminator], [v7].[FuelType], [v7].[GrainGeometry]
+    FROM [Vehicles] AS [v7]
+    INNER JOIN (
+        SELECT [v8].[Name], [v8].[Discriminator], [v8].[SeatingCapacity]
+        FROM [Vehicles] AS [v8]
+        WHERE [v8].[Discriminator] = N'PoweredVehicle'
+    ) AS [t6] ON [v7].[Name] = [t6].[Name]
+    WHERE [v7].[FuelTank_Discriminator] IN (N'FuelTank', N'SolidFuelTank')
+    UNION
+    SELECT [v9].[Name], [v9].[Capacity], [v9].[FuelTank_Discriminator], [v9].[FuelType], [v9].[GrainGeometry]
+    FROM [Vehicles] AS [v9]
+    INNER JOIN (
+        SELECT [v10].[Name], [v10].[Description], [v10].[Engine_Discriminator], [t7].[Name] AS [Name0]
+        FROM [Vehicles] AS [v10]
+        INNER JOIN (
+            SELECT [v11].[Name], [v11].[Discriminator], [v11].[SeatingCapacity]
+            FROM [Vehicles] AS [v11]
+            WHERE [v11].[Discriminator] = N'PoweredVehicle'
+        ) AS [t7] ON [v10].[Name] = [t7].[Name]
+        WHERE [v10].[Engine_Discriminator] IN (N'ContinuousCombustionEngine', N'IntermittentCombustionEngine', N'SolidRocket')
+    ) AS [t8] ON [v9].[Name] = [t8].[Name]
+) AS [t9] ON [t5].[Name] = [t9].[Name]
+WHERE [v].[Discriminator] IN (N'Vehicle', N'PoweredVehicle')
 ORDER BY [v].[Name]");
         }
 
@@ -60,7 +102,60 @@ ORDER BY [v].[Name]");
             AssertSql(
                 @"SELECT [v].[Name], [v].[Operator_Discriminator], [v].[Operator_Name], [v].[LicenseType]
 FROM [Vehicles] AS [v]
-WHERE [v].[Discriminator] IN (N'PoweredVehicle', N'Vehicle') AND [v].[Operator_Discriminator] IN (N'LicensedOperator', N'Operator')");
+INNER JOIN (
+    SELECT [v0].[Name], [v0].[Discriminator], [v0].[SeatingCapacity]
+    FROM [Vehicles] AS [v0]
+    WHERE [v0].[Discriminator] IN (N'Vehicle', N'PoweredVehicle')
+) AS [t] ON [v].[Name] = [t].[Name]
+WHERE [v].[Operator_Discriminator] IN (N'Operator', N'LicensedOperator')");
+        }
+
+        public override void Can_query_shared_nonhierarchy()
+        {
+            base.Can_query_shared_nonhierarchy();
+
+            AssertSql(
+                @"SELECT [t0].[Name], [t0].[Operator_Name]
+FROM (
+    SELECT [v].[Name], [v].[Operator_Name]
+    FROM [Vehicles] AS [v]
+    WHERE [v].[Operator_Name] IS NOT NULL
+    UNION
+    SELECT [v0].[Name], [v0].[Operator_Name]
+    FROM [Vehicles] AS [v0]
+    INNER JOIN (
+        SELECT [v1].[Name], [v1].[Type]
+        FROM [Vehicles] AS [v1]
+        WHERE [v1].[Type] IS NOT NULL
+    ) AS [t] ON [v0].[Name] = [t].[Name]
+) AS [t0]
+INNER JOIN (
+    SELECT [v2].[Name], [v2].[Discriminator], [v2].[SeatingCapacity]
+    FROM [Vehicles] AS [v2]
+    WHERE [v2].[Discriminator] IN (N'Vehicle', N'PoweredVehicle')
+) AS [t1] ON [t0].[Name] = [t1].[Name]");
+        }
+
+        public override void Can_query_shared_nonhierarchy_with_nonshared_dependent()
+        {
+            base.Can_query_shared_nonhierarchy_with_nonshared_dependent();
+
+            AssertSql(
+                @"SELECT [t].[Name], [t].[Operator_Name]
+FROM (
+    SELECT [v].[Name], [v].[Operator_Name]
+    FROM [Vehicles] AS [v]
+    WHERE [v].[Operator_Name] IS NOT NULL
+    UNION
+    SELECT [v0].[Name], [v0].[Operator_Name]
+    FROM [Vehicles] AS [v0]
+    INNER JOIN [OperatorDetails] AS [o] ON [v0].[Name] = [o].[VehicleName]
+) AS [t]
+INNER JOIN (
+    SELECT [v1].[Name], [v1].[Discriminator], [v1].[SeatingCapacity]
+    FROM [Vehicles] AS [v1]
+    WHERE [v1].[Discriminator] IN (N'Vehicle', N'PoweredVehicle')
+) AS [t0] ON [t].[Name] = [t0].[Name]");
         }
 
         public override void Can_query_shared_derived_hierarchy()
@@ -70,7 +165,25 @@ WHERE [v].[Discriminator] IN (N'PoweredVehicle', N'Vehicle') AND [v].[Operator_D
             AssertSql(
                 @"SELECT [v].[Name], [v].[Capacity], [v].[FuelTank_Discriminator], [v].[FuelType], [v].[GrainGeometry]
 FROM [Vehicles] AS [v]
-WHERE (([v].[Discriminator] = N'PoweredVehicle') AND [v].[FuelTank_Discriminator] IN (N'SolidFuelTank', N'FuelTank')) OR ((([v].[Discriminator] = N'PoweredVehicle') AND [v].[Engine_Discriminator] IN (N'SolidRocket', N'IntermittentCombustionEngine', N'ContinuousCombustionEngine')) AND [v].[FuelTank_Discriminator] IN (N'SolidFuelTank', N'FuelTank'))");
+INNER JOIN (
+    SELECT [v0].[Name], [v0].[Discriminator], [v0].[SeatingCapacity]
+    FROM [Vehicles] AS [v0]
+    WHERE [v0].[Discriminator] = N'PoweredVehicle'
+) AS [t] ON [v].[Name] = [t].[Name]
+WHERE [v].[FuelTank_Discriminator] IN (N'FuelTank', N'SolidFuelTank')
+UNION
+SELECT [v1].[Name], [v1].[Capacity], [v1].[FuelTank_Discriminator], [v1].[FuelType], [v1].[GrainGeometry]
+FROM [Vehicles] AS [v1]
+INNER JOIN (
+    SELECT [v2].[Name], [v2].[Description], [v2].[Engine_Discriminator], [t0].[Name] AS [Name0]
+    FROM [Vehicles] AS [v2]
+    INNER JOIN (
+        SELECT [v3].[Name], [v3].[Discriminator], [v3].[SeatingCapacity]
+        FROM [Vehicles] AS [v3]
+        WHERE [v3].[Discriminator] = N'PoweredVehicle'
+    ) AS [t0] ON [v2].[Name] = [t0].[Name]
+    WHERE [v2].[Engine_Discriminator] IN (N'ContinuousCombustionEngine', N'IntermittentCombustionEngine', N'SolidRocket')
+) AS [t1] ON [v1].[Name] = [t1].[Name]");
         }
 
         public override void Can_query_shared_derived_nonhierarchy()
@@ -80,7 +193,25 @@ WHERE (([v].[Discriminator] = N'PoweredVehicle') AND [v].[FuelTank_Discriminator
             AssertSql(
                 @"SELECT [v].[Name], [v].[Capacity], [v].[FuelType]
 FROM [Vehicles] AS [v]
-WHERE (([v].[Discriminator] = N'PoweredVehicle') AND ([v].[FuelType] IS NOT NULL OR [v].[Capacity] IS NOT NULL)) OR ((([v].[Discriminator] = N'PoweredVehicle') AND [v].[Engine_Discriminator] IN (N'SolidRocket', N'IntermittentCombustionEngine', N'ContinuousCombustionEngine')) AND ([v].[FuelType] IS NOT NULL OR [v].[Capacity] IS NOT NULL))");
+INNER JOIN (
+    SELECT [v0].[Name], [v0].[Discriminator], [v0].[SeatingCapacity]
+    FROM [Vehicles] AS [v0]
+    WHERE [v0].[Discriminator] = N'PoweredVehicle'
+) AS [t] ON [v].[Name] = [t].[Name]
+WHERE [v].[FuelType] IS NOT NULL OR [v].[Capacity] IS NOT NULL
+UNION
+SELECT [v1].[Name], [v1].[Capacity], [v1].[FuelType]
+FROM [Vehicles] AS [v1]
+INNER JOIN (
+    SELECT [v2].[Name], [v2].[Description], [v2].[Engine_Discriminator], [t0].[Name] AS [Name0]
+    FROM [Vehicles] AS [v2]
+    INNER JOIN (
+        SELECT [v3].[Name], [v3].[Discriminator], [v3].[SeatingCapacity]
+        FROM [Vehicles] AS [v3]
+        WHERE [v3].[Discriminator] = N'PoweredVehicle'
+    ) AS [t0] ON [v2].[Name] = [t0].[Name]
+    WHERE [v2].[Engine_Discriminator] IN (N'ContinuousCombustionEngine', N'IntermittentCombustionEngine', N'SolidRocket')
+) AS [t1] ON [v1].[Name] = [t1].[Name]");
         }
 
         public override void Can_query_shared_derived_nonhierarchy_all_required()
@@ -90,7 +221,25 @@ WHERE (([v].[Discriminator] = N'PoweredVehicle') AND ([v].[FuelType] IS NOT NULL
             AssertSql(
                 @"SELECT [v].[Name], [v].[Capacity], [v].[FuelType]
 FROM [Vehicles] AS [v]
-WHERE (([v].[Discriminator] = N'PoweredVehicle') AND ([v].[FuelType] IS NOT NULL AND [v].[Capacity] IS NOT NULL)) OR ((([v].[Discriminator] = N'PoweredVehicle') AND [v].[Engine_Discriminator] IN (N'SolidRocket', N'IntermittentCombustionEngine', N'ContinuousCombustionEngine')) AND ([v].[FuelType] IS NOT NULL AND [v].[Capacity] IS NOT NULL))");
+INNER JOIN (
+    SELECT [v0].[Name], [v0].[Discriminator], [v0].[SeatingCapacity]
+    FROM [Vehicles] AS [v0]
+    WHERE [v0].[Discriminator] = N'PoweredVehicle'
+) AS [t] ON [v].[Name] = [t].[Name]
+WHERE [v].[FuelType] IS NOT NULL AND [v].[Capacity] IS NOT NULL
+UNION
+SELECT [v1].[Name], [v1].[Capacity], [v1].[FuelType]
+FROM [Vehicles] AS [v1]
+INNER JOIN (
+    SELECT [v2].[Name], [v2].[Description], [v2].[Engine_Discriminator], [t0].[Name] AS [Name0]
+    FROM [Vehicles] AS [v2]
+    INNER JOIN (
+        SELECT [v3].[Name], [v3].[Discriminator], [v3].[SeatingCapacity]
+        FROM [Vehicles] AS [v3]
+        WHERE [v3].[Discriminator] = N'PoweredVehicle'
+    ) AS [t0] ON [v2].[Name] = [t0].[Name]
+    WHERE [v2].[Engine_Discriminator] IN (N'ContinuousCombustionEngine', N'IntermittentCombustionEngine', N'SolidRocket')
+) AS [t1] ON [v1].[Name] = [t1].[Name]");
         }
 
         public override void Can_change_dependent_instance_non_derived()

--- a/test/EFCore.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
@@ -97,17 +97,37 @@ namespace Microsoft.EntityFrameworkCore
             base.ConcurrencyCheckAttribute_throws_if_value_in_database_changed();
 
             AssertSql(
-                @"SELECT ""s"".""UniqueNo"", ""s"".""MaxLengthProperty"", ""s"".""Name"", ""s"".""RowVersion"", ""s0"".""UniqueNo"", ""s0"".""AdditionalDetails_Name"", ""s1"".""UniqueNo"", ""s1"".""Details_Name""
+                @"SELECT ""s"".""UniqueNo"", ""s"".""MaxLengthProperty"", ""s"".""Name"", ""s"".""RowVersion"", ""t"".""UniqueNo"", ""t"".""AdditionalDetails_Name"", ""t0"".""UniqueNo"", ""t0"".""Details_Name""
 FROM ""Sample"" AS ""s""
-LEFT JOIN ""Sample"" AS ""s0"" ON ""s"".""UniqueNo"" = ""s0"".""UniqueNo""
-LEFT JOIN ""Sample"" AS ""s1"" ON ""s"".""UniqueNo"" = ""s1"".""UniqueNo""
+LEFT JOIN (
+    SELECT ""s0"".""UniqueNo"", ""s0"".""AdditionalDetails_Name"", ""s1"".""UniqueNo"" AS ""UniqueNo0""
+    FROM ""Sample"" AS ""s0""
+    INNER JOIN ""Sample"" AS ""s1"" ON ""s0"".""UniqueNo"" = ""s1"".""UniqueNo""
+    WHERE ""s0"".""AdditionalDetails_Name"" IS NOT NULL
+) AS ""t"" ON ""s"".""UniqueNo"" = ""t"".""UniqueNo""
+LEFT JOIN (
+    SELECT ""s2"".""UniqueNo"", ""s2"".""Details_Name"", ""s3"".""UniqueNo"" AS ""UniqueNo0""
+    FROM ""Sample"" AS ""s2""
+    INNER JOIN ""Sample"" AS ""s3"" ON ""s2"".""UniqueNo"" = ""s3"".""UniqueNo""
+    WHERE ""s2"".""Details_Name"" IS NOT NULL
+) AS ""t0"" ON ""s"".""UniqueNo"" = ""t0"".""UniqueNo""
 WHERE ""s"".""UniqueNo"" = 1
 LIMIT 1",
                 //
-                @"SELECT ""s"".""UniqueNo"", ""s"".""MaxLengthProperty"", ""s"".""Name"", ""s"".""RowVersion"", ""s0"".""UniqueNo"", ""s0"".""AdditionalDetails_Name"", ""s1"".""UniqueNo"", ""s1"".""Details_Name""
+                @"SELECT ""s"".""UniqueNo"", ""s"".""MaxLengthProperty"", ""s"".""Name"", ""s"".""RowVersion"", ""t"".""UniqueNo"", ""t"".""AdditionalDetails_Name"", ""t0"".""UniqueNo"", ""t0"".""Details_Name""
 FROM ""Sample"" AS ""s""
-LEFT JOIN ""Sample"" AS ""s0"" ON ""s"".""UniqueNo"" = ""s0"".""UniqueNo""
-LEFT JOIN ""Sample"" AS ""s1"" ON ""s"".""UniqueNo"" = ""s1"".""UniqueNo""
+LEFT JOIN (
+    SELECT ""s0"".""UniqueNo"", ""s0"".""AdditionalDetails_Name"", ""s1"".""UniqueNo"" AS ""UniqueNo0""
+    FROM ""Sample"" AS ""s0""
+    INNER JOIN ""Sample"" AS ""s1"" ON ""s0"".""UniqueNo"" = ""s1"".""UniqueNo""
+    WHERE ""s0"".""AdditionalDetails_Name"" IS NOT NULL
+) AS ""t"" ON ""s"".""UniqueNo"" = ""t"".""UniqueNo""
+LEFT JOIN (
+    SELECT ""s2"".""UniqueNo"", ""s2"".""Details_Name"", ""s3"".""UniqueNo"" AS ""UniqueNo0""
+    FROM ""Sample"" AS ""s2""
+    INNER JOIN ""Sample"" AS ""s3"" ON ""s2"".""UniqueNo"" = ""s3"".""UniqueNo""
+    WHERE ""s2"".""Details_Name"" IS NOT NULL
+) AS ""t0"" ON ""s"".""UniqueNo"" = ""t0"".""UniqueNo""
 WHERE ""s"".""UniqueNo"" = 1
 LIMIT 1",
                 //
@@ -128,6 +148,7 @@ SELECT changes();",
 UPDATE ""Sample"" SET ""Name"" = @p0, ""RowVersion"" = @p1
 WHERE ""UniqueNo"" = @p2 AND ""RowVersion"" = @p3;
 SELECT changes();");
+
         }
 
         public override void DatabaseGeneratedAttribute_autogenerates_values_when_set_to_identity()

--- a/test/EFCore.Sqlite.FunctionalTests/PropertyEntrySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/PropertyEntrySqliteTest.cs
@@ -16,9 +16,14 @@ namespace Microsoft.EntityFrameworkCore
             base.Property_entry_original_value_is_set();
 
             AssertSql(
-                @"SELECT ""e"".""Id"", ""e"".""EngineSupplierId"", ""e"".""Name"", ""e0"".""Id"", ""e0"".""StorageLocation_Latitude"", ""e0"".""StorageLocation_Longitude""
+                @"SELECT ""e"".""Id"", ""e"".""EngineSupplierId"", ""e"".""Name"", ""t"".""Id"", ""t"".""StorageLocation_Latitude"", ""t"".""StorageLocation_Longitude""
 FROM ""Engines"" AS ""e""
-LEFT JOIN ""Engines"" AS ""e0"" ON ""e"".""Id"" = ""e0"".""Id""
+LEFT JOIN (
+    SELECT ""e0"".""Id"", ""e0"".""StorageLocation_Latitude"", ""e0"".""StorageLocation_Longitude"", ""e1"".""Id"" AS ""Id0""
+    FROM ""Engines"" AS ""e0""
+    INNER JOIN ""Engines"" AS ""e1"" ON ""e0"".""Id"" = ""e1"".""Id""
+    WHERE ""e0"".""StorageLocation_Longitude"" IS NOT NULL AND ""e0"".""StorageLocation_Latitude"" IS NOT NULL
+) AS ""t"" ON ""e"".""Id"" = ""t"".""Id""
 ORDER BY ""e"".""Id""
 LIMIT 1",
                 //

--- a/test/EFCore.Sqlite.FunctionalTests/TableSplittingSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/TableSplittingSqliteTest.cs
@@ -6,8 +6,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore
 {
-    // Issue #16032
-    internal class TableSplittingSqliteTest : TableSplittingTestBase
+    public class TableSplittingSqliteTest : TableSplittingTestBase
     {
         public TableSplittingSqliteTest(ITestOutputHelper testOutputHelper)
             : base(testOutputHelper)


### PR DESCRIPTION
Materialize owned entities with all null properties if they are being referenced by other entities

Fixes #16032
