### PR TITLE
Improvements to asserters in query tests.

### DIFF
--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -899,16 +899,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 l1s => l1s.OrderBy(e => e.Id).Select(e => e.OneToMany_Required1.Select(i => i.Id)),
                 assertOrder: true,
-                elementAsserter: (e, a) =>
-                {
-                    var expectedList = ((IEnumerable<int>)e).OrderBy(ee => ee).ToList();
-                    var actualList = ((IEnumerable<int>)a).OrderBy(aa => aa).ToList();
-                    Assert.Equal(expectedList.Count, actualList.Count);
-                    for (var i = 0; i < expectedList.Count; i++)
-                    {
-                        Assert.Equal(expectedList[i], actualList[i]);
-                    }
-                });
+                elementAsserter: (e, a) => AssertCollection<int>(e, a));
         }
 
         [ConditionalTheory]
@@ -2208,7 +2199,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery<Level3>(
                 isAsync,
                 l3s => l3s.OrderBy(l3 => l3.OneToOne_Required_FK_Inverse3.Id).Select(l3 => l3.OneToOne_Required_FK_Inverse3),
-                elementAsserter: (e, a) => Assert.Equal(e.Id, a.Id),
+                elementAsserter: (e, a) => AssertEqual<Level2>(e, a),
                 assertOrder: true);
         }
 
@@ -2221,7 +2212,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 l3s => l3s.OrderBy(l3 => l3.OneToOne_Required_FK_Inverse3.Id)
                     .Select(l3 => EF.Property<Level2>(l3, "OneToOne_Required_FK_Inverse3")),
                 l3s => l3s.OrderBy(l3 => l3.OneToOne_Required_FK_Inverse3.Id).Select(l3 => l3.OneToOne_Required_FK_Inverse3),
-                elementAsserter: (e, a) => Assert.Equal(e.Id, a.Id),
+                elementAsserter: (e, a) => AssertEqual<Level2>(e, a),
                 assertOrder: true);
         }
 
@@ -2234,7 +2225,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 l3s => l3s.OrderBy(l3 => EF.Property<Level2>(l3, "OneToOne_Required_FK_Inverse3").Id)
                     .Select(l3 => l3.OneToOne_Required_FK_Inverse3),
                 l3s => l3s.OrderBy(l3 => l3.OneToOne_Required_FK_Inverse3.Id).Select(l3 => l3.OneToOne_Required_FK_Inverse3),
-                elementAsserter: (e, a) => Assert.Equal(e.Id, a.Id),
+                elementAsserter: (e, a) => AssertEqual<Level2>(e, a),
                 assertOrder: true);
         }
 
@@ -2247,7 +2238,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 l3s => from l3 in l3s
                        orderby l3.OneToOne_Required_FK_Inverse3.Id
                        select l3.OneToOne_Required_FK_Inverse3.OneToOne_Required_FK_Inverse2,
-                elementAsserter: (e, a) => Assert.Equal(e.Id, a.Id),
+                elementAsserter: (e, a) => AssertEqual<Level1>(e, a),
                 assertOrder: true);
         }
 
@@ -2922,8 +2913,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.l1?.Id + " " + e.l2?.Id,
                 elementAsserter: (e, a) =>
                 {
-                    Assert.Equal(e.l1.Id, a.l1.Id);
-                    Assert.Equal(e.l2.Id, a.l2.Id);
+                    AssertEqual<Level1>(e.l1, a.l1);
+                    AssertEqual<Level2>(e.l2, a.l2);
                 });
         }
 
@@ -2952,8 +2943,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.l2?.Id + " " + e.l1?.Id,
                 elementAsserter: (e, a) =>
                 {
-                    Assert.Equal(e.l2.Id, a.l2.Id);
-                    Assert.Equal(e.l1.Id, a.l1.Id);
+                    AssertEqual<Level2>(e.l2, a.l2);
+                    AssertEqual<Level1>(e.l1, a.l1);
                 });
         }
 
@@ -2981,8 +2972,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.l4?.Id + " " + e.l2?.Id,
                 elementAsserter: (e, a) =>
                 {
-                    Assert.Equal(e.l4.Id, a.l4.Id);
-                    Assert.Equal(e.l2.Id, a.l2.Id);
+                    AssertEqual<Level4>(e.l4, a.l4);
+                    AssertEqual<Level2>(e.l2, a.l2);
                 });
         }
 
@@ -3012,8 +3003,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.l4?.Id + " " + e.l2?.Id,
                 elementAsserter: (e, a) =>
                 {
-                    Assert.Equal(e.l4?.Id, a.l4?.Id);
-                    Assert.Equal(e.l2?.Id, a.l2?.Id);
+                    AssertEqual<Level4>(e.l4, a.l4);
+                    AssertEqual<Level2>(e.l2, a.l2);
                 });
         }
 
@@ -3051,8 +3042,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.l4?.Id + " " + e.l2?.Id,
                 elementAsserter: (e, a) =>
                 {
-                    Assert.Equal(e.l4.Id, a.l4.Id);
-                    Assert.Equal(e.l2.Id, a.l2.Id);
+                    AssertEqual<Level4>(e.l4, a.l4);
+                    AssertEqual<Level2>(e.l2, a.l2);
                 });
         }
 
@@ -3179,8 +3170,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.Entity.Id,
                 elementAsserter: (e, a) =>
                 {
-                    Assert.Equal(e.Entity.Id, a.Entity.Id);
-                    CollectionAsserter<Level2>(ee => ee.Id, (ee, aa) => Assert.Equal(ee.Id, aa.Id))(e.Collection, a.Collection);
+                    AssertEqual<Level4>(e.Entity, a.Entity);
+                    AssertCollection<Level2>(e.Collection, a.Collection);
                     Assert.Equal(e.Property, a.Property);
                 });
         }
@@ -3227,8 +3218,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.l1.Id + " " + e.l2.Id,
                 elementAsserter: (e, a) =>
                 {
-                    Assert.Equal(e.l1.Id, a.l1.Id);
-                    Assert.Equal(e.l2.Id, a.l2.Id);
+                    AssertEqual<Level1>(e.l1, a.l1);
+                    AssertEqual<Level2>(e.l2, a.l2);
                 });
         }
 
@@ -3242,7 +3233,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                               join l2 in l2s on l1.Id equals l2s.Select(l => l.Id).OrderBy(l => l).FirstOrDefault()
                               select new { l1, l2 },
                 elementSorter: e => e.l1.Id + " " + e.l2.Id,
-                elementAsserter: (e, a) => Assert.Equal(e.l1.Name + " " + e.l2.Name, a.l1.Name + " " + a.l2.Name));
+                elementAsserter: (e, a) =>
+                {
+                    AssertEqual<Level1>(e.l1, a.l1);
+                    AssertEqual<Level2>(e.l2, a.l2);
+                });
         }
 
         [ConditionalTheory(Skip = " Issue#16093")]
@@ -3255,9 +3250,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 l1s => l1s.Where(
                     l1 => MaybeScalar<bool>(
                               l1.OneToOne_Optional_FK1,
-                              () => l1.OneToOne_Optional_FK1.OneToMany_Optional2.Distinct().Select(l3 => l3.Id).Contains(1)) == true),
-                elementSorter: e => e.Id,
-                elementAsserter: (e, a) => Assert.Equal(e.Id, a.Id));
+                              () => l1.OneToOne_Optional_FK1.OneToMany_Optional2.Distinct().Select(l3 => l3.Id).Contains(1)) == true));
         }
 
         [ConditionalTheory]
@@ -3276,9 +3269,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                                       l2.OneToOne_Optional_FK2,
                                       () => MaybeScalar<int>(
                                           l2.OneToOne_Optional_FK2.OneToOne_Optional_FK3,
-                                          () => l2.OneToOne_Optional_FK2.OneToOne_Optional_FK3.Id))).All(a => true)),
-                    elementSorter: e => e.Id,
-                    elementAsserter: (e, a) => Assert.Equal(e.Id, a.Id)))).Message;
+                                          () => l2.OneToOne_Optional_FK2.OneToOne_Optional_FK3.Id))).All(a => true))))).Message;
 
             Assert.Contains("ClientMethod((Nullable<int>)", message);
         }
@@ -3441,7 +3432,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.property,
                 elementAsserter: (e, a) =>
                 {
-                    Assert.Equal(e.entity?.Id, a.entity?.Id);
+                    AssertEqual<Level2>(e.entity, a.entity);
                     Assert.Equal(e.property, a.property);
                 });
         }
@@ -4043,9 +4034,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                            join l2 in l2s on l1_inner.Id equals l2.Level1_Optional_Id into grouping
                            from l2 in grouping.DefaultIfEmpty()
                            select l1_inner).Count() > 4
-                    select l1,
-                elementSorter: e => e.Id,
-                elementAsserter: (e, a) => Assert.Equal(e.Id, a.Id));
+                    select l1);
         }
 
         [ConditionalTheory]
@@ -4061,9 +4050,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                            join l2 in l2s on l1_inner.Id equals l2.Level1_Optional_Id into grouping
                            from l2 in grouping.DefaultIfEmpty()
                            select l1_inner).Distinct().Count() > 4
-                    select l1,
-                elementSorter: e => e.Id,
-                elementAsserter: (e, a) => Assert.Equal(e.Id, a.Id));
+                    select l1);
         }
 
         [ConditionalTheory]
@@ -4097,9 +4084,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     join l2 in l2s
                         on new { A = MaybeScalar<int>(l1.OneToMany_Optional_Self_Inverse1, () => l1.OneToMany_Optional_Self_Inverse1.Id) }
                         equals new { A = l2.Level1_Optional_Id }
-                    select l1,
-                elementSorter: e => e.Id,
-                elementAsserter: (e, a) => Assert.Equal(e.Id, a.Id));
+                    select l1);
         }
 
         [ConditionalTheory]
