### PR TITLE
Add null propagation/protection logic for InMemory provider.

### DIFF
--- a/src/EFCore.InMemory/Query/Internal/EntityProjectionExpression.cs
+++ b/src/EFCore.InMemory/Query/Internal/EntityProjectionExpression.cs
@@ -5,10 +5,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Query;
 
 namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
 {
-    public class EntityProjectionExpression : Expression
+    public class EntityProjectionExpression : Expression, IPrintableExpression
     {
         private readonly IDictionary<IProperty, Expression> _readExpressionMap;
 
@@ -49,6 +50,20 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
             }
 
             return _readExpressionMap[property];
+        }
+
+        public virtual void Print(ExpressionPrinter expressionPrinter)
+        {
+            expressionPrinter.AppendLine(nameof(EntityProjectionExpression) + ":");
+            using (expressionPrinter.Indent())
+            {
+                foreach (var readExpressionMapEntry in _readExpressionMap)
+                {
+                    expressionPrinter.Append(readExpressionMapEntry.Key + " -> ");
+                    expressionPrinter.Visit(readExpressionMapEntry.Value);
+                    expressionPrinter.AppendLine();
+                }
+            }
         }
     }
 }

--- a/src/EFCore.InMemory/Query/Internal/InMemoryProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryProjectionBindingExpressionVisitor.cs
@@ -127,9 +127,17 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                     }
 
                     var translation = _expressionTranslatingExpressionVisitor.Translate(expression);
