### PR TITLE
Allow to add and delete dependents sharing a table

### DIFF
--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -2036,9 +2036,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         private object GetValue(ColumnModification columnModification)
         {
             var converter = GetValueConverter(columnModification.Property);
+            var value = columnModification.UseCurrentValueParameter
+                ? columnModification.Value
+                : columnModification.OriginalValue;
             return converter != null
-                ? converter.ConvertToProvider(columnModification.Value)
-                : columnModification.Value;
+                ? converter.ConvertToProvider(value)
+                : value;
         }
 
         #endregion

--- a/src/EFCore.Relational/Update/ColumnModification.cs
+++ b/src/EFCore.Relational/Update/ColumnModification.cs
@@ -149,24 +149,24 @@ namespace Microsoft.EntityFrameworkCore.Update
         /// <summary>
         ///     Indicates whether the original value of the property must be passed as a parameter to the SQL
         /// </summary>
-        public virtual bool UseOriginalValueParameter => _useParameters && IsCondition && IsConcurrencyToken;
+        public virtual bool UseOriginalValueParameter => _useParameters && IsCondition;
 
         /// <summary>
         ///     Indicates whether the current value of the property must be passed as a parameter to the SQL
         /// </summary>
-        public virtual bool UseCurrentValueParameter => _useParameters && (IsWrite || IsCondition && !IsConcurrencyToken);
+        public virtual bool UseCurrentValueParameter => _useParameters && IsWrite;
 
         /// <summary>
         ///     The parameter name to use for the current value parameter (<see cref="UseCurrentValueParameter" />), if needed.
         /// </summary>
         public virtual string ParameterName
-            => _parameterName ?? (_parameterName = _generateParameterName());
+            => _parameterName ?? (_parameterName = UseCurrentValueParameter ? _generateParameterName() : null);
 
         /// <summary>
         ///     The parameter name to use for the original value parameter (<see cref="UseOriginalValueParameter" />), if needed.
         /// </summary>
         public virtual string OriginalParameterName
-            => _originalParameterName ?? (_originalParameterName = _generateParameterName());
+            => _originalParameterName ?? (_originalParameterName = UseOriginalValueParameter ? _generateParameterName() : null);
 
         /// <summary>
         ///     The name of the column.
@@ -187,7 +187,9 @@ namespace Microsoft.EntityFrameworkCore.Update
         /// </summary>
         public virtual object Value
         {
-            get => Entry == null ? _value : Entry.GetCurrentValue(Property);
+            get => Entry == null
+                ? _value
+                : Entry.EntityState == EntityState.Deleted ? null : Entry.GetCurrentValue(Property);
             [param: CanBeNull]
             set
             {

--- a/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
+++ b/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
@@ -184,6 +184,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                 var tableKey = (schema, table);
 
                 ModificationCommand command;
+                var isMainEntry = true;
                 if (_sharedTableEntryMapFactories.TryGetValue(tableKey, out var commandIdentityMapFactory))
                 {
                     if (sharedTablesCommandsMap == null)
@@ -201,6 +202,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                     }
 
                     command = sharedCommandsMap.GetOrAddValue(entry);
+                    isMainEntry = sharedCommandsMap.GetPrincipals(entry.EntityType.GetRootType()).Count == 0;
                 }
                 else
                 {
@@ -208,13 +210,12 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                         table, schema, generateParameterName, _sensitiveLoggingEnabled, comparer: null);
                 }
 
-                command.AddEntry(entry);
+                command.AddEntry(entry, isMainEntry);
                 commands.Add(command);
             }
 
             if (sharedTablesCommandsMap != null)
             {
-                Validate(sharedTablesCommandsMap);
                 AddUnchangedSharingEntries(sharedTablesCommandsMap, entries);
             }
 
@@ -223,86 +224,20 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                      || c.ColumnModifications.Any(m => m.IsWrite));
         }
 
