### PR TITLE
[preview9] Fix to #16323 - Query: add support for keyless entity types with defining query

### DIFF
--- a/src/EFCore.Relational/Extensions/RelationalQueryableExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalQueryableExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore
     /// </summary>
     public static class RelationalQueryableExtensions
     {
-        private static readonly MethodInfo _fromSqlOnQueryableMethodInfo
+        internal static readonly MethodInfo FromSqlOnQueryableMethodInfo
             = typeof(RelationalQueryableExtensions)
                 .GetTypeInfo().GetDeclaredMethods(nameof(FromSqlOnQueryable))
                 .Single();
@@ -71,7 +71,7 @@ namespace Microsoft.EntityFrameworkCore
             return source.Provider.CreateQuery<TEntity>(
                 Expression.Call(
                     null,
-                    _fromSqlOnQueryableMethodInfo.MakeGenericMethod(typeof(TEntity)),
+                    FromSqlOnQueryableMethodInfo.MakeGenericMethod(typeof(TEntity)),
                     source.Expression,
                     Expression.Constant(sql.Format),
                     Expression.Constant(parameters)));
@@ -115,7 +115,7 @@ namespace Microsoft.EntityFrameworkCore
             return source.Provider.CreateQuery<TEntity>(
                 Expression.Call(
                     null,
-                    _fromSqlOnQueryableMethodInfo.MakeGenericMethod(typeof(TEntity)),
+                    FromSqlOnQueryableMethodInfo.MakeGenericMethod(typeof(TEntity)),
                     source.Expression,
                     Expression.Constant(sql.Format),
                     Expression.Constant(sql.GetArguments())));
@@ -164,7 +164,7 @@ namespace Microsoft.EntityFrameworkCore
             return queryableSource.Provider.CreateQuery<TEntity>(
                 Expression.Call(
                     null,
-                    _fromSqlOnQueryableMethodInfo.MakeGenericMethod(typeof(TEntity)),
+                    FromSqlOnQueryableMethodInfo.MakeGenericMethod(typeof(TEntity)),
                     queryableSource.Expression,
                     Expression.Constant(sql),
                     Expression.Constant(parameters)));
@@ -204,7 +204,7 @@ namespace Microsoft.EntityFrameworkCore
             return queryableSource.Provider.CreateQuery<TEntity>(
                 Expression.Call(
                     null,
-                    _fromSqlOnQueryableMethodInfo.MakeGenericMethod(typeof(TEntity)),
+                    FromSqlOnQueryableMethodInfo.MakeGenericMethod(typeof(TEntity)),
                     queryableSource.Expression,
                     Expression.Constant(sql.Format),
                     Expression.Constant(sql.GetArguments())));

--- a/src/EFCore.Relational/Metadata/Conventions/Infrastructure/RelationalConventionSetBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Infrastructure/RelationalConventionSetBuilder.cs
@@ -101,6 +101,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
                 new DbFunctionTypeMappingConvention(Dependencies, RelationalDependencies),
                 typeof(ValidatingConvention));
 
+            ReplaceConvention(
+                conventionSet.ModelFinalizedConventions,
+                (QueryFilterDefiningQueryRewritingConvention)new RelationalQueryFilterDefiningQueryRewritingConvention(Dependencies, RelationalDependencies));
+
             return conventionSet;
         }
     }

