### PR TITLE
Query: Add RowNumberExpression support to convert lateral joins to joins

### DIFF
--- a/src/EFCore.Relational/Query/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/QuerySqlGenerator.cs
@@ -762,5 +762,22 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             return scalarSubqueryExpression;
         }
+
+        protected override Expression VisitRowNumber(RowNumberExpression rowNumberExpression)
+        {
+            _relationalCommandBuilder.Append("ROW_NUMBER() OVER(");
+            if (rowNumberExpression.Partitions.Any())
+            {
+                _relationalCommandBuilder.Append("PARTITION BY ");
+                GenerateList(rowNumberExpression.Partitions, e => Visit(e));
+                _relationalCommandBuilder.Append(" ");
+            }
+
+            _relationalCommandBuilder.Append("ORDER BY ");
+            GenerateList(rowNumberExpression.Orderings, e => Visit(e));
+            _relationalCommandBuilder.Append(")");
+
+            return rowNumberExpression;
+        }
     }
 }

--- a/src/EFCore.Relational/Query/SqlExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/SqlExpressionVisitor.cs
@@ -3,7 +3,6 @@
 
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
-using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
@@ -52,6 +51,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 case ProjectionExpression projectionExpression:
                     return VisitProjection(projectionExpression);
 
+                case RowNumberExpression rowNumberExpression:
+                    return VisitRowNumber(rowNumberExpression);
+
                 case SelectExpression selectExpression:
                     return VisitSelect(selectExpression);
 
@@ -83,6 +85,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return base.VisitExtension(extensionExpression);
         }
 
+        protected abstract Expression VisitRowNumber(RowNumberExpression rowNumberExpression);
         protected abstract Expression VisitExists(ExistsExpression existsExpression);
         protected abstract Expression VisitIn(InExpression inExpression);
         protected abstract Expression VisitCrossJoin(CrossJoinExpression crossJoinExpression);

