### PR TITLE
Don't call SqliteConnection.RemoveCommand() from command finalizer

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteCommand.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteCommand.cs
@@ -206,7 +206,11 @@ namespace Microsoft.Data.Sqlite
         protected override void Dispose(bool disposing)
         {
             DisposePreparedStatements(disposing);
-            _connection?.RemoveCommand(this);
+
+            if (disposing)
+            {
+                _connection?.RemoveCommand(this);
+            }
 
             base.Dispose(disposing);
         }

--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
@@ -332,13 +332,17 @@ namespace Microsoft.Data.Sqlite
 
             Transaction?.Dispose();
 
-            // command.Dispose() removes itself from _commands
             for (var i = _commands.Count - 1; i >= 0; i--)
             {
                 var reference = _commands[i];
                 if (reference.TryGetTarget(out var command))
                 {
+                    // NB: Calls RemoveCommand()
                     command.Dispose();
+                }
+                else
+                {
+                    _commands.RemoveAt(i);
                 }
             }
 
@@ -397,8 +401,8 @@ namespace Microsoft.Data.Sqlite
         {
             for (var i = _commands.Count - 1; i >= 0; i--)
             {
-                if (!_commands[i].TryGetTarget(out var item)
-                    || item == command)
+                if (_commands[i].TryGetTarget(out var item)
+                    && item == command)
                 {
                     _commands.RemoveAt(i);
                 }


### PR DESCRIPTION
Wrote a test locally to generate lots of garbage. This fixed a NullRef. Still couldn't repro #16234