### PR TITLE
Fix some Cosmos discriminator issues

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -197,8 +197,8 @@ dotnet_naming_rule.interface_naming.symbols = interface_symbol
 dotnet_naming_rule.interface_naming.style = interface_style
 dotnet_naming_rule.interface_naming.severity = suggestion
 
-# Classes, Structs, Enums, Properties, Methods, Events, Namespaces
-dotnet_naming_symbols.class_symbol.applicable_kinds = class, struct, enum, property, method, event, namespace
+# Classes, Structs, Enums, Properties, Methods, Local Functions, Events, Namespaces
+dotnet_naming_symbols.class_symbol.applicable_kinds = class, struct, enum, property, method, local_function, event, namespace
 dotnet_naming_symbols.class_symbol.applicable_accessibilities = *
 
 dotnet_naming_rule.class_naming.symbols = class_symbol

--- a/src/EFCore.Cosmos/Metadata/Conventions/CosmosDiscriminatorConvention.cs
+++ b/src/EFCore.Cosmos/Metadata/Conventions/CosmosDiscriminatorConvention.cs
@@ -1,8 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections;
+using System.Linq;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -12,7 +13,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
     /// <summary>
     ///     A convention that configures the discriminator value for entity types as the entity type name.
     /// </summary>
-    public class CosmosDiscriminatorConvention : DiscriminatorConvention, IEntityTypeAddedConvention
+    public class CosmosDiscriminatorConvention :
+        DiscriminatorConvention,
+        IForeignKeyOwnershipChangedConvention,
+        IForeignKeyRemovedConvention,
+        IEntityTypeAddedConvention
     {
         /// <summary>
         ///     Creates a new instance of <see cref="CosmosDiscriminatorConvention" />.
@@ -36,22 +41,56 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             Check.NotNull(context, nameof(context));
 
             var entityType = entityTypeBuilder.Metadata;
-            if (entityTypeBuilder.Metadata.BaseType == null
-                && !Any(entityTypeBuilder.Metadata.GetDerivedTypes()))
+            if (entityType.BaseType == null
+                && !entityType.GetDerivedTypes().Any()
+                && entityType.IsDocumentRoot())
             {
                 entityTypeBuilder.HasDiscriminator(typeof(string))
-                    .HasValue(entityType, entityType.ShortName());
+                    ?.HasValue(entityType, entityType.ShortName());
             }
         }
 
-        private static bool Any([NotNull] IEnumerable source)
+        /// <summary>
+        ///     Called after the ownership value for a foreign key is changed.
+        /// </summary>
+        /// <param name="relationshipBuilder"> The builder for the foreign key. </param>
+        /// <param name="context"> Additional information associated with convention execution. </param>
+        public virtual void ProcessForeignKeyOwnershipChanged(
+            IConventionRelationshipBuilder relationshipBuilder,
+            IConventionContext<IConventionRelationshipBuilder> context)
         {
-            foreach (var _ in source)
-            {
-                return true;
-            }
+            Check.NotNull(relationshipBuilder, nameof(relationshipBuilder));
+            Check.NotNull(context, nameof(context));
 
-            return false;
+            var entityType = relationshipBuilder.Metadata.DeclaringEntityType;
+            if (relationshipBuilder.Metadata.IsOwnership
+                && !entityType.IsDocumentRoot()
+                && entityType.BaseType == null
+                && !entityType.GetDerivedTypes().Any())
+            {
+                entityType.Builder.HasNoDeclaredDiscriminator();
+            }
+        }
+
+        /// <summary>
+        ///     Called after a foreign key is removed.
+        /// </summary>
+        /// <param name="entityTypeBuilder"> The builder for the entity type. </param>
+        /// <param name="foreignKey"> The removed foreign key. </param>
+        /// <param name="context"> Additional information associated with convention execution. </param>
+        public virtual void ProcessForeignKeyRemoved(
+            IConventionEntityTypeBuilder entityTypeBuilder,
+            IConventionForeignKey foreignKey,
+            IConventionContext<IConventionForeignKey> context)
+        {
+            var entityType = foreignKey.DeclaringEntityType;
+            if (foreignKey.IsOwnership
+                && !entityType.IsDocumentRoot()
+                && entityType.BaseType == null
+                && !entityType.GetDerivedTypes().Any())
+            {
+                entityType.Builder.HasNoDeclaredDiscriminator();
+            }
         }
 
         /// <summary>
@@ -72,11 +111,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 return;
             }
 