--- a/src/EFCore.Relational/Query/SqlExpressions/CaseExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/CaseExpression.cs
@@ -122,6 +122,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         public override int GetHashCode()
         {
             var hash = new HashCode();
+            hash.Add(base.GetHashCode());
             hash.Add(Operand);
             for (var i = 0; i < WhenClauses.Count; i++)
             {

--- a/src/EFCore.Relational/Query/SqlExpressions/RowNumberExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/RowNumberExpression.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
+{
+    public class RowNumberExpression : SqlExpression
+    {
+        public RowNumberExpression(IReadOnlyList<SqlExpression> partitions, IReadOnlyList<OrderingExpression> orderings, RelationalTypeMapping typeMapping)
+            : base(typeof(long), typeMapping)
+        {
+            Check.NotEmpty(orderings, nameof(orderings));
+
+            Partitions = partitions;
+            Orderings = orderings;
+        }
+
+        public virtual IReadOnlyList<SqlExpression> Partitions { get; }
+        public virtual IReadOnlyList<OrderingExpression> Orderings { get; }
+
+        protected override Expression VisitChildren(ExpressionVisitor visitor)
+        {
+            var changed = false;
+            var partitions = new List<SqlExpression>();
+            foreach (var partition in Partitions)
+            {
+                var newPartition = (SqlExpression)visitor.Visit(partition);
+                changed |= newPartition != partition;
+                partitions.Add(newPartition);
+            }
+
+            var orderings = new List<OrderingExpression>();
+            foreach (var ordering in Orderings)
+            {
+                var newOrdering = (OrderingExpression)visitor.Visit(ordering);
+                changed |= newOrdering != ordering;
+                orderings.Add(newOrdering);
+            }
+
+            return changed
+                ? new RowNumberExpression(partitions, orderings, TypeMapping)
+                : this;
+        }
+
+        public virtual RowNumberExpression Update(IReadOnlyList<SqlExpression> partitions, IReadOnlyList<OrderingExpression> orderings)
+        {
+            return (Partitions == null ? partitions == null : Partitions.SequenceEqual(partitions))
+                    && Orderings.SequenceEqual(orderings)
+                ? this
+                : new RowNumberExpression(partitions, orderings, TypeMapping);
+        }
+
+        public override void Print(ExpressionPrinter expressionPrinter)
+        {
+            expressionPrinter.Append("ROW_NUMBER() OVER(");
+            if (Partitions.Any())
+            {
+                expressionPrinter.Append("PARTITION BY ");
+                expressionPrinter.VisitList(Partitions);
+                expressionPrinter.Append(" ");
+            }
+            expressionPrinter.Append("ORDER BY ");
+            expressionPrinter.VisitList(Orderings);
+            expressionPrinter.Append(")");
+        }
+
+        public override bool Equals(object obj)
+            => obj != null
+            && (ReferenceEquals(this, obj)
+                || obj is RowNumberExpression rowNumberExpression
+                    && Equals(rowNumberExpression));
+
+        private bool Equals(RowNumberExpression rowNumberExpression)
+            => base.Equals(rowNumberExpression)
+            && (Partitions == null ? rowNumberExpression.Partitions == null : Partitions.SequenceEqual(rowNumberExpression.Partitions))
+            && Orderings.SequenceEqual(rowNumberExpression.Orderings);
+
+        public override int GetHashCode()
+        {
+            var hash = new HashCode();
+            hash.Add(base.GetHashCode());
+            foreach (var partition in Partitions)
+            {
+                hash.Add(partition);
+            }
+
+            foreach (var ordering in Orderings)
+            {
+                hash.Add(ordering);
+            }
+
+            return hash.ToHashCode();
+        }
+    }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryNavigationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryNavigationsSqlServerTest.cs
@@ -116,14 +116,16 @@ FROM (
     SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
-) AS [t]
-OUTER APPLY (
-    SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-    FROM [Orders] AS [o]
-    WHERE ([t].[CustomerID] = [o].[CustomerID]) AND [o].[CustomerID] IS NOT NULL
-    ORDER BY [o].[OrderID]
-) AS [t0]
-ORDER BY [t].[CustomerID]");
+) AS [t1]
+LEFT JOIN (
+    SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+    FROM (
+        SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], ROW_NUMBER() OVER(PARTITION BY [o].[CustomerID] ORDER BY [o].[OrderID]) AS [row]
+        FROM [Orders] AS [o]
+    ) AS [t]
+    WHERE [t].[row] <= 1
+) AS [t0] ON [t1].[CustomerID] = [t0].[CustomerID]
+ORDER BY [t1].[CustomerID]");
         }
 
         public override async Task Select_collection_FirstOrDefault_project_single_column1(bool isAsync)
@@ -170,14 +172,16 @@ FROM (
     SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
-) AS [t]
-OUTER APPLY (
-    SELECT TOP(1) [o].[CustomerID], [o].[OrderID]
-    FROM [Orders] AS [o]
-    WHERE ([t].[CustomerID] = [o].[CustomerID]) AND [o].[CustomerID] IS NOT NULL
-    ORDER BY [o].[OrderID]
-) AS [t0]
-ORDER BY [t].[CustomerID]");
+) AS [t1]
+LEFT JOIN (
+    SELECT [t].[CustomerID], [t].[OrderID]
+    FROM (
+        SELECT [o].[CustomerID], [o].[OrderID], ROW_NUMBER() OVER(PARTITION BY [o].[CustomerID] ORDER BY [o].[OrderID]) AS [row]
+        FROM [Orders] AS [o]
+    ) AS [t]
+    WHERE [t].[row] <= 1
+) AS [t0] ON [t1].[CustomerID] = [t0].[CustomerID]
+ORDER BY [t1].[CustomerID]");
         }
 
         public override async Task Select_collection_FirstOrDefault_project_entity(bool isAsync)
@@ -192,14 +196,16 @@ FROM (
     SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
-) AS [t]
-OUTER APPLY (
-    SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-    FROM [Orders] AS [o]
-    WHERE ([t].[CustomerID] = [o].[CustomerID]) AND [o].[CustomerID] IS NOT NULL
-    ORDER BY [o].[OrderID]
-) AS [t0]
-ORDER BY [t].[CustomerID]");
+) AS [t1]
+LEFT JOIN (
+    SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+    FROM (
+        SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], ROW_NUMBER() OVER(PARTITION BY [o].[CustomerID] ORDER BY [o].[OrderID]) AS [row]
+        FROM [Orders] AS [o]
+    ) AS [t]
+    WHERE [t].[row] <= 1
+) AS [t0] ON [t1].[CustomerID] = [t0].[CustomerID]
+ORDER BY [t1].[CustomerID]");
         }
 
         public override async Task Skip_Select_Navigation(bool isAsync)
