### PR TITLE
Accurately assign type to ShapedQueryExpression

### DIFF
--- a/src/EFCore/Query/ShapedQueryExpression.cs
+++ b/src/EFCore/Query/ShapedQueryExpression.cs
@@ -18,7 +18,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Expression QueryExpression { get; set; }
         public virtual ResultCardinality ResultCardinality { get; set; }
         public virtual Expression ShaperExpression { get; set; }
-        public override Type Type => typeof(IQueryable<>).MakeGenericType(ShaperExpression.Type);
+        public override Type Type => ResultCardinality == ResultCardinality.Enumerable
+            ? typeof(IQueryable<>).MakeGenericType(ShaperExpression.Type)
+            : ShaperExpression.Type;
+
         public sealed override ExpressionType NodeType => ExpressionType.Extension;
 
         protected override Expression VisitChildren(ExpressionVisitor visitor)

--- a/test/EFCore.Specification.Tests/Query/CompiledQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/CompiledQueryTestBase.cs
@@ -531,6 +531,19 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
+        [ConditionalFact]
+        public virtual void Compiled_query_when_does_not_end_in_query_operator()
+        {
+            var query = EF.CompileQuery(
+                (NorthwindContext context, string customerID)
+                    => context.Customers.Where(c => c.CustomerID == customerID).Count() == 1);
+
+            using (var context = CreateContext())
+            {
+                Assert.True(query(context, "ALFKI"));
+            }
+        }
+
         protected NorthwindContext CreateContext() => Fixture.CreateContext();
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/CompiledQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/CompiledQuerySqlServerTest.cs
@@ -182,6 +182,18 @@ ORDER BY [c].[CompanyName]");
                 @"SELECT [c].[CustomerID] + N'' as [CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region] FROM [Customers] AS [c]");
         }
 
+        public override void Compiled_query_when_does_not_end_in_query_operator()
+        {
+            base.Compiled_query_when_does_not_end_in_query_operator();
+
+            AssertSql(
+                @"@__customerID='ALFKI' (Size = 5)
+
+SELECT COUNT(*)
+FROM [Customers] AS [c]
+WHERE ([c].[CustomerID] = @__customerID) AND @__customerID IS NOT NULL");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }


### PR DESCRIPTION
#### Description
Accurately assign type to ShapedQueryExpression
Earlier we assumed IQueryable<T> only. Now it sets based on actual cardinality

Resolves #13895

#### Customer impact
Customer may not be able to use EF.CompileQuery API when the expression tree does not terminate in queryable operator.

#### Regression
It never worked in past.

#### Risk
Low