### PR TITLE
Convert ToList().Count() to AsQueryable().Count()

### DIFF
--- a/src/EFCore/Query/Internal/EnumerableToQueryableMethodConvertingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/EnumerableToQueryableMethodConvertingExpressionVisitor.cs
@@ -12,6 +12,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 {
     public class EnumerableToQueryableMethodConvertingExpressionVisitor : ExpressionVisitor
     {
+        private readonly MethodInfo _enumerableToListMethodInfo = typeof(Enumerable).GetTypeInfo()
+            .GetDeclaredMethods(nameof(Enumerable.ToList)).Single(mi => mi.GetParameters().Length == 1);
+
         protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
         {
             if (methodCallExpression.Method.DeclaringType == typeof(Enumerable))
@@ -99,12 +102,27 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                         if (CanConvertEnumerableToQueryable(enumerableParameterType, queryableParameterType))
                         {
-                            if (arguments[i].Type.TryGetElementType(typeof(IQueryable<>)) == null)
+                            var innerArgument = arguments[i];
+                            var genericType = innerArgument.Type.TryGetSequenceType();
+
+                            // If innerArgument has ToList applied to it then unwrap it.
+                            // Also preserve generic argument of ToList is applied to different type
+                            if (arguments[i].Type.TryGetElementType(typeof(List<>)) != null
+                                && arguments[i] is MethodCallExpression toListMethodCallExpression
+                                && toListMethodCallExpression.Method.IsGenericMethod
+                                && toListMethodCallExpression.Method.GetGenericMethodDefinition() == _enumerableToListMethodInfo)
+                            {
+                                genericType = toListMethodCallExpression.Method.GetGenericArguments()[0];
+                                innerArgument = toListMethodCallExpression.Arguments[0];
+                            }
+
+                            var innerQueryableElementType = innerArgument.Type.TryGetElementType(typeof(IQueryable<>));
+                            if (innerQueryableElementType == null
+                                || innerQueryableElementType != genericType)
                             {
                                 arguments[i] = Expression.Call(
-                                    QueryableMethods.AsQueryable.MakeGenericMethod(
-                                        arguments[i].Type.TryGetSequenceType()),
-                                    arguments[i]);
+                                    QueryableMethods.AsQueryable.MakeGenericMethod(genericType),
+                                    innerArgument);
                             }
 
                             continue;

--- a/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.Select.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.Select.cs
@@ -877,5 +877,11 @@ WHERE (c[""Discriminator""] = ""Customer"")");
         {
             return base.Filtered_collection_projection_with_to_list_is_tracked(isAsync);
         }
+
+        [ConditionalTheory(Skip = "Issue#17246")]
+        public override Task ToList_Count_in_projection_works(bool isAsync)
+        {
+            return base.ToList_Count_in_projection_works(isAsync);
+        }
     }
 }

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
@@ -1399,5 +1399,26 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 cs => cs.Select(c => c.Orders.OrderBy(o => o.OrderID).Select(o => o.EmployeeID).FirstOrDefault()));
         }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task ToList_Count_in_projection_works(bool isAsync)
+        {
+            return AssertQuery<Customer>(
+                isAsync,
+                cs => cs.Where(c => c.CustomerID.StartsWith("A"))
+                        .Select(c => new
+                        {
+                            c,
+                            Count = c.Orders.ToList().Count()
+                        }),
+                entryCount: 4,
+                elementSorter: r => r.c.CustomerID,
+                elementAsserter: (e, a) =>
+                {
+                    AssertEqual(e.c, a.c);
+                    Assert.Equal(e.Count, a.Count);
+                });
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
@@ -1170,5 +1170,18 @@ CROSS APPLY (
     ORDER BY [o].[OrderID])
 FROM [Customers] AS [c]");
         }
+
+        public override async Task ToList_Count_in_projection_works(bool isAsync)
+        {
+            await base.ToList_Count_in_projection_works(isAsync);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], (
+    SELECT COUNT(*)
+    FROM [Orders] AS [o]
+    WHERE ([c].[CustomerID] = [o].[CustomerID]) AND [o].[CustomerID] IS NOT NULL) AS [Count]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'A%'");
+        }
     }
 }


### PR DESCRIPTION
#### Description
Convert ToList().Count() to AsQueryable().Count()
When enumerable operators appears after ToList, we can convert them to queryable operators by removing ToList.
Also take care when ToList uses a different generic type than inner type.
Avoid adding AsQueryable if inner is already queryable of correct type.

Resolves #13744

#### Customer impact
A query which was throwing exception now evaluates correctly on server.

#### Regression
It never worked in past.

#### Risk
Low