-            IConventionDiscriminatorBuilder discriminator;
+            IConventionDiscriminatorBuilder discriminator = null;
             var entityType = entityTypeBuilder.Metadata;
             if (newBaseType == null)
             {
-                discriminator = entityTypeBuilder.HasDiscriminator(typeof(string));
+                if (entityType.IsDocumentRoot())
+                {
+                    discriminator = entityTypeBuilder.HasDiscriminator(typeof(string));
+                }
             }
             else
             {

--- a/src/EFCore.Cosmos/Metadata/Conventions/Internal/CosmosConventionSetBuilder.cs
+++ b/src/EFCore.Cosmos/Metadata/Conventions/Internal/CosmosConventionSetBuilder.cs
@@ -49,6 +49,10 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Metadata.Conventions.Internal
             conventionSet.EntityTypeBaseTypeChangedConventions.Add(storeKeyConvention);
             ReplaceConvention(conventionSet.EntityTypeBaseTypeChangedConventions, (DiscriminatorConvention)discriminatorConvention);
 
+            conventionSet.ForeignKeyRemovedConventions.Add(discriminatorConvention);
+            conventionSet.ForeignKeyRemovedConventions.Add(storeKeyConvention);
+
+            conventionSet.ForeignKeyOwnershipChangedConventions.Add(discriminatorConvention);
             conventionSet.ForeignKeyOwnershipChangedConventions.Add(storeKeyConvention);
 
             conventionSet.EntityTypeAnnotationChangedConventions.Add(storeKeyConvention);

--- a/src/EFCore.Cosmos/Metadata/Conventions/StoreKeyConvention.cs
+++ b/src/EFCore.Cosmos/Metadata/Conventions/StoreKeyConvention.cs
@@ -23,6 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
     public class StoreKeyConvention :
         IEntityTypeAddedConvention,
         IForeignKeyOwnershipChangedConvention,
+        IForeignKeyRemovedConvention,
         IEntityTypeAnnotationChangedConvention,
         IEntityTypeBaseTypeChangedConvention
     {
@@ -111,6 +112,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             Check.NotNull(context, nameof(context));
 
             Process(relationshipBuilder.Metadata.DeclaringEntityType.Builder);
+        }
+
+        /// <summary>
+        ///     Called after a foreign key is removed.
+        /// </summary>
+        /// <param name="entityTypeBuilder"> The builder for the entity type. </param>
+        /// <param name="foreignKey"> The removed foreign key. </param>
+        /// <param name="context"> Additional information associated with convention execution. </param>
+        public virtual void ProcessForeignKeyRemoved(
+            IConventionEntityTypeBuilder entityTypeBuilder,
+            IConventionForeignKey foreignKey,
+            IConventionContext<IConventionForeignKey> context)
+        {
+            if (foreignKey.IsOwnership)
+            {
+                Process(foreignKey.DeclaringEntityType.Builder);
+            }
         }
 
         /// <summary>

--- a/src/EFCore.Cosmos/Storage/Internal/CosmosDatabaseWrapper.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosDatabaseWrapper.cs
@@ -204,8 +204,12 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
                     {
                         document = documentSource.CreateDocument(entry);
 
-                        document[entityType.GetDiscriminatorProperty().GetPropertyName()] =
-                            JToken.FromObject(entityType.GetDiscriminatorValue(), CosmosClientWrapper.Serializer);
+                        var propertyName = entityType.GetDiscriminatorProperty()?.GetPropertyName();
+                        if (propertyName != null)
+                        {
+                            document[propertyName] =
+                                JToken.FromObject(entityType.GetDiscriminatorValue(), CosmosClientWrapper.Serializer);
+                        }
                     }
 
                     return _cosmosClient.ReplaceItem(
@@ -255,8 +259,12 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
                     {
                         document = documentSource.CreateDocument(entry);
 
-                        document[entityType.GetDiscriminatorProperty().GetPropertyName()] =
-                            JToken.FromObject(entityType.GetDiscriminatorValue(), CosmosClientWrapper.Serializer);
+                        var propertyName = entityType.GetDiscriminatorProperty()?.GetPropertyName();
+                        if (propertyName != null)
+                        {
+                            document[propertyName] =
+                                JToken.FromObject(entityType.GetDiscriminatorValue(), CosmosClientWrapper.Serializer);
+                        }
                     }
 
                     return _cosmosClient.ReplaceItemAsync(

--- a/src/EFCore/Infrastructure/ModelSource.cs
+++ b/src/EFCore/Infrastructure/ModelSource.cs
@@ -1,9 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Concurrent;
-using System.Threading;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;

--- a/test/EFCore.Cosmos.FunctionalTests/CustomConvertersCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/CustomConvertersCosmosTest.cs
@@ -113,12 +113,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
             base.Can_insert_and_query_struct_to_string_converter_for_pk();
         }
 
-        [ConditionalTheory(Skip = "Issue #17814")]
-        public override Task Can_query_custom_type_not_mapped_by_default_equality(bool isAsync)
-        {
-            return base.Can_query_custom_type_not_mapped_by_default_equality(isAsync);
-        }
-
         public class CustomConvertersCosmosFixture : CustomConvertersFixtureBase
         {
             protected override ITestStoreFactory TestStoreFactory => CosmosTestStoreFactory.Instance;
@@ -147,6 +141,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
                 shadowJObject.SetConfigurationSource(ConfigurationSource.Convention);
                 var nullableShadowJObject = (Property)modelBuilder.Entity<BuiltInNullableDataTypesShadow>().Property("__jObject").Metadata;
                 nullableShadowJObject.SetConfigurationSource(ConfigurationSource.Convention);
+
+                modelBuilder.Entity<SimpleCounter>(b => b.ToContainer("SimpleCounters"));
             }
         }
     }

