### PR TITLE
Entity equality: fix mis-identification as collection navigation

### DIFF
--- a/src/EFCore/Query/Internal/EntityEqualityRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/EntityEqualityRewritingExpressionVisitor.cs
@@ -1085,16 +1085,15 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
 
             public EntityReferenceExpression(Expression underlying, IEntityType entityType)
-                : this(underlying, entityType, null, false)
+                : this(underlying, entityType, subqueryTraversed: false)
             {
             }
 
             private EntityReferenceExpression(
-                Expression underlying, IEntityType entityType, INavigation lastNavigation, bool subqueryTraversed)
+                Expression underlying, IEntityType entityType, bool subqueryTraversed)
             {
                 Underlying = underlying;
                 EntityType = entityType;
-                _lastNavigation = lastNavigation;
                 SubqueryTraversed = subqueryTraversed;
             }
 
@@ -1126,6 +1125,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                             destinationExpression,
                             navigation.GetTargetType(),
                             navigation,
+                            null,
                             SubqueryTraversed)
                         : destinationExpression;
                 }
@@ -1146,7 +1146,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
 
             public EntityReferenceExpression Update(Expression newUnderlying)
-                => new EntityReferenceExpression(newUnderlying, EntityType, _lastNavigation, DtoType, SubqueryTraversed);
+                => new EntityReferenceExpression(newUnderlying, EntityType, null, DtoType, SubqueryTraversed);
 
             protected override Expression VisitChildren(ExpressionVisitor visitor)
                 => Update(visitor.Visit(Underlying));

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -4981,7 +4981,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory(Skip = "Issue #17229")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_optional_navigation_property_string_concat(bool isAsync)
         {


### PR DESCRIPTION
We now flow the last navigation only for pure traversal (via member, EF.Property) and not for Select and others. This corrects valid entity references which were misidentified as collection navigations.

Fixes #17229