### PR TITLE
Query: Convert lateral joins into predicate joins only when appropriate

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.cs
@@ -4084,6 +4084,30 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             return base.Multiple_select_many_with_predicate(isAsync);
         }
 
+        [ConditionalTheory(Skip = "Issue#14935")]
+        public override Task SelectMany_correlated_with_outer_1(bool isAsync)
+        {
+            return base.SelectMany_correlated_with_outer_1(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "Issue#14935")]
+        public override Task SelectMany_correlated_with_outer_2(bool isAsync)
+        {
+            return base.SelectMany_correlated_with_outer_2(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "Issue#14935")]
+        public override Task SelectMany_correlated_with_outer_3(bool isAsync)
+        {
+            return base.SelectMany_correlated_with_outer_3(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "Issue#14935")]
+        public override Task SelectMany_correlated_with_outer_4(bool isAsync)
+        {
+            return base.SelectMany_correlated_with_outer_4(isAsync);
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.InMemory.FunctionalTests/Query/SimpleQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/SimpleQueryInMemoryTest.cs
@@ -405,6 +405,30 @@ namespace Microsoft.EntityFrameworkCore.Query
             return base.SelectMany_without_result_selector_collection_navigation_composed(isAsync);
         }
 
+        [ConditionalTheory(Skip = "Issue#16963")]
+        public override Task SelectMany_correlated_with_outer_1(bool isAsync)
+        {
+            return base.SelectMany_correlated_with_outer_1(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "Issue#16963")]
+        public override Task SelectMany_correlated_with_outer_2(bool isAsync)
+        {
+            return base.SelectMany_correlated_with_outer_2(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "Issue#16963")]
+        public override Task SelectMany_correlated_with_outer_3(bool isAsync)
+        {
+            return base.SelectMany_correlated_with_outer_3(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "Issue#16963")]
+        public override Task SelectMany_correlated_with_outer_4(bool isAsync)
+        {
+            return base.SelectMany_correlated_with_outer_4(isAsync);
+        }
+
         #endregion
     }
 }

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -4893,7 +4893,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "Issue#16311")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_inner_subquery_selector_references_outer_qsre(bool isAsync)
         {
@@ -4919,7 +4919,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "Issue#16311")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_inner_subquery_predicate_references_outer_qsre(bool isAsync)
         {
@@ -4945,7 +4945,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "Issue#16311")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_nested_inner_subquery_references_outer_qsre_one_level_up(bool isAsync)
         {
@@ -4984,7 +4984,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "Issue#16311")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_nested_inner_subquery_references_outer_qsre_two_levels_up(bool isAsync)
         {
@@ -5729,7 +5729,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 lls => lls.Where(ll => ll is LocustCommander ? ((LocustCommander)ll).HighCommand.IsOperational : false));
         }
 
-        [ConditionalTheory(Skip = "Issue#16311")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Outer_parameter_in_join_key(bool isAsync)
         {
@@ -5748,7 +5748,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) => CollectionAsserter<string>(elementSorter: ee => ee)(e.Collection, a.Collection));
         }
 
-        [ConditionalTheory(Skip = "Issue#16311")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Outer_parameter_in_join_key_inner_and_outer(bool isAsync)
         {
@@ -5786,7 +5786,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) => CollectionAsserter<string>(elementSorter: ee => ee)(e.Collection, a.Collection));
         }
 
-        [ConditionalTheory(Skip = "Issue#16311")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Outer_parameter_in_group_join_with_DefaultIfEmpty(bool isAsync)
         {

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
@@ -592,7 +592,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Count);
         }
 
