### PR TITLE
Fix validation for field configuration

### DIFF
--- a/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
@@ -177,6 +177,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             conventionSet.ModelFinalizedConventions.Add(nonNullableNavigationConvention);
             conventionSet.ModelFinalizedConventions.Add(new QueryFilterDefiningQueryRewritingConvention(Dependencies));
             conventionSet.ModelFinalizedConventions.Add(inversePropertyAttributeConvention);
+            conventionSet.ModelFinalizedConventions.Add(backingFieldConvention);
             conventionSet.ModelFinalizedConventions.Add(new ValidatingConvention(Dependencies));
             // Don't add any more conventions to ModelFinalizedConventions after ValidatingConvention
 

--- a/src/EFCore/Metadata/Internal/CoreAnnotationNames.cs
+++ b/src/EFCore/Metadata/Internal/CoreAnnotationNames.cs
@@ -227,6 +227,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public const string AmbiguousField = "BackingFieldConvention:AmbiguousField";
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public static readonly ISet<string> AllNames = new HashSet<string>
         {
             MaxLength,
@@ -254,7 +262,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             InverseNavigations,
             NavigationCandidates,
             AmbiguousNavigations,
-            DuplicateServiceProperties
+            DuplicateServiceProperties,
+            AmbiguousField
         };
     }
 }

--- a/test/EFCore.Cosmos.FunctionalTests/EmbeddedDocumentsTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/EmbeddedDocumentsTest.cs
@@ -409,7 +409,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
                 .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
                 .BuildServiceProvider(validateScopes: true);
 
-
             TestStore.Initialize(ServiceProvider, CreateContext, c =>
             {
                 if (seed)

--- a/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
@@ -862,12 +862,14 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                     {
                         b.Property<int>("Up").HasField("_forUp");
                         b.Property(e => e.Down).HasField("_forDown");
+                        b.Property<int?>("_forWierd").HasField("_forWierd");
                     });
 
                 var entityType = (IEntityType)model.FindEntityType(typeof(Quarks));
 
                 Assert.Equal("_forUp", entityType.FindProperty("Up").GetFieldName());
                 Assert.Equal("_forDown", entityType.FindProperty("Down").GetFieldName());
+                Assert.Equal("_forWierd", entityType.FindProperty("_forWierd").GetFieldName());
             }
 
             [ConditionalFact]

--- a/test/EFCore.Tests/ModelBuilding/TestModel.cs
+++ b/test/EFCore.Tests/ModelBuilding/TestModel.cs
@@ -220,6 +220,13 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
         {
             private int _forUp;
             private string _forDown;
+#pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0051 // Remove unused private members
+#pragma warning disable CS0169 // Remove unused private fields
+            private int? _forWierd;
+#pragma warning restore CS0169 // Remove unused private fields
+#pragma warning restore IDE0051 // Remove unused private members
+#pragma warning restore IDE0044 // Add readonly modifier
 
             public int Id { get; set; }
 


### PR DESCRIPTION
#### Description
Don't throw when configuring a field for a shadow property.
Don't throw from BackingFieldConvention until the model is finalized.

Fixes #15307
Fixes #17691

#### Customer impact
Allows to use field-only properties and properties that have several matching fields

#### Regression
Yes

#### Risk
Low