### PR TITLE
Remove previous primary key when overriden

### DIFF
--- a/EFCore.Runtime.slnf
+++ b/EFCore.Runtime.slnf
@@ -15,6 +15,7 @@
       "src\\EFCore.Sqlite.NTS\\EFCore.Sqlite.NTS.csproj",
       "src\\EFCore.Sqlite\\EFCore.Sqlite.csproj",
       "src\\EFCore\\EFCore.csproj",
+      "src\\Microsoft.Data.Sqlite.Core\\Microsoft.Data.Sqlite.Core.csproj",
       "test\\EFCore.Analyzers.Tests\\EFCore.Analyzers.Test.csproj",
       "test\\EFCore.Cosmos.FunctionalTests\\EFCore.Cosmos.FunctionalTests.csproj",
       "test\\EFCore.Cosmos.Tests\\EFCore.Cosmos.Tests.csproj",

--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -532,12 +532,15 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 GenerateKey(builderName, primaryKey, stringBuilder, primary: true);
             }
 
-            foreach (var key in keys.Where(
-                key => key != primaryKey
-                       && (!key.GetReferencingForeignKeys().Any()
-                           || key.GetAnnotations().Any())))
+            if (primaryKey?.DeclaringEntityType.IsOwned() != true)
             {
-                GenerateKey(builderName, key, stringBuilder);
+                foreach (var key in keys.Where(
+                    key => key != primaryKey
+                           && (!key.GetReferencingForeignKeys().Any()
+                               || key.GetAnnotations().Any())))
+                {
+                    GenerateKey(builderName, key, stringBuilder);
+                }
             }
         }
 

--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -114,7 +114,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
                     if (previousPrimaryKey?.Builder != null)
                     {
-                        RemoveKeyIfUnused(previousPrimaryKey);
+                        RemoveKeyIfUnused(previousPrimaryKey, configurationSource);
                     }
                 }
             }
@@ -1530,13 +1530,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     detachedRelationships.AddRange(
                         key.GetReferencingForeignKeys().ToList()
                             .Select(DetachRelationship));
-                    var removed = HasNoKey(key, configurationSource);
+                    var removed = key.DeclaringEntityType.Builder.HasNoKey(key, configurationSource);
                     Debug.Assert(removed != null);
                 }
 
                 foreach (var index in property.GetContainingIndexes().ToList())
                 {
-                    var removed = HasNoIndex(index, configurationSource);
+                    var removed = index.DeclaringEntityType.Builder.HasNoIndex(index, configurationSource);
                     Debug.Assert(removed != null);
                 }
 
@@ -1706,7 +1706,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             return new EntityType.Snapshot(entityType, detachedProperties, detachedIndexes, detachedKeys, detachedRelationships);
         }
 
-        private void RemoveKeyIfUnused(Key key)
+        private void RemoveKeyIfUnused(Key key, ConfigurationSource configurationSource = ConfigurationSource.Convention)
         {
             if (Metadata.FindPrimaryKey() == key)
             {
@@ -1718,7 +1718,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return;
             }
 
-            HasNoKey(key, ConfigurationSource.Convention);
+            HasNoKey(key, configurationSource);
         }
 
         /// <summary>

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Reflection;
@@ -124,6 +125,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
         private class EntityWithTwoProperties
         {
+            [Key]
             public int Id { get; set; }
             public int AlternateId { get; set; }
             public EntityWithOneProperty EntityWithOneProperty { get; set; }

--- a/test/EFCore.Tests/Metadata/Conventions/ForeignKeyPropertyDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/ForeignKeyPropertyDiscoveryConventionTest.cs
@@ -431,13 +431,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         public void Matches_PK_name_properties_if_subset_of_dependent_PK()
         {
             var dependentTypeBuilder = DependentType.Builder;
-            dependentTypeBuilder.PrimaryKey(new[] { DependentEntity.PrincipalEntityPeEKaYProperty }, ConfigurationSource.Explicit);
             var pkProperty = dependentTypeBuilder.Property(
                     DependentEntity.IDProperty, ConfigurationSource.Convention)
                 .IsRequired(true, ConfigurationSource.Convention)
                 .Metadata;
             var fkProperty = dependentTypeBuilder.Property(
-                    DependentEntity.PeEKaYProperty, ConfigurationSource.Convention)
+                    DependentEntity.PrincipalEntityPeEKaYProperty, ConfigurationSource.Convention)
                 .Metadata;
 
             dependentTypeBuilder.PrimaryKey(new[] { pkProperty, fkProperty }, ConfigurationSource.Explicit);


### PR DESCRIPTION
Don't try to generate snapshots with alternate keys for owned types

Fixes #15698
Fixes #13628
Fixes #12414