### PR TITLE
Cosmos: Populate owned entities nested more than one level down

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/EmbeddedDocumentsTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/EmbeddedDocumentsTest.cs
@@ -245,8 +245,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
             }
         }
 
-        [ConditionalFact(Skip = "Issue #17733")]
-        public virtual async Task Can_query_nested_embedded_types()
+        [ConditionalFact]
+        public virtual async Task Can_query_and_modify_nested_embedded_types()
         {
             await using (var testDatabase = CreateTestStore())
             {
@@ -255,6 +255,17 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
                     var missile = context.Set<Vehicle>().First(v => v.Name == "AIM-9M Sidewinder");
 
                     Assert.Equal("Heat-seeking", missile.Operator.Details.Type);
+
+                    missile.Operator.Details.Type = "IR";
+
+                    await context.SaveChangesAsync();
+                }
+
+                using (var context = CreateContext())
+                {
+                    var missile = context.Set<Vehicle>().First(v => v.Name == "AIM-9M Sidewinder");
+
+                    Assert.Equal("IR", missile.Operator.Details.Type);
                 }
             }
         }


### PR DESCRIPTION
#### Description
Use the full owner access expression instead of just the jObject variable to allow accessing values on the owner of the owner.

Fixes #17733

#### Customer impact
Owned entities nested more than one level down are unusable without this fix.

#### Regression
N/A, 3.0 will be the first RTM release for the Cosmos provider

#### Risk
Low
