### PR TITLE
[3.0] Perf: Skip visiting table inside ColumnExpression

### DIFF
--- a/src/EFCore.Relational/Query/Internal/NullSemanticsRewritingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/NullSemanticsRewritingExpressionVisitor.cs
@@ -73,10 +73,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
         private ColumnExpression VisitColumnExpression(ColumnExpression columnExpression)
         {
-            var newTable = (TableExpressionBase)Visit(columnExpression.Table);
             _isNullable = columnExpression.IsNullable;
 
-            return columnExpression.Update(newTable);
+            return columnExpression;
         }
 
         private SqlParameterExpression VisitSqlParameterExpression(SqlParameterExpression sqlParameterExpression)

--- a/src/EFCore.Relational/Query/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/QuerySqlGenerator.cs
@@ -104,7 +104,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 && selectExpression.Tables[0] is SetOperationBase setOperation
                 && selectExpression.Projection.Count == setOperation.Source1.Projection.Count
                 && selectExpression.Projection.Select((pe, index) => pe.Expression is ColumnExpression column
-                    && column.Table.Equals(setOperation)
+                    && string.Equals(column.Table.Alias, setOperation.Alias, StringComparison.OrdinalIgnoreCase)
                     && string.Equals(column.Name, setOperation.Source1.Projection[index].Alias, StringComparison.OrdinalIgnoreCase))
                     .All(e => e);
 

--- a/src/EFCore.Relational/Query/SqlExpressions/ColumnExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/ColumnExpression.cs
@@ -50,13 +50,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         public TableExpressionBase Table { get; }
         public bool IsNullable { get; }
 
-        protected override Expression VisitChildren(ExpressionVisitor visitor)
-            => Update((TableExpressionBase)visitor.Visit(Table));
-
-        public virtual ColumnExpression Update(TableExpressionBase table)
-            => table != Table
-                ? new ColumnExpression(Name, table, Type, TypeMapping, IsNullable)
-                : this;
+        protected override Expression VisitChildren(ExpressionVisitor visitor) => this;
 
         public ColumnExpression MakeNullable()
             => new ColumnExpression(Name, Table, Type.MakeNullable(), TypeMapping, true);

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -99,7 +99,8 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                 && Orderings.Count == 0
                 && Tables.Count == 1
                 && Tables[0] is FromSqlExpression fromSql
-                && Projection.All(pe => pe.Expression is ColumnExpression column ? ReferenceEquals(column.Table, fromSql) : false);
+                && Projection.All(pe => pe.Expression is ColumnExpression column
+                    && string.Equals(fromSql.Alias, column.Table.Alias, StringComparison.OrdinalIgnoreCase));
 
         public void ApplyProjection()
         {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsWeakQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsWeakQuerySqlServerTest.cs
@@ -234,27 +234,27 @@ FROM (
 
             AssertSql(
                 @"SELECT SUM(CASE
-    WHEN [t].[Id] IS NULL THEN 0
-    ELSE [t].[Level1_Required_Id]
+    WHEN [t1].[Id] IS NULL THEN 0
+    ELSE [t1].[Level1_Required_Id]
 END)
-FROM [Level1] AS [l1]
+FROM [Level1] AS [l]
 LEFT JOIN (
-    SELECT [l2].[Id], [l2].[Date], [l2].[Name], [t0].[Id] AS [Id0], [t0].[OneToOne_Required_PK_Date], [t0].[Level1_Optional_Id], [t0].[Level1_Required_Id], [t0].[Level2_Name], [t0].[OneToMany_Optional_Inverse2Id], [t0].[OneToMany_Required_Inverse2Id], [t0].[OneToOne_Optional_PK_Inverse2Id]
-    FROM [Level1] AS [l2]
+    SELECT [l0].[Id], [l0].[Date], [l0].[Name], [t].[Id] AS [Id0], [t].[OneToOne_Required_PK_Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Level2_Name], [t].[OneToMany_Optional_Inverse2Id], [t].[OneToMany_Required_Inverse2Id], [t].[OneToOne_Optional_PK_Inverse2Id]
+    FROM [Level1] AS [l0]
     LEFT JOIN (
-        SELECT [l3].[Id], [l3].[OneToOne_Required_PK_Date], [l3].[Level1_Optional_Id], [l3].[Level1_Required_Id], [l3].[Level2_Name], [l3].[OneToMany_Optional_Inverse2Id], [l3].[OneToMany_Required_Inverse2Id], [l3].[OneToOne_Optional_PK_Inverse2Id], [l4].[Id] AS [Id0]
-        FROM [Level1] AS [l3]
-        INNER JOIN [Level1] AS [l4] ON [l3].[Id] = [l4].[Id]
-        WHERE [l3].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l3].[Level1_Required_Id] IS NOT NULL AND [l3].[OneToOne_Required_PK_Date] IS NOT NULL)
-    ) AS [t0] ON [l2].[Id] = [t0].[Id]
-    WHERE [t0].[Id] IS NOT NULL
-) AS [t1] ON [l1].[Id] = [t1].[Level1_Optional_Id]
+        SELECT [l1].[Id], [l1].[OneToOne_Required_PK_Date], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[Level2_Name], [l1].[OneToMany_Optional_Inverse2Id], [l1].[OneToMany_Required_Inverse2Id], [l1].[OneToOne_Optional_PK_Inverse2Id], [l2].[Id] AS [Id0]
+        FROM [Level1] AS [l1]
+        INNER JOIN [Level1] AS [l2] ON [l1].[Id] = [l2].[Id]
+        WHERE [l1].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l1].[Level1_Required_Id] IS NOT NULL AND [l1].[OneToOne_Required_PK_Date] IS NOT NULL)
+    ) AS [t] ON [l0].[Id] = [t].[Id]
+    WHERE [t].[Id] IS NOT NULL
+) AS [t0] ON [l].[Id] = [t0].[Level1_Optional_Id]
 LEFT JOIN (
-    SELECT [l].[Id], [l].[OneToOne_Required_PK_Date], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Level2_Name], [l].[OneToMany_Optional_Inverse2Id], [l].[OneToMany_Required_Inverse2Id], [l].[OneToOne_Optional_PK_Inverse2Id], [l0].[Id] AS [Id0]
-    FROM [Level1] AS [l]
-    INNER JOIN [Level1] AS [l0] ON [l].[Id] = [l0].[Id]
-    WHERE [l].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l].[Level1_Required_Id] IS NOT NULL AND [l].[OneToOne_Required_PK_Date] IS NOT NULL)
-) AS [t] ON [t1].[Id] = [t].[Id]");
+    SELECT [l3].[Id], [l3].[OneToOne_Required_PK_Date], [l3].[Level1_Optional_Id], [l3].[Level1_Required_Id], [l3].[Level2_Name], [l3].[OneToMany_Optional_Inverse2Id], [l3].[OneToMany_Required_Inverse2Id], [l3].[OneToOne_Optional_PK_Inverse2Id], [l4].[Id] AS [Id0]
+    FROM [Level1] AS [l3]
+    INNER JOIN [Level1] AS [l4] ON [l3].[Id] = [l4].[Id]
+    WHERE [l3].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l3].[Level1_Required_Id] IS NOT NULL AND [l3].[OneToOne_Required_PK_Date] IS NOT NULL)
+) AS [t1] ON [t0].[Id] = [t1].[Id]");
         }
 
 
@@ -263,14 +263,14 @@ LEFT JOIN (
             await base.SelectMany_with_Include1(isAsync);
 
             AssertSql(
-                @"SELECT [t].[Id], [t].[OneToOne_Required_PK_Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Level2_Name], [t].[OneToMany_Optional_Inverse2Id], [t].[OneToMany_Required_Inverse2Id], [t].[OneToOne_Optional_PK_Inverse2Id], [l1].[Id], [t].[Id0], [t1].[Id], [t1].[Level2_Optional_Id], [t1].[Level2_Required_Id], [t1].[Level3_Name], [t1].[OneToMany_Optional_Inverse3Id], [t1].[OneToMany_Required_Inverse3Id], [t1].[OneToOne_Optional_PK_Inverse3Id], [t1].[Id0], [t1].[Id00]
-FROM [Level1] AS [l1]
+                @"SELECT [t].[Id], [t].[OneToOne_Required_PK_Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Level2_Name], [t].[OneToMany_Optional_Inverse2Id], [t].[OneToMany_Required_Inverse2Id], [t].[OneToOne_Optional_PK_Inverse2Id], [l].[Id], [t].[Id0], [t1].[Id], [t1].[Level2_Optional_Id], [t1].[Level2_Required_Id], [t1].[Level3_Name], [t1].[OneToMany_Optional_Inverse3Id], [t1].[OneToMany_Required_Inverse3Id], [t1].[OneToOne_Optional_PK_Inverse3Id], [t1].[Id0], [t1].[Id00]
+FROM [Level1] AS [l]
 INNER JOIN (
-    SELECT [l].[Id], [l].[OneToOne_Required_PK_Date], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Level2_Name], [l].[OneToMany_Optional_Inverse2Id], [l].[OneToMany_Required_Inverse2Id], [l].[OneToOne_Optional_PK_Inverse2Id], [l0].[Id] AS [Id0]
-    FROM [Level1] AS [l]
-    INNER JOIN [Level1] AS [l0] ON [l].[Id] = [l0].[Id]
-    WHERE [l].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l].[Level1_Required_Id] IS NOT NULL AND [l].[OneToOne_Required_PK_Date] IS NOT NULL)
-) AS [t] ON [l1].[Id] = [t].[OneToMany_Optional_Inverse2Id]
+    SELECT [l0].[Id], [l0].[OneToOne_Required_PK_Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Level2_Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l1].[Id] AS [Id0]
+    FROM [Level1] AS [l0]
+    INNER JOIN [Level1] AS [l1] ON [l0].[Id] = [l1].[Id]
+    WHERE [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l0].[Level1_Required_Id] IS NOT NULL AND [l0].[OneToOne_Required_PK_Date] IS NOT NULL)
+) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
 LEFT JOIN (
     SELECT [l2].[Id], [l2].[Level2_Optional_Id], [l2].[Level2_Required_Id], [l2].[Level3_Name], [l2].[OneToMany_Optional_Inverse3Id], [l2].[OneToMany_Required_Inverse3Id], [l2].[OneToOne_Optional_PK_Inverse3Id], [t0].[Id] AS [Id0], [t0].[Id0] AS [Id00]
     FROM [Level1] AS [l2]
@@ -282,7 +282,7 @@ LEFT JOIN (
     ) AS [t0] ON [l2].[Id] = [t0].[Id]
     WHERE [l2].[OneToMany_Required_Inverse3Id] IS NOT NULL AND [l2].[Level2_Required_Id] IS NOT NULL
 ) AS [t1] ON [t].[Id] = [t1].[OneToMany_Optional_Inverse3Id]
-ORDER BY [l1].[Id], [t].[Id], [t].[Id0], [t1].[Id], [t1].[Id0], [t1].[Id00]");
+ORDER BY [l].[Id], [t].[Id], [t].[Id0], [t1].[Id], [t1].[Id0], [t1].[Id00]");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FiltersSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FiltersSqlServerTest.cs
@@ -168,18 +168,18 @@ WHERE [t].[CompanyName] IS NOT NULL");
 @__ef_filter___quantity_0='50'
 
 SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate]
-FROM [Order Details] AS [o0]
+FROM [Order Details] AS [o]
 INNER JOIN (
-    SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID] AS [CustomerID0], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
-    FROM [Orders] AS [o]
+    SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [t].[CustomerID] AS [CustomerID0], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
+    FROM [Orders] AS [o0]
     LEFT JOIN (
         SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
         FROM [Customers] AS [c]
         WHERE ((@__ef_filter__TenantPrefix_1 = N'') AND @__ef_filter__TenantPrefix_1 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_1 IS NOT NULL AND (([c].[CompanyName] LIKE [c].[CompanyName] + N'%') AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_1)) = @__ef_filter__TenantPrefix_1) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_1)) IS NOT NULL AND @__ef_filter__TenantPrefix_1 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_1)) IS NULL AND @__ef_filter__TenantPrefix_1 IS NULL)))))
-    ) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
+    ) AS [t] ON [o0].[CustomerID] = [t].[CustomerID]
     WHERE [t].[CompanyName] IS NOT NULL
-) AS [t0] ON [o0].[OrderID] = [t0].[OrderID]
-WHERE [o0].[Quantity] > @__ef_filter___quantity_0");
+) AS [t0] ON [o].[OrderID] = [t0].[OrderID]
+WHERE [o].[Quantity] > @__ef_filter___quantity_0");
         }
 
         public override void Navs_query()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -174,14 +174,14 @@ WHERE [g].[Discriminator] IN (N'Gear', N'Officer')");
             await base.Include_with_join_reference2(isAsync);
 
             AssertSql(
-                @"SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [c].[Name], [c].[Location], [c].[Nation]
-FROM [Tags] AS [t0]
+                @"SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOrBirthName], [t0].[Discriminator], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [c].[Name], [c].[Location], [c].[Nation]
+FROM [Tags] AS [t]
 INNER JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
     FROM [Gears] AS [g]
     WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t] ON (([t0].[GearSquadId] = [t].[SquadId]) AND [t0].[GearSquadId] IS NOT NULL) AND (([t0].[GearNickName] = [t].[Nickname]) AND [t0].[GearNickName] IS NOT NULL)
-INNER JOIN [Cities] AS [c] ON [t].[CityOrBirthName] = [c].[Name]");
+) AS [t0] ON (([t].[GearSquadId] = [t0].[SquadId]) AND [t].[GearSquadId] IS NOT NULL) AND (([t].[GearNickName] = [t0].[Nickname]) AND [t].[GearNickName] IS NOT NULL)
+INNER JOIN [Cities] AS [c] ON [t0].[CityOrBirthName] = [c].[Name]");
         }
 
         public override async Task Include_with_join_collection1(bool isAsync)
@@ -202,15 +202,15 @@ ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id], [w].[Id]");
             await base.Include_with_join_collection2(isAsync);
 
             AssertSql(
-                @"SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t0].[Id], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
-FROM [Tags] AS [t0]
+                @"SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOrBirthName], [t0].[Discriminator], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t].[Id], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Tags] AS [t]
 INNER JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
     FROM [Gears] AS [g]
     WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t] ON (([t0].[GearSquadId] = [t].[SquadId]) AND [t0].[GearSquadId] IS NOT NULL) AND (([t0].[GearNickName] = [t].[Nickname]) AND [t0].[GearNickName] IS NOT NULL)
-LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
-ORDER BY [t0].[Id], [t].[Nickname], [t].[SquadId], [w].[Id]");
+) AS [t0] ON (([t].[GearSquadId] = [t0].[SquadId]) AND [t].[GearSquadId] IS NOT NULL) AND (([t].[GearNickName] = [t0].[Nickname]) AND [t].[GearNickName] IS NOT NULL)
+LEFT JOIN [Weapons] AS [w] ON [t0].[FullName] = [w].[OwnerFullName]
+ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId], [w].[Id]");
         }
 
         public override void Include_where_list_contains_navigation(bool isAsync)
@@ -278,14 +278,14 @@ ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id], [c].[Name], [t0].[Nickname], [
             await base.Include_with_join_and_inheritance1(isAsync);
 
             AssertSql(
-                @"SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [c].[Name], [c].[Location], [c].[Nation]
-FROM [Tags] AS [t0]
+                @"SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOrBirthName], [t0].[Discriminator], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [c].[Name], [c].[Location], [c].[Nation]
+FROM [Tags] AS [t]
 INNER JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
     FROM [Gears] AS [g]
     WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND ([g].[Discriminator] = N'Officer')
-) AS [t] ON (([t0].[GearSquadId] = [t].[SquadId]) AND [t0].[GearSquadId] IS NOT NULL) AND (([t0].[GearNickName] = [t].[Nickname]) AND [t0].[GearNickName] IS NOT NULL)
-INNER JOIN [Cities] AS [c] ON [t].[CityOrBirthName] = [c].[Name]");
+) AS [t0] ON (([t].[GearSquadId] = [t0].[SquadId]) AND [t].[GearSquadId] IS NOT NULL) AND (([t].[GearNickName] = [t0].[Nickname]) AND [t].[GearNickName] IS NOT NULL)
+INNER JOIN [Cities] AS [c] ON [t0].[CityOrBirthName] = [c].[Name]");
         }
 
         public override async Task Include_with_join_and_inheritance_with_orderby_before_and_after_include(bool isAsync)
@@ -314,19 +314,19 @@ ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id], [w].[Id]");
             await base.Include_with_join_and_inheritance3(isAsync);
 
             AssertSql(
-                @"SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t0].[Id], [t1].[Nickname], [t1].[SquadId], [t1].[AssignedCityName], [t1].[CityOrBirthName], [t1].[Discriminator], [t1].[FullName], [t1].[HasSoulPatch], [t1].[LeaderNickname], [t1].[LeaderSquadId], [t1].[Rank]
-FROM [Tags] AS [t0]
+                @"SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOrBirthName], [t0].[Discriminator], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t].[Id], [t1].[Nickname], [t1].[SquadId], [t1].[AssignedCityName], [t1].[CityOrBirthName], [t1].[Discriminator], [t1].[FullName], [t1].[HasSoulPatch], [t1].[LeaderNickname], [t1].[LeaderSquadId], [t1].[Rank]
+FROM [Tags] AS [t]
 INNER JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
     FROM [Gears] AS [g]
     WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND ([g].[Discriminator] = N'Officer')
-) AS [t] ON (([t0].[GearSquadId] = [t].[SquadId]) AND [t0].[GearSquadId] IS NOT NULL) AND (([t0].[GearNickName] = [t].[Nickname]) AND [t0].[GearNickName] IS NOT NULL)
+) AS [t0] ON (([t].[GearSquadId] = [t0].[SquadId]) AND [t].[GearSquadId] IS NOT NULL) AND (([t].[GearNickName] = [t0].[Nickname]) AND [t].[GearNickName] IS NOT NULL)
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
     FROM [Gears] AS [g0]
     WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t1] ON (([t].[Nickname] = [t1].[LeaderNickname]) AND [t1].[LeaderNickname] IS NOT NULL) AND ([t].[SquadId] = [t1].[LeaderSquadId])
-ORDER BY [t0].[Id], [t].[Nickname], [t].[SquadId], [t1].[Nickname], [t1].[SquadId]");
+) AS [t1] ON (([t0].[Nickname] = [t1].[LeaderNickname]) AND [t1].[LeaderNickname] IS NOT NULL) AND ([t0].[SquadId] = [t1].[LeaderSquadId])
+ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId], [t1].[Nickname], [t1].[SquadId]");
         }
 
         public override async Task Include_with_nested_navigation_in_order_by(bool isAsync)
@@ -1031,13 +1031,13 @@ WHERE [g].[Discriminator] IN (N'Gear', N'Officer')");
     END
     ELSE NULL
 END AS [Condition]
-FROM [Gears] AS [g0]
+FROM [Gears] AS [g]
 LEFT JOIN (
-    SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
-    FROM [Gears] AS [g]
-    WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t] ON [g0].[HasSoulPatch] = CAST(1 AS bit)
-WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
+    SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
+    FROM [Gears] AS [g0]
+    WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
+) AS [t] ON [g].[HasSoulPatch] = CAST(1 AS bit)
+WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
 ORDER BY [t].[Nickname]");
         }
 
@@ -1050,13 +1050,13 @@ ORDER BY [t].[Nickname]");
     WHEN [t].[Nickname] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [t].[Nickname]
-FROM [Gears] AS [g0]
+FROM [Gears] AS [g]
 LEFT JOIN (
-    SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
-    FROM [Gears] AS [g]
-    WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t] ON [g0].[HasSoulPatch] = CAST(1 AS bit)
-WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
+    SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
+    FROM [Gears] AS [g0]
+    WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
+) AS [t] ON [g].[HasSoulPatch] = CAST(1 AS bit)
+WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
 ORDER BY [t].[Nickname]");
         }
 
@@ -1069,13 +1069,13 @@ ORDER BY [t].[Nickname]");
     WHEN [t].[Nickname] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [t].[Nickname]
-FROM [Gears] AS [g0]
+FROM [Gears] AS [g]
 LEFT JOIN (
-    SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
-    FROM [Gears] AS [g]
-    WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t] ON [g0].[HasSoulPatch] = CAST(1 AS bit)
-WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
+    SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
+    FROM [Gears] AS [g0]
+    WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
+) AS [t] ON [g].[HasSoulPatch] = CAST(1 AS bit)
+WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
 ORDER BY [t].[Nickname]");
         }
 
@@ -1135,13 +1135,13 @@ LEFT JOIN [Cities] AS [c] ON [t0].[AssignedCityName] = [c].[Name]");
             await base.Select_null_propagation_works_for_navigations_with_composite_keys(isAsync);
 
             AssertSql(
-                @"SELECT [t].[Nickname]
-FROM [Tags] AS [t0]
+                @"SELECT [t0].[Nickname]
+FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
     FROM [Gears] AS [g]
     WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t] ON (([t0].[GearNickName] = [t].[Nickname]) AND [t0].[GearNickName] IS NOT NULL) AND (([t0].[GearSquadId] = [t].[SquadId]) AND [t0].[GearSquadId] IS NOT NULL)");
+) AS [t0] ON (([t].[GearNickName] = [t0].[Nickname]) AND [t].[GearNickName] IS NOT NULL) AND (([t].[GearSquadId] = [t0].[SquadId]) AND [t].[GearSquadId] IS NOT NULL)");
         }
 
         public override async Task Select_null_propagation_works_for_multiple_navigations_with_composite_keys(bool isAsync)