-        [ConditionalTheory(Skip = "Issue#16311")]
+        [ConditionalTheory(Skip = "Issue#16314")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_nested_collection_deep(bool isAsync)
         {
@@ -1228,6 +1228,70 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery<Customer>(
                 isAsync,
                 cs => cs.SelectMany(c => c.Orders.Select(o => o.CustomerID)));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task SelectMany_correlated_with_outer_1(bool isAsync)
+        {
+            return AssertQuery<Customer, Order>(
+                isAsync,
+                (cs, os) => from c in cs
+                            from o in os.Where(o => c.CustomerID == o.CustomerID).Select(o => c.City)
+                            select new
+                            {
+                                c,
+                                o
+                            },
+                entryCount: 89);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task SelectMany_correlated_with_outer_2(bool isAsync)
+        {
+            return AssertQuery<Customer, Order>(
+                isAsync,
+                (cs, os) => from c in cs
+                            from o in os.Where(o => c.CustomerID == o.CustomerID).OrderBy(o => c.City).Take(2)
+                            select new
+                            {
+                                c,
+                                o
+                            },
+                entryCount: 266);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task SelectMany_correlated_with_outer_3(bool isAsync)
+        {
+            return AssertQuery<Customer, Order>(
+                isAsync,
+                (cs, os) => from c in cs
+                            from o in os.Where(o => c.CustomerID == o.CustomerID).Select(o => c.City).DefaultIfEmpty()
+                            select new
+                            {
+                                c,
+                                o
+                            },
+                entryCount: 91);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task SelectMany_correlated_with_outer_4(bool isAsync)
+        {
+            return AssertQuery<Customer, Order>(
+                isAsync,
+                (cs, os) => from c in cs
+                            from o in os.Where(o => c.CustomerID == o.CustomerID).OrderBy(o => c.City).Take(2).DefaultIfEmpty()
+                            select new
+                            {
+                                c,
+                                o
+                            },
+                entryCount: 268);
         }
     }
 }

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -1919,7 +1919,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 1);
         }
 
-        [ConditionalTheory(Skip = "Issue#16311")]
+        [ConditionalTheory(Skip = "Issue#16314")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_subquery_recursive_trivial(bool isAsync)
         {
@@ -3266,14 +3266,14 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 (cs, os) =>
                     from c in cs
-                    from o in os.Where(o => o.CustomerID == c.CustomerID).Take(1000)
+                    from o in os.Where(o => o.CustomerID == c.CustomerID).Take(4)
                     select new
                     {
                         c.ContactName,
                         o
                     },
                 e => e.o.OrderID,
-                entryCount: 830);
+                entryCount: 342);
         }
 
         [ConditionalTheory]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AsyncSimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AsyncSimpleQuerySqlServerTest.cs
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
-        [ConditionalFact(Skip = "Issue#16311")]
+        [ConditionalFact(Skip = "Issue#16314")]
         public Task Query_compiler_concurrency()
         {
             const int threadCount = 50;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
@@ -327,11 +327,11 @@ ORDER BY [o].[OrderID]");
             AssertSql(
                 @"SELECT [c].[CustomerID], [t].[OrderDate], [t].[OrderID]
 FROM [Customers] AS [c]
-LEFT JOIN (
-    SELECT TOP(3) [o].[OrderDate], [o].[OrderID], [o].[CustomerID]
+OUTER APPLY (
+    SELECT TOP(3) [o].[OrderDate], [o].[OrderID]
     FROM [Orders] AS [o]
-    WHERE [o].[OrderID] < 10500
-) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
+    WHERE (([c].[CustomerID] = [o].[CustomerID]) AND [o].[CustomerID] IS NOT NULL) AND ([o].[OrderID] < 10500)
+) AS [t]
 WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY [c].[CustomerID], [t].[OrderID]");
         }
@@ -1006,6 +1006,64 @@ INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]");
                 @"SELECT [o].[CustomerID]
 FROM [Customers] AS [c]
 INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]");
