### PR TITLE
Be more resilient when using the model from the model snapshot

### DIFF
--- a/src/EFCore.Design/Migrations/Internal/SnapshotModelProcessor.cs
+++ b/src/EFCore.Design/Migrations/Internal/SnapshotModelProcessor.cs
@@ -76,9 +76,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 }
             }
 
-            return (model is IMutableModel mutableModel)
-                ? mutableModel.FinalizeModel()
-                : model;
+            return model;
         }
 
         private void ProcessCollection(IEnumerable<IAnnotatable> metadata, string version)

--- a/src/EFCore.InMemory/Storage/Internal/InMemoryTable.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryTable.cs
@@ -89,7 +89,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
             => properties.Select(GetStructuralComparer).ToList();
 
         private static ValueComparer GetStructuralComparer(IProperty p)
-            => p.GetStructuralValueComparer() ?? p.GetTypeMapping().StructuralComparer;
+            => p.GetStructuralValueComparer() ?? p.FindTypeMapping()?.StructuralComparer;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Infrastructure/ModelSnapshot.cs
+++ b/src/EFCore.Relational/Infrastructure/ModelSnapshot.cs
@@ -3,7 +3,7 @@
 
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
-using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Infrastructure
 {
@@ -14,12 +14,14 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
     {
         private IModel _model;
 
-        private IMutableModel CreateModel()
+        private IModel CreateModel()
         {
-            var modelBuilder = new ModelBuilder(new ConventionSet());
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+
             BuildModel(modelBuilder);
 
-            return modelBuilder.Model;
+            return model.FinalizeModel();
         }
 
         /// <summary>

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -1814,8 +1814,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                             var targetValue = entry.GetCurrentValue(targetProperty);
                             var comparer = targetProperty.GetValueComparer() ??
                                            sourceProperty.GetValueComparer() ??
-                                           targetProperty.GetTypeMapping().Comparer ??
-                                           sourceProperty.GetTypeMapping().Comparer;
+                                           targetProperty.FindTypeMapping()?.Comparer ??
+                                           sourceProperty.FindTypeMapping()?.Comparer;
 
                             var modelValuesChanged
                                 = sourceProperty.ClrType.UnwrapNullableType() == targetProperty.ClrType.UnwrapNullableType()

--- a/src/EFCore/ChangeTracking/Internal/ChangeDetector.cs
+++ b/src/EFCore/ChangeTracking/Internal/ChangeDetector.cs
@@ -252,7 +252,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 var currentValue = entry[property];
 
                 var comparer = property.GetKeyValueComparer()
-                               ?? property.GetTypeMapping().KeyComparer;
+                               ?? property.FindTypeMapping()?.KeyComparer;
 
                 // Note that mutation of a byte[] key is not supported or detected, but two different instances
                 // of byte[] with the same content must be detected as equal.

--- a/src/EFCore/ChangeTracking/Internal/CompositeValueFactory.cs
+++ b/src/EFCore/ChangeTracking/Internal/CompositeValueFactory.cs
@@ -133,7 +133,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         /// </summary>
         protected static IEqualityComparer<object[]> CreateEqualityComparer([NotNull] IReadOnlyList<IProperty> properties)
         {
-            var comparers = properties.Select(p => p.GetKeyValueComparer() ?? p.GetTypeMapping().KeyComparer).ToList();
+            var comparers = properties.Select(p => p.GetKeyValueComparer() ?? p.FindTypeMapping()?.KeyComparer).ToList();
 
             return comparers.All(c => c != null)
                 ? new CompositeCustomComparer(comparers)

--- a/src/EFCore/ChangeTracking/Internal/SimplePrincipalKeyValueFactory.cs
+++ b/src/EFCore/ChangeTracking/Internal/SimplePrincipalKeyValueFactory.cs
@@ -35,7 +35,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             _propertyAccessors = _property.GetPropertyAccessors();
 
             var comparer = property.GetKeyValueComparer()
-                           ?? property.GetTypeMapping().KeyComparer;
+                           ?? property.FindTypeMapping()?.KeyComparer;
 
             EqualityComparer
                 = comparer != null

--- a/src/EFCore/ChangeTracking/Internal/StateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/StateManager.cs
@@ -1067,7 +1067,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
         private static bool KeyValuesEqual(IProperty property, object value, object currentValue)
             => (property.GetKeyValueComparer()
-                ?? property.GetTypeMapping().KeyComparer)
+                ?? property.FindTypeMapping()?.KeyComparer)
                ?.Equals(currentValue, value)
                ?? Equals(currentValue, value);
 

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -2328,7 +2328,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     {
                         if (propertyBase is IProperty property)
                         {
-                            valueConverter = property.GetTypeMapping().Converter
+                            valueConverter = property.FindTypeMapping()?.Converter
                                              ?? property.GetValueConverter();
                         }
 

--- a/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
+++ b/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
@@ -299,7 +299,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public static PropertyCounts CalculateCounts([NotNull] this EntityType entityType)
         {
-            Debug.Assert(entityType.Model.ConventionDispatcher == null, "Should not be called on a mutable model");
+            Check.DebugAssert(entityType.Model.IsReadonly, "Should not be called on a mutable model");
 
             var index = 0;
             var navigationIndex = 0;

--- a/src/EFCore/Metadata/Internal/Model.cs
+++ b/src/EFCore/Metadata/Internal/Model.cs
@@ -89,6 +89,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public virtual bool IsReadonly
+            => ConventionDispatcher == null;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public virtual InternalModelBuilder Builder { [DebuggerStepThrough] get; }
 
         /// <summary>
@@ -824,7 +833,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual IModel FinalizeModel()
         {
             var finalModel = (Model)ConventionDispatcher.OnModelFinalized(Builder)?.Metadata;
-            return finalModel?.MakeReadonly();
+            return finalModel?.MakeReadonly() ?? this;
         }
 
         /// <summary>

--- a/src/EFCore/ValueGeneration/ValueGeneratorSelector.cs
+++ b/src/EFCore/ValueGeneration/ValueGeneratorSelector.cs
@@ -73,7 +73,7 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration
 
             if (factory == null)
             {
-                var mapping = property.GetTypeMapping();
+                var mapping = property.FindTypeMapping();
                 factory = mapping?.ValueGeneratorFactory;
 
                 if (factory == null)

--- a/src/Shared/Check.cs
+++ b/src/Shared/Check.cs
@@ -93,5 +93,14 @@ namespace Microsoft.EntityFrameworkCore.Utilities
 
             return value;
         }
+
+        [Conditional("DEBUG")]
+        public static void DebugAssert([System.Diagnostics.CodeAnalysis.DoesNotReturnIf(false)] bool condition, string message)
+        {
+            if (!condition)
+            {
+                throw new Exception($"Check.DebugAssert failed: {message}");
+            }
+        }
     }
 }

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -3642,7 +3642,7 @@ namespace RootNamespace
                 Activator.CreateInstance(factoryType),
                 new object[] { builder });
 
-            var modelFromSnapshot = new SnapshotModelProcessor(new TestOperationReporter()).Process(builder.Model);
+            var modelFromSnapshot = new SnapshotModelProcessor(new TestOperationReporter()).Process(builder.Model.FinalizeModel());
 
             assert(modelFromSnapshot, model);
         }

