### PR TITLE
Revert "Use IMemoryCache for model caching."

### DIFF
--- a/src/EFCore/Infrastructure/ModelSourceDependencies.cs
+++ b/src/EFCore/Infrastructure/ModelSourceDependencies.cs
@@ -3,7 +3,6 @@
 
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.Infrastructure
@@ -55,16 +54,13 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         [EntityFrameworkInternal]
         public ModelSourceDependencies(
             [NotNull] IModelCustomizer modelCustomizer,
-            [NotNull] IModelCacheKeyFactory modelCacheKeyFactory,
-            [NotNull] IMemoryCache memoryCache)
+            [NotNull] IModelCacheKeyFactory modelCacheKeyFactory)
         {
             Check.NotNull(modelCustomizer, nameof(modelCustomizer));
             Check.NotNull(modelCacheKeyFactory, nameof(modelCacheKeyFactory));
-            Check.NotNull(memoryCache, nameof(memoryCache));
 
             ModelCustomizer = modelCustomizer;
             ModelCacheKeyFactory = modelCacheKeyFactory;
-            MemoryCache = memoryCache;
         }
 
         /// <summary>
@@ -80,17 +76,12 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         public IModelCacheKeyFactory ModelCacheKeyFactory { get; }
 
         /// <summary>
-        ///     Gets the <see cref="IMemoryCache" /> that will be used to cache models.
-        /// </summary>
-        public IMemoryCache MemoryCache { get; }
-
-        /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
         /// </summary>
         /// <param name="modelCustomizer"> A replacement for the current dependency of this type. </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
         public ModelSourceDependencies With([NotNull] IModelCustomizer modelCustomizer)
-            => new ModelSourceDependencies(modelCustomizer, ModelCacheKeyFactory, MemoryCache);
+            => new ModelSourceDependencies(modelCustomizer, ModelCacheKeyFactory);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -98,14 +89,6 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <param name="modelCacheKeyFactory"> A replacement for the current dependency of this type. </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
         public ModelSourceDependencies With([NotNull] IModelCacheKeyFactory modelCacheKeyFactory)
-            => new ModelSourceDependencies(ModelCustomizer, modelCacheKeyFactory, MemoryCache);
-
-        /// <summary>
-        ///     Clones this dependency parameter object with one service replaced.
-        /// </summary>
-        /// <param name="memoryCache"> A replacement for the current dependency of this type. </param>
-        /// <returns> A new parameter object with the given service replaced. </returns>
-        public ModelSourceDependencies With([NotNull] IMemoryCache memoryCache)
-            => new ModelSourceDependencies(ModelCustomizer, ModelCacheKeyFactory, memoryCache);
+            => new ModelSourceDependencies(ModelCustomizer, modelCacheKeyFactory);
     }
 }

--- a/test/EFCore.Tests/ModelSourceTest.cs
+++ b/test/EFCore.Tests/ModelSourceTest.cs
@@ -15,7 +15,6 @@ using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -166,8 +165,7 @@ namespace Microsoft.EntityFrameworkCore
                 : base(
                     new ModelSourceDependencies(
                         new ModelCustomizer(new ModelCustomizerDependencies(setFinder)),
-                        InMemoryTestHelpers.Instance.CreateContextServices().GetRequiredService<IModelCacheKeyFactory>(),
-                        new MemoryCache(new MemoryCacheOptions() { SizeLimit = 200 })))
+                        InMemoryTestHelpers.Instance.CreateContextServices().GetRequiredService<IModelCacheKeyFactory>()))
             {
             }
         }


### PR DESCRIPTION
This reverts commit 4978c1af692ed62f9a188f22ece1cf44aeb0411d.

This is the alternative fix to https://github.com/aspnet/EntityFrameworkCore/pull/17835