@@ -4135,9 +4120,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                             A = l2.Level1_Optional_Id,
                             B = MaybeScalar<int>(l2.OneToMany_Optional_Self_Inverse2, () => l2.OneToMany_Optional_Self_Inverse2.Id)
                         }
-                    select l1,
-                elementSorter: e => e.Id,
-                elementAsserter: (e, a) => Assert.Equal(e.Id, a.Id));
+                    select l1);
         }
 
         [ConditionalTheory(Skip = "Issue #17068")]
@@ -4412,16 +4395,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 l1s => from l1 in l1s
                        select l1.OneToMany_Optional1,
                 elementSorter: e => e != null ? e.Count : 0,
-                elementAsserter: (e, a) =>
-                {
-                    var actualCollection = new List<Level2>();
-                    foreach (var actualElement in a)
-                    {
-                        actualCollection.Add(actualElement);
-                    }
-
-                    Assert.Equal(((IEnumerable<Level2>)e)?.Count() ?? 0, actualCollection.Count);
-                });
+                elementAsserter: (e, a) => AssertCollection<Level2>(e, a));
         }
 
         [ConditionalTheory]
@@ -4433,18 +4407,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 l1s => from l1 in l1s
                        select l1.OneToOne_Optional_FK1.OneToMany_Optional2,
                 l1s => from l1 in l1s
-                       select Maybe(l1.OneToOne_Optional_FK1, () => l1.OneToOne_Optional_FK1.OneToMany_Optional2),
-                elementSorter: e => e != null ? e.Count : 0,
-                elementAsserter: (e, a) =>
-                {
-                    var actualCollection = new List<Level3>();
-                    foreach (var actualElement in a)
-                    {
-                        actualCollection.Add(actualElement);
-                    }
-
-                    Assert.Equal(((IEnumerable<Level3>)e)?.Count() ?? 0, actualCollection.Count);
-                });
+                       select Maybe(l1.OneToOne_Optional_FK1, () => l1.OneToOne_Optional_FK1.OneToMany_Optional2) ?? new List<Level3>(),
+                elementSorter: e => e.Count,
+                elementAsserter: (e, a) => AssertCollection<Level3>(e, a));
         }
 
         [ConditionalTheory]
@@ -4456,18 +4421,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 l1s => from l1 in l1s
                        select l1.OneToOne_Optional_FK1.OneToMany_Optional2.Take(50),
                 l1s => from l1 in l1s
-                       select Maybe(l1.OneToOne_Optional_FK1, () => l1.OneToOne_Optional_FK1.OneToMany_Optional2.Take(50)),
+                       select Maybe(l1.OneToOne_Optional_FK1, () => l1.OneToOne_Optional_FK1.OneToMany_Optional2.Take(50)) ?? new List<Level3>(),
                 elementSorter: e => ((IEnumerable<Level3>)e)?.Count() ?? 0,
-                elementAsserter: (e, a) =>
-                {
-                    var actualCollection = new List<Level3>();
-                    foreach (var actualElement in a)
-                    {
-                        actualCollection.Add(actualElement);
-                    }
-
-                    Assert.Equal(((IEnumerable<Level3>)e)?.Count() ?? 0, actualCollection.Count);
-                });
+                elementAsserter: (e, a) => AssertCollection<Level3>(e, a));
         }
 
         [ConditionalTheory]
@@ -4483,18 +4439,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                                "OneToOne_Optional_FK1"),
                            "OneToMany_Optional2"),
                 l1s => from l1 in l1s
-                       select Maybe(l1.OneToOne_Optional_FK1, () => l1.OneToOne_Optional_FK1.OneToMany_Optional2),
-                elementSorter: e => e != null ? e.Count : 0,
-                elementAsserter: (e, a) =>
-                {
-                    var actualCollection = new List<Level3>();
-                    foreach (var actualElement in a)
-                    {
-                        actualCollection.Add(actualElement);
-                    }
-
-                    Assert.Equal(((IEnumerable<Level3>)e)?.Count() ?? 0, actualCollection.Count);
-                });
+                       select Maybe(l1.OneToOne_Optional_FK1, () => l1.OneToOne_Optional_FK1.OneToMany_Optional2) ?? new List<Level3>(),
+                elementSorter: e => e.Count,
+                elementAsserter: (e, a) => AssertCollection<Level3>(e, a));
         }
 
         [ConditionalTheory]
@@ -4511,20 +4458,13 @@ namespace Microsoft.EntityFrameworkCore.Query
                            l1.Id,
                            OneToMany_Optional2 = Maybe(
                                l1.OneToOne_Optional_FK1,
-                               () => l1.OneToOne_Optional_FK1.OneToMany_Optional2)
+                               () => l1.OneToOne_Optional_FK1.OneToMany_Optional2) ?? new List<Level3>()
                        },
                 elementSorter: e => e.Id,
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.Id, a.Id);
-
-                    var actualCollection = new List<Level3>();
-                    foreach (var actualElement in a.OneToMany_Optional2)
-                    {
-                        actualCollection.Add(actualElement);
-                    }
-
-                    Assert.Equal(((IEnumerable<Level3>)e.OneToMany_Optional2)?.Count() ?? 0, actualCollection.Count);
+                    AssertCollection<Level3>(e.OneToMany_Optional2, a.OneToMany_Optional2);
                 });
         }
 
@@ -4562,14 +4502,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.Id, a.Id);
-
-                    var actualCollection = new List<Level2>();
-                    foreach (var actualElement in a.collection)
-                    {
-                        actualCollection.Add(actualElement);
-                    }
-
-                    Assert.Equal(((IEnumerable<Level2>)e.collection).Count(), actualCollection.Count);
+                    AssertCollection<Level2>(e.collection, a.collection);
                 });
         }
 
@@ -4585,14 +4518,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.l1.Id, a.l1.Id);
-
-                    var actualCollection = new List<Level2>();
-                    foreach (var actualElement in a.OneToMany_Optional1)
-                    {
-                        actualCollection.Add(actualElement);
-                    }
-
-                    Assert.Equal(((IEnumerable<Level2>)e.OneToMany_Optional1).Count(), actualCollection.Count);
+                    AssertCollection<Level2>(e.OneToMany_Optional1, a.OneToMany_Optional1);
                 });
         }
 
@@ -4608,14 +4534,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.l1.Id, a.l1.Id);
-
-                    var actualCollection = new List<Level2>();
-                    foreach (var actualElement in a.OneToMany_Optional1)
-                    {
-                        actualCollection.Add(actualElement);
-                    }
-
-                    Assert.Equal(((IEnumerable<Level2>)e.OneToMany_Optional1).Count(), actualCollection.Count);
+                    AssertCollection<Level2>(e.OneToMany_Optional1, a.OneToMany_Optional1);
                 });
         }
 
@@ -4631,20 +4550,13 @@ namespace Microsoft.EntityFrameworkCore.Query
                        select new
                        {
                            l1.OneToOne_Optional_FK1,
-                           OneToMany_Optional2 = Maybe(l1.OneToOne_Optional_FK1, () => l1.OneToOne_Optional_FK1.OneToMany_Optional2)
+                           OneToMany_Optional2 = Maybe(l1.OneToOne_Optional_FK1, () => l1.OneToOne_Optional_FK1.OneToMany_Optional2) ?? new List<Level3>()
                        },
                 elementSorter: e => e.OneToOne_Optional_FK1?.Id,
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.OneToOne_Optional_FK1?.Id, a.OneToOne_Optional_FK1?.Id);
-
-                    var actualCollection = new List<Level3>();
-                    foreach (var actualElement in a.OneToMany_Optional2)
-                    {
-                        actualCollection.Add(actualElement);
-                    }
-
-                    Assert.Equal(((IEnumerable<Level3>)e.OneToMany_Optional2)?.Count() ?? 0, actualCollection.Count);
+                    AssertCollection<Level3>(e.OneToMany_Optional2, a.OneToMany_Optional2);
                 });
         }
 
@@ -5098,7 +5010,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true,
                 elementAsserter: (e, a) =>
                 {
-                    CollectionAsserter<dynamic>(
+                    CustomCollectionAsserter<dynamic>(
                         elementSorter: e1 => e1.Level3.Name,
                         elementAsserter: (e1, a1) => Assert.Equal(e1.Level3.Name, a1.Level3.Name))(e.Level2s, a.Level2s);
                 });
@@ -5124,7 +5036,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true,
                 elementAsserter: (e, a) =>
                 {
-                    CollectionAsserter<dynamic>(
+                    CustomCollectionAsserter<dynamic>(
                         elementSorter: e1 => e1.Level3.Value,
                         elementAsserter: (e1, a1) => Assert.Equal(e1.Level3.Value, a1.Level3.Value))(e.Level2s, a.Level2s);
                 });
@@ -5146,8 +5058,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.Id, a.Id);
-                    CollectionAsserter<Level3>(ee => ee.Id, (ee, aa) => Assert.Equal(ee.Id, aa.Id))(
-                        e.OneToMany_Optional2, a.OneToMany_Optional2);
+                    AssertCollection<Level3>(e.OneToMany_Optional2, a.OneToMany_Optional2);
                 });
         }
 
@@ -5163,8 +5074,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.Id, a.Id);
-                    CollectionAsserter<Level4>(ee => ee.Id, (ee, aa) => Assert.Equal(ee.Id, aa.Id))(
-                        e.OneToMany_Optional3, a.OneToMany_Optional3);
+                    AssertCollection<Level4>(e.OneToMany_Optional3, a.OneToMany_Optional3);
                 });
         }
 

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryFixtureBase.cs
@@ -71,6 +71,26 @@ namespace Microsoft.EntityFrameworkCore.Query
                             Assert.Equal(e.Id, a.Id);
                             Assert.Equal(e.Name, a.Name);
                             Assert.Equal(e.CapitalName, a.CapitalName);
