### PR TITLE
Query: Fix Set Operation design

### DIFF
--- a/src/EFCore.Relational/Query/Internal/CollectionJoinApplyingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/CollectionJoinApplyingExpressionVisitor.cs
@@ -21,7 +21,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 if (selectExpression.IsDistinct
                     || selectExpression.Limit != null
                     || selectExpression.Offset != null
-                    || selectExpression.IsSetOperation
                     || selectExpression.GroupBy.Count > 1)
                 {
                     selectExpression.PushdownIntoSubquery();

--- a/src/EFCore.Relational/Query/Internal/NullSemanticsRewritingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/NullSemanticsRewritingExpressionVisitor.cs
@@ -73,9 +73,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
         private ColumnExpression VisitColumnExpression(ColumnExpression columnExpression)
         {
+            var newTable = (TableExpressionBase)Visit(columnExpression.Table);
             _isNullable = columnExpression.IsNullable;
 
-            return columnExpression;
+            return columnExpression.Update(newTable);
         }
 
         private SqlParameterExpression VisitSqlParameterExpression(SqlParameterExpression sqlParameterExpression)

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -183,9 +183,8 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         protected override ShapedQueryExpression TranslateConcat(ShapedQueryExpression source1, ShapedQueryExpression source2)
         {
-            var operand1 = (SelectExpression)source1.QueryExpression;
-            var operand2 = (SelectExpression)source2.QueryExpression;
-            source1.ShaperExpression = operand1.ApplySetOperation(SetOperationType.UnionAll, operand2, source1.ShaperExpression);
+            ((SelectExpression)source1.QueryExpression).ApplyUnion((SelectExpression)source2.QueryExpression, distinct: false);
+
             return source1;
         }
 
@@ -262,9 +261,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         protected override ShapedQueryExpression TranslateExcept(ShapedQueryExpression source1, ShapedQueryExpression source2)
         {
-            var operand1 = (SelectExpression)source1.QueryExpression;
-            var operand2 = (SelectExpression)source2.QueryExpression;
-            source1.ShaperExpression = operand1.ApplySetOperation(SetOperationType.Except, operand2, source1.ShaperExpression);
+            ((SelectExpression)source1.QueryExpression).ApplyExcept((SelectExpression)source2.QueryExpression, distinct: true);
             return source1;
         }
 
@@ -444,9 +441,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         protected override ShapedQueryExpression TranslateIntersect(ShapedQueryExpression source1, ShapedQueryExpression source2)
         {
-            var operand1 = (SelectExpression)source1.QueryExpression;
-            var operand2 = (SelectExpression)source2.QueryExpression;
-            source1.ShaperExpression = operand1.ApplySetOperation(SetOperationType.Intersect, operand2, source1.ShaperExpression);
+            ((SelectExpression)source1.QueryExpression).ApplyIntersect((SelectExpression)source2.QueryExpression, distinct: true);
             return source1;
         }
 
@@ -937,9 +932,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         protected override ShapedQueryExpression TranslateUnion(ShapedQueryExpression source1, ShapedQueryExpression source2)
         {
-            var operand1 = (SelectExpression)source1.QueryExpression;
-            var operand2 = (SelectExpression)source2.QueryExpression;
-            source1.ShaperExpression = operand1.ApplySetOperation(SetOperationType.Union, operand2, source1.ShaperExpression);
+            ((SelectExpression)source1.QueryExpression).ApplyUnion((SelectExpression)source2.QueryExpression, distinct: true);
             return source1;
         }
 

--- a/src/EFCore.Relational/Query/SqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/SqlExpressionFactory.cs
@@ -500,7 +500,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                                 var otherSelectExpression = new SelectExpression(entityType);
 
                                 AddInnerJoin(otherSelectExpression, otherFk, sharingTypes, skipInnerJoins: false);
-                                selectExpression.ApplySetOperation(SetOperationType.Union, otherSelectExpression, null);
+                                selectExpression.ApplyUnion(otherSelectExpression, distinct: true);
                             }
                         }
                     }
@@ -629,7 +629,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         AddInnerJoin(otherSelectExpression, referencingFk,
                                         sameTable ? sharingTypes : null,
                                         skipInnerJoins: sameTable);