@@ -1261,14 +1261,14 @@ WHERE (([t1].[Nickname] = [t2].[Nickname]) AND ([t1].[Nickname] IS NOT NULL AND 
             await base.Select_Singleton_Navigation_With_Member_Access(isAsync);
 
             AssertSql(
-                @"SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
-FROM [Tags] AS [t0]
+                @"SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOrBirthName], [t0].[Discriminator], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank]
+FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
     FROM [Gears] AS [g]
     WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t] ON (([t0].[GearNickName] = [t].[Nickname]) AND [t0].[GearNickName] IS NOT NULL) AND (([t0].[GearSquadId] = [t].[SquadId]) AND [t0].[GearSquadId] IS NOT NULL)
-WHERE (([t].[Nickname] = N'Marcus') AND [t].[Nickname] IS NOT NULL) AND (([t].[CityOrBirthName] <> N'Ephyra') OR [t].[CityOrBirthName] IS NULL)");
+) AS [t0] ON (([t].[GearNickName] = [t0].[Nickname]) AND [t].[GearNickName] IS NOT NULL) AND (([t].[GearSquadId] = [t0].[SquadId]) AND [t].[GearSquadId] IS NOT NULL)
+WHERE (([t0].[Nickname] = N'Marcus') AND [t0].[Nickname] IS NOT NULL) AND (([t0].[CityOrBirthName] <> N'Ephyra') OR [t0].[CityOrBirthName] IS NULL)");
         }
 
         public override async Task Select_Where_Navigation(bool isAsync)
@@ -1363,10 +1363,10 @@ WHERE (([t1].[Nickname] = [t2].[Nickname]) AND ([t1].[Nickname] IS NOT NULL AND 
             await base.Optional_Navigation_Null_Coalesce_To_Clr_Type(isAsync);
 
             AssertSql(
-                @"SELECT TOP(1) COALESCE([w].[IsAutomatic], CAST(0 AS bit))
-FROM [Weapons] AS [w0]
-LEFT JOIN [Weapons] AS [w] ON [w0].[SynergyWithId] = [w].[Id]
-ORDER BY [w0].[Id]");
+                @"SELECT TOP(1) COALESCE([w0].[IsAutomatic], CAST(0 AS bit))
+FROM [Weapons] AS [w]
+LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
+ORDER BY [w].[Id]");
         }
 
         public override async Task Where_subquery_boolean(bool isAsync)
@@ -1684,14 +1684,14 @@ WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND ([g].[HasSoulPatch] = CAS
             await base.Singleton_Navigation_With_Member_Access(isAsync);
 
             AssertSql(
-                @"SELECT [t].[CityOrBirthName] AS [B]
-FROM [Tags] AS [t0]
+                @"SELECT [t0].[CityOrBirthName] AS [B]
+FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
     FROM [Gears] AS [g]
     WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t] ON (([t0].[GearNickName] = [t].[Nickname]) AND [t0].[GearNickName] IS NOT NULL) AND (([t0].[GearSquadId] = [t].[SquadId]) AND [t0].[GearSquadId] IS NOT NULL)
-WHERE (([t].[Nickname] = N'Marcus') AND [t].[Nickname] IS NOT NULL) AND (([t].[CityOrBirthName] <> N'Ephyra') OR [t].[CityOrBirthName] IS NULL)");
+) AS [t0] ON (([t].[GearNickName] = [t0].[Nickname]) AND [t].[GearNickName] IS NOT NULL) AND (([t].[GearSquadId] = [t0].[SquadId]) AND [t].[GearSquadId] IS NOT NULL)
+WHERE (([t0].[Nickname] = N'Marcus') AND [t0].[Nickname] IS NOT NULL) AND (([t0].[CityOrBirthName] <> N'Ephyra') OR [t0].[CityOrBirthName] IS NULL)");
         }
 
         public override async Task GroupJoin_Composite_Key(bool isAsync)
@@ -1699,13 +1699,13 @@ WHERE (([t].[Nickname] = N'Marcus') AND [t].[Nickname] IS NOT NULL) AND (([t].[C
             await base.GroupJoin_Composite_Key(isAsync);
 
             AssertSql(
-                @"SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
-FROM [Tags] AS [t0]
+                @"SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOrBirthName], [t0].[Discriminator], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank]
+FROM [Tags] AS [t]
 INNER JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
     FROM [Gears] AS [g]
     WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t] ON (([t0].[GearNickName] = [t].[Nickname]) AND [t0].[GearNickName] IS NOT NULL) AND (([t0].[GearSquadId] = [t].[SquadId]) AND [t0].[GearSquadId] IS NOT NULL)");
+) AS [t0] ON (([t].[GearNickName] = [t0].[Nickname]) AND [t].[GearNickName] IS NOT NULL) AND (([t].[GearSquadId] = [t0].[SquadId]) AND [t].[GearSquadId] IS NOT NULL)");
         }
 
         public override async Task Join_navigation_translated_to_subquery_composite_key(bool isAsync)
@@ -1757,14 +1757,14 @@ WHERE [g].[Discriminator] IN (N'Gear', N'Officer')");
             await base.Collection_with_inheritance_and_join_include_joined(isAsync);
 
             AssertSql(
-                @"SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t0].[Id], [t0].[GearNickName], [t0].[GearSquadId], [t0].[Note]
-FROM [Tags] AS [t1]
+                @"SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOrBirthName], [t0].[Discriminator], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [t1].[Id], [t1].[GearNickName], [t1].[GearSquadId], [t1].[Note]
+FROM [Tags] AS [t]
 INNER JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
     FROM [Gears] AS [g]
     WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND ([g].[Discriminator] = N'Officer')
-) AS [t] ON (([t1].[GearSquadId] = [t].[SquadId]) AND [t1].[GearSquadId] IS NOT NULL) AND (([t1].[GearNickName] = [t].[Nickname]) AND [t1].[GearNickName] IS NOT NULL)
-LEFT JOIN [Tags] AS [t0] ON (([t].[Nickname] = [t0].[GearNickName]) AND [t0].[GearNickName] IS NOT NULL) AND (([t].[SquadId] = [t0].[GearSquadId]) AND [t0].[GearSquadId] IS NOT NULL)");
+) AS [t0] ON (([t].[GearSquadId] = [t0].[SquadId]) AND [t].[GearSquadId] IS NOT NULL) AND (([t].[GearNickName] = [t0].[Nickname]) AND [t].[GearNickName] IS NOT NULL)
+LEFT JOIN [Tags] AS [t1] ON (([t0].[Nickname] = [t1].[GearNickName]) AND [t1].[GearNickName] IS NOT NULL) AND (([t0].[SquadId] = [t1].[GearSquadId]) AND [t1].[GearSquadId] IS NOT NULL)");
         }
 
         public override async Task Collection_with_inheritance_and_join_include_source(bool isAsync)
@@ -1772,10 +1772,10 @@ LEFT JOIN [Tags] AS [t0] ON (([t].[Nickname] = [t0].[GearNickName]) AND [t0].[Ge
             await base.Collection_with_inheritance_and_join_include_source(isAsync);
 
             AssertSql(
-                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[Note]
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [t0].[Id], [t0].[GearNickName], [t0].[GearSquadId], [t0].[Note]
 FROM [Gears] AS [g]
-INNER JOIN [Tags] AS [t0] ON (([g].[SquadId] = [t0].[GearSquadId]) AND [t0].[GearSquadId] IS NOT NULL) AND (([g].[Nickname] = [t0].[GearNickName]) AND [t0].[GearNickName] IS NOT NULL)
-LEFT JOIN [Tags] AS [t] ON (([g].[Nickname] = [t].[GearNickName]) AND [t].[GearNickName] IS NOT NULL) AND (([g].[SquadId] = [t].[GearSquadId]) AND [t].[GearSquadId] IS NOT NULL)
+INNER JOIN [Tags] AS [t] ON (([g].[SquadId] = [t].[GearSquadId]) AND [t].[GearSquadId] IS NOT NULL) AND (([g].[Nickname] = [t].[GearNickName]) AND [t].[GearNickName] IS NOT NULL)
+LEFT JOIN [Tags] AS [t0] ON (([g].[Nickname] = [t0].[GearNickName]) AND [t0].[GearNickName] IS NOT NULL) AND (([g].[SquadId] = [t0].[GearSquadId]) AND [t0].[GearSquadId] IS NOT NULL)
 WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND ([g].[Discriminator] = N'Officer')");
         }
 
@@ -1874,16 +1874,16 @@ WHERE CHARINDEX('Add', [c].[Location] + 'Added') > 0");
 
             // Issue#16897
             AssertSql(
-                @"SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
-FROM [Gears] AS [g0]
+                @"SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Gears] AS [g]
 LEFT JOIN (
-    SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
-    FROM [Gears] AS [g]
-    WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t] ON [g0].[LeaderNickname] = [t].[Nickname]
-LEFT JOIN [Weapons] AS [w] ON [g0].[FullName] = [w].[OwnerFullName]
-WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
-ORDER BY [g0].[Nickname], [g0].[SquadId], [w].[Id]");
+    SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
+    FROM [Gears] AS [g0]
+    WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
+) AS [t] ON [g].[LeaderNickname] = [t].[Nickname]
+LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
+WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
+ORDER BY [g].[Nickname], [g].[SquadId], [w].[Id]");
         }
 
         public override void Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result2()
@@ -1892,16 +1892,16 @@ ORDER BY [g0].[Nickname], [g0].[SquadId], [w].[Id]");
 
             // Issue#16897
             AssertSql(
-                @"SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
-FROM [Gears] AS [g0]
+                @"SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Gears] AS [g]
 LEFT JOIN (
-    SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
-    FROM [Gears] AS [g]
-    WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t] ON [g0].[LeaderNickname] = [t].[Nickname]
+    SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
+    FROM [Gears] AS [g0]
+    WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
+) AS [t] ON [g].[LeaderNickname] = [t].[Nickname]
 LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
-WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
-ORDER BY [g0].[Nickname], [g0].[SquadId], [w].[Id]");
+WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
+ORDER BY [g].[Nickname], [g].[SquadId], [w].[Id]");
         }
 
         public override async Task Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result3(bool isAsync)
@@ -1910,17 +1910,17 @@ ORDER BY [g0].[Nickname], [g0].[SquadId], [w].[Id]");
 
             // Issue#16897
             AssertSql(
-                @"SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
-FROM [Gears] AS [g0]
+                @"SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+FROM [Gears] AS [g]
 LEFT JOIN (
-    SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
-    FROM [Gears] AS [g]
-    WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t] ON [g0].[LeaderNickname] = [t].[Nickname]
+    SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
+    FROM [Gears] AS [g0]
+    WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
+) AS [t] ON [g].[LeaderNickname] = [t].[Nickname]
 LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
-LEFT JOIN [Weapons] AS [w0] ON [g0].[FullName] = [w0].[OwnerFullName]
-WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
-ORDER BY [g0].[Nickname], [g0].[SquadId], [w].[Id], [w0].[Id]");
+LEFT JOIN [Weapons] AS [w0] ON [g].[FullName] = [w0].[OwnerFullName]
+WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
+ORDER BY [g].[Nickname], [g].[SquadId], [w].[Id], [w0].[Id]");
         }
 
         public override async Task Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result4(bool isAsync)
@@ -1974,17 +1974,17 @@ ORDER BY [t3].[FullName0], [t3].[FullName]");
 
             // Issue#16897
             AssertSql(
-                @"SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
-FROM [Gears] AS [g0]
+                @"SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+FROM [Gears] AS [g]
 LEFT JOIN (
-    SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
-    FROM [Gears] AS [g]
-    WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND ([g].[Discriminator] = N'Officer')
-) AS [t] ON [g0].[LeaderNickname] = [t].[Nickname]
+    SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
+    FROM [Gears] AS [g0]
+    WHERE [g0].[Discriminator] IN (N'Gear', N'Officer') AND ([g0].[Discriminator] = N'Officer')
+) AS [t] ON [g].[LeaderNickname] = [t].[Nickname]
 LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
-LEFT JOIN [Weapons] AS [w0] ON [g0].[FullName] = [w0].[OwnerFullName]
-WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
-ORDER BY [g0].[Nickname], [g0].[SquadId], [w].[Id], [w0].[Id]");
+LEFT JOIN [Weapons] AS [w0] ON [g].[FullName] = [w0].[OwnerFullName]
+WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
+ORDER BY [g].[Nickname], [g].[SquadId], [w].[Id], [w0].[Id]");
         }
 
         public override async Task Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_conditional_result(bool isAsync)
@@ -1996,17 +1996,17 @@ ORDER BY [g0].[Nickname], [g0].[SquadId], [w].[Id], [w0].[Id]");
                 @"SELECT CASE
     WHEN [t].[Nickname] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
-END, [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
-FROM [Gears] AS [g0]
+END, [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+FROM [Gears] AS [g]
 LEFT JOIN (
-    SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
-    FROM [Gears] AS [g]
-    WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t] ON [g0].[LeaderNickname] = [t].[Nickname]
+    SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
+    FROM [Gears] AS [g0]
+    WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
+) AS [t] ON [g].[LeaderNickname] = [t].[Nickname]
 LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
-LEFT JOIN [Weapons] AS [w0] ON [g0].[FullName] = [w0].[OwnerFullName]
-WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
-ORDER BY [g0].[Nickname], [g0].[SquadId], [w].[Id], [w0].[Id]");
+LEFT JOIN [Weapons] AS [w0] ON [g].[FullName] = [w0].[OwnerFullName]
+WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
+ORDER BY [g].[Nickname], [g].[SquadId], [w].[Id], [w0].[Id]");
         }
 
         public override async Task Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_complex_projection_result(bool isAsync)
@@ -2185,15 +2185,15 @@ WHERE ([t0].[HasSoulPatch] = CAST(1 AS bit)) OR (CHARINDEX(N'Cole', [t].[Note]) 
 
             AssertSql(
                 @"SELECT CASE
-    WHEN ([t].[HasSoulPatch] = CAST(1 AS bit)) AND (CHARINDEX(N'Cole', [t0].[Note]) > 0) THEN CAST(1 AS bit)
+    WHEN ([t0].[HasSoulPatch] = CAST(1 AS bit)) AND (CHARINDEX(N'Cole', [t].[Note]) > 0) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
-FROM [Tags] AS [t0]
+FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
     FROM [Gears] AS [g]
     WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t] ON (([t0].[GearNickName] = [t].[Nickname]) AND [t0].[GearNickName] IS NOT NULL) AND (([t0].[GearSquadId] = [t].[SquadId]) AND [t0].[GearSquadId] IS NOT NULL)");
+) AS [t0] ON (([t].[GearNickName] = [t0].[Nickname]) AND [t].[GearNickName] IS NOT NULL) AND (([t].[GearSquadId] = [t0].[SquadId]) AND [t].[GearSquadId] IS NOT NULL)");
         }
 
         public override async Task Optional_navigation_type_compensation_works_with_projection(bool isAsync)
@@ -2201,14 +2201,14 @@ LEFT JOIN (
             await base.Optional_navigation_type_compensation_works_with_projection(isAsync);
 
             AssertSql(
-                @"SELECT [t].[SquadId]
-FROM [Tags] AS [t0]
+                @"SELECT [t0].[SquadId]
+FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
     FROM [Gears] AS [g]
     WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t] ON (([t0].[GearNickName] = [t].[Nickname]) AND [t0].[GearNickName] IS NOT NULL) AND (([t0].[GearSquadId] = [t].[SquadId]) AND [t0].[GearSquadId] IS NOT NULL)
-WHERE ([t0].[Note] <> N'K.I.A.') OR [t0].[Note] IS NULL");
+) AS [t0] ON (([t].[GearNickName] = [t0].[Nickname]) AND [t].[GearNickName] IS NOT NULL) AND (([t].[GearSquadId] = [t0].[SquadId]) AND [t].[GearSquadId] IS NOT NULL)
+WHERE ([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL");
         }
 
         public override async Task Optional_navigation_type_compensation_works_with_projection_into_anonymous_type(bool isAsync)
@@ -2216,14 +2216,14 @@ WHERE ([t0].[Note] <> N'K.I.A.') OR [t0].[Note] IS NULL");
             await base.Optional_navigation_type_compensation_works_with_projection_into_anonymous_type(isAsync);
 
             AssertSql(
-                @"SELECT [t].[SquadId]
-FROM [Tags] AS [t0]
+                @"SELECT [t0].[SquadId]
+FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
     FROM [Gears] AS [g]
     WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t] ON (([t0].[GearNickName] = [t].[Nickname]) AND [t0].[GearNickName] IS NOT NULL) AND (([t0].[GearSquadId] = [t].[SquadId]) AND [t0].[GearSquadId] IS NOT NULL)
-WHERE ([t0].[Note] <> N'K.I.A.') OR [t0].[Note] IS NULL");
+) AS [t0] ON (([t].[GearNickName] = [t0].[Nickname]) AND [t].[GearNickName] IS NOT NULL) AND (([t].[GearSquadId] = [t0].[SquadId]) AND [t].[GearSquadId] IS NOT NULL)
+WHERE ([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL");
         }
 
         public override async Task Optional_navigation_type_compensation_works_with_DTOs(bool isAsync)
@@ -2231,14 +2231,14 @@ WHERE ([t0].[Note] <> N'K.I.A.') OR [t0].[Note] IS NULL");
             await base.Optional_navigation_type_compensation_works_with_DTOs(isAsync);
 
             AssertSql(
-                @"SELECT [t].[SquadId] AS [Id]
-FROM [Tags] AS [t0]
+                @"SELECT [t0].[SquadId] AS [Id]
+FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
     FROM [Gears] AS [g]
     WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t] ON (([t0].[GearNickName] = [t].[Nickname]) AND [t0].[GearNickName] IS NOT NULL) AND (([t0].[GearSquadId] = [t].[SquadId]) AND [t0].[GearSquadId] IS NOT NULL)
-WHERE ([t0].[Note] <> N'K.I.A.') OR [t0].[Note] IS NULL");
+) AS [t0] ON (([t].[GearNickName] = [t0].[Nickname]) AND [t].[GearNickName] IS NOT NULL) AND (([t].[GearSquadId] = [t0].[SquadId]) AND [t].[GearSquadId] IS NOT NULL)
+WHERE ([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL");
         }
 
         public override async Task Optional_navigation_type_compensation_works_with_list_initializers(bool isAsync)
@@ -2246,15 +2246,15 @@ WHERE ([t0].[Note] <> N'K.I.A.') OR [t0].[Note] IS NULL");
             await base.Optional_navigation_type_compensation_works_with_list_initializers(isAsync);
 
             AssertSql(
-                @"SELECT [t].[SquadId], [t].[SquadId] + 1
-FROM [Tags] AS [t0]
+                @"SELECT [t0].[SquadId], [t0].[SquadId] + 1
+FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
     FROM [Gears] AS [g]
     WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t] ON (([t0].[GearNickName] = [t].[Nickname]) AND [t0].[GearNickName] IS NOT NULL) AND (([t0].[GearSquadId] = [t].[SquadId]) AND [t0].[GearSquadId] IS NOT NULL)
-WHERE ([t0].[Note] <> N'K.I.A.') OR [t0].[Note] IS NULL
-ORDER BY [t0].[Note]");
+) AS [t0] ON (([t].[GearNickName] = [t0].[Nickname]) AND [t].[GearNickName] IS NOT NULL) AND (([t].[GearSquadId] = [t0].[SquadId]) AND [t].[GearSquadId] IS NOT NULL)
+WHERE ([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL
+ORDER BY [t].[Note]");
         }
 
         public override async Task Optional_navigation_type_compensation_works_with_array_initializers(bool isAsync)
@@ -2262,14 +2262,14 @@ ORDER BY [t0].[Note]");
             await base.Optional_navigation_type_compensation_works_with_array_initializers(isAsync);
 
             AssertSql(
-                @"SELECT [t].[SquadId]
-FROM [Tags] AS [t0]
+                @"SELECT [t0].[SquadId]
+FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
     FROM [Gears] AS [g]
     WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t] ON (([t0].[GearNickName] = [t].[Nickname]) AND [t0].[GearNickName] IS NOT NULL) AND (([t0].[GearSquadId] = [t].[SquadId]) AND [t0].[GearSquadId] IS NOT NULL)
-WHERE ([t0].[Note] <> N'K.I.A.') OR [t0].[Note] IS NULL");
+) AS [t0] ON (([t].[GearNickName] = [t0].[Nickname]) AND [t].[GearNickName] IS NOT NULL) AND (([t].[GearSquadId] = [t0].[SquadId]) AND [t].[GearSquadId] IS NOT NULL)
+WHERE ([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL");
         }
 
         public override async Task Optional_navigation_type_compensation_works_with_orderby(bool isAsync)
@@ -3630,25 +3630,25 @@ WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'Locust
             base.Project_collection_navigation_with_inheritance1();
 
             AssertSql(
-                @"SELECT [f].[Id], [t].[Name], [t].[Discriminator], [t].[LocustHordeId], [t].[ThreatLevel], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId]
+                @"SELECT [f].[Id], [t1].[Name], [t1].[Discriminator], [t1].[LocustHordeId], [t1].[ThreatLevel], [t1].[DefeatedByNickname], [t1].[DefeatedBySquadId], [t1].[HighCommandId]
 FROM [Factions] AS [f]
 LEFT JOIN (
-    SELECT [l0].[Name], [l0].[Discriminator], [l0].[LocustHordeId], [l0].[ThreatLevel], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId]
-    FROM [LocustLeaders] AS [l0]
-    WHERE [l0].[Discriminator] = N'LocustCommander'
-) AS [t0] ON [f].[CommanderName] = [t0].[Name]
+    SELECT [l].[Name], [l].[Discriminator], [l].[LocustHordeId], [l].[ThreatLevel], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [l].[HighCommandId]
+    FROM [LocustLeaders] AS [l]
+    WHERE [l].[Discriminator] = N'LocustCommander'
+) AS [t] ON [f].[CommanderName] = [t].[Name]
 LEFT JOIN (
     SELECT [f0].[Id], [f0].[CapitalName], [f0].[Discriminator], [f0].[Name], [f0].[CommanderName], [f0].[Eradicated]
     FROM [Factions] AS [f0]
     WHERE [f0].[Discriminator] = N'LocustHorde'
-) AS [t1] ON [t0].[Name] = [t1].[CommanderName]
+) AS [t0] ON [t].[Name] = [t0].[CommanderName]
 LEFT JOIN (
-    SELECT [l].[Name], [l].[Discriminator], [l].[LocustHordeId], [l].[ThreatLevel], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [l].[HighCommandId]
-    FROM [LocustLeaders] AS [l]
-    WHERE [l].[Discriminator] IN (N'LocustLeader', N'LocustCommander')
-) AS [t] ON [t1].[Id] = [t].[LocustHordeId]
+    SELECT [l0].[Name], [l0].[Discriminator], [l0].[LocustHordeId], [l0].[ThreatLevel], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId]
+    FROM [LocustLeaders] AS [l0]
+    WHERE [l0].[Discriminator] IN (N'LocustLeader', N'LocustCommander')
+) AS [t1] ON [t0].[Id] = [t1].[LocustHordeId]
 WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')