+                            if (e is LocustHorde locustHorde)
+                            {
+                                Assert.Equal(e.CommanderName, a.CommanderName);
+                                Assert.Equal(e.Eradicated, a.Eradicated);
+                            }
+                        }
+                    }
+                },
+                {
+                    typeof(LocustHorde), (e, a) =>
+                    {
+                        Assert.Equal(e == null, a == null);
+
+                        if (a != null)
+                        {
+                            Assert.Equal(e.Id, a.Id);
+                            Assert.Equal(e.Name, a.Name);
+                            Assert.Equal(e.CapitalName, a.CapitalName);
+                            Assert.Equal(e.CommanderName, a.CommanderName);
+                            Assert.Equal(e.Eradicated, a.Eradicated);
                         }
                     }
                 },
@@ -93,61 +113,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                     }
                 },
                 {
-                    typeof(LocustCommander), (e, a) =>
-                    {
-                        Assert.Equal(e == null, a == null);
-
-                        if (a != null)
-                        {
-                            Assert.Equal(e.Name, a.Name);
-                            Assert.Equal(e.ThreatLevel, a.ThreatLevel);
-                            Assert.Equal(e.DefeatedByNickname, a.DefeatedByNickname);
-                            Assert.Equal(e.DefeatedBySquadId, a.DefeatedBySquadId);
-                        }
-                    }
-                },
-                {
-                    typeof(LocustHorde), (e, a) =>
-                    {
-                        Assert.Equal(e == null, a == null);
-
-                        if (a != null)
-                        {
-                            Assert.Equal(e.Id, a.Id);
-                            Assert.Equal(e.Name, a.Name);
-                            Assert.Equal(e.CapitalName, a.CapitalName);
-                            Assert.Equal(e.CommanderName, a.CommanderName);
-                            Assert.Equal(e.Eradicated, a.Eradicated);
-                        }
-                    }
-                },
-                {
-                    typeof(LocustLeader), (e, a) =>
-                    {
-                        Assert.Equal(e == null, a == null);
-
-                        if (a != null)
-                        {
-                            Assert.Equal(e.Name, a.Name);
-                            Assert.Equal(e.ThreatLevel, a.ThreatLevel);
-                        }
-                    }
-                },
-                {
-                    typeof(Mission), (e, a) =>
-                    {
-                        Assert.Equal(e == null, a == null);
-
-                        if (a != null)
-                        {
-                            Assert.Equal(e.Id, a.Id);
-                            Assert.Equal(e.CodeName, a.CodeName);
-                            Assert.Equal(e.Rating, a.Rating);
-                            Assert.Equal(e.Timeline, a.Timeline);
-                        }
-                    }
-                },
-                {
                     typeof(Officer), (e, a) =>
                     {
                         Assert.Equal(e == null, a == null);
@@ -162,6 +127,51 @@ namespace Microsoft.EntityFrameworkCore.Query
                             Assert.Equal(e.LeaderNickname, a.LeaderNickname);
                             Assert.Equal(e.LeaderSquadId, a.LeaderSquadId);
                             Assert.Equal(e.Rank, a.Rank);
+                        }
+                    }
+                },
+                {
+                    typeof(LocustLeader), (e, a) =>
+                    {
+                        Assert.Equal(e == null, a == null);
+
+                        if (a != null)
+                        {
+                            Assert.Equal(e.Name, a.Name);
+                            Assert.Equal(e.ThreatLevel, a.ThreatLevel);
+                            if (e is LocustCommander locustCommander)
+                            {
+                                Assert.Equal(e.DefeatedByNickname, a.DefeatedByNickname);
+                                Assert.Equal(e.DefeatedBySquadId, a.DefeatedBySquadId);
+                            }
+                        }
+                    }
+                },
+                {
+                    typeof(LocustCommander), (e, a) =>
+                    {
+                        Assert.Equal(e == null, a == null);
+
+                        if (a != null)
+                        {
+                            Assert.Equal(e.Name, a.Name);
+                            Assert.Equal(e.ThreatLevel, a.ThreatLevel);
+                            Assert.Equal(e.DefeatedByNickname, a.DefeatedByNickname);
+                            Assert.Equal(e.DefeatedBySquadId, a.DefeatedBySquadId);
+                        }
+                    }
+                },
+                {
+                    typeof(Mission), (e, a) =>
+                    {
+                        Assert.Equal(e == null, a == null);
+
+                        if (a != null)
+                        {
+                            Assert.Equal(e.Id, a.Id);
+                            Assert.Equal(e.CodeName, a.CodeName);
+                            Assert.Equal(e.Rating, a.Rating);
+                            Assert.Equal(e.Timeline, a.Timeline);
                         }
                     }
                 },

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -1479,8 +1479,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.Tag1.Id + " " + e.Tag2.Id,
                 elementAsserter: (e, a) =>
                 {
-                    Assert.Equal(e.Tag1.Id, a.Tag1.Id);
-                    Assert.Equal(e.Tag2.Id, a.Tag2.Id);
+                    AssertEqual<CogTag>(e.Tag1, a.Tag1);
+                    AssertEqual<CogTag>(e.Tag2, a.Tag2);
                 });
         }
 
@@ -1855,8 +1855,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.t1.Id + " " + e.t2.Id,
                 elementAsserter: (e, a) =>
                 {
-                    Assert.Equal(e.t1.Id, a.t1.Id);
-                    Assert.Equal(e.t2.Id, a.t2.Id);
+                    AssertEqual<CogTag>(e.t1, a.t1);
+                    AssertEqual<CogTag>(e.t2, e.t2);
                 });
         }
 
@@ -1908,7 +1908,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.A.Nickname,
                 elementAsserter: (e, a) =>
                 {
-                    Assert.Equal(e.A.Nickname, e.A.Nickname);
+                    AssertEqual<Gear>(e.A, a.A);
                     Assert.Equal(e.B, e.B);
                 });
         }
@@ -2546,7 +2546,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 (ts, gs) => ts.Where(t => t.Note != "K.I.A.").OrderBy(t => t.Note)
                     .Select(t => gs.OrderBy(g => g.Nickname).Skip(t.Gear.SquadId)),
                 assertOrder: true,
-                elementAsserter: CollectionAsserter<Gear>(e => e.Nickname, (e, a) => Assert.Equal(e.Nickname, a.Nickname)));
+                elementAsserter: (e, a) => AssertCollection<Gear>(e, a, ordered: true));
         }
 
         [ConditionalTheory(Skip = "Issue#16313")]
@@ -2558,7 +2558,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 (ts, gs) => ts.Where(t => t.Note != "K.I.A.").OrderBy(t => t.Note)
                     .Select(t => gs.OrderBy(g => g.Nickname).Take(t.Gear.SquadId)),
                 assertOrder: true,
-                elementAsserter: CollectionAsserter<Gear>(e => e.Nickname, (e, a) => Assert.Equal(e.Nickname, a.Nickname)));
+                elementAsserter: (e, a) => AssertCollection<Gear>(e, a, ordered: true));
         }
 
         [ConditionalTheory]
@@ -2572,7 +2572,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .OrderBy(g => g.Nickname)
                     .Select(g => g.Weapons.Where(w => w.Name != "Lancer").ToList()),
                 assertOrder: true,
-                elementAsserter: CollectionAsserter<Weapon>(e => e.Id, (e, a) => Assert.Equal(e.Id, a.Id)));
+                elementAsserter: (e, a) => AssertCollection<Weapon>(e, a));
         }
 
         [ConditionalTheory]
@@ -2583,7 +2583,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 gs => gs.OfType<Officer>().OrderBy(g => g.Nickname).Select(g => g.Reports.Where(r => r.Nickname != "Dom").ToList()),
                 assertOrder: true,
-                elementAsserter: CollectionAsserter<Gear>(e => e.Nickname, (e, a) => Assert.Equal(e.Nickname, a.Nickname)));
+                elementAsserter: (e, a) => AssertCollection<Gear>(e, a));
         }
 
         [ConditionalTheory(Skip = "Issue#16314")]
@@ -2594,7 +2594,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 (ts, gs) => ts.OrderBy(t => t.Note).Select(t => gs.Where(g => g.Nickname == t.GearNickName)),
                 assertOrder: true,
-                elementAsserter: CollectionAsserter<Gear>(g => g.Nickname, (e, a) => Assert.Equal(e.Nickname, a.Nickname)));
+                elementAsserter: (e, a) => AssertCollection<Gear>(e, a));
         }
 
         [ConditionalTheory]
@@ -3088,8 +3088,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             var message = (await Assert.ThrowsAsync<InvalidOperationException>(
                 () => AssertQuery<Gear>(
                 isAsync,
-                gs => gs.Where(g => ClientEquals(g.Tag.Note, prm)),
-                elementAsserter: (e, a) => Assert.Equal(e.Nickname, a.Nickname)))).Message;
+                gs => gs.Where(g => ClientEquals(g.Tag.Note, prm))))).Message;
 
             Assert.Equal(
                 CoreStrings.TranslationFailed("Where<TransparentIdentifier<Gear, CogTag>>(    source: LeftJoin<Gear, CogTag, AnonymousObject, TransparentIdentifier<Gear, CogTag>>(        outer: DbSet<Gear>,         inner: DbSet<CogTag>,         outerKeySelector: (g) => new AnonymousObject(new object[]        {             (object)Property<string>(g, \"Nickname\"),             (object)Property<Nullable<int>>(g, \"SquadId\")         }),         innerKeySelector: (c) => new AnonymousObject(new object[]        {             (object)Property<string>(c, \"GearNickName\"),             (object)Property<Nullable<int>>(c, \"GearSquadId\")         }),         resultSelector: (o, i) => new TransparentIdentifier<Gear, CogTag>(            Outer = o,             Inner = i        )),     predicate: (g) => ClientEquals(        first: g.Inner.Note,         second: (Unhandled parameter: __prm_0)))"),
@@ -4368,7 +4367,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       orderby g.Nickname
                       select g.Weapons.ToList(),
                 assertOrder: true,
-                elementAsserter: CollectionAsserter<Weapon>(e => e.Id, (e, a) => Assert.Equal(e.Id, a.Id)));
+                elementAsserter: (e, a) => AssertCollection<Weapon>(e, a));
         }
 
         [ConditionalTheory]
