### PR TITLE
[3.0] Remove suffix from Cosmos Metadata extensions

### DIFF
--- a/src/EFCore.Cosmos/Extensions/CosmosEntityTypeBuilderExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosEntityTypeBuilderExtensions.cs
@@ -31,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore
             Check.NotNull(entityTypeBuilder, nameof(entityTypeBuilder));
             Check.NullButNotEmpty(name, nameof(name));
 
-            entityTypeBuilder.Metadata.SetCosmosContainer(name);
+            entityTypeBuilder.Metadata.SetContainer(name);
 
             return entityTypeBuilder;
         }
@@ -69,7 +69,7 @@ namespace Microsoft.EntityFrameworkCore
                 return null;
             }
 
-            entityTypeBuilder.Metadata.SetCosmosContainer(name, fromDataAnnotation);
+            entityTypeBuilder.Metadata.SetContainer(name, fromDataAnnotation);
 
             return entityTypeBuilder;
         }
@@ -101,7 +101,7 @@ namespace Microsoft.EntityFrameworkCore
             [NotNull] this OwnedNavigationBuilder entityTypeBuilder,
             [CanBeNull] string name)
         {
-            entityTypeBuilder.OwnedEntityType.SetCosmosContainingPropertyName(name);
+            entityTypeBuilder.OwnedEntityType.SetContainingPropertyName(name);
 
             return entityTypeBuilder;
         }
@@ -118,7 +118,7 @@ namespace Microsoft.EntityFrameworkCore
             where TEntity : class
             where TDependentEntity : class
         {
-            entityTypeBuilder.OwnedEntityType.SetCosmosContainingPropertyName(name);
+            entityTypeBuilder.OwnedEntityType.SetContainingPropertyName(name);
 
             return entityTypeBuilder;
         }
@@ -143,7 +143,7 @@ namespace Microsoft.EntityFrameworkCore
                 return null;
             }
 
-            entityTypeBuilder.Metadata.SetCosmosContainingPropertyName(name, fromDataAnnotation);
+            entityTypeBuilder.Metadata.SetContainingPropertyName(name, fromDataAnnotation);
 
             return entityTypeBuilder;
         }
@@ -175,7 +175,7 @@ namespace Microsoft.EntityFrameworkCore
             [NotNull] this EntityTypeBuilder entityTypeBuilder,
             [CanBeNull] string name)
         {
-            entityTypeBuilder.Metadata.SetCosmosPartitionKeyPropertyName(name);
+            entityTypeBuilder.Metadata.SetPartitionKeyPropertyName(name);
 
             return entityTypeBuilder;
         }
@@ -191,7 +191,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] string name)
             where TEntity : class
         {
-            entityTypeBuilder.Metadata.SetCosmosPartitionKeyPropertyName(name);
+            entityTypeBuilder.Metadata.SetPartitionKeyPropertyName(name);
 
             return entityTypeBuilder;
         }
@@ -209,7 +209,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             Check.NotNull(propertyExpression, nameof(propertyExpression));
 
-            entityTypeBuilder.Metadata.SetCosmosPartitionKeyPropertyName(propertyExpression.GetPropertyAccess().GetSimpleMemberName());
+            entityTypeBuilder.Metadata.SetPartitionKeyPropertyName(propertyExpression.GetPropertyAccess().GetSimpleMemberName());
 
             return entityTypeBuilder;
         }
@@ -234,7 +234,7 @@ namespace Microsoft.EntityFrameworkCore
                 return null;
             }
 
-            entityTypeBuilder.Metadata.SetCosmosPartitionKeyPropertyName(name, fromDataAnnotation);
+            entityTypeBuilder.Metadata.SetPartitionKeyPropertyName(name, fromDataAnnotation);
 
             return entityTypeBuilder;
         }

--- a/src/EFCore.Cosmos/Extensions/CosmosEntityTypeExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosEntityTypeExtensions.cs
@@ -19,14 +19,14 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entityType"> The entity type to get the container name for. </param>
         /// <returns> The name of the container to which the entity type is mapped. </returns>
-        public static string GetCosmosContainer([NotNull] this IEntityType entityType) =>
+        public static string GetContainer([NotNull] this IEntityType entityType) =>
             entityType.BaseType != null
-                ? entityType.GetRootType().GetCosmosContainer()
+                ? entityType.GetRootType().GetContainer()
                 : (string)entityType[CosmosAnnotationNames.ContainerName]
-                  ?? GetCosmosDefaultContainer(entityType);
+                  ?? GetDefaultContainer(entityType);
 