-                        selectExpression.ApplySetOperation(SetOperationType.Union, otherSelectExpression, null);
+                        selectExpression.ApplyUnion(otherSelectExpression, distinct: true);
                     }
                 }
             }

--- a/src/EFCore.Relational/Query/SqlExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/SqlExpressionVisitor.cs
@@ -80,12 +80,24 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 case TableExpression tableExpression:
                     return VisitTable(tableExpression);
+
+                case ExceptExpression exceptExpression:
+                    return VisitExcept(exceptExpression);
+
+                case IntersectExpression intersectExpression:
+                    return VisitIntersect(intersectExpression);
+
+                case UnionExpression unionExpression:
+                    return VisitUnion(unionExpression);
             }
 
             return base.VisitExtension(extensionExpression);
         }
 
         protected abstract Expression VisitRowNumber(RowNumberExpression rowNumberExpression);
+        protected abstract Expression VisitExcept(ExceptExpression exceptExpression);
+        protected abstract Expression VisitIntersect(IntersectExpression intersectExpression);
+        protected abstract Expression VisitUnion(UnionExpression unionExpression);
         protected abstract Expression VisitExists(ExistsExpression existsExpression);
         protected abstract Expression VisitIn(InExpression inExpression);
         protected abstract Expression VisitCrossJoin(CrossJoinExpression crossJoinExpression);

--- a/src/EFCore.Relational/Query/SqlExpressions/ColumnExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/ColumnExpression.cs
@@ -51,13 +51,12 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         public bool IsNullable { get; }
 
         protected override Expression VisitChildren(ExpressionVisitor visitor)
-        {
-            var newTable = (TableExpressionBase)visitor.Visit(Table);
+            => Update((TableExpressionBase)visitor.Visit(Table));
 
-            return newTable != Table
-                ? new ColumnExpression(Name, newTable, Type, TypeMapping, IsNullable)
+        public virtual ColumnExpression Update(TableExpressionBase table)
+            => table != Table
+                ? new ColumnExpression(Name, table, Type, TypeMapping, IsNullable)
                 : this;
-        }
 
         public ColumnExpression MakeNullable()
             => new ColumnExpression(Name, Table, Type.MakeNullable(), TypeMapping, true);

--- a/src/EFCore.Relational/Query/SqlExpressions/ExceptExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/ExceptExpression.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
+{
+    public class ExceptExpression : SetOperationBase
+    {
+        public ExceptExpression(string alias, SelectExpression source1, SelectExpression source2, bool distinct)
+            : base(alias, source1, source2, distinct)
+        {
+        }
+
+        protected override Expression VisitChildren(ExpressionVisitor visitor)
+        {
+            var source1 = (SelectExpression)visitor.Visit(Source1);
+            var source2 = (SelectExpression)visitor.Visit(Source2);
+
+            return Update(source1, source2);
+        }
+
+        public virtual ExceptExpression Update(SelectExpression source1, SelectExpression source2)
+            => source1 != Source1 || source2 != Source2
+                ? new ExceptExpression(Alias, source1, source2, IsDistinct)
+                : this;
+
+        public override void Print(ExpressionPrinter expressionPrinter)
+        {
+            expressionPrinter.Append("(");
+            using (expressionPrinter.Indent())
+            {
+                expressionPrinter.Visit(Source1);
+                expressionPrinter.AppendLine();
+                expressionPrinter.Append("EXCEPT");
+                if (!IsDistinct)
+                {
+                    expressionPrinter.AppendLine(" ALL");
+                }
+                expressionPrinter.Visit(Source2);
+            }
+            expressionPrinter.AppendLine()
+                .AppendLine($") AS {Alias}");
+        }
+
+        public override bool Equals(object obj)
+            => obj != null
+            && (ReferenceEquals(this, obj)
+                || obj is ExceptExpression exceptExpression
+                    && Equals(exceptExpression));
+
+        private bool Equals(ExceptExpression exceptExpression)
+            => base.Equals(exceptExpression);
+
+        public override int GetHashCode()
+            => HashCode.Combine(base.GetHashCode(), GetType());
+    }
+}

