### PR TITLE
Query: Fix bug in type inference of LikeExpression

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.Where.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.Where.cs
@@ -1884,5 +1884,17 @@ WHERE ((c[""Discriminator""] = ""Order"") AND @__p_0)");
         {
             return base.Filter_non_nullable_value_after_FirstOrDefault_on_empty_collection(isAsync);
         }
+
+        [ConditionalTheory(Skip = "Issue #17246")]
+        public override Task Like_with_non_string_column_using_ToString(bool isAsync)
+        {
+            return base.Like_with_non_string_column_using_ToString(isAsync);
+        }
+
+        [ConditionalTheory(Skip = "Issue #17246")]
+        public override Task Like_with_non_string_column_using_double_cast(bool isAsync)
+        {
+            return base.Like_with_non_string_column_using_double_cast(isAsync);
+        }
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/Query/SimpleQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/SimpleQueryInMemoryTest.cs
@@ -175,5 +175,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return base.Where_equals_on_null_nullable_int_types(isAsync);
         }
+
+        // Casting int to object to string is invalid for InMemory
+        public override Task Like_with_non_string_column_using_double_cast(bool isAsync) => Task.CompletedTask;
     }
 }

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
@@ -2022,5 +2022,26 @@ namespace Microsoft.EntityFrameworkCore.Query
                 (cs, os) => cs.Where(c => os.Where(o => o.CustomerID == "John Doe").Select(o => o.CustomerID).FirstOrDefault().Length == 0),
                 (cs, os) => cs.Where(c => false));
         }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Like_with_non_string_column_using_ToString(bool isAsync)
+        {
+            return AssertQuery<Order>(
+                isAsync,
+                os => os.Where(o => EF.Functions.Like(o.OrderID.ToString(), "%20%")),
+                entryCount: 8);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Like_with_non_string_column_using_double_cast(bool isAsync)
+        {
+            return AssertQuery<Order>(
+                isAsync,
+                os => os.Where(o => EF.Functions.Like((string)(object)o.OrderID, "%20%")),
+                os => os.Where(o => EF.Functions.Like(o.OrderID.ToString(), "%20%")),
+                entryCount: 8);
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Where.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Where.cs
@@ -1776,5 +1776,25 @@ WHERE ((
     FROM [Orders] AS [o]
     WHERE ([o].[CustomerID] = N'John Doe') AND [o].[CustomerID] IS NOT NULL) IS NOT NULL");
         }
+
+        public override async Task Like_with_non_string_column_using_ToString(bool isAsync)
+        {
+            await base.Like_with_non_string_column_using_ToString(isAsync);
+
+            AssertSql(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE CONVERT(VARCHAR(11), [o].[OrderID]) LIKE N'%20%'");
+        }
+
+        public override async Task Like_with_non_string_column_using_double_cast(bool isAsync)
+        {
+            await base.Like_with_non_string_column_using_double_cast(isAsync);
+
+            AssertSql(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE CAST([o].[OrderID] AS nvarchar(max)) LIKE N'%20%'");
+        }
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
@@ -1323,6 +1323,12 @@ FROM (
             return base.Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault_2(isAsync);
         }
 
+        [ConditionalTheory(Skip = "Issue#17223")]
+        public override Task Like_with_non_string_column_using_ToString(bool isAsync)
+        {
+            return base.Like_with_non_string_column_using_ToString(isAsync);
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }


### PR DESCRIPTION
Also remove convert to object when it is just to add convert to another type (double casting)
Covers both variation described in the issue
Resolves #17389