--- a/test/EFCore.Cosmos.FunctionalTests/EmbeddedDocumentsTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/EmbeddedDocumentsTest.cs
@@ -182,7 +182,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
                     var addressJson = existingAddressEntry.Property<JObject>("__jObject").CurrentValue;
 
                     Assert.Equal("Second", addressJson[nameof(Address.Street)]);
-                    Assert.Equal(4, addressJson.Count);
+                    Assert.Equal(3, addressJson.Count);
                     Assert.Equal(2, addressJson["unmappedId"]);
 
                     addresses = people[2].Addresses.ToList();

--- a/test/EFCore.Cosmos.FunctionalTests/EndToEndCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/EndToEndCosmosTest.cs
@@ -23,101 +23,163 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
             Fixture = fixture;
         }
 
-        [ConditionalFact(Skip = "Issue#16146")]
+        [ConditionalFact]
         public async Task Can_add_update_delete_end_to_end()
         {
-            await using (var testDatabase = CosmosTestStore.CreateInitialized(DatabaseName))
+            await using var testDatabase = CosmosTestStore.CreateInitialized(DatabaseName);
+            var options = Fixture.CreateOptions(testDatabase);
+
+            var customer = new Customer { Id = 42, Name = "Theon" };
+
+            using (var context = new CustomerContext(options))
             {
-                var options = Fixture.CreateOptions(testDatabase);
+                context.Database.EnsureCreated();
 
-                var customer = new Customer { Id = 42, Name = "Theon" };
+                context.Add(customer);
 
-                using (var context = new CustomerContext(options))
-                {
-                    context.Database.EnsureCreated();
+                context.SaveChanges();
+            }
 
-                    context.Add(customer);
+            using (var context = new CustomerContext(options))
+            {
+                var customerFromStore = context.Set<Customer>().Single();
 
-                    context.SaveChanges();
-                }
+                Assert.Equal(42, customerFromStore.Id);
+                Assert.Equal("Theon", customerFromStore.Name);
 
-                using (var context = new CustomerContext(options))
-                {
-                    var customerFromStore = context.Set<Customer>().Single();
+                customerFromStore.Name = "Theon Greyjoy";
 
-                    Assert.Equal(42, customerFromStore.Id);
-                    Assert.Equal("Theon", customerFromStore.Name);
+                context.SaveChanges();
+            }
 
-                    customerFromStore.Name = "Theon Greyjoy";
+            using (var context = new CustomerContext(options))
+            {
+                var customerFromStore = context.Set<Customer>().Single();
 
-                    context.SaveChanges();
-                }
+                Assert.Equal(42, customerFromStore.Id);
+                Assert.Equal("Theon Greyjoy", customerFromStore.Name);
 
-                using (var context = new CustomerContext(options))
-                {
-                    var customerFromStore = context.Set<Customer>().Single();
+                context.Remove(customerFromStore);
 
-                    Assert.Equal(42, customerFromStore.Id);
-                    Assert.Equal("Theon Greyjoy", customerFromStore.Name);
+                context.SaveChanges();
+            }
 
-                    context.Remove(customerFromStore);
-
-                    context.SaveChanges();
-                }
-
-                using (var context = new CustomerContext(options))
-                {
-                    Assert.Equal(0, context.Set<Customer>().Count());
-                }
+            using (var context = new CustomerContext(options))
+            {
+                Assert.Empty(context.Set<Customer>().ToList());
             }
         }
 