--- a/src/EFCore.Relational/Metadata/Conventions/RelationalQueryFilterDefiningQueryRewritingConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/RelationalQueryFilterDefiningQueryRewritingConvention.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
+{
+    public class RelationalQueryFilterDefiningQueryRewritingConvention : QueryFilterDefiningQueryRewritingConvention
+    {
+        /// <summary>
+        ///     Creates a new instance of <see cref="RelationalQueryFilterDefiningQueryRewritingConvention" />.
+        /// </summary>
+        /// <param name="dependencies"> Parameter object containing dependencies for this convention. </param>
+        /// <param name="relationalDependencies">  Parameter object containing relational dependencies for this convention. </param>
+        public RelationalQueryFilterDefiningQueryRewritingConvention(
+            [NotNull] ProviderConventionSetBuilderDependencies dependencies,
+            [NotNull] RelationalConventionSetBuilderDependencies relationalDependencies)
+            : base(dependencies)
+        {
+            DbSetAccessRewriter = new RelationalDbSetAccessRewritingExpressionVisitor(Dependencies.ContextType);
+        }
+
+        protected class RelationalDbSetAccessRewritingExpressionVisitor : DbSetAccessRewritingExpressionVisitor
+        {
+            public RelationalDbSetAccessRewritingExpressionVisitor(Type contextType)
+                : base(contextType)
+            {
+            }
+
+            protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
+            {
+                if (methodCallExpression.Method.DeclaringType == typeof(RelationalQueryableExtensions)
+                    && (methodCallExpression.Method.Name == nameof(RelationalQueryableExtensions.FromSql)
+                        || methodCallExpression.Method.Name == nameof(RelationalQueryableExtensions.FromSqlRaw)
+                        || methodCallExpression.Method.Name == nameof(RelationalQueryableExtensions.FromSqlInterpolated)))
+                {
+                    var newSource = Visit(methodCallExpression.Arguments[0]);
+                    var fromSqlOnQueryableMethod = RelationalQueryableExtensions.FromSqlOnQueryableMethodInfo.MakeGenericMethod(newSource.Type.GetGenericArguments()[0]);
+
+                    switch (methodCallExpression.Method.Name)
+                    {
+                        case nameof(RelationalQueryableExtensions.FromSqlRaw):
+                            return Expression.Call(
+                                null,
+                                fromSqlOnQueryableMethod,
+                                newSource,
+                                methodCallExpression.Arguments[1],
+                                methodCallExpression.Arguments[2]);
+
+                        case nameof(RelationalQueryableExtensions.FromSqlInterpolated):
+                        case nameof(RelationalQueryableExtensions.FromSql) when methodCallExpression.Arguments.Count == 2:
+                            var formattableString = Expression.Lambda<Func<FormattableString>>(Expression.Convert(methodCallExpression.Arguments[1], typeof(FormattableString))).Compile().Invoke();
+
+                            return Expression.Call(
+                                null,
+                                fromSqlOnQueryableMethod,
+                                newSource,
+                                Expression.Constant(formattableString.Format),
+                                Expression.Constant(formattableString.GetArguments()));
+
+                        case nameof(RelationalQueryableExtensions.FromSql) when methodCallExpression.Arguments.Count == 3:
+#pragma warning disable CS0618 // Type or member is obsolete
+                            var rawSqlStringString = Expression.Lambda<Func<RawSqlString>>(Expression.Convert(methodCallExpression.Arguments[1], typeof(RawSqlString))).Compile().Invoke();
+#pragma warning restore CS0618 // Type or member is obsolete
+
+                            return Expression.Call(
+                                null,
+                                fromSqlOnQueryableMethod,
+                                newSource,
+                                Expression.Constant(rawSqlStringString.Format),
+                                methodCallExpression.Arguments[2]);
+                    }
+                }
+
+                return base.VisitMethodCall(methodCallExpression);
+            }
+        }
+    }
+}

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Runtime.InteropServices.ComTypes;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.FromSqlParameterApplyingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.FromSqlParameterApplyingExpressionVisitor.cs
@@ -84,10 +84,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                                 break;
 
                             case ConstantExpression constantExpression:
-                                var constantValues = (object[])constantExpression.Value;
-                                for (var i = 0; i < constantValues.Length; i++)
+                                var existingValues = (object[])constantExpression.Value;
+                                var constantValues = new object[existingValues.Length];
+                                for (var i = 0; i < existingValues.Length; i++)
                                 {
-                                    var value = constantValues[i];
+                                    var value = existingValues[i];
                                     if (value is DbParameter dbParameter)
                                     {
                                         var parameterName = _parameterNameGenerator.GenerateNext();

--- a/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
@@ -175,6 +175,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             conventionSet.ModelFinalizedConventions.Add(servicePropertyDiscoveryConvention);
             conventionSet.ModelFinalizedConventions.Add(nonNullableReferencePropertyConvention);
             conventionSet.ModelFinalizedConventions.Add(nonNullableNavigationConvention);
+            conventionSet.ModelFinalizedConventions.Add(new QueryFilterDefiningQueryRewritingConvention(Dependencies));
             conventionSet.ModelFinalizedConventions.Add(new ValidatingConvention(Dependencies));
             // Don't add any more conventions to ModelFinalizedConventions after ValidatingConvention
 

--- a/src/EFCore/Metadata/Conventions/QueryFilterDefiningQueryRewritingConvention.cs
+++ b/src/EFCore/Metadata/Conventions/QueryFilterDefiningQueryRewritingConvention.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
+{
+    /// <summary>
+    ///     Convention that converts accesses of DbSets inside query filters and defining queries into EntityQueryables.
+    ///     This makes them consistent with how DbSet accesses in the actual queries are represented, which allows for easier processing in the query pipeline.
+    /// </summary>
+    public class QueryFilterDefiningQueryRewritingConvention : IModelFinalizedConvention
+    {
+        /// <summary>
+        ///     Creates a new instance of <see cref="QueryFilterDefiningQueryRewritingConvention" />.
+        /// </summary>
+        /// <param name="dependencies"> Parameter object containing dependencies for this convention. </param>
+        public QueryFilterDefiningQueryRewritingConvention([NotNull] ProviderConventionSetBuilderDependencies dependencies)
+        {
+            Dependencies = dependencies;
+            DbSetAccessRewriter = new DbSetAccessRewritingExpressionVisitor(dependencies.ContextType);
+        }
+
+        /// <summary>
+        ///     Parameter object containing service dependencies.
+        /// </summary>
+        protected virtual ProviderConventionSetBuilderDependencies Dependencies { get; }
+
+        /// <summary>
+        ///     Visitor used to rewrite DbSets accesses encountered in query filters and defining queries to EntityQueryables.
+        /// </summary>
+        protected virtual DbSetAccessRewritingExpressionVisitor DbSetAccessRewriter { get; [param: NotNull] set; }
+
+        /// <summary>
+        ///     Called after a model is finalized.
+        /// </summary>
+        /// <param name="modelBuilder"> The builder for the model. </param>
+        /// <param name="context"> Additional information associated with convention execution. </param>
+        public virtual void ProcessModelFinalized(
+            IConventionModelBuilder modelBuilder,
+            IConventionContext<IConventionModelBuilder> context)
+        {
+            foreach (var entityType in modelBuilder.Metadata.GetEntityTypes())
+            {
+                var queryFilter = entityType.GetQueryFilter();
+                if (queryFilter != null)
+                {
+                    entityType.SetQueryFilter((LambdaExpression)DbSetAccessRewriter.Visit(queryFilter));
+                }
+
+                var definingQuery = entityType.GetDefiningQuery();
+                if (definingQuery != null)
+                {
+                    entityType.SetDefiningQuery((LambdaExpression)DbSetAccessRewriter.Visit(definingQuery));
+                }
+            }
+        }
+
+        protected class DbSetAccessRewritingExpressionVisitor : ExpressionVisitor
+        {
+            private readonly Type _contextType;
+
+            public DbSetAccessRewritingExpressionVisitor(Type contextType)
+            {
+                _contextType = contextType;
+            }
+
+            protected override Expression VisitMember(MemberExpression memberExpression)
+            {
+                if (memberExpression.Expression != null
+                    && (memberExpression.Expression.Type.IsAssignableFrom(_contextType)
+                        || _contextType.IsAssignableFrom(memberExpression.Expression.Type))
+                    && memberExpression.Type.IsGenericType
+                    && (memberExpression.Type.GetGenericTypeDefinition() == typeof(DbSet<>)
+#pragma warning disable CS0618 // Type or member is obsolete
+                        || memberExpression.Type.GetGenericTypeDefinition() == typeof(DbQuery<>)))
+#pragma warning restore CS0618 // Type or member is obsolete
+                {
+                    return NullAsyncQueryProvider.Instance.CreateEntityQueryableExpression(memberExpression.Type.GetGenericArguments()[0]);
+                }
+
+                return base.VisitMember(memberExpression);
+            }
+
+            protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
+            {
+                if (methodCallExpression.Method.Name == nameof(DbContext.Set)
+                    && methodCallExpression.Object != null
+                    && typeof(DbContext).IsAssignableFrom(methodCallExpression.Object.Type)
+                    && methodCallExpression.Type.IsGenericType
+                    && methodCallExpression.Type.GetGenericTypeDefinition() == typeof(DbSet<>))
+                {
+                    return NullAsyncQueryProvider.Instance.CreateEntityQueryableExpression(methodCallExpression.Type.GetGenericArguments()[0]);
+                }
+
+                return base.VisitMethodCall(methodCallExpression);
+            }
+        }
+    }
+}

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2190,6 +2190,15 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public static string SetOperationWithDifferentIncludesInOperands
             => GetString("SetOperationWithDifferentIncludesInOperands");
 
+        /// <summary>
+        ///     Include is not supported for entities with defining query. Entity type: '{entityType}'. 
+        /// </summary>
+        /// <returns></returns>
+        public static string IncludeOnEntityWithDefiningQueryNotSupported([CanBeNull] object entityType)
+            => string.Format(
+                GetString("IncludeOnEntityWithDefiningQueryNotSupported", nameof(entityType)),
+                entityType);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1204,4 +1204,7 @@
   <data name="SetOperationWithDifferentIncludesInOperands" xml:space="preserve">
     <value>When performing a set operation, both operands must have the same Include operations.</value>
   </data>
+  <data name="IncludeOnEntityWithDefiningQueryNotSupported" xml:space="preserve">
+    <value>Include is not supported for entities with defining query. Entity type: '{entityType}'</value>
+  </data>
 </root>

--- a/src/EFCore/Query/Internal/ParameterExtractingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/ParameterExtractingExpressionVisitor.cs
@@ -59,8 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             _generateContextAccessors = generateContextAccessors;
             if (_generateContextAccessors)
             {
-                _contextParameterReplacingExpressionVisitor
-                    = new ContextParameterReplacingExpressionVisitor(contextType);
+                _contextParameterReplacingExpressionVisitor = new ContextParameterReplacingExpressionVisitor(contextType);
             }
         }
 

--- a/src/EFCore/Query/QueryTranslationPreprocessorDependencies.cs
+++ b/src/EFCore/Query/QueryTranslationPreprocessorDependencies.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/src/EFCore/Query/ReplacingExpressionVisitor.cs
+++ b/src/EFCore/Query/ReplacingExpressionVisitor.cs
@@ -58,8 +58,11 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             if (innerExpression is MemberInitExpression memberInitExpression)
             {
-                return ((MemberAssignment)memberInitExpression.Bindings
-                    .Single(mb => mb.Member == memberExpression.Member)).Expression;
+                var matchingBinding = memberInitExpression.Bindings.Where(mb => mb.Member == memberExpression.Member).SingleOrDefault();
+                if (matchingBinding != null)
+                {
+                    return ((MemberAssignment)matchingBinding).Expression;
+                }
             }
 
             return memberExpression.Update(innerExpression);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.KeylessEntities.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.KeylessEntities.cs
@@ -10,47 +10,46 @@ namespace Microsoft.EntityFrameworkCore.Query
 {
     public partial class SimpleQueryCosmosTest
     {
-        [ConditionalTheory(Skip = "See issue#13857")]
+        [ConditionalTheory]
         public override async Task KeylessEntity_simple(bool isAsync)
         {
             await base.KeylessEntity_simple(isAsync);
 
             AssertSql(
-                @"SELECT c
+                @"SELECT c[""Address""], c[""City""], c[""CompanyName""], c[""ContactName""], c[""ContactTitle""]
 FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
-        [ConditionalTheory(Skip = "See issue#13857")]
+        [ConditionalTheory]
         public override async Task KeylessEntity_where_simple(bool isAsync)
         {
             await base.KeylessEntity_where_simple(isAsync);
 
             AssertSql(
-                @"SELECT c
+                @"SELECT c[""Address""], c[""City""], c[""CompanyName""], c[""ContactName""], c[""ContactTitle""]
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))");
         }
 
-        [ConditionalFact(Skip = "See issue#13857")]
+        [ConditionalFact]
         public override void KeylessEntity_by_database_view()
         {
             base.KeylessEntity_by_database_view();
 
             AssertSql(
-                @"SELECT c
+                @"SELECT c[""ProductID""], c[""ProductName""], ""Food"" AS CategoryName
 FROM root c
 WHERE ((c[""Discriminator""] = ""Product"") AND NOT(c[""Discontinued""]))");
         }
 
+        [ConditionalFact(Skip = "issue #12086")] // collection support
         public override void KeylessEntity_with_nav_defining_query()
         {
             base.KeylessEntity_with_nav_defining_query();
 
             AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+                @"");
         }
 
         public override async Task KeylessEntity_with_mixed_tracking(bool isAsync)
@@ -78,9 +77,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))");
             await base.KeylessEntity_with_defining_query(isAsync);
 
             AssertSql(
-                @"SELECT c
+                @"SELECT c[""CustomerID""]
 FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
         }
 
         public override async Task KeylessEntity_with_defining_query_and_correlated_collection(bool isAsync)
@@ -93,36 +92,15 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
-        public override async Task KeylessEntity_with_included_nav(bool isAsync)
-        {
-            await base.KeylessEntity_with_included_nav(isAsync);
-
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
-        }
-
-        public override async Task KeylessEntity_with_included_navs_multi_level(bool isAsync)
-        {
-            await base.KeylessEntity_with_included_navs_multi_level(isAsync);
-
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
-        }
-
+        [ConditionalTheory(Skip = "issue 312086")] // left join translation
         public override async Task KeylessEntity_select_where_navigation(bool isAsync)
         {
             await base.KeylessEntity_select_where_navigation(isAsync);
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+            AssertSql(@"");
         }
 
+        [ConditionalTheory(Skip = "issue 312086")] // left join translation
         public override async Task KeylessEntity_select_where_navigation_multi_level(bool isAsync)
         {
             await AssertQuery<OrderQuery>(
@@ -131,10 +109,7 @@ WHERE (c[""Discriminator""] = ""Order"")");
                        where ov.Customer.Orders.Any()
                        select ov);
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+            AssertSql(@"");
         }
     }
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/InheritanceRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/InheritanceRelationalTestBase.cs
@@ -36,10 +36,6 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "Issue #16323")]
-        public override void Can_query_all_animal_views()
-            => base.Can_query_all_animal_views();
-
         private string NormalizeDelimetersInRawString(string sql)
             => ((RelationalTestStore)Fixture.TestStore).NormalizeDelimetersInRawString(sql);
 