-ORDER BY [f].[Id], [t].[Name]");
+ORDER BY [f].[Id], [t1].[Name]");
         }
 
         public override void Project_collection_navigation_with_inheritance2()
@@ -3656,25 +3656,25 @@ ORDER BY [f].[Id], [t].[Name]");
             base.Project_collection_navigation_with_inheritance2();
 
             AssertSql(
-                @"SELECT [f].[Id], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
+                @"SELECT [f].[Id], [t1].[Nickname], [t1].[SquadId], [t1].[AssignedCityName], [t1].[CityOrBirthName], [t1].[Discriminator], [t1].[FullName], [t1].[HasSoulPatch], [t1].[LeaderNickname], [t1].[LeaderSquadId], [t1].[Rank]
 FROM [Factions] AS [f]
 LEFT JOIN (
     SELECT [l].[Name], [l].[Discriminator], [l].[LocustHordeId], [l].[ThreatLevel], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [l].[HighCommandId]
     FROM [LocustLeaders] AS [l]
     WHERE [l].[Discriminator] = N'LocustCommander'
-) AS [t0] ON [f].[CommanderName] = [t0].[Name]
-LEFT JOIN (
-    SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
-    FROM [Gears] AS [g0]
-    WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t1] ON (([t0].[DefeatedByNickname] = [t1].[Nickname]) AND [t0].[DefeatedByNickname] IS NOT NULL) AND (([t0].[DefeatedBySquadId] = [t1].[SquadId]) AND [t0].[DefeatedBySquadId] IS NOT NULL)
+) AS [t] ON [f].[CommanderName] = [t].[Name]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
     FROM [Gears] AS [g]
     WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t] ON ((([t1].[Nickname] = [t].[LeaderNickname]) AND ([t1].[Nickname] IS NOT NULL AND [t].[LeaderNickname] IS NOT NULL)) OR ([t1].[Nickname] IS NULL AND [t].[LeaderNickname] IS NULL)) AND (([t1].[SquadId] = [t].[LeaderSquadId]) AND [t1].[SquadId] IS NOT NULL)
+) AS [t0] ON (([t].[DefeatedByNickname] = [t0].[Nickname]) AND [t].[DefeatedByNickname] IS NOT NULL) AND (([t].[DefeatedBySquadId] = [t0].[SquadId]) AND [t].[DefeatedBySquadId] IS NOT NULL)
+LEFT JOIN (
+    SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
+    FROM [Gears] AS [g0]
+    WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
+) AS [t1] ON ((([t0].[Nickname] = [t1].[LeaderNickname]) AND ([t0].[Nickname] IS NOT NULL AND [t1].[LeaderNickname] IS NOT NULL)) OR ([t0].[Nickname] IS NULL AND [t1].[LeaderNickname] IS NULL)) AND (([t0].[SquadId] = [t1].[LeaderSquadId]) AND [t0].[SquadId] IS NOT NULL)
 WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')
-ORDER BY [f].[Id], [t].[Nickname], [t].[SquadId]");
+ORDER BY [f].[Id], [t1].[Nickname], [t1].[SquadId]");
         }
 
         public override void Project_collection_navigation_with_inheritance3()
@@ -3682,25 +3682,25 @@ ORDER BY [f].[Id], [t].[Nickname], [t].[SquadId]");
             base.Project_collection_navigation_with_inheritance3();
 
             AssertSql(
-                @"SELECT [f].[Id], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
+                @"SELECT [f].[Id], [t1].[Nickname], [t1].[SquadId], [t1].[AssignedCityName], [t1].[CityOrBirthName], [t1].[Discriminator], [t1].[FullName], [t1].[HasSoulPatch], [t1].[LeaderNickname], [t1].[LeaderSquadId], [t1].[Rank]
 FROM [Factions] AS [f]
 LEFT JOIN (
     SELECT [l].[Name], [l].[Discriminator], [l].[LocustHordeId], [l].[ThreatLevel], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [l].[HighCommandId]
     FROM [LocustLeaders] AS [l]
     WHERE [l].[Discriminator] = N'LocustCommander'
-) AS [t0] ON [f].[CommanderName] = [t0].[Name]
-LEFT JOIN (
-    SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
-    FROM [Gears] AS [g0]
-    WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t1] ON (([t0].[DefeatedByNickname] = [t1].[Nickname]) AND [t0].[DefeatedByNickname] IS NOT NULL) AND (([t0].[DefeatedBySquadId] = [t1].[SquadId]) AND [t0].[DefeatedBySquadId] IS NOT NULL)
+) AS [t] ON [f].[CommanderName] = [t].[Name]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
     FROM [Gears] AS [g]
     WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t] ON ((([t1].[Nickname] = [t].[LeaderNickname]) AND ([t1].[Nickname] IS NOT NULL AND [t].[LeaderNickname] IS NOT NULL)) OR ([t1].[Nickname] IS NULL AND [t].[LeaderNickname] IS NULL)) AND (([t1].[SquadId] = [t].[LeaderSquadId]) AND [t1].[SquadId] IS NOT NULL)
+) AS [t0] ON (([t].[DefeatedByNickname] = [t0].[Nickname]) AND [t].[DefeatedByNickname] IS NOT NULL) AND (([t].[DefeatedBySquadId] = [t0].[SquadId]) AND [t].[DefeatedBySquadId] IS NOT NULL)
+LEFT JOIN (
+    SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
+    FROM [Gears] AS [g0]
+    WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
+) AS [t1] ON ((([t0].[Nickname] = [t1].[LeaderNickname]) AND ([t0].[Nickname] IS NOT NULL AND [t1].[LeaderNickname] IS NOT NULL)) OR ([t0].[Nickname] IS NULL AND [t1].[LeaderNickname] IS NULL)) AND (([t0].[SquadId] = [t1].[LeaderSquadId]) AND [t0].[SquadId] IS NOT NULL)
 WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')
-ORDER BY [f].[Id], [t].[Nickname], [t].[SquadId]");
+ORDER BY [f].[Id], [t1].[Nickname], [t1].[SquadId]");
         }
 
         public override async Task Include_reference_on_derived_type_using_string(bool isAsync)
@@ -3995,16 +3995,16 @@ ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId], [t].[Id],
             await base.Projecting_nullable_bool_in_conditional_works(isAsync);
 
             AssertSql(
-                @"SELECT CASE
-    WHEN [t].[Nickname] IS NOT NULL THEN [t].[HasSoulPatch]
+                 @"SELECT CASE
+    WHEN [t0].[Nickname] IS NOT NULL THEN [t0].[HasSoulPatch]
     ELSE CAST(0 AS bit)
 END AS [Prop]
-FROM [Tags] AS [t0]
+FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
     FROM [Gears] AS [g]
     WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t] ON (([t0].[GearNickName] = [t].[Nickname]) AND [t0].[GearNickName] IS NOT NULL) AND (([t0].[GearSquadId] = [t].[SquadId]) AND [t0].[GearSquadId] IS NOT NULL)");
+) AS [t0] ON (([t].[GearNickName] = [t0].[Nickname]) AND [t].[GearNickName] IS NOT NULL) AND (([t].[GearSquadId] = [t0].[SquadId]) AND [t].[GearSquadId] IS NOT NULL)");
         }
 
         public override async Task Enum_ToString_is_client_eval(bool isAsync)
@@ -4385,28 +4385,28 @@ ORDER BY [g].[HasSoulPatch] DESC, [t].[Note]");
             await base.Multiple_orderby_with_navigation_expansion_on_one_of_the_order_bys_inside_subquery(isAsync);
 
             AssertSql(
-                @"SELECT [g].[FullName], [g].[Nickname], [g].[SquadId], [t0].[Id], [t0].[AmmunitionType], [t0].[IsAutomatic], [t0].[Name], [t0].[OwnerFullName], [t0].[SynergyWithId]
+                @"SELECT [g].[FullName], [g].[Nickname], [g].[SquadId], [t2].[Id], [t2].[AmmunitionType], [t2].[IsAutomatic], [t2].[Name], [t2].[OwnerFullName], [t2].[SynergyWithId]
 FROM [Gears] AS [g]
-LEFT JOIN [Tags] AS [t1] ON (([g].[Nickname] = [t1].[GearNickName]) AND [t1].[GearNickName] IS NOT NULL) AND (([g].[SquadId] = [t1].[GearSquadId]) AND [t1].[GearSquadId] IS NOT NULL)
+LEFT JOIN [Tags] AS [t] ON (([g].[Nickname] = [t].[GearNickName]) AND [t].[GearNickName] IS NOT NULL) AND (([g].[SquadId] = [t].[GearSquadId]) AND [t].[GearSquadId] IS NOT NULL)
 LEFT JOIN (
-    SELECT [g1].[Nickname], [g1].[SquadId], [g1].[AssignedCityName], [g1].[CityOrBirthName], [g1].[Discriminator], [g1].[FullName], [g1].[HasSoulPatch], [g1].[LeaderNickname], [g1].[LeaderSquadId], [g1].[Rank]
-    FROM [Gears] AS [g1]
-    WHERE [g1].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t2] ON (([t1].[GearNickName] = [t2].[Nickname]) AND [t1].[GearNickName] IS NOT NULL) AND (([t1].[GearSquadId] = [t2].[SquadId]) AND [t1].[GearSquadId] IS NOT NULL)
+    SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
+    FROM [Gears] AS [g0]
+    WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
+) AS [t0] ON (([t].[GearNickName] = [t0].[Nickname]) AND [t].[GearNickName] IS NOT NULL) AND (([t].[GearSquadId] = [t0].[SquadId]) AND [t].[GearSquadId] IS NOT NULL)
 LEFT JOIN (
-    SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [t].[Nickname]
+    SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [t1].[Nickname]
     FROM [Weapons] AS [w]
     LEFT JOIN (
-        SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
-        FROM [Gears] AS [g0]
-        WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
-    ) AS [t] ON [w].[OwnerFullName] = [t].[FullName]
-) AS [t0] ON [t2].[FullName] = [t0].[OwnerFullName]
+        SELECT [g1].[Nickname], [g1].[SquadId], [g1].[AssignedCityName], [g1].[CityOrBirthName], [g1].[Discriminator], [g1].[FullName], [g1].[HasSoulPatch], [g1].[LeaderNickname], [g1].[LeaderSquadId], [g1].[Rank]
+        FROM [Gears] AS [g1]
+        WHERE [g1].[Discriminator] IN (N'Gear', N'Officer')
+    ) AS [t1] ON [w].[OwnerFullName] = [t1].[FullName]
+) AS [t2] ON [t0].[FullName] = [t2].[OwnerFullName]
 WHERE ([g].[Discriminator] IN (N'Gear', N'Officer') AND ([g].[Discriminator] = N'Officer')) AND EXISTS (
     SELECT 1
     FROM [Gears] AS [g2]
     WHERE [g2].[Discriminator] IN (N'Gear', N'Officer') AND ((([g].[Nickname] = [g2].[LeaderNickname]) AND [g2].[LeaderNickname] IS NOT NULL) AND ([g].[SquadId] = [g2].[LeaderSquadId])))
-ORDER BY [g].[HasSoulPatch] DESC, [t1].[Note], [g].[Nickname], [g].[SquadId], [t0].[IsAutomatic], [t0].[Nickname] DESC, [t0].[Id]");
+ORDER BY [g].[HasSoulPatch] DESC, [t].[Note], [g].[Nickname], [g].[SquadId], [t2].[IsAutomatic], [t2].[Nickname] DESC, [t2].[Id]");
         }
 
         public override async Task Multiple_orderby_with_navigation_expansion_on_one_of_the_order_bys_inside_subquery_duplicated_orderings(bool isAsync)
@@ -4414,28 +4414,28 @@ ORDER BY [g].[HasSoulPatch] DESC, [t1].[Note], [g].[Nickname], [g].[SquadId], [t
             await base.Multiple_orderby_with_navigation_expansion_on_one_of_the_order_bys_inside_subquery_duplicated_orderings(isAsync);
 
             AssertSql(
-                @"SELECT [g].[FullName], [g].[Nickname], [g].[SquadId], [t0].[Id], [t0].[AmmunitionType], [t0].[IsAutomatic], [t0].[Name], [t0].[OwnerFullName], [t0].[SynergyWithId]
+                @"SELECT [g].[FullName], [g].[Nickname], [g].[SquadId], [t2].[Id], [t2].[AmmunitionType], [t2].[IsAutomatic], [t2].[Name], [t2].[OwnerFullName], [t2].[SynergyWithId]
 FROM [Gears] AS [g]
-LEFT JOIN [Tags] AS [t1] ON (([g].[Nickname] = [t1].[GearNickName]) AND [t1].[GearNickName] IS NOT NULL) AND (([g].[SquadId] = [t1].[GearSquadId]) AND [t1].[GearSquadId] IS NOT NULL)
+LEFT JOIN [Tags] AS [t] ON (([g].[Nickname] = [t].[GearNickName]) AND [t].[GearNickName] IS NOT NULL) AND (([g].[SquadId] = [t].[GearSquadId]) AND [t].[GearSquadId] IS NOT NULL)
 LEFT JOIN (
-    SELECT [g1].[Nickname], [g1].[SquadId], [g1].[AssignedCityName], [g1].[CityOrBirthName], [g1].[Discriminator], [g1].[FullName], [g1].[HasSoulPatch], [g1].[LeaderNickname], [g1].[LeaderSquadId], [g1].[Rank]
-    FROM [Gears] AS [g1]
-    WHERE [g1].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t2] ON (([t1].[GearNickName] = [t2].[Nickname]) AND [t1].[GearNickName] IS NOT NULL) AND (([t1].[GearSquadId] = [t2].[SquadId]) AND [t1].[GearSquadId] IS NOT NULL)
+    SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
+    FROM [Gears] AS [g0]
+    WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
+) AS [t0] ON (([t].[GearNickName] = [t0].[Nickname]) AND [t].[GearNickName] IS NOT NULL) AND (([t].[GearSquadId] = [t0].[SquadId]) AND [t].[GearSquadId] IS NOT NULL)
 LEFT JOIN (
-    SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [t].[Nickname]
+    SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [t1].[Nickname]
     FROM [Weapons] AS [w]
     LEFT JOIN (
-        SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
-        FROM [Gears] AS [g0]
-        WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
-    ) AS [t] ON [w].[OwnerFullName] = [t].[FullName]
-) AS [t0] ON [t2].[FullName] = [t0].[OwnerFullName]
+        SELECT [g1].[Nickname], [g1].[SquadId], [g1].[AssignedCityName], [g1].[CityOrBirthName], [g1].[Discriminator], [g1].[FullName], [g1].[HasSoulPatch], [g1].[LeaderNickname], [g1].[LeaderSquadId], [g1].[Rank]
+        FROM [Gears] AS [g1]
+        WHERE [g1].[Discriminator] IN (N'Gear', N'Officer')
+    ) AS [t1] ON [w].[OwnerFullName] = [t1].[FullName]
+) AS [t2] ON [t0].[FullName] = [t2].[OwnerFullName]
 WHERE ([g].[Discriminator] IN (N'Gear', N'Officer') AND ([g].[Discriminator] = N'Officer')) AND EXISTS (
     SELECT 1
     FROM [Gears] AS [g2]
     WHERE [g2].[Discriminator] IN (N'Gear', N'Officer') AND ((([g].[Nickname] = [g2].[LeaderNickname]) AND [g2].[LeaderNickname] IS NOT NULL) AND ([g].[SquadId] = [g2].[LeaderSquadId])))
-ORDER BY [g].[HasSoulPatch] DESC, [t1].[Note], [g].[Nickname], [g].[SquadId], [t0].[IsAutomatic], [t0].[Nickname] DESC, [t0].[Id]");
+ORDER BY [g].[HasSoulPatch] DESC, [t].[Note], [g].[Nickname], [g].[SquadId], [t2].[IsAutomatic], [t2].[Nickname] DESC, [t2].[Id]");
         }
 
         public override async Task Multiple_orderby_with_navigation_expansion_on_one_of_the_order_bys_inside_subquery_complex_orderings(bool isAsync)
@@ -4443,31 +4443,31 @@ ORDER BY [g].[HasSoulPatch] DESC, [t1].[Note], [g].[Nickname], [g].[SquadId], [t
             await base.Multiple_orderby_with_navigation_expansion_on_one_of_the_order_bys_inside_subquery_complex_orderings(isAsync);
 
             AssertSql(
-                @"SELECT [g].[FullName], [g].[Nickname], [g].[SquadId], [t0].[Id], [t0].[AmmunitionType], [t0].[IsAutomatic], [t0].[Name], [t0].[OwnerFullName], [t0].[SynergyWithId]
+                @"SELECT [g].[FullName], [g].[Nickname], [g].[SquadId], [t2].[Id], [t2].[AmmunitionType], [t2].[IsAutomatic], [t2].[Name], [t2].[OwnerFullName], [t2].[SynergyWithId]
 FROM [Gears] AS [g]
-LEFT JOIN [Tags] AS [t1] ON (([g].[Nickname] = [t1].[GearNickName]) AND [t1].[GearNickName] IS NOT NULL) AND (([g].[SquadId] = [t1].[GearSquadId]) AND [t1].[GearSquadId] IS NOT NULL)
+LEFT JOIN [Tags] AS [t] ON (([g].[Nickname] = [t].[GearNickName]) AND [t].[GearNickName] IS NOT NULL) AND (([g].[SquadId] = [t].[GearSquadId]) AND [t].[GearSquadId] IS NOT NULL)
 LEFT JOIN (
-    SELECT [g1].[Nickname], [g1].[SquadId], [g1].[AssignedCityName], [g1].[CityOrBirthName], [g1].[Discriminator], [g1].[FullName], [g1].[HasSoulPatch], [g1].[LeaderNickname], [g1].[LeaderSquadId], [g1].[Rank]
-    FROM [Gears] AS [g1]
-    WHERE [g1].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t2] ON (([t1].[GearNickName] = [t2].[Nickname]) AND [t1].[GearNickName] IS NOT NULL) AND (([t1].[GearSquadId] = [t2].[SquadId]) AND [t1].[GearSquadId] IS NOT NULL)
+    SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
+    FROM [Gears] AS [g0]
+    WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
+) AS [t0] ON (([t].[GearNickName] = [t0].[Nickname]) AND [t].[GearNickName] IS NOT NULL) AND (([t].[GearSquadId] = [t0].[SquadId]) AND [t].[GearSquadId] IS NOT NULL)
 LEFT JOIN (
-    SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], (
+    SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId], (
         SELECT COUNT(*)
-        FROM [Weapons] AS [w0]
-        WHERE (([t].[FullName] = [w0].[OwnerFullName]) AND ([t].[FullName] IS NOT NULL AND [w0].[OwnerFullName] IS NOT NULL)) OR ([t].[FullName] IS NULL AND [w0].[OwnerFullName] IS NULL)) AS [c]
-    FROM [Weapons] AS [w]
+        FROM [Weapons] AS [w]
+        WHERE (([t1].[FullName] = [w].[OwnerFullName]) AND ([t1].[FullName] IS NOT NULL AND [w].[OwnerFullName] IS NOT NULL)) OR ([t1].[FullName] IS NULL AND [w].[OwnerFullName] IS NULL)) AS [c]
+    FROM [Weapons] AS [w0]
     LEFT JOIN (
-        SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
-        FROM [Gears] AS [g0]
-        WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
-    ) AS [t] ON [w].[OwnerFullName] = [t].[FullName]
-) AS [t0] ON [t2].[FullName] = [t0].[OwnerFullName]
+        SELECT [g1].[Nickname], [g1].[SquadId], [g1].[AssignedCityName], [g1].[CityOrBirthName], [g1].[Discriminator], [g1].[FullName], [g1].[HasSoulPatch], [g1].[LeaderNickname], [g1].[LeaderSquadId], [g1].[Rank]
+        FROM [Gears] AS [g1]
+        WHERE [g1].[Discriminator] IN (N'Gear', N'Officer')
+    ) AS [t1] ON [w0].[OwnerFullName] = [t1].[FullName]
+) AS [t2] ON [t0].[FullName] = [t2].[OwnerFullName]
 WHERE ([g].[Discriminator] IN (N'Gear', N'Officer') AND ([g].[Discriminator] = N'Officer')) AND EXISTS (
     SELECT 1
     FROM [Gears] AS [g2]
     WHERE [g2].[Discriminator] IN (N'Gear', N'Officer') AND ((([g].[Nickname] = [g2].[LeaderNickname]) AND [g2].[LeaderNickname] IS NOT NULL) AND ([g].[SquadId] = [g2].[LeaderSquadId])))