@@ -4395,7 +4394,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       orderby g.Nickname
                       select g.Weapons.ToArray(),
                 assertOrder: true,
-                elementAsserter: CollectionAsserter<Weapon>(e => e.Id, (e, a) => Assert.Equal(e.Id, a.Id)));
+                elementAsserter: (e, a) => AssertCollection<Weapon>(e, a));
         }
 
         [ConditionalTheory]
@@ -4411,7 +4410,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                               where w.IsAutomatic || w.Name != "foo"
                               select w).ToList(),
                 assertOrder: true,
-                elementAsserter: CollectionAsserter<Weapon>(e => e.Id, (e, a) => Assert.Equal(e.Id, a.Id)));
+                elementAsserter: (e, a) => AssertCollection<Weapon>(e, a));
         }
 
         [ConditionalTheory]
@@ -4427,7 +4426,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                               where w.IsAutomatic || w.Name != "foo"
                               select w).ToList(),
                 assertOrder: true,
-                elementAsserter: CollectionAsserter<Weapon>(e => e.Id, (e, a) => Assert.Equal(e.Id, a.Id)));
+                elementAsserter: (e, a) => AssertCollection<Weapon>(e, a));
         }
 
         [ConditionalTheory]
@@ -4443,7 +4442,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                               where w.IsAutomatic || w.Name != "foo"
                               select w).ToArray(),
                 assertOrder: true,
-                elementAsserter: CollectionAsserter<Weapon>(e => e.Id, (e, a) => Assert.Equal(e.Id, a.Id)));
+                elementAsserter: (e, a) => AssertCollection<Weapon>(e, a));
         }
 
         [ConditionalTheory]
@@ -4460,7 +4459,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                               orderby w.Name descending
                               select w).ToList(),
                 assertOrder: true,
-                elementAsserter: CollectionAsserter<Weapon>(elementAsserter: (e, a) => Assert.Equal(e.Id, a.Id)));
+                elementAsserter: (e, a) => AssertCollection<Weapon>(e, a, ordered: true));
         }
 
         [ConditionalTheory]
@@ -4487,7 +4486,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.Nickname, a.Nickname);
-                    CollectionAsserter<dynamic>(elementSorter: ee => ee.FullName)(e.Collection, a.Collection);
+                    CustomCollectionAsserter<dynamic>(elementSorter: ee => ee.FullName)(e.Collection, a.Collection);
                 });
         }
 
@@ -4504,7 +4503,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                               where w.IsAutomatic || w.Name != "foo"
                               select w.Name).ToList(),
                 assertOrder: true,
-                elementAsserter: CollectionAsserter<string>(e => e));
+                elementAsserter: (e, a) => AssertCollection<string>(e, a));
         }
 
         [ConditionalTheory]
@@ -4520,7 +4519,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                               where w.IsAutomatic || w.Name != "foo"
                               select "BFG").ToList(),
                 assertOrder: true,
-                elementAsserter: CollectionAsserter<string>());
+                elementAsserter: (e, a) => AssertCollection<string>(e, a));
         }
 
         [ConditionalTheory]
@@ -4536,7 +4535,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                               where w.IsAutomatic || w.Name != "foo"
                               select true).ToList(),
                 assertOrder: true,
-                elementAsserter: CollectionAsserter<bool>());
+                elementAsserter: (e, a) => AssertCollection<bool>(e, a));
         }
 
         [ConditionalTheory]
@@ -4550,13 +4549,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       where g.Nickname != "Marcus"
                       select g.Squad.Missions.Where(m => m.MissionId != 17).ToList(),
                 assertOrder: true,
-                elementAsserter: CollectionAsserter<SquadMission>(
-                    e => e.MissionId + " " + e.SquadId,
-                    (e, a) =>
-                    {
-                        Assert.Equal(e.MissionId, a.MissionId);
-                        Assert.Equal(e.SquadId, a.SquadId);
-                    }));
+                elementAsserter: (e, a) => AssertCollection<SquadMission>(e, a));
         }
 
         [ConditionalTheory]
@@ -4581,7 +4574,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.Name, a.Name);
-                    CollectionAsserter<dynamic>(ee => ee.FullName + " " + ee.Rank)(e.Collection, a.Collection);
+                    CustomCollectionAsserter<dynamic>(ee => ee.FullName + " " + ee.Rank)(e.Collection, a.Collection);
                 });
         }
 
@@ -4598,18 +4591,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                                       where ps.SquadId < 7
                                       select ps).ToList()).ToList(),
                 elementSorter: CollectionSorter<object>(),
-                elementAsserter: (e, a) =>
-                {
-                    CollectionAsserter(
-                        CollectionSorter<SquadMission>(),
-                        CollectionAsserter<SquadMission>(
-                            ee => ee.SquadId + " " + ee.MissionId,
-                            (ee, aa) =>
-                            {
-                                Assert.Equal(ee.SquadId, aa.SquadId);
-                                Assert.Equal(ee.MissionId, aa.MissionId);
-                            }))(e, a);
-                });
+                elementAsserter: CustomCollectionAsserter(
+                    elementSorter: CollectionSorter<SquadMission>(),
+                    elementAsserter: (ee, aa) => AssertCollection<SquadMission>(ee, aa)));
         }
 
         [ConditionalTheory]
@@ -4625,18 +4609,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                                       where ps.SquadId < 2
                                       select ps).ToList()),
                 elementSorter: CollectionSorter<object>(),
-                elementAsserter: (e, a) =>
-                {
-                    CollectionAsserter(
-                        CollectionSorter<SquadMission>(),
-                        CollectionAsserter<SquadMission>(
-                            ee => ee.SquadId + " " + ee.MissionId,
-                            (ee, aa) =>
-                            {
-                                Assert.Equal(ee.SquadId, aa.SquadId);
-                                Assert.Equal(ee.MissionId, aa.MissionId);
-                            }))(e, a);
-                });
+                elementAsserter: CustomCollectionAsserter(
+                    elementSorter: CollectionSorter<SquadMission>(),
+                    elementAsserter: (ee, aa) => AssertCollection<SquadMission>(ee, aa)));
         }
 
         [ConditionalTheory]
@@ -4652,18 +4627,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                                       where ps.SquadId < 7
                                       select ps)).ToList(),
                 elementSorter: CollectionSorter<object>(),
-                elementAsserter: (e, a) =>
-                {
-                    CollectionAsserter(
-                        CollectionSorter<SquadMission>(),
-                        CollectionAsserter<SquadMission>(
-                            ee => ee.SquadId + " " + ee.MissionId,
-                            (ee, aa) =>
-                            {
-                                Assert.Equal(ee.SquadId, aa.SquadId);
-                                Assert.Equal(ee.MissionId, aa.MissionId);
-                            }))(e, a);
-                });
+                elementAsserter: CustomCollectionAsserter(
+                    elementSorter: CollectionSorter<SquadMission>(),
+                    elementAsserter: (ee, aa) => AssertCollection<SquadMission>(ee, aa)));
         }
 
         [ConditionalTheory]
@@ -4695,14 +4661,12 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.FullName, a.FullName);
-                    CollectionAsserter<dynamic>(
-                        ee => ee.FullName,
-                        (ee, aa) =>
+                    CustomCollectionAsserter<dynamic>(
+                        elementSorter: ee => ee.FullName,
+                        elementAsserter:(ee, aa) =>
                         {
                             Assert.Equal(ee.FullName, aa.FullName);
-                            CollectionAsserter<dynamic>(
-                                eee => eee.Name,
-                                (eee, aaa) => Assert.Equal(eee.Name, aaa.Name))(ee.InnerCollection, aa.InnerCollection);
+                            AssertCollection<Weapon>(ee.InnerCollection, aa.InnerCollection);
                         })(e.OuterCollection, a.OuterCollection);
                 });
         }
@@ -4725,8 +4689,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.FullName, a.FullName);
-                    CollectionAsserter<Weapon>(ee => ee.Id, (ee, aa) => Assert.Equal(ee.Id, aa.Id))(e.First, a.First);
-                    CollectionAsserter<Weapon>(ee => ee.Id, (ee, aa) => Assert.Equal(ee.Id, aa.Id))(e.Second, a.Second);
+                    AssertCollection<Weapon>(e.First, a.First);
+                    AssertCollection<Weapon>(e.Second, a.Second);
                 });
         }
 
@@ -4749,8 +4713,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.FullName, a.FullName);
-                    CollectionAsserter<Weapon>(ee => ee.Id, (ee, aa) => Assert.Equal(ee.Id, aa.Id))(e.First, a.First);
-                    CollectionAsserter<Weapon>(ee => ee.Id, (ee, aa) => Assert.Equal(ee.Id, aa.Id))(e.Second, a.Second);
+                    AssertCollection<Weapon>(e.First, a.First);
+                    AssertCollection<Weapon>(e.Second, a.Second);
                 });
         }
 
@@ -4783,8 +4747,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.Nickname, a.Nickname);
-                    CollectionAsserter<dynamic>()(e.First, a.First);
-                    CollectionAsserter<dynamic>()(e.Second, a.Second);
+                    CustomCollectionAsserter<dynamic>()(e.First, a.First);
+                    CustomCollectionAsserter<dynamic>()(e.Second, a.Second);
                 });
         }
 
@@ -4823,10 +4787,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.FullName, a.FullName);
-
-                    CollectionAsserter<dynamic>(
-                        ee => ee.Id,
-                        (ee, aa) => Assert.Equal(ee.Id, aa.Id))(e.OuterCollection2, a.OuterCollection2);
+                    AssertCollection<Weapon>(e.OuterCollection2, a.OuterCollection2, ordered: true);
                 });
         }
 