-        private static string GetCosmosDefaultContainer(IEntityType entityType)
-            => entityType.Model.GetCosmosDefaultContainer()
+        private static string GetDefaultContainer(IEntityType entityType)
+            => entityType.Model.GetDefaultContainer()
                ?? entityType.ShortName();
 
         /// <summary>
@@ -34,7 +34,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entityType"> The entity type to set the container name for. </param>
         /// <param name="name"> The name to set. </param>
-        public static void SetCosmosContainer([NotNull] this IMutableEntityType entityType, [CanBeNull] string name)
+        public static void SetContainer([NotNull] this IMutableEntityType entityType, [CanBeNull] string name)
             => entityType.SetOrRemoveAnnotation(
                 CosmosAnnotationNames.ContainerName,
                 Check.NullButNotEmpty(name, nameof(name)));
@@ -45,7 +45,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type to set the container name for. </param>
         /// <param name="name"> The name to set. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
-        public static void SetCosmosContainer(
+        public static void SetContainer(
             [NotNull] this IConventionEntityType entityType, [CanBeNull] string name, bool fromDataAnnotation = false)
             => entityType.SetOrRemoveAnnotation(
                 CosmosAnnotationNames.ContainerName,
@@ -57,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entityType"> The entity type to find configuration source for. </param>
         /// <returns> The <see cref="ConfigurationSource" /> for the container to which the entity type is mapped. </returns>
-        public static ConfigurationSource? GetCosmosContainerConfigurationSource([NotNull] this IConventionEntityType entityType)
+        public static ConfigurationSource? GetContainerConfigurationSource([NotNull] this IConventionEntityType entityType)
             => entityType.FindAnnotation(CosmosAnnotationNames.ContainerName)
                 ?.GetConfigurationSource();
 
@@ -66,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entityType"> The entity type to get the containing property name for. </param>
         /// <returns> The name of the parent property to which the entity type is mapped. </returns>
-        public static string GetCosmosContainingPropertyName([NotNull] this IEntityType entityType) =>
+        public static string GetContainingPropertyName([NotNull] this IEntityType entityType) =>
             entityType[CosmosAnnotationNames.PropertyName] as string
             ?? GetDefaultContainingPropertyName(entityType);
 
@@ -78,7 +78,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entityType"> The entity type to set the containing property name for. </param>
         /// <param name="name"> The name to set. </param>
-        public static void SetCosmosContainingPropertyName([NotNull] this IMutableEntityType entityType, [CanBeNull] string name)
+        public static void SetContainingPropertyName([NotNull] this IMutableEntityType entityType, [CanBeNull] string name)
             => entityType.SetOrRemoveAnnotation(
                 CosmosAnnotationNames.PropertyName,
                 Check.NullButNotEmpty(name, nameof(name)));
@@ -89,7 +89,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type to set the containing property name for. </param>
         /// <param name="name"> The name to set. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
-        public static void SetCosmosContainingPropertyName(
+        public static void SetContainingPropertyName(
             [NotNull] this IConventionEntityType entityType, [CanBeNull] string name, bool fromDataAnnotation = false)
             => entityType.SetOrRemoveAnnotation(
                 CosmosAnnotationNames.PropertyName,
@@ -101,7 +101,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entityType"> The entity type to find configuration source for. </param>
         /// <returns> The <see cref="ConfigurationSource" /> for the parent property to which the entity type is mapped. </returns>
-        public static ConfigurationSource? GetCosmosContainingPropertyNameConfigurationSource([NotNull] this IConventionEntityType entityType)
+        public static ConfigurationSource? GetContainingPropertyNameConfigurationSource([NotNull] this IConventionEntityType entityType)
             => entityType.FindAnnotation(CosmosAnnotationNames.PropertyName)
                 ?.GetConfigurationSource();
 
@@ -110,15 +110,15 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entityType"> The entity type to get the partition key property name for. </param>
         /// <returns> The name of the partition key property. </returns>
-        public static string GetCosmosPartitionKeyPropertyName([NotNull] this IEntityType entityType) =>
-            entityType[CosmosAnnotationNames.PartitionKeyName] as string;
+        public static string GetPartitionKeyPropertyName([NotNull] this IEntityType entityType)
+            => entityType[CosmosAnnotationNames.PartitionKeyName] as string;
 
         /// <summary>
         ///     Sets the name of the property that is used to store the partition key key.
         /// </summary>
         /// <param name="entityType"> The entity type to set the partition key property name for. </param>
         /// <param name="name"> The name to set. </param>
-        public static void SetCosmosPartitionKeyPropertyName([NotNull] this IMutableEntityType entityType, [CanBeNull] string name)
+        public static void SetPartitionKeyPropertyName([NotNull] this IMutableEntityType entityType, [CanBeNull] string name)
             => entityType.SetOrRemoveAnnotation(
                 CosmosAnnotationNames.PartitionKeyName,
                 Check.NullButNotEmpty(name, nameof(name)));
@@ -129,7 +129,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type to set the partition key property name for. </param>
         /// <param name="name"> The name to set. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
-        public static void SetCosmosPartitionKeyPropertyName(
+        public static void SetPartitionKeyPropertyName(
             [NotNull] this IConventionEntityType entityType, [CanBeNull] string name, bool fromDataAnnotation = false)
             => entityType.SetOrRemoveAnnotation(
                 CosmosAnnotationNames.PartitionKeyName,
@@ -141,7 +141,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entityType"> The entity type to find configuration source for. </param>
         /// <returns> The <see cref="ConfigurationSource" /> for the partition key property. </returns>
-        public static ConfigurationSource? GetCosmosPartitionKeyPropertyNameConfigurationSource([NotNull] this IConventionEntityType entityType)
+        public static ConfigurationSource? GetPartitionKeyPropertyNameConfigurationSource([NotNull] this IConventionEntityType entityType)
             => entityType.FindAnnotation(CosmosAnnotationNames.PartitionKeyName)
                 ?.GetConfigurationSource();
     }

--- a/src/EFCore.Cosmos/Extensions/CosmosModelBuilderExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosModelBuilderExtensions.cs
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore
             Check.NotNull(modelBuilder, nameof(modelBuilder));
             Check.NullButNotEmpty(name, nameof(name));
 
-            modelBuilder.Model.SetCosmosDefaultContainer(name);
+            modelBuilder.Model.SetDefaultContainer(name);
 
             return modelBuilder;
         }
@@ -54,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore
                 return null;
             }
 
-            modelBuilder.Metadata.SetCosmosDefaultContainer(name, fromDataAnnotation);
+            modelBuilder.Metadata.SetDefaultContainer(name, fromDataAnnotation);
 
             return modelBuilder;
         }

--- a/src/EFCore.Cosmos/Extensions/CosmosModelExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosModelExtensions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="model"> The model. </param>
         /// <returns> The default container name. </returns>
-        public static string GetCosmosDefaultContainer([NotNull] this IModel model)
+        public static string GetDefaultContainer([NotNull] this IModel model)
             => (string)model[CosmosAnnotationNames.ContainerName];
 
         /// <summary>
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="model"> The model. </param>
         /// <param name="name"> The name to set. </param>
-        public static void SetCosmosDefaultContainer([NotNull] this IMutableModel model, [CanBeNull] string name)
+        public static void SetDefaultContainer([NotNull] this IMutableModel model, [CanBeNull] string name)
             => model.SetOrRemoveAnnotation(
                 CosmosAnnotationNames.ContainerName,
                 Check.NullButNotEmpty(name, nameof(name)));
@@ -38,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="model"> The model. </param>
         /// <param name="name"> The name to set. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
-        public static void SetCosmosDefaultContainer([NotNull] this IConventionModel model, [CanBeNull] string name, bool fromDataAnnotation = false)
+        public static void SetDefaultContainer([NotNull] this IConventionModel model, [CanBeNull] string name, bool fromDataAnnotation = false)
             => model.SetOrRemoveAnnotation(
                 CosmosAnnotationNames.ContainerName,
                 Check.NullButNotEmpty(name, nameof(name)),
@@ -49,7 +49,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="model"> The model. </param>
         /// <returns> The configuration source for the default container name.</returns>
-        public static ConfigurationSource? GetCosmosDefaultContainerConfigurationSource([NotNull] this IConventionModel model)
+        public static ConfigurationSource? GetDefaultContainerConfigurationSource([NotNull] this IConventionModel model)
             => model.FindAnnotation(CosmosAnnotationNames.ContainerName)?.GetConfigurationSource();
     }
 }

--- a/src/EFCore.Cosmos/Extensions/CosmosPropertyBuilderExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosPropertyBuilderExtensions.cs
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
             Check.NotNull(name, nameof(name));
 
-            propertyBuilder.Metadata.SetCosmosPropertyName(name);
+            propertyBuilder.Metadata.SetPropertyName(name);
 
             return propertyBuilder;
         }