-ORDER BY [g].[HasSoulPatch] DESC, [t1].[Note], [g].[Nickname], [g].[SquadId], [t0].[Id] DESC, [t0].[c]");
+ORDER BY [g].[HasSoulPatch] DESC, [t].[Note], [g].[Nickname], [g].[SquadId], [t2].[Id] DESC, [t2].[c]");
         }
 
         public override async Task Correlated_collections_multiple_nested_complex_collections(bool isAsync)
@@ -4475,50 +4475,50 @@ ORDER BY [g].[HasSoulPatch] DESC, [t1].[Note], [g].[Nickname], [g].[SquadId], [t
             await base.Correlated_collections_multiple_nested_complex_collections(isAsync);
 
             AssertSql(
-                @"SELECT [g].[FullName], [g].[Nickname], [g].[SquadId], [t2].[FullName], [t2].[Nickname], [t2].[SquadId], [t2].[Id], [t2].[Name], [t2].[IsAutomatic], [t2].[Id0], [t2].[Nickname0], [t2].[HasSoulPatch], [t2].[SquadId0], [t4].[Id], [t4].[AmmunitionType], [t4].[IsAutomatic], [t4].[Name], [t4].[OwnerFullName], [t4].[SynergyWithId]
+                @"SELECT [g].[FullName], [g].[Nickname], [g].[SquadId], [t4].[FullName], [t4].[Nickname], [t4].[SquadId], [t4].[Id], [t4].[Name], [t4].[IsAutomatic], [t4].[Id0], [t4].[Nickname0], [t4].[HasSoulPatch], [t4].[SquadId0], [t6].[Id], [t6].[AmmunitionType], [t6].[IsAutomatic], [t6].[Name], [t6].[OwnerFullName], [t6].[SynergyWithId]
 FROM [Gears] AS [g]
-LEFT JOIN [Tags] AS [t5] ON (([g].[Nickname] = [t5].[GearNickName]) AND [t5].[GearNickName] IS NOT NULL) AND (([g].[SquadId] = [t5].[GearSquadId]) AND [t5].[GearSquadId] IS NOT NULL)
+LEFT JOIN [Tags] AS [t] ON (([g].[Nickname] = [t].[GearNickName]) AND [t].[GearNickName] IS NOT NULL) AND (([g].[SquadId] = [t].[GearSquadId]) AND [t].[GearSquadId] IS NOT NULL)
 LEFT JOIN (
-    SELECT [g4].[Nickname], [g4].[SquadId], [g4].[AssignedCityName], [g4].[CityOrBirthName], [g4].[Discriminator], [g4].[FullName], [g4].[HasSoulPatch], [g4].[LeaderNickname], [g4].[LeaderSquadId], [g4].[Rank]
-    FROM [Gears] AS [g4]
-    WHERE [g4].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t6] ON (([t5].[GearNickName] = [t6].[Nickname]) AND [t5].[GearNickName] IS NOT NULL) AND (([t5].[GearSquadId] = [t6].[SquadId]) AND [t5].[GearSquadId] IS NOT NULL)
-LEFT JOIN (
-    SELECT [g0].[FullName], [g0].[Nickname], [g0].[SquadId], [t1].[Id], [t1].[Name], [t1].[IsAutomatic], [t1].[Id0], [t1].[Nickname] AS [Nickname0], [t1].[HasSoulPatch], [t1].[SquadId] AS [SquadId0], [g0].[Rank], [t1].[IsAutomatic0], [g0].[LeaderNickname], [g0].[LeaderSquadId]
+    SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
     FROM [Gears] AS [g0]
+    WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
+) AS [t0] ON (([t].[GearNickName] = [t0].[Nickname]) AND [t].[GearNickName] IS NOT NULL) AND (([t].[GearSquadId] = [t0].[SquadId]) AND [t].[GearSquadId] IS NOT NULL)
+LEFT JOIN (
+    SELECT [g1].[FullName], [g1].[Nickname], [g1].[SquadId], [t3].[Id], [t3].[Name], [t3].[IsAutomatic], [t3].[Id0], [t3].[Nickname] AS [Nickname0], [t3].[HasSoulPatch], [t3].[SquadId] AS [SquadId0], [g1].[Rank], [t3].[IsAutomatic0], [g1].[LeaderNickname], [g1].[LeaderSquadId]
+    FROM [Gears] AS [g1]
     LEFT JOIN (
-        SELECT [w].[Id], [w0].[Name], [w0].[IsAutomatic], [w0].[Id] AS [Id0], [t].[Nickname], [t].[HasSoulPatch], [t].[SquadId], [w].[IsAutomatic] AS [IsAutomatic0], [w].[OwnerFullName]
+        SELECT [w].[Id], [w0].[Name], [w0].[IsAutomatic], [w0].[Id] AS [Id0], [t2].[Nickname], [t2].[HasSoulPatch], [t2].[SquadId], [w].[IsAutomatic] AS [IsAutomatic0], [w].[OwnerFullName]
         FROM [Weapons] AS [w]
         LEFT JOIN (
             SELECT [g2].[Nickname], [g2].[SquadId], [g2].[AssignedCityName], [g2].[CityOrBirthName], [g2].[Discriminator], [g2].[FullName], [g2].[HasSoulPatch], [g2].[LeaderNickname], [g2].[LeaderSquadId], [g2].[Rank]
             FROM [Gears] AS [g2]
             WHERE [g2].[Discriminator] IN (N'Gear', N'Officer')
-        ) AS [t0] ON [w].[OwnerFullName] = [t0].[FullName]
-        LEFT JOIN [Squads] AS [s] ON [t0].[SquadId] = [s].[Id]
-        LEFT JOIN [Weapons] AS [w0] ON [t0].[FullName] = [w0].[OwnerFullName]
+        ) AS [t1] ON [w].[OwnerFullName] = [t1].[FullName]
+        LEFT JOIN [Squads] AS [s] ON [t1].[SquadId] = [s].[Id]
+        LEFT JOIN [Weapons] AS [w0] ON [t1].[FullName] = [w0].[OwnerFullName]
         LEFT JOIN (
-            SELECT [g1].[Nickname], [g1].[HasSoulPatch], [g1].[SquadId]
-            FROM [Gears] AS [g1]
-            WHERE [g1].[Discriminator] IN (N'Gear', N'Officer')
-        ) AS [t] ON [s].[Id] = [t].[SquadId]
+            SELECT [g3].[Nickname], [g3].[HasSoulPatch], [g3].[SquadId]
+            FROM [Gears] AS [g3]
+            WHERE [g3].[Discriminator] IN (N'Gear', N'Officer')
+        ) AS [t2] ON [s].[Id] = [t2].[SquadId]
         WHERE ([w].[Name] <> N'Bar') OR [w].[Name] IS NULL
-    ) AS [t1] ON [g0].[FullName] = [t1].[OwnerFullName]
-    WHERE [g0].[Discriminator] IN (N'Gear', N'Officer') AND ([g0].[FullName] <> N'Foo')
-) AS [t2] ON (([g].[Nickname] = [t2].[LeaderNickname]) AND [t2].[LeaderNickname] IS NOT NULL) AND ([g].[SquadId] = [t2].[LeaderSquadId])
+    ) AS [t3] ON [g1].[FullName] = [t3].[OwnerFullName]
+    WHERE [g1].[Discriminator] IN (N'Gear', N'Officer') AND ([g1].[FullName] <> N'Foo')
+) AS [t4] ON (([g].[Nickname] = [t4].[LeaderNickname]) AND [t4].[LeaderNickname] IS NOT NULL) AND ([g].[SquadId] = [t4].[LeaderSquadId])
 LEFT JOIN (
-    SELECT [w1].[Id], [w1].[AmmunitionType], [w1].[IsAutomatic], [w1].[Name], [w1].[OwnerFullName], [w1].[SynergyWithId], [t3].[Nickname]
+    SELECT [w1].[Id], [w1].[AmmunitionType], [w1].[IsAutomatic], [w1].[Name], [w1].[OwnerFullName], [w1].[SynergyWithId], [t5].[Nickname]
     FROM [Weapons] AS [w1]
     LEFT JOIN (
-        SELECT [g3].[Nickname], [g3].[SquadId], [g3].[AssignedCityName], [g3].[CityOrBirthName], [g3].[Discriminator], [g3].[FullName], [g3].[HasSoulPatch], [g3].[LeaderNickname], [g3].[LeaderSquadId], [g3].[Rank]
-        FROM [Gears] AS [g3]
-        WHERE [g3].[Discriminator] IN (N'Gear', N'Officer')
-    ) AS [t3] ON [w1].[OwnerFullName] = [t3].[FullName]
-) AS [t4] ON [t6].[FullName] = [t4].[OwnerFullName]
+        SELECT [g4].[Nickname], [g4].[SquadId], [g4].[AssignedCityName], [g4].[CityOrBirthName], [g4].[Discriminator], [g4].[FullName], [g4].[HasSoulPatch], [g4].[LeaderNickname], [g4].[LeaderSquadId], [g4].[Rank]
+        FROM [Gears] AS [g4]
+        WHERE [g4].[Discriminator] IN (N'Gear', N'Officer')
+    ) AS [t5] ON [w1].[OwnerFullName] = [t5].[FullName]
+) AS [t6] ON [t0].[FullName] = [t6].[OwnerFullName]
 WHERE ([g].[Discriminator] IN (N'Gear', N'Officer') AND ([g].[Discriminator] = N'Officer')) AND EXISTS (
     SELECT 1
     FROM [Gears] AS [g5]
     WHERE [g5].[Discriminator] IN (N'Gear', N'Officer') AND ((([g].[Nickname] = [g5].[LeaderNickname]) AND [g5].[LeaderNickname] IS NOT NULL) AND ([g].[SquadId] = [g5].[LeaderSquadId])))
-ORDER BY [g].[HasSoulPatch] DESC, [t5].[Note], [g].[Nickname], [g].[SquadId], [t2].[Rank], [t2].[Nickname], [t2].[SquadId], [t2].[IsAutomatic0], [t2].[Id], [t2].[Id0], [t2].[Nickname0], [t2].[SquadId0], [t4].[IsAutomatic], [t4].[Nickname] DESC, [t4].[Id]");
+ORDER BY [g].[HasSoulPatch] DESC, [t].[Note], [g].[Nickname], [g].[SquadId], [t4].[Rank], [t4].[Nickname], [t4].[SquadId], [t4].[IsAutomatic0], [t4].[Id], [t4].[Id0], [t4].[Nickname0], [t4].[SquadId0], [t6].[IsAutomatic], [t6].[Nickname] DESC, [t6].[Id]");
         }
 
         public override async Task Correlated_collections_inner_subquery_selector_references_outer_qsre(bool isAsync)
@@ -4701,16 +4701,16 @@ ORDER BY [s].[Name]");
             await base.Correlated_collections_on_left_join_with_predicate(isAsync);
 
             AssertSql(
-                @"SELECT [t].[Nickname], [t0].[Id], [w].[Name], [w].[Id]
-FROM [Tags] AS [t0]
+                @"SELECT [t0].[Nickname], [t].[Id], [w].[Name], [w].[Id]
+FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
     FROM [Gears] AS [g]
     WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t] ON [t0].[GearNickName] = [t].[Nickname]
-LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
-WHERE [t].[HasSoulPatch] <> CAST(1 AS bit)
-ORDER BY [t0].[Id], [w].[Id]");
+) AS [t0] ON [t].[GearNickName] = [t0].[Nickname]
+LEFT JOIN [Weapons] AS [w] ON [t0].[FullName] = [w].[OwnerFullName]
+WHERE [t0].[HasSoulPatch] <> CAST(1 AS bit)
+ORDER BY [t].[Id], [w].[Id]");
         }
 
         public override async Task Correlated_collections_on_left_join_with_null_value(bool isAsync)
@@ -4734,19 +4734,19 @@ ORDER BY [t].[Note], [t].[Id], [w].[Id]");
             await base.Correlated_collections_left_join_with_self_reference(isAsync);
 
             AssertSql(
-                @"SELECT [t].[Note], [t].[Id], [t0].[FullName], [t0].[Nickname], [t0].[SquadId]
+                @"SELECT [t].[Note], [t].[Id], [t1].[FullName], [t1].[Nickname], [t1].[SquadId]
 FROM [Tags] AS [t]
 LEFT JOIN (
-    SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
-    FROM [Gears] AS [g0]
-    WHERE [g0].[Discriminator] IN (N'Gear', N'Officer') AND ([g0].[Discriminator] = N'Officer')
-) AS [t1] ON [t].[GearNickName] = [t1].[Nickname]
-LEFT JOIN (
-    SELECT [g].[FullName], [g].[Nickname], [g].[SquadId], [g].[LeaderNickname], [g].[LeaderSquadId]
+    SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
     FROM [Gears] AS [g]
-    WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t0] ON ((([t1].[Nickname] = [t0].[LeaderNickname]) AND ([t1].[Nickname] IS NOT NULL AND [t0].[LeaderNickname] IS NOT NULL)) OR ([t1].[Nickname] IS NULL AND [t0].[LeaderNickname] IS NULL)) AND (([t1].[SquadId] = [t0].[LeaderSquadId]) AND [t1].[SquadId] IS NOT NULL)
-ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId]");
+    WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND ([g].[Discriminator] = N'Officer')
+) AS [t0] ON [t].[GearNickName] = [t0].[Nickname]
+LEFT JOIN (
+    SELECT [g0].[FullName], [g0].[Nickname], [g0].[SquadId], [g0].[LeaderNickname], [g0].[LeaderSquadId]
+    FROM [Gears] AS [g0]
+    WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
+) AS [t1] ON ((([t0].[Nickname] = [t1].[LeaderNickname]) AND ([t0].[Nickname] IS NOT NULL AND [t1].[LeaderNickname] IS NOT NULL)) OR ([t0].[Nickname] IS NULL AND [t1].[LeaderNickname] IS NULL)) AND (([t0].[SquadId] = [t1].[LeaderSquadId]) AND [t0].[SquadId] IS NOT NULL)
+ORDER BY [t].[Id], [t1].[Nickname], [t1].[SquadId]");
         }
 
         public override async Task Correlated_collections_deeply_nested_left_join(bool isAsync)
@@ -4754,25 +4754,25 @@ ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId]");
             await base.Correlated_collections_deeply_nested_left_join(isAsync);
 
             AssertSql(
-                @"SELECT [t].[Id], [t1].[Nickname], [t1].[SquadId], [t1].[Id], [t1].[AmmunitionType], [t1].[IsAutomatic], [t1].[Name], [t1].[OwnerFullName], [t1].[SynergyWithId]
+                @"SELECT [t].[Id], [t2].[Nickname], [t2].[SquadId], [t2].[Id], [t2].[AmmunitionType], [t2].[IsAutomatic], [t2].[Name], [t2].[OwnerFullName], [t2].[SynergyWithId]
 FROM [Tags] AS [t]
 LEFT JOIN (
-    SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
-    FROM [Gears] AS [g0]
-    WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t2] ON [t].[GearNickName] = [t2].[Nickname]
-LEFT JOIN [Squads] AS [s] ON [t2].[SquadId] = [s].[Id]
-LEFT JOIN (
-    SELECT [g].[Nickname], [g].[SquadId], [t0].[Id], [t0].[AmmunitionType], [t0].[IsAutomatic], [t0].[Name], [t0].[OwnerFullName], [t0].[SynergyWithId]
+    SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
     FROM [Gears] AS [g]
+    WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
+) AS [t0] ON [t].[GearNickName] = [t0].[Nickname]
+LEFT JOIN [Squads] AS [s] ON [t0].[SquadId] = [s].[Id]
+LEFT JOIN (
+    SELECT [g0].[Nickname], [g0].[SquadId], [t1].[Id], [t1].[AmmunitionType], [t1].[IsAutomatic], [t1].[Name], [t1].[OwnerFullName], [t1].[SynergyWithId]
+    FROM [Gears] AS [g0]
     LEFT JOIN (
         SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
         FROM [Weapons] AS [w]
         WHERE [w].[IsAutomatic] = CAST(1 AS bit)
-    ) AS [t0] ON [g].[FullName] = [t0].[OwnerFullName]
-    WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND ([g].[HasSoulPatch] = CAST(1 AS bit))
-) AS [t1] ON [s].[Id] = [t1].[SquadId]
-ORDER BY [t].[Note], [t2].[Nickname] DESC, [t].[Id], [t1].[Nickname], [t1].[SquadId], [t1].[Id]");
+    ) AS [t1] ON [g0].[FullName] = [t1].[OwnerFullName]
+    WHERE [g0].[Discriminator] IN (N'Gear', N'Officer') AND ([g0].[HasSoulPatch] = CAST(1 AS bit))
+) AS [t2] ON [s].[Id] = [t2].[SquadId]
+ORDER BY [t].[Note], [t0].[Nickname] DESC, [t].[Id], [t2].[Nickname], [t2].[SquadId], [t2].[Id]");
         }
 
         public override async Task Correlated_collections_from_left_join_with_additional_elements_projected_of_that_join(bool isAsync)
@@ -4780,25 +4780,25 @@ ORDER BY [t].[Note], [t2].[Nickname] DESC, [t].[Id], [t1].[Nickname], [t1].[Squa
             await base.Correlated_collections_from_left_join_with_additional_elements_projected_of_that_join(isAsync);
 
             AssertSql(
-                @"SELECT [w].[Id], [t0].[Rank], [t0].[Nickname], [t0].[SquadId], [t0].[Id], [t0].[AmmunitionType], [t0].[IsAutomatic], [t0].[Name], [t0].[OwnerFullName], [t0].[SynergyWithId]
+                @"SELECT [w].[Id], [t1].[Rank], [t1].[Nickname], [t1].[SquadId], [t1].[Id], [t1].[AmmunitionType], [t1].[IsAutomatic], [t1].[Name], [t1].[OwnerFullName], [t1].[SynergyWithId]
 FROM [Weapons] AS [w]
 LEFT JOIN (
-    SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
-    FROM [Gears] AS [g0]
-    WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t1] ON [w].[OwnerFullName] = [t1].[FullName]
-LEFT JOIN [Squads] AS [s] ON [t1].[SquadId] = [s].[Id]
-LEFT JOIN (
-    SELECT [g].[Rank], [g].[Nickname], [g].[SquadId], [t].[Id], [t].[AmmunitionType], [t].[IsAutomatic], [t].[Name], [t].[OwnerFullName], [t].[SynergyWithId], [g].[FullName]
+    SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
     FROM [Gears] AS [g]
+    WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
+) AS [t] ON [w].[OwnerFullName] = [t].[FullName]
+LEFT JOIN [Squads] AS [s] ON [t].[SquadId] = [s].[Id]
+LEFT JOIN (
+    SELECT [g0].[Rank], [g0].[Nickname], [g0].[SquadId], [t0].[Id], [t0].[AmmunitionType], [t0].[IsAutomatic], [t0].[Name], [t0].[OwnerFullName], [t0].[SynergyWithId], [g0].[FullName]
+    FROM [Gears] AS [g0]
     LEFT JOIN (
         SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
         FROM [Weapons] AS [w0]
         WHERE [w0].[IsAutomatic] <> CAST(1 AS bit)
-    ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
-    WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t0] ON [s].[Id] = [t0].[SquadId]
-ORDER BY [w].[Name], [w].[Id], [t0].[FullName] DESC, [t0].[Nickname], [t0].[SquadId], [t0].[Id]");
+    ) AS [t0] ON [g0].[FullName] = [t0].[OwnerFullName]
+    WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
+) AS [t1] ON [s].[Id] = [t1].[SquadId]
+ORDER BY [w].[Name], [w].[Id], [t1].[FullName] DESC, [t1].[Nickname], [t1].[SquadId], [t1].[Id]");
         }
 
         public override async Task Correlated_collections_complex_scenario1(bool isAsync)
@@ -4809,19 +4809,19 @@ ORDER BY [w].[Name], [w].[Id], [t0].[FullName] DESC, [t0].[Nickname], [t0].[Squa
                 @"SELECT [g].[FullName], [g].[Nickname], [g].[SquadId], [t1].[Id], [t1].[Nickname], [t1].[HasSoulPatch], [t1].[SquadId]
 FROM [Gears] AS [g]
 LEFT JOIN (
-    SELECT [w].[Id], [t].[Nickname], [t].[HasSoulPatch], [t].[SquadId], [w].[OwnerFullName]
+    SELECT [w].[Id], [t0].[Nickname], [t0].[HasSoulPatch], [t0].[SquadId], [w].[OwnerFullName]
     FROM [Weapons] AS [w]
     LEFT JOIN (
-        SELECT [g1].[Nickname], [g1].[SquadId], [g1].[AssignedCityName], [g1].[CityOrBirthName], [g1].[Discriminator], [g1].[FullName], [g1].[HasSoulPatch], [g1].[LeaderNickname], [g1].[LeaderSquadId], [g1].[Rank]
-        FROM [Gears] AS [g1]
-        WHERE [g1].[Discriminator] IN (N'Gear', N'Officer')
-    ) AS [t0] ON [w].[OwnerFullName] = [t0].[FullName]
-    LEFT JOIN [Squads] AS [s] ON [t0].[SquadId] = [s].[Id]
-    LEFT JOIN (
-        SELECT [g0].[Nickname], [g0].[HasSoulPatch], [g0].[SquadId]
+        SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
         FROM [Gears] AS [g0]
         WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
-    ) AS [t] ON [s].[Id] = [t].[SquadId]
+    ) AS [t] ON [w].[OwnerFullName] = [t].[FullName]
+    LEFT JOIN [Squads] AS [s] ON [t].[SquadId] = [s].[Id]
+    LEFT JOIN (
+        SELECT [g1].[Nickname], [g1].[HasSoulPatch], [g1].[SquadId]
+        FROM [Gears] AS [g1]
+        WHERE [g1].[Discriminator] IN (N'Gear', N'Officer')
+    ) AS [t0] ON [s].[Id] = [t0].[SquadId]
 ) AS [t1] ON [g].[FullName] = [t1].[OwnerFullName]
 WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
 ORDER BY [g].[Nickname], [g].[SquadId], [t1].[Id], [t1].[Nickname], [t1].[SquadId]");