-                    return translation == null
-                        ? base.Visit(expression)
-                        : new ProjectionBindingExpression(_queryExpression, _queryExpression.AddToProjection(translation), expression.Type);
+                    if (translation == null)
+                    {
+                        return base.Visit(expression);
+                    }
+
+                    if (translation.Type != expression.Type)
+                    {
+                        translation = Expression.Convert(translation, expression.Type);
+                    }
+
+                    return new ProjectionBindingExpression(_queryExpression, _queryExpression.AddToProjection(translation), expression.Type);
                 }
                 else
                 {
@@ -137,6 +145,11 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                     if (translation == null)
                     {
                         return null;
+                    }
+
+                    if (translation.Type != expression.Type)
+                    {
+                        translation = Expression.Convert(translation, expression.Type);
                     }
 
                     _projectionMapping[_projectionMembers.Peek()] = translation;

--- a/src/EFCore.InMemory/Query/Internal/InMemoryQueryExpression.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryQueryExpression.cs
@@ -13,7 +13,7 @@ using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
 {
-    public partial class InMemoryQueryExpression : Expression
+    public partial class InMemoryQueryExpression : Expression, IPrintableExpression
     {
         private static readonly ConstructorInfo _valueBufferConstructor
             = typeof(ValueBuffer).GetConstructors().Single(ci => ci.GetParameters().Length == 1);
@@ -615,6 +615,31 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                 resultSelector);
 
             _projectionMapping = projectionMapping;
+        }
+
+        public virtual void Print(ExpressionPrinter expressionPrinter)
+        {
+            expressionPrinter.AppendLine(nameof(InMemoryQueryExpression) + ": ");
+            using (expressionPrinter.Indent())
+            {
+                expressionPrinter.AppendLine(nameof(ServerQueryExpression) + ": ");
+                using (expressionPrinter.Indent())
+                {
+                    expressionPrinter.Visit(ServerQueryExpression);
+                }
+
+                expressionPrinter.AppendLine("ProjectionMapping:");
+                using (expressionPrinter.Indent())
+                {
+                    foreach (var projectionMapping in _projectionMapping)
+                    {
+                        expressionPrinter.Append("Member: " + projectionMapping.Key + " Projection: ");
+                        expressionPrinter.Visit(projectionMapping.Value);
+                    }
+                }
+
+                expressionPrinter.AppendLine();
+            }
         }
 
         private class NullableReadValueExpressionVisitor : ExpressionVisitor

--- a/src/EFCore.InMemory/Query/Internal/InMemoryTableExpression.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryTableExpression.cs
@@ -5,11 +5,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
 {
-    public class InMemoryTableExpression : Expression
+    public class InMemoryTableExpression : Expression, IPrintableExpression
     {
         public InMemoryTableExpression(IEntityType entityType)
         {
@@ -26,6 +27,10 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
         {
             return this;
         }
-    }
 
+        public virtual void Print(ExpressionPrinter expressionPrinter)
+        {
+            expressionPrinter.Append(nameof(InMemoryTableExpression) + ": Entity: " + EntityType.DisplayName());
+        }
+    }
 }

--- a/src/EFCore/Query/Internal/SubqueryMemberPushdownExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/SubqueryMemberPushdownExpressionVisitor.cs
@@ -52,6 +52,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     (target, nullable) =>
                     {
                         var memberAccessExpression = Expression.MakeMemberAccess(target, memberExpression.Member);
+
                         return nullable && !memberAccessExpression.Type.IsNullableType()
                         ? Expression.Convert(memberAccessExpression, memberAccessExpression.Type.MakeNullable())
                         : (Expression)memberAccessExpression;

--- a/test/EFCore.InMemory.FunctionalTests/Query/ComplexNavigationsQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/ComplexNavigationsQueryInMemoryTest.cs
@@ -7,12 +7,180 @@ using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
-    internal class ComplexNavigationsQueryInMemoryTest : ComplexNavigationsQueryTestBase<ComplexNavigationsQueryInMemoryFixture>
+    public class ComplexNavigationsQueryInMemoryTest : ComplexNavigationsQueryTestBase<ComplexNavigationsQueryInMemoryFixture>
     {
         public ComplexNavigationsQueryInMemoryTest(ComplexNavigationsQueryInMemoryFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
             //TestLoggerFactory.TestOutputHelper = testOutputHelper;
+        }
+
+        [ConditionalTheory(Skip = "issue #16963")] //SelectMany
+        public override Task Complex_SelectMany_with_nested_navigations_and_explicit_DefaultIfEmpty_with_other_query_operators_composed_on_top(bool isAsync)
+        {
+            return base.Complex_SelectMany_with_nested_navigations_and_explicit_DefaultIfEmpty_with_other_query_operators_composed_on_top(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #16963")] //SelectMany
+        public override Task Multiple_SelectMany_with_navigation_and_explicit_DefaultIfEmpty(bool isAsync)
+        {
+            return base.Multiple_SelectMany_with_navigation_and_explicit_DefaultIfEmpty(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #16963")] //SelectMany
+        public override Task Multiple_SelectMany_with_nested_navigations_and_explicit_DefaultIfEmpty_joined_together(bool isAsync)
+        {
+            return base.Multiple_SelectMany_with_nested_navigations_and_explicit_DefaultIfEmpty_joined_together(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #16963")] //SelectMany
+        public override Task SelectMany_with_navigation_and_explicit_DefaultIfEmpty(bool isAsync)
+        {
+            return base.SelectMany_with_navigation_and_explicit_DefaultIfEmpty(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #16963")] //SelectMany
+        public override Task SelectMany_with_navigation_filter_and_explicit_DefaultIfEmpty(bool isAsync)
+        {
+            return base.SelectMany_with_navigation_filter_and_explicit_DefaultIfEmpty(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #16963")] //SelectMany
+        public override Task SelectMany_with_navigation_filter_paging_and_explicit_DefaultIfEmpty(bool isAsync)
+        {
+            return base.SelectMany_with_navigation_filter_paging_and_explicit_DefaultIfEmpty(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #16963")] //SelectMany
+        public override Task SelectMany_with_nested_navigations_and_explicit_DefaultIfEmpty_followed_by_Select_required_navigation_using_different_navs(bool isAsync)
+        {
+            return base.SelectMany_with_nested_navigations_and_explicit_DefaultIfEmpty_followed_by_Select_required_navigation_using_different_navs(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #16963")] //SelectMany
+        public override Task SelectMany_with_nested_navigations_and_explicit_DefaultIfEmpty_followed_by_Select_required_navigation_using_same_navs(bool isAsync)
+        {
+            return base.SelectMany_with_nested_navigations_and_explicit_DefaultIfEmpty_followed_by_Select_required_navigation_using_same_navs(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #16963")] //SelectMany
+        public override Task SelectMany_with_nested_navigations_explicit_DefaultIfEmpty_and_additional_joins_outside_of_SelectMany(bool isAsync)
+        {
+            return base.SelectMany_with_nested_navigations_explicit_DefaultIfEmpty_and_additional_joins_outside_of_SelectMany(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #16963")] //SelectMany
+        public override Task SelectMany_with_nested_navigations_explicit_DefaultIfEmpty_and_additional_joins_outside_of_SelectMany2(bool isAsync)
+        {
+            return base.SelectMany_with_nested_navigations_explicit_DefaultIfEmpty_and_additional_joins_outside_of_SelectMany2(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #16963")] //SelectMany
+        public override Task SelectMany_with_nested_navigations_explicit_DefaultIfEmpty_and_additional_joins_outside_of_SelectMany3(bool isAsync)
+        {
+            return base.SelectMany_with_nested_navigations_explicit_DefaultIfEmpty_and_additional_joins_outside_of_SelectMany3(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #16963")] //SelectMany
+        public override Task SelectMany_with_nested_navigations_explicit_DefaultIfEmpty_and_additional_joins_outside_of_SelectMany4(bool isAsync)
+        {
+            return base.SelectMany_with_nested_navigations_explicit_DefaultIfEmpty_and_additional_joins_outside_of_SelectMany4(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #16963")] //SelectMany
+        public override Task SelectMany_with_nested_navigation_and_explicit_DefaultIfEmpty(bool isAsync)
+        {
+            return base.SelectMany_with_nested_navigation_and_explicit_DefaultIfEmpty(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #16963")] //SelectMany
+        public override Task SelectMany_with_nested_navigation_filter_and_explicit_DefaultIfEmpty(bool isAsync)
+        {
+            return base.SelectMany_with_nested_navigation_filter_and_explicit_DefaultIfEmpty(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #16963")] //SelectMany
+        public override Task SelectMany_with_nested_required_navigation_filter_and_explicit_DefaultIfEmpty(bool isAsync)
+        {
+            return base.SelectMany_with_nested_required_navigation_filter_and_explicit_DefaultIfEmpty(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #16963")] //GroupBy
+        public override Task Simple_level1_level2_GroupBy_Count(bool isAsync)
+        {
+            return base.Simple_level1_level2_GroupBy_Count(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #16963")] //GroupBy
+        public override Task Simple_level1_level2_GroupBy_Having_Count(bool isAsync)
+        {
+            return base.Simple_level1_level2_GroupBy_Having_Count(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #17386")]
+        public override Task Complex_query_with_optional_navigations_and_client_side_evaluation(bool isAsync)
+        {
+            return base.Complex_query_with_optional_navigations_and_client_side_evaluation(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #17453")]
+        public override Task Project_collection_navigation_nested(bool isAsync)
+        {
+            return base.Project_collection_navigation_nested(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #17453")]
+        public override Task Project_collection_navigation_nested_anonymous(bool isAsync)
+        {
+            return base.Project_collection_navigation_nested_anonymous(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #17453")]
+        public override Task Project_collection_navigation_using_ef_property(bool isAsync)
+        {
+            return base.Project_collection_navigation_using_ef_property(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #17453")]
+        public override Task Project_navigation_and_collection(bool isAsync)
+        {
+            return base.Project_navigation_and_collection(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #17453")]
+        public override Task SelectMany_nested_navigation_property_optional_and_projection(bool isAsync)
+        {
+            return base.SelectMany_nested_navigation_property_optional_and_projection(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #17453")]
+        public override Task SelectMany_nested_navigation_property_required(bool isAsync)
+        {
+            return base.SelectMany_nested_navigation_property_required(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #17460")]
+        public override Task Where_complex_predicate_with_with_nav_prop_and_OrElse4(bool isAsync)
+        {
+            return base.Where_complex_predicate_with_with_nav_prop_and_OrElse4(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #17460")]
+        public override Task Join_flattening_bug_4539(bool isAsync)
+        {
+            return base.Join_flattening_bug_4539(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #17463")]
+        public override Task Include18_3_3(bool isAsync)
+        {
+            return base.Include18_3_3(isAsync);
+        }
+
+        [ConditionalFact(Skip = "issue #17463")]
+        public override void Include19()
+        {
+            base.Include19();
         }
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/Query/GearsOfWarQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/GearsOfWarQueryInMemoryTest.cs
@@ -7,12 +7,114 @@ using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
-    internal class GearsOfWarQueryInMemoryTest : GearsOfWarQueryTestBase<GearsOfWarQueryInMemoryFixture>
+    public class GearsOfWarQueryInMemoryTest : GearsOfWarQueryTestBase<GearsOfWarQueryInMemoryFixture>
     {
         public GearsOfWarQueryInMemoryTest(GearsOfWarQueryInMemoryFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
             //TestLoggerFactory.TestOutputHelper = testOutputHelper;
+        }
+
+        [ConditionalTheory(Skip = "issue #16963")] // groupby
+        public override Task GroupBy_Property_Include_Aggregate_with_anonymous_selector(bool isAsync)
+        {
+            return base.GroupBy_Property_Include_Aggregate_with_anonymous_selector(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #16963")] // groupby
+        public override Task GroupBy_Property_Include_Select_Count(bool isAsync)
+        {
+            return base.GroupBy_Property_Include_Select_Count(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #16963")] // groupby
+        public override Task GroupBy_Property_Include_Select_LongCount(bool isAsync)
+        {
+            return base.GroupBy_Property_Include_Select_LongCount(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #16963")] // groupby
+        public override Task GroupBy_Property_Include_Select_Max(bool isAsync)
+        {
+            return base.GroupBy_Property_Include_Select_Max(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #16963")] // groupby
+        public override Task GroupBy_Property_Include_Select_Min(bool isAsync)
+        {
+            return base.GroupBy_Property_Include_Select_Min(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #17386")]
+        public override Task Correlated_collection_order_by_constant_null_of_non_mapped_type(bool isAsync)
+        {
+            return base.Correlated_collection_order_by_constant_null_of_non_mapped_type(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #17386")]
+        public override Task Client_side_equality_with_parameter_works_with_optional_navigations(bool isAsync)
+        {
+            return base.Client_side_equality_with_parameter_works_with_optional_navigations(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #17386")]
+        public override Task Where_coalesce_with_anonymous_types(bool isAsync)
+        {
+            return base.Where_coalesce_with_anonymous_types(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #17386")]
+        public override Task Where_conditional_with_anonymous_type(bool isAsync)
+        {
+            return base.Where_conditional_with_anonymous_type(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #17386")]
+        public override Task GetValueOrDefault_on_DateTimeOffset(bool isAsync)
+        {
+            return base.GetValueOrDefault_on_DateTimeOffset(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #17453")]
+        public override Task Correlated_collection_with_complex_OrderBy(bool isAsync)
+        {
+            return base.Correlated_collection_with_complex_OrderBy(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #17453")]
+        public override Task Correlated_collection_with_very_complex_order_by(bool isAsync)
+        {
+            return base.Correlated_collection_with_very_complex_order_by(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #17463")]
+        public override Task Include_collection_OrderBy_aggregate(bool isAsync)
+        {
+            return base.Include_collection_OrderBy_aggregate(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #17463")]
+        public override Task Include_collection_with_complex_OrderBy3(bool isAsync)
+        {
+            return base.Include_collection_with_complex_OrderBy3(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "issue #17463")]
+        public override void Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result1()
+        {
+            base.Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result1();
+        }
+
+        [ConditionalTheory(Skip = "issue #17463")]
+        public override void Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result2()
+        {
+            base.Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result2();
+        }
+
+        [ConditionalTheory(Skip = "issue #16963")] //length
+        public override Task Null_semantics_is_correctly_applied_for_function_comparisons_that_take_arguments_from_optional_navigation_complex(bool isAsync)
+        {
+            return base.Null_semantics_is_correctly_applied_for_function_comparisons_that_take_arguments_from_optional_navigation_complex(isAsync);
         }
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/Query/QueryFilterFuncletizationInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/QueryFilterFuncletizationInMemoryTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -18,6 +19,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         public class QueryFilterFuncletizationInMemoryFixture : QueryFilterFuncletizationFixtureBase
         {
             protected override ITestStoreFactory TestStoreFactory => InMemoryTestStoreFactory.Instance;
+        }
+
+        [ConditionalFact(Skip = "issue #17386")]
+        public override void DbContext_list_is_parameterized()
+        {
+            base.DbContext_list_is_parameterized();
         }
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/Query/SimpleQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/SimpleQueryInMemoryTest.cs
@@ -244,5 +244,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         #endregion
+
+        [ConditionalTheory(Skip = "issue #17386")]
+        public override Task Where_equals_on_null_nullable_int_types(bool isAsync)
+        {
+            return base.Where_equals_on_null_nullable_int_types(isAsync);
+        }
     }
 }


### PR DESCRIPTION
When we bind to a non-nullable property on entity that can be nullable (e.g. due to left join) we modify the result to be nullable, to avoid "nullable object must have a value" errors. This nullability is then propagated further. We have few blockers:
- predicates (Where, Any, First, Count, etc): always need to be of type bool. When necessary we add "== true".
- conditional expression Test: needs to be bool, same as above
- method call arguments: we can't reliably rewrite methodcall when the arguments types change (generic methods specifically), we convert arguments back to their original types if they were changed to nullable versions.
- method call caller: if the caller was changed from non-nullable to nullable we still need to call the method with the original type, but we add null check before - caller.Method(args) -> nullable_caller == null ? null : (resultType?)caller.Method(args)
- selectors (Select, Max etc): we need to preserve the original result type, we use convert
- anonymous type, array init: we need to preserve the original type, we use convert

Also enable GearsOfWar and ComplexNavigation tests for in memory.