-        [ConditionalFact(Skip = "Issue#16146")]
+        [ConditionalFact]
         public async Task Can_add_update_delete_end_to_end_async()
         {
-            await using (var testDatabase = CosmosTestStore.CreateInitialized(DatabaseName))
+            await using var testDatabase = CosmosTestStore.CreateInitialized(DatabaseName);
+            var options = Fixture.CreateOptions(testDatabase);
+
+            var customer = new Customer { Id = 42, Name = "Theon" };
+
+            using (var context = new CustomerContext(options))
             {
-                var options = Fixture.CreateOptions(testDatabase);
+                await context.Database.EnsureCreatedAsync();
 
-                var customer = new Customer { Id = 42, Name = "Theon" };
+                context.Add(customer);
 
-                using (var context = new CustomerContext(options))
-                {
-                    await context.Database.EnsureCreatedAsync();
+                await context.SaveChangesAsync();
+            }
 
-                    context.Add(customer);
+            using (var context = new CustomerContext(options))
+            {
+                var customerFromStore = await context.Set<Customer>().SingleAsync();
 
-                    await context.SaveChangesAsync();
-                }
+                Assert.Equal(42, customerFromStore.Id);
+                Assert.Equal("Theon", customerFromStore.Name);
 
-                using (var context = new CustomerContext(options))
-                {
-                    var customerFromStore = context.Set<Customer>().Single();
+                customerFromStore.Name = "Theon Greyjoy";
 
-                    Assert.Equal(42, customerFromStore.Id);
-                    Assert.Equal("Theon", customerFromStore.Name);
+                await context.SaveChangesAsync();
+            }
 
-                    customerFromStore.Name = "Theon Greyjoy";
+            using (var context = new CustomerContext(options))
+            {
+                var customerFromStore = await context.Set<Customer>().SingleAsync();
 
-                    await context.SaveChangesAsync();
-                }
+                Assert.Equal(42, customerFromStore.Id);
+                Assert.Equal("Theon Greyjoy", customerFromStore.Name);
 
-                using (var context = new CustomerContext(options))
-                {
-                    var customerFromStore = context.Set<Customer>().Single();
+                context.Remove(customerFromStore);
 
-                    Assert.Equal(42, customerFromStore.Id);
-                    Assert.Equal("Theon Greyjoy", customerFromStore.Name);
+                await context.SaveChangesAsync();
+            }
 
-                    context.Remove(customerFromStore);
+            using (var context = new CustomerContext(options))
+            {
+                Assert.Empty(await context.Set<Customer>().ToListAsync());
+            }
+        }
 
-                    await context.SaveChangesAsync();
-                }
+        [ConditionalFact]
+        public async Task Can_add_update_delete_detached_entity_end_to_end_async()
+        {
+            await using var testDatabase = CosmosTestStore.CreateInitialized(DatabaseName);
+            var options = Fixture.CreateOptions(testDatabase);
 
-                using (var context = new CustomerContext(options))
-                {
-                    Assert.Equal(0, await context.Set<Customer>().CountAsync());
-                }
+            var customer = new Customer { Id = 42, Name = "Theon" };
+            string storeId = null;
+            using (var context = new CustomerContext(options))
+            {
+                await context.Database.EnsureCreatedAsync();
+
+                var entry = context.Add(customer);
+
+                await context.SaveChangesAsync();
+
+                context.Add(customer);
+
+                storeId = entry.Property<string>("id").CurrentValue;
+            }
+
+            Assert.NotNull(storeId);
+
+            using (var context = new CustomerContext(options))
+            {
+                var customerFromStore = context.Set<Customer>().Single();
+
+                Assert.Equal(42, customerFromStore.Id);
+                Assert.Equal("Theon", customerFromStore.Name);
+            }
+
+            using (var context = new CustomerContext(options))
+            {
+                customer.Name = "Theon Greyjoy";
+
+                var entry = context.Entry(customer);
+                entry.Property<string>("id").CurrentValue = storeId;
+
+                entry.State = EntityState.Modified;
+
+                await context.SaveChangesAsync();
+            }
+
+            using (var context = new CustomerContext(options))
+            {
+                var customerFromStore = context.Set<Customer>().Single();
+
+                Assert.Equal(42, customerFromStore.Id);
+                Assert.Equal("Theon Greyjoy", customerFromStore.Name);
+            }
+
+            using (var context = new CustomerContext(options))
+            {
+                var entry = context.Entry(customer);
+                entry.Property<string>("id").CurrentValue = storeId;
+                entry.State = EntityState.Deleted;
+
+                await context.SaveChangesAsync();
+            }
+
+            using (var context = new CustomerContext(options))
+            {
+                Assert.Empty(context.Set<Customer>().ToList());
             }
         }
 
@@ -141,123 +203,52 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
             }
         }
 