@@ -4838,19 +4838,19 @@ LEFT JOIN (
     SELECT [g0].[FullName], [g0].[Nickname], [g0].[SquadId], [t1].[Id], [t1].[Nickname] AS [Nickname0], [t1].[HasSoulPatch], [t1].[SquadId] AS [SquadId0], [g0].[LeaderNickname], [g0].[LeaderSquadId]
     FROM [Gears] AS [g0]
     LEFT JOIN (
-        SELECT [w].[Id], [t].[Nickname], [t].[HasSoulPatch], [t].[SquadId], [w].[OwnerFullName]
+        SELECT [w].[Id], [t0].[Nickname], [t0].[HasSoulPatch], [t0].[SquadId], [w].[OwnerFullName]
         FROM [Weapons] AS [w]
         LEFT JOIN (
-            SELECT [g2].[Nickname], [g2].[SquadId], [g2].[AssignedCityName], [g2].[CityOrBirthName], [g2].[Discriminator], [g2].[FullName], [g2].[HasSoulPatch], [g2].[LeaderNickname], [g2].[LeaderSquadId], [g2].[Rank]
-            FROM [Gears] AS [g2]
-            WHERE [g2].[Discriminator] IN (N'Gear', N'Officer')
-        ) AS [t0] ON [w].[OwnerFullName] = [t0].[FullName]
-        LEFT JOIN [Squads] AS [s] ON [t0].[SquadId] = [s].[Id]
-        LEFT JOIN (
-            SELECT [g1].[Nickname], [g1].[HasSoulPatch], [g1].[SquadId]
+            SELECT [g1].[Nickname], [g1].[SquadId], [g1].[AssignedCityName], [g1].[CityOrBirthName], [g1].[Discriminator], [g1].[FullName], [g1].[HasSoulPatch], [g1].[LeaderNickname], [g1].[LeaderSquadId], [g1].[Rank]
             FROM [Gears] AS [g1]
             WHERE [g1].[Discriminator] IN (N'Gear', N'Officer')
-        ) AS [t] ON [s].[Id] = [t].[SquadId]
+        ) AS [t] ON [w].[OwnerFullName] = [t].[FullName]
+        LEFT JOIN [Squads] AS [s] ON [t].[SquadId] = [s].[Id]
+        LEFT JOIN (
+            SELECT [g2].[Nickname], [g2].[HasSoulPatch], [g2].[SquadId]
+            FROM [Gears] AS [g2]
+            WHERE [g2].[Discriminator] IN (N'Gear', N'Officer')
+        ) AS [t0] ON [s].[Id] = [t0].[SquadId]
     ) AS [t1] ON [g0].[FullName] = [t1].[OwnerFullName]
     WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
 ) AS [t2] ON (([g].[Nickname] = [t2].[LeaderNickname]) AND [t2].[LeaderNickname] IS NOT NULL) AND ([g].[SquadId] = [t2].[LeaderSquadId])
@@ -4866,19 +4866,19 @@ ORDER BY [g].[Nickname], [g].[SquadId], [t2].[Nickname], [t2].[SquadId], [t2].[I
                 @"SELECT [g].[FullName], [g].[Nickname], [g].[SquadId], [t1].[Id], [t1].[Nickname], [t1].[HasSoulPatch], [t1].[SquadId]
 FROM [Gears] AS [g]
 LEFT JOIN (
-    SELECT [w].[Id], [t].[Nickname], [t].[HasSoulPatch], [t].[SquadId], [w].[OwnerFullName]
+    SELECT [w].[Id], [t0].[Nickname], [t0].[HasSoulPatch], [t0].[SquadId], [w].[OwnerFullName]
     FROM [Weapons] AS [w]
     LEFT JOIN (
-        SELECT [g1].[Nickname], [g1].[SquadId], [g1].[AssignedCityName], [g1].[CityOrBirthName], [g1].[Discriminator], [g1].[FullName], [g1].[HasSoulPatch], [g1].[LeaderNickname], [g1].[LeaderSquadId], [g1].[Rank]
-        FROM [Gears] AS [g1]
-        WHERE [g1].[Discriminator] IN (N'Gear', N'Officer')
-    ) AS [t0] ON [w].[OwnerFullName] = [t0].[FullName]
-    LEFT JOIN [Squads] AS [s] ON [t0].[SquadId] = [s].[Id]
-    LEFT JOIN (
-        SELECT [g0].[Nickname], [g0].[HasSoulPatch], [g0].[SquadId]
+        SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
         FROM [Gears] AS [g0]
         WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
-    ) AS [t] ON [s].[Id] = [t].[SquadId]
+    ) AS [t] ON [w].[OwnerFullName] = [t].[FullName]
+    LEFT JOIN [Squads] AS [s] ON [t].[SquadId] = [s].[Id]
+    LEFT JOIN (
+        SELECT [g1].[Nickname], [g1].[HasSoulPatch], [g1].[SquadId]
+        FROM [Gears] AS [g1]
+        WHERE [g1].[Discriminator] IN (N'Gear', N'Officer')
+    ) AS [t0] ON [s].[Id] = [t0].[SquadId]
 ) AS [t1] ON [g].[FullName] = [t1].[OwnerFullName]
 WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
 ORDER BY [g].[FullName], [g].[Nickname] DESC, [g].[SquadId], [t1].[Id], [t1].[Nickname], [t1].[SquadId]");
@@ -4895,19 +4895,19 @@ LEFT JOIN (
     SELECT [g0].[FullName], [g0].[Nickname], [g0].[SquadId], [t1].[Id], [t1].[Nickname] AS [Nickname0], [t1].[HasSoulPatch], [t1].[SquadId] AS [SquadId0], [g0].[HasSoulPatch] AS [HasSoulPatch0], [t1].[IsAutomatic], [t1].[Name], [g0].[LeaderNickname], [g0].[LeaderSquadId]
     FROM [Gears] AS [g0]
     LEFT JOIN (
-        SELECT [w].[Id], [t].[Nickname], [t].[HasSoulPatch], [t].[SquadId], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName]
+        SELECT [w].[Id], [t0].[Nickname], [t0].[HasSoulPatch], [t0].[SquadId], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName]
         FROM [Weapons] AS [w]
         LEFT JOIN (
-            SELECT [g2].[Nickname], [g2].[SquadId], [g2].[AssignedCityName], [g2].[CityOrBirthName], [g2].[Discriminator], [g2].[FullName], [g2].[HasSoulPatch], [g2].[LeaderNickname], [g2].[LeaderSquadId], [g2].[Rank]
-            FROM [Gears] AS [g2]
-            WHERE [g2].[Discriminator] IN (N'Gear', N'Officer')
-        ) AS [t0] ON [w].[OwnerFullName] = [t0].[FullName]
-        LEFT JOIN [Squads] AS [s] ON [t0].[SquadId] = [s].[Id]
-        LEFT JOIN (
-            SELECT [g1].[Nickname], [g1].[HasSoulPatch], [g1].[SquadId]
+            SELECT [g1].[Nickname], [g1].[SquadId], [g1].[AssignedCityName], [g1].[CityOrBirthName], [g1].[Discriminator], [g1].[FullName], [g1].[HasSoulPatch], [g1].[LeaderNickname], [g1].[LeaderSquadId], [g1].[Rank]
             FROM [Gears] AS [g1]
             WHERE [g1].[Discriminator] IN (N'Gear', N'Officer')
-        ) AS [t] ON [s].[Id] = [t].[SquadId]
+        ) AS [t] ON [w].[OwnerFullName] = [t].[FullName]
+        LEFT JOIN [Squads] AS [s] ON [t].[SquadId] = [s].[Id]
+        LEFT JOIN (
+            SELECT [g2].[Nickname], [g2].[HasSoulPatch], [g2].[SquadId]
+            FROM [Gears] AS [g2]
+            WHERE [g2].[Discriminator] IN (N'Gear', N'Officer')
+        ) AS [t0] ON [s].[Id] = [t0].[SquadId]
     ) AS [t1] ON [g0].[FullName] = [t1].[OwnerFullName]
     WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
 ) AS [t2] ON (([g].[Nickname] = [t2].[LeaderNickname]) AND [t2].[LeaderNickname] IS NOT NULL) AND ([g].[SquadId] = [t2].[LeaderSquadId])
@@ -5104,16 +5104,16 @@ WHERE [l].[Discriminator] IN (N'LocustLeader', N'LocustCommander') AND (([t].[Er
 
 SELECT [t1].[Name], [t1].[Discriminator], [t1].[LocustHordeId], [t1].[ThreatLevel], [t1].[DefeatedByNickname], [t1].[DefeatedBySquadId], [t1].[HighCommandId], [t2].[Nickname], [t2].[SquadId], [t2].[AssignedCityName], [t2].[CityOrBirthName], [t2].[Discriminator], [t2].[FullName], [t2].[HasSoulPatch], [t2].[LeaderNickname], [t2].[LeaderSquadId], [t2].[Rank], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM (
-    SELECT TOP(@__p_0) [l].[Name], [l].[Discriminator], [l].[LocustHordeId], [l].[ThreatLevel], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [l].[HighCommandId], [t].[Note]
+    SELECT TOP(@__p_0) [l].[Name], [l].[Discriminator], [l].[LocustHordeId], [l].[ThreatLevel], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [l].[HighCommandId], [t0].[Note]
     FROM [LocustLeaders] AS [l]
     LEFT JOIN (
         SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
         FROM [Gears] AS [g]
         WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
-    ) AS [t0] ON (([l].[DefeatedByNickname] = [t0].[Nickname]) AND [l].[DefeatedByNickname] IS NOT NULL) AND (([l].[DefeatedBySquadId] = [t0].[SquadId]) AND [l].[DefeatedBySquadId] IS NOT NULL)
-    LEFT JOIN [Tags] AS [t] ON ((([t0].[Nickname] = [t].[GearNickName]) AND ([t0].[Nickname] IS NOT NULL AND [t].[GearNickName] IS NOT NULL)) OR ([t0].[Nickname] IS NULL AND [t].[GearNickName] IS NULL)) AND ((([t0].[SquadId] = [t].[GearSquadId]) AND ([t0].[SquadId] IS NOT NULL AND [t].[GearSquadId] IS NOT NULL)) OR ([t0].[SquadId] IS NULL AND [t].[GearSquadId] IS NULL))
+    ) AS [t] ON (([l].[DefeatedByNickname] = [t].[Nickname]) AND [l].[DefeatedByNickname] IS NOT NULL) AND (([l].[DefeatedBySquadId] = [t].[SquadId]) AND [l].[DefeatedBySquadId] IS NOT NULL)
+    LEFT JOIN [Tags] AS [t0] ON ((([t].[Nickname] = [t0].[GearNickName]) AND ([t].[Nickname] IS NOT NULL AND [t0].[GearNickName] IS NOT NULL)) OR ([t].[Nickname] IS NULL AND [t0].[GearNickName] IS NULL)) AND ((([t].[SquadId] = [t0].[GearSquadId]) AND ([t].[SquadId] IS NOT NULL AND [t0].[GearSquadId] IS NOT NULL)) OR ([t].[SquadId] IS NULL AND [t0].[GearSquadId] IS NULL))
     WHERE [l].[Discriminator] IN (N'LocustLeader', N'LocustCommander')
-    ORDER BY [t].[Note]
+    ORDER BY [t0].[Note]
 ) AS [t1]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
@@ -5263,17 +5263,17 @@ ORDER BY [g].[Nickname], [g].[SquadId], [t1].[Id]");
             AssertSql(
                 @"SELECT CASE
     WHEN CASE
-        WHEN [t].[HasSoulPatch] = CAST(1 AS bit) THEN CAST(1 AS bit)
-        ELSE COALESCE([t].[HasSoulPatch], CAST(1 AS bit))
+        WHEN [t0].[HasSoulPatch] = CAST(1 AS bit) THEN CAST(1 AS bit)
+        ELSE COALESCE([t0].[HasSoulPatch], CAST(1 AS bit))
     END <> CAST(1 AS bit) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [c]
-FROM [Tags] AS [t0]
+FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
     FROM [Gears] AS [g]
     WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
-) AS [t] ON (([t0].[GearNickName] = [t].[Nickname]) AND [t0].[GearNickName] IS NOT NULL) AND (([t0].[GearSquadId] = [t].[SquadId]) AND [t0].[GearSquadId] IS NOT NULL)");
+) AS [t0] ON (([t].[GearNickName] = [t0].[Nickname]) AND [t].[GearNickName] IS NOT NULL) AND (([t].[GearSquadId] = [t0].[SquadId]) AND [t].[GearSquadId] IS NOT NULL)");
         }
 
         public override async Task Order_by_entity_qsre(bool isAsync)
@@ -5370,10 +5370,10 @@ INNER JOIN [Weapons] AS [w0] ON [w].[Id] = [w0].[Id]");
             await base.Join_on_entity_qsre_keys_outer_key_is_navigation(isAsync);
 
             AssertSql(
-                @"SELECT [w].[Name] AS [Name1], [w0].[Name] AS [Name2]
+                @"SELECT [w].[Name] AS [Name1], [w1].[Name] AS [Name2]
 FROM [Weapons] AS [w]
-LEFT JOIN [Weapons] AS [w1] ON [w].[SynergyWithId] = [w1].[Id]
-INNER JOIN [Weapons] AS [w0] ON [w1].[Id] = [w0].[Id]");
+LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
+INNER JOIN [Weapons] AS [w1] ON [w0].[Id] = [w1].[Id]");
         }
 
         public override async Task Join_on_entity_qsre_keys_inner_key_is_navigation(bool isAsync)
@@ -6213,10 +6213,10 @@ ORDER BY [t].[c] DESC, [t].[Nickname], [t].[SquadId], [t].[FullName]");
             await base.Double_order_by_on_nullable_bool_coming_from_optional_navigation(isAsync);
 
             AssertSql(
-                @"SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
-FROM [Weapons] AS [w0]
-LEFT JOIN [Weapons] AS [w] ON [w0].[SynergyWithId] = [w].[Id]
-ORDER BY [w].[IsAutomatic], [w].[Id]");
+                @"SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+FROM [Weapons] AS [w]
+LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
+ORDER BY [w0].[IsAutomatic], [w0].[Id]");
         }
 
         public override async Task Double_order_by_on_Like(bool isAsync)
@@ -6224,11 +6224,11 @@ ORDER BY [w].[IsAutomatic], [w].[Id]");
             await base.Double_order_by_on_Like(isAsync);
 
             AssertSql(
-                @"SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
-FROM [Weapons] AS [w0]
-LEFT JOIN [Weapons] AS [w] ON [w0].[SynergyWithId] = [w].[Id]
+                @"SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+FROM [Weapons] AS [w]
+LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
 ORDER BY CASE
-    WHEN [w].[Name] LIKE N'%Lancer' THEN CAST(1 AS bit)
+    WHEN [w0].[Name] LIKE N'%Lancer' THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END");
         }
@@ -6238,11 +6238,11 @@ END");
             await base.Double_order_by_on_is_null(isAsync);
 
             AssertSql(
-                @"SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
-FROM [Weapons] AS [w0]
-LEFT JOIN [Weapons] AS [w] ON [w0].[SynergyWithId] = [w].[Id]
+                @"SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+FROM [Weapons] AS [w]
+LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
 ORDER BY CASE
-    WHEN [w].[Name] IS NULL THEN CAST(1 AS bit)
+    WHEN [w0].[Name] IS NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END");
         }
@@ -6306,10 +6306,10 @@ ORDER BY [w].[Id] + 2");
             await base.String_concat_with_null_conditional_argument(isAsync);
 
             AssertSql(
-                @"SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
-FROM [Weapons] AS [w0]
-LEFT JOIN [Weapons] AS [w] ON [w0].[SynergyWithId] = [w].[Id]
-ORDER BY [w].[Name] + CAST(5 AS nvarchar(max))");
+                @"SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+FROM [Weapons] AS [w]
+LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
+ORDER BY [w0].[Name] + CAST(5 AS nvarchar(max))");
         }
 
         public override async Task String_concat_with_null_conditional_argument2(bool isAsync)
@@ -6317,10 +6317,10 @@ ORDER BY [w].[Name] + CAST(5 AS nvarchar(max))");
             await base.String_concat_with_null_conditional_argument2(isAsync);
 
             AssertSql(
-                @"SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
-FROM [Weapons] AS [w0]
-LEFT JOIN [Weapons] AS [w] ON [w0].[SynergyWithId] = [w].[Id]
-ORDER BY [w].[Name] + N'Marcus'' Lancer'");
+                @"SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+FROM [Weapons] AS [w]
+LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
+ORDER BY [w0].[Name] + N'Marcus'' Lancer'");
         }
 
         public override async Task String_concat_on_various_types(bool isAsync)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
@@ -922,10 +922,10 @@ GROUP BY [c].[CustomerID]");
             await base.GroupBy_required_navigation_member_Aggregate(isAsync);
 
             AssertSql(
-                @"SELECT [o].[CustomerID] AS [CustomerId], COUNT(*) AS [Count]
-FROM [Order Details] AS [o0]
-INNER JOIN [Orders] AS [o] ON [o0].[OrderID] = [o].[OrderID]
-GROUP BY [o].[CustomerID]");
+                @"SELECT [o0].[CustomerID] AS [CustomerId], COUNT(*) AS [Count]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+GROUP BY [o0].[CustomerID]");
         }
 
         public override async Task Join_complex_GroupBy_Aggregate(bool isAsync)
@@ -937,21 +937,21 @@ GROUP BY [o].[CustomerID]");
 @__p_1='10'
 @__p_2='50'
 
-SELECT [t].[CustomerID] AS [Key], AVG(CAST([t0].[OrderID] AS float)) AS [Count]
+SELECT [t0].[CustomerID] AS [Key], AVG(CAST([t].[OrderID] AS float)) AS [Count]
 FROM (
     SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
     WHERE [o].[OrderID] < 10400
     ORDER BY [o].[OrderDate]
-) AS [t0]
+) AS [t]
 INNER JOIN (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     WHERE ([c].[CustomerID] <> N'DRACD') AND ([c].[CustomerID] <> N'FOLKO')
     ORDER BY [c].[City]
     OFFSET @__p_1 ROWS FETCH NEXT @__p_2 ROWS ONLY
-) AS [t] ON [t0].[CustomerID] = [t].[CustomerID]
-GROUP BY [t].[CustomerID]");
+) AS [t0] ON [t].[CustomerID] = [t0].[CustomerID]
+GROUP BY [t0].[CustomerID]");
         }
 
         public override async Task GroupJoin_GroupBy_Aggregate(bool isAsync)
@@ -1030,22 +1030,22 @@ GROUP BY [c].[Country]");
 @__p_1='50'
 @__p_2='100'
 
-SELECT [t].[CustomerID] AS [Key], AVG(CAST([t].[OrderID] AS float)) AS [Count]
+SELECT [t0].[CustomerID] AS [Key], AVG(CAST([t0].[OrderID] AS float)) AS [Count]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     WHERE ([c].[CustomerID] <> N'DRACD') AND ([c].[CustomerID] <> N'FOLKO')
     ORDER BY [c].[City]
     OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
-) AS [t0]
+) AS [t]
 INNER JOIN (
     SELECT TOP(@__p_2) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
     WHERE [o].[OrderID] < 10400
     ORDER BY [o].[OrderDate]
-) AS [t] ON [t0].[CustomerID] = [t].[CustomerID]
-WHERE [t].[OrderID] > 10300
-GROUP BY [t].[CustomerID]");
+) AS [t0] ON [t].[CustomerID] = [t0].[CustomerID]
+WHERE [t0].[OrderID] > 10300
+GROUP BY [t0].[CustomerID]");
         }
 
         public override async Task Self_join_GroupBy_Aggregate(bool isAsync)
@@ -1065,11 +1065,11 @@ GROUP BY [o].[CustomerID]");
             await base.GroupBy_multi_navigation_members_Aggregate(isAsync);
 
             AssertSql(
-                @"SELECT [o].[CustomerID], [p].[ProductName], COUNT(*) AS [Count]
-FROM [Order Details] AS [o0]
-INNER JOIN [Orders] AS [o] ON [o0].[OrderID] = [o].[OrderID]
-INNER JOIN [Products] AS [p] ON [o0].[ProductID] = [p].[ProductID]
-GROUP BY [o].[CustomerID], [p].[ProductName]");
+                @"SELECT [o0].[CustomerID], [p].[ProductName], COUNT(*) AS [Count]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]
+GROUP BY [o0].[CustomerID], [p].[ProductName]");
         }
 
         public override async Task Union_simple_groupby(bool isAsync)