@@ -4852,13 +4813,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.FullName, a.FullName);
-
-                    CollectionAsserter<dynamic>(
-                        ee => ee.Id,
-                        (ee, aa) => Assert.Equal(ee.Id, aa.Id))(e.OuterCollection2, a.OuterCollection2);
+                    AssertCollection<Weapon>(e.OuterCollection2, a.OuterCollection2, ordered: true);
                 });
         }
-
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
@@ -4881,10 +4838,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.FullName, a.FullName);
-
-                    CollectionAsserter<dynamic>(
-                        ee => ee.Id,
-                        (ee, aa) => Assert.Equal(ee.Id, aa.Id))(e.OuterCollection2, a.OuterCollection2);
+                    AssertCollection<Weapon>(e.OuterCollection2, a.OuterCollection2, ordered: true);
                 });
         }
 
@@ -4936,24 +4890,22 @@ namespace Microsoft.EntityFrameworkCore.Query
                 {
                     Assert.Equal(e.FullName, a.FullName);
 
-                    CollectionAsserter<dynamic>(
+                    CustomCollectionAsserter<dynamic>(
                         ee => ee.FullName,
                         (ee, aa) =>
                         {
                             Assert.Equal(ee.FullName, aa.FullName);
-                            CollectionAsserter<dynamic>(
+                            CustomCollectionAsserter<dynamic>(
                                 eee => eee.Id,
                                 (eee, aaa) =>
                                 {
                                     Assert.Equal(eee.Id, aaa.Id);
-                                    CollectionAsserter<dynamic>(eeee => eeee.Name)(eee.InnerFirst, aaa.InnerFirst);
-                                    CollectionAsserter<dynamic>()(eee.InnerSecond, aaa.InnerSecond);
+                                    CustomCollectionAsserter<dynamic>(eeee => eeee.Name)(eee.InnerFirst, aaa.InnerFirst);
+                                    CustomCollectionAsserter<dynamic>()(eee.InnerSecond, aaa.InnerSecond);
                                 })(ee.InnerCollection, aa.InnerCollection);
                         })(e.OuterCollection, a.OuterCollection);
 
-                    CollectionAsserter<dynamic>(
-                        ee => ee.Id,
-                        (ee, aa) => Assert.Equal(ee.Id, aa.Id))(e.OuterCollection2, a.OuterCollection2);
+                    AssertCollection<Weapon>(e.OuterCollection2, a.OuterCollection2, ordered: true);
                 });
         }
 
@@ -4979,7 +4931,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.FullName, a.FullName);
-                    CollectionAsserter<dynamic>(ee => ee.ReportName)(e.Collection, a.Collection);
+                    CustomCollectionAsserter<dynamic>(ee => ee.ReportName)(e.Collection, a.Collection);
                 });
         }
 
@@ -5005,7 +4957,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.FullName, a.FullName);
-                    CollectionAsserter<dynamic>(ee => ee.ReportName)(e.Collection, a.Collection);
+                    CustomCollectionAsserter<dynamic>(ee => ee.ReportName)(e.Collection, a.Collection);
                 });
         }
 
@@ -5038,12 +4990,12 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.FullName, a.FullName);
-                    CollectionAsserter<dynamic>(
+                    CustomCollectionAsserter<dynamic>(
                         ee => ee.FullName,
                         (ee, aa) =>
                         {
                             Assert.Equal(ee.FullName, aa.FullName);
-                            CollectionAsserter<dynamic>(eee => eee.Name)(ee.InnerCollection, aa.InnerCollection);
+                            CustomCollectionAsserter<dynamic>(eee => eee.Name)(ee.InnerCollection, aa.InnerCollection);
                         })(e.OuterCollection, a.OuterCollection);
                 });
         }
@@ -5077,12 +5029,12 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.FullName, a.FullName);
-                    CollectionAsserter<dynamic>(
+                    CustomCollectionAsserter<dynamic>(
                         ee => ee.FullName,
                         (ee, aa) =>
                         {
                             Assert.Equal(ee.FullName, aa.FullName);
-                            CollectionAsserter<dynamic>(eee => eee.Name)(ee.InnerCollection, aa.InnerCollection);
+                            CustomCollectionAsserter<dynamic>(eee => eee.Name)(ee.InnerCollection, aa.InnerCollection);
                         })(e.OuterCollection, a.OuterCollection);
                 });
         }
@@ -5115,9 +5067,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                     Assert.Equal(e.GearNickname, e.GearNickname);
                     Assert.Equal(e.SquadName, e.SquadName);
 
-                    CollectionAsserter<Weapon>(ee => ee.Id, (ee, aa) => Assert.Equal(ee.Id, aa.Id))(e.Collection1, a.Collection1);
-                    CollectionAsserter<Gear>(ee => ee.Nickname, (ee, aa) => Assert.Equal(ee.Nickname, aa.Nickname))(
-                        e.Collection2, a.Collection2);
+                    AssertCollection<Weapon>(e.Collection1, a.Collection1);
+                    AssertCollection<Gear>(e.Collection2, a.Collection2);
                 });
         }
 
@@ -5129,8 +5080,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 ss => ss.OrderBy(s => s.Name).Select(s => s.Members.OrderBy(m => m.Nickname).Skip(1)),
                 assertOrder: true,
-                elementAsserter: (e, a) =>
-                    CollectionAsserter<Gear>(elementAsserter: (ee, aa) => Assert.Equal(ee.Nickname, aa.Nickname))(e, a));
+                elementAsserter: (e, a) => AssertCollection<Gear>(e, a, ordered: true));
         }
 
         [ConditionalTheory(Skip = "Issue#16313")]
@@ -5141,8 +5091,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 ss => ss.OrderBy(s => s.Name).Select(s => s.Members.OrderBy(m => m.Nickname).Take(2)),
                 assertOrder: true,
-                elementAsserter: (e, a) =>
-                    CollectionAsserter<Gear>(elementAsserter: (ee, aa) => Assert.Equal(ee.Nickname, aa.Nickname))(e, a));
+                elementAsserter: (e, a) => AssertCollection<Gear>(e, a, ordered: true));
         }
 
         [ConditionalTheory]
@@ -5153,8 +5102,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 ss => ss.OrderBy(s => s.Name).Select(s => s.Members.OrderBy(m => m.Nickname).Distinct()),
                 assertOrder: true,
-                elementAsserter: (e, a) =>
-                    CollectionAsserter<Gear>(elementAsserter: (ee, aa) => Assert.Equal(ee.Nickname, aa.Nickname))(e, a));
+                elementAsserter: (e, a) => AssertCollection<Gear>(e, a, ordered: true));
         }
 
         [ConditionalTheory]
@@ -5164,8 +5112,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery<Squad>(
                 isAsync,
                 ss => ss.OrderBy(s => s.Name).Select(s => s.Members.OrderBy(m => m.Nickname).Select(m => m.FullName).FirstOrDefault()),
-                assertOrder: true,
-                elementAsserter: (e, a) => CollectionAsserter<Gear>(elementAsserter: (ee, aa) => Assert.Equal(ee.Nickname, aa.Nickname)));
+                assertOrder: true);
         }
 
         [ConditionalTheory]
@@ -5198,7 +5145,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.Nickname, a.Nickname);
-                    CollectionAsserter<string>(ee => ee)(e.WeaponNames, a.WeaponNames);
+                    AssertCollection<string>(e.WeaponNames, a.WeaponNames);
                 });
         }
 
@@ -5221,7 +5168,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     orderby t.Note
                     select g != null ? g.Weapons.Select(w => w.Name) : new List<string>(),
                 assertOrder: true,
-                elementAsserter: (e, a) => CollectionAsserter<string>(ee => ee));
+                elementAsserter: (e, a) => AssertCollection<string>(e, a));
         }
 
         [ConditionalTheory]
@@ -5252,7 +5199,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.Note, a.Note);
-                    CollectionAsserter<string>(ee => ee)(e.ReportNames, a.ReportNames);
+                    AssertCollection<string>(e.ReportNames, a.ReportNames);
                 });
         }
 
@@ -5284,9 +5231,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                         : new List<List<Weapon>>(),
                 assertOrder: true,
                 elementAsserter: (e, a) =>
-                    CollectionAsserter<dynamic>(
-                        elementAsserter: (ee, aa) => CollectionAsserter<Weapon>(
-                            eee => eee.Id, (eee, aaa) => Assert.Equal(eee.Id, aaa.Id))));
+                    CustomCollectionAsserter<dynamic>(
+                        elementAsserter: (ee, aa) => AssertCollection<Weapon>(ee, aa)));
         }
 
         [ConditionalTheory]
@@ -5311,12 +5257,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true,
                 elementAsserter: (e, a) =>
                 {
-                    CollectionAsserter<dynamic>(
+                    CustomCollectionAsserter<dynamic>(
                         elementAsserter: (ee, aa) =>
                         {
+                            AssertCollection<Weapon>(ee.Item1, aa.Weapons, ordered: true);
                             Assert.Equal(ee.Item2, aa.Rank);
-                            CollectionAsserter<Weapon>(
-                                elementAsserter: (eee, aaa) => Assert.Equal(eee.Id, aaa.Id))(ee.Item1, aa.Weapons);
                         })(e, a);
                 });
         }
@@ -5349,12 +5294,12 @@ namespace Microsoft.EntityFrameworkCore.Query
                 {
                     Assert.Equal(e.FullName, a.FullName);
 
-                    CollectionAsserter<dynamic>(
+                    CustomCollectionAsserter<dynamic>(
                         ee => ee.Id,
                         (ee, aa) =>
                         {
                             Assert.Equal(ee.Id, aa.Id);
-                            CollectionAsserter<dynamic>(eee => eee.Nickname)(ee.InnerCollection, aa.InnerCollection);
+                            CustomCollectionAsserter<dynamic>(eee => eee.Nickname)(ee.InnerCollection, aa.InnerCollection);
                         })(e.OuterCollection, a.OuterCollection);
                 });
         }
