### PR TITLE
SQLite SaveChanges: Enable non-rowid store-generated keys

### DIFF
--- a/EFCore.Sqlite.slnf
+++ b/EFCore.Sqlite.slnf
@@ -5,6 +5,7 @@
       "src\\EFCore.Abstractions\\EFCore.Abstractions.csproj",
       "src\\EFCore.Analyzers\\EFCore.Analyzers.csproj",
       "src\\EFCore.Design\\EFCore.Design.csproj",
+      "src\\EFCore.InMemory\\EFCore.InMemory.csproj",
       "src\\EFCore.Proxies\\EFCore.Proxies.csproj",
       "src\\EFCore.Relational\\EFCore.Relational.csproj",
       "src\\EFCore.Sqlite.Core\\EFCore.Sqlite.Core.csproj",

--- a/src/EFCore.Sqlite.Core/Update/Internal/SqliteUpdateSqlGenerator.cs
+++ b/src/EFCore.Sqlite.Core/Update/Internal/SqliteUpdateSqlGenerator.cs
@@ -48,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Update.Internal
             Check.NotNull(commandStringBuilder, nameof(commandStringBuilder));
             Check.NotNull(columnModification, nameof(columnModification));
 
-            SqlGenerationHelper.DelimitIdentifier(commandStringBuilder, columnModification.ColumnName);
+            SqlGenerationHelper.DelimitIdentifier(commandStringBuilder, "rowid");
             commandStringBuilder.Append(" = ")
                 .Append("last_insert_rowid()");
         }

--- a/test/EFCore.Relational.Tests/Update/UpdateSqlGeneratorTestBase.cs
+++ b/test/EFCore.Relational.Tests/Update/UpdateSqlGeneratorTestBase.cs
@@ -69,7 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                 "SELECT " + OpenDelimiter + "Id" + CloseDelimiter + ", " + OpenDelimiter + "Computed" + CloseDelimiter + ""
                 + Environment.NewLine +
                 "FROM " + SchemaPrefix + OpenDelimiter + "Ducks" + CloseDelimiter + "" + Environment.NewLine +
-                "WHERE " + RowsAffected + " = 1 AND " + OpenDelimiter + "Id" + CloseDelimiter + " = " + Identity + ";" + Environment.NewLine
+                "WHERE " + RowsAffected + " = 1 AND " + GetIdentityWhereCondition("Id") + ";" + Environment.NewLine
                 + Environment.NewLine,
                 stringBuilder.ToString());
         }
@@ -138,7 +138,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                 "VALUES (@p0, @p1, @p2);" + Environment.NewLine +
                 "SELECT " + OpenDelimiter + "Id" + CloseDelimiter + "" + Environment.NewLine +
                 "FROM " + SchemaPrefix + OpenDelimiter + "Ducks" + CloseDelimiter + "" + Environment.NewLine +
-                "WHERE " + RowsAffected + " = 1 AND " + OpenDelimiter + "Id" + CloseDelimiter + " = " + Identity + ";" + Environment.NewLine
+                "WHERE " + RowsAffected + " = 1 AND " + GetIdentityWhereCondition("Id") + ";" + Environment.NewLine
                 + Environment.NewLine,
                 stringBuilder.ToString());
         }
@@ -163,7 +163,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                 "SELECT " + OpenDelimiter + "Id" + CloseDelimiter + ", " + OpenDelimiter + "Computed" + CloseDelimiter + ""
                 + Environment.NewLine +
                 "FROM " + SchemaPrefix + OpenDelimiter + "Ducks" + CloseDelimiter + "" + Environment.NewLine +
-                "WHERE " + RowsAffected + " = 1 AND " + OpenDelimiter + "Id" + CloseDelimiter + " = " + Identity + ";" + Environment.NewLine
+                "WHERE " + RowsAffected + " = 1 AND " + GetIdentityWhereCondition("Id") + ";" + Environment.NewLine
                 + Environment.NewLine,
                 stringBuilder.ToString());
         }
@@ -187,7 +187,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                 "DEFAULT VALUES;" + Environment.NewLine +
                 "SELECT " + OpenDelimiter + "Id" + CloseDelimiter + "" + Environment.NewLine +
                 "FROM " + SchemaPrefix + OpenDelimiter + "Ducks" + CloseDelimiter + "" + Environment.NewLine +
-                "WHERE " + RowsAffected + " = 1 AND " + OpenDelimiter + "Id" + CloseDelimiter + " = " + Identity + ";" + Environment.NewLine
+                "WHERE " + RowsAffected + " = 1 AND " + GetIdentityWhereCondition("Id") + ";" + Environment.NewLine
                 + Environment.NewLine,
                 stringBuilder.ToString());
         }
@@ -303,7 +303,7 @@ namespace Microsoft.EntityFrameworkCore.Update
 
         protected abstract string RowsAffected { get; }
 
-        protected abstract string Identity { get; }
+        protected virtual string Identity => throw new NotImplementedException();
 
         protected virtual string OpenDelimiter => "\"";
 
@@ -313,6 +313,9 @@ namespace Microsoft.EntityFrameworkCore.Update
 
         protected virtual string SchemaPrefix =>
             string.IsNullOrEmpty(Schema) ? string.Empty : OpenDelimiter + Schema + CloseDelimiter + ".";
+
+        protected virtual string GetIdentityWhereCondition(string columnName)
+            => OpenDelimiter + columnName + CloseDelimiter + " = " + Identity;
 
         protected ModificationCommand CreateInsertCommand(bool identityKey = true, bool isComputed = true, bool defaultsOnly = false)
         {

--- a/test/EFCore.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
@@ -165,7 +165,7 @@ INSERT INTO ""Sample"" (""MaxLengthProperty"", ""Name"", ""RowVersion"", ""Addit
 VALUES (@p0, @p1, @p2, @p3, @p4);
 SELECT ""UniqueNo""
 FROM ""Sample""
-WHERE changes() = 1 AND ""UniqueNo"" = last_insert_rowid();");
+WHERE changes() = 1 AND ""rowid"" = last_insert_rowid();");
         }
 
         // Sqlite does not support length
@@ -189,7 +189,7 @@ INSERT INTO ""BookDetails"" (""AdditionalBookDetailsId"", ""AnotherBookId"")
 VALUES (@p0, @p1);
 SELECT ""Id""
 FROM ""BookDetails""
-WHERE changes() = 1 AND ""Id"" = last_insert_rowid();",
+WHERE changes() = 1 AND ""rowid"" = last_insert_rowid();",
                 //
                 @"@p0=''
 @p1='' (Nullable = false)
@@ -198,7 +198,7 @@ INSERT INTO ""BookDetails"" (""AdditionalBookDetailsId"", ""AnotherBookId"")
 VALUES (@p0, @p1);
 SELECT ""Id""
 FROM ""BookDetails""
-WHERE changes() = 1 AND ""Id"" = last_insert_rowid();");
+WHERE changes() = 1 AND ""rowid"" = last_insert_rowid();");
         }
 
         public override void RequiredAttribute_for_property_throws_while_inserting_null_value()
@@ -216,7 +216,7 @@ INSERT INTO ""Sample"" (""MaxLengthProperty"", ""Name"", ""RowVersion"", ""Addit
 VALUES (@p0, @p1, @p2, @p3, @p4);
 SELECT ""UniqueNo""
 FROM ""Sample""
-WHERE changes() = 1 AND ""UniqueNo"" = last_insert_rowid();",
+WHERE changes() = 1 AND ""rowid"" = last_insert_rowid();",
                 //
                 @"@p0=''
 @p1='' (Nullable = false)
@@ -228,7 +228,7 @@ INSERT INTO ""Sample"" (""MaxLengthProperty"", ""Name"", ""RowVersion"", ""Addit
 VALUES (@p0, @p1, @p2, @p3, @p4);
 SELECT ""UniqueNo""
 FROM ""Sample""
-WHERE changes() = 1 AND ""UniqueNo"" = last_insert_rowid();");
+WHERE changes() = 1 AND ""rowid"" = last_insert_rowid();");
         }
 
         // Sqlite does not support length

--- a/test/EFCore.Sqlite.Tests/Update/SqliteUpdateSqlGeneratorTest.cs
+++ b/test/EFCore.Sqlite.Tests/Update/SqliteUpdateSqlGeneratorTest.cs
@@ -23,8 +23,10 @@ namespace Microsoft.EntityFrameworkCore.Update
         protected override TestHelpers TestHelpers => SqliteTestHelpers.Instance;
 
         protected override string RowsAffected => "changes()";
-        protected override string Identity => "last_insert_rowid()";
         protected override string Schema => null;
+
+        protected override string GetIdentityWhereCondition(string columnName)
+            => OpenDelimiter + "rowid" + CloseDelimiter + " = last_insert_rowid()";
 
         public override void GenerateNextSequenceValueOperation_correctly_handles_schemas()
         {


### PR DESCRIPTION
Enables using default constraints and triggers to generate keys on SQLite.

Fixes #11603