@@ -217,14 +223,16 @@ FROM (
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
     OFFSET @__p_0 ROWS
-) AS [t]
-OUTER APPLY (
-    SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-    FROM [Orders] AS [o]
-    WHERE ([t].[CustomerID] = [o].[CustomerID]) AND [o].[CustomerID] IS NOT NULL
-    ORDER BY [o].[OrderID]
-) AS [t0]
-ORDER BY [t].[CustomerID]");
+) AS [t1]
+LEFT JOIN (
+    SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+    FROM (
+        SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], ROW_NUMBER() OVER(PARTITION BY [o].[CustomerID] ORDER BY [o].[OrderID]) AS [row]
+        FROM [Orders] AS [o]
+    ) AS [t]
+    WHERE [t].[row] <= 1
+) AS [t0] ON [t1].[CustomerID] = [t0].[CustomerID]
+ORDER BY [t1].[CustomerID]");
             }
         }
 
@@ -675,14 +683,16 @@ WHERE (
             await base.Collection_select_nav_prop_first_or_default(isAsync);
 
             AssertSql(
-                @"SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+                @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate]
 FROM [Customers] AS [c]
-OUTER APPLY (
-    SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-    FROM [Orders] AS [o]
-    WHERE ([c].[CustomerID] = [o].[CustomerID]) AND [o].[CustomerID] IS NOT NULL
-    ORDER BY [o].[OrderID]
-) AS [t]
+LEFT JOIN (
+    SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+    FROM (
+        SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], ROW_NUMBER() OVER(PARTITION BY [o].[CustomerID] ORDER BY [o].[OrderID]) AS [row]
+        FROM [Orders] AS [o]
+    ) AS [t]
+    WHERE [t].[row] <= 1
+) AS [t0] ON [c].[CustomerID] = [t0].[CustomerID]
 ORDER BY [c].[CustomerID]");
         }
 
@@ -691,14 +701,18 @@ ORDER BY [c].[CustomerID]");
             await base.Collection_select_nav_prop_first_or_default_then_nav_prop(isAsync);
 
             AssertSql(
-                @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
+                @"SELECT [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
 FROM [Customers] AS [c0]
-OUTER APPLY (
-    SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID]
-    FROM [Orders] AS [o]
-    LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-    WHERE (([c0].[CustomerID] = [o].[CustomerID]) AND [o].[CustomerID] IS NOT NULL) AND [o].[OrderID] IN (10643, 10692, 10702, 10835, 10952, 11011)
-) AS [t]
+LEFT JOIN (
+    SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [t].[OrderID], [t].[CustomerID0]
+    FROM (
+        SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID] AS [CustomerID0], ROW_NUMBER() OVER(PARTITION BY [o].[CustomerID] ORDER BY [o].[OrderID]) AS [row]
+        FROM [Orders] AS [o]
+        LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+        WHERE [o].[OrderID] IN (10643, 10692, 10702, 10835, 10952, 11011)
+    ) AS [t]
+    WHERE [t].[row] <= 1
+) AS [t0] ON [c0].[CustomerID] = [t0].[CustomerID0]
 WHERE [c0].[CustomerID] LIKE N'A%'
 ORDER BY [c0].[CustomerID]");
         }