@@ -5391,18 +5336,17 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.FullName, a.FullName);
-
-                    CollectionAsserter<dynamic>(
+                    CustomCollectionAsserter<dynamic>(
                         ee => ee.FullName,
                         (ee, aa) =>
                         {
                             Assert.Equal(ee.FullName, aa.FullName);
-                            CollectionAsserter<dynamic>(
+                            CustomCollectionAsserter<dynamic>(
                                 eee => eee.Id,
                                 (eee, aaa) =>
                                 {
                                     Assert.Equal(eee.Id, aaa.Id);
-                                    CollectionAsserter<dynamic>()(eee.InnerSecond, aaa.InnerSecond);
+                                    CustomCollectionAsserter<dynamic>()(eee.InnerSecond, aaa.InnerSecond);
                                 })(ee.InnerCollection, aa.InnerCollection);
                         })(e.OuterCollection, a.OuterCollection);
                 });
@@ -5436,13 +5380,12 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.FullName, a.FullName);
-
-                    CollectionAsserter<dynamic>(
+                    CustomCollectionAsserter<dynamic>(
                         ee => ee.Id,
                         (ee, aa) =>
                         {
                             Assert.Equal(ee.Id, aa.Id);
-                            CollectionAsserter<dynamic>(eee => eee.Nickname)(ee.InnerCollection, aa.InnerCollection);
+                            CustomCollectionAsserter<dynamic>(eee => eee.Nickname)(ee.InnerCollection, aa.InnerCollection);
                         })(e.OuterCollection, a.OuterCollection);
                 });
         }
@@ -5483,18 +5426,17 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.FullName, a.FullName);
-
-                    CollectionAsserter<dynamic>(
+                    CustomCollectionAsserter<dynamic>(
                         ee => ee.FullName,
                         (ee, aa) =>
                         {
                             Assert.Equal(ee.FullName, aa.FullName);
-                            CollectionAsserter<dynamic>(
+                            CustomCollectionAsserter<dynamic>(
                                 eee => eee.Id,
                                 (eee, aaa) =>
                                 {
                                     Assert.Equal(eee.Id, aaa.Id);
-                                    CollectionAsserter<dynamic>()(eee.InnerSecond, aaa.InnerSecond);
+                                    CustomCollectionAsserter<dynamic>()(eee.InnerSecond, aaa.InnerSecond);
                                 })(ee.InnerCollection, aa.InnerCollection);
                         })(e.OuterCollection, a.OuterCollection);
                 });
@@ -5809,7 +5751,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                                       select t.Note).ToList()
                     },
                 assertOrder: true,
-                elementAsserter: (e, a) => CollectionAsserter<string>(elementSorter: ee => ee)(e.Collection, a.Collection));
+                elementAsserter: (e, a) => AssertCollection<string>(e.Collection, a.Collection));
         }
 
         [ConditionalTheory]
@@ -5828,7 +5770,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                                       select t.Note).ToList()
                     },
                 assertOrder: true,
-                elementAsserter: (e, a) => CollectionAsserter<string>(elementSorter: ee => ee)(e.Collection, a.Collection));
+                elementAsserter: (e, a) => AssertCollection<string>(e.Collection, a.Collection));
         }
 
         [ConditionalTheory(Skip = "Issue#17068")]
@@ -5847,7 +5789,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                                       select t.Note).ToList()
                     },
                 assertOrder: true,
-                elementAsserter: (e, a) => CollectionAsserter<string>(elementSorter: ee => ee)(e.Collection, a.Collection));
+                elementAsserter: (e, a) => AssertCollection<string>(e.Collection, a.Collection));
         }
 
         [ConditionalTheory]
@@ -5867,7 +5809,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                                       select t.Note).ToList()
                     },
                 assertOrder: true,
-                elementAsserter: (e, a) => CollectionAsserter<string>(elementSorter: ee => ee)(e.Collection, a.Collection));
+                elementAsserter: (e, a) => AssertCollection<string>(e.Collection, a.Collection));
         }
 
         [ConditionalTheory]
@@ -6399,7 +6341,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.Nickname, a.Nickname);
-                    CollectionAsserter<string>(ee => ee)(e.Weapons, a.Weapons);
+                    AssertCollection<string>(e.Weapons, a.Weapons);
                 });
         }
 
@@ -6484,7 +6426,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.Nickname, a.Nickname);
-                    CollectionAsserter<string>()(e.Weapons, a.Weapons);
+                    AssertCollection<string>(e.Weapons, a.Weapons);
                 }))).Message;
 
             Assert.Equal(
@@ -6575,7 +6517,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .OrderBy(o => o.Weapons.Count).ThenBy(g => g.Nickname)
                     .Select(o => o.Reports.Where(g => !g.HasSoulPatch).ToList()),
                 assertOrder: true,
-                elementAsserter: CollectionAsserter<Gear>(ee => ee.FullName, (ee, aa) => Assert.Equal(ee.FullName, aa.FullName)));
+                elementAsserter: (e, a) => AssertCollection<Gear>(e, a));
         }
 
         [ConditionalTheory]
@@ -6591,7 +6533,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                             .Count()).ThenBy(g => g.Nickname)
                     .Select(o => o.Reports.Where(g => !g.HasSoulPatch).ToList()),
                 assertOrder: true,
-                elementAsserter: CollectionAsserter<Gear>(ee => ee.FullName, (ee, aa) => Assert.Equal(ee.FullName, aa.FullName)));
+                elementAsserter: (e, a) => AssertCollection<Gear>(e, a));
         }
 
         [ConditionalFact]
@@ -6791,7 +6733,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                             SquadId = g.SquadId
                         }).ToList<Gear>()),
                 assertOrder: true,
-                elementAsserter: CollectionAsserter<Gear>(e => e.Nickname, (e, a) => Assert.Equal(e.Nickname, a.Nickname)));
+                elementAsserter: (e, a) => AssertCollection<Gear>(e, a));
         }
 
         [ConditionalTheory]
@@ -6814,7 +6756,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                             SquadId = g.SquadId
                         }).ToArray<Gear>()),
                 assertOrder: true,
-                elementAsserter: CollectionAsserter<Gear>(e => e.Nickname, (e, a) => Assert.Equal(e.Nickname, a.Nickname)));
+                elementAsserter: (e, a) => AssertCollection<Gear>(e, a, ordered: true));
         }
 
         [ConditionalTheory(Skip = "Issue#15713")]
@@ -6831,7 +6773,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.Nickname, a.Nickname);
-                    CollectionAsserter<string>(ee => ee)(e.Weapons, a.Weapons);
+                    AssertCollection<string>(e.Weapons, a.Weapons);
                 });
         }
 
@@ -7552,16 +7494,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       where t.Gear is Officer
                       select Maybe(t.Gear, () => ((Officer)t.Gear).Reports.Take(50)),
                 elementSorter: e => ((IEnumerable<Gear>)e)?.Count() ?? 0,
-                elementAsserter: (e, a) =>
-                {
-                    var actualCollection = new List<Gear>();
-                    foreach (var actualElement in a)
-                    {
-                        actualCollection.Add(actualElement);
-                    }
-
-                    Assert.Equal(((IEnumerable<Gear>)e)?.Count() ?? 0, actualCollection.Count);
-                });
+                elementAsserter: (e, a) => AssertCollection<Gear>(e, a));
         }
 
         [ConditionalTheory]
@@ -7577,16 +7510,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       where t.Gear is Officer
                       select Maybe(t.Gear, () => ((Officer)t.Gear).Reports),
                 elementSorter: e => ((IEnumerable<Gear>)e)?.Count() ?? 0,
-                elementAsserter: (e, a) =>
-                {
-                    var actualCollection = new List<Gear>();
-                    foreach (var actualElement in a)
-                    {
-                        actualCollection.Add(actualElement);
-                    }
-
-                    Assert.Equal(((IEnumerable<Gear>)e)?.Count() ?? 0, actualCollection.Count);
-                });
+                elementAsserter: (e, a) => AssertCollection<Gear>(e, a));
         }
 
         [ConditionalTheory]
@@ -7607,7 +7531,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.key, a.key);
-                    CollectionAsserter<Gear>(elementSorter: gg => gg.Nickname, (ee, aa) => Assert.Equal(ee.Nickname, aa.Nickname))(e.collection, a.collection);
+                    AssertCollection<Gear>(e.collection, a.collection);
                 });
         }
 

--- a/test/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
@@ -1957,7 +1957,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .OrderBy(g => g.Key)
                     .Select(g => g.OrderBy(o => o)),
                 assertOrder: true,
-                elementAsserter: CollectionAsserter<int>());
+                elementAsserter: (e, a) => AssertCollection<int>(e, a, ordered: true));
         }
 
         [ConditionalTheory(Skip = "Issue #17068")]
@@ -1970,7 +1970,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .OrderBy(g => g.Key)
                     .Select(g => g.OrderBy(o => o.OrderID)),
                 assertOrder: true,
-                elementAsserter: CollectionAsserter<Order>());
+                elementAsserter: (e, a) => AssertCollection<Order>(e, a, ordered: true));
         }
 
         [ConditionalTheory(Skip = "Issue #17068")]

--- a/test/EFCore.Specification.Tests/Query/QueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/QueryTestBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -1564,18 +1565,29 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #region Helpers - Asserters
 