--- a/test/EFCore.Relational.Specification.Tests/TestModels/Northwind/NorthwindRelationalContext.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/Northwind/NorthwindRelationalContext.cs
@@ -12,6 +12,8 @@ namespace Microsoft.EntityFrameworkCore.TestModels.Northwind
         {
         }
 
+        public string _empty = string.Empty;
+
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);
@@ -27,7 +29,8 @@ namespace Microsoft.EntityFrameworkCore.TestModels.Northwind
 
 #pragma warning disable CS0618 // Type or member is obsolete
             modelBuilder.Query<CustomerView>().HasNoKey().ToQuery(
-                () => CustomerQueries.FromSqlRaw("SELECT * FROM Customers"));
+                () => CustomerQueries.FromSqlInterpolated($"SELECT [c].[CustomerID] + {_empty} as [CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region] FROM [Customers] AS [c]"
+));
 
             modelBuilder
                 .Query<OrderQuery>()

--- a/test/EFCore.Specification.Tests/Query/QueryFilterFuncletizationTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/QueryFilterFuncletizationTestBase.cs
@@ -330,7 +330,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "See issue#17111")]
+        [ConditionalFact]
         public virtual void Using_DbSet_in_filter_works()
         {
             using (var context = CreateContext())
@@ -339,7 +339,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "See issue#17111")]
+        [ConditionalFact]
         public virtual void Using_Context_set_method_in_filter_works()
         {
             using (var context = CreateContext())

--- a/test/EFCore.SqlServer.FunctionalTests/Query/CompiledQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/CompiledQuerySqlServerTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
@@ -138,21 +139,53 @@ FROM [Customers] AS [c]
 WHERE [c].[CustomerID] = N'ALFKI'");
         }
 