-        [ConditionalFact(Skip = "Issue #16146")]
-        public async Task Can_add_update_delete_detached_entity_end_to_end_async()
-        {
-            await using (var testDatabase = CosmosTestStore.CreateInitialized(DatabaseName))
-            {
-                var options = Fixture.CreateOptions(testDatabase);
-
-                var customer = new Customer { Id = 42, Name = "Theon" };
-
-                string storeId = null;
-                using (var context = new CustomerContext(options))
-                {
-                    await context.Database.EnsureCreatedAsync();
-
-                    var entry = context.Add(customer);
-
-                    await context.SaveChangesAsync();
-
-                    context.Add(customer);
-
-                    storeId = entry.Property<string>("id").CurrentValue;
-                }
-
-                Assert.NotNull(storeId);
-
-                using (var context = new CustomerContext(options))
-                {
-                    var customerFromStore = context.Set<Customer>().Single();
-
-                    Assert.Equal(42, customerFromStore.Id);
-                    Assert.Equal("Theon", customerFromStore.Name);
-                }
-
-                using (var context = new CustomerContext(options))
-                {
-                    customer.Name = "Theon Greyjoy";
-
-                    var entry = context.Entry(customer);
-                    entry.Property<string>("id").CurrentValue = storeId;
-
-                    entry.State = EntityState.Modified;
-
-                    await context.SaveChangesAsync();
-                }
-
-                using (var context = new CustomerContext(options))
-                {
-                    var customerFromStore = context.Set<Customer>().Single();
-
-                    Assert.Equal(42, customerFromStore.Id);
-                    Assert.Equal("Theon Greyjoy", customerFromStore.Name);
-                }
-
-                using (var context = new CustomerContext(options))
-                {
-                    var entry = context.Entry(customer);
-                    entry.Property<string>("id").CurrentValue = storeId;
-                    entry.State = EntityState.Deleted;
-
-                    await context.SaveChangesAsync();
-                }
-
-                using (var context = new CustomerContext(options))
-                {
-                    Assert.Equal(0, context.Set<Customer>().Count());
-                }
-            }
-        }
-
-        [ConditionalFact(Skip = "Issue#16146")]
+        [ConditionalFact]
         public async Task Can_add_update_delete_end_to_end_with_partition_key()
         {
-            await using (var testDatabase = CosmosTestStore.CreateInitialized(DatabaseName))
+            await using var testDatabase = CosmosTestStore.CreateInitialized(DatabaseName);
+            var options = Fixture.CreateOptions(testDatabase);
+
+            var customer = new Customer { Id = 42, Name = "Theon", PartitionKey = 1 };
+
+            using (var context = new PartitionKeyContext(options))
             {
-                var options = Fixture.CreateOptions(testDatabase);
+                context.Database.EnsureCreated();
 
-                var customer = new Customer { Id = 42, Name = "Theon", PartitionKey = 1 };
+                context.Add(customer);
 
-                using (var context = new PartitionKeyContext(options))
-                {
-                    context.Database.EnsureCreated();
+                context.SaveChanges();
+            }
 
-                    context.Add(customer);
+            using (var context = new PartitionKeyContext(options))
+            {
+                var customerFromStore = context.Set<Customer>().Single();
 
-                    context.SaveChanges();
-                }
+                Assert.Equal(42, customerFromStore.Id);
+                Assert.Equal("Theon", customerFromStore.Name);
+                Assert.Equal(1, customerFromStore.PartitionKey);
 
-                using (var context = new PartitionKeyContext(options))
-                {
-                    var customerFromStore = context.Set<Customer>().Single();
+                customerFromStore.Name = "Theon Greyjoy";
 
-                    Assert.Equal(42, customerFromStore.Id);
-                    Assert.Equal("Theon", customerFromStore.Name);
-                    Assert.Equal(1, customerFromStore.PartitionKey);
+                context.SaveChanges();
+            }
 
-                    customerFromStore.Name = "Theon Greyjoy";
+            using (var context = new PartitionKeyContext(options))
+            {
+                var customerFromStore = context.Set<Customer>().Single();
 
-                    context.SaveChanges();
-                }
+                Assert.Equal(42, customerFromStore.Id);
+                Assert.Equal("Theon Greyjoy", customerFromStore.Name);
+                Assert.Equal(1, customerFromStore.PartitionKey);
 
-                using (var context = new PartitionKeyContext(options))
-                {
-                    var customerFromStore = context.Set<Customer>().Single();
+                context.Remove(customerFromStore);
 
-                    Assert.Equal(42, customerFromStore.Id);
-                    Assert.Equal("Theon Greyjoy", customerFromStore.Name);
-                    Assert.Equal(1, customerFromStore.PartitionKey);
+                context.SaveChanges();
+            }
 
-                    context.Remove(customerFromStore);
-
-                    context.SaveChanges();
-                }
-
-                using (var context = new PartitionKeyContext(options))
-                {
-                    Assert.Equal(0, context.Set<Customer>().Count());
-                }
+            using (var context = new PartitionKeyContext(options))
+            {
+                Assert.Empty(context.Set<Customer>().ToList());
             }
         }
 
