### PR TITLE
InMemory: Avoid N+1 queries for Include

### DIFF
--- a/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
@@ -144,7 +144,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                     return null;
                 }
 
-                subquery.ApplyServerProjection();
+                subquery.ApplyProjection();
                 if (subquery.Projection.Count != 1)
                 {
                     return null;

--- a/src/EFCore.InMemory/Query/Internal/InMemoryProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryProjectionBindingExpressionVisitor.cs
@@ -89,10 +89,16 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                             var translated = _queryableMethodTranslatingExpressionVisitor.TranslateSubquery(
                                 materializeCollectionNavigationExpression.Subquery);
 
-                            return new ProjectionBindingExpression(
-                                _queryExpression,
-                                _queryExpression.AddToProjection(translated),
-                                typeof(IEnumerable<>).MakeGenericType(materializeCollectionNavigationExpression.Navigation.GetTargetType().ClrType));
+                            var index = _queryExpression.AddSubqueryProjection(translated, out var innerShaper);
+
+                            return new CollectionShaperExpression(
+                                new ProjectionBindingExpression(
+                                    _queryExpression,
+                                    index,
+                                    typeof(IEnumerable<ValueBuffer>)),
+                                innerShaper,
+                                materializeCollectionNavigationExpression.Navigation,
+                                materializeCollectionNavigationExpression.Navigation.GetTargetType().ClrType);
 
                         case MethodCallExpression methodCallExpression:
                         {

--- a/src/EFCore.InMemory/Query/Internal/InMemoryQueryExpression.ResultEnumerable.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryQueryExpression.ResultEnumerable.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
+{
+    public partial class InMemoryQueryExpression
+    {
+        private sealed class ResultEnumerable : IEnumerable<ValueBuffer>
+        {
+            private readonly Func<ValueBuffer> _getElement;
+
+            public ResultEnumerable(Func<ValueBuffer> getElement)
+            {
+                _getElement = getElement;
+            }
+
+            public IEnumerator<ValueBuffer> GetEnumerator() => new ResultEnumerator(_getElement());
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+            private sealed class ResultEnumerator : IEnumerator<ValueBuffer>
+            {
+                private readonly ValueBuffer _value;
+                private bool _moved;
+
+                public ResultEnumerator(ValueBuffer value)
+                {
+                    _value = value;
+                    _moved = _value.IsEmpty;
+                }
+
+                public bool MoveNext()
+                {
+                    if (!_moved)
+                    {
+                        _moved = true;
+
+                        return _moved;
+                    }
+
+                    return false;
+                }
+
+                public void Reset()
+                {
+                    _moved = false;
+                }
+
+                object IEnumerator.Current => Current;
+
+                public ValueBuffer Current => !_moved ? ValueBuffer.Empty : _value;
+
+                void IDisposable.Dispose()
+                {
+                }
+            }
+        }
+    }
+}

--- a/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
@@ -189,7 +189,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
         {
             var inMemoryQueryExpression = (InMemoryQueryExpression)source.QueryExpression;
 
-            inMemoryQueryExpression.ApplyPendingSelector();
+            inMemoryQueryExpression.PushdownIntoSubquery();
             inMemoryQueryExpression.ServerQueryExpression
                 = Expression.Call(
                     InMemoryLinqOperatorProvider.Distinct.MakeGenericMethod(typeof(ValueBuffer)),

--- a/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.cs
@@ -32,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
             switch (extensionExpression)
             {
                 case InMemoryQueryExpression inMemoryQueryExpression:
-                    inMemoryQueryExpression.ApplyServerProjection();
+                    inMemoryQueryExpression.ApplyProjection();
                     return Visit(inMemoryQueryExpression.ServerQueryExpression);
 
                 case InMemoryTableExpression inMemoryTableExpression:
@@ -49,14 +49,15 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
         {
             var inMemoryQueryExpression = (InMemoryQueryExpression)shapedQueryExpression.QueryExpression;
 
-            var shaper = new ShaperExpressionProcessingExpressionVisitor(inMemoryQueryExpression)
+            var shaper = new ShaperExpressionProcessingExpressionVisitor(
+                inMemoryQueryExpression, inMemoryQueryExpression.ValueBufferParameter)
                 .Inject(shapedQueryExpression.ShaperExpression);
 
             shaper = InjectEntityMaterializers(shaper);
 
             var innerEnumerable = Visit(inMemoryQueryExpression);
 
-            shaper = new InMemoryProjectionBindingRemovingExpressionVisitor(inMemoryQueryExpression).Visit(shaper);
+            shaper = new InMemoryProjectionBindingRemovingExpressionVisitor().Visit(shaper);
 
             shaper = new CustomShaperCompilingExpressionVisitor(IsTracking).Visit(shaper);
 

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.CustomShaperCompilingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.CustomShaperCompilingExpressionVisitor.cs
@@ -216,8 +216,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                             if (!trackingQuery)
                             {
                                 fixup(entity, relatedEntity);
-                                if (inverseNavigation != null
-                                    && !inverseNavigation.IsCollection())
+                                if (inverseNavigation != null)
                                 {
                                     SetIsLoadedNoTracking(relatedEntity, inverseNavigation);
                                 }


### PR DESCRIPTION
Don't send shapers to ServerQueryExpression
Laying ground work for collection projection

Part of #16963