+        public void AssertEqual<T>(T expected, T actual, Action<dynamic, dynamic> asserter = null)
+            => Fixture.QueryAsserter.AssertEqual(expected, actual, asserter);
+
+        public void AssertCollection<TElement>(
+            IEnumerable<TElement> expected,
+            IEnumerable<TElement> actual,
+            bool ordered = false)
+            => Fixture.QueryAsserter.AssertCollection(expected, actual, ordered);
+
         public static Action<dynamic, dynamic> GroupingAsserter<TKey, TElement>(
-            Func<TElement, object> elementSorter = null, Action<TElement, TElement> elementAsserter = null)
+            Func<TElement, object> elementSorter = null,
+            Action<TElement, TElement> elementAsserter = null)
         {
             return (e, a) =>
             {
                 Assert.Equal(((IGrouping<TKey, TElement>)e).Key, ((IGrouping<TKey, TElement>)a).Key);
-                CollectionAsserter(elementSorter, elementAsserter)(e, a);
+                CustomCollectionAsserter(elementSorter, elementAsserter)(e, a);
             };
         }
 
-        public static Action<dynamic, dynamic> CollectionAsserter<TElement>(
-            Func<TElement, object> elementSorter = null, Action<TElement, TElement> elementAsserter = null)
+        public static Action<dynamic, dynamic> CustomCollectionAsserter<TElement>(
+            Func<TElement, object> elementSorter = null,
+            Action<TElement, TElement> elementAsserter = null)
         {
             return (e, a) =>
             {

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Functions.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Functions.cs
@@ -1413,7 +1413,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 cs => cs.OrderBy(c => c.CustomerID.Length).ThenBy(c => c.CustomerID.Length).ThenBy(c => c.CustomerID).Select(c => c.Orders),
                 assertOrder: true,
-                elementAsserter: CollectionAsserter<Order>(o => o.OrderID, (e, a) => Assert.Equal(e.OrderID, a.OrderID)),
+                elementAsserter: (e, a) => AssertCollection<Order>(e, a),
                 entryCount: 830);
         }
 

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.JoinGroupJoin.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.JoinGroupJoin.cs
@@ -343,8 +343,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.customer.CustomerID,
                 elementAsserter: (e, a) =>
                 {
-                    Assert.Equal(e.customer.CustomerID, a.customer.CustomerID);
-                    CollectionAsserter<Order>(o => o.OrderID)(e.orders, a.orders);
+                    AssertEqual<Customer>(e.customer, a.customer);
+                    AssertCollection<Order>(e.orders, a.orders);
                 },
                 entryCount: 91);
         }
@@ -481,7 +481,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     join o in os on c.CustomerID equals o.CustomerID into orders
                     select orders,
                 elementSorter: CollectionSorter<Order>(),
-                elementAsserter: CollectionAsserter<Order>(o => o.OrderID),
+                elementAsserter: (e, a) => AssertCollection<Order>(e, a),
                 entryCount: 830);
         }
 
@@ -498,8 +498,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.c.CustomerID,
                 elementAsserter: (e, a) =>
                 {
-                    Assert.Equal(e.c.CustomerID, a.c.CustomerID);
-                    CollectionAsserter<Order>(o => o.OrderID)(e.orders, a.orders);
+                    AssertEqual<Customer>(e.c, a.c);
+                    AssertCollection<Order>(e.orders, a.orders);
                 },
                 entryCount: 921);
         }
@@ -555,11 +555,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 (cs, os) => cs.GroupJoin(
                     os, c => c.CustomerID, o => o.CustomerID, (c, o) => new { c.City, o }),
-                e => (e.City, CollectionSorter<Order>()(e.o)),
+                elementSorter: e => (e.City, CollectionSorter<Order>()(e.o)),
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.City, a.City);
-                    CollectionAsserter<Order>(o => o.OrderID)(e.o, a.o);
+                    AssertCollection<Order>(e.o, a.o);
                 },
                 entryCount: 830);
         }
@@ -572,11 +572,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 (cs, os) => cs.GroupJoin(
                     os, c => c.CustomerID, o => o.CustomerID, (c, g) => new { c.City, g = g.Select(o => o.CustomerID) }),
-                e => (e.City, CollectionSorter<string>()(e.g)),
+                elementSorter: e => (e.City, CollectionSorter<string>()(e.g)),
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.City, a.City);
-                    CollectionAsserter<string>(s => s)(e.g, a.g);
+                    AssertCollection<string>(e.g, a.g);
                 });
         }
 
@@ -588,8 +588,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 (cs, os) => cs.GroupJoin(
                     os, c => c.CustomerID, o => o.CustomerID, (c, g) => new { g = g.Select(o => o.CustomerID) }),
-                e => CollectionSorter<string>()(e.g),
-                elementAsserter: (e, a) => CollectionAsserter<string>(s => s)(e.g, a.g));
+                elementSorter: e => CollectionSorter<string>()(e.g),
+                elementAsserter: (e, a) => AssertCollection<string>(e.g, a.g));
         }
 
         [ConditionalTheory(Skip = "Issue#17068")]
@@ -600,7 +600,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 (cs, os) => cs.GroupJoin(os, c => c.CustomerID, o => o.CustomerID, (c, g) => g.Select(o => o.CustomerID)),
                 elementSorter: CollectionSorter<string>(),
-                elementAsserter: CollectionAsserter<string>(s => s));
+                elementAsserter: (e, a) => AssertCollection<string>(e, a));
         }
 
         [ConditionalTheory(Skip = "Issue#17068")]
@@ -615,7 +615,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.CustomerID, a.CustomerID);
-                    CollectionAsserter<Customer>(c => c.CustomerID)(e.c, a.c);
+                    AssertCollection<Customer>(e.c, a.c);
                 },
                 entryCount: 89);
         }
@@ -632,7 +632,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.CustomerID, a.CustomerID);
-                    CollectionAsserter<string>(s => s)(e.g, a.g);
+                    AssertCollection<string>(e.g, a.g);
                 });
         }
 

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.KeylessEntities.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.KeylessEntities.cs
@@ -86,7 +86,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .OrderBy(c => c.CustomerID)
                     .Select(cv => cv.Orders.Where(cc => true).ToList()),
                 assertOrder: true,
-                elementAsserter: CollectionAsserter<Order>(),
+                elementAsserter: (e, a) => AssertCollection<Order>(e, a),
                 entryCount: 6);
         }
 

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -1708,7 +1708,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     from c in cs.OrderBy(cc => cc.CustomerID).Take(3)
                     select os.Where(o => o.CustomerID == c.CustomerID),
                 assertOrder: true,
-                elementAsserter: CollectionAsserter<Order>(o => o.OrderID));
+                elementAsserter: (e, a) => AssertCollection<Order>(e, a));
         }
 
         [ConditionalTheory(Skip = "Issue#16314")]
@@ -1723,7 +1723,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     orderby c.CustomerID
                     select os.Where(o => o.CustomerID == c.CustomerID),
                 assertOrder: true,
-                elementAsserter: CollectionAsserter<Order>(o => o.OrderID));
+                elementAsserter: (e, a) => AssertCollection<Order>(e, a));
         }
 
         [ConditionalTheory(Skip = "Issue #16314")]
@@ -1736,7 +1736,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     from c in cs.OrderBy(c => c.CustomerID).Take(3)
                     select os.OrderBy(o => o.OrderID).ThenBy(o => c.CustomerID).Skip(100).Take(2),
                 elementSorter: CollectionSorter<Order>(),
-                elementAsserter: CollectionAsserter<Order>());
+                elementAsserter: (e, a) => AssertCollection<Order>(e, a, ordered: true));
         }
 
         [ConditionalTheory(Skip = "Issue#16314")]
@@ -1762,8 +1762,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.CustomerId, a.CustomerId);
-                    Assert.Equal((IEnumerable<int>)e.OrderIds, (IEnumerable<int>)a.OrderIds);
-                    Assert.Equal(e.Customer, a.Customer);
+                    AssertCollection<int>(e.OrderIds, a.OrderIds);
+                    AssertEqual<Customer>(e.Customer, a.Customer);
                 },
                 entryCount: 1);
         }
@@ -1781,13 +1781,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                                     orderby e3.EmployeeID
                                     select e3)),
                 e => ((IEnumerable<IEnumerable<Employee>>)e).Count(),
-                elementAsserter: (e, a) =>
-                {
-                    var expected = ((IEnumerable<IEnumerable<Employee>>)e).SelectMany(i => i).ToList();
-                    var actual = ((IEnumerable<IEnumerable<Employee>>)e).SelectMany(i => i).ToList();
-
-                    Assert.Equal(expected, actual);
-                });
+                elementAsserter: CustomCollectionAsserter(
+                    elementSorter: CollectionSorter<Employee>(),
+                    elementAsserter: (ee, aa) => AssertCollection<Employee>(ee, aa, ordered: true)));
         }
 
         [ConditionalTheory]
@@ -5521,7 +5517,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       orderby g.Key
                       select g.OrderByDescending(x => x.OrderID),
                 assertOrder: true,
-                elementAsserter: CollectionAsserter<Order>(elementAsserter: (e, a) => Assert.Equal(e.OrderID, a.OrderID)));
+                elementAsserter: (e, a) => AssertCollection<Order>(e, a, ordered: true));
         }
 
         [ConditionalTheory(Skip = "Issue #17068")]
@@ -5537,7 +5533,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       orderby g.Key
                       select g.OrderByDescending(x => x.OrderID),
                 assertOrder: true,
-                elementAsserter: CollectionAsserter<Order>(elementAsserter: (e, a) => Assert.Equal(e.OrderID, a.OrderID)));
+                elementAsserter: (e, a) => AssertCollection<Order>(e, a, ordered: true));
         }
 
         [ConditionalTheory]
@@ -5557,7 +5553,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                                   orderby g.Key
                                   select g.OrderByDescending(x => x.OrderID),
                             assertOrder: true,
-                            elementAsserter: CollectionAsserter<Order>(elementAsserter: (e, a) => Assert.Equal(e.OrderID, a.OrderID)))))
+                            elementAsserter: (e, a) => AssertCollection<Order>(e, a, ordered: true))))
                     .Message));
         }
 

--- a/test/EFCore.Specification.Tests/TestUtilities/QueryAsserter.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/QueryAsserter.cs
@@ -37,6 +37,70 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             _includeResultAsserter = new IncludeQueryResultAsserter(_entitySorters, _entityAsserters);
         }
 