+        }
+
+        public override async Task SelectMany_correlated_with_outer_1(bool isAsync)
+        {
+            await base.SelectMany_correlated_with_outer_1(isAsync);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[City] AS [o]
+FROM [Customers] AS [c]
+CROSS APPLY (
+    SELECT [c].[City], [o].[OrderID], [o].[CustomerID]
+    FROM [Orders] AS [o]
+    WHERE ([c].[CustomerID] = [o].[CustomerID]) AND [o].[CustomerID] IS NOT NULL
+) AS [t]");
+        }
+
+        public override async Task SelectMany_correlated_with_outer_2(bool isAsync)
+        {
+            await base.SelectMany_correlated_with_outer_2(isAsync);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+FROM [Customers] AS [c]
+CROSS APPLY (
+    SELECT TOP(2) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[City]
+    FROM [Orders] AS [o]
+    WHERE ([c].[CustomerID] = [o].[CustomerID]) AND [o].[CustomerID] IS NOT NULL
+    ORDER BY [c].[City]
+) AS [t]");
+        }
+
+        public override async Task SelectMany_correlated_with_outer_3(bool isAsync)
+        {
+            await base.SelectMany_correlated_with_outer_3(isAsync);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[City] AS [o]
+FROM [Customers] AS [c]
+OUTER APPLY (
+    SELECT [c].[City], [o].[OrderID], [o].[CustomerID]
+    FROM [Orders] AS [o]
+    WHERE ([c].[CustomerID] = [o].[CustomerID]) AND [o].[CustomerID] IS NOT NULL
+) AS [t]");
+        }
+
+        public override async Task SelectMany_correlated_with_outer_4(bool isAsync)
+        {
+            await base.SelectMany_correlated_with_outer_4(isAsync);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+FROM [Customers] AS [c]
+OUTER APPLY (
+    SELECT TOP(2) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[City]
+    FROM [Orders] AS [o]
+    WHERE ([c].[CustomerID] = [o].[CustomerID]) AND [o].[CustomerID] IS NOT NULL
+    ORDER BY [c].[City]
+) AS [t]");
         }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -1950,10 +1950,11 @@ LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]");
             AssertSql(
                 @"SELECT [c].[ContactName], [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
 FROM [Customers] AS [c]
-INNER JOIN (
-    SELECT TOP(1000) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+CROSS APPLY (
+    SELECT TOP(4) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
-) AS [t] ON [c].[CustomerID] = [t].[CustomerID]");
+    WHERE ([o].[CustomerID] = [c].[CustomerID]) AND [o].[CustomerID] IS NOT NULL
+) AS [t]");
         }
 
         public override async Task Take_with_single(bool isAsync)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -50,5 +50,20 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         // Skip for SQLite. Issue #14935. Cannot eval 'where ([m].Timeline >= x)'
         public override Task DateTimeOffset_Contains_Less_than_Greater_than(bool isAsync) => null;
+
+        // Sqlite does not support lateral joins
+        public override Task Correlated_collections_inner_subquery_predicate_references_outer_qsre(bool isAsync) => null;
+
+        public override Task Correlated_collections_inner_subquery_selector_references_outer_qsre(bool isAsync) => null;
+
+        public override Task Correlated_collections_nested_inner_subquery_references_outer_qsre_one_level_up(bool isAsync) => null;
+
+        public override Task Correlated_collections_nested_inner_subquery_references_outer_qsre_two_levels_up(bool isAsync) => null;
+
+        public override Task Outer_parameter_in_group_join_with_DefaultIfEmpty(bool isAsync) => null;
+
+        public override Task Outer_parameter_in_join_key(bool isAsync) => null;
+
+        public override Task Outer_parameter_in_join_key_inner_and_outer(bool isAsync) => null;
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
@@ -1067,6 +1067,19 @@ FROM (
         public override Task KeylessEntity_where_simple(bool isAsync)
             => base.KeylessEntity_where_simple(isAsync);
 
+        // Sqlite does not support lateral joins
+        public override void Select_nested_collection_multi_level()
+        {
+        }
+
+        public override Task SelectMany_correlated_with_outer_1(bool isAsync) => null;
+
+        public override Task SelectMany_correlated_with_outer_2(bool isAsync) => null;
+
+        public override Task SelectMany_correlated_with_outer_3(bool isAsync) => null;
+
+        public override Task SelectMany_correlated_with_outer_4(bool isAsync) => null;
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }


### PR DESCRIPTION
- Validate inner select expression after extracting join predicate that it does not contain reference to outer.
- Also apply same logic for generating collections in projection.
- Identify DefaultIfEmpty in collectionSelector of SelectMany accurately.

This fix up a lot of N+1 evaluation queries.

Resolves #17112
Resolves #16311
