### PR TITLE
[release/3.0] RevEng: Fix bad logic around connection strings

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/ReverseEngineerScaffolder.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/ReverseEngineerScaffolder.cs
@@ -98,7 +98,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             {
                 codeOptions.SuppressConnectionStringWarning = true;
             }
-            else if (codeOptions.ConnectionString == null)
+
+            if (codeOptions.ConnectionString == null)
             {
                 codeOptions.ConnectionString = connectionString;
             }

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/ReverseEngineerScaffolderTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/ReverseEngineerScaffolderTest.cs
@@ -1,12 +1,15 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Data.Common;
 using System.Globalization;
 using System.IO;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -181,5 +184,60 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 .AddSingleton<IScaffoldingModelFactory, FakeScaffoldingModelFactory>()
                 .BuildServiceProvider()
                 .GetRequiredService<IReverseEngineerScaffolder>();
+
+        [ConditionalFact]
+        public void ScaffoldModel_works_with_named_connection_string()
+        {
+            var resolver = new TestNamedConnectionStringResolver("Data Source=Test");
+            var databaseModelFactory = new TestDatabaseModelFactory();
+            var scaffolder = new ServiceCollection()
+                .AddEntityFrameworkDesignTimeServices()
+                .AddSingleton<INamedConnectionStringResolver>(resolver)
+                .AddSingleton<IDatabaseModelFactory>(databaseModelFactory)
+                .AddSingleton<IRelationalTypeMappingSource, TestRelationalTypeMappingSource>()
+                .AddSingleton<LoggingDefinitions, TestRelationalLoggingDefinitions>()
+                .AddSingleton<IProviderConfigurationCodeGenerator, TestProviderCodeGenerator>()
+                .AddSingleton<IAnnotationCodeGenerator, AnnotationCodeGenerator>()
+                .BuildServiceProvider()
+                .GetRequiredService<IReverseEngineerScaffolder>();
+
+            var result = scaffolder.ScaffoldModel(
+                "Name=DefaultConnection",
+                new DatabaseModelFactoryOptions(),
+                new ModelReverseEngineerOptions(),
+                new ModelCodeGenerationOptions());
+
+            Assert.Equal("Data Source=Test", databaseModelFactory.ConnectionString);
+
+            Assert.Contains("Name=DefaultConnection", result.ContextFile.Code);
+            Assert.DoesNotContain("Data Source=Test", result.ContextFile.Code);
+            Assert.DoesNotContain("#warning", result.ContextFile.Code);
+        }
+
+        private class TestNamedConnectionStringResolver : INamedConnectionStringResolver
+        {
+            private readonly string _resolvedConnectionString;
+
+            public TestNamedConnectionStringResolver(string resolvedConnectionString)
+                => _resolvedConnectionString = resolvedConnectionString;
+
+            public string ResolveConnectionString(string connectionString)
+                => _resolvedConnectionString;
+        }
+
+        private class TestDatabaseModelFactory : IDatabaseModelFactory
+        {
+            public string ConnectionString { get; set; }
+
+            public DatabaseModel Create(string connectionString, DatabaseModelFactoryOptions options)
+            {
+                ConnectionString = connectionString;
+
+                return new DatabaseModel();
+            }
+
+            public DatabaseModel Create(DbConnection connection, DatabaseModelFactoryOptions options)
+                => throw new System.NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
Fixes #17375

### Description
Reverse engineering a database using a secure, named connection string will crash. This is a common scenario except that referencing the connection string via name is less common than reading it directly. Specifically:
* Developer sets up a connection string in user-secrets (common)
* Developer names that connection string in ASP.NET-style config (common)
* Developer references the connection string by name in EF Core (less common, but not uncommon)
* Scaffolding a `DbContext` (common) will now fail with an exception

### Customer Impact
Customers will not be able to reverse engineer a database when using a named, secure connection string.

A workaround is to read the connection string manually from config and pass it to EF. This isn't a bad workaround, but we expect this to be something that people commonly hit and finding the workaround is not obvious. That being said, it would not be unreasonable to reject this at Ask Mode because the workaround is available.

### How found
Customer feedback on preview 8.

### Test coverage and why we missed this
We missed this because our tests don't typically use user-secrets or named connection strings. We have added a unit test to cover this case, and we will also add a new manual CTI test that scaffolds from the database using user-secrets and named connection strings.

### Regression?
Yes, from 2.2.
 
### Risk
The risk here is very low; code change is trivial.
