### PR TITLE
Query: Allow providers to create subquery translating visitor

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitor.cs
@@ -57,6 +57,31 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        protected CosmosQueryableMethodTranslatingExpressionVisitor(
+            CosmosQueryableMethodTranslatingExpressionVisitor parentVisitor)
+            : base(parentVisitor.Dependencies, subquery: true)
+        {
+            _model = parentVisitor._model;
+            _sqlExpressionFactory = parentVisitor._sqlExpressionFactory;
+            _sqlTranslator = parentVisitor._sqlTranslator;
+            _projectionBindingExpressionVisitor = new CosmosProjectionBindingExpressionVisitor(_sqlTranslator);
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        protected override QueryableMethodTranslatingExpressionVisitor CreateSubqueryVisitor()
+            => new CosmosQueryableMethodTranslatingExpressionVisitor(this);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public override ShapedQueryExpression TranslateSubquery(Expression expression)
         {
             throw new InvalidOperationException(CoreStrings.TranslationFailed(expression.Print()));
@@ -727,7 +752,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
             return TranslateExpression(lambdaBody);
         }
 
-        private Expression RemapLambdaBody(Expression shaperBody, LambdaExpression lambdaExpression)
+        private static Expression RemapLambdaBody(Expression shaperBody, LambdaExpression lambdaExpression)
         {
             return ReplacingExpressionVisitor.Replace(lambdaExpression.Parameters.Single(), shaperBody, lambdaExpression.Body);
         }

--- a/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
@@ -29,25 +29,17 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
             _model = model;
         }
 
-        public InMemoryQueryableMethodTranslatingExpressionVisitor(
-            QueryableMethodTranslatingExpressionVisitorDependencies dependencies,
-            IModel model,
-            InMemoryExpressionTranslatingExpressionVisitor expressionTranslator)
-            : base(dependencies, subquery: true)
+        protected InMemoryQueryableMethodTranslatingExpressionVisitor(
+            InMemoryQueryableMethodTranslatingExpressionVisitor parentVisitor)
+            : base(parentVisitor.Dependencies, subquery: true)
         {
-            _expressionTranslator = expressionTranslator;
-            _projectionBindingExpressionVisitor = new InMemoryProjectionBindingExpressionVisitor(this, expressionTranslator);
-            _model = model;
+            _expressionTranslator = parentVisitor._expressionTranslator;
+            _projectionBindingExpressionVisitor = new InMemoryProjectionBindingExpressionVisitor(this, _expressionTranslator);
+            _model = parentVisitor._model;
         }
 
-        public override ShapedQueryExpression TranslateSubquery(Expression expression)
-        {
-            return (ShapedQueryExpression)new InMemoryQueryableMethodTranslatingExpressionVisitor(
-                    Dependencies,
-                    _model,
-                    _expressionTranslator)
-                .Visit(expression);
-        }
+        protected override QueryableMethodTranslatingExpressionVisitor CreateSubqueryVisitor()
+            => new InMemoryQueryableMethodTranslatingExpressionVisitor(this);
 
         protected override ShapedQueryExpression CreateShapedQueryExpression(Type elementType)
         {

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryableMethodTranslatingExpressionVisitor.cs
@@ -22,6 +22,15 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
         {
         }
 
+        protected SqliteQueryableMethodTranslatingExpressionVisitor(
+            SqliteQueryableMethodTranslatingExpressionVisitor parentVisitor)
+            : base(parentVisitor)
+        {
+        }
+
+        protected override QueryableMethodTranslatingExpressionVisitor CreateSubqueryVisitor()
+            => new SqliteQueryableMethodTranslatingExpressionVisitor(this);
+
         protected override ShapedQueryExpression TranslateOrderBy(ShapedQueryExpression source, LambdaExpression keySelector, bool ascending)
         {
             var translation = base.TranslateOrderBy(source, keySelector, ascending);

--- a/src/EFCore/Query/QueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore/Query/QueryableMethodTranslatingExpressionVisitor.cs
@@ -491,6 +491,11 @@ namespace Microsoft.EntityFrameworkCore.Query
             return Expression.Field(targetExpression, fieldInfo);
         }
 
+        public virtual ShapedQueryExpression TranslateSubquery(Expression expression)
+            => (ShapedQueryExpression)CreateSubqueryVisitor().Visit(expression);
+
+        protected abstract QueryableMethodTranslatingExpressionVisitor CreateSubqueryVisitor();
+
         protected abstract ShapedQueryExpression CreateShapedQueryExpression(Type elementType);
         protected abstract ShapedQueryExpression TranslateAll(ShapedQueryExpression source, LambdaExpression predicate);
         protected abstract ShapedQueryExpression TranslateAny(ShapedQueryExpression source, LambdaExpression predicate);
@@ -528,6 +533,5 @@ namespace Microsoft.EntityFrameworkCore.Query
         protected abstract ShapedQueryExpression TranslateThenBy(ShapedQueryExpression source, LambdaExpression keySelector, bool ascending);
         protected abstract ShapedQueryExpression TranslateUnion(ShapedQueryExpression source1, ShapedQueryExpression source2);
         protected abstract ShapedQueryExpression TranslateWhere(ShapedQueryExpression source, LambdaExpression predicate);
-        public abstract ShapedQueryExpression TranslateSubquery(Expression expression);
     }
 }


### PR DESCRIPTION
Fixes #17156
