### PR TITLE
Maintain referential integrity in SelectExpression and prevent multiple visitations

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressions/TableExpressionBase.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/TableExpressionBase.cs
@@ -19,6 +19,16 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
 
         public virtual string Alias { get; internal set; }
 
+        /// <summary>
+        /// Populated after this expression is first visited from its containing <see cref="SelectExpression"/>, to make sure that
+        /// subsequent visits return the same instance, and to prevent needless multiple deep visits. Used only by visitors.
+        /// </summary>
+        /// <remarks>
+        /// If you implement an expression visitor which contains specific logic for visiting <see cref="TableExpressionBase"/>,
+        /// you should properly populate and check this field (<see cref="SelectExpression.VisitChildren"/> for an example).
+        /// </remarks>
+        public TableExpressionBase VisitedExpression { get; set; }
+
         protected override Expression VisitChildren(ExpressionVisitor visitor) => this;
 
         public override Type Type => typeof(object);

--- a/test/EFCore.Relational.Tests/Query/SelectExpressionTest.cs
+++ b/test/EFCore.Relational.Tests/Query/SelectExpressionTest.cs
@@ -1,0 +1,61 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public class SelectExpressionTest
+    {
+        [ConditionalFact]
+        public void Table_referential_integrity_is_preserved()
+        {
+            var model = CreateModel();
+            var property = model.FindEntityType(typeof(Foo)).FindProperty("Id");
+            var table = new TableExpression("SomeTable", null, "t");
+            var ordering = new OrderingExpression(new ColumnExpression(property, table, false), true);
+
+            var select = new SelectExpression(
+                "s",
+                new List<ProjectionExpression>(),
+                new List<TableExpressionBase> { table },
+                new List<SqlExpression>(),
+                new List<OrderingExpression> { ordering });
+
+            var visitor = new TableSwitchingExpressionVisitor();
+            var visitedSelect = (SelectExpression)visitor.Visit(select);
+            Assert.Same(visitedSelect.Tables[0], ((ColumnExpression)visitedSelect.Orderings[0].Expression).Table);
+        }
+
+        private class TableSwitchingExpressionVisitor : ExpressionVisitor
+        {
+            protected override Expression VisitExtension(Expression node)
+            {
+                if (node is TableExpression tableExpression)
+                {
+                    return tableExpression.VisitedExpression ?? new TableExpression(
+                               tableExpression.Name + "2", tableExpression.Schema, tableExpression.Alias);
+                }
+                return base.VisitExtension(node);
+            }
+        }
+
+        protected IMutableModel CreateModel()
+        {
+            var builder = RelationalTestHelpers.Instance.CreateConventionBuilder();
+            builder.Entity<Foo>();
+            builder.FinalizeModel();
+            return builder.Model;
+        }
+
+        private class Foo
+        {
+            public int Id { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #17337

@smitpatel, here's an attempt at fixing SelectExpression visitation - not sure if this is the kind of solution you had in mind, but it fixes the perf issue in #17455. Some tests are failing, will work on that if the general approach is OK.

* We don't have any unit tests on this kind of thing, it seems we should consider starting adding these. What do you think?
* Should also take care of subqueries inside set operations.
