### PR TITLE
Cosmos: Add the partition key to the store key

### DIFF
--- a/src/EFCore.Cosmos/Metadata/Conventions/StoreKeyConvention.cs
+++ b/src/EFCore.Cosmos/Metadata/Conventions/StoreKeyConvention.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Cosmos.ValueGeneration.Internal;
@@ -46,24 +47,50 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
         private static void Process(IConventionEntityTypeBuilder entityTypeBuilder)
         {
+            IConventionKey newKey = null;
+            IConventionProperty idProperty = null;
             var entityType = entityTypeBuilder.Metadata;
             if (entityType.BaseType == null
                 && entityType.IsDocumentRoot()
                 && !entityType.IsKeyless)
             {
-                var idProperty = entityTypeBuilder.Property(typeof(string), IdPropertyName);
-                idProperty.HasValueGenerator((_, __) => new IdValueGenerator());
-                entityTypeBuilder.HasKey(new[] { idProperty.Metadata });
+                idProperty = entityTypeBuilder.Property(typeof(string), IdPropertyName, setTypeConfigurationSource: false)
+                    ?.Metadata;
+
+                if (idProperty != null)
+                {
+                    if (idProperty.ClrType == typeof(string))
+                    {
+                        idProperty.Builder.HasValueGenerator((_, __) => new IdValueGenerator());
+                    }
+
+                    var partitionKey = entityType.GetPartitionKeyPropertyName();
+                    if (partitionKey != null)
+                    {
+                        var partitionKeyProperty = entityType.FindProperty(partitionKey);
+                        if (partitionKeyProperty != null)
+                        {
+                            newKey = entityTypeBuilder.HasKey(new[] { idProperty, partitionKeyProperty })?.Metadata;
+                        }
+                    }
+                    else
+                    {
+                        newKey = entityTypeBuilder.HasKey(new[] { idProperty })?.Metadata;
+                    }
+                }
             }
             else
             {
-                var idProperty = entityType.FindDeclaredProperty(IdPropertyName);
-                if (idProperty != null)
+                idProperty = entityType.FindDeclaredProperty(IdPropertyName);
+            }
+
+            if (idProperty != null)
+            {
+                foreach (var key in idProperty.GetContainingKeys().ToList())
                 {
-                    var key = entityType.FindKey(idProperty);
-                    if (key != null)
+                    if (key != newKey)
                     {
-                        entityType.Builder.HasNoKey(key);
+                        key.DeclaringEntityType.Builder.HasNoKey(key);
                     }
                 }
             }
@@ -150,7 +177,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             Check.NotEmpty(name, nameof(name));
             Check.NotNull(context, nameof(context));
 
-            if (name == CosmosAnnotationNames.ContainerName)
+            if (name == CosmosAnnotationNames.ContainerName
+                || name == CosmosAnnotationNames.PartitionKeyName)
             {
                 Process(entityTypeBuilder);
             }

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
@@ -25,6 +25,38 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
             => GetString("CosmosNotInUse");
 
         /// <summary>
+        ///     Create container failed. Status code: {statusCode}. Message: '{errorMessage}'
+        /// </summary>
+        public static string CreateContainerFailed([CanBeNull] object statusCode, [CanBeNull] object errorMessage)
+            => string.Format(
+                GetString("CreateContainerFailed", nameof(statusCode), nameof(errorMessage)),
+                statusCode, errorMessage);
+
+        /// <summary>
+        ///     Create item failed. Status code: {statusCode}. Message: '{errorMessage}'
+        /// </summary>
+        public static string CreateItemFailed([CanBeNull] object statusCode, [CanBeNull] object errorMessage)
+            => string.Format(
+                GetString("CreateItemFailed", nameof(statusCode), nameof(errorMessage)),
+                statusCode, errorMessage);
+
+        /// <summary>
+        ///     Delete database failed. Status code: {statusCode}. Message: '{errorMessage}'
+        /// </summary>
+        public static string DeleteDatabaseFailed([CanBeNull] object statusCode, [CanBeNull] object errorMessage)
+            => string.Format(
+                GetString("DeleteDatabaseFailed", nameof(statusCode), nameof(errorMessage)),
+                statusCode, errorMessage);
+
+        /// <summary>
+        ///     Delete item failed. Status code: {statusCode}. Message: '{errorMessage}'
+        /// </summary>
+        public static string DeleteItemFailed([CanBeNull] object statusCode, [CanBeNull] object errorMessage)
+            => string.Format(
+                GetString("DeleteItemFailed", nameof(statusCode), nameof(errorMessage)),
+                statusCode, errorMessage);
+
+        /// <summary>
         ///     The discriminator value for '{entityType1}' is '{discriminatorValue}' which is the same for '{entityType2}'. Every concrete entity type mapped to the container '{container}' needs to have a unique discriminator value.
         /// </summary>
         public static string DuplicateDiscriminatorValue([CanBeNull] object entityType1, [CanBeNull] object discriminatorValue, [CanBeNull] object entityType2, [CanBeNull] object container)
@@ -95,6 +127,22 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
             => string.Format(
                 GetString("PartitionKeyStoreNameMismatch", nameof(property1), nameof(entityType1), nameof(storeName1), nameof(property2), nameof(entityType2), nameof(storeName2)),
                 property1, entityType1, storeName1, property2, entityType2, storeName2);
+
+        /// <summary>
+        ///     Query failed. Status code: {statusCode}. Message: '{errorMessage}'
+        /// </summary>
+        public static string QueryFailed([CanBeNull] object statusCode, [CanBeNull] object errorMessage)
+            => string.Format(
+                GetString("QueryFailed", nameof(statusCode), nameof(errorMessage)),
+                statusCode, errorMessage);
+
+        /// <summary>
+        ///     Replace item failed. Status code: {statusCode}. Message: '{errorMessage}'
+        /// </summary>
+        public static string ReplaceItemFailed([CanBeNull] object statusCode, [CanBeNull] object errorMessage)
+            => string.Format(
+                GetString("ReplaceItemFailed", nameof(statusCode), nameof(errorMessage)),
+                statusCode, errorMessage);
 
         private static string GetString(string name, params string[] formatterNames)
         {

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.resx
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.resx
@@ -120,6 +120,18 @@
   <data name="CosmosNotInUse" xml:space="preserve">
     <value>Cosmos-specific methods can only be used when the context is using the Cosmos provider.</value>
   </data>
+  <data name="CreateContainerFailed" xml:space="preserve">
+    <value>Create container failed. Status code: {statusCode}. Message: '{errorMessage}'</value>
+  </data>
+  <data name="CreateItemFailed" xml:space="preserve">
+    <value>Create item failed. Status code: {statusCode}. Message: '{errorMessage}'</value>
+  </data>
+  <data name="DeleteDatabaseFailed" xml:space="preserve">
+    <value>Delete database failed. Status code: {statusCode}. Message: '{errorMessage}'</value>
+  </data>
+  <data name="DeleteItemFailed" xml:space="preserve">
+    <value>Delete item failed. Status code: {statusCode}. Message: '{errorMessage}'</value>
+  </data>
   <data name="DuplicateDiscriminatorValue" xml:space="preserve">
     <value>The discriminator value for '{entityType1}' is '{discriminatorValue}' which is the same for '{entityType2}'. Every concrete entity type mapped to the container '{container}' needs to have a unique discriminator value.</value>
   </data>
@@ -146,5 +158,11 @@
   </data>
   <data name="PartitionKeyStoreNameMismatch" xml:space="preserve">
     <value>The partition key property '{property1}' on '{entityType1}' is mapped as '{storeName1}', but the partition key property '{property2}' on '{entityType2}' is mapped as '{storeName2}'. All partition key properties need to be mapped to the same store property.</value>
+  </data>
+  <data name="QueryFailed" xml:space="preserve">
+    <value>Query failed. Status code: {statusCode}. Message: '{errorMessage}'</value>
+  </data>
+  <data name="ReplaceItemFailed" xml:space="preserve">
+    <value>Replace item failed. Status code: {statusCode}. Message: '{errorMessage}'</value>
   </data>
 </root>


### PR DESCRIPTION
#### Description
Add the partition key to the store key
Throw when an error is detected during a store operation.

Fixes #17435
Fixes #17616
Fixes #17624

#### Customer impact
Without these fixes errors like modifying an immutable partition key, saving changes to or quering a non-existant container as well as other similar errors are silently ignored leading to confusion and potential data loss.

#### Regression
N/A, 3.0 will be the first RTM release for the Cosmos provider

#### Risk
Low