@@ -271,57 +262,118 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
             protected override void OnModelCreating(ModelBuilder modelBuilder)
             {
                 modelBuilder.Entity<Customer>().HasPartitionKey(c => c.PartitionKey);
+                modelBuilder.Entity<Customer>().Property(c => c.PartitionKey).HasConversion<string>();
+            }
+        }
+
+        [ConditionalFact]
+        public async Task Can_use_detached_entities_without_discriminators()
+        {
+            await using var testDatabase = CosmosTestStore.CreateInitialized(DatabaseName);
+            var options = Fixture.CreateOptions(testDatabase);
+
+            var customer = new Customer { Id = 42, Name = "Theon" };
+
+            using (var context = new NoDiscriminatorCustomerContext(options))
+            {
+                context.Database.EnsureCreated();
+
+                context.Add(customer);
+
+                context.SaveChanges();
+            }
+
+            using (var context = new NoDiscriminatorCustomerContext(options))
+            {
+                context.Add(customer).State = EntityState.Modified;
+
+                customer.Name = "Theon Greyjoy";
+
+                context.SaveChanges();
+            }
+
+            using (var context = new NoDiscriminatorCustomerContext(options))
+            {
+                var customerFromStore = context.Set<Customer>().AsNoTracking().Single();
+
+                Assert.Equal(42, customerFromStore.Id);
+                Assert.Equal("Theon Greyjoy", customerFromStore.Name);
+
+                context.Add(customer).State = EntityState.Deleted;
+
+                context.SaveChanges();
+            }
+
+            using (var context = new NoDiscriminatorCustomerContext(options))
+            {
+                Assert.Empty(context.Set<Customer>().ToList());
+            }
+        }
+
+        private class NoDiscriminatorCustomerContext : CustomerContext
+        {
+            public NoDiscriminatorCustomerContext(DbContextOptions dbContextOptions)
+                : base(dbContextOptions)
+            {
+            }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<Customer>().HasNoDiscriminator();
             }
         }
 
         [ConditionalFact]
         public async Task Can_update_unmapped_properties()
         {
-            await using (var testDatabase = CosmosTestStore.CreateInitialized(DatabaseName))
+            await using var testDatabase = CosmosTestStore.CreateInitialized(DatabaseName);
+            var options = Fixture.CreateOptions(testDatabase);
+
+            var customer = new Customer { Id = 42, Name = "Theon" };
+
+            using (var context = new ExtraCustomerContext(options))
             {
-                var options = Fixture.CreateOptions(testDatabase);
+                context.Database.EnsureCreated();
 
-                var customer = new Customer { Id = 42, Name = "Theon" };
+                var entry = context.Add(customer);
+                entry.Property<string>("EMail").CurrentValue = "theon.g@winterfell.com";
 
-                using (var context = new ExtraCustomerContext(options))
-                {
-                    context.Database.EnsureCreated();
+                context.SaveChanges();
+            }
 
-                    var entry = context.Add(customer);
-                    entry.Property<string>("EMail").CurrentValue = "theon.g@winterfell.com";
+            using (var context = new ExtraCustomerContext(options))
+            {
+                var customerFromStore = context.Set<Customer>().Single();
 
-                    context.SaveChanges();
-                }
+                Assert.Equal(42, customerFromStore.Id);
+                Assert.Equal("Theon", customerFromStore.Name);
 
-                using (var context = new CustomerContext(options))
-                {
-                    var customerFromStore = context.Set<Customer>().Single();
+                customerFromStore.Name = "Theon Greyjoy";
 
-                    Assert.Equal(42, customerFromStore.Id);
-                    Assert.Equal("Theon", customerFromStore.Name);
+                context.SaveChanges();
+            }
 
-                    customerFromStore.Name = "Theon Greyjoy";
+            using (var context = new ExtraCustomerContext(options))
+            {
+                var customerFromStore = context.Set<Customer>().Single();
 
-                    context.SaveChanges();
-                }
+                Assert.Equal(42, customerFromStore.Id);
+                Assert.Equal("Theon Greyjoy", customerFromStore.Name);
 
-                using (var context = new ExtraCustomerContext(options))
-                {
-                    var customerFromStore = context.Set<Customer>().Single();
+                var entry = context.Entry(customerFromStore);
+                Assert.Equal("theon.g@winterfell.com", entry.Property<string>("EMail").CurrentValue);
 
-                    Assert.Equal(42, customerFromStore.Id);
-                    Assert.Equal("Theon Greyjoy", customerFromStore.Name);
+                var json = entry.Property<JObject>("__jObject").CurrentValue;
+                Assert.Equal("theon.g@winterfell.com", json["e-mail"]);
 
-                    var entry = context.Entry(customerFromStore);
-                    Assert.Equal("theon.g@winterfell.com", entry.Property<string>("EMail").CurrentValue);
+                context.Remove(customerFromStore);
 
-                    var json = entry.Property<JObject>("__jObject").CurrentValue;
-                    Assert.Equal("theon.g@winterfell.com", json["e-mail"]);
+                context.SaveChanges();
+            }
 
-                    context.Remove(customerFromStore);
-
-                    context.SaveChanges();
-                }
+            using (var context = new ExtraCustomerContext(options))
+            {
+                Assert.Empty(context.Set<Customer>().ToList());
             }
         }
 
@@ -339,36 +391,34 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
             }
         }
 