--- a/src/EFCore.Relational/Query/SqlExpressions/IntersectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/IntersectExpression.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
+{
+    public class IntersectExpression : SetOperationBase
+    {
+        public IntersectExpression(string alias, SelectExpression source1, SelectExpression source2, bool distinct)
+            : base(alias, source1, source2, distinct)
+        {
+        }
+
+        protected override Expression VisitChildren(ExpressionVisitor visitor)
+        {
+            var source1 = (SelectExpression)visitor.Visit(Source1);
+            var source2 = (SelectExpression)visitor.Visit(Source2);
+
+            return Update(source1, source2);
+        }
+
+        public virtual IntersectExpression Update(SelectExpression source1, SelectExpression source2)
+            => source1 != Source1 || source2 != Source2
+                ? new IntersectExpression(Alias, source1, source2, IsDistinct)
+                : this;
+
+        public override void Print(ExpressionPrinter expressionPrinter)
+        {
+            expressionPrinter.Append("(");
+            using (expressionPrinter.Indent())
+            {
+                expressionPrinter.Visit(Source1);
+                expressionPrinter.AppendLine();
+                expressionPrinter.Append("INTERSECT");
+                if (!IsDistinct)
+                {
+                    expressionPrinter.AppendLine(" ALL");
+                }
+                expressionPrinter.Visit(Source2);
+            }
+            expressionPrinter.AppendLine()
+                .AppendLine($") AS {Alias}");
+        }
+
+        public override bool Equals(object obj)
+            => obj != null
+            && (ReferenceEquals(this, obj)
+                || obj is IntersectExpression intersectExpression
+                    && Equals(intersectExpression));
+
+        private bool Equals(IntersectExpression intersectExpression)
+            => base.Equals(intersectExpression);
+
+        public override int GetHashCode()
+            => HashCode.Combine(base.GetHashCode(), GetType());
+    }
+}

--- a/src/EFCore.Relational/Query/SqlExpressions/SetOperationBase.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SetOperationBase.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
+{
+    public abstract class SetOperationBase : TableExpressionBase
+    {
+        protected SetOperationBase([NotNull] string alias, SelectExpression source1, SelectExpression source2, bool distinct)
+            : base(Check.NotEmpty(alias, nameof(alias)))
+        {
+            IsDistinct = distinct;
+            Source1 = source1;
+            Source2 = source2;
+        }
+
+        public virtual bool IsDistinct { get; }
+        public virtual SelectExpression Source1 { get; }
+        public virtual SelectExpression Source2 { get; }
+
+        public override bool Equals(object obj)
+            => obj != null
+            && (ReferenceEquals(this, obj)
+                || obj is SetOperationBase setOperationBase
+                    && Equals(setOperationBase));
+
+        private bool Equals(SetOperationBase setOperationBase)
+            => IsDistinct == setOperationBase.IsDistinct
+            && Source1.Equals(setOperationBase.Source1)
+            && Source2.Equals(setOperationBase.Source2);
+
+        public override int GetHashCode()
+            => HashCode.Combine(base.GetHashCode(), IsDistinct, Source1, Source2);
+    }
+}

--- a/src/EFCore.Relational/Query/SqlExpressions/SqlConstantExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlConstantExpression.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
+using System.Collections;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Storage;
 
@@ -35,9 +37,36 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
 
         private bool Equals(SqlConstantExpression sqlConstantExpression)
             => base.Equals(sqlConstantExpression)
-            && (Value == null
-                ? sqlConstantExpression.Value == null
-                : Value.Equals(sqlConstantExpression.Value));
+            && ValueEquals(Value, sqlConstantExpression.Value);
+
+        private bool ValueEquals(object value1, object value2)
+        {
+            if (value1 == null)
+            {
+                return value2 == null;
+            }
+
+            if (value1 is IList list1
+                && value2 is IList list2)
+            {
+                if (list1.Count != list2.Count)
+                {
+                    return false;
+                }
+
+                for (var i = 0; i < list1.Count; i++)
+                {
+                    if (!ValueEquals(list1[i], list2[i]))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            return value1.Equals(value2);
+        }
 
         public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Value);
     }

--- a/src/EFCore.Relational/Query/SqlExpressions/TableExpressionBase.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/TableExpressionBase.cs
@@ -33,14 +33,6 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         private bool Equals(TableExpressionBase tableExpressionBase)
             => string.Equals(Alias, tableExpressionBase.Alias);
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = (Alias?.GetHashCode() ?? 0);
-
-                return hashCode;
-            }
-        }
+        public override int GetHashCode() => HashCode.Combine(Alias);
     }
 }