@@ -925,14 +939,16 @@ FROM [Customers] AS [c]");
             await base.Project_single_entity_value_subquery_works(isAsync);
 
             AssertSql(
-                @"SELECT [c].[CustomerID], [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+                @"SELECT [c].[CustomerID], [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate]
 FROM [Customers] AS [c]
-OUTER APPLY (
-    SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-    FROM [Orders] AS [o]
-    WHERE ([c].[CustomerID] = [o].[CustomerID]) AND [o].[CustomerID] IS NOT NULL
-    ORDER BY [o].[OrderID]
-) AS [t]
+LEFT JOIN (
+    SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+    FROM (
+        SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], ROW_NUMBER() OVER(PARTITION BY [o].[CustomerID] ORDER BY [o].[OrderID]) AS [row]
+        FROM [Orders] AS [o]
+    ) AS [t]
+    WHERE [t].[row] <= 1
+) AS [t0] ON [c].[CustomerID] = [t0].[CustomerID]
 WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY [c].[CustomerID]");
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -1820,13 +1820,16 @@ LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]");
             await base.SelectMany_Joined_Take(isAsync);
 
             AssertSql(
-                @"SELECT [c].[ContactName], [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+                @"SELECT [c].[ContactName], [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate]
 FROM [Customers] AS [c]
-CROSS APPLY (
-    SELECT TOP(4) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-    FROM [Orders] AS [o]
-    WHERE ([o].[CustomerID] = [c].[CustomerID]) AND [o].[CustomerID] IS NOT NULL
-) AS [t]");
+INNER JOIN (
+    SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+    FROM (
+        SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], ROW_NUMBER() OVER(PARTITION BY [o].[CustomerID] ORDER BY [o].[OrderID]) AS [row]
+        FROM [Orders] AS [o]
+    ) AS [t]
+    WHERE [t].[row] <= 4
+) AS [t0] ON [c].[CustomerID] = [t0].[CustomerID]");
         }
 
         public override async Task Take_with_single(bool isAsync)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/QueryNavigationsSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/QueryNavigationsSqliteTest.cs
@@ -1,9 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.TestUtilities;
-using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
@@ -12,48 +10,6 @@ namespace Microsoft.EntityFrameworkCore.Query
         public QueryNavigationsSqliteTest(NorthwindQuerySqliteFixture<NoopModelCustomizer> fixture)
             : base(fixture)
         {
-        }
-
-        [ConditionalTheory(Skip = "Issue #17292")]
-        public override Task Collection_select_nav_prop_first_or_default(bool isAsync)
-        {
-            return base.Collection_select_nav_prop_first_or_default(isAsync);
-        }
-
-        [ConditionalTheory(Skip = "Issue #17292")]
-        public override Task Collection_select_nav_prop_first_or_default_then_nav_prop(bool isAsync)
-        {
-            return base.Collection_select_nav_prop_first_or_default_then_nav_prop(isAsync);
-        }
-
-        [ConditionalTheory(Skip = "Issue #17292")]
-        public override Task Project_single_entity_value_subquery_works(bool isAsync)
-        {
-            return base.Project_single_entity_value_subquery_works(isAsync);
-        }
-
-        [ConditionalTheory(Skip = "Issue #17292")]
-        public override Task Select_collection_FirstOrDefault_project_anonymous_type(bool isAsync)
-        {
-            return base.Select_collection_FirstOrDefault_project_anonymous_type(isAsync);
-        }
-
-        [ConditionalTheory(Skip = "Issue #17292")]
-        public override Task Select_collection_FirstOrDefault_project_entity(bool isAsync)
-        {
-            return base.Select_collection_FirstOrDefault_project_entity(isAsync);
-        }
-
-        [ConditionalTheory(Skip = "Issue #17292")]
-        public override Task Skip_Select_Navigation(bool isAsync)
-        {
-            return base.Skip_Select_Navigation(isAsync);
-        }
-
-        [ConditionalTheory(Skip = "Issue #17292")]
-        public override Task Take_Select_Navigation(bool isAsync)
-        {
-            return base.Take_Select_Navigation(isAsync);
         }
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
@@ -1323,7 +1323,7 @@ FROM (
         public override Task SelectMany_correlated_with_outer_4(bool isAsync) => null;
 
 
-        [ConditionalTheory(Skip = "Issue#17292")]
+        [ConditionalTheory(Skip = "Issue#17324")]
         public override Task Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault_2(bool isAsync)
         {
             return base.Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault_2(isAsync);


### PR DESCRIPTION
This enables support for non-scalar single result on Sqlite.

Resolves #10001 for Sqlite
Resolves #17292