-        [ConditionalFact(Skip = "Issue #16323")]
-        public override Task DbQuery_query_async()
-            => base.DbQuery_query_async();
+        [ConditionalFact]
+        public override async Task DbQuery_query_async()
+        {
+            await base.DbQuery_query_async();
 
-        [ConditionalFact(Skip = "Issue #16323")]
+            AssertSql(
+                @"SELECT [c].[CustomerID] + N'' as [CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region] FROM [Customers] AS [c]",
+                //
+                @"SELECT [c].[CustomerID] + N'' as [CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region] FROM [Customers] AS [c]");
+        }
+
+        [ConditionalFact]
         public override void DbQuery_query_first()
-            => base.DbQuery_query_first();
+        {
+            base.DbQuery_query_first();
 
-        [ConditionalFact(Skip = "Issue #16323")]
-        public override Task DbQuery_query_first_async()
-            => base.DbQuery_query_first_async();
+            AssertSql(
+                @"SELECT TOP(1) [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle]
+FROM (
+    SELECT [c].[CustomerID] + N'' as [CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region] FROM [Customers] AS [c]
+) AS [c]
+ORDER BY [c].[CompanyName]");
+        }
 
-        [ConditionalFact(Skip = "Issue #16323")]
+        [ConditionalFact]
+        public override async Task DbQuery_query_first_async()
+        {
+            await base.DbQuery_query_first_async();
+
+            AssertSql(
+                @"SELECT TOP(1) [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle]
+FROM (
+    SELECT [c].[CustomerID] + N'' as [CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region] FROM [Customers] AS [c]
+) AS [c]
+ORDER BY [c].[CompanyName]");
+        }
+
+        [ConditionalFact]
         public override void DbQuery_query()
-            => base.DbQuery_query();
+        {
+            base.DbQuery_query();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID] + N'' as [CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region] FROM [Customers] AS [c]",
+                //
+                @"SELECT [c].[CustomerID] + N'' as [CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region] FROM [Customers] AS [c]");
+        }
 
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceSqlServerTest.cs
@@ -218,7 +218,9 @@ ORDER BY [a].[Species]");
 
             AssertSql(
                 @"SELECT [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
-FROM [Animal] AS [a]
+FROM (
+    SELECT * FROM Animal
+) AS [a]
 WHERE [a].[Discriminator] IN (N'Eagle', N'Kiwi')
 ORDER BY [a].[CountryId]");
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -5316,7 +5316,7 @@ ORDER BY [p].[Id], [t0].[Id]");
 
         #region Bug13346
 
-        [ConditionalFact(Skip = "Issue #16323")]
+        [ConditionalFact]
         public virtual void ToQuery_can_define_in_own_terms_using_FromSql()
         {
             using (CreateDatabase13346())

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryFilterFuncletizationSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryFilterFuncletizationSqlServerTest.cs
@@ -348,12 +348,17 @@ WHERE ([e].[IsEnabled] = @__ef_filter__Enabled_0) AND @__ef_filter__Enabled_0 IS
             base.Using_DbSet_in_filter_works();
 
             AssertSql(
-                @"SELECT [p].[Id], [p].[Filler]
+                @"@__ef_filter__Property_0='False'
+
+SELECT [p].[Id], [p].[Filler]
 FROM [PrincipalSetFilter] AS [p]
 WHERE EXISTS (
     SELECT 1
     FROM [Dependents] AS [d]
-    WHERE [d].[PrincipalSetFilterId] = [p].[Id])");
+    WHERE EXISTS (
+        SELECT 1
+        FROM [MultiContextFilter] AS [m]
+        WHERE ((([m].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL) AND ([m].[BossId] = 1)) AND ([m].[BossId] = [d].[PrincipalSetFilterId])) AND ([d].[PrincipalSetFilterId] = [p].[Id]))");
         }
 
         public override void Using_Context_set_method_in_filter_works()
@@ -361,12 +366,14 @@ WHERE EXISTS (
             base.Using_Context_set_method_in_filter_works();
 
             AssertSql(
-                @"SELECT [p].[Id], [p].[PrincipalSetFilterId]
-FROM [Dependents] AS [p]
+                @"@__ef_filter__Property_0='False'
+
+SELECT [d].[Id], [d].[PrincipalSetFilterId]
+FROM [Dependents] AS [d]
 WHERE EXISTS (
     SELECT 1
-    FROM [MultiContextFilter] AS [b]
-    WHERE [b].[BossId] = [p].[PrincipalSetFilterId])");
+    FROM [MultiContextFilter] AS [m]
+    WHERE ((([m].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL) AND ([m].[BossId] = 1)) AND ([m].[BossId] = [d].[PrincipalSetFilterId]))");
         }
 
         public override void Static_member_from_dbContext_is_inlined()

--- a/test/EFCore.Sqlite.FunctionalTests/Query/CompiledQueryInMemoryTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/CompiledQueryInMemoryTest.cs
@@ -1,9 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.TestUtilities;
-using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
@@ -13,21 +11,5 @@ namespace Microsoft.EntityFrameworkCore.Query
             : base(fixture)
         {
         }
-
-        [ConditionalFact(Skip = "Issue #16323")]
-        public override Task DbQuery_query_async()
-            => base.DbQuery_query_async();
-
-        [ConditionalFact(Skip = "Issue #16323")]
-        public override void DbQuery_query_first()
-            => base.DbQuery_query_first();
-
-        [ConditionalFact(Skip = "Issue #16323")]
-        public override Task DbQuery_query_first_async()
-            => base.DbQuery_query_first_async();
-
-        [ConditionalFact(Skip = "Issue #16323")]
-        public override void DbQuery_query()
-            => base.DbQuery_query();
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
@@ -1309,18 +1309,6 @@ FROM (
         public override Task Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault_2(bool isAsync)
             => base.Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault_2(isAsync);
 
-        [ConditionalFact(Skip = "Issue #16323")]
-        public override void Auto_initialized_view_set()
-            => base.Auto_initialized_view_set();
-
-        [ConditionalTheory(Skip = "Issue #16323")]
-        public override Task KeylessEntity_simple(bool isAsync)
-            => base.KeylessEntity_simple(isAsync);
-
-        [ConditionalTheory(Skip = "Issue #16323")]
-        public override Task KeylessEntity_where_simple(bool isAsync)
-            => base.KeylessEntity_where_simple(isAsync);
-
         // Sqlite does not support lateral joins
         public override void Select_nested_collection_multi_level()
         {

--- a/test/EFCore.Sqlite.FunctionalTests/WithConstructorsSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/WithConstructorsSqliteTest.cs
@@ -4,7 +4,6 @@
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
-using Xunit;
 
 namespace Microsoft.EntityFrameworkCore
 {
@@ -14,10 +13,6 @@ namespace Microsoft.EntityFrameworkCore
             : base(fixture)
         {
         }
-
-        [ConditionalFact(Skip = "Issue #16323")]
-        public override void Query_with_keyless_type()
-            => base.Query_with_keyless_type();
 
         protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
             => facade.UseTransaction(transaction.GetDbTransaction());


### PR DESCRIPTION
During nav expansion, when visiting EntityQueryables we now peek into entity metadata looking for defining query and query filter. If they are found, nav expansion applies them and expands navigations in the resulting query (recursively).

Also, fix to #17111 - Cannot use DbSet in query filter

DbSet accesses are converted into EntityQueryables during model finialization. We need to do this early, because otherwise we would need a dbcontext to create a queryable, and that dbcontext could be disposed at the time nav expansion runs.
Since FromSql/FromSqlRaw/FromSqlInterpolated are constrained to DbSet<T> they need to be converted to FromSqlOnQueryable at the same time.