### PR TITLE
Query: Rename Lateral joins to Cross/Outer Apply

### DIFF
--- a/src/EFCore.Relational/Query/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/QuerySqlGenerator.cs
@@ -674,20 +674,20 @@ namespace Microsoft.EntityFrameworkCore.Query
             return crossJoinExpression;
         }
 
-        protected override Expression VisitInnerJoinLateral(InnerJoinLateralExpression innerJoinLateralExpression)
+        protected override Expression VisitCrossApply(CrossApplyExpression crossApplyExpression)
         {
-            _relationalCommandBuilder.Append("INNER JOIN LATERAL ");
-            Visit(innerJoinLateralExpression.Table);
+            _relationalCommandBuilder.Append("CROSS APPLY ");
+            Visit(crossApplyExpression.Table);
 
-            return innerJoinLateralExpression;
+            return crossApplyExpression;
         }
 
-        protected override Expression VisitLeftJoinLateral(LeftJoinLateralExpression leftJoinLateralExpression)
+        protected override Expression VisitOuterApply(OuterApplyExpression outerApplyExpression)
         {
-            _relationalCommandBuilder.Append("LEFT JOIN LATERAL ");
-            Visit(leftJoinLateralExpression.Table);
+            _relationalCommandBuilder.Append("OUTER APPLY ");
+            Visit(outerApplyExpression.Table);
 
-            return leftJoinLateralExpression;
+            return outerApplyExpression;
         }
 
         protected override Expression VisitInnerJoin(InnerJoinExpression innerJoinExpression)

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -742,13 +742,13 @@ namespace Microsoft.EntityFrameworkCore.Query
                     var innerShaperExpression = inner.ShaperExpression;
                     if (defaultIfEmpty)
                     {
-                        ((SelectExpression)source.QueryExpression).AddLeftJoinLateral(
+                        ((SelectExpression)source.QueryExpression).AddOuterApply(
                             (SelectExpression)inner.QueryExpression, transparentIdentifierType);
                         innerShaperExpression = MarkShaperNullable(innerShaperExpression);
                     }
                     else
                     {
-                        ((SelectExpression)source.QueryExpression).AddInnerJoinLateral(
+                        ((SelectExpression)source.QueryExpression).AddCrossApply(
                            (SelectExpression)inner.QueryExpression, transparentIdentifierType);
                     }
 

--- a/src/EFCore.Relational/Query/SqlExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/SqlExpressionVisitor.cs
@@ -21,11 +21,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                 case CrossJoinExpression crossJoinExpression:
                     return VisitCrossJoin(crossJoinExpression);
 
-                case InnerJoinLateralExpression innerJoinLateralExpression:
-                    return VisitInnerJoinLateral(innerJoinLateralExpression);
+                case CrossApplyExpression crossApplyExpression:
+                    return VisitCrossApply(crossApplyExpression);
 
-                case LeftJoinLateralExpression leftJoinLateralExpression:
-                    return VisitLeftJoinLateral(leftJoinLateralExpression);
+                case OuterApplyExpression outerApplyExpression:
+                    return VisitOuterApply(outerApplyExpression);
 
                 case ExistsExpression existsExpression:
                     return VisitExists(existsExpression);
@@ -101,8 +101,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         protected abstract Expression VisitExists(ExistsExpression existsExpression);
         protected abstract Expression VisitIn(InExpression inExpression);
         protected abstract Expression VisitCrossJoin(CrossJoinExpression crossJoinExpression);
-        protected abstract Expression VisitInnerJoinLateral(InnerJoinLateralExpression innerJoinLateralExpression);
-        protected abstract Expression VisitLeftJoinLateral(LeftJoinLateralExpression leftJoinLateralExpression);
+        protected abstract Expression VisitCrossApply(CrossApplyExpression crossApplyExpression);
+        protected abstract Expression VisitOuterApply(OuterApplyExpression outerApplyExpression);
         protected abstract Expression VisitFromSql(FromSqlExpression fromSqlExpression);
         protected abstract Expression VisitInnerJoin(InnerJoinExpression innerJoinExpression);
         protected abstract Expression VisitLeftJoin(LeftJoinExpression leftJoinExpression);

--- a/src/EFCore.Relational/Query/SqlExpressions/CrossApplyExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/CrossApplyExpression.cs
@@ -5,9 +5,9 @@ using System.Linq.Expressions;
 
 namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
 {
-    public class LeftJoinLateralExpression : JoinExpressionBase
+    public class CrossApplyExpression : JoinExpressionBase
     {
-        public LeftJoinLateralExpression(TableExpressionBase table)
+        public CrossApplyExpression(TableExpressionBase table)
             : base(table)
         {
         }
@@ -15,25 +15,25 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         protected override Expression VisitChildren(ExpressionVisitor visitor)
             => Update((TableExpressionBase)visitor.Visit(Table));
 
-        public virtual LeftJoinLateralExpression Update(TableExpressionBase table)
+        public virtual CrossApplyExpression Update(TableExpressionBase table)
             => table != Table
-                ? new LeftJoinLateralExpression(table)
+                ? new CrossApplyExpression(table)
                 : this;
 
         public override void Print(ExpressionPrinter expressionPrinter)
         {
-            expressionPrinter.Append("LEFT JOIN LATERAL ");
+            expressionPrinter.Append("CROSS APPLY ");
             expressionPrinter.Visit(Table);
         }
 
         public override bool Equals(object obj)
             => obj != null
             && (ReferenceEquals(this, obj)
-                || obj is LeftJoinLateralExpression leftJoinLateralExpression
-                    && Equals(leftJoinLateralExpression));
+                || obj is CrossApplyExpression crossApplyExpression
+                    && Equals(crossApplyExpression));
 
-        private bool Equals(LeftJoinLateralExpression leftJoinLateralExpression)
-            => base.Equals(leftJoinLateralExpression);
+        private bool Equals(CrossApplyExpression crossApplyExpression)
+            => base.Equals(crossApplyExpression);
 
         public override int GetHashCode() => base.GetHashCode();
     }

--- a/src/EFCore.Relational/Query/SqlExpressions/OuterApplyExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/OuterApplyExpression.cs
@@ -5,9 +5,9 @@ using System.Linq.Expressions;
 
 namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
 {
-    public class InnerJoinLateralExpression : JoinExpressionBase
+    public class OuterApplyExpression : JoinExpressionBase
     {
-        public InnerJoinLateralExpression(TableExpressionBase table)
+        public OuterApplyExpression(TableExpressionBase table)
             : base(table)
         {
         }
@@ -15,25 +15,25 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         protected override Expression VisitChildren(ExpressionVisitor visitor)
             => Update((TableExpressionBase)visitor.Visit(Table));
 
-        public virtual InnerJoinLateralExpression Update(TableExpressionBase table)
+        public virtual OuterApplyExpression Update(TableExpressionBase table)
             => table != Table
-                ? new InnerJoinLateralExpression(table)
+                ? new OuterApplyExpression(table)
                 : this;
 
         public override void Print(ExpressionPrinter expressionPrinter)
         {
-            expressionPrinter.Append("INNER JOIN LATERAL ");
+            expressionPrinter.Append("OUTER APPLY ");
             expressionPrinter.Visit(Table);
         }
 
         public override bool Equals(object obj)
             => obj != null
             && (ReferenceEquals(this, obj)
-                || obj is InnerJoinLateralExpression innerJoinLateralExpression
-                    && Equals(innerJoinLateralExpression));
+                || obj is OuterApplyExpression outerApplyExpression
+                    && Equals(outerApplyExpression));
 
-        private bool Equals(InnerJoinLateralExpression innerJoinLateralExpression)
-            => base.Equals(innerJoinLateralExpression);
+        private bool Equals(OuterApplyExpression outerApplyExpression)
+            => base.Equals(outerApplyExpression);
 
         public override int GetHashCode() => base.GetHashCode();
     }

--- a/src/EFCore.SqlServer/Query/Internal/SearchConditionConvertingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SearchConditionConvertingExpressionVisitor.cs
@@ -309,7 +309,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
             return crossJoinExpression.Update(table);
         }
 
-        protected override Expression VisitInnerJoinLateral(InnerJoinLateralExpression crossApplyExpression)
+        protected override Expression VisitCrossApply(CrossApplyExpression crossApplyExpression)
         {
             var parentSearchCondition = _isSearchCondition;
             _isSearchCondition = false;
@@ -319,7 +319,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
             return crossApplyExpression.Update(table);
         }
 
-        protected override Expression VisitLeftJoinLateral(LeftJoinLateralExpression outerApplyExpression)
+        protected override Expression VisitOuterApply(OuterApplyExpression outerApplyExpression)
         {
             var parentSearchCondition = _isSearchCondition;
             _isSearchCondition = false;

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQuerySqlGenerator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQuerySqlGenerator.cs
@@ -67,21 +67,5 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
 
             return base.VisitSqlFunction(sqlFunctionExpression);
         }
-
-        protected override Expression VisitInnerJoinLateral(InnerJoinLateralExpression innerJoinLateralExpression)
-        {
-            Sql.Append("CROSS APPLY ");
-            Visit(innerJoinLateralExpression.Table);
-
-            return innerJoinLateralExpression;
-        }
-
-        protected override Expression VisitLeftJoinLateral(LeftJoinLateralExpression leftJoinLateralExpression)
-        {
-            Sql.Append("OUTER APPLY ");
-            Visit(leftJoinLateralExpression.Table);
-
-            return leftJoinLateralExpression;
-        }
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -140,7 +140,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         private string RemoveNewLines(string message)
             => message.Replace("\n", "").Replace("\r", "");
 
-        // Sqlite does not support lateral joins
+        // Sqlite does not support cross/outer apply
         public override Task Correlated_collections_inner_subquery_predicate_references_outer_qsre(bool isAsync) => null;
 
         public override Task Correlated_collections_inner_subquery_selector_references_outer_qsre(bool isAsync) => null;

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
@@ -1309,7 +1309,7 @@ FROM (
         public override Task Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault_2(bool isAsync)
             => base.Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault_2(isAsync);
 
-        // Sqlite does not support lateral joins
+        // Sqlite does not support cross/outer apply
         public override void Select_nested_collection_multi_level()
         {
         }


### PR DESCRIPTION
Since they don't represent lateral join truly