@@ -70,7 +70,7 @@ namespace Microsoft.EntityFrameworkCore
                 return null;
             }
 
-            propertyBuilder.Metadata.SetCosmosPropertyName(name, fromDataAnnotation);
+            propertyBuilder.Metadata.SetPropertyName(name, fromDataAnnotation);
 
             return propertyBuilder;
         }

--- a/src/EFCore.Cosmos/Extensions/CosmosPropertyExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosPropertyExtensions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="property"> The property. </param>
         /// <returns> The property name used when targeting Cosmos. </returns>
-        public static string GetCosmosPropertyName([NotNull] this IProperty property) =>
+        public static string GetPropertyName([NotNull] this IProperty property) =>
             (string)property[CosmosAnnotationNames.PropertyName]
             ?? GetDefaultPropertyName(property);
 
@@ -48,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="property"> The property. </param>
         /// <param name="name"> The name to set. </param>
-        public static void SetCosmosPropertyName([NotNull] this IMutableProperty property, [CanBeNull] string name)
+        public static void SetPropertyName([NotNull] this IMutableProperty property, [CanBeNull] string name)
             => property.SetOrRemoveAnnotation(
                 CosmosAnnotationNames.PropertyName,
                 name);
@@ -59,7 +59,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="property"> The property. </param>
         /// <param name="name"> The name to set. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
