### PR TITLE
SelectExpression.VisitChildren optimizations

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -1294,63 +1294,126 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             {
                 var changed = false;
 
-                var projections = new List<ProjectionExpression>();
-                IDictionary<ProjectionMember, Expression> projectionMapping;
-                if (Projection.Any())
+                var newProjections = _projection;
+                var newProjectionMapping = _projectionMapping;
+                if (_projection.Any())
                 {
-                    projectionMapping = _projectionMapping;
-                    foreach (var item in Projection)
+                    for (var i = 0; i < _projection.Count; i++)
                     {
+                        var item = _projection[i];
                         var projection = (ProjectionExpression)visitor.Visit(item);
-                        projections.Add(projection);
+                        if (projection != item
+                            && newProjections == _projection)
+                        {
+                            newProjections = new List<ProjectionExpression>(_projection.Count);
+                            for (var j = 0; j < i; j++)
+                            {
+                                newProjections.Add(_projection[j]);
+                            }
+                            changed = true;
+                        }
 
-                        changed |= projection != item;
+                        if (newProjections != _projection)
+                        {
+                            newProjections.Add(projection);
+                        }
                     }
                 }
                 else
                 {
-                    projectionMapping = new Dictionary<ProjectionMember, Expression>();
                     foreach (var mapping in _projectionMapping)
                     {
                         var newProjection = visitor.Visit(mapping.Value);
-                        changed |= newProjection != mapping.Value;
+                        if (newProjection != mapping.Value
+                            && newProjectionMapping == _projectionMapping)
+                        {
+                            newProjectionMapping = new Dictionary<ProjectionMember, Expression>(_projectionMapping);
+                            changed = true;
+                        }
 
-                        projectionMapping[mapping.Key] = newProjection;
+                        if (newProjectionMapping != _projectionMapping)
+                        {
+                            newProjectionMapping[mapping.Key] = newProjection;
+                        }
                     }
                 }
 
-                var tables = new List<TableExpressionBase>();
-                foreach (var table in _tables)
+                var newTables = _tables;
+                for (var i = 0; i < _tables.Count; i++)
                 {
+                    var table = _tables[i];
                     var newTable = (TableExpressionBase)visitor.Visit(table);
-                    changed |= newTable != table;
-                    tables.Add(newTable);
+                    if (newTable != table
+                        && newTables == _tables)
+                    {
+                        newTables = new List<TableExpressionBase>(_tables.Count);
+                        for (var j = 0; j < i; j++)
+                        {
+                            newTables.Add(_tables[j]);
+                        }
+                        changed = true;
+                    }
+
+                    if (newTables != _tables)
+                    {
+                        newTables.Add(newTable);
+                    }
                 }
 
                 var predicate = (SqlExpression)visitor.Visit(Predicate);
                 changed |= predicate != Predicate;
 
-                var groupBy = new List<SqlExpression>();
-                foreach (var groupingKey in _groupBy)
+                var newGroupBy = _groupBy;
+                for (var i = 0; i < _groupBy.Count; i++)
                 {
+                    var groupingKey = _groupBy[i];
                     var newGroupingKey = (SqlExpression)visitor.Visit(groupingKey);
-                    changed |= newGroupingKey != groupingKey;
-                    if (!(newGroupingKey is SqlConstantExpression
-                          || newGroupingKey is SqlParameterExpression))
+                    if (newGroupingKey != groupingKey
+                        || newGroupingKey is SqlConstantExpression
+                        || newGroupingKey is SqlParameterExpression)
                     {
-                        groupBy.Add(newGroupingKey);
+                        if (newGroupBy == _groupBy)
+                        {
+                            newGroupBy = new List<SqlExpression>(_groupBy.Count);
+                            for (var j = 0; j < i; j++)
+                            {
+                                newGroupBy.Add(_groupBy[j]);
+                            }
+                        }
+                        changed = true;
+                    }
+
+                    if (newGroupBy != _groupBy &&
+                        !(newGroupingKey is SqlConstantExpression
+                        || newGroupingKey is SqlParameterExpression))
+                    {
+                        newGroupBy.Add(newGroupingKey);
                     }
                 }
 
                 var havingExpression = (SqlExpression)visitor.Visit(Having);
                 changed |= havingExpression != Having;
 
-                var orderings = new List<OrderingExpression>();
-                foreach (var ordering in _orderings)
+                var newOrderings = _orderings;
+                for (var i = 0; i < _orderings.Count; i++)
                 {
-                    var orderingExpression = (SqlExpression)visitor.Visit(ordering.Expression);
-                    changed |= orderingExpression != ordering.Expression;
-                    orderings.Add(ordering.Update(orderingExpression));
+                    var ordering = _orderings[i];
+                    var newOrdering = (OrderingExpression)visitor.Visit(ordering);
+                    if (newOrdering != ordering
+                        && newOrderings == _orderings)
+                    {
+                        newOrderings = new List<OrderingExpression>(_orderings.Count);
+                        for (var j = 0; j < i; j++)
+                        {
+                            newOrderings.Add(_orderings[j]);
+                        }
+                        changed = true;
+                    }
+
+                    if (newOrderings != _orderings)
+                    {
+                        newOrderings.Add(newOrdering);
+                    }
                 }
 
                 var offset = (SqlExpression)visitor.Visit(Offset);
@@ -1361,9 +1424,9 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
 
                 if (changed)
                 {
-                    var newSelectExpression = new SelectExpression(Alias, projections, tables, groupBy, orderings)
+                    var newSelectExpression = new SelectExpression(Alias, newProjections, newTables, newGroupBy, newOrderings)
                     {
-                        _projectionMapping = projectionMapping,
+                        _projectionMapping = newProjectionMapping,
                         Predicate = predicate,
                         Having = havingExpression,
                         Offset = offset,


### PR DESCRIPTION
Profiling the scenario in #17455 showed that SelectExpression.VisitChildren was a major compilation perf hotspot (own time, not including child calls). This PR changes the logic to only allocate new data structures and copy if a Visit actually returned a different result.

This reduced the time for #17455 from 22 seconds to 15 on my machine. Memory allocated notably goes down from 61.86MB to 12.17MB.

Also added a compilation micro-benchmark which does three joins, here are the results. Note that #17455 includes 6 results and so the difference is considerably more significant.

### Before
```
BenchmarkDotNet=v0.11.3, OS=ubuntu 19.04
Intel Xeon W-2133 CPU 3.60GHz, 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=3.0.100-preview8-013656
  [Host] : .NET Core 3.0.0-rc1-19430-09 (CoreCLR 4.700.19.43003, CoreFX 4.700.19.42010), 64bit RyuJIT

Toolchain=InProcessToolchain  

        Method |     Mean |    Error |   StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
-------------- |---------:|---------:|---------:|------------:|------------:|------------:|--------------------:|
 MultipleJoins | 215.8 ms | 4.067 ms | 3.605 ms |  15000.0000 |   1000.0000 |           - |            61.86 MB |
```

### After
```
BenchmarkDotNet=v0.11.3, OS=ubuntu 19.04
Intel Xeon W-2133 CPU 3.60GHz, 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=3.0.100-preview8-013656
  [Host] : .NET Core 3.0.0-rc1-19430-09 (CoreCLR 4.700.19.43003, CoreFX 4.700.19.42010), 64bit RyuJIT

Toolchain=InProcessToolchain  

        Method |     Mean |    Error |   StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
-------------- |---------:|---------:|---------:|------------:|------------:|------------:|--------------------:|
 MultipleJoins | 173.2 ms | 3.538 ms | 3.309 ms |   2666.6667 |    666.6667 |           - |            12.17 MB |
```