-        [ConditionalFact(Skip = "Issue#16146")]
+        [ConditionalFact]
         public async Task Can_use_non_persisted_properties()
         {
-            await using (var testDatabase = CosmosTestStore.CreateInitialized(DatabaseName))
+            await using var testDatabase = CosmosTestStore.CreateInitialized(DatabaseName);
+            var options = Fixture.CreateOptions(testDatabase);
+
+            var customer = new Customer { Id = 42, Name = "Theon" };
+
+            using (var context = new UnmappedCustomerContext(options))
             {
-                var options = Fixture.CreateOptions(testDatabase);
+                context.Database.EnsureCreated();
 
-                var customer = new Customer { Id = 42, Name = "Theon" };
+                context.Add(customer);
 
-                using (var context = new UnmappedCustomerContext(options))
-                {
-                    context.Database.EnsureCreated();
+                context.SaveChanges();
+                Assert.Equal("Theon", customer.Name);
+            }
 
-                    context.Add(customer);
+            using (var context = new UnmappedCustomerContext(options))
+            {
+                var customerFromStore = context.Set<Customer>().Single();
 
-                    context.SaveChanges();
-                    Assert.Equal("Theon", customer.Name);
-                }
+                Assert.Equal(42, customerFromStore.Id);
+                Assert.Null(customerFromStore.Name);
 
-                using (var context = new UnmappedCustomerContext(options))
-                {
-                    var customerFromStore = context.Set<Customer>().Single();
+                customerFromStore.Name = "Theon Greyjoy";
 
-                    Assert.Equal(42, customerFromStore.Id);
-                    Assert.Null(customerFromStore.Name);
-
-                    customerFromStore.Name = "Theon Greyjoy";
-
-                    Assert.Equal(0, context.SaveChanges());
-                }
+                Assert.Equal(0, context.SaveChanges());
             }
         }
 
@@ -388,22 +438,20 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
         [ConditionalFact]
         public async Task Using_a_conflicting_incompatible_id_throws()
         {
-            await using (var testDatabase = CosmosTestStore.CreateInitialized(DatabaseName))
+            await using var testDatabase = CosmosTestStore.CreateInitialized(DatabaseName);
+            var options = Fixture.CreateOptions(testDatabase);
+
+            using (var context = new ConflictingIncompatibleIdContext(options))
             {
-                var options = Fixture.CreateOptions(testDatabase);
+                await Assert.ThrowsAnyAsync<Exception>(
+                    async () =>
+                    {
+                        await context.Database.EnsureCreatedAsync();
 
-                using (var context = new ConflictingIncompatibleIdContext(options))
-                {
-                    await Assert.ThrowsAnyAsync<Exception>(
-                        async () =>
-                        {
-                            await context.Database.EnsureCreatedAsync();
+                        context.Add(new ConflictingIncompatibleId { id = 42 });
 
-                            context.Add(new ConflictingIncompatibleId { id = 42 });
-
-                            await context.SaveChangesAsync();
-                        });
-                }
+                        await context.SaveChangesAsync();
+                    });
             }
         }
 
@@ -427,60 +475,58 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
             }
         }
 
-        [ConditionalFact(Skip = "Issue #16146")]
+        [ConditionalFact]
         public async Task Can_add_update_delete_end_to_end_with_conflicting_id()
         {
-            await using (var testDatabase = CosmosTestStore.CreateInitialized(DatabaseName))
+            await using var testDatabase = CosmosTestStore.CreateInitialized(DatabaseName);
+            var options = Fixture.CreateOptions(testDatabase);
+
+            var entity = new ConflictingId { id = "42", Name = "Theon" };
+
+            using (var context = new ConflictingIdContext(options))
             {
-                var options = Fixture.CreateOptions(testDatabase);
+                await context.Database.EnsureCreatedAsync();
 
-                var entity = new ConflictingId { id = "42", Name = "Theon" };
+                context.Add(entity);
 
-                using (var context = new ConflictingIdContext(options))
-                {
-                    await context.Database.EnsureCreatedAsync();
+                await context.SaveChangesAsync();
+            }
 
-                    context.Add(entity);
+            using (var context = new ConflictingIdContext(options))
+            {
+                var entityFromStore = context.Set<ConflictingId>().Single();
 
-                    await context.SaveChangesAsync();
-                }
+                Assert.Equal("42", entityFromStore.id);
+                Assert.Equal("Theon", entityFromStore.Name);
+            }
 
-                using (var context = new ConflictingIdContext(options))
-                {
-                    var entityFromStore = context.Set<ConflictingId>().Single();
+            using (var context = new ConflictingIdContext(options))
+            {
+                entity.Name = "Theon Greyjoy";
 
-                    Assert.Equal("42", entityFromStore.id);
-                    Assert.Equal("Theon", entityFromStore.Name);
-                }
+                context.Update(entity);
 
-                using (var context = new ConflictingIdContext(options))
-                {
-                    entity.Name = "Theon Greyjoy";
+                await context.SaveChangesAsync();
+            }
 
-                    context.Update(entity);
+            using (var context = new ConflictingIdContext(options))
+            {
+                var entityFromStore = context.Set<ConflictingId>().Single();
 
-                    await context.SaveChangesAsync();
-                }
+                Assert.Equal("42", entityFromStore.id);
+                Assert.Equal("Theon Greyjoy", entityFromStore.Name);
+            }
 
-                using (var context = new ConflictingIdContext(options))
-                {
-                    var entityFromStore = context.Set<ConflictingId>().Single();
+            using (var context = new ConflictingIdContext(options))
+            {
+                context.Remove(entity);
 
-                    Assert.Equal("42", entityFromStore.id);
-                    Assert.Equal("Theon Greyjoy", entityFromStore.Name);
-                }
+                await context.SaveChangesAsync();
+            }
 
-                using (var context = new ConflictingIdContext(options))
-                {
-                    context.Remove(entity);
-
-                    await context.SaveChangesAsync();
-                }
-
-                using (var context = new ConflictingIdContext(options))
-                {
-                    Assert.Equal(0, context.Set<ConflictingId>().Count());
-                }
+            using (var context = new ConflictingIdContext(options))
+            {
+                Assert.Empty(context.Set<ConflictingId>().ToList());
             }
         }
 