--- a/test/EFCore.SqlServer.FunctionalTests/MigrationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/MigrationsSqlServerTest.cs
@@ -528,6 +528,13 @@ Foos
                         b.HasKey("Id");
 
                         b.ToTable("Blogs");
+
+                        b.HasData(
+                            new
+                            {
+                                Id = 1,
+                                Name = "HalfADonkey"
+                            });
                     });
 
                 modelBuilder.Entity(
@@ -1349,6 +1356,15 @@ namespace ModelSnapshot22
             => optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=Test;ConnectRetryCount=0");
 
         public DbSet<Blog> Blogs { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Blog>().HasData(
+                new Blog
+                {
+                    Id = 1, Name = "HalfADonkey"
+                });
+        }
     }
 }
 

--- a/test/EFCore.Tests/Metadata/Conventions/ConventionDispatcherTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/ConventionDispatcherTest.cs
@@ -84,11 +84,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             if (useBuilder)
             {
-                Assert.Null(new InternalModelBuilder(model).Metadata.FinalizeModel());
+                Assert.Same(model, new InternalModelBuilder(model).Metadata.FinalizeModel());
             }
             else
             {
-                Assert.Null(model.FinalizeModel());
+                Assert.Same(model, model.FinalizeModel());
             }
 
             Assert.Equal(1, convention1.Calls);


### PR DESCRIPTION
Fixes #17145 but see also #17205

The fix here allows the state manager to work, which is required when the model snapshot has model data in it.