@@ -1269,15 +1269,15 @@ ORDER BY COUNT(*), [o].[CustomerID]");
             await base.GroupBy_Aggregate_Join(isAsync);
 
             AssertSql(
-                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM (
-    SELECT [o0].[CustomerID], MAX([o0].[OrderID]) AS [c]
-    FROM [Orders] AS [o0]
-    GROUP BY [o0].[CustomerID]
+    SELECT [o].[CustomerID], MAX([o].[OrderID]) AS [c]
+    FROM [Orders] AS [o]
+    GROUP BY [o].[CustomerID]
     HAVING COUNT(*) > 5
 ) AS [t]
 INNER JOIN [Customers] AS [c] ON [t].[CustomerID] = [c].[CustomerID]
-INNER JOIN [Orders] AS [o] ON [t].[c] = [o].[OrderID]");
+INNER JOIN [Orders] AS [o0] ON [t].[c] = [o0].[OrderID]");
         }
 
         public override async Task Join_GroupBy_Aggregate_multijoins(bool isAsync)
@@ -1285,15 +1285,15 @@ INNER JOIN [Orders] AS [o] ON [t].[c] = [o].[OrderID]");
             await base.Join_GroupBy_Aggregate_multijoins(isAsync);
 
             AssertSql(
-                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Customers] AS [c]
 INNER JOIN (
-    SELECT [o0].[CustomerID], MAX([o0].[OrderID]) AS [c]
-    FROM [Orders] AS [o0]
-    GROUP BY [o0].[CustomerID]
+    SELECT [o].[CustomerID], MAX([o].[OrderID]) AS [c]
+    FROM [Orders] AS [o]
+    GROUP BY [o].[CustomerID]
     HAVING COUNT(*) > 5
 ) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
-INNER JOIN [Orders] AS [o] ON [t].[c] = [o].[OrderID]");
+INNER JOIN [Orders] AS [o0] ON [t].[c] = [o0].[OrderID]");
         }
 
         public override async Task Join_GroupBy_Aggregate_single_join(bool isAsync)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/IncludeSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/IncludeSqlServerTest.cs
@@ -508,15 +508,15 @@ ORDER BY [c].[CustomerID], [o].[OrderID], [o0].[OrderID]");
             base.Include_collection_on_additional_from_clause_with_filter(useString);
 
             AssertSql(
-                @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [c0].[CustomerID], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Customers] AS [c0]
+                @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [c].[CustomerID], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
 CROSS JOIN (
-    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-    FROM [Customers] AS [c]
-    WHERE [c].[CustomerID] = N'ALFKI'
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[CustomerID] = N'ALFKI'
 ) AS [t]
 LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
-ORDER BY [c0].[CustomerID], [t].[CustomerID], [o].[OrderID]");
+ORDER BY [c].[CustomerID], [t].[CustomerID], [o].[OrderID]");
         }
 
         public override void Include_collection_on_additional_from_clause(bool useString)
@@ -526,15 +526,15 @@ ORDER BY [c0].[CustomerID], [t].[CustomerID], [o].[OrderID]");
             AssertSql(
                 @"@__p_0='5'
 
-SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[CustomerID], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [t].[CustomerID], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
-    FROM [Customers] AS [c0]
-    ORDER BY [c0].[CustomerID]
+    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[CustomerID]
 ) AS [t]
-CROSS JOIN [Customers] AS [c]
-LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
-ORDER BY [t].[CustomerID], [c].[CustomerID], [o].[OrderID]");
+CROSS JOIN [Customers] AS [c0]
+LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID], [c0].[CustomerID], [o].[OrderID]");
         }
 
         public override void Include_duplicate_collection(bool useString)
@@ -692,15 +692,15 @@ ORDER BY [t].[CustomerID]");
                     @"@__p_0='1'
 @__p_1='2'
 
-SELECT [o].[CustomerID]
+SELECT [o0].[CustomerID]
 FROM (
-    SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
-    FROM [Order Details] AS [o0]
-    WHERE [o0].[Quantity] = CAST(10 AS smallint)
-    ORDER BY [o0].[OrderID], [o0].[ProductID]
+    SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
+    FROM [Order Details] AS [o]
+    WHERE [o].[Quantity] = CAST(10 AS smallint)
+    ORDER BY [o].[OrderID], [o].[ProductID]
     OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
 ) AS [t]
-INNER JOIN [Orders] AS [o] ON [t].[OrderID] = [o].[OrderID]
+INNER JOIN [Orders] AS [o0] ON [t].[OrderID] = [o0].[OrderID]
 ORDER BY [t].[OrderID], [t].[ProductID]");
             }
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
@@ -19,85 +19,85 @@ namespace Microsoft.EntityFrameworkCore.Query
             base.Query_with_owned_entity_equality_operator();
 
             AssertSql(
-                @"SELECT [o].[Id], [o].[Discriminator], [t0].[Id], [t3].[Id], [t3].[PersonAddress_Country_Name], [t3].[PersonAddress_Country_PlanetId], [t5].[Id], [t8].[Id], [t8].[BranchAddress_Country_Name], [t8].[BranchAddress_Country_PlanetId], [t10].[Id], [t13].[Id], [t13].[LeafAAddress_Country_Name], [t13].[LeafAAddress_Country_PlanetId], [t14].[Id], [o16].[ClientId], [o16].[Id]
+                @"SELECT [o].[Id], [o].[Discriminator], [t1].[Id], [t4].[Id], [t4].[PersonAddress_Country_Name], [t4].[PersonAddress_Country_PlanetId], [t6].[Id], [t9].[Id], [t9].[BranchAddress_Country_Name], [t9].[BranchAddress_Country_PlanetId], [t11].[Id], [t14].[Id], [t14].[LeafAAddress_Country_Name], [t14].[LeafAAddress_Country_PlanetId], [t].[Id], [o16].[ClientId], [o16].[Id]
 FROM [OwnedPerson] AS [o]
 CROSS JOIN (
-    SELECT [o15].[Id], [o15].[Discriminator]
-    FROM [OwnedPerson] AS [o15]
-    WHERE [o15].[Discriminator] = N'LeafB'
-) AS [t14]
-LEFT JOIN (
-    SELECT [o0].[Id], [t].[Id] AS [Id0]
+    SELECT [o0].[Id], [o0].[Discriminator]
     FROM [OwnedPerson] AS [o0]
-    INNER JOIN (
-        SELECT [o1].[Id], [o1].[Discriminator]
-        FROM [OwnedPerson] AS [o1]
-        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-    ) AS [t] ON [o0].[Id] = [t].[Id]
-) AS [t0] ON [o].[Id] = [t0].[Id]
+    WHERE [o0].[Discriminator] = N'LeafB'
+) AS [t]
 LEFT JOIN (
-    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o2]
+    SELECT [o1].[Id], [t0].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o1]
     INNER JOIN (
-        SELECT [o3].[Id], [t1].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o3]
+        SELECT [o2].[Id], [o2].[Discriminator]
+        FROM [OwnedPerson] AS [o2]
+        WHERE [o2].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+    ) AS [t0] ON [o1].[Id] = [t0].[Id]
+) AS [t1] ON [o].[Id] = [t1].[Id]
+LEFT JOIN (
+    SELECT [o3].[Id], [o3].[PersonAddress_Country_Name], [o3].[PersonAddress_Country_PlanetId], [t3].[Id] AS [Id0], [t3].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o3]
+    INNER JOIN (
+        SELECT [o4].[Id], [t2].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o4]
         INNER JOIN (
-            SELECT [o4].[Id], [o4].[Discriminator]
-            FROM [OwnedPerson] AS [o4]
-            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-        ) AS [t1] ON [o3].[Id] = [t1].[Id]
-    ) AS [t2] ON [o2].[Id] = [t2].[Id]
-    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t3] ON [t0].[Id] = [t3].[Id]
+            SELECT [o5].[Id], [o5].[Discriminator]
+            FROM [OwnedPerson] AS [o5]
+            WHERE [o5].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+        ) AS [t2] ON [o4].[Id] = [t2].[Id]
+    ) AS [t3] ON [o3].[Id] = [t3].[Id]
+    WHERE [o3].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t4] ON [t1].[Id] = [t4].[Id]
 LEFT JOIN (
-    SELECT [o5].[Id], [t4].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o5]
+    SELECT [o6].[Id], [t5].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o6]
     INNER JOIN (
-        SELECT [o6].[Id], [o6].[Discriminator]
-        FROM [OwnedPerson] AS [o6]
-        WHERE [o6].[Discriminator] IN (N'Branch', N'LeafA')
-    ) AS [t4] ON [o5].[Id] = [t4].[Id]
-) AS [t5] ON [o].[Id] = [t5].[Id]
+        SELECT [o7].[Id], [o7].[Discriminator]
+        FROM [OwnedPerson] AS [o7]
+        WHERE [o7].[Discriminator] IN (N'Branch', N'LeafA')
+    ) AS [t5] ON [o6].[Id] = [t5].[Id]
+) AS [t6] ON [o].[Id] = [t6].[Id]
 LEFT JOIN (
-    SELECT [o7].[Id], [o7].[BranchAddress_Country_Name], [o7].[BranchAddress_Country_PlanetId], [t7].[Id] AS [Id0], [t7].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o7]
+    SELECT [o8].[Id], [o8].[BranchAddress_Country_Name], [o8].[BranchAddress_Country_PlanetId], [t8].[Id] AS [Id0], [t8].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o8]
     INNER JOIN (
-        SELECT [o8].[Id], [t6].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o8]
+        SELECT [o9].[Id], [t7].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o9]
         INNER JOIN (
-            SELECT [o9].[Id], [o9].[Discriminator]
-            FROM [OwnedPerson] AS [o9]
-            WHERE [o9].[Discriminator] IN (N'Branch', N'LeafA')
-        ) AS [t6] ON [o8].[Id] = [t6].[Id]
-    ) AS [t7] ON [o7].[Id] = [t7].[Id]
-    WHERE [o7].[BranchAddress_Country_PlanetId] IS NOT NULL
-) AS [t8] ON [t5].[Id] = [t8].[Id]
+            SELECT [o10].[Id], [o10].[Discriminator]
+            FROM [OwnedPerson] AS [o10]
+            WHERE [o10].[Discriminator] IN (N'Branch', N'LeafA')
+        ) AS [t7] ON [o9].[Id] = [t7].[Id]
+    ) AS [t8] ON [o8].[Id] = [t8].[Id]
+    WHERE [o8].[BranchAddress_Country_PlanetId] IS NOT NULL
+) AS [t9] ON [t6].[Id] = [t9].[Id]
 LEFT JOIN (
-    SELECT [o10].[Id], [t9].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o10]
+    SELECT [o11].[Id], [t10].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o11]
     INNER JOIN (
-        SELECT [o11].[Id], [o11].[Discriminator]
-        FROM [OwnedPerson] AS [o11]
-        WHERE [o11].[Discriminator] = N'LeafA'
-    ) AS [t9] ON [o10].[Id] = [t9].[Id]
-) AS [t10] ON [o].[Id] = [t10].[Id]
+        SELECT [o12].[Id], [o12].[Discriminator]
+        FROM [OwnedPerson] AS [o12]
+        WHERE [o12].[Discriminator] = N'LeafA'
+    ) AS [t10] ON [o11].[Id] = [t10].[Id]
+) AS [t11] ON [o].[Id] = [t11].[Id]
 LEFT JOIN (
-    SELECT [o12].[Id], [o12].[LeafAAddress_Country_Name], [o12].[LeafAAddress_Country_PlanetId], [t12].[Id] AS [Id0], [t12].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o12]
+    SELECT [o13].[Id], [o13].[LeafAAddress_Country_Name], [o13].[LeafAAddress_Country_PlanetId], [t13].[Id] AS [Id0], [t13].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o13]
     INNER JOIN (
-        SELECT [o13].[Id], [t11].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o13]
+        SELECT [o14].[Id], [t12].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o14]
         INNER JOIN (
-            SELECT [o14].[Id], [o14].[Discriminator]
-            FROM [OwnedPerson] AS [o14]
-            WHERE [o14].[Discriminator] = N'LeafA'
-        ) AS [t11] ON [o13].[Id] = [t11].[Id]
-    ) AS [t12] ON [o12].[Id] = [t12].[Id]
-    WHERE [o12].[LeafAAddress_Country_PlanetId] IS NOT NULL
-) AS [t13] ON [t10].[Id] = [t13].[Id]
+            SELECT [o15].[Id], [o15].[Discriminator]
+            FROM [OwnedPerson] AS [o15]
+            WHERE [o15].[Discriminator] = N'LeafA'
+        ) AS [t12] ON [o14].[Id] = [t12].[Id]
+    ) AS [t13] ON [o13].[Id] = [t13].[Id]
+    WHERE [o13].[LeafAAddress_Country_PlanetId] IS NOT NULL
+) AS [t14] ON [t11].[Id] = [t14].[Id]
 LEFT JOIN [Order] AS [o16] ON [o].[Id] = [o16].[ClientId]
 WHERE CAST(0 AS bit) = CAST(1 AS bit)
-ORDER BY [o].[Id], [t14].[Id], [o16].[ClientId], [o16].[Id]");
+ORDER BY [o].[Id], [t].[Id], [o16].[ClientId], [o16].[Id]");
         }
 
         public override void Query_for_base_type_loads_all_owned_navs()
@@ -484,7 +484,7 @@ ORDER BY [t15].[Id]");
             AssertSql(
                 @"@__p_0='5'
 
-SELECT [t0].[Id], [t0].[Discriminator], [t2].[Id], [t5].[Id], [t5].[PersonAddress_Country_Name], [t5].[PersonAddress_Country_PlanetId], [t7].[Id], [t10].[Id], [t10].[BranchAddress_Country_Name], [t10].[BranchAddress_Country_PlanetId], [t12].[Id], [t15].[Id], [t15].[LeafBAddress_Country_Name], [t15].[LeafBAddress_Country_PlanetId], [t17].[Id], [t20].[Id], [t20].[LeafAAddress_Country_Name], [t20].[LeafAAddress_Country_PlanetId], [o20].[ClientId], [o20].[Id]
+SELECT [t0].[Id], [t0].[Discriminator], [t4].[Id], [t7].[Id], [t7].[PersonAddress_Country_Name], [t7].[PersonAddress_Country_PlanetId], [t9].[Id], [t12].[Id], [t12].[BranchAddress_Country_Name], [t12].[BranchAddress_Country_PlanetId], [t14].[Id], [t17].[Id], [t17].[LeafBAddress_Country_Name], [t17].[LeafBAddress_Country_PlanetId], [t19].[Id], [t22].[Id], [t22].[LeafAAddress_Country_Name], [t22].[LeafAAddress_Country_PlanetId], [o22].[ClientId], [o22].[Id]
 FROM (
     SELECT TOP(@__p_0) [t].[Id], [t].[Discriminator]
     FROM (
@@ -495,15 +495,6 @@ FROM (
     ORDER BY [t].[Id]
 ) AS [t0]
 LEFT JOIN (
-    SELECT [o21].[Id], [t21].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o21]
-    INNER JOIN (
-        SELECT [o22].[Id], [o22].[Discriminator]
-        FROM [OwnedPerson] AS [o22]
-        WHERE [o22].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-    ) AS [t21] ON [o21].[Id] = [t21].[Id]
-) AS [t22] ON [t0].[Id] = [t22].[Id]
-LEFT JOIN (
     SELECT [o0].[Id], [t1].[Id] AS [Id0]
     FROM [OwnedPerson] AS [o0]
     INNER JOIN (
@@ -513,90 +504,99 @@ LEFT JOIN (
     ) AS [t1] ON [o0].[Id] = [t1].[Id]
 ) AS [t2] ON [t0].[Id] = [t2].[Id]
 LEFT JOIN (
-    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t4].[Id] AS [Id0], [t4].[Id0] AS [Id00]
+    SELECT [o2].[Id], [t3].[Id] AS [Id0]
     FROM [OwnedPerson] AS [o2]
     INNER JOIN (
-        SELECT [o3].[Id], [t3].[Id] AS [Id0]
+        SELECT [o3].[Id], [o3].[Discriminator]
         FROM [OwnedPerson] AS [o3]
-        INNER JOIN (
-            SELECT [o4].[Id], [o4].[Discriminator]
-            FROM [OwnedPerson] AS [o4]
-            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-        ) AS [t3] ON [o3].[Id] = [t3].[Id]
-    ) AS [t4] ON [o2].[Id] = [t4].[Id]
-    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t5] ON [t2].[Id] = [t5].[Id]
+        WHERE [o3].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+    ) AS [t3] ON [o2].[Id] = [t3].[Id]
+) AS [t4] ON [t0].[Id] = [t4].[Id]
 LEFT JOIN (
-    SELECT [o5].[Id], [t6].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o5]
+    SELECT [o4].[Id], [o4].[PersonAddress_Country_Name], [o4].[PersonAddress_Country_PlanetId], [t6].[Id] AS [Id0], [t6].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o4]
     INNER JOIN (
-        SELECT [o6].[Id], [o6].[Discriminator]
-        FROM [OwnedPerson] AS [o6]
-        WHERE [o6].[Discriminator] IN (N'Branch', N'LeafA')
-    ) AS [t6] ON [o5].[Id] = [t6].[Id]
-) AS [t7] ON [t0].[Id] = [t7].[Id]
+        SELECT [o5].[Id], [t5].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o5]
+        INNER JOIN (
+            SELECT [o6].[Id], [o6].[Discriminator]
+            FROM [OwnedPerson] AS [o6]
+            WHERE [o6].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+        ) AS [t5] ON [o5].[Id] = [t5].[Id]
+    ) AS [t6] ON [o4].[Id] = [t6].[Id]
+    WHERE [o4].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t7] ON [t4].[Id] = [t7].[Id]
 LEFT JOIN (
-    SELECT [o7].[Id], [o7].[BranchAddress_Country_Name], [o7].[BranchAddress_Country_PlanetId], [t9].[Id] AS [Id0], [t9].[Id0] AS [Id00]
+    SELECT [o7].[Id], [t8].[Id] AS [Id0]
     FROM [OwnedPerson] AS [o7]
     INNER JOIN (
-        SELECT [o8].[Id], [t8].[Id] AS [Id0]
+        SELECT [o8].[Id], [o8].[Discriminator]
         FROM [OwnedPerson] AS [o8]
-        INNER JOIN (
-            SELECT [o9].[Id], [o9].[Discriminator]
-            FROM [OwnedPerson] AS [o9]
-            WHERE [o9].[Discriminator] IN (N'Branch', N'LeafA')
-        ) AS [t8] ON [o8].[Id] = [t8].[Id]
-    ) AS [t9] ON [o7].[Id] = [t9].[Id]
-    WHERE [o7].[BranchAddress_Country_PlanetId] IS NOT NULL
-) AS [t10] ON [t7].[Id] = [t10].[Id]
+        WHERE [o8].[Discriminator] IN (N'Branch', N'LeafA')
+    ) AS [t8] ON [o7].[Id] = [t8].[Id]
+) AS [t9] ON [t0].[Id] = [t9].[Id]
 LEFT JOIN (
-    SELECT [o10].[Id], [t11].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o10]
+    SELECT [o9].[Id], [o9].[BranchAddress_Country_Name], [o9].[BranchAddress_Country_PlanetId], [t11].[Id] AS [Id0], [t11].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o9]
     INNER JOIN (
-        SELECT [o11].[Id], [o11].[Discriminator]
-        FROM [OwnedPerson] AS [o11]
-        WHERE [o11].[Discriminator] = N'LeafB'
-    ) AS [t11] ON [o10].[Id] = [t11].[Id]
-) AS [t12] ON [t0].[Id] = [t12].[Id]
+        SELECT [o10].[Id], [t10].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o10]
+        INNER JOIN (
+            SELECT [o11].[Id], [o11].[Discriminator]
+            FROM [OwnedPerson] AS [o11]
+            WHERE [o11].[Discriminator] IN (N'Branch', N'LeafA')
+        ) AS [t10] ON [o10].[Id] = [t10].[Id]
+    ) AS [t11] ON [o9].[Id] = [t11].[Id]
+    WHERE [o9].[BranchAddress_Country_PlanetId] IS NOT NULL
+) AS [t12] ON [t9].[Id] = [t12].[Id]
 LEFT JOIN (
-    SELECT [o12].[Id], [o12].[LeafBAddress_Country_Name], [o12].[LeafBAddress_Country_PlanetId], [t14].[Id] AS [Id0], [t14].[Id0] AS [Id00]
+    SELECT [o12].[Id], [t13].[Id] AS [Id0]
     FROM [OwnedPerson] AS [o12]
     INNER JOIN (
-        SELECT [o13].[Id], [t13].[Id] AS [Id0]
+        SELECT [o13].[Id], [o13].[Discriminator]
         FROM [OwnedPerson] AS [o13]
-        INNER JOIN (
-            SELECT [o14].[Id], [o14].[Discriminator]
-            FROM [OwnedPerson] AS [o14]
-            WHERE [o14].[Discriminator] = N'LeafB'
-        ) AS [t13] ON [o13].[Id] = [t13].[Id]
-    ) AS [t14] ON [o12].[Id] = [t14].[Id]
-    WHERE [o12].[LeafBAddress_Country_PlanetId] IS NOT NULL
-) AS [t15] ON [t12].[Id] = [t15].[Id]
+        WHERE [o13].[Discriminator] = N'LeafB'
+    ) AS [t13] ON [o12].[Id] = [t13].[Id]
+) AS [t14] ON [t0].[Id] = [t14].[Id]
 LEFT JOIN (
-    SELECT [o15].[Id], [t16].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o15]
+    SELECT [o14].[Id], [o14].[LeafBAddress_Country_Name], [o14].[LeafBAddress_Country_PlanetId], [t16].[Id] AS [Id0], [t16].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o14]
     INNER JOIN (
-        SELECT [o16].[Id], [o16].[Discriminator]
-        FROM [OwnedPerson] AS [o16]
-        WHERE [o16].[Discriminator] = N'LeafA'
-    ) AS [t16] ON [o15].[Id] = [t16].[Id]
-) AS [t17] ON [t0].[Id] = [t17].[Id]
+        SELECT [o15].[Id], [t15].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o15]
+        INNER JOIN (
+            SELECT [o16].[Id], [o16].[Discriminator]
+            FROM [OwnedPerson] AS [o16]
+            WHERE [o16].[Discriminator] = N'LeafB'
+        ) AS [t15] ON [o15].[Id] = [t15].[Id]
+    ) AS [t16] ON [o14].[Id] = [t16].[Id]
+    WHERE [o14].[LeafBAddress_Country_PlanetId] IS NOT NULL
+) AS [t17] ON [t14].[Id] = [t17].[Id]
 LEFT JOIN (
-    SELECT [o17].[Id], [o17].[LeafAAddress_Country_Name], [o17].[LeafAAddress_Country_PlanetId], [t19].[Id] AS [Id0], [t19].[Id0] AS [Id00]
+    SELECT [o17].[Id], [t18].[Id] AS [Id0]
     FROM [OwnedPerson] AS [o17]
     INNER JOIN (
-        SELECT [o18].[Id], [t18].[Id] AS [Id0]
+        SELECT [o18].[Id], [o18].[Discriminator]
         FROM [OwnedPerson] AS [o18]
+        WHERE [o18].[Discriminator] = N'LeafA'
+    ) AS [t18] ON [o17].[Id] = [t18].[Id]
+) AS [t19] ON [t0].[Id] = [t19].[Id]
+LEFT JOIN (
+    SELECT [o19].[Id], [o19].[LeafAAddress_Country_Name], [o19].[LeafAAddress_Country_PlanetId], [t21].[Id] AS [Id0], [t21].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o19]
+    INNER JOIN (
+        SELECT [o20].[Id], [t20].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o20]
         INNER JOIN (
-            SELECT [o19].[Id], [o19].[Discriminator]
-            FROM [OwnedPerson] AS [o19]
-            WHERE [o19].[Discriminator] = N'LeafA'
-        ) AS [t18] ON [o18].[Id] = [t18].[Id]
-    ) AS [t19] ON [o17].[Id] = [t19].[Id]
-    WHERE [o17].[LeafAAddress_Country_PlanetId] IS NOT NULL
-) AS [t20] ON [t17].[Id] = [t20].[Id]
-LEFT JOIN [Order] AS [o20] ON [t0].[Id] = [o20].[ClientId]
-ORDER BY [t0].[Id], [o20].[ClientId], [o20].[Id]");
+            SELECT [o21].[Id], [o21].[Discriminator]
+            FROM [OwnedPerson] AS [o21]
+            WHERE [o21].[Discriminator] = N'LeafA'
+        ) AS [t20] ON [o20].[Id] = [t20].[Id]
+    ) AS [t21] ON [o19].[Id] = [t21].[Id]
+    WHERE [o19].[LeafAAddress_Country_PlanetId] IS NOT NULL
+) AS [t22] ON [t19].[Id] = [t22].[Id]
+LEFT JOIN [Order] AS [o22] ON [t0].[Id] = [o22].[ClientId]
+ORDER BY [t0].[Id], [o22].[ClientId], [o22].[Id]");
         }
 
         public override void Navigation_rewrite_on_owned_reference_projecting_scalar()
