### PR TITLE
Removed allocation introduced by ExpressionComparer

### DIFF
--- a/src/EFCore/Query/Internal/ExpressionEqualityComparer.cs
+++ b/src/EFCore/Query/Internal/ExpressionEqualityComparer.cs
@@ -333,7 +333,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             return x.Zip(y, (l, r) => comparer.Compare(l, r)).All(r => r);
         }
 
-        private sealed class ExpressionComparer
+        private struct ExpressionComparer
         {
             private ScopedDictionary<ParameterExpression, ParameterExpression> _parameterScope;
 


### PR DESCRIPTION
Because `ExpressionComparer` was a class each expression comparison did one additional allocation on the heap. This change removes it by changing the type to be a `struct`.