@@ -500,6 +546,47 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
             protected override void OnModelCreating(ModelBuilder modelBuilder)
             {
                 modelBuilder.Entity<ConflictingId>();
+            }
+        }
+
+        [ConditionalFact]
+        public async Task Can_have_non_string_property_named_Discriminator()
+        {
+            await using var testDatabase = CosmosTestStore.CreateInitialized(DatabaseName);
+
+            using (var context = new NonStringDiscriminatorContext(Fixture.CreateOptions(testDatabase)))
+            {
+                context.Database.EnsureCreated();
+
+                context.Add(new NonStringDiscriminator { Id = 1 });
+                await context.SaveChangesAsync();
+
+                Assert.NotNull(await context.Set<NonStringDiscriminator>().FirstOrDefaultAsync());
+            }
+        }
+
+        private class NonStringDiscriminator
+        {
+            public int Id { get; set; }
+            public EntityType Discriminator { get; set; }
+        }
+
+        private enum EntityType
+        {
+            Base,
+            Derived
+        }
+
+        public class NonStringDiscriminatorContext : DbContext
+        {
+            public NonStringDiscriminatorContext(DbContextOptions dbContextOptions)
+                : base(dbContextOptions)
+            {
+            }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<NonStringDiscriminator>();
             }
         }
 

--- a/test/EFCore.Specification.Tests/CustomConvertersTestBase.cs
+++ b/test/EFCore.Specification.Tests/CustomConvertersTestBase.cs
@@ -358,7 +358,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             using (var context = CreateContext())
             {
-                context.Set<SimpleCounter>().Add(new SimpleCounter() { StyleKey = "Swag" });
+                context.Set<SimpleCounter>().Add(new SimpleCounter() { CounterId = 1, StyleKey = "Swag" });
                 context.SaveChanges();
             }
 
@@ -738,18 +738,15 @@ namespace Microsoft.EntityFrameworkCore
                         b.Property(o => o.Id).HasConversion(new OrderIdEntityFrameworkValueConverter());
                     });
 
-                // See issue#17814
-                if (context.Database.ProviderName != "Microsoft.EntityFrameworkCore.Cosmos")
-                {
-                    modelBuilder.Entity<SimpleCounter>(
-                        b =>
-                        {
-                            b.HasKey(c => c.CounterId);
-                            b.Property(c => c.Discriminator).HasConversion(
-                                d => StringToDictionarySerializer.Serialize(d),
-                                json => StringToDictionarySerializer.Deserialize(json));
-                        });
-                }
+                modelBuilder.Entity<SimpleCounter>(
+                    b =>
+                    {
+                        b.Property(e => e.CounterId).ValueGeneratedNever();
+                        b.HasKey(c => c.CounterId);
+                        b.Property(c => c.Discriminator).HasConversion(
+                            d => StringToDictionarySerializer.Serialize(d),
+                            json => StringToDictionarySerializer.Deserialize(json));
+                    });
             }
 
             public static class StringToDictionarySerializer


### PR DESCRIPTION
#### Description
Don't add discriminators for embedded entities 
Allow to update entities without discriminators
Don't try to add the default discriminator if a conflicting property already exists

Fixes #17764
Fixes #17302
Fixes #17814

#### Customer impact
Several basic scenarios involving discriminators will be unblocked now.

#### Regression
N/A, 3.0 will be the first RTM release for the Cosmos provider

#### Risk
Low