-        private void Validate(
-            Dictionary<(string Schema, string Name),
-                SharedTableEntryMap<ModificationCommand>> sharedTablesCommandsMap)
-        {
-            foreach (var modificationCommandIdentityMap in sharedTablesCommandsMap.Values)
-            {
-                foreach (var command in modificationCommandIdentityMap.Values)
-                {
-                    if (command.EntityState != EntityState.Added
-                        && command.EntityState != EntityState.Deleted)
-                    {
-                        continue;
-                    }
-
-                    // ReSharper disable once ForCanBeConvertedToForeach
-                    for (var entryIndex = 0; entryIndex < command.Entries.Count; entryIndex++)
-                    {
-                        var entry = command.Entries[entryIndex];
-                        var principals = modificationCommandIdentityMap.GetPrincipals(entry.EntityType);
-                        // ReSharper disable once ForCanBeConvertedToForeach
-                        for (var principalIndex = 0; principalIndex < principals.Count; principalIndex++)
-                        {
-                            var principalEntityType = principals[principalIndex];
-                            var principalFound = false;
-                            // ReSharper disable once ForCanBeConvertedToForeach
-                            for (var otherEntryIndex = 0; otherEntryIndex < command.Entries.Count; otherEntryIndex++)
-                            {
-                                var principalEntry = command.Entries[otherEntryIndex];
-                                if (principalEntry != entry
-                                    && principalEntityType.IsAssignableFrom(principalEntry.EntityType))
-                                {
-                                    principalFound = true;
-                                    break;
-                                }
-                            }
-
-                            if (principalFound)
-                            {
-                                continue;
-                            }
-
-                            var tableName = (string.IsNullOrEmpty(command.Schema) ? "" : command.Schema + ".") +
-                                            command.TableName;
-                            if (_sensitiveLoggingEnabled)
-                            {
-                                throw new InvalidOperationException(
-                                    RelationalStrings.SharedRowEntryCountMismatchSensitive(
-                                        entry.EntityType.DisplayName(),
-                                        tableName,
-                                        principalEntityType.DisplayName(),
-                                        entry.BuildCurrentValuesString(entry.EntityType.FindPrimaryKey().Properties),
-                                        command.EntityState));
-                            }
-
-                            throw new InvalidOperationException(
-                                RelationalStrings.SharedRowEntryCountMismatch(
-                                    entry.EntityType.DisplayName(),
-                                    tableName,
-                                    principalEntityType.DisplayName(),
-                                    command.EntityState));
-                        }
-                    }
-                }
-            }
-        }
-
         private void AddUnchangedSharingEntries(
             Dictionary<(string Schema, string Name), SharedTableEntryMap<ModificationCommand>> sharedTablesCommandsMap,
             IList<IUpdateEntry> entries)
         {
-            foreach (var modificationCommandIdentityMap in sharedTablesCommandsMap.Values)
+            foreach (var sharedCommandsMap in sharedTablesCommandsMap.Values)
             {
-                foreach (var command in modificationCommandIdentityMap.Values)
+                foreach (var command in sharedCommandsMap.Values)
                 {
                     if (command.EntityState != EntityState.Modified)
                     {
                         continue;
                     }
 
-                    foreach (var entry in modificationCommandIdentityMap.GetAllEntries(command.Entries[0]))
+                    foreach (var entry in sharedCommandsMap.GetAllEntries(command.Entries[0]))
                     {
                         if (entry.EntityState != EntityState.Unchanged)
                         {
@@ -311,7 +246,8 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
 
                         entry.EntityState = EntityState.Modified;
 
-                        command.AddEntry(entry);
+                        var isMainEntry = sharedCommandsMap.GetPrincipals(entry.EntityType.GetRootType()).Count == 0;
+                        command.AddEntry(entry, isMainEntry);
                         entries.Add(entry);
                     }
                 }

--- a/src/EFCore.Relational/Update/Internal/SharedTableEntryMap.cs
+++ b/src/EFCore.Relational/Update/Internal/SharedTableEntryMap.cs
@@ -257,14 +257,11 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
             }
 
             public int Compare(IUpdateEntry x, IUpdateEntry y)
-            {
-                if (_principals[x.EntityType].Count == 0)
-                {
-                    return -1;
-                }
-
-                return _principals[y.EntityType].Count == 0 ? 1 : StringComparer.Ordinal.Compare(x.EntityType.Name, y.EntityType.Name);
-            }
+                => _principals[x.EntityType].Count == 0
+                    ? -1
+                    : _principals[y.EntityType].Count == 0
+                        ? 1
+                        : StringComparer.Ordinal.Compare(x.EntityType.Name, y.EntityType.Name);
         }
     }
 }

--- a/test/EFCore.Relational.Specification.Tests/TableSplittingTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/TableSplittingTestBase.cs
@@ -218,15 +218,95 @@ namespace Microsoft.EntityFrameworkCore
         {
             using (CreateTestStore(onModelCreating))
             {
+                using var context = CreateContext();
+                context.AssertSeeded();
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Can_manipulate_entities_sharing_row_independently()
+        {
+            using (CreateTestStore(
+                modelBuilder =>
+                {
+                    OnModelCreating(modelBuilder);
+                    modelBuilder.Entity<FuelTank>(eb => eb.Ignore(e => e.Engine));
+                }))
+            {
+                PoweredVehicle streetcar;
                 using (var context = CreateContext())
                 {
-                    context.AssertSeeded();
+                    streetcar = context.Set<PoweredVehicle>().Include(v => v.Engine)
+                        .Single(v => v.Name == "1984 California Car");
+
+                    Assert.Null(streetcar.Engine);
+
+                    streetcar.Engine = new Engine { Description = "Streetcar engine" };
+
+                    context.SaveChanges();
+                }
+
+                using (var context = CreateContext())
+                {
+                    var streetcarFromStore = context.Set<PoweredVehicle>().Include(v => v.Engine).AsNoTracking()
+                        .Single(v => v.Name == "1984 California Car");
+
+                    Assert.Equal("Streetcar engine", streetcarFromStore.Engine.Description);
+
+                    streetcarFromStore.Engine.Description = "Line";
+
+                    context.Update(streetcarFromStore);
+                    context.SaveChanges();
+                }
+
+                using (var context = CreateContext())
+                {
+                    var streetcarFromStore = context.Set<PoweredVehicle>().Include(v => v.Engine)
+                        .Single(v => v.Name == "1984 California Car");
+
+                    Assert.Equal("Line", streetcarFromStore.Engine.Description);
+
+                    streetcarFromStore.SeatingCapacity = 40;
+                    streetcarFromStore.Engine.Description = "Streetcar engine";
+
+                    context.SaveChanges();
+                }
+
+                using (var context = CreateContext())
+                {
+                    var streetcarFromStore = context.Set<PoweredVehicle>().Include(v => v.Engine).AsNoTracking()
+                        .Single(v => v.Name == "1984 California Car");
+
+                    Assert.Equal(40, streetcarFromStore.SeatingCapacity);
+                    Assert.Equal("Streetcar engine", streetcarFromStore.Engine.Description);
+
+                    context.Remove(streetcarFromStore.Engine);
+
+                    context.SaveChanges();
+                }
+
+                using (var context = CreateContext())
+                {
+                    var streetcarFromStore = context.Set<PoweredVehicle>().Include(v => v.Engine).AsNoTracking()
+                        .Single(v => v.Name == "1984 California Car");
+
+                    Assert.Null(streetcarFromStore.Engine);
+
+                    context.Remove(streetcarFromStore);
+
+                    context.SaveChanges();
+                }
+
+                using (var context = CreateContext())
+                {
+                    Assert.Null(context.Set<PoweredVehicle>().AsNoTracking().SingleOrDefault(v => v.Name == "1984 California Car"));
+                    Assert.Null(context.Set<Engine>().AsNoTracking().SingleOrDefault(e => e.VehicleName == "1984 California Car"));
                 }
             }
         }
 
         [ConditionalFact]
-        public virtual void Inserting_dependent_with_just_one_parent_throws()
+        public virtual void Can_insert_dependent_with_just_one_parent()
         {
             using (CreateTestStore(OnModelCreating))
             {
@@ -242,10 +322,7 @@ namespace Microsoft.EntityFrameworkCore
                     context.Add(
                         new FuelTank { Capacity = "10000 l", FuelType = "Gas", VehicleName = "Fuel transport" });
 
-                    Assert.Equal(
-                        RelationalStrings.SharedRowEntryCountMismatchSensitive(
-                            nameof(FuelTank), "Vehicles", nameof(CombustionEngine), "{VehicleName: Fuel transport}", "Added"),
-                        Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
+                    context.SaveChanges();
                 }
             }
         }

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -1096,16 +1096,16 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                             v => Assert.Equal(42, v));
                         AssertMultidimensionalArray(
                             m.Values,
-                            v => Assert.Equal("San Francisco", v),
-                            v => Assert.Equal("Lombard", v),
                             v => Assert.Equal("London", v),
-                            v => Assert.Equal("Abbey Road", v));
+                            v => Assert.Equal("Abbey Road", v),
+                            v => Assert.Equal("San Francisco", v),
+                            v => Assert.Equal("Lombard", v));
                         Assert.Collection(
                             m.Columns,
-                            v => Assert.Equal("ShippingAddress_City", v),
-                            v => Assert.Equal("ShippingAddress_Street", v),
                             v => Assert.Equal("BillingAddress_City", v),
-                            v => Assert.Equal("BillingAddress_Street", v));
+                            v => Assert.Equal("BillingAddress_Street", v),
+                            v => Assert.Equal("ShippingAddress_City", v),
+                            v => Assert.Equal("ShippingAddress_Street", v));
                     }),
                 downOps => Assert.Collection(
                     downOps,

--- a/test/EFCore.Relational.Tests/Update/ModificationCommandComparerTest.cs
+++ b/test/EFCore.Relational.Tests/Update/ModificationCommandComparerTest.cs
@@ -35,19 +35,19 @@ namespace Microsoft.EntityFrameworkCore.Update
             entry1[key] = 1;
             entry1.SetEntityState(EntityState.Added);
             var modificationCommandAdded = new ModificationCommand("A", null, new ParameterNameGenerator().GenerateNext, false, null);
-            modificationCommandAdded.AddEntry(entry1);
+            modificationCommandAdded.AddEntry(entry1, true);
 
             var entry2 = stateManager.GetOrCreateEntry(new object());
             entry2[key] = 2;
             entry2.SetEntityState(EntityState.Modified);
             var modificationCommandModified = new ModificationCommand("A", null, new ParameterNameGenerator().GenerateNext, false, null);
-            modificationCommandModified.AddEntry(entry2);
+            modificationCommandModified.AddEntry(entry2, true);
 
             var entry3 = stateManager.GetOrCreateEntry(new object());
             entry3[key] = 3;
             entry3.SetEntityState(EntityState.Deleted);
             var modificationCommandDeleted = new ModificationCommand("A", null, new ParameterNameGenerator().GenerateNext, false, null);
-            modificationCommandDeleted.AddEntry(entry3);
+            modificationCommandDeleted.AddEntry(entry3, true);
 
             var mCC = new ModificationCommandComparer();
 
@@ -171,16 +171,16 @@ namespace Microsoft.EntityFrameworkCore.Update
             entry1[keyProperty] = value1;
             entry1.SetEntityState(EntityState.Modified);
             var modificationCommand1 = new ModificationCommand("A", null, new ParameterNameGenerator().GenerateNext, false, null);
-            modificationCommand1.AddEntry(entry1);
+            modificationCommand1.AddEntry(entry1, true);
 
             var entry2 = stateManager.GetOrCreateEntry(new object());
             entry2[keyProperty] = value2;
             entry2.SetEntityState(EntityState.Modified);
             var modificationCommand2 = new ModificationCommand("A", null, new ParameterNameGenerator().GenerateNext, false, null);
-            modificationCommand2.AddEntry(entry2);
+            modificationCommand2.AddEntry(entry2, true);
 
             var modificationCommand3 = new ModificationCommand("A", null, new ParameterNameGenerator().GenerateNext, false, null);
-            modificationCommand3.AddEntry(entry1);
+            modificationCommand3.AddEntry(entry1, true);
 
             var mCC = new ModificationCommandComparer();
 

--- a/test/EFCore.Relational.Tests/Update/ModificationCommandTest.cs
+++ b/test/EFCore.Relational.Tests/Update/ModificationCommandTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Update
             entry.SetTemporaryValue(entry.EntityType.FindPrimaryKey().Properties[0], -1);
 
             var command = new ModificationCommand("T1", null, new ParameterNameGenerator().GenerateNext, false, null);
-            command.AddEntry(entry);
+            command.AddEntry(entry, true);
 
             Assert.Equal("T1", command.TableName);
             Assert.Null(command.Schema);
@@ -67,7 +67,7 @@ namespace Microsoft.EntityFrameworkCore.Update
             var entry = CreateEntry(EntityState.Added, generateKeyValues: true);
 
             var command = new ModificationCommand("T1", null, new ParameterNameGenerator().GenerateNext, false, null);
-            command.AddEntry(entry);
+            command.AddEntry(entry, true);
 
             Assert.Equal("T1", command.TableName);
             Assert.Null(command.Schema);
@@ -111,7 +111,7 @@ namespace Microsoft.EntityFrameworkCore.Update
             var entry = CreateEntry(EntityState.Added);
 
             var command = new ModificationCommand("T1", null, new ParameterNameGenerator().GenerateNext, false, null);
-            command.AddEntry(entry);
+            command.AddEntry(entry, true);
 
             Assert.Equal("T1", command.TableName);
             Assert.Null(command.Schema);
@@ -155,7 +155,7 @@ namespace Microsoft.EntityFrameworkCore.Update
             var entry = CreateEntry(EntityState.Modified, generateKeyValues: true);
 
             var command = new ModificationCommand("T1", null, new ParameterNameGenerator().GenerateNext, false, null);
-            command.AddEntry(entry);
+            command.AddEntry(entry, true);
 
             Assert.Equal("T1", command.TableName);
             Assert.Null(command.Schema);
@@ -199,7 +199,7 @@ namespace Microsoft.EntityFrameworkCore.Update
             var entry = CreateEntry(EntityState.Modified);
 
             var command = new ModificationCommand("T1", null, new ParameterNameGenerator().GenerateNext, false, null);
-            command.AddEntry(entry);
+            command.AddEntry(entry, true);
 
             Assert.Equal("T1", command.TableName);
             Assert.Null(command.Schema);
@@ -243,7 +243,7 @@ namespace Microsoft.EntityFrameworkCore.Update
             var entry = CreateEntry(EntityState.Modified, computeNonKeyValue: true);
 
             var command = new ModificationCommand("T1", null, new ParameterNameGenerator().GenerateNext, false, null);
-            command.AddEntry(entry);
+            command.AddEntry(entry, true);
 
             Assert.Equal("T1", command.TableName);
             Assert.Null(command.Schema);
@@ -287,7 +287,7 @@ namespace Microsoft.EntityFrameworkCore.Update
             var entry = CreateEntry(EntityState.Deleted);
 
             var command = new ModificationCommand("T1", null, new ParameterNameGenerator().GenerateNext, false, null);
-            command.AddEntry(entry);
+            command.AddEntry(entry, true);
 
             Assert.Equal("T1", command.TableName);
             Assert.Null(command.Schema);
@@ -311,7 +311,7 @@ namespace Microsoft.EntityFrameworkCore.Update
             var entry = CreateEntry(EntityState.Deleted, computeNonKeyValue: true);
 
             var command = new ModificationCommand("T1", null, new ParameterNameGenerator().GenerateNext, false, null);
-            command.AddEntry(entry);
+            command.AddEntry(entry, true);
 
             Assert.Equal("T1", command.TableName);
             Assert.Null(command.Schema);
@@ -358,7 +358,7 @@ namespace Microsoft.EntityFrameworkCore.Update
 
             Assert.Equal(
                 RelationalStrings.ModificationCommandInvalidEntityState(EntityState.Unchanged),
-                Assert.Throws<ArgumentException>(() => command.AddEntry(entry)).Message);
+                Assert.Throws<ArgumentException>(() => command.AddEntry(entry, true)).Message);
         }
 
         [ConditionalFact]
@@ -370,7 +370,7 @@ namespace Microsoft.EntityFrameworkCore.Update
 
             Assert.Equal(
                 RelationalStrings.ModificationCommandInvalidEntityState(EntityState.Detached),
-                Assert.Throws<ArgumentException>(() => command.AddEntry(entry)).Message);
+                Assert.Throws<ArgumentException>(() => command.AddEntry(entry, true)).Message);
         }
 
         [ConditionalFact]
@@ -380,7 +380,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                 EntityState.Deleted, generateKeyValues: true, computeNonKeyValue: true);
 
             var command = new ModificationCommand("T1", null, new ParameterNameGenerator().GenerateNext, false, null);
-            command.AddEntry(entry);
+            command.AddEntry(entry, true);
 
             Assert.False(command.RequiresResultPropagation);
         }
@@ -392,7 +392,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                 EntityState.Added, generateKeyValues: true, computeNonKeyValue: true);
 
             var command = new ModificationCommand("T1", null, new ParameterNameGenerator().GenerateNext, false, null);
-            command.AddEntry(entry);
+            command.AddEntry(entry, true);
 
             Assert.True(command.RequiresResultPropagation);
         }
@@ -403,7 +403,7 @@ namespace Microsoft.EntityFrameworkCore.Update
             var entry = CreateEntry(EntityState.Added);
 
             var command = new ModificationCommand("T1", null, new ParameterNameGenerator().GenerateNext, false, null);
-            command.AddEntry(entry);
+            command.AddEntry(entry, true);
 
             Assert.False(command.RequiresResultPropagation);
         }
@@ -415,7 +415,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                 EntityState.Modified, generateKeyValues: true, computeNonKeyValue: true);
 
             var command = new ModificationCommand("T1", null, new ParameterNameGenerator().GenerateNext, false, null);
-            command.AddEntry(entry);
+            command.AddEntry(entry, true);
 
             Assert.True(command.RequiresResultPropagation);
         }
@@ -426,7 +426,7 @@ namespace Microsoft.EntityFrameworkCore.Update
             var entry = CreateEntry(EntityState.Modified, generateKeyValues: true);
 
             var command = new ModificationCommand("T1", null, new ParameterNameGenerator().GenerateNext, false, null);
-            command.AddEntry(entry);
+            command.AddEntry(entry, true);
 
             Assert.False(command.RequiresResultPropagation);
         }

--- a/test/EFCore.SqlServer.FunctionalTests/TableSplittingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TableSplittingSqlServerTest.cs
@@ -85,16 +85,6 @@ WHERE [v].[Discriminator] IN (N'Vehicle', N'PoweredVehicle')
 ORDER BY [v].[Name]");
         }
 
-        public override void Can_use_with_chained_relationships()
-        {
-            base.Can_use_with_chained_relationships();
-        }
-
-        public override void Can_use_with_fanned_relationships()
-        {
-            base.Can_use_with_fanned_relationships();
-        }
-
         public override void Can_query_shared()
         {
             base.Can_query_shared();


### PR DESCRIPTION
#### Description
Modifications to a shared row will derive their state only from the main entry (the entry that isn't a dependent of any other entry in the row). If the main entry isn't present the row is assumed to be modified.
The principal entry is now not required to be in the same state as the dependent when saving changes to a shared row.

Fixes #17422
Fixes #17935

#### Customer impact
Allows to add and delete just the dependent entities when using table splitting.

#### Regression
No, optional dependents in table splitting is a new feature in 3.0

#### Risk
Medium, can impact other update scenarios.