### PR TITLE
InMemory support for DefaultIfEmpty

### DIFF
--- a/src/EFCore.InMemory/Query/Internal/InMemoryLinqOperatorProvider.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryLinqOperatorProvider.cs
@@ -25,7 +25,8 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
 
         public static MethodInfo Join = GetMethod(nameof(Enumerable.Join), 4);
         public static MethodInfo GroupJoin = GetMethod(nameof(Enumerable.GroupJoin), 4);
-        public static MethodInfo DefaultIfEmptyWithArg = GetMethod(nameof(Enumerable.DefaultIfEmpty), 1);
+        public static MethodInfo DefaultIfEmptyWithoutArgument = GetMethod(nameof(Enumerable.DefaultIfEmpty));
+        public static MethodInfo DefaultIfEmptyWithArgument = GetMethod(nameof(Enumerable.DefaultIfEmpty), 1);
         public static MethodInfo SelectMany = GetMethods(nameof(Enumerable.SelectMany), 2)
             .Single(mi => mi.GetParameters()[1].ParameterType.GetGenericArguments().Length == 2);
         public static MethodInfo Contains = GetMethod(nameof(Enumerable.Contains), 1);

--- a/src/EFCore.InMemory/Query/Internal/InMemoryProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryProjectionBindingExpressionVisitor.cs
@@ -139,7 +139,6 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
 
                     return new ProjectionBindingExpression(_queryExpression, _projectionMembers.Peek(), expression.Type);
                 }
-
             }
 
             return base.Visit(expression);

--- a/test/EFCore.InMemory.FunctionalTests/Query/SimpleQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/SimpleQueryInMemoryTest.cs
@@ -150,34 +150,14 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
         }
 
-        [ConditionalTheory(Skip = "Issue #16963")]
+        [ConditionalTheory(Skip = "Issue #16963 (SelectMany)")]
         public override Task DefaultIfEmpty_in_subquery(bool isAsync) => null;
 
-        [ConditionalTheory(Skip = "Issue #16963")]
+        [ConditionalTheory(Skip = "Issue #16963 (SelectMany)")]
         public override Task DefaultIfEmpty_in_subquery_nested(bool isAsync) => null;
 
-        [ConditionalTheory(Skip = "Issue #16963")]
+        [ConditionalTheory(Skip = "Issue #16963 (SelectMany)")]
         public override Task DefaultIfEmpty_in_subquery_not_correlated(bool isAsync) => null;
-
-        [ConditionalFact(Skip = "Issue #16963")]
-        public override void DefaultIfEmpty_without_group_join()
-        {
-        }
-
-        [ConditionalTheory(Skip = "Issue #16963")]
-        public override Task Default_if_empty_top_level(bool isAsync) => null;
-
-        [ConditionalTheory(Skip = "Issue #16963")]
-        public override Task Default_if_empty_top_level_followed_by_projecting_constant(bool isAsync) => null;
-
-        [ConditionalTheory(Skip = "Issue #16963")]
-        public override Task Default_if_empty_top_level_positive(bool isAsync) => null;
-
-        [ConditionalTheory(Skip = "Issue #16963")]
-        public override Task Default_if_empty_top_level_projection(bool isAsync) => null;
-
-        [ConditionalTheory(Skip = "Issue #16963")]
-        public override Task Join_with_default_if_empty_on_both_sources(bool isAsync) => null;
 
         [ConditionalFact(Skip = "Issue #16963")]
         public override void OfType_Select()
@@ -228,10 +208,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         [ConditionalTheory(Skip = "Issue #16963")]
         public override Task SelectMany_Joined(bool isAsync) => null;
 
-        [ConditionalTheory(Skip = "Issue #16963")]
+        [ConditionalTheory(Skip = "Issue #16963 (SelectMany)")]
         public override Task SelectMany_Joined_DefaultIfEmpty(bool isAsync) => null;
 
-        [ConditionalTheory(Skip = "Issue #16963")]
+        [ConditionalTheory(Skip = "Issue #16963 (SelectMany)")]
         public override Task SelectMany_Joined_DefaultIfEmpty2(bool isAsync) => null;
 
         [ConditionalTheory(Skip = "Issue #16963")]


### PR DESCRIPTION
Part of #16963 

First time going into InMemory so would appreciate a good review :)

One particular complication: for Default_if_empty_top_level_projection we need to apply Coalesce if a non-nullable value type member is accessed on a nullable entity projection (i.e. after DefaultIfEmpty). However, GroupJoin_DefaultIfEmpty_Project has the same structure within a Convert to object, which is then identified in VisitUnary and handled in a special way. I rewrote the pattern recognition to identify and remove the Coalesce for this particular case, but am not sure it's the right thing to do.