### PR TITLE
Fix to #17253 - Global Query Filter with reference to same entity

### DIFF
--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
@@ -126,6 +126,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 {
                     var processedDefiningQueryBody = _parameterExtractingExpressionVisitor.ExtractParameters(definingQuery.Body);
                     processedDefiningQueryBody = _enumerableToQueryableMethodConvertingExpressionVisitor.Visit(processedDefiningQueryBody);
+                    processedDefiningQueryBody = new SelfReferenceEntityQueryableRewritingExpressionVisitor(this, entityType).Visit(processedDefiningQueryBody);
+
                     navigationExpansionExpression = (NavigationExpansionExpression)Visit(processedDefiningQueryBody);
 
                     var expanded = ExpandAndReduce(navigationExpansionExpression, applyInclude: false);
@@ -170,6 +172,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         _parameterizedQueryFilterPredicateCache[rootEntityType] = filterPredicate;
                     }
 
+                    filterPredicate = (LambdaExpression)new SelfReferenceEntityQueryableRewritingExpressionVisitor(this, entityType).Visit(filterPredicate);
                     var sequenceType = navigationExpansionExpression.Type.GetSequenceType();
 
                     // if we are constructing EntityQueryable of a derived type, we need to re-map filter predicate to the correct derived type


### PR DESCRIPTION
When expanding defining query and/or query filters in nav rewrite we now replace instances of EntityQueryable of the entity for which defining query (or filter) is expanded into NavigationExpansionExpressions - this way we don't recursively try to visit and expand them.