+        public override void AssertEqual<T>(T expected, T actual, Action<dynamic, dynamic> asserter = null)
+        {
+            if (asserter == null && expected != null)
+            {
+                _entityAsserters.TryGetValue(expected.GetType(), out asserter);
+            }
+
+            asserter ??= Assert.Equal;
+            asserter(expected, actual);
+        }
+
+        public override void AssertCollection<TElement>(
+            IEnumerable<TElement> expected,
+            IEnumerable<TElement> actual,
+            bool ordered = false)
+        {
+            if (expected == null !=  (actual == null))
+            {
+                throw new InvalidOperationException(
+                    $"Nullability doesn't match. Expected: {(expected == null ? "NULL" : "NOT NULL")}. Actual: {(actual == null ? "NULL." : "NOT NULL.")}.");
+            }
+
+            _entitySorters.TryGetValue(typeof(TElement), out var elementSorter);
+            _entityAsserters.TryGetValue(typeof(TElement), out var elementAsserter);
+            elementAsserter ??= Assert.Equal;
+
+            if (!ordered)
+            {
+                if (elementSorter != null)
+                {
+                    var sortedActual = ((IEnumerable<dynamic>)actual).OrderBy(elementSorter).ToList();
+                    var sortedExpected = ((IEnumerable<dynamic>)expected).OrderBy(elementSorter).ToList();
+
+                    Assert.Equal(sortedExpected.Count, sortedActual.Count);
+                    for (var i = 0; i < sortedExpected.Count; i++)
+                    {
+                        elementAsserter(sortedExpected[i], sortedActual[i]);
+                    }
+                }
+                else
+                {
+                    var sortedActual = actual.OrderBy(e => e).ToList();
+                    var sortedExpected = expected.OrderBy(e => e).ToList();
+
+                    Assert.Equal(sortedExpected.Count, sortedActual.Count);
+                    for (var i = 0; i < sortedExpected.Count; i++)
+                    {
+                        elementAsserter(sortedExpected[i], sortedActual[i]);
+                    }
+                }
+            }
+            else
+            {
+                var expectedList = expected.ToList();
+                var actualList = actual.ToList();
+
+                Assert.Equal(expectedList.Count, actualList.Count);
+                for (var i = 0; i < expectedList.Count; i++)
+                {
+                    elementAsserter(expectedList[i], actualList[i]);
+                }
+            }
+        }
+
         #region AssertSingleResult
 
         public override async Task AssertSingleResult<TItem1>(
@@ -63,21 +127,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>());
 
-                if (asserter == null
-                    && expected != null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
             }
         }
@@ -106,21 +156,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>());
 
-                if (asserter == null
-                    && expected != null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
             }
         }
@@ -149,21 +185,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>(), ExpectedData.Set<TItem2>());
 
-                if (asserter == null
-                    && expected != null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
             }
         }
@@ -192,21 +214,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>(), ExpectedData.Set<TItem2>());
 
-                if (asserter == null
-                    && expected != null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
             }
         }
@@ -237,21 +245,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>(), ExpectedData.Set<TItem2>(), ExpectedData.Set<TItem3>());
 
-                if (asserter == null
-                    && expected != null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
             }
         }
@@ -282,21 +276,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>(), ExpectedData.Set<TItem2>(), ExpectedData.Set<TItem3>());
 
-                if (asserter == null
-                    && expected != null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
             }
         }
@@ -1116,21 +1096,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>()).First();
 
-                if (asserter == null
-                    && expected != null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
             }
         }
@@ -1152,21 +1118,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>()).First(expectedFirstPredicate);
 
-                if (asserter == null
-                    && expected != null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
             }
         }
@@ -1190,21 +1142,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>()).FirstOrDefault();
 
-                if (asserter == null
-                    && expected != null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
             }
         }
@@ -1224,21 +1162,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>(), ExpectedData.Set<TItem2>()).FirstOrDefault();
 
-                if (asserter == null
-                    && expected != null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
             }
         }
@@ -1262,21 +1186,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 var expected = expectedQuery(ExpectedData.Set<TItem1>(), ExpectedData.Set<TItem2>(), ExpectedData.Set<TItem3>())
                     .FirstOrDefault();
 
-                if (asserter == null
-                    && expected != null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
             }
         }
@@ -1298,21 +1208,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>()).FirstOrDefault(expectedPredicate);
 
-                if (asserter == null
-                    && expected != null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
             }
         }
@@ -1336,21 +1232,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>()).Single();
 
-                if (asserter == null
-                    && expected != null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
             }
         }
@@ -1370,21 +1252,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>(), ExpectedData.Set<TItem2>()).Single();
 
-                if (asserter == null
-                    && expected != null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
             }
         }
@@ -1406,21 +1274,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>()).Single(expectedFirstPredicate);
 
-                if (asserter == null
-                    && expected != null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
             }
         }
@@ -1444,21 +1298,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>()).SingleOrDefault();
 
-                if (asserter == null
-                    && expected != null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
             }
         }
@@ -1480,21 +1320,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>()).SingleOrDefault(expectedPredicate);
 
-                if (asserter == null
-                    && expected != null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
             }
         }
@@ -1518,21 +1344,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>()).Last();
 
-                if (asserter == null
-                    && expected != null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
             }
         }
@@ -1554,21 +1366,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>()).Last(expectedPredicate);
 
-                if (asserter == null
-                    && expected != null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
             }
         }
@@ -1592,21 +1390,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>()).LastOrDefault();
 
-                if (asserter == null
-                    && expected != null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
             }
         }
@@ -1628,21 +1412,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>()).LastOrDefault(expectedPredicate);
 
-                if (asserter == null
-                    && expected != null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
             }
         }
@@ -1820,21 +1590,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>()).Min();
 
-                if (asserter == null
-                    && expected != null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
             }
         }
@@ -1854,21 +1610,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>()).Min();
 
-                if (asserter == null
-                    && expected != null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
             }
         }
@@ -1890,21 +1632,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>()).Min(expectedSelector);
 
-                if (asserter == null
-                    && expected != null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
             }
         }
@@ -1928,21 +1656,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>()).Max();
 
-                if (asserter == null
-                    && expected != null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
             }
         }
@@ -1962,21 +1676,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>()).Max();
 
-                if (asserter == null
-                    && expected != null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
             }
         }
@@ -1998,21 +1698,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>()).Max(expectedSelector);
 
-                if (asserter == null
-                    && expected != null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
             }
         }
@@ -2035,20 +1721,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>()).Sum();
 
-                if (asserter == null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Empty(context.ChangeTracker.Entries());
             }
         }
@@ -2067,21 +1740,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>()).Sum();
 
-                if (asserter == null
-                    && expected != null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Empty(context.ChangeTracker.Entries());
             }
         }
@@ -2102,20 +1761,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>()).Sum(expectedSelector);
 
-                if (asserter == null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Empty(context.ChangeTracker.Entries());
             }
         }
@@ -2136,21 +1782,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>()).Sum(expectedSelector);
 
-                if (asserter == null
-                    && expected != null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Empty(context.ChangeTracker.Entries());
             }
         }
@@ -2171,20 +1803,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>()).Sum(expectedSelector);
 
-                if (asserter == null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Empty(context.ChangeTracker.Entries());
             }
         }
@@ -2205,20 +1824,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>()).Sum(expectedSelector);
 
-                if (asserter == null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Empty(context.ChangeTracker.Entries());
             }
         }
@@ -2239,20 +1845,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>(), ExpectedData.Set<TItem2>()).Sum(expectedSelector);
 
-                if (asserter == null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Empty(context.ChangeTracker.Entries());
             }
         }
@@ -2275,20 +1868,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>()).Average();
 
-                if (asserter == null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Empty(context.ChangeTracker.Entries());
             }
         }
@@ -2307,20 +1887,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>()).Average();
 
-                if (asserter == null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Empty(context.ChangeTracker.Entries());
             }
         }
@@ -2339,20 +1906,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>()).Average();
 
-                if (asserter == null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Empty(context.ChangeTracker.Entries());
             }
         }
@@ -2373,20 +1927,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>()).Average(expectedSelector);
 
-                if (asserter == null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Empty(context.ChangeTracker.Entries());
             }
         }
@@ -2407,20 +1948,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>()).Average(expectedSelector);
 
-                if (asserter == null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Empty(context.ChangeTracker.Entries());
             }
         }
@@ -2441,20 +1969,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>()).Average(expectedSelector);
 
-                if (asserter == null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Empty(context.ChangeTracker.Entries());
             }
         }
@@ -2475,20 +1990,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>()).Average(expectedSelector);
 
-                if (asserter == null)
-                {
-                    _entityAsserters.TryGetValue(expected.GetType(), out asserter);
-                }
-
-                if (asserter != null)
-                {
-                    asserter(expected, actual);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-
+                AssertEqual(expected, actual, asserter);
                 Assert.Empty(context.ChangeTracker.Entries());
             }
         }

--- a/test/EFCore.Specification.Tests/TestUtilities/QueryAsserterBase.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/QueryAsserterBase.cs
@@ -14,6 +14,16 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         public virtual ISetExtractor SetExtractor { get; set; }
         public virtual IExpectedData ExpectedData { get; set; }
 
+        public abstract void AssertEqual<T>(
+            T expected,
+            T actual,
+            Action<dynamic, dynamic> asserter = null);
+
+        public abstract void AssertCollection<TElement>(
+            IEnumerable<TElement> expected,
+            IEnumerable<TElement> actual,
+            bool ordered = false);
+
         #region AssertSingleResult
 
         public abstract Task AssertSingleResult<TItem1>(


### PR DESCRIPTION
- added `AssertEqual<T>` which now automatically use elementAsserters for a given test base.
- added `AssertCollection<TElement>` which can also use elementAsserters automatically.
- cleaned up elementAsserter lambdas in the current tests