@@ -604,32 +604,32 @@ ORDER BY [t0].[Id], [o20].[ClientId], [o20].[Id]");
             base.Navigation_rewrite_on_owned_reference_projecting_scalar();
 
             AssertSql(
-                @"SELECT [t1].[PersonAddress_Country_Name]
-FROM [OwnedPerson] AS [o2]
+                @"SELECT [t3].[PersonAddress_Country_Name]
+FROM [OwnedPerson] AS [o]
 LEFT JOIN (
-    SELECT [o3].[Id], [t2].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o3]
+    SELECT [o0].[Id], [t].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o0]
     INNER JOIN (
-        SELECT [o4].[Id], [o4].[Discriminator]
-        FROM [OwnedPerson] AS [o4]
-        WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-    ) AS [t2] ON [o3].[Id] = [t2].[Id]
-) AS [t3] ON [o2].[Id] = [t3].[Id]
+        SELECT [o1].[Id], [o1].[Discriminator]
+        FROM [OwnedPerson] AS [o1]
+        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+    ) AS [t] ON [o0].[Id] = [t].[Id]
+) AS [t0] ON [o].[Id] = [t0].[Id]
 LEFT JOIN (
-    SELECT [o].[Id], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [t0].[Id] AS [Id0], [t0].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o]
+    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o2]
     INNER JOIN (
-        SELECT [o0].[Id], [t].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o0]
+        SELECT [o3].[Id], [t1].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o3]
         INNER JOIN (
-            SELECT [o1].[Id], [o1].[Discriminator]
-            FROM [OwnedPerson] AS [o1]
-            WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-        ) AS [t] ON [o0].[Id] = [t].[Id]
-    ) AS [t0] ON [o].[Id] = [t0].[Id]
-    WHERE [o].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t1] ON [t3].[Id] = [t1].[Id]
-WHERE [o2].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA') AND (([t1].[PersonAddress_Country_Name] = N'USA') AND [t1].[PersonAddress_Country_Name] IS NOT NULL)");
+            SELECT [o4].[Id], [o4].[Discriminator]
+            FROM [OwnedPerson] AS [o4]
+            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+        ) AS [t1] ON [o3].[Id] = [t1].[Id]
+    ) AS [t2] ON [o2].[Id] = [t2].[Id]
+    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t3] ON [t0].[Id] = [t3].[Id]
+WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA') AND (([t3].[PersonAddress_Country_Name] = N'USA') AND [t3].[PersonAddress_Country_Name] IS NOT NULL)");
         }
 
         public override void Navigation_rewrite_on_owned_reference_projecting_entity()
@@ -773,37 +773,37 @@ WHERE [o0].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
 
             AssertSql(
                 @"SELECT (
-    SELECT TOP(1) [t1].[PersonAddress_Country_Name]
-    FROM [Order] AS [o2]
+    SELECT TOP(1) [t4].[PersonAddress_Country_Name]
+    FROM [Order] AS [o]
     LEFT JOIN (
-        SELECT [o3].[Id], [o3].[Discriminator]
+        SELECT [o0].[Id], [o0].[Discriminator]
+        FROM [OwnedPerson] AS [o0]
+        WHERE [o0].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+    ) AS [t] ON [o].[ClientId] = [t].[Id]
+    LEFT JOIN (
+        SELECT [o1].[Id], [t0].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o1]
+        INNER JOIN (
+            SELECT [o2].[Id], [o2].[Discriminator]
+            FROM [OwnedPerson] AS [o2]
+            WHERE [o2].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+        ) AS [t0] ON [o1].[Id] = [t0].[Id]
+    ) AS [t1] ON [t].[Id] = [t1].[Id]
+    LEFT JOIN (
+        SELECT [o3].[Id], [o3].[PersonAddress_Country_Name], [o3].[PersonAddress_Country_PlanetId], [t3].[Id] AS [Id0], [t3].[Id0] AS [Id00]
         FROM [OwnedPerson] AS [o3]
-        WHERE [o3].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-    ) AS [t2] ON [o2].[ClientId] = [t2].[Id]
-    LEFT JOIN (
-        SELECT [o4].[Id], [t3].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o4]
         INNER JOIN (
-            SELECT [o5].[Id], [o5].[Discriminator]
-            FROM [OwnedPerson] AS [o5]
-            WHERE [o5].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-        ) AS [t3] ON [o4].[Id] = [t3].[Id]
-    ) AS [t4] ON [t2].[Id] = [t4].[Id]
-    LEFT JOIN (
-        SELECT [o].[Id], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [t0].[Id] AS [Id0], [t0].[Id0] AS [Id00]
-        FROM [OwnedPerson] AS [o]
-        INNER JOIN (
-            SELECT [o0].[Id], [t].[Id] AS [Id0]
-            FROM [OwnedPerson] AS [o0]
+            SELECT [o4].[Id], [t2].[Id] AS [Id0]
+            FROM [OwnedPerson] AS [o4]
             INNER JOIN (
-                SELECT [o1].[Id], [o1].[Discriminator]
-                FROM [OwnedPerson] AS [o1]
-                WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-            ) AS [t] ON [o0].[Id] = [t].[Id]
-        ) AS [t0] ON [o].[Id] = [t0].[Id]
-        WHERE [o].[PersonAddress_Country_PlanetId] IS NOT NULL
-    ) AS [t1] ON [t4].[Id] = [t1].[Id]
-    WHERE [o6].[Id] = [o2].[ClientId])
+                SELECT [o5].[Id], [o5].[Discriminator]
+                FROM [OwnedPerson] AS [o5]
+                WHERE [o5].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+            ) AS [t2] ON [o4].[Id] = [t2].[Id]
+        ) AS [t3] ON [o3].[Id] = [t3].[Id]
+        WHERE [o3].[PersonAddress_Country_PlanetId] IS NOT NULL
+    ) AS [t4] ON [t1].[Id] = [t4].[Id]
+    WHERE [o6].[Id] = [o].[ClientId])
 FROM [OwnedPerson] AS [o6]
 WHERE [o6].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
         }
@@ -813,10 +813,10 @@ WHERE [o6].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
             base.SelectMany_on_owned_collection();
 
             AssertSql(
-                @"SELECT [o].[ClientId], [o].[Id]
-FROM [OwnedPerson] AS [o0]
-INNER JOIN [Order] AS [o] ON [o0].[Id] = [o].[ClientId]
-WHERE [o0].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
+                @"SELECT [o0].[ClientId], [o0].[Id]
+FROM [OwnedPerson] AS [o]
+INNER JOIN [Order] AS [o0] ON [o].[Id] = [o0].[ClientId]
+WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
         }
 
         public override void Navigation_rewrite_on_owned_reference_followed_by_regular_entity()
@@ -858,35 +858,35 @@ WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
             base.Filter_owned_entity_chained_with_regular_entity_followed_by_projecting_owned_collection();
 
             AssertSql(
-                @"SELECT [o].[Id], [o0].[ClientId], [o0].[Id]
+                @"SELECT [o].[Id], [o5].[ClientId], [o5].[Id]
 FROM [OwnedPerson] AS [o]
 LEFT JOIN (
-    SELECT [o1].[Id], [t].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o1]
+    SELECT [o0].[Id], [t].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o0]
     INNER JOIN (
-        SELECT [o2].[Id], [o2].[Discriminator]
-        FROM [OwnedPerson] AS [o2]
-        WHERE [o2].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-    ) AS [t] ON [o1].[Id] = [t].[Id]
+        SELECT [o1].[Id], [o1].[Discriminator]
+        FROM [OwnedPerson] AS [o1]
+        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+    ) AS [t] ON [o0].[Id] = [t].[Id]
 ) AS [t0] ON [o].[Id] = [t0].[Id]
 LEFT JOIN (
-    SELECT [o3].[Id], [o3].[PersonAddress_Country_Name], [o3].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o3]
+    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o2]
     INNER JOIN (
-        SELECT [o4].[Id], [t1].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o4]
+        SELECT [o3].[Id], [t1].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o3]
         INNER JOIN (
-            SELECT [o5].[Id], [o5].[Discriminator]
-            FROM [OwnedPerson] AS [o5]
-            WHERE [o5].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-        ) AS [t1] ON [o4].[Id] = [t1].[Id]
-    ) AS [t2] ON [o3].[Id] = [t2].[Id]
-    WHERE [o3].[PersonAddress_Country_PlanetId] IS NOT NULL
+            SELECT [o4].[Id], [o4].[Discriminator]
+            FROM [OwnedPerson] AS [o4]
+            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+        ) AS [t1] ON [o3].[Id] = [t1].[Id]
+    ) AS [t2] ON [o2].[Id] = [t2].[Id]
+    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
 ) AS [t3] ON [t0].[Id] = [t3].[Id]
 LEFT JOIN [Planet] AS [p] ON [t3].[PersonAddress_Country_PlanetId] = [p].[Id]
-LEFT JOIN [Order] AS [o0] ON [o].[Id] = [o0].[ClientId]
+LEFT JOIN [Order] AS [o5] ON [o].[Id] = [o5].[ClientId]
 WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA') AND (([p].[Id] <> 42) OR [p].[Id] IS NULL)
-ORDER BY [o].[Id], [o0].[ClientId], [o0].[Id]");
+ORDER BY [o].[Id], [o5].[ClientId], [o5].[Id]");
         }
 
         public override void Project_multiple_owned_navigations()
@@ -894,35 +894,35 @@ ORDER BY [o].[Id], [o0].[ClientId], [o0].[Id]");
             base.Project_multiple_owned_navigations();
 
             AssertSql(
-                @"SELECT [t0].[Id], [t3].[Id], [t3].[PersonAddress_Country_Name], [t3].[PersonAddress_Country_PlanetId], [p].[Id], [p].[StarId], [o4].[Id], [o5].[ClientId], [o5].[Id]
-FROM [OwnedPerson] AS [o4]
+                @"SELECT [t0].[Id], [t3].[Id], [t3].[PersonAddress_Country_Name], [t3].[PersonAddress_Country_PlanetId], [p].[Id], [p].[StarId], [o].[Id], [o5].[ClientId], [o5].[Id]
+FROM [OwnedPerson] AS [o]
 LEFT JOIN (
-    SELECT [o].[Id], [t].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o]
+    SELECT [o0].[Id], [t].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o0]
     INNER JOIN (
-        SELECT [o0].[Id], [o0].[Discriminator]
-        FROM [OwnedPerson] AS [o0]
-        WHERE [o0].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-    ) AS [t] ON [o].[Id] = [t].[Id]
-) AS [t0] ON [o4].[Id] = [t0].[Id]
+        SELECT [o1].[Id], [o1].[Discriminator]
+        FROM [OwnedPerson] AS [o1]
+        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+    ) AS [t] ON [o0].[Id] = [t].[Id]
+) AS [t0] ON [o].[Id] = [t0].[Id]
 LEFT JOIN (
-    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o1]
+    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
+    FROM [OwnedPerson] AS [o2]
     INNER JOIN (
-        SELECT [o2].[Id], [t1].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o2]
+        SELECT [o3].[Id], [t1].[Id] AS [Id0]
+        FROM [OwnedPerson] AS [o3]
         INNER JOIN (
-            SELECT [o3].[Id], [o3].[Discriminator]
-            FROM [OwnedPerson] AS [o3]
-            WHERE [o3].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-        ) AS [t1] ON [o2].[Id] = [t1].[Id]
-    ) AS [t2] ON [o1].[Id] = [t2].[Id]
-    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
+            SELECT [o4].[Id], [o4].[Discriminator]
+            FROM [OwnedPerson] AS [o4]
+            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+        ) AS [t1] ON [o3].[Id] = [t1].[Id]
+    ) AS [t2] ON [o2].[Id] = [t2].[Id]
+    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
 ) AS [t3] ON [t0].[Id] = [t3].[Id]
 LEFT JOIN [Planet] AS [p] ON [t3].[PersonAddress_Country_PlanetId] = [p].[Id]
-LEFT JOIN [Order] AS [o5] ON [o4].[Id] = [o5].[ClientId]
-WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-ORDER BY [o4].[Id], [o5].[ClientId], [o5].[Id]");
+LEFT JOIN [Order] AS [o5] ON [o].[Id] = [o5].[ClientId]
+WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+ORDER BY [o].[Id], [o5].[ClientId], [o5].[Id]");
         }
 
         public override void Project_multiple_owned_navigations_with_expansion_on_owned_collections()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -3478,14 +3478,14 @@ ORDER BY [t].[c], [t].[c0], [t].[Id], [t].[Id0], [o].[Id]");
 
                     AssertSql(
                         @"SELECT CASE
-    WHEN [c].[Id] IS NOT NULL THEN CASE
-        WHEN [c].[Processed] <> CAST(1 AS bit) THEN CAST(1 AS bit)
+    WHEN [c0].[Id] IS NOT NULL THEN CASE
+        WHEN [c0].[Processed] <> CAST(1 AS bit) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     ELSE NULL
 END AS [Processing]
-FROM [Carts] AS [c0]
-LEFT JOIN [Configuration9468] AS [c] ON [c0].[ConfigurationId] = [c].[Id]");
+FROM [Carts] AS [c]
+LEFT JOIN [Configuration9468] AS [c0] ON [c].[ConfigurationId] = [c0].[Id]");
                 }
             }
         }
@@ -3959,15 +3959,15 @@ WHERE [b].[IsTwo] IN (CAST(0 AS bit), CAST(1 AS bit))");
                         .ToList();
 
                     AssertSql(
-                @"SELECT [t1].[Name] AS [Key], COUNT(*) + 5 AS [cnt]
-FROM [Table] AS [t2]
+                        @"SELECT [t2].[Name] AS [Key], COUNT(*) + 5 AS [cnt]
+FROM [Table] AS [t]
 LEFT JOIN (
-    SELECT [t].[Id], [t].[Name], [t0].[Id] AS [Id0]
-    FROM [Table] AS [t]
-    INNER JOIN [Table] AS [t0] ON [t].[Id] = [t0].[Id]
-    WHERE [t].[Name] IS NOT NULL
-) AS [t1] ON [t2].[Id] = [t1].[Id]
-GROUP BY [t1].[Name]");
+    SELECT [t0].[Id], [t0].[Name], [t1].[Id] AS [Id0]
+    FROM [Table] AS [t0]
+    INNER JOIN [Table] AS [t1] ON [t0].[Id] = [t1].[Id]
+    WHERE [t0].[Name] IS NOT NULL
+) AS [t2] ON [t].[Id] = [t2].[Id]
+GROUP BY [t2].[Name]");
                 }
             }
         }
@@ -4006,21 +4006,21 @@ GROUP BY [t1].[Name]");
                         .ToList();
 
                     AssertSql(
-                @"SELECT [t1].[Name] AS [MyKey], COUNT(*) + 5 AS [cnt]
-FROM [Table] AS [t2]
+                        @"SELECT [t2].[Name] AS [MyKey], COUNT(*) + 5 AS [cnt]
+FROM [Table] AS [t]
 LEFT JOIN (
-    SELECT [t].[Id], [t].[Name], [t0].[Id] AS [Id0]
-    FROM [Table] AS [t]
-    INNER JOIN [Table] AS [t0] ON [t].[Id] = [t0].[Id]
-    WHERE [t].[Name] IS NOT NULL
-) AS [t1] ON [t2].[Id] = [t1].[Id]
+    SELECT [t0].[Id], [t0].[Name], [t1].[Id] AS [Id0]
+    FROM [Table] AS [t0]
+    INNER JOIN [Table] AS [t1] ON [t0].[Id] = [t1].[Id]
+    WHERE [t0].[Name] IS NOT NULL
+) AS [t2] ON [t].[Id] = [t2].[Id]
 LEFT JOIN (
     SELECT [t3].[Id], [t3].[MaumarEntity11818_Name], [t4].[Id] AS [Id0]
     FROM [Table] AS [t3]
     INNER JOIN [Table] AS [t4] ON [t3].[Id] = [t4].[Id]
     WHERE [t3].[MaumarEntity11818_Name] IS NOT NULL
-) AS [t5] ON [t2].[Id] = [t5].[Id]
-GROUP BY [t1].[Name], [t5].[MaumarEntity11818_Name]");
+) AS [t5] ON [t].[Id] = [t5].[Id]
+GROUP BY [t2].[Name], [t5].[MaumarEntity11818_Name]");
                 }
             }
         }
@@ -5251,20 +5251,20 @@ END IN ('0a47bcb7-a1cb-4345-8944-c58f82d6aac7', '5f221fb9-66f4-442a-92c9-d97ed59
                     Assert.Equal(10, partners[0].Addresses[0].Turnovers.AmountIn);
 
                     AssertSql(
-                @"SELECT [p].[Id], [t0].[c], [t0].[Turnovers_AmountIn], [t0].[Id]
+                        @"SELECT [p].[Id], [t0].[c], [t0].[Turnovers_AmountIn], [t0].[Id]
 FROM [Partners] AS [p]
 LEFT JOIN (
     SELECT CASE
         WHEN [t].[Id] IS NULL THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
-    END AS [c], [t].[Turnovers_AmountIn], [a1].[Id], [a1].[Partner13157Id]
-    FROM [Address13157] AS [a1]
+    END AS [c], [t].[Turnovers_AmountIn], [a].[Id], [a].[Partner13157Id]
+    FROM [Address13157] AS [a]
     LEFT JOIN (
-        SELECT [a].[Id], [a].[Turnovers_AmountIn], [a0].[Id] AS [Id0]
-        FROM [Address13157] AS [a]
-        INNER JOIN [Address13157] AS [a0] ON [a].[Id] = [a0].[Id]
-        WHERE [a].[Turnovers_AmountIn] IS NOT NULL
-    ) AS [t] ON [a1].[Id] = [t].[Id]
+        SELECT [a0].[Id], [a0].[Turnovers_AmountIn], [a1].[Id] AS [Id0]
+        FROM [Address13157] AS [a0]
+        INNER JOIN [Address13157] AS [a1] ON [a0].[Id] = [a1].[Id]
+        WHERE [a0].[Turnovers_AmountIn] IS NOT NULL
+    ) AS [t] ON [a].[Id] = [t].[Id]
 ) AS [t0] ON [p].[Id] = [t0].[Partner13157Id]
 ORDER BY [p].[Id], [t0].[Id]");
                 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryNavigationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryNavigationsSqlServerTest.cs
@@ -111,21 +111,21 @@ ORDER BY [o].[OrderID], [o].[ProductID]");
             AssertSql(
                 @"@__p_0='2'
 
-SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate]
+SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate]
 FROM (
     SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
-) AS [t1]
+) AS [t]
 LEFT JOIN (
-    SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+    SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate]
     FROM (
         SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], ROW_NUMBER() OVER(PARTITION BY [o].[CustomerID] ORDER BY [o].[OrderID]) AS [row]
         FROM [Orders] AS [o]