--- a/src/EFCore.Relational/Query/SqlExpressions/UnionExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/UnionExpression.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
+{
+    public class UnionExpression : SetOperationBase
+    {
+        public UnionExpression(string alias, SelectExpression source1, SelectExpression source2, bool distinct)
+            : base(alias, source1, source2, distinct)
+        {
+        }
+
+        protected override Expression VisitChildren(ExpressionVisitor visitor)
+        {
+            var source1 = (SelectExpression)visitor.Visit(Source1);
+            var source2 = (SelectExpression)visitor.Visit(Source2);
+
+            return Update(source1, source2);
+        }
+
+        public virtual UnionExpression Update(SelectExpression source1, SelectExpression source2)
+            => source1 != Source1 || source2 != Source2
+                ? new UnionExpression(Alias, source1, source2, IsDistinct)
+                : this;
+
+        public override void Print(ExpressionPrinter expressionPrinter)
+        {
+            expressionPrinter.Append("(");
+            using (expressionPrinter.Indent())
+            {
+                expressionPrinter.Visit(Source1);
+                expressionPrinter.AppendLine();
+                expressionPrinter.Append("UNION");
+                if (!IsDistinct)
+                {
+                    expressionPrinter.AppendLine(" ALL");
+                }
+                expressionPrinter.Visit(Source2);
+            }
+            expressionPrinter.AppendLine()
+                .AppendLine($") AS {Alias}");
+        }
+
+        public override bool Equals(object obj)
+            => obj != null
+            && (ReferenceEquals(this, obj)
+                || obj is UnionExpression unionExpression
+                    && Equals(unionExpression));
+
+        private bool Equals(UnionExpression unionExpression)
+            => base.Equals(unionExpression);
+
+        public override int GetHashCode()
+            => HashCode.Combine(base.GetHashCode(), GetType());
+    }
+}

--- a/src/EFCore.SqlServer/Query/Internal/SearchConditionConvertingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SearchConditionConvertingExpressionVisitor.cs
@@ -387,5 +387,38 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
 
             return ApplyConversion(rowNumberExpression.Update(partitions, orderings), condition: false);
         }
+
+        protected override Expression VisitExcept(ExceptExpression exceptExpression)
+        {
+            var parentSearchCondition = _isSearchCondition;
+            _isSearchCondition = false;
+            var source1 = (SelectExpression)Visit(exceptExpression.Source1);
+            var source2 = (SelectExpression)Visit(exceptExpression.Source2);
+            _isSearchCondition = parentSearchCondition;
+
+            return exceptExpression.Update(source1, source2);
+        }
+
+        protected override Expression VisitIntersect(IntersectExpression intersectExpression)
+        {
+            var parentSearchCondition = _isSearchCondition;
+            _isSearchCondition = false;
+            var source1 = (SelectExpression)Visit(intersectExpression.Source1);
+            var source2 = (SelectExpression)Visit(intersectExpression.Source2);
+            _isSearchCondition = parentSearchCondition;
+
+            return intersectExpression.Update(source1, source2);
+        }
+
+        protected override Expression VisitUnion(UnionExpression unionExpression)
+        {
+            var parentSearchCondition = _isSearchCondition;
+            _isSearchCondition = false;
+            var source1 = (SelectExpression)Visit(unionExpression.Source1);
+            var source2 = (SelectExpression)Visit(unionExpression.Source2);
+            _isSearchCondition = parentSearchCondition;
+
+            return unionExpression.Update(source1, source2);
+        }
     }
 }

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteQuerySqlGenerator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteQuerySqlGenerator.cs
@@ -45,21 +45,10 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
             }
         }
 
-        protected override void GenerateSetOperationOperand(
-            SelectExpression setOperationExpression,
-            SelectExpression operandExpression)
+        protected override void GenerateSetOperationOperand(SetOperationBase setOperation, SelectExpression operand)
         {
             // Sqlite doesn't support parentheses around set operation operands
-
-            IDisposable indent = null;
-            if (!operandExpression.IsSetOperation)
-            {
-                indent = Sql.Indent();
-            }
-
-            Visit(operandExpression);
-
-            indent?.Dispose();
+            Visit(operand);
         }
     }
 }

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.SetOperations.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.SetOperations.cs
@@ -353,7 +353,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         .GroupBy(c => c.CustomerID)
                         .Select(g => new { CustomerID = g.Key, Count = g.Count() })));
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Issue#17339")]
         [MemberData(nameof(GetSetOperandTestCases))]
         public virtual Task Union_over_different_projection_types(bool isAsync, string leftType, string rightType)
         {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -1615,7 +1615,7 @@ FROM (
     FROM [Gears] AS [g]
     WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
     UNION ALL
-    SELECT [g0].[FullName]
+    SELECT [g0].[FullName] AS [Nickname]
     FROM [Gears] AS [g0]
     WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
 ) AS [t]");
@@ -1628,11 +1628,11 @@ FROM (
             AssertSql(
                 @"SELECT COUNT(*)
 FROM (
-    SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+    SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g].[Nickname] AS [Name]
     FROM [Gears] AS [g]
     WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
     UNION ALL
-    SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
+    SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], [g0].[FullName] AS [Name]
     FROM [Gears] AS [g0]
     WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
 ) AS [t]");

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.SetOperations.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.SetOperations.cs
@@ -167,13 +167,36 @@ FROM [Customers] AS [c1]
 WHERE CHARINDEX(N'Thomas', [c1].[ContactName]) > 0");
         }
 
-        [ConditionalTheory(Skip = "Need to push down set operation on take without orderby+skip on SQL Server, waiting on design")]
+        [ConditionalTheory]
         public override async Task Union_Take_Union_Take(bool isAsync)
         {
             await base.Union_Take_Union_Take(isAsync);
 
-            throw new NotImplementedException("Take is being ignored");
-            //AssertSql(@"");
+            AssertSql(
+                @"@__p_0='1'
+
+SELECT [t1].[CustomerID], [t1].[Address], [t1].[City], [t1].[CompanyName], [t1].[ContactName], [t1].[ContactTitle], [t1].[Country], [t1].[Fax], [t1].[Phone], [t1].[PostalCode], [t1].[Region]
+FROM (
+    SELECT TOP(@__p_0) [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
+    FROM (
+        SELECT TOP(@__p_0) [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
+        FROM (
+            SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+            FROM [Customers] AS [c]
+            WHERE ([c].[City] = N'Berlin') AND [c].[City] IS NOT NULL
+            UNION
+            SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+            FROM [Customers] AS [c0]
+            WHERE ([c0].[City] = N'London') AND [c0].[City] IS NOT NULL
+        ) AS [t]
+        ORDER BY [t].[CustomerID]
+        UNION
+        SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
+        FROM [Customers] AS [c1]
+        WHERE ([c1].[City] = N'Mannheim') AND [c1].[City] IS NOT NULL
+    ) AS [t0]
+) AS [t1]
+ORDER BY [t1].[CustomerID]");
         }
 
         public override async Task Select_Union(bool isAsync)
@@ -211,13 +234,16 @@ WHERE CHARINDEX(N'Hanover', [t].[Address]) > 0");
             await base.Union_with_anonymous_type_projection(isAsync);
 
             AssertSql(
-                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-WHERE [c].[CompanyName] IS NOT NULL AND ([c].[CompanyName] LIKE N'A%')
-UNION
-SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
-FROM [Customers] AS [c0]
-WHERE [c0].[CompanyName] IS NOT NULL AND ([c0].[CompanyName] LIKE N'B%')");
+                @"SELECT [t].[CustomerID] AS [Id]
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE [c].[CompanyName] IS NOT NULL AND ([c].[CompanyName] LIKE N'A%')
+    UNION
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[CompanyName] IS NOT NULL AND ([c0].[CompanyName] LIKE N'B%')
+) AS [t]");
         }
 
         public override async Task Select_Union_unrelated(bool isAsync)
@@ -230,7 +256,7 @@ FROM (
     SELECT [c].[ContactName]
     FROM [Customers] AS [c]
     UNION
-    SELECT [p].[ProductName]
+    SELECT [p].[ProductName] AS [ContactName]
     FROM [Products] AS [p]
 ) AS [t]
 WHERE [t].[ContactName] IS NOT NULL AND ([t].[ContactName] LIKE N'C%')


### PR DESCRIPTION
Remove SetOperationType enum
Add support for Intersect/Except Distinct

Resolves #16709