-        public static void SetCosmosPropertyName([NotNull] this IConventionProperty property, [CanBeNull] string name, bool fromDataAnnotation = false)
+        public static void SetPropertyName([NotNull] this IConventionProperty property, [CanBeNull] string name, bool fromDataAnnotation = false)
             => property.SetOrRemoveAnnotation(
                 CosmosAnnotationNames.PropertyName,
                 name,
@@ -70,7 +70,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="property"> The property. </param>
         /// <returns> The <see cref="ConfigurationSource" /> for the property name used when targeting Cosmos. </returns>
-        public static ConfigurationSource? GetCosmosPropertyNameConfigurationSource([NotNull] this IConventionProperty property)
+        public static ConfigurationSource? GetPropertyNameConfigurationSource([NotNull] this IConventionProperty property)
             => property.FindAnnotation(CosmosAnnotationNames.PropertyName)?.GetConfigurationSource();
     }
 }

--- a/src/EFCore.Cosmos/Internal/CosmosModelValidator.cs
+++ b/src/EFCore.Cosmos/Internal/CosmosModelValidator.cs
@@ -56,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
             var containers = new Dictionary<string, List<IEntityType>>();
             foreach (var entityType in model.GetEntityTypes().Where(et => et.FindPrimaryKey() != null))
             {
-                var container = entityType.GetCosmosContainer();
+                var container = entityType.GetContainer();
 
                 if (!containers.TryGetValue(container, out var mappedTypes))
                 {
@@ -91,7 +91,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
             IEntityType firstEntityType = null;
             foreach (var entityType in mappedTypes)
             {
-                var partitionKeyPropertyName = entityType.GetCosmosPartitionKeyPropertyName();
+                var partitionKeyPropertyName = entityType.GetPartitionKeyPropertyName();
                 if (partitionKeyPropertyName != null)
                 {
                     var nextPartitionKeyProperty = entityType.FindProperty(partitionKeyPropertyName);
@@ -117,12 +117,12 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
                         }
                         partitionKey = nextPartitionKeyProperty;
                     }
-                    else if (partitionKey.GetCosmosPropertyName() != nextPartitionKeyProperty.GetCosmosPropertyName())
+                    else if (partitionKey.GetPropertyName() != nextPartitionKeyProperty.GetPropertyName())
                     {
                         throw new InvalidOperationException(
                             CosmosStrings.PartitionKeyStoreNameMismatch(
-                                partitionKey.Name, firstEntityType.DisplayName(), partitionKey.GetCosmosPropertyName(),
-                                nextPartitionKeyProperty.Name, entityType.DisplayName(), nextPartitionKeyProperty.GetCosmosPropertyName()));
+                                partitionKey.Name, firstEntityType.DisplayName(), partitionKey.GetPropertyName(),
+                                nextPartitionKeyProperty.Name, entityType.DisplayName(), nextPartitionKeyProperty.GetPropertyName()));
                     }
                 }
                 else if (partitionKey != null)
@@ -141,7 +141,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
                 }
 
                 if (entityType.ClrType?.IsInstantiable() == true
-                    && entityType.GetCosmosContainingPropertyName() == null)
+                    && entityType.GetContainingPropertyName() == null)
                 {
                     if (entityType.GetDiscriminatorProperty() == null)
                     {

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitor.cs
@@ -540,7 +540,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                     return _projectionBindings[jObjectExpression];
                 }
 
-                var storeName = property.GetCosmosPropertyName();
+                var storeName = property.GetPropertyName();
                 if (storeName.Length == 0)
                 {
                     var entityType = property.DeclaringEntityType;

--- a/src/EFCore.Cosmos/Query/Internal/KeyAccessExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/KeyAccessExpression.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         public KeyAccessExpression(IProperty property, Expression accessExpression)
             : base(property.ClrType, property.GetTypeMapping())
         {
-            Name = property.GetCosmosPropertyName();
+            Name = property.GetPropertyName();
             Property = property;
             AccessExpression = accessExpression;
         }

--- a/src/EFCore.Cosmos/Query/Internal/ObjectAccessExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/ObjectAccessExpression.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         /// </summary>
         public ObjectAccessExpression(INavigation navigation, Expression accessExpression)
         {
-            Name = navigation.GetTargetType().GetCosmosContainingPropertyName();
+            Name = navigation.GetTargetType().GetContainingPropertyName();
             if (Name == null)
             {
                 throw new InvalidOperationException(

--- a/src/EFCore.Cosmos/Query/Internal/ObjectArrayProjectionExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/ObjectArrayProjectionExpression.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
             var targetType = navigation.GetTargetType();
             Type = typeof(IEnumerable<>).MakeGenericType(targetType.ClrType);
 
-            Name = targetType.GetCosmosContainingPropertyName();
+            Name = targetType.GetContainingPropertyName();
             if (Name == null)
             {
                 throw new InvalidOperationException(

--- a/src/EFCore.Cosmos/Query/Internal/SelectExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/SelectExpression.cs
@@ -33,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         /// </summary>
         public SelectExpression(IEntityType entityType)
         {
-            Container = entityType.GetCosmosContainer();
+            Container = entityType.GetContainer();
             FromExpression = new RootReferenceExpression(entityType, RootAlias);
             _projectionMapping[new ProjectionMember()] = new EntityProjectionExpression(entityType, FromExpression);
         }

--- a/src/EFCore.Cosmos/Storage/Internal/CosmosDatabaseCreator.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosDatabaseCreator.cs
@@ -54,8 +54,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
             foreach (var entityType in _model.GetEntityTypes())
             {
                 created |= _cosmosClient.CreateContainerIfNotExists(
-                    entityType.GetCosmosContainer(),
-                    GetCosmosPartitionKeyStoreName(entityType));
+                    entityType.GetContainer(),
+                    GetPartitionKeyStoreName(entityType));
             }
 
             if (created)
@@ -88,8 +88,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
             foreach (var entityType in _model.GetEntityTypes())
             {
                 created |= await _cosmosClient.CreateContainerIfNotExistsAsync(
-                    entityType.GetCosmosContainer(),
-                    GetCosmosPartitionKeyStoreName(entityType),
+                    entityType.GetContainer(),
+                    GetPartitionKeyStoreName(entityType),
                     cancellationToken);
             }
 
@@ -151,12 +151,12 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         /// </summary>
         /// <param name="entityType"> The entity type to get the partition key property name for. </param>
         /// <returns> The name of the partition key property. </returns>
-        private static string GetCosmosPartitionKeyStoreName([NotNull] IEntityType entityType)
+        private static string GetPartitionKeyStoreName([NotNull] IEntityType entityType)
         {
-            var name = entityType.GetCosmosPartitionKeyPropertyName();
+            var name = entityType.GetPartitionKeyPropertyName();
             if (name != null)
             {
-                return entityType.FindProperty(name).GetCosmosPropertyName();
+                return entityType.FindProperty(name).GetPropertyName();
             }
 
             return CosmosClientWrapper.DefaultPartitionKey;

--- a/src/EFCore.Cosmos/Storage/Internal/CosmosDatabaseWrapper.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosDatabaseWrapper.cs
@@ -204,7 +204,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
                     {
                         document = documentSource.CreateDocument(entry);
 
-                        document[entityType.GetDiscriminatorProperty().GetCosmosPropertyName()] =
+                        document[entityType.GetDiscriminatorProperty().GetPropertyName()] =
                             JToken.FromObject(entityType.GetDiscriminatorValue(), CosmosClientWrapper.Serializer);
                     }
 
@@ -255,7 +255,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
                     {
                         document = documentSource.CreateDocument(entry);
 
-                        document[entityType.GetDiscriminatorProperty().GetCosmosPropertyName()] =
+                        document[entityType.GetDiscriminatorProperty().GetPropertyName()] =
                             JToken.FromObject(entityType.GetDiscriminatorValue(), CosmosClientWrapper.Serializer);
                     }
 
@@ -313,7 +313,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         private static string GetPartitionKey(IUpdateEntry entry)
         {
             object partitionKey = null;
-            var partitionKeyPropertyName = entry.EntityType.GetCosmosPartitionKeyPropertyName();
+            var partitionKeyPropertyName = entry.EntityType.GetPartitionKeyPropertyName();
             if (partitionKeyPropertyName != null)
             {
                 var partitionKeyProperty = entry.EntityType.FindProperty(partitionKeyPropertyName);

--- a/src/EFCore.Cosmos/Update/Internal/DocumentSource.cs
+++ b/src/EFCore.Cosmos/Update/Internal/DocumentSource.cs
@@ -33,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Update.Internal
         /// </summary>
         public DocumentSource(IEntityType entityType, CosmosDatabaseWrapper database)
         {
-            _collectionId = entityType.GetCosmosContainer();
+            _collectionId = entityType.GetContainer();
             _database = database;
             _idProperty = entityType.FindProperty(StoreKeyConvention.IdPropertyName);
             _jObjectProperty = entityType.FindProperty(StoreKeyConvention.JObjectPropertyName);
@@ -68,7 +68,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Update.Internal
             var document = new JObject();
             foreach (var property in entry.EntityType.GetProperties())
             {
-                var storeName = property.GetCosmosPropertyName();
+                var storeName = property.GetPropertyName();
                 if (storeName.Length != 0)
                 {
                     document[storeName] = ConvertPropertyValue(property, entry.GetCurrentValue(property));
@@ -90,7 +90,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Update.Internal
                 }
 
                 var embeddedValue = entry.GetCurrentValue(embeddedNavigation);
-                var embeddedPropertyName = fk.DeclaringEntityType.GetCosmosContainingPropertyName();
+                var embeddedPropertyName = fk.DeclaringEntityType.GetContainingPropertyName();
                 if (embeddedValue == null)
                 {
                     document[embeddedPropertyName] = null;
@@ -130,7 +130,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Update.Internal
                 if (entry.EntityState == EntityState.Added
                     || entry.IsModified(property))
                 {
-                    var storeName = property.GetCosmosPropertyName();
+                    var storeName = property.GetPropertyName();
                     if (storeName.Length != 0)
                     {
                         document[storeName] = ConvertPropertyValue(property, entry.GetCurrentValue(property));
@@ -155,7 +155,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Update.Internal
 
                 var embeddedDocumentSource = _database.GetDocumentSource(fk.DeclaringEntityType);
                 var embeddedValue = entry.GetCurrentValue(ownedNavigation);
-                var embeddedPropertyName = fk.DeclaringEntityType.GetCosmosContainingPropertyName();
+                var embeddedPropertyName = fk.DeclaringEntityType.GetContainingPropertyName();
                 if (embeddedValue == null)
                 {
                     if (document[embeddedPropertyName] != null)

--- a/src/EFCore.Cosmos/ValueGeneration/Internal/CosmosValueGeneratorSelector.cs
+++ b/src/EFCore.Cosmos/ValueGeneration/Internal/CosmosValueGeneratorSelector.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.ValueGeneration.Internal
         {
             var type = property.ClrType.UnwrapNullableType().UnwrapEnumType();
 
-            if (property.GetCosmosPropertyName() == ""
+            if (property.GetPropertyName() == ""
                 && type == typeof(int))
             {
                 return new TemporaryIntValueGenerator();

--- a/src/EFCore.Cosmos/ValueGeneration/Internal/IdValueGenerator.cs
+++ b/src/EFCore.Cosmos/ValueGeneration/Internal/IdValueGenerator.cs
@@ -46,7 +46,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.ValueGeneration.Internal
                 builder.Append("|");
             }
 
-            var partitionKey = entityType.GetCosmosPartitionKeyPropertyName() ?? CosmosClientWrapper.DefaultPartitionKey;
+            var partitionKey = entityType.GetPartitionKeyPropertyName() ?? CosmosClientWrapper.DefaultPartitionKey;
             foreach (var property in pk.Properties)
             {
                 if (property.Name == partitionKey)

--- a/test/EFCore.Cosmos.Tests/Metadata/CosmosBuilderExtensionsTest.cs
+++ b/test/EFCore.Cosmos.Tests/Metadata/CosmosBuilderExtensionsTest.cs
@@ -17,16 +17,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             var entityType = modelBuilder
                 .Entity<Customer>();
 
-            Assert.Equal(nameof(DbContext), entityType.Metadata.GetCosmosContainer());
+            Assert.Equal(nameof(DbContext), entityType.Metadata.GetContainer());
 
             entityType.ToContainer("Customizer");
-            Assert.Equal("Customizer", entityType.Metadata.GetCosmosContainer());
+            Assert.Equal("Customizer", entityType.Metadata.GetContainer());
 
             entityType.ToContainer(null);
-            Assert.Equal(nameof(DbContext), entityType.Metadata.GetCosmosContainer());
+            Assert.Equal(nameof(DbContext), entityType.Metadata.GetContainer());
 
             modelBuilder.HasDefaultContainer("Unicorn");
-            Assert.Equal("Unicorn", entityType.Metadata.GetCosmosContainer());
+            Assert.Equal("Unicorn", entityType.Metadata.GetContainer());
         }
 
         [ConditionalFact]
@@ -38,20 +38,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             var entityType = entityTypeBuilder.Metadata;
 
             ((IConventionEntityType)entityType).Builder.HasPartitionKey("pk");
-            Assert.Equal("pk", entityType.GetCosmosPartitionKeyPropertyName());
+            Assert.Equal("pk", entityType.GetPartitionKeyPropertyName());
             Assert.Equal(ConfigurationSource.Convention,
-                ((IConventionEntityType)entityType).GetCosmosPartitionKeyPropertyNameConfigurationSource());
+                ((IConventionEntityType)entityType).GetPartitionKeyPropertyNameConfigurationSource());
 
             entityTypeBuilder.HasPartitionKey("pk");
-            Assert.Equal("pk", entityType.GetCosmosPartitionKeyPropertyName());
+            Assert.Equal("pk", entityType.GetPartitionKeyPropertyName());
             Assert.Equal(ConfigurationSource.Explicit,
-                ((IConventionEntityType)entityType).GetCosmosPartitionKeyPropertyNameConfigurationSource());
+                ((IConventionEntityType)entityType).GetPartitionKeyPropertyNameConfigurationSource());
 
             Assert.False(((IConventionEntityType)entityType).Builder.CanSetPartitionKey("partition"));
 
             entityTypeBuilder.HasPartitionKey(null);
-            Assert.Null(entityType.GetCosmosPartitionKeyPropertyName());
-            Assert.Null(((IConventionEntityType)entityType).GetCosmosPartitionKeyPropertyNameConfigurationSource());
+            Assert.Null(entityType.GetPartitionKeyPropertyName());
+            Assert.Null(((IConventionEntityType)entityType).GetPartitionKeyPropertyNameConfigurationSource());
         }
 
         [ConditionalFact]
@@ -65,19 +65,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             var entityType = modelBuilder.Model.FindEntityType(typeof(Customer));
             modelBuilder.HasDefaultContainer(null);
 
-            Assert.Equal(nameof(Customer), entityType.GetCosmosContainer());
-            Assert.Null(modelBuilder.Model.GetCosmosDefaultContainer());
+            Assert.Equal(nameof(Customer), entityType.GetContainer());
+            Assert.Null(modelBuilder.Model.GetDefaultContainer());
 
             modelBuilder.HasDefaultContainer("db0");
 
-            Assert.Equal("db0", entityType.GetCosmosContainer());
-            Assert.Equal("db0", modelBuilder.Model.GetCosmosDefaultContainer());
+            Assert.Equal("db0", entityType.GetContainer());
+            Assert.Equal("db0", modelBuilder.Model.GetDefaultContainer());
 
             modelBuilder
                 .Entity<Customer>()
                 .ToContainer("db1");
 
-            Assert.Equal("db1", entityType.GetCosmosContainer());
+            Assert.Equal("db1", entityType.GetContainer());
         }
 
         [ConditionalFact]

--- a/test/EFCore.Cosmos.Tests/Metadata/CosmosMetadataExtensionsTest.cs
+++ b/test/EFCore.Cosmos.Tests/Metadata/CosmosMetadataExtensionsTest.cs
@@ -18,22 +18,22 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             var entityType = modelBuilder
                 .Entity<Customer>().Metadata;
 
-            Assert.Equal(nameof(Customer), entityType.GetCosmosContainer());
+            Assert.Equal(nameof(Customer), entityType.GetContainer());
 
-            ((IConventionEntityType)entityType).SetCosmosContainer("Customizer");
-            Assert.Equal("Customizer", entityType.GetCosmosContainer());
-            Assert.Equal(ConfigurationSource.Convention, ((IConventionEntityType)entityType).GetCosmosContainerConfigurationSource());
+            ((IConventionEntityType)entityType).SetContainer("Customizer");
+            Assert.Equal("Customizer", entityType.GetContainer());
+            Assert.Equal(ConfigurationSource.Convention, ((IConventionEntityType)entityType).GetContainerConfigurationSource());
 
-            entityType.SetCosmosContainer("Customizer");
-            Assert.Equal("Customizer", entityType.GetCosmosContainer());
-            Assert.Equal(ConfigurationSource.Explicit, ((IConventionEntityType)entityType).GetCosmosContainerConfigurationSource());
+            entityType.SetContainer("Customizer");
+            Assert.Equal("Customizer", entityType.GetContainer());
+            Assert.Equal(ConfigurationSource.Explicit, ((IConventionEntityType)entityType).GetContainerConfigurationSource());
 
-            entityType.SetCosmosContainer(null);
-            Assert.Equal(nameof(Customer), entityType.GetCosmosContainer());
-            Assert.Null(((IConventionEntityType)entityType).GetCosmosContainerConfigurationSource());
+            entityType.SetContainer(null);
+            Assert.Equal(nameof(Customer), entityType.GetContainer());
+            Assert.Null(((IConventionEntityType)entityType).GetContainerConfigurationSource());
 
             ((IConventionModel)modelBuilder.Model).Builder.HasDefaultContainer("Unicorn");
-            Assert.Equal("Unicorn", entityType.GetCosmosContainer());
+            Assert.Equal("Unicorn", entityType.GetContainer());
         }
 
         [ConditionalFact]
@@ -44,19 +44,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             var entityType = modelBuilder
                 .Entity<Customer>().Metadata;
 
-            Assert.Null(entityType.GetCosmosPartitionKeyPropertyName());
+            Assert.Null(entityType.GetPartitionKeyPropertyName());
 
-            ((IConventionEntityType)entityType).SetCosmosPartitionKeyPropertyName("pk");
-            Assert.Equal("pk", entityType.GetCosmosPartitionKeyPropertyName());
-            Assert.Equal(ConfigurationSource.Convention, ((IConventionEntityType)entityType).GetCosmosPartitionKeyPropertyNameConfigurationSource());
+            ((IConventionEntityType)entityType).SetPartitionKeyPropertyName("pk");
+            Assert.Equal("pk", entityType.GetPartitionKeyPropertyName());
+            Assert.Equal(ConfigurationSource.Convention, ((IConventionEntityType)entityType).GetPartitionKeyPropertyNameConfigurationSource());
 
-            entityType.SetCosmosPartitionKeyPropertyName("pk");
-            Assert.Equal("pk", entityType.GetCosmosPartitionKeyPropertyName());
-            Assert.Equal(ConfigurationSource.Explicit, ((IConventionEntityType)entityType).GetCosmosPartitionKeyPropertyNameConfigurationSource());
+            entityType.SetPartitionKeyPropertyName("pk");
+            Assert.Equal("pk", entityType.GetPartitionKeyPropertyName());
+            Assert.Equal(ConfigurationSource.Explicit, ((IConventionEntityType)entityType).GetPartitionKeyPropertyNameConfigurationSource());
 
-            entityType.SetCosmosPartitionKeyPropertyName(null);
-            Assert.Null(entityType.GetCosmosPartitionKeyPropertyName());
-            Assert.Null(((IConventionEntityType)entityType).GetCosmosPartitionKeyPropertyNameConfigurationSource());
+            entityType.SetPartitionKeyPropertyName(null);
+            Assert.Null(entityType.GetPartitionKeyPropertyName());
+            Assert.Null(((IConventionEntityType)entityType).GetPartitionKeyPropertyNameConfigurationSource());
         }
 
         private static ModelBuilder CreateModelBuilder() => new ModelBuilder(new ConventionSet());


### PR DESCRIPTION
### Description
We missed some method renames when doing API review of the Cosmos provider. We are asking to do these renames now before we ship the first GA release of the Cosmos provider. (It was only in preview for 2.x.)

We could instead obsolete the existing methods so as not to break from the last preview, but that would mean introducing new methods in a GA release that are already marked as obsolete when they ship.

### Customer Impact
Current APIs are inconsistent with the pattern we use elsewhere; this change brings them into line. 

Customers coming from a previous preview could be broken by this, but the fix is easy, and Cosmos usage is low.

### How found
Found while doing exploratory testing/prep for 3.1.

### Test coverage
N/A

### Regression?
No
 
### Risk
Risk is close to zero from a GA perspective, but it could break a small number of customers moving from previews to GA.

----

These methods are new in 3.0, renaming them afterwards would be a breaking change.

Fixes #17534