-    ) AS [t]
-    WHERE [t].[row] <= 1
-) AS [t0] ON [t1].[CustomerID] = [t0].[CustomerID]
-ORDER BY [t1].[CustomerID]");
+    ) AS [t0]
+    WHERE [t0].[row] <= 1
+) AS [t1] ON [t].[CustomerID] = [t1].[CustomerID]
+ORDER BY [t].[CustomerID]");
         }
 
         public override async Task Select_collection_FirstOrDefault_project_single_column1(bool isAsync)
@@ -167,21 +167,21 @@ ORDER BY [c].[CustomerID]");
             AssertSql(
                 @"@__p_0='2'
 
-SELECT [t0].[CustomerID], [t0].[OrderID]
+SELECT [t1].[CustomerID], [t1].[OrderID]
 FROM (
     SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
-) AS [t1]
+) AS [t]
 LEFT JOIN (
-    SELECT [t].[CustomerID], [t].[OrderID]
+    SELECT [t0].[CustomerID], [t0].[OrderID]
     FROM (
         SELECT [o].[CustomerID], [o].[OrderID], ROW_NUMBER() OVER(PARTITION BY [o].[CustomerID] ORDER BY [o].[OrderID]) AS [row]
         FROM [Orders] AS [o]
-    ) AS [t]
-    WHERE [t].[row] <= 1
-) AS [t0] ON [t1].[CustomerID] = [t0].[CustomerID]
-ORDER BY [t1].[CustomerID]");
+    ) AS [t0]
+    WHERE [t0].[row] <= 1
+) AS [t1] ON [t].[CustomerID] = [t1].[CustomerID]
+ORDER BY [t].[CustomerID]");
         }
 
         public override async Task Select_collection_FirstOrDefault_project_entity(bool isAsync)
@@ -191,21 +191,21 @@ ORDER BY [t1].[CustomerID]");
             AssertSql(
                 @"@__p_0='2'
 
-SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate]
+SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate]
 FROM (
     SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
-) AS [t1]
+) AS [t]
 LEFT JOIN (
-    SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+    SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate]
     FROM (
         SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], ROW_NUMBER() OVER(PARTITION BY [o].[CustomerID] ORDER BY [o].[OrderID]) AS [row]
         FROM [Orders] AS [o]
-    ) AS [t]
-    WHERE [t].[row] <= 1
-) AS [t0] ON [t1].[CustomerID] = [t0].[CustomerID]
-ORDER BY [t1].[CustomerID]");
+    ) AS [t0]
+    WHERE [t0].[row] <= 1
+) AS [t1] ON [t].[CustomerID] = [t1].[CustomerID]
+ORDER BY [t].[CustomerID]");
         }
 
         public override async Task Skip_Select_Navigation(bool isAsync)
@@ -217,22 +217,22 @@ ORDER BY [t1].[CustomerID]");
                 AssertSql(
                     @"@__p_0='20'
 
-SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate]
+SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate]
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
     OFFSET @__p_0 ROWS
-) AS [t1]
+) AS [t]
 LEFT JOIN (
-    SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+    SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate]
     FROM (
         SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], ROW_NUMBER() OVER(PARTITION BY [o].[CustomerID] ORDER BY [o].[OrderID]) AS [row]
         FROM [Orders] AS [o]
-    ) AS [t]
-    WHERE [t].[row] <= 1
-) AS [t0] ON [t1].[CustomerID] = [t0].[CustomerID]
-ORDER BY [t1].[CustomerID]");
+    ) AS [t0]
+    WHERE [t0].[row] <= 1
+) AS [t1] ON [t].[CustomerID] = [t1].[CustomerID]
+ORDER BY [t].[CustomerID]");
             }
         }
 
@@ -320,11 +320,11 @@ WHERE (([c].[City] = N'Seattle') AND [c].[City] IS NOT NULL) AND (([c].[Phone] <
                 @"SELECT (
     SELECT SUM(CAST([o].[Quantity] AS int))
     FROM [Order Details] AS [o]
-    WHERE [o0].[OrderID] = [o].[OrderID]) + (
+    WHERE [o1].[OrderID] = [o].[OrderID]) + (
     SELECT COUNT(*)
-    FROM [Order Details] AS [o1]
-    WHERE [o0].[OrderID] = [o1].[OrderID]) AS [Total]
-FROM [Orders] AS [o0]");
+    FROM [Order Details] AS [o0]
+    WHERE [o1].[OrderID] = [o0].[OrderID]) AS [Total]
+FROM [Orders] AS [o1]");
         }
 
         public override async Task Singleton_Navigation_With_Member_Access(bool isAsync)
@@ -622,27 +622,27 @@ FROM [Customers] AS [c]");
                 @"SELECT (
     SELECT COUNT(*)
     FROM [Order Details] AS [o]
-    WHERE [o0].[OrderID] = [o].[OrderID]) AS [collection1], [o0].[OrderDate] AS [scalar1], CASE
+    WHERE [o3].[OrderID] = [o].[OrderID]) AS [collection1], [o3].[OrderDate] AS [scalar1], CASE
     WHEN EXISTS (
         SELECT 1
-        FROM [Order Details] AS [o1]
-        WHERE ([o0].[OrderID] = [o1].[OrderID]) AND ([o1].[UnitPrice] > 10.0)) THEN CAST(1 AS bit)
+        FROM [Order Details] AS [o0]
+        WHERE ([o3].[OrderID] = [o0].[OrderID]) AND ([o0].[UnitPrice] > 10.0)) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [any], CASE
-    WHEN ([o0].[CustomerID] = N'ALFKI') AND [o0].[CustomerID] IS NOT NULL THEN N'50'
+    WHEN ([o3].[CustomerID] = N'ALFKI') AND [o3].[CustomerID] IS NOT NULL THEN N'50'
     ELSE N'10'
-END AS [conditional], [o0].[OrderID] AS [scalar2], CASE
+END AS [conditional], [o3].[OrderID] AS [scalar2], CASE
     WHEN NOT EXISTS (
         SELECT 1
-        FROM [Order Details] AS [o2]
-        WHERE ([o0].[OrderID] = [o2].[OrderID]) AND ([o2].[OrderID] <> 42)) THEN CAST(1 AS bit)
+        FROM [Order Details] AS [o1]
+        WHERE ([o3].[OrderID] = [o1].[OrderID]) AND ([o1].[OrderID] <> 42)) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [all], (
     SELECT COUNT_BIG(*)
-    FROM [Order Details] AS [o3]
-    WHERE [o0].[OrderID] = [o3].[OrderID]) AS [collection2]
-FROM [Orders] AS [o0]
-WHERE [o0].[CustomerID] IS NOT NULL AND ([o0].[CustomerID] LIKE N'A%')");
+    FROM [Order Details] AS [o2]
+    WHERE [o3].[OrderID] = [o2].[OrderID]) AS [collection2]
+FROM [Orders] AS [o3]
+WHERE [o3].[CustomerID] IS NOT NULL AND ([o3].[CustomerID] LIKE N'A%')");
         }
 
         public override async Task Collection_select_nav_prop_sum(bool isAsync)
@@ -702,19 +702,19 @@ ORDER BY [c].[CustomerID]");
 
             AssertSql(
                 @"SELECT [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
-FROM [Customers] AS [c0]
+FROM [Customers] AS [c]
 LEFT JOIN (
     SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [t].[OrderID], [t].[CustomerID0]
     FROM (
-        SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID] AS [CustomerID0], ROW_NUMBER() OVER(PARTITION BY [o].[CustomerID] ORDER BY [o].[OrderID]) AS [row]
+        SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o].[OrderID], [o].[CustomerID] AS [CustomerID0], ROW_NUMBER() OVER(PARTITION BY [o].[CustomerID] ORDER BY [o].[OrderID]) AS [row]
         FROM [Orders] AS [o]
-        LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+        LEFT JOIN [Customers] AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
         WHERE [o].[OrderID] IN (10643, 10692, 10702, 10835, 10952, 11011)
     ) AS [t]
     WHERE [t].[row] <= 1
-) AS [t0] ON [c0].[CustomerID] = [t0].[CustomerID0]
-WHERE [c0].[CustomerID] LIKE N'A%'
-ORDER BY [c0].[CustomerID]");
+) AS [t0] ON [c].[CustomerID] = [t0].[CustomerID0]
+WHERE [c].[CustomerID] LIKE N'A%'
+ORDER BY [c].[CustomerID]");
         }
 
         public override async Task Collection_select_nav_prop_first_or_default_then_nav_prop_nested(bool isAsync)
@@ -960,14 +960,14 @@ ORDER BY [c].[CustomerID]");
             AssertSql(
                 @"@__p_0='3'
 
-SELECT TOP(@__p_0) [o].[OrderID], (
-    SELECT TOP(1) [o0].[OrderID]
-    FROM [Order Details] AS [o0]
-    WHERE [o].[OrderID] = [o0].[OrderID]
-    ORDER BY [o0].[OrderID], [o0].[ProductID]) AS [OrderDetail], [c].[City]
-FROM [Orders] AS [o]
-LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-ORDER BY [o].[OrderID]");
+SELECT TOP(@__p_0) [o0].[OrderID], (
+    SELECT TOP(1) [o].[OrderID]
+    FROM [Order Details] AS [o]
+    WHERE [o0].[OrderID] = [o].[OrderID]
+    ORDER BY [o].[OrderID], [o].[ProductID]) AS [OrderDetail], [c].[City]
+FROM [Orders] AS [o0]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+ORDER BY [o0].[OrderID]");
         }
 
         public override async Task GroupJoin_with_complex_subquery_and_LOJ_gets_flattened(bool isAsync)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.JoinGroupJoin.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.JoinGroupJoin.cs
@@ -225,10 +225,10 @@ FROM [Customers] AS [c]");
             await base.Join_same_collection_multiple(isAsync);
 
             AssertSql(
-                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c0]
-INNER JOIN [Customers] AS [c1] ON [c0].[CustomerID] = [c1].[CustomerID]
-INNER JOIN [Customers] AS [c] ON [c0].[CustomerID] = [c].[CustomerID]");
+                @"SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
+FROM [Customers] AS [c]
+INNER JOIN [Customers] AS [c0] ON [c].[CustomerID] = [c0].[CustomerID]
+INNER JOIN [Customers] AS [c1] ON [c].[CustomerID] = [c1].[CustomerID]");
         }
 
         public override async Task Join_same_collection_force_alias_uniquefication(bool isAsync)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.ResultOperators.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.ResultOperators.cs
@@ -134,12 +134,12 @@ WHERE [o].[ProductID] = 1");
             await base.Sum_on_float_column_in_subquery(isAsync);
 
             AssertSql(
-                @"SELECT [o].[OrderID], (
-    SELECT CAST(SUM([o0].[Discount]) AS real)
-    FROM [Order Details] AS [o0]
-    WHERE [o].[OrderID] = [o0].[OrderID]) AS [Sum]
-FROM [Orders] AS [o]
-WHERE [o].[OrderID] < 10300");
+                @"SELECT [o0].[OrderID], (
+    SELECT CAST(SUM([o].[Discount]) AS real)
+    FROM [Order Details] AS [o]
+    WHERE [o0].[OrderID] = [o].[OrderID]) AS [Sum]
+FROM [Orders] AS [o0]
+WHERE [o0].[OrderID] < 10300");
         }
 
         public override async Task Average_with_no_arg(bool isAsync)
@@ -256,12 +256,12 @@ WHERE [o].[ProductID] = 1");
             await base.Average_on_float_column_in_subquery(isAsync);
 
             AssertSql(
-                @"SELECT [o].[OrderID], (
-    SELECT CAST(AVG([o0].[Discount]) AS real)
-    FROM [Order Details] AS [o0]
-    WHERE [o].[OrderID] = [o0].[OrderID]) AS [Sum]
-FROM [Orders] AS [o]
-WHERE [o].[OrderID] < 10300");
+                @"SELECT [o0].[OrderID], (
+    SELECT CAST(AVG([o].[Discount]) AS real)
+    FROM [Order Details] AS [o]
+    WHERE [o0].[OrderID] = [o].[OrderID]) AS [Sum]
+FROM [Orders] AS [o0]
+WHERE [o0].[OrderID] < 10300");
         }
 
         public override async Task Average_on_float_column_in_subquery_with_cast(bool isAsync)
@@ -269,12 +269,12 @@ WHERE [o].[OrderID] < 10300");
             await base.Average_on_float_column_in_subquery_with_cast(isAsync);
 
             AssertSql(
-                @"SELECT [o].[OrderID], (
-    SELECT CAST(AVG([o0].[Discount]) AS real)
-    FROM [Order Details] AS [o0]
-    WHERE [o].[OrderID] = [o0].[OrderID]) AS [Sum]
-FROM [Orders] AS [o]
-WHERE [o].[OrderID] < 10300");
+                @"SELECT [o0].[OrderID], (
+    SELECT CAST(AVG([o].[Discount]) AS real)
+    FROM [Order Details] AS [o]
+    WHERE [o0].[OrderID] = [o].[OrderID]) AS [Sum]
+FROM [Orders] AS [o0]
+WHERE [o0].[OrderID] < 10300");
         }
 
         public override async Task Min_with_no_arg(bool isAsync)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
@@ -33,18 +33,18 @@ FROM [Orders] AS [o]");
             AssertSql(
                 @"@__p_0='10'
 
-SELECT CAST([t].[EmployeeID] AS bigint) + CAST([t0].[OrderID] AS bigint) AS [Add], [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], 42 AS [Literal], [t].[EmployeeID], [t].[City], [t].[Country], [t].[FirstName], [t].[ReportsTo], [t].[Title]
+SELECT CAST([t0].[EmployeeID] AS bigint) + CAST([t].[OrderID] AS bigint) AS [Add], [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], 42 AS [Literal], [t0].[EmployeeID], [t0].[City], [t0].[Country], [t0].[FirstName], [t0].[ReportsTo], [t0].[Title]
 FROM (
     SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
-) AS [t0]
+) AS [t]
 CROSS JOIN (
     SELECT TOP(5) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
     FROM [Employees] AS [e]
     ORDER BY [e].[EmployeeID]
-) AS [t]
-ORDER BY [t0].[OrderID]");
+) AS [t0]
+ORDER BY [t].[OrderID]");
         }
 
         public override async Task Projection_when_null_value(bool isAsync)
@@ -344,15 +344,15 @@ WHERE [c].[CustomerID] LIKE N'A%'");
     SELECT TOP(1) (
         SELECT TOP(1) [o].[ProductID]
         FROM [Order Details] AS [o]
-        WHERE ([o0].[OrderID] = [o].[OrderID]) AND (([o].[OrderID] <> (
+        WHERE ([o1].[OrderID] = [o].[OrderID]) AND (([o].[OrderID] <> (
             SELECT COUNT(*)
-            FROM [Orders] AS [o1]
-            WHERE ([c].[CustomerID] = [o1].[CustomerID]) AND [o1].[CustomerID] IS NOT NULL)) OR (
+            FROM [Orders] AS [o0]
+            WHERE ([c].[CustomerID] = [o0].[CustomerID]) AND [o0].[CustomerID] IS NOT NULL)) OR (
             SELECT COUNT(*)
-            FROM [Orders] AS [o1]
-            WHERE ([c].[CustomerID] = [o1].[CustomerID]) AND [o1].[CustomerID] IS NOT NULL) IS NULL))
-    FROM [Orders] AS [o0]
-    WHERE (([c].[CustomerID] = [o0].[CustomerID]) AND [o0].[CustomerID] IS NOT NULL) AND ([o0].[OrderID] < 10500)) AS [Order]
+            FROM [Orders] AS [o0]
+            WHERE ([c].[CustomerID] = [o0].[CustomerID]) AND [o0].[CustomerID] IS NOT NULL) IS NULL))
+    FROM [Orders] AS [o1]
+    WHERE (([c].[CustomerID] = [o1].[CustomerID]) AND [o1].[CustomerID] IS NOT NULL) AND ([o1].[OrderID] < 10500)) AS [Order]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'A%'");
         }
@@ -724,19 +724,19 @@ WHERE [o0].[OrderID] < 10300");
 
             AssertSql(
                 @"SELECT [t0].[OrderID], [t0].[ProductID], [t0].[Discount], [t0].[Quantity], [t0].[UnitPrice]
-FROM [Orders] AS [o0]
+FROM [Orders] AS [o]
 OUTER APPLY (
     SELECT TOP(1) [t].[OrderID], [t].[ProductID], [t].[Discount], [t].[Quantity], [t].[UnitPrice], [t].[ProductID0], [t].[ProductName]
     FROM (
-        SELECT TOP(1) [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [p].[ProductID] AS [ProductID0], [p].[ProductName]
-        FROM [Order Details] AS [o]
-        INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]
-        WHERE [o0].[OrderID] = [o].[OrderID]
+        SELECT TOP(1) [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [p].[ProductID] AS [ProductID0], [p].[ProductName]
+        FROM [Order Details] AS [o0]
+        INNER JOIN [Products] AS [p] ON [o0].[ProductID] = [p].[ProductID]
+        WHERE [o].[OrderID] = [o0].[OrderID]
         ORDER BY [p].[ProductName]
     ) AS [t]
     ORDER BY [t].[ProductName]
 ) AS [t0]
-WHERE [o0].[OrderID] < 10250");
+WHERE [o].[OrderID] < 10250");
         }
 
         public override async Task Select_datetime_year_component(bool isAsync)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -1662,10 +1662,10 @@ CROSS JOIN [Employees] AS [e0]");
             await base.SelectMany_entity_deep(isAsync);
 
             AssertSql(
-                @"SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title], [e0].[EmployeeID], [e0].[City], [e0].[Country], [e0].[FirstName], [e0].[ReportsTo], [e0].[Title], [e1].[EmployeeID], [e1].[City], [e1].[Country], [e1].[FirstName], [e1].[ReportsTo], [e1].[Title], [e2].[EmployeeID], [e2].[City], [e2].[Country], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title]
-FROM [Employees] AS [e1]
-CROSS JOIN [Employees] AS [e]
+                @"SELECT [e0].[EmployeeID], [e0].[City], [e0].[Country], [e0].[FirstName], [e0].[ReportsTo], [e0].[Title], [e1].[EmployeeID], [e1].[City], [e1].[Country], [e1].[FirstName], [e1].[ReportsTo], [e1].[Title], [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title], [e2].[EmployeeID], [e2].[City], [e2].[Country], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title]
+FROM [Employees] AS [e]
 CROSS JOIN [Employees] AS [e0]
+CROSS JOIN [Employees] AS [e1]
 CROSS JOIN [Employees] AS [e2]");
         }
 
@@ -2540,9 +2540,9 @@ WHERE CAST(5 AS smallint) IN (
             await base.Select_many_cross_join_same_collection(isAsync);
 
             AssertSql(
-                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c0]
-CROSS JOIN [Customers] AS [c]");
+                @"SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+FROM [Customers] AS [c]
+CROSS JOIN [Customers] AS [c0]");
         }
 
         public override async Task OrderBy_null_coalesce_operator(bool isAsync)


### PR DESCRIPTION
### Description

An algorithmic issue in the 3.0 query code can cause execution time to grow quadratically with increasing number of includes and entity properties. This can make queries both compile and execute much slower in some scenarios.

### Customer Impact

Some queries with many `Include` calls could be so slow that they appear to hang.

### How found
Customer reported.

### Test coverage
We don't currently have perf testing for queries of this level of complexity. Perf testing is something we are already actively working on.

See below for local perf numbers before and after the change--in this case we're going from 175 seconds to 19 milliseconds.

### Regression?
Yes, regression in perf from 2.2.
 
### Risk
We have spent some time deciding what to do now and going forward. For now, we have a low-risk fix that is not 100% architecturally correct, but which fixes the issue in a safe way for the current code. (The current code only uses `SelectExpression` in certain ways, for which this fix is correct.) We are planning to follow up in 3.1 with a more architecturally sound solution.

----

Resolves #17455
```C#
_query = _context.Blogs
                .AsNoTracking()
                .Include(x => x.Posts)
                .ThenInclude(x => x.PostInstances)
                .ThenInclude(x => x.Comments)
                .ThenInclude(x => x.AcquiredComments)
                .ThenInclude(x => x.Tag_AcquiredComments)
                .ThenInclude(x => x.Tag);
```
5 levels of collection include and 1 reference include. Each class containing 5 properties (+ 1 for shadow prop as needed for FK).
No data on server side. (no shaper code executed)
Run includes time to compile the query and execute it against the server.
On preview9 package
```
|   Method |    Mean |   Error |  StdDev |
|--------- |--------:|--------:|--------:|
| RunQuery | 174.9 s | 1.927 s | 1.803 s |
```
After the fix
```
|   Method |     Mean |     Error |    StdDev |
|--------- |---------:|----------:|----------:|
| RunQuery | 19.17 ms | 0.1993 ms | 0.1864 ms |
```