### PR TITLE
Fix non-deterministic CROSS APPLY tests

### DIFF
--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
@@ -1259,7 +1259,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery<Customer, Order>(
                 isAsync,
                 (cs, os) => from c in cs
-                            from o in os.Where(o => c.CustomerID == o.CustomerID).OrderBy(o => c.City).Take(2)
+                            from o in os.Where(o => c.CustomerID == o.CustomerID)
+                                .OrderBy(o => c.City).ThenBy(o => o.OrderID).Take(2)
                             select new
                             {
                                 c,
@@ -1291,7 +1292,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery<Customer, Order>(
                 isAsync,
                 (cs, os) => from c in cs
-                            from o in os.Where(o => c.CustomerID == o.CustomerID).OrderBy(o => c.City).Take(2).DefaultIfEmpty()
+                            from o in os.Where(o => c.CustomerID == o.CustomerID)
+                                .OrderBy(o => c.City).ThenBy(o => o.OrderID).Take(2).DefaultIfEmpty()
                             select new
                             {
                                 c,

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
@@ -974,7 +974,7 @@ CROSS APPLY (
     SELECT TOP(2) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[City]
     FROM [Orders] AS [o]
     WHERE ([c].[CustomerID] = [o].[CustomerID]) AND [o].[CustomerID] IS NOT NULL
-    ORDER BY [c].[City]
+    ORDER BY [c].[City], [o].[OrderID]
 ) AS [t]");
         }
 
@@ -1003,7 +1003,7 @@ OUTER APPLY (
     SELECT TOP(2) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[City]
     FROM [Orders] AS [o]
     WHERE ([c].[CustomerID] = [o].[CustomerID]) AND [o].[CustomerID] IS NOT NULL
-    ORDER BY [c].[City]
+    ORDER BY [c].[City], [o].[OrderID]
 ) AS [t]");
         }
     }


### PR DESCRIPTION
City is the same for each customer, so effectively the lateral subquery is doing Take(2) without ordering.

(are we still sending PRs to 3.0-preview9?)