### PR TITLE
Don't use Northwind in CrossStore tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,26 +64,6 @@ stages:
               - script: "echo ##vso[build.addbuildtag]release-candidate"
                 condition: and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['IsFinalBuild'], 'true'))
                 displayName: 'Set CI tags'
-              - powershell: |
-                  SqlLocalDB stop MSSQLLocalDB -i
-                  SqlLocalDB start MSSQLLocalDB
-                  & "$env:ProgramFiles\Microsoft SQL Server\110\Tools\Binn\SQLCMD.EXE" -S '(localdb)\MSSQLLocalDB' -b -Q @'
-                    DECLARE @name nvarchar(255);
-                    DECLARE db CURSOR FOR SELECT Name FROM sysdatabases WHERE Name NOT IN ('master', 'tempdb', 'model', 'msdb');
-                    OPEN db;
-                    FETCH NEXT FROM db INTO @name;
-                    WHILE @@FETCH_STATUS = 0
-                    BEGIN
-                      SET @name = REPLACE(@name, ']', ']]');
-                      PRINT 'Dropping database [' + @name + ']';
-                      SET @name = 'DROP DATABASE [' + @name + ']';
-                      EXEC (@name);
-                      FETCH NEXT FROM db INTO @name;
-                    END;
-                    CLOSE db;
-                    DEALLOCATE db;
-                  '@
-                displayName: Cleanup databases
               - script: eng\common\cibuild.cmd -configuration $(_BuildConfig) -prepareMachine $(_InternalBuildArgs)
                 env:
                   Test__Cosmos__DefaultConnection: $(_CosmosConnectionUrl)

--- a/test/EFCore.Cosmos.FunctionalTests/Internal/CosmosDatabaseCreatorTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Internal/CosmosDatabaseCreatorTest.cs
@@ -54,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         {
             await using (var testDatabase = CosmosTestStore.Create("EnsureCreatedReady"))
             {
-                testDatabase.Initialize(null, () => new BloggingContext(testDatabase), null);
+                testDatabase.Initialize(null, testStore => new BloggingContext((CosmosTestStore)testStore));
 
                 using (var context = new BloggingContext(testDatabase))
                 {

--- a/test/EFCore.CrossStore.FunctionalTests/ConfigurationPatternsTest.cs
+++ b/test/EFCore.CrossStore.FunctionalTests/ConfigurationPatternsTest.cs
@@ -4,18 +4,24 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.TestModels;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 // ReSharper disable UnusedMember.Local
-
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore
 {
     [SqlServerConfiguredCondition]
-    public class ConfigurationPatternsTest
+    public class ConfigurationPatternsTest : IClassFixture<CrossStoreFixture>
     {
+        public ConfigurationPatternsTest(CrossStoreFixture fixture)
+        {
+            Fixture = fixture;
+            ExistingTestStore = Fixture.CreateTestStore(SqlServerTestStoreFactory.Instance, StoreName, Seed);
+        }
+
         [ConditionalFact]
         public void Can_register_multiple_context_types()
         {
@@ -24,38 +30,32 @@ namespace Microsoft.EntityFrameworkCore
                 .AddDbContext<MultipleContext2>()
                 .BuildServiceProvider();
 
-            using (SqlServerTestStore.GetNorthwindStore())
+            using (var context = serviceProvider.GetRequiredService<MultipleContext1>())
             {
-                using (var context = serviceProvider.GetRequiredService<MultipleContext1>())
-                {
-                    Assert.True(context.Customers.Any());
-                }
+                Assert.True(context.SimpleEntities.Any());
+            }
 
-                using (var context = serviceProvider.GetRequiredService<MultipleContext2>())
-                {
-                    Assert.False(context.Customers.Any());
-                }
+            using (var context = serviceProvider.GetRequiredService<MultipleContext2>())
+            {
+                Assert.False(context.SimpleEntities.Any());
             }
         }
 
         [ConditionalFact]
         public void Can_register_multiple_context_types_with_default_service_provider()
         {
-            using (SqlServerTestStore.GetNorthwindStore())
+            using (var context = new MultipleContext1(new DbContextOptions<MultipleContext1>()))
             {
-                using (var context = new MultipleContext1(new DbContextOptions<MultipleContext1>()))
-                {
-                    Assert.True(context.Customers.Any());
-                }
+                Assert.True(context.SimpleEntities.Any());
+            }
 
-                using (var context = new MultipleContext2(new DbContextOptions<MultipleContext2>()))
-                {
-                    Assert.False(context.Customers.Any());
-                }
+            using (var context = new MultipleContext2(new DbContextOptions<MultipleContext2>()))
+            {
+                Assert.False(context.SimpleEntities.Any());
             }
         }
 
-        private class MultipleContext1 : NorthwindContextBase
+        private class MultipleContext1 : CrossStoreContext
         {
             private readonly DbContextOptions<MultipleContext1> _options;
 
@@ -69,13 +69,13 @@ namespace Microsoft.EntityFrameworkCore
             {
                 Assert.Same(_options, optionsBuilder.Options);
 
-                optionsBuilder.UseSqlServer(SqlServerNorthwindTestStoreFactory.NorthwindConnectionString, b => b.ApplyConfiguration());
+                optionsBuilder.UseSqlServer(SqlServerTestStore.CreateConnectionString(StoreName), b => b.ApplyConfiguration());
 
                 Assert.NotSame(_options, optionsBuilder.Options);
             }
         }
 
-        private class MultipleContext2 : NorthwindContextBase
+        private class MultipleContext2 : CrossStoreContext
         {
             private readonly DbContextOptions<MultipleContext2> _options;
 
@@ -89,7 +89,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 Assert.Same(_options, optionsBuilder.Options);
 
-                optionsBuilder.UseInMemoryDatabase(nameof(NorthwindContextBase));
+                optionsBuilder.UseInMemoryDatabase(StoreName);
 
                 Assert.NotSame(_options, optionsBuilder.Options);
             }
@@ -104,94 +104,63 @@ namespace Microsoft.EntityFrameworkCore
                     .AddDbContext<MultipleProvidersContext>()
                     .BuildServiceProvider();
 
-            using (SqlServerTestStore.GetNorthwindStore())
+            MultipleProvidersContext context1;
+            MultipleProvidersContext context2;
+
+            using (var serviceScope = serviceProvider.GetRequiredService<IServiceScopeFactory>().CreateScope())
             {
-                MultipleProvidersContext context1;
-                MultipleProvidersContext context2;
-
-                using (var serviceScope = serviceProvider.GetRequiredService<IServiceScopeFactory>().CreateScope())
+                using (context1 = serviceScope.ServiceProvider.GetRequiredService<MultipleProvidersContext>())
                 {
-                    using (context1 = serviceScope.ServiceProvider.GetRequiredService<MultipleProvidersContext>())
-                    {
-                        context1.UseSqlServer = true;
+                    context1.UseSqlServer = true;
 
-                        Assert.True(context1.Customers.Any());
-                    }
-
-                    using (var context1B = serviceScope.ServiceProvider.GetRequiredService<MultipleProvidersContext>())
-                    {
-                        Assert.Same(context1, context1B);
-                    }
-
-                    var someService = serviceScope.ServiceProvider.GetRequiredService<SomeService>();
-                    Assert.Same(context1, someService.Context);
+                    Assert.True(context1.SimpleEntities.Any());
                 }
 
-                using (var serviceScope = serviceProvider.GetRequiredService<IServiceScopeFactory>().CreateScope())
+                using (var context1B = serviceScope.ServiceProvider.GetRequiredService<MultipleProvidersContext>())
                 {
-                    using (context2 = serviceScope.ServiceProvider.GetRequiredService<MultipleProvidersContext>())
-                    {
-                        context2.UseSqlServer = false;
-
-                        Assert.False(context2.Customers.Any());
-                    }
-
-                    using (var context2B = serviceScope.ServiceProvider.GetRequiredService<MultipleProvidersContext>())
-                    {
-                        Assert.Same(context2, context2B);
-                    }
-
-                    var someService = serviceScope.ServiceProvider.GetRequiredService<SomeService>();
-                    Assert.Same(context2, someService.Context);
+                    Assert.Same(context1, context1B);
                 }
 
-                Assert.NotSame(context1, context2);
+                var someService = serviceScope.ServiceProvider.GetRequiredService<SomeService>();
+                Assert.Same(context1, someService.Context);
             }
+
+            using (var serviceScope = serviceProvider.GetRequiredService<IServiceScopeFactory>().CreateScope())
+            {
+                using (context2 = serviceScope.ServiceProvider.GetRequiredService<MultipleProvidersContext>())
+                {
+                    context2.UseSqlServer = false;
+
+                    Assert.False(context2.SimpleEntities.Any());
+                }
+
+                using (var context2B = serviceScope.ServiceProvider.GetRequiredService<MultipleProvidersContext>())
+                {
+                    Assert.Same(context2, context2B);
+                }
+
+                var someService = serviceScope.ServiceProvider.GetRequiredService<SomeService>();
+                Assert.Same(context2, someService.Context);
+            }
+
+            Assert.NotSame(context1, context2);
         }
 
         [ConditionalFact]
         public void Can_select_appropriate_provider_when_multiple_registered_with_default_service_provider()
         {
-            using (SqlServerTestStore.GetNorthwindStore())
+            using (var context = new MultipleProvidersContext())
             {
-                using (var context = new MultipleProvidersContext())
-                {
-                    context.UseSqlServer = true;
+                context.UseSqlServer = true;
 
-                    Assert.True(context.Customers.Any());
-                }
-
-                using (var context = new MultipleProvidersContext())
-                {
-                    context.UseSqlServer = false;
-
-                    Assert.False(context.Customers.Any());
-                }
-            }
-        }
-
-        private class NorthwindContextBase : DbContext
-        {
-            protected NorthwindContextBase()
-            {
+                Assert.True(context.SimpleEntities.Any());
             }
 
-            protected NorthwindContextBase(DbContextOptions options)
-                : base(options)
+            using (var context = new MultipleProvidersContext())
             {
-            }
+                context.UseSqlServer = false;
 
-            // ReSharper disable once UnusedAutoPropertyAccessor.Local
-            public DbSet<Customer> Customers { get; set; }
-
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-            {
-                modelBuilder.Entity<Customer>(
-                    b =>
-                    {
-                        b.HasKey(c => c.CustomerID);
-                        b.ToTable("Customers");
-                    });
+                Assert.False(context.SimpleEntities.Any());
             }
         }
 
@@ -205,7 +174,7 @@ namespace Microsoft.EntityFrameworkCore
             public string Fax { get; set; }
         }
 
-        private class MultipleProvidersContext : NorthwindContextBase
+        private class MultipleProvidersContext : CrossStoreContext
         {
             // ReSharper disable once MemberCanBePrivate.Local
             public bool UseSqlServer { get; set; }
@@ -214,11 +183,11 @@ namespace Microsoft.EntityFrameworkCore
             {
                 if (UseSqlServer)
                 {
-                    optionsBuilder.UseSqlServer(SqlServerNorthwindTestStoreFactory.NorthwindConnectionString, b => b.ApplyConfiguration());
+                    optionsBuilder.UseSqlServer(SqlServerTestStore.CreateConnectionString(StoreName), b => b.ApplyConfiguration());
                 }
                 else
                 {
-                    optionsBuilder.UseInMemoryDatabase(nameof(NorthwindContextBase));
+                    optionsBuilder.UseInMemoryDatabase(StoreName);
                 }
             }
         }
@@ -234,47 +203,57 @@ namespace Microsoft.EntityFrameworkCore
             public MultipleProvidersContext Context { get; }
         }
 
-        [SqlServerConfiguredCondition]
-        public class NestedContextDifferentStores
+        private CrossStoreFixture Fixture { get; }
+        private TestStore ExistingTestStore { get; }
+        private static readonly string StoreName = "CrossStoreConfigurationPatternsTest";
+
+        private void Seed(CrossStoreContext context)
         {
+            context.SimpleEntities.Add(new SimpleEntity { StringProperty = "Entity 1" });
+
+            context.SaveChanges();
+        }
+
+        public void Dispose() => ExistingTestStore.Dispose();
+
+        [SqlServerConfiguredCondition]
+        public class NestedContextDifferentStores : IClassFixture<CrossStoreFixture>
+        {
+            public NestedContextDifferentStores(CrossStoreFixture fixture)
+            {
+                Fixture = fixture;
+                ExistingTestStore = Fixture.CreateTestStore(SqlServerTestStoreFactory.Instance, StoreName, Seed);
+            }
+
             [ConditionalFact]
             public async Task Can_use_one_context_nested_inside_another_of_a_different_type()
             {
-                using (SqlServerTestStore.GetNorthwindStore())
-                {
-                    var inMemoryServiceProvider = InMemoryFixture.DefaultServiceProvider;
-                    var sqlServerServiceProvider = SqlServerFixture.DefaultServiceProvider;
+                var inMemoryServiceProvider = InMemoryFixture.DefaultServiceProvider;
+                var sqlServerServiceProvider = SqlServerFixture.DefaultServiceProvider;
 
-                    await NestedContextTest(
-                        () => new BlogContext(inMemoryServiceProvider),
-                        () => new NorthwindContext(sqlServerServiceProvider));
-                }
+                await NestedContextTest(
+                    () => new BlogContext(inMemoryServiceProvider),
+                    () => new ExternalProviderContext(sqlServerServiceProvider));
             }
 
             [ConditionalFact]
-            public async Task Can_use_one_context_nested_inside_another_of_a_different_type_with_implicit_services()
-            {
-                using (SqlServerTestStore.GetNorthwindStore())
-                {
-                    await NestedContextTest(() => new BlogContext(), () => new NorthwindContext());
-                }
-            }
+            public Task Can_use_one_context_nested_inside_another_of_a_different_type_with_implicit_services()
+                => NestedContextTest(() => new BlogContext(), () => new ExternalProviderContext());
 
-            private async Task NestedContextTest(Func<BlogContext> createBlogContext, Func<NorthwindContext> createNorthwindContext)
+            private async Task NestedContextTest(Func<BlogContext> createBlogContext, Func<CrossStoreContext> createSimpleContext)
             {
                 using (var context0 = createBlogContext())
                 {
                     Assert.Equal(0, context0.ChangeTracker.Entries().Count());
-                    var blog0 = context0.Add(
-                        new Blog { Id = 1, Name = "Giddyup" }).Entity;
+                    var blog0 = context0.Add(new Blog { Id = 1, Name = "Giddyup" }).Entity;
                     Assert.Same(blog0, context0.ChangeTracker.Entries().Select(e => e.Entity).Single());
                     await context0.SaveChangesAsync();
 
-                    using (var context1 = createNorthwindContext())
+                    using (var context1 = createSimpleContext())
                     {
-                        var customers1 = await context1.Customers.ToListAsync();
-                        Assert.Equal(91, customers1.Count);
-                        Assert.Equal(91, context1.ChangeTracker.Entries().Count());
+                        var customers1 = await context1.SimpleEntities.ToListAsync();
+                        Assert.Equal(1, customers1.Count);
+                        Assert.Equal(1, context1.ChangeTracker.Entries().Count());
                         Assert.Same(blog0, context0.ChangeTracker.Entries().Select(e => e.Entity).Single());
 
                         using (var context2 = createBlogContext())
@@ -291,6 +270,19 @@ namespace Microsoft.EntityFrameworkCore
                     }
                 }
             }
+
+            private CrossStoreFixture Fixture { get; }
+            private TestStore ExistingTestStore { get; }
+            private static readonly string StoreName = "CrossStoreNestedContextTest";
+
+            private void Seed(CrossStoreContext context)
+            {
+                context.SimpleEntities.Add(new SimpleEntity { StringProperty = "Entity 1" });
+
+                context.SaveChanges();
+            }
+
+            public void Dispose() => ExistingTestStore.Dispose();
 
             private class BlogContext : DbContext
             {
@@ -319,22 +311,22 @@ namespace Microsoft.EntityFrameworkCore
                 public string Name { get; set; }
             }
 
-            private class NorthwindContext : NorthwindContextBase
+            private class ExternalProviderContext : CrossStoreContext
             {
                 private readonly IServiceProvider _serviceProvider;
 
-                public NorthwindContext()
+                public ExternalProviderContext()
                 {
                 }
 
-                public NorthwindContext(IServiceProvider serviceProvider)
+                public ExternalProviderContext(IServiceProvider serviceProvider)
                 {
                     _serviceProvider = serviceProvider;
                 }
 
                 protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
                     => optionsBuilder
-                        .UseSqlServer(SqlServerNorthwindTestStoreFactory.NorthwindConnectionString, b => b.ApplyConfiguration())
+                        .UseSqlServer(SqlServerTestStore.CreateConnectionString(StoreName), b => b.ApplyConfiguration())
                         .UseInternalServiceProvider(_serviceProvider);
             }
         }

--- a/test/EFCore.CrossStore.FunctionalTests/CrossStoreFixture.cs
+++ b/test/EFCore.CrossStore.FunctionalTests/CrossStoreFixture.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.EntityFrameworkCore.TestModels;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -9,8 +10,6 @@ namespace Microsoft.EntityFrameworkCore
 {
     public class CrossStoreFixture : FixtureBase
     {
-        protected virtual string StoreName { get; } = "CrossStoreTest";
-
         public DbContextOptions CreateOptions(TestStore testStore)
             => AddOptions(testStore.AddProviderOptions(new DbContextOptionsBuilder()))
                 .UseInternalServiceProvider(testStore.ServiceProvider)
@@ -19,24 +18,11 @@ namespace Microsoft.EntityFrameworkCore
         public CrossStoreContext CreateContext(TestStore testStore)
             => new CrossStoreContext(CreateOptions(testStore));
 
-        public TestStore CreateTestStore(ITestStoreFactory testStoreFactory)
-        {
-            return testStoreFactory.GetOrCreate(StoreName)
+        public TestStore CreateTestStore(ITestStoreFactory testStoreFactory, string storeName, Action<CrossStoreContext> seed = null)
+            => testStoreFactory.GetOrCreate(storeName)
                 .Initialize(
-                    AddServices(testStoreFactory.AddProviderServices(new ServiceCollection()))
-                        .BuildServiceProvider(validateScopes: true), CreateContext, c => { });
-        }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
-        {
-            modelBuilder.Entity<SimpleEntity>(
-                eb =>
-                {
-                    eb.ToTable("RelationalSimpleEntity");
-                    eb.Property(typeof(string), SimpleEntity.ShadowPropertyName);
-                    eb.HasKey(e => e.Id);
-                    eb.Property(e => e.Id).UseIdentityColumn();
-                });
-        }
+                    AddServices(testStoreFactory.AddProviderServices(new ServiceCollection())).BuildServiceProvider(validateScopes: true),
+                    CreateContext,
+                    seed);
     }
 }

--- a/test/EFCore.CrossStore.FunctionalTests/DiscriminatorTest.cs
+++ b/test/EFCore.CrossStore.FunctionalTests/DiscriminatorTest.cs
@@ -10,7 +10,7 @@ namespace Microsoft.EntityFrameworkCore
 {
     public class DiscriminatorTest
     {
-        [ConditionalFact(Skip = "Tasklist#21")]
+        [ConditionalFact]
         public void Can_save_entities_with_discriminators()
         {
             using (var context = new Context4285())
@@ -32,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [ConditionalFact(Skip = "Tasklist#21")]
+        [ConditionalFact]
         public void Can_save_entities_with_int_discriminators()
         {
             using (var context = new Context4285())
@@ -54,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        private class BaseProduct
+        private abstract class BaseProduct
         {
             public Guid Id { get; set; }
         }
@@ -69,7 +69,7 @@ namespace Microsoft.EntityFrameworkCore
             public string SomeName2 { get; set; }
         }
 
-        private class BaseIntProduct
+        private abstract class BaseIntProduct
         {
             public Guid Id { get; set; }
         }

--- a/test/EFCore.CrossStore.FunctionalTests/EFCore.CrossStore.FunctionalTests.csproj
+++ b/test/EFCore.CrossStore.FunctionalTests/EFCore.CrossStore.FunctionalTests.csproj
@@ -4,8 +4,6 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AssemblyName>Microsoft.EntityFrameworkCore.CrossStore.FunctionalTests</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
-    <!-- Put this project into its own test group to avoid running parallel with other test projects. Northwind is not initialized properly in this test assembly. -->
-    <TestGroupName>CrossStore.FunctionalTests</TestGroupName>
     <CodeAnalysisRuleSet>..\..\EFCore.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/test/EFCore.CrossStore.FunctionalTests/EndToEndTest.cs
+++ b/test/EFCore.CrossStore.FunctionalTests/EndToEndTest.cs
@@ -15,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore
         protected EndToEndTest(CrossStoreFixture fixture)
         {
             Fixture = fixture;
-            TestStore = Fixture.CreateTestStore(TestStoreFactory);
+            TestStore = Fixture.CreateTestStore(TestStoreFactory, "CrossStoreTest");
         }
 
         protected CrossStoreFixture Fixture { get; }

--- a/test/EFCore.CrossStore.FunctionalTests/TestModels/CrossStoreContext.cs
+++ b/test/EFCore.CrossStore.FunctionalTests/TestModels/CrossStoreContext.cs
@@ -5,12 +5,29 @@ namespace Microsoft.EntityFrameworkCore.TestModels
 {
     public class CrossStoreContext : DbContext
     {
+        public CrossStoreContext()
+            : base()
+        {
+        }
+
         public CrossStoreContext(DbContextOptions options)
             : base(options)
         {
         }
 
         public virtual DbSet<SimpleEntity> SimpleEntities { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<SimpleEntity>(
+                eb =>
+                {
+                    eb.ToTable("RelationalSimpleEntity");
+                    eb.Property(typeof(string), SimpleEntity.ShadowPropertyName);
+                    eb.HasKey(e => e.Id);
+                    eb.Property(e => e.Id).UseIdentityColumn();
+                });
+        }
 
         public static void RemoveAllEntities(CrossStoreContext context)
             => context.SimpleEntities.RemoveRange(context.SimpleEntities);

--- a/test/EFCore.Relational.Specification.Tests/TestUtilities/RelationalDatabaseCleaner.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestUtilities/RelationalDatabaseCleaner.cs
@@ -1,8 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
@@ -82,9 +85,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                     var customSql = BuildCustomSql(databaseModel);
                     if (!string.IsNullOrWhiteSpace(customSql))
                     {
-                        sqlBuilder.Build(customSql).ExecuteNonQuery(
-                            new RelationalCommandParameterObject(
-                                connection, null, null, null));
+                        ExecuteScript(connection, sqlBuilder, customSql);
                     }
 
                     if (operations.Count > 0)
@@ -96,8 +97,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                     customSql = BuildCustomEndingSql(databaseModel);
                     if (!string.IsNullOrWhiteSpace(customSql))
                     {
-                        sqlBuilder.Build(customSql).ExecuteNonQuery(
-                            new RelationalCommandParameterObject(connection, null, null, null));
+                        ExecuteScript(connection, sqlBuilder, customSql);
                     }
                 }
                 finally
@@ -107,6 +107,31 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             }
 
             creator.CreateTables();
+        }
+
+        private static void ExecuteScript(IRelationalConnection connection, IRawSqlCommandBuilder sqlBuilder, string customSql)
+        {
+            var batches = Regex.Split(
+                Regex.Replace(
+                    customSql,
+                    @"\\\r?\n",
+                    string.Empty,
+                    default,
+                    TimeSpan.FromMilliseconds(1000.0)),
+                @"^\s*(GO[ \t]+[0-9]+|GO)(?:\s+|$)",
+                RegexOptions.IgnoreCase | RegexOptions.Multiline,
+                TimeSpan.FromMilliseconds(1000.0));
+            for (var i = 0; i < batches.Length; i++)
+            {
+                if (batches[i].StartsWith("GO", StringComparison.OrdinalIgnoreCase)
+                    || string.IsNullOrWhiteSpace(batches[i]))
+                {
+                    continue;
+                }
+
+                sqlBuilder.Build(batches[i])
+                    .ExecuteNonQuery(new RelationalCommandParameterObject(connection, null, null, null));
+            }
         }
 
         protected virtual MigrationOperation Drop(DatabaseSequence sequence)

--- a/test/EFCore.Specification.Tests/TestUtilities/TestStore.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/TestStore.cs
@@ -25,7 +25,10 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         public string Name { get; protected set; }
 
         public virtual TestStore Initialize(
-            IServiceProvider serviceProvider, Func<DbContext> createContext, Action<DbContext> seed = null, Action<DbContext> clean = null)
+            IServiceProvider serviceProvider,
+            Func<DbContext> createContext,
+            Action<DbContext> seed = null,
+            Action<DbContext> clean = null)
         {
             ServiceProvider = serviceProvider;
             if (createContext == null)
@@ -45,10 +48,24 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             return this;
         }
 
-        public TestStore Initialize(
-            IServiceProvider serviceProvider, Func<TestStore, DbContext> createContext, Action<DbContext> seed = null,
+        public virtual TestStore Initialize(
+            IServiceProvider serviceProvider,
+            Func<TestStore, DbContext> createContext,
+            Action<DbContext> seed = null,
             Action<DbContext> clean = null)
             => Initialize(serviceProvider, () => createContext(this), seed, clean);
+
+        public virtual TestStore Initialize<TContext>(
+            IServiceProvider serviceProvider,
+            Func<TestStore, TContext> createContext,
+            Action<TContext> seed = null,
+            Action<TContext> clean = null)
+            where TContext : DbContext
+            => Initialize(
+                serviceProvider,
+                createContext,
+                seed == null ? (Action<DbContext>)null : c => seed((TContext)c),
+                clean == null ? (Action<DbContext>)null : c => clean((TContext)c));
 
         protected virtual void Initialize(Func<DbContext> createContext, Action<DbContext> seed, Action<DbContext> clean)
         {

--- a/test/EFCore.SqlServer.FunctionalTests/EFCore.SqlServer.FunctionalTests.csproj
+++ b/test/EFCore.SqlServer.FunctionalTests/EFCore.SqlServer.FunctionalTests.csproj
@@ -4,8 +4,6 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AssemblyName>Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
-    <!-- Put this project into its own test group to avoid running parallel with other test projects. SqlServer is not able to finalize properly for next test run. -->
-    <TestGroupName>SqlServer.FunctionalTests</TestGroupName>
     <CodeAnalysisRuleSet>..\..\EFCore.ruleset</CodeAnalysisRuleSet>
     <SkipTests Condition="'$(OS)' != 'Windows_NT' AND '$(Test__SqlServer__DefaultConnection)' == ''">True</SkipTests>
   </PropertyGroup>

--- a/test/EFCore.SqlServer.FunctionalTests/MigrationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/MigrationsSqlServerTest.cs
@@ -20,7 +20,7 @@ using Xunit;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore
 {
-    [SqlServerCondition(SqlServerCondition.IsNotSqlAzure)]
+    [SqlServerCondition(SqlServerCondition.IsNotSqlAzure | SqlServerCondition.IsNotCI)]
     public class MigrationsSqlServerTest : MigrationsTestBase<MigrationsSqlServerFixture>
     {
         public MigrationsSqlServerTest(MigrationsSqlServerFixture fixture)

--- a/test/EFCore.SqlServer.FunctionalTests/SequenceEndToEndTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SequenceEndToEndTest.cs
@@ -69,7 +69,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
-        [PlatformSkipCondition(TestPlatform.Linux, SkipReason = "Test is flaky on CI.")]
+        [SqlServerCondition(SqlServerCondition.IsNotCI)]
         public void Can_use_sequence_end_to_end_on_multiple_databases()
         {
             var serviceProvider = new ServiceCollection()

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/DbContextOptionsBuilderExtensions.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/DbContextOptionsBuilderExtensions.cs
@@ -21,10 +21,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 optionsBuilder.UseRowNumberForPaging();
             }
 
-            if (TestEnvironment.IsSqlAzure)
-            {
-                optionsBuilder.ExecutionStrategy(c => new TestSqlServerRetryingExecutionStrategy(c));
-            }
+            optionsBuilder.ExecutionStrategy(c => new TestSqlServerRetryingExecutionStrategy(c));
 
             return optionsBuilder;
         }

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerTestStore.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerTestStore.cs
@@ -109,7 +109,9 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             {
                 if (ExecuteScalar<int>(master, $"SELECT COUNT(*) FROM sys.databases WHERE name = N'{Name}'") > 0)
                 {
-                    if (_scriptPath != null)
+                    // Only reseed scripted databases during CI runs
+                    if (_scriptPath != null
+                        && !TestEnvironment.IsCI)
                     {
                         return false;
                     }


### PR DESCRIPTION
Disable tests that delete databases on CI
Don't delete databases in CI script, instead clean Northwind
Change DbContextOptionsBuilderExtensions.ApplyConfiguration to always use an ExecutionStrategy

Fixes #16342