### PR TITLE
Query: Parameterize member access in expression tree

### DIFF
--- a/src/EFCore/Query/Internal/ParameterExtractingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/ParameterExtractingExpressionVisitor.cs
@@ -535,13 +535,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             protected override Expression VisitMember(MemberExpression memberExpression)
             {
-                if (memberExpression.Expression == null)
-                {
-                    // Static members which can change value
-                    _containsClosure
-                        = !(memberExpression.Member is FieldInfo fieldInfo && fieldInfo.IsInitOnly);
-                }
-
+                _containsClosure = memberExpression.Expression != null
+                    || !(memberExpression.Member is FieldInfo fieldInfo && fieldInfo.IsInitOnly);
                 return base.VisitMember(memberExpression);
             }
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.Where.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.Where.cs
@@ -592,13 +592,17 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = @__city_Nested_I
             await base.Where_new_instance_field_access_query_cache(isAsync);
 
             AssertSql(
-                @"SELECT c
+                @"@__InstanceFieldValue_0='London'
+
+SELECT c
 FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))",
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = @__InstanceFieldValue_0))",
                 //
-                @"SELECT c
+                @"@__InstanceFieldValue_0='Seattle'
+
+SELECT c
 FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""Seattle""))");
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = @__InstanceFieldValue_0))");
         }
 
         public override async Task Where_new_instance_field_access_closure_via_query_cache(bool isAsync)

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
@@ -1233,7 +1233,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 (cs, es) =>
                     from c in cs
                     from e in es
-                    // ReSharper disable ArrangeRedundantParentheses
+                        // ReSharper disable ArrangeRedundantParentheses
 #pragma warning disable RCS1032 // Remove redundant parentheses.
                     where (c.City == "London" && c.Country == "UK")
                           && (e.City == "London" && e.Country == "UK")
@@ -2028,5 +2028,44 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 ps => ps.Where(p => p is Product ? false : true));
         }
+
+        [ConditionalTheory]  // issue #17172
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Enclosing_class_settable_member_generates_parameter(bool isAsync)
+        {
+            SettableProperty = 4;
+
+            await AssertQuery<Order>(
+                isAsync,
+                os => os.Where(o => o.OrderID == SettableProperty));
+
+            SettableProperty = 10;
+
+            await AssertQuery<Order>(
+               isAsync,
+               os => os.Where(o => o.OrderID == SettableProperty));
+        }
+
+        [ConditionalTheory]  // issue #17172
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Enclosing_class_readonly_member_generates_parameter(bool isAsync)
+        {
+            return AssertQuery<Order>(
+                isAsync,
+                os => os.Where(o => o.OrderID == ReadOnlyProperty));
+        }
+
+        [ConditionalTheory]  // issue #17172
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Enclosing_class_const_member_does_not_generate_parameter(bool isAsync)
+        {
+            return AssertQuery<Order>(
+                isAsync,
+                os => os.Where(o => o.OrderID == ConstantProperty));
+        }
+
+        private int SettableProperty { get; set; }
+        private int ReadOnlyProperty => 5;
+        private const int ConstantProperty = 1;
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Where.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Where.cs
@@ -287,13 +287,17 @@ WHERE (([c].[City] = @__city_Nested_InstancePropertyValue_0) AND ([c].[City] IS 
             await base.Where_new_instance_field_access_query_cache(isAsync);
 
             AssertSql(
-                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+                @"@__InstanceFieldValue_0='London' (Size = 4000)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ([c].[City] = N'London') AND [c].[City] IS NOT NULL",
+WHERE (([c].[City] = @__InstanceFieldValue_0) AND ([c].[City] IS NOT NULL AND @__InstanceFieldValue_0 IS NOT NULL)) OR ([c].[City] IS NULL AND @__InstanceFieldValue_0 IS NULL)",
                 //
-                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+                @"@__InstanceFieldValue_0='Seattle' (Size = 4000)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ([c].[City] = N'Seattle') AND [c].[City] IS NOT NULL");
+WHERE (([c].[City] = @__InstanceFieldValue_0) AND ([c].[City] IS NOT NULL AND @__InstanceFieldValue_0 IS NOT NULL)) OR ([c].[City] IS NULL AND @__InstanceFieldValue_0 IS NULL)");
         }
 
         public override async Task Where_new_instance_field_access_closure_via_query_cache(bool isAsync)
@@ -1785,6 +1789,46 @@ WHERE CASE
     WHEN CAST(1 AS bit) = CAST(1 AS bit) THEN CAST(0 AS bit)
     ELSE CAST(1 AS bit)
 END = CAST(1 AS bit)");
+        }
+
+        public override async Task Enclosing_class_settable_member_generates_parameter(bool isAsync)
+        {
+            await base.Enclosing_class_settable_member_generates_parameter(isAsync);
+
+            AssertSql(
+                @"@__SettableProperty_0='4'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE ([o].[OrderID] = @__SettableProperty_0) AND @__SettableProperty_0 IS NOT NULL",
+                //
+                @"@__SettableProperty_0='10'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE ([o].[OrderID] = @__SettableProperty_0) AND @__SettableProperty_0 IS NOT NULL");
+        }
+
+        public override async Task Enclosing_class_readonly_member_generates_parameter(bool isAsync)
+        {
+            await base.Enclosing_class_readonly_member_generates_parameter(isAsync);
+
+            AssertSql(
+                @"@__ReadOnlyProperty_0='5'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE ([o].[OrderID] = @__ReadOnlyProperty_0) AND @__ReadOnlyProperty_0 IS NOT NULL");
+        }
+
+        public override async Task Enclosing_class_const_member_does_not_generate_parameter(bool isAsync)
+        {
+            await base.Enclosing_class_const_member_does_not_generate_parameter(isAsync);
+
+            AssertSql(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[OrderID] = 1");
         }
     }
 }


### PR DESCRIPTION
Except for static readonly fields

const fields are always inlined as constant by compiler

Resolves #17172
