### PR TITLE
Fix shared column nullability validation

### DIFF
--- a/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
@@ -378,7 +378,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                                 currentTypeString));
                     }
 
-                    if (property.IsColumnNullable() != duplicateProperty.IsColumnNullable())
+                    if (property.IsNullable != duplicateProperty.IsNullable)
                     {
                         throw new InvalidOperationException(
                             RelationalStrings.DuplicateColumnNameNullabilityMismatch(

--- a/src/EFCore.Relational/Metadata/Internal/TableMapping.cs
+++ b/src/EFCore.Relational/Metadata/Internal/TableMapping.cs
@@ -93,7 +93,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             foreach (var property in EntityTypes.SelectMany(EntityFrameworkCore.EntityTypeExtensions.GetDeclaredProperties))
             {
                 var columnName = property.GetColumnName();
-                if (!dictionary.ContainsKey(columnName))
+                if (!dictionary.TryGetValue(columnName, out var otherProperty)
+                    || (otherProperty.IsColumnNullable() && !property.IsColumnNullable()))
                 {
                     dictionary[columnName] = property;
                 }

--- a/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.cs
+++ b/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.cs
@@ -440,11 +440,11 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             var modelBuilder = CreateConventionalModelBuilder();
             modelBuilder.Entity<Animal>();
             modelBuilder.Entity<Cat>();
-            modelBuilder.Entity<Dog>().Property(d => d.Type).HasColumnName("Id");
+            modelBuilder.Entity<Dog>().Property<int?>("OtherId").HasColumnName("Id");
 
             VerifyError(
                 RelationalStrings.DuplicateColumnNameNullabilityMismatch(
-                    nameof(Animal), nameof(Animal.Id), nameof(Dog), nameof(Dog.Type), nameof(Animal.Id), nameof(Animal)),
+                    nameof(Animal), nameof(Animal.Id), nameof(Dog), "OtherId", nameof(Animal.Id), nameof(Animal)),
                 modelBuilder.Model);
         }
 


### PR DESCRIPTION
#### Description
Validate that properties sharing a column have the same nullability, not that the corresponding column would have the same nullability

Fixes #17820

#### Customer impact
Allows to share a column with a required property on the main entity type.

#### Regression
No

#### Risk
Low
