### PR TITLE
Query: Bind with members when type has cast to interface

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
@@ -123,6 +123,13 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
 
             if (source is EntityProjectionExpression entityProjectionExpression)
             {
+                if (convertedType != null
+                    && convertedType.IsInterface
+                    && convertedType.IsAssignableFrom(entityProjectionExpression.Type))
+                {
+                    convertedType = entityProjectionExpression.Type;
+                }
+
                 expression = member.MemberInfo != null
                     ? entityProjectionExpression.BindMember(member.MemberInfo, convertedType, clientEval: false, out _)
                     : entityProjectionExpression.BindMember(member.Name, convertedType, clientEval: false, out _);

--- a/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
@@ -97,11 +97,12 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
             if (source is EntityProjectionExpression entityProjection)
             {
                 var entityType = entityProjection.EntityType;
-                if (convertedType != null)
+                if (convertedType != null
+                    && !(convertedType.IsInterface
+                         && convertedType.IsAssignableFrom(entityType.ClrType)))
                 {
                     entityType = entityType.GetRootType().GetDerivedTypesInclusive()
                         .FirstOrDefault(et => et.ClrType == convertedType);
-
                     if (entityType == null)
                     {
                         return null;

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -207,11 +207,12 @@ namespace Microsoft.EntityFrameworkCore.Query
             if (source is EntityProjectionExpression entityProjectionExpression)
             {
                 var entityType = entityProjectionExpression.EntityType;
-                if (convertedType != null)
+                if (convertedType != null
+                    && !(convertedType.IsInterface
+                         && convertedType.IsAssignableFrom(entityType.ClrType)))
                 {
                     entityType = entityType.GetRootType().GetDerivedTypesInclusive()
                         .FirstOrDefault(et => et.ClrType == convertedType);
-
                     if (entityType == null)
                     {
                         return false;

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
@@ -103,9 +103,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 if (UnwrapEntityReference(innerExpression) is EntityReference entityReference)
                 {
                     var entityType = entityReference.EntityType;
-                    if (convertedType != null)
+                    if (convertedType != null
+                        && !(convertedType.IsInterface
+                             && convertedType.IsAssignableFrom(entityType.ClrType)))
                     {
-                        entityType = entityType.GetTypesInHierarchy().FirstOrDefault(et => et.ClrType == convertedType);
+                        entityType = entityType.GetTypesInHierarchy()
+                            .FirstOrDefault(et => et.ClrType == convertedType);
                         if (entityType == null)
                         {
                             return null;


### PR DESCRIPTION
Resolves #17276
Resolves #17099
Resolves #16759

### Description
EF Core doesn't support mapping to interfaces directly. However, people frequently work with interfaces and we have provided guidance many times in the past on patterns that involve casting or using generic type constraints to work with interfaces. These patterns are not working in the new query pipeline like they were in the old, so we want to take a change for 3.0 that will allow these patterns to work again.

Example:
```C#
public static List<T> List<T>(this IQueryable<T> query) where T : IRemovable
    => query.Where(x => !x.IsRemoved).ToList();
```

### Customer Impact
We expect that continuing to work with interfaces will be a common customer requirement for EF Core 3.0. We have not been able to come up with other workarounds that allow this.

### Regression?
Yes, from 2.2.
 
### Risk
The risk here is low because the code now handles interfaces types where it previously it would result in an exception. These changes are localized to specific places in the code and should have no impact on the handling of non-interface types.


