### PR TITLE
Fix to #18002 - Query/Test: convert AssertQuery methods to strongly typed versions (part2)

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.Select.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.Select.cs
@@ -662,11 +662,10 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")
         [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault(bool isAsync)
         {
-            await AssertQueryScalar<Order>(
+            await AssertQueryScalar(
                 isAsync,
-                os => os.Where(o => o.OrderID < 10250)
-                    .Select(
-                        o => o.OrderDetails.OrderBy(od => od.Product.ProductName).Select(od => od.OrderID).Take(1).FirstOrDefault()));
+                ss => ss.Set<Order>().Where(o => o.OrderID < 10250)
+                    .Select(o => o.OrderDetails.OrderBy(od => od.Product.ProductName).Select(od => od.OrderID).Take(1).FirstOrDefault()));
 
             AssertSql(
                 @"SELECT c

--- a/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.SetOperations.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.SetOperations.cs
@@ -20,8 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         public override Task Intersect_non_entity(bool isAsync) => Task.CompletedTask;
         public override Task Union(bool isAsync) => Task.CompletedTask;
         public override Task Union_nested(bool isAsync) => Task.CompletedTask;
-        // issue #18002
-        //public override void Union_non_entity(bool isAsync) { }
+        public override Task Union_non_entity(bool isAsync) => Task.CompletedTask;
         public override Task Union_OrderBy_Skip_Take(bool isAsync) => Task.CompletedTask;
         public override Task Union_Where(bool isAsync) => Task.CompletedTask;
         public override Task Union_Skip_Take_OrderBy_ThenBy_Where(bool isAsync) => Task.CompletedTask;

--- a/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.cs
@@ -1027,11 +1027,12 @@ WHERE (c[""Discriminator""] = ""Customer"")");
         [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task All_top_level_subquery(bool isAsync)
         {
-            await AssertSingleResult<Customer>(
+            await AssertSingleResult(
                 isAsync,
-                syncQuery: cs => cs.All(c1 => c1.CustomerID == "ALFKI" && cs.Any(c2 => cs.Any(c3 => c1.CustomerID == c3.CustomerID))),
-                asyncQuery: cs =>
-                    cs.AllAsync(c1 => c1.CustomerID == "ALFKI" && cs.Any(c2 => cs.Any(c3 => c1.CustomerID == c3.CustomerID))));
+                syncQuery: ss => ss.Set<Customer>()
+                    .All(c1 => c1.CustomerID == "ALFKI" && ss.Set<Customer>().Any(c2 => ss.Set<Customer>().Any(c3 => c1.CustomerID == c3.CustomerID))),
+                asyncQuery: ss => ss.Set<Customer>()
+                    .AllAsync(c1 => c1.CustomerID == "ALFKI" && ss.Set<Customer>().Any(c2 => ss.Set<Customer>().Any(c3 => c1.CustomerID == c3.CustomerID))));
 
             AssertSql(
                 @"SELECT c
@@ -1042,12 +1043,16 @@ WHERE (c[""Discriminator""] = ""Customer"")");
         [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task All_top_level_subquery_ef_property(bool isAsync)
         {
-            await AssertSingleResult<Customer>(
+            await AssertSingleResult(
                 isAsync,
-                syncQuery: cs => cs.All(
-                    c1 => c1.CustomerID == "ALFKI" && cs.Any(c2 => cs.Any(c3 => EF.Property<string>(c1, "CustomerID") == c3.CustomerID))),
-                asyncQuery: cs => cs.AllAsync(
-                    c1 => c1.CustomerID == "ALFKI" && cs.Any(c2 => cs.Any(c3 => EF.Property<string>(c1, "CustomerID") == c3.CustomerID))));
+                syncQuery: ss => ss.Set<Customer>()
+                    .All(c1 => c1.CustomerID == "ALFKI" && ss.Set<Customer>()
+                        .Any(c2 => ss.Set<Customer>()
+                            .Any(c3 => EF.Property<string>(c1, "CustomerID") == c3.CustomerID))),
+                asyncQuery: ss => ss.Set<Customer>()
+                    .AllAsync(c1 => c1.CustomerID == "ALFKI" && ss.Set<Customer>()
+                        .Any(c2 => ss.Set<Customer>()
+                            .Any(c3 => EF.Property<string>(c1, "CustomerID") == c3.CustomerID))));
 
             AssertSql(
                 @"SELECT c

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -9,18 +9,18 @@ using Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
-// ReSharper disable ConvertClosureToMethodGroup
-// ReSharper disable PossibleUnintendedReferenceComparison
-// ReSharper disable ArgumentsStyleLiteral
-// ReSharper disable PossibleMultipleEnumeration
-// ReSharper disable UnusedVariable
-// ReSharper disable EqualExpressionComparison
-// ReSharper disable AccessToDisposedClosure
-// ReSharper disable StringStartsWithIsCultureSpecific
-// ReSharper disable InconsistentNaming
-// ReSharper disable MergeConditionalExpression
-// ReSharper disable ReplaceWithSingleCallToSingle
-// ReSharper disable ReturnValueOfPureMethodIsNotUsed
+// ReSharper disable ConvertClosureToMethodGroup	
+// ReSharper disable PossibleUnintendedReferenceComparison	
+// ReSharper disable ArgumentsStyleLiteral	
+// ReSharper disable PossibleMultipleEnumeration	
+// ReSharper disable UnusedVariable	
+// ReSharper disable EqualExpressionComparison	
+// ReSharper disable AccessToDisposedClosure	
+// ReSharper disable StringStartsWithIsCultureSpecific	
+// ReSharper disable InconsistentNaming	
+// ReSharper disable MergeConditionalExpression	
+// ReSharper disable ReplaceWithSingleCallToSingle	
+// ReSharper disable ReturnValueOfPureMethodIsNotUsed	
 // ReSharper disable ConvertToExpressionBodyWhenPossible
 #pragma warning disable RCS1155 // Use StringComparison when comparing strings.
 namespace Microsoft.EntityFrameworkCore.Query
@@ -200,17 +200,16 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2, "OneToMany_Optional2", navigationPath: "OneToMany_Optional1")
             };
 
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s.Include(e => e.OneToMany_Optional1).ThenInclude(e => e.OneToMany_Optional2),
+                ss => ss.Set<Level1>().Include(e => e.OneToMany_Optional1).ThenInclude(e => e.OneToMany_Optional2),
                 expectedIncludes,
                 elementSorter: e => e.Id);
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual Task Multi_level_include_correct_PK_is_chosen_as_the_join_predicate_for_queries_that_join_same_table_multiple_times(
-            bool isAsync)
+        public virtual Task Multi_level_include_correct_PK_is_chosen_as_the_join_predicate_for_queries_that_join_same_table_multiple_times(bool isAsync)
         {
             var expectedIncludes = new List<IExpectedInclude>
             {
@@ -224,9 +223,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                     navigationPath: "OneToMany_Optional1.OneToMany_Optional2.OneToMany_Required_Inverse3")
             };
 
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s.Include(e => e.OneToMany_Optional1).ThenInclude(e => e.OneToMany_Optional2)
+                ss => ss.Set<Level1>().Include(e => e.OneToMany_Optional1).ThenInclude(e => e.OneToMany_Optional2)
                     .ThenInclude(e => e.OneToMany_Required_Inverse3.OneToMany_Optional2),
                 expectedIncludes,
                 elementSorter: e => e.Id);
@@ -319,16 +318,14 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Navigation_key_access_optional_comparison(bool isAsync)
         {
-            return AssertQueryScalar<Level2>(
+            return AssertQueryScalar(
                 isAsync,
-                l2s =>
-                    from e2 in l2s
-                    where e2.OneToOne_Optional_PK_Inverse2.Id > 5
-                    select e2.Id,
-                l2s =>
-                    from e2 in l2s
-                    where MaybeScalar<int>(e2.OneToOne_Optional_PK_Inverse2, () => e2.OneToOne_Optional_PK_Inverse2.Id) > 5
-                    select e2.Id);
+                ss => from e2 in ss.Set<Level2>()
+                      where e2.OneToOne_Optional_PK_Inverse2.Id > 5
+                      select e2.Id,
+                ss => from e2 in ss.Set<Level2>()
+                      where MaybeScalar<int>(e2.OneToOne_Optional_PK_Inverse2, () => e2.OneToOne_Optional_PK_Inverse2.Id) > 5
+                      select e2.Id);
         }
 
         [ConditionalTheory]
@@ -362,12 +359,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Simple_level1_level2_GroupBy_Count(bool isAsync)
         {
-            return AssertQueryScalar<Level1>(
+            return AssertQueryScalar(
                 isAsync,
-                l1s => l1s.GroupBy(
+                ss => ss.Set<Level1>().GroupBy(
                         l1 => l1.OneToOne_Required_PK1.OneToOne_Required_PK2.Name)
                     .Select(g => g.Count()),
-                l1s => l1s.GroupBy(
+                ss => ss.Set<Level1>().GroupBy(
                         l1 => Maybe(
                             l1.OneToOne_Required_PK1,
                             () => Maybe(
@@ -380,14 +377,14 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Simple_level1_level2_GroupBy_Having_Count(bool isAsync)
         {
-            return AssertQueryScalar<Level1>(
+            return AssertQueryScalar(
                 isAsync,
-                l1s => l1s.GroupBy(
+                ss => ss.Set<Level1>().GroupBy(
                         l1 => l1.OneToOne_Required_PK1.OneToOne_Required_PK2.Name,
                         l1 => new { Id = ((int?)l1.OneToOne_Required_PK1.Id ?? 0) })
                     .Where(g => g.Min(l1 => l1.Id) > 0)
                     .Select(g => g.Count()),
-                l1s => l1s.GroupBy(
+                ss => ss.Set<Level1>().GroupBy(
                         l1 => Maybe(
                             l1.OneToOne_Required_PK1,
                             () => Maybe(
@@ -412,12 +409,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Navigation_key_access_required_comparison(bool isAsync)
         {
-            return AssertQueryScalar<Level2>(
+            return AssertQueryScalar(
                 isAsync,
-                l2s =>
-                    from e2 in l2s
-                    where e2.OneToOne_Required_PK_Inverse2.Id > 5
-                    select e2.Id);
+                ss => from e2 in ss.Set<Level2>()
+                      where e2.OneToOne_Required_PK_Inverse2.Id > 5
+                      select e2.Id);
         }
 
         [ConditionalTheory]
@@ -812,9 +808,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                     l2 => l2.OneToOne_Optional_FK2, "OneToOne_Optional_FK2", navigationPath: "OneToMany_Optional1")
             };
 
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .Include(e => e.OneToOne_Optional_FK1)
                     .ThenInclude(e => e.OneToMany_Optional2)
                     .Include(e => e.OneToMany_Optional1)
@@ -837,9 +833,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                     l2 => l2.OneToOne_Optional_Self1, "OneToOne_Optional_Self1", navigationPath: "OneToMany_Optional_Self1")
             };
 
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .Include(e => e.OneToOne_Optional_Self1)
                     .ThenInclude(e => e.OneToMany_Optional_Self1)
                     .Include(e => e.OneToMany_Optional_Self1)
@@ -862,9 +858,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                     l2 => l2.OneToOne_Optional_FK2, "OneToOne_Optional_FK2", navigationPath: "OneToMany_Optional1")
             };
 
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .Select(e => e)
                     .Include(e => e.OneToOne_Optional_FK1)
                     .ThenInclude(e => e.OneToMany_Optional2)
@@ -922,28 +918,26 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_nav_prop_reference_optional2(bool isAsync)
         {
-            return AssertQueryScalar<Level1>(
+            return AssertQueryScalar(
                 isAsync,
-                l1s => l1s.Select(e => (int?)e.OneToOne_Optional_FK1.Id),
-                l1s => l1s.Select(e => MaybeScalar<int>(e.OneToOne_Optional_FK1, () => e.OneToOne_Optional_FK1.Id)));
+                ss => ss.Set<Level1>().Select(e => (int?)e.OneToOne_Optional_FK1.Id),
+                ss => ss.Set<Level1>().Select(e => MaybeScalar<int>(e.OneToOne_Optional_FK1, () => e.OneToOne_Optional_FK1.Id)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_nav_prop_reference_optional2_via_DefaultIfEmpty(bool isAsync)
         {
-            return AssertQueryScalar<Level1, Level2>(
+            return AssertQueryScalar(
                 isAsync,
-                (l1s, l2s) =>
-                    from l1 in l1s
-                    join l2 in l2s on l1.Id equals l2.Level1_Optional_Id into groupJoin
-                    from l2 in groupJoin.DefaultIfEmpty()
-                    select l2 == null ? null : (int?)l2.Id,
-                (l1s, l2s) =>
-                    from l1 in l1s
-                    join l2 in l2s on l1.Id equals MaybeScalar(l2, () => l2.Level1_Optional_Id) into groupJoin
-                    from l2 in Maybe(groupJoin, () => groupJoin.DefaultIfEmpty())
-                    select l2 == null ? null : (int?)l2.Id);
+                ss => from l1 in ss.Set<Level1>()
+                      join l2 in ss.Set<Level2>() on l1.Id equals l2.Level1_Optional_Id into groupJoin
+                      from l2 in groupJoin.DefaultIfEmpty()
+                      select l2 == null ? null : (int?)l2.Id,
+                ss => from l1 in ss.Set<Level1>()
+                      join l2 in ss.Set<Level2>() on l1.Id equals MaybeScalar(l2, () => l2.Level1_Optional_Id) into groupJoin
+                      from l2 in Maybe(groupJoin, () => groupJoin.DefaultIfEmpty())
+                      select l2 == null ? null : (int?)l2.Id);
         }
 
         [ConditionalTheory]
@@ -960,12 +954,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_nav_prop_reference_optional1(bool isAsync)
         {
-            return AssertQueryScalar<Level1>(
+            return AssertQueryScalar(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .Where(e => e.OneToOne_Optional_FK1.Name == "L2 05" || e.OneToOne_Optional_FK1.Name == "L2 07")
                     .Select(e => e.Id),
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .Where(
                         e => Maybe(e.OneToOne_Optional_FK1, () => e.OneToOne_Optional_FK1.Name) == "L2 05"
                              || Maybe(e.OneToOne_Optional_FK1, () => e.OneToOne_Optional_FK1.Name) == "L2 07")
@@ -976,33 +970,31 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_nav_prop_reference_optional1_via_DefaultIfEmpty(bool isAsync)
         {
-            return AssertQueryScalar<Level1, Level2>(
+            return AssertQueryScalar(
                 isAsync,
-                (l1s, l2s) =>
-                    from l1 in l1s
-                    join l2Left in l2s on l1.Id equals l2Left.Level1_Optional_Id into groupJoinLeft
-                    from l2Left in groupJoinLeft.DefaultIfEmpty()
-                    join l2Right in l2s on l1.Id equals l2Right.Level1_Optional_Id into groupJoinRight
-                    from l2Right in groupJoinRight.DefaultIfEmpty()
+                ss => from l1 in ss.Set<Level1>()
+                      join l2Left in ss.Set<Level2>() on l1.Id equals l2Left.Level1_Optional_Id into groupJoinLeft
+                      from l2Left in groupJoinLeft.DefaultIfEmpty()
+                      join l2Right in ss.Set<Level2>() on l1.Id equals l2Right.Level1_Optional_Id into groupJoinRight
+                      from l2Right in groupJoinRight.DefaultIfEmpty()
 #pragma warning disable IDE0031 // Use null propagation
-                    where (l2Left == null ? null : l2Left.Name) == "L2 05" || (l2Right == null ? null : l2Right.Name) == "L2 07"
+                      where (l2Left == null ? null : l2Left.Name) == "L2 05" || (l2Right == null ? null : l2Right.Name) == "L2 07"
 #pragma warning restore IDE0031 // Use null propagation
-                    select l1.Id);
+                      select l1.Id);
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_nav_prop_reference_optional2(bool isAsync)
         {
-            return AssertQueryScalar<Level1>(
+            return AssertQueryScalar(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .Where(e => e.OneToOne_Optional_FK1.Name == "L2 05" || e.OneToOne_Optional_FK1.Name != "L2 42")
                     .Select(e => e.Id),
-                l1s => l1s
-                    .Where(
-                        e => Maybe(e.OneToOne_Optional_FK1, () => e.OneToOne_Optional_FK1.Name) == "L2 05"
-                             || Maybe(e.OneToOne_Optional_FK1, () => e.OneToOne_Optional_FK1.Name) != "L2 42")
+                ss => ss.Set<Level1>()
+                    .Where(e => Maybe(e.OneToOne_Optional_FK1, () => e.OneToOne_Optional_FK1.Name) == "L2 05"
+                        || Maybe(e.OneToOne_Optional_FK1, () => e.OneToOne_Optional_FK1.Name) != "L2 42")
                     .Select(e => e.Id));
         }
 
@@ -1010,28 +1002,27 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_nav_prop_reference_optional2_via_DefaultIfEmpty(bool isAsync)
         {
-            return AssertQueryScalar<Level1, Level2>(
+            return AssertQueryScalar(
                 isAsync,
-                (l1s, l2s) =>
-                    from l1 in l1s
-                    join l2Left in l2s on l1.Id equals l2Left.Level1_Optional_Id into groupJoinLeft
-                    from l2Left in groupJoinLeft.DefaultIfEmpty()
-                    join l2Right in l2s on l1.Id equals l2Right.Level1_Optional_Id into groupJoinRight
-                    from l2Right in groupJoinRight.DefaultIfEmpty()
+                ss => from l1 in ss.Set<Level1>()
+                      join l2Left in ss.Set<Level2>() on l1.Id equals l2Left.Level1_Optional_Id into groupJoinLeft
+                      from l2Left in groupJoinLeft.DefaultIfEmpty()
+                      join l2Right in ss.Set<Level2>() on l1.Id equals l2Right.Level1_Optional_Id into groupJoinRight
+                      from l2Right in groupJoinRight.DefaultIfEmpty()
 #pragma warning disable IDE0031 // Use null propagation
-                    where (l2Left == null ? null : l2Left.Name) == "L2 05" || (l2Right == null ? null : l2Right.Name) != "L2 42"
+                      where (l2Left == null ? null : l2Left.Name) == "L2 05" || (l2Right == null ? null : l2Right.Name) != "L2 42"
 #pragma warning restore IDE0031 // Use null propagation
-                    select l1.Id);
+                      select l1.Id);
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_multiple_nav_prop_reference_optional(bool isAsync)
         {
-            return AssertQueryScalar<Level1>(
+            return AssertQueryScalar(
                 isAsync,
-                l1s => l1s.Select(e => (int?)e.OneToOne_Optional_FK1.OneToOne_Optional_FK2.Id),
-                l1s => l1s.Select(
+                ss => ss.Set<Level1>().Select(e => (int?)e.OneToOne_Optional_FK1.OneToOne_Optional_FK2.Id),
+                ss => ss.Set<Level1>().Select(
                     e => MaybeScalar(
                         e.OneToOne_Optional_FK1,
                         () => MaybeScalar<int>(
@@ -1182,10 +1173,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_multiple_nav_prop_reference_required(bool isAsync)
         {
-            return AssertQueryScalar<Level1>(
+            return AssertQueryScalar(
                 isAsync,
-                l1s => l1s.Select(e => (int?)e.OneToOne_Required_FK1.OneToOne_Required_FK2.Id),
-                l1s => l1s.Select(
+                ss => ss.Set<Level1>().Select(e => (int?)e.OneToOne_Required_FK1.OneToOne_Required_FK2.Id),
+                ss => ss.Set<Level1>().Select(
                     e => MaybeScalar(
                         e.OneToOne_Required_FK1,
                         () => MaybeScalar<int>(
@@ -1197,27 +1188,25 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_multiple_nav_prop_reference_required2(bool isAsync)
         {
-            return AssertQueryScalar<Level3>(
+            return AssertQueryScalar(
                 isAsync,
-                l3s => l3s.Select(e => e.OneToOne_Required_FK_Inverse3.OneToOne_Required_FK_Inverse2.Id));
+                ss => ss.Set<Level3>().Select(e => e.OneToOne_Required_FK_Inverse3.OneToOne_Required_FK_Inverse2.Id));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_multiple_nav_prop_optional_required(bool isAsync)
         {
-            return AssertQueryScalar<Level1>(
+            return AssertQueryScalar(
                 isAsync,
-                l1s =>
-                    from l1 in l1s
-                    select (int?)l1.OneToOne_Optional_FK1.OneToOne_Required_FK2.Id,
-                l1s =>
-                    from l1 in l1s
-                    select MaybeScalar(
-                        l1.OneToOne_Optional_FK1,
-                        () => MaybeScalar<int>(
-                            l1.OneToOne_Optional_FK1.OneToOne_Required_FK2,
-                            () => l1.OneToOne_Optional_FK1.OneToOne_Required_FK2.Id)));
+                ss => from l1 in ss.Set<Level1>()
+                      select (int?)l1.OneToOne_Optional_FK1.OneToOne_Required_FK2.Id,
+                ss => from l1 in ss.Set<Level1>()
+                      select MaybeScalar(
+                          l1.OneToOne_Optional_FK1,
+                          () => MaybeScalar<int>(
+                              l1.OneToOne_Optional_FK1.OneToOne_Required_FK2,
+                              () => l1.OneToOne_Optional_FK1.OneToOne_Required_FK2.Id)));
         }
 
         [ConditionalTheory]
@@ -1323,68 +1312,62 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_complex_predicate_with_with_nav_prop_and_OrElse2(bool isAsync)
         {
-            return AssertQueryScalar<Level1>(
+            return AssertQueryScalar(
                 isAsync,
-                l1s =>
-                    from l1 in l1s
-                    where l1.OneToOne_Optional_FK1.OneToOne_Required_FK2.Name == "L3 05" || l1.OneToOne_Optional_FK1.Name != "L2 05"
-                    select l1.Id,
-                l1s =>
-                    from l1 in l1s
-                    where Maybe(
-                              l1.OneToOne_Optional_FK1,
-                              () => Maybe(
-                                  l1.OneToOne_Optional_FK1.OneToOne_Required_FK2,
-                                  () => l1.OneToOne_Optional_FK1.OneToOne_Required_FK2.Name)) == "L3 05"
+                ss => from l1 in ss.Set<Level1>()
+                      where l1.OneToOne_Optional_FK1.OneToOne_Required_FK2.Name == "L3 05" || l1.OneToOne_Optional_FK1.Name != "L2 05"
+                      select l1.Id,
+                ss => from l1 in ss.Set<Level1>()
+                      where Maybe(
+                          l1.OneToOne_Optional_FK1,
+                          () => Maybe(
+                              l1.OneToOne_Optional_FK1.OneToOne_Required_FK2,
+                              () => l1.OneToOne_Optional_FK1.OneToOne_Required_FK2.Name)) == "L3 05"
                           || Maybe(
                               l1.OneToOne_Optional_FK1,
                               () => l1.OneToOne_Optional_FK1.Name) != "L2 05"
-                    select l1.Id);
+                      select l1.Id);
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_complex_predicate_with_with_nav_prop_and_OrElse3(bool isAsync)
         {
-            return AssertQueryScalar<Level1>(
+            return AssertQueryScalar(
                 isAsync,
-                l1s =>
-                    from l1 in l1s
-                    where l1.OneToOne_Optional_FK1.Name != "L2 05" || l1.OneToOne_Required_FK1.OneToOne_Optional_FK2.Name == "L3 05"
-                    select l1.Id,
-                l1s =>
-                    from l1 in l1s
-                    where Maybe(
-                              l1.OneToOne_Optional_FK1,
-                              () => l1.OneToOne_Optional_FK1.Name) != "L2 05"
+                ss => from l1 in ss.Set<Level1>()
+                      where l1.OneToOne_Optional_FK1.Name != "L2 05" || l1.OneToOne_Required_FK1.OneToOne_Optional_FK2.Name == "L3 05"
+                      select l1.Id,
+                ss => from l1 in ss.Set<Level1>()
+                      where Maybe(
+                          l1.OneToOne_Optional_FK1,
+                          () => l1.OneToOne_Optional_FK1.Name) != "L2 05"
                           || Maybe(
                               l1.OneToOne_Required_FK1,
                               () => Maybe(
                                   l1.OneToOne_Required_FK1.OneToOne_Optional_FK2,
                                   () => l1.OneToOne_Required_FK1.OneToOne_Optional_FK2.Name)) == "L3 05"
-                    select l1.Id);
+                      select l1.Id);
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_complex_predicate_with_with_nav_prop_and_OrElse4(bool isAsync)
         {
-            return AssertQueryScalar<Level3>(
+            return AssertQueryScalar(
                 isAsync,
-                l3s =>
-                    from l3 in l3s
-                    where l3.OneToOne_Optional_FK_Inverse3.Name != "L2 05"
+                ss => from l3 in ss.Set<Level3>()
+                      where l3.OneToOne_Optional_FK_Inverse3.Name != "L2 05"
                           || l3.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2.Name == "L1 05"
-                    select l3.Id,
-                l3s =>
-                    from l3 in l3s
-                    where Maybe(
-                              l3.OneToOne_Optional_FK_Inverse3,
-                              () => l3.OneToOne_Optional_FK_Inverse3.Name) != "L2 05"
+                      select l3.Id,
+                ss => from l3 in ss.Set<Level3>()
+                      where Maybe(
+                          l3.OneToOne_Optional_FK_Inverse3,
+                          () => l3.OneToOne_Optional_FK_Inverse3.Name) != "L2 05"
                           || Maybe(
                               l3.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2,
                               () => l3.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2.Name) == "L1 05"
-                    select l3.Id);
+                      select l3.Id);
         }
 
         [ConditionalTheory]
@@ -1516,13 +1499,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task OrderBy_nav_prop_reference_optional(bool isAsync)
         {
-            return AssertQueryScalar<Level1>(
+            return AssertQueryScalar(
                 isAsync,
-                l1s =>
-                    l1s.OrderBy(e => e.OneToOne_Optional_FK1.Name).ThenBy(e => e.Id).Select(e => e.Id),
-                l1s =>
-                    l1s.OrderBy(e => Maybe(e.OneToOne_Optional_FK1, () => e.OneToOne_Optional_FK1.Name)).ThenBy(e => e.Id)
-                        .Select(e => e.Id),
+                ss => ss.Set<Level1>().OrderBy(e => e.OneToOne_Optional_FK1.Name).ThenBy(e => e.Id).Select(e => e.Id),
+                ss => ss.Set<Level1>().OrderBy(e => Maybe(e.OneToOne_Optional_FK1, () => e.OneToOne_Optional_FK1.Name))
+                    .ThenBy(e => e.Id)
+                    .Select(e => e.Id),
                 assertOrder: true);
         }
 
@@ -1530,16 +1512,15 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task OrderBy_nav_prop_reference_optional_via_DefaultIfEmpty(bool isAsync)
         {
-            return AssertQueryScalar<Level1, Level2>(
+            return AssertQueryScalar(
                 isAsync,
-                (l1s, l2s) =>
-                    from l1 in l1s
-                    join l2 in l2s on l1.Id equals l2.Level1_Optional_Id into groupJoin
-                    from l2 in groupJoin.DefaultIfEmpty()
+                ss => from l1 in ss.Set<Level1>()
+                      join l2 in ss.Set<Level2>() on l1.Id equals l2.Level1_Optional_Id into groupJoin
+                      from l2 in groupJoin.DefaultIfEmpty()
 #pragma warning disable IDE0031 // Use null propagation
-                    orderby l2 == null ? null : l2.Name, l1.Id
+                      orderby l2 == null ? null : l2.Name, l1.Id
 #pragma warning restore IDE0031 // Use null propagation
-                    select l1.Id,
+                      select l1.Id,
                 assertOrder: true);
         }
 
@@ -1630,14 +1611,14 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_with_optional_navigation(bool isAsync)
         {
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => from l1 in l1s.Include(e => e.OneToOne_Optional_FK1)
-                       where l1.OneToOne_Optional_FK1.Name != "L2 05"
-                       select l1,
-                l1s => from l1 in l1s.Include(e => e.OneToOne_Optional_FK1)
-                       where Maybe(l1.OneToOne_Optional_FK1, () => l1.OneToOne_Optional_FK1.Name) != "L2 05"
-                       select l1,
+                ss => from l1 in ss.Set<Level1>().Include(e => e.OneToOne_Optional_FK1)
+                      where l1.OneToOne_Optional_FK1.Name != "L2 05"
+                      select l1,
+                ss => from l1 in ss.Set<Level1>().Include(e => e.OneToOne_Optional_FK1)
+                      where Maybe(l1.OneToOne_Optional_FK1, () => l1.OneToOne_Optional_FK1.Name) != "L2 05"
+                      select l1,
                 new List<IExpectedInclude> { new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1, "OneToOne_Optional_FK1") },
                 elementSorter: e => e.Id);
         }
@@ -1654,16 +1635,16 @@ namespace Microsoft.EntityFrameworkCore.Query
                     l1 => l1.OneToOne_Required_FK3, "OneToOne_Required_FK3", "OneToOne_Optional_FK1.OneToMany_Required2")
             };
 
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => from l1 in l1s
-                           .Include(e => e.OneToOne_Optional_FK1.OneToMany_Required2)
-                           .ThenInclude(e => e.OneToOne_Required_FK3)
-                       where l1.OneToOne_Optional_FK1.Name != "L2 09"
-                       select l1,
-                l1s => from l1 in l1s
-                       where Maybe(l1.OneToOne_Optional_FK1, () => l1.OneToOne_Optional_FK1.Name) != "L2 09"
-                       select l1,
+                ss => from l1 in ss.Set<Level1>()
+                          .Include(e => e.OneToOne_Optional_FK1.OneToMany_Required2)
+                          .ThenInclude(e => e.OneToOne_Required_FK3)
+                      where l1.OneToOne_Optional_FK1.Name != "L2 09"
+                      select l1,
+                ss => from l1 in ss.Set<Level1>()
+                      where Maybe(l1.OneToOne_Optional_FK1, () => l1.OneToOne_Optional_FK1.Name) != "L2 09"
+                      select l1,
                 expectedIncludes,
                 elementSorter: l1 => l1.Id);
         }
@@ -1679,13 +1660,13 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Level2>(l2 => l2.OneToOne_Required_PK2, "OneToOne_Required_PK2")
             };
 
-            return AssertIncludeQuery<Level1, Level2>(
+            return AssertIncludeQuery(
                 isAsync,
-                (l1s, l2s) =>
-                    (from l1 in l1s
+                ss =>
+                    (from l1 in ss.Set<Level1>()
                          .Include(e => e.OneToMany_Optional1)
                          .ThenInclude(e => e.OneToOne_Optional_FK2)
-                     join l2 in l2s.Include(e => e.OneToOne_Required_PK2)
+                     join l2 in ss.Set<Level2>().Include(e => e.OneToOne_Required_PK2)
 #pragma warning disable IDE0031 // Use null propagation
                          on (int?)l1.Id equals l2 != null ? l2.Level1_Optional_Id : null into grouping
 #pragma warning restore IDE0031 // Use null propagation
@@ -1719,28 +1700,27 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Query_source_materialization_bug_4547(bool isAsync)
         {
-            return AssertQueryScalar<Level1, Level2, Level3>(
+            return AssertQueryScalar(
                 isAsync,
-                (l1s, l2s, l3s) =>
-                    from e3 in l3s
-                    join e1 in l1s
-                        on
-                        (int?)e3.Id
-                        equals
-                        (
-                            from subQuery2 in l2s
-                            join subQuery3 in l3s
-                                on
-                                subQuery2 != null ? (int?)subQuery2.Id : null
-                                equals
-                                subQuery3.Level2_Optional_Id
-                                into
-                                grouping
-                            from subQuery3 in grouping.DefaultIfEmpty()
-                            orderby subQuery3 != null ? (int?)subQuery3.Id : null
-                            select subQuery3 != null ? (int?)subQuery3.Id : null
-                        ).FirstOrDefault()
-                    select e1.Id);
+                ss => from e3 in ss.Set<Level3>()
+                      join e1 in ss.Set<Level1>()
+                          on
+                          e3.Id
+                          equals
+                          (
+                              from subQuery2 in ss.Set<Level2>()
+                              join subQuery3 in ss.Set<Level3>()
+                                  on
+                                  subQuery2 != null ? (int?)subQuery2.Id : null
+                                  equals
+                                  subQuery3.Level2_Optional_Id
+                                  into
+                                  grouping
+                              from subQuery3 in grouping.DefaultIfEmpty()
+                              orderby subQuery3 != null ? (int?)subQuery3.Id : null
+                              select subQuery3 != null ? (int?)subQuery3.Id : null
+                          ).FirstOrDefault()
+                      select e1.Id);
         }
 
         [ConditionalTheory]
@@ -1907,9 +1887,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Level2>(l1 => l1.OneToMany_Required2, "OneToMany_Required2", "OneToOne_Required_FK1")
             };
 
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .Include(e => e.OneToOne_Required_FK1).ThenInclude(e => e.OneToMany_Optional2)
                     .Include(e => e.OneToOne_Required_FK1).ThenInclude(e => e.OneToMany_Required2)
                     .OrderBy(t => t.Name)
@@ -1930,9 +1910,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Level2>(l2 => l2.OneToMany_Required2, "OneToMany_Required2", "OneToOne_Required_FK1")
             };
 
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .Include(e => e.OneToOne_Optional_FK1).ThenInclude(e => e.OneToMany_Optional2)
                     .Include(e => e.OneToOne_Required_FK1).ThenInclude(e => e.OneToMany_Required2)
                     .OrderBy(t => t.Name)
@@ -1952,9 +1932,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                     l3 => l3.OneToMany_Optional3, "OneToMany_Optional3", "OneToOne_Optional_FK1.OneToOne_Required_FK2")
             };
 
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .Include(e => e.OneToOne_Optional_FK1.OneToOne_Required_FK2).ThenInclude(e => e.OneToMany_Optional3)
                     .OrderBy(t => t.Name)
                     .Skip(0).Take(10),
@@ -1974,15 +1954,15 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2, "OneToOne_Optional_FK2", "OneToOne_Optional_FK1")
             };
 
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .Include(e => e.OneToOne_Required_FK1).ThenInclude(e => e.OneToMany_Optional2)
                     .Include(e => e.OneToOne_Required_FK1).ThenInclude(e => e.OneToOne_Optional_FK2)
                     .Include(e => e.OneToOne_Optional_FK1).ThenInclude(e => e.OneToOne_Optional_FK2)
                     .Where(e => e.OneToOne_Required_FK1.OneToOne_Optional_PK2.Name != "Foo")
                     .OrderBy(e => e.Id),
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .Where(
                         e => Maybe(
                                  e.OneToOne_Required_FK1,
@@ -2328,9 +2308,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task SelectMany_with_Include1(bool isAsync)
         {
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .SelectMany(l1 => l1.OneToMany_Optional1)
                     .Include(l2 => l2.OneToMany_Optional2),
                 expectedIncludes: new List<IExpectedInclude>
@@ -2344,9 +2324,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Orderby_SelectMany_with_Include1(bool isAsync)
         {
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s.OrderBy(l1 => l1.Id)
+                ss => ss.Set<Level1>().OrderBy(l1 => l1.Id)
                     .SelectMany(l1 => l1.OneToMany_Optional1)
                     .Include(l2 => l2.OneToMany_Optional2),
                 expectedIncludes: new List<IExpectedInclude>
@@ -2360,9 +2340,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task SelectMany_with_Include2(bool isAsync)
         {
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .SelectMany(l1 => l1.OneToMany_Optional1)
                     .Include(l2 => l2.OneToOne_Required_FK2),
                 expectedIncludes: new List<IExpectedInclude>
@@ -2382,9 +2362,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Level3>(l3 => l3.OneToMany_Optional3, "OneToMany_Optional3", "OneToOne_Required_FK2")
             };
 
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .SelectMany(l1 => l1.OneToMany_Optional1)
                     .Include(l2 => l2.OneToOne_Required_FK2)
                     .ThenInclude(l3 => l3.OneToMany_Optional3),
@@ -2402,9 +2382,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Level3>(l3 => l3.OneToMany_Optional3, "OneToMany_Optional3")
             };
 
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .SelectMany(l1 => l1.OneToMany_Optional1)
                     .SelectMany(l2 => l2.OneToMany_Optional2)
                     .Include(l3 => l3.OneToOne_Required_FK3)
@@ -2417,9 +2397,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task SelectMany_with_string_based_Include1(bool isAsync)
         {
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .SelectMany(l1 => l1.OneToMany_Optional1)
                     .Include("OneToOne_Required_FK2"),
                 expectedIncludes: new List<IExpectedInclude>
@@ -2439,9 +2419,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Level3>(l3 => l3.OneToOne_Required_FK3, "OneToOne_Required_FK3", "OneToOne_Required_FK2")
             };
 
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .SelectMany(l1 => l1.OneToMany_Optional1)
                     .Include("OneToOne_Required_FK2.OneToOne_Required_FK3"),
                 expectedIncludes,
@@ -2452,9 +2432,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multiple_SelectMany_with_string_based_Include(bool isAsync)
         {
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .SelectMany(l1 => l1.OneToMany_Optional1)
                     .SelectMany(l1 => l1.OneToMany_Optional2)
                     .Include("OneToOne_Required_FK3"),
@@ -2469,9 +2449,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Required_navigation_with_Include(bool isAsync)
         {
-            return AssertIncludeQuery<Level3>(
+            return AssertIncludeQuery(
                 isAsync,
-                l3s => l3s
+                ss => ss.Set<Level3>()
                     .Select(l3 => l3.OneToOne_Required_FK_Inverse3)
                     .Include(l2 => l2.OneToMany_Required_Inverse2),
                 expectedIncludes: new List<IExpectedInclude>
@@ -2492,9 +2472,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                     l2 => l2.OneToMany_Optional_Inverse2, "OneToMany_Optional_Inverse2", "OneToMany_Required_Inverse3")
             };
 
-            return AssertIncludeQuery<Level4>(
+            return AssertIncludeQuery(
                 isAsync,
-                l4s => l4s
+                ss => ss.Set<Level4>()
                     .Select(l4 => l4.OneToOne_Required_FK_Inverse4)
                     .Include(l3 => l3.OneToMany_Required_Inverse3)
                     .ThenInclude(l2 => l2.OneToMany_Optional_Inverse2),
@@ -2506,9 +2486,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multiple_required_navigations_with_Include(bool isAsync)
         {
-            return AssertIncludeQuery<Level4>(
+            return AssertIncludeQuery(
                 isAsync,
-                l4s => l4s
+                ss => ss.Set<Level4>()
                     .Select(l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Required_FK_Inverse3)
                     .Include(l2 => l2.OneToOne_Optional_FK2),
                 expectedIncludes: new List<IExpectedInclude>
@@ -2522,9 +2502,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multiple_required_navigation_using_multiple_selects_with_Include(bool isAsync)
         {
-            return AssertIncludeQuery<Level4>(
+            return AssertIncludeQuery(
                 isAsync,
-                l4s => l4s
+                ss => ss.Set<Level4>()
                     .Select(l4 => l4.OneToOne_Required_FK_Inverse4)
                     .Select(l3 => l3.OneToOne_Required_FK_Inverse3)
                     .Include(l2 => l2.OneToOne_Optional_FK2),
@@ -2539,9 +2519,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multiple_required_navigation_with_string_based_Include(bool isAsync)
         {
-            return AssertIncludeQuery<Level4>(
+            return AssertIncludeQuery(
                 isAsync,
-                l4s => l4s
+                ss => ss.Set<Level4>()
                     .Select(l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Required_FK_Inverse3)
                     .Include("OneToOne_Optional_FK2"),
                 expectedIncludes: new List<IExpectedInclude>
@@ -2555,9 +2535,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multiple_required_navigation_using_multiple_selects_with_string_based_Include(bool isAsync)
         {
-            return AssertIncludeQuery<Level4>(
+            return AssertIncludeQuery(
                 isAsync,
-                l4s => l4s
+                ss => ss.Set<Level4>()
                     .Select(l4 => l4.OneToOne_Required_FK_Inverse4)
                     .Select(l3 => l3.OneToOne_Required_FK_Inverse3)
                     .Include("OneToOne_Optional_FK2"),
@@ -2572,9 +2552,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Optional_navigation_with_Include(bool isAsync)
         {
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .Select(l1 => l1.OneToOne_Optional_FK1)
                     .Include(l2 => l2.OneToOne_Optional_FK2),
                 expectedIncludes: new List<IExpectedInclude>
@@ -2594,9 +2574,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Level3>(l3 => l3.OneToOne_Optional_FK3, "OneToOne_Optional_FK3", "OneToMany_Optional2")
             };
 
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .Select(l1 => l1.OneToOne_Optional_FK1)
                     .Include(l2 => l2.OneToMany_Optional2)
                     .ThenInclude(l3 => l3.OneToOne_Optional_FK3),
@@ -2608,12 +2588,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multiple_optional_navigation_with_Include(bool isAsync)
         {
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .Select(l1 => l1.OneToOne_Optional_FK1.OneToOne_Optional_PK2)
                     .Include(l3 => l3.OneToMany_Optional3),
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .Select(l1 => Maybe(l1.OneToOne_Optional_FK1, () => l1.OneToOne_Optional_FK1.OneToOne_Optional_PK2)),
                 expectedIncludes: new List<IExpectedInclude>
                 {
@@ -2626,13 +2606,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multiple_optional_navigation_with_string_based_Include(bool isAsync)
         {
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .Select(l1 => l1.OneToOne_Optional_FK1)
                     .Select(l2 => l2.OneToOne_Optional_PK2)
                     .Include("OneToMany_Optional3"),
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .Select(l1 => l1.OneToOne_Optional_FK1)
                     .Select(l2 => Maybe(l2, () => l2.OneToOne_Optional_PK2)),
                 expectedIncludes: new List<IExpectedInclude>
@@ -2646,13 +2626,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Optional_navigation_with_order_by_and_Include(bool isAsync)
         {
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .Select(l1 => l1.OneToOne_Optional_FK1)
                     .OrderBy(l2 => l2.Name)
                     .Include(l2 => l2.OneToMany_Optional2),
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .Select(l1 => l1.OneToOne_Optional_FK1)
                     .OrderBy(l2 => Maybe(l2, () => l2.Name)),
                 expectedIncludes: new List<IExpectedInclude>
@@ -2666,13 +2646,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Optional_navigation_with_Include_and_order(bool isAsync)
         {
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .Select(l1 => l1.OneToOne_Optional_FK1)
                     .Include(l2 => l2.OneToMany_Optional2)
                     .OrderBy(l2 => l2.Name),
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .Select(l1 => l1.OneToOne_Optional_FK1)
                     .OrderBy(l2 => Maybe(l2, () => l2.Name)),
                 expectedIncludes: new List<IExpectedInclude>
@@ -2686,13 +2666,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task SelectMany_with_order_by_and_Include(bool isAsync)
         {
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .SelectMany(l1 => l1.OneToMany_Optional1)
                     .OrderBy(l2 => l2.Name)
                     .Include(l2 => l2.OneToMany_Optional2),
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .SelectMany(l1 => l1.OneToMany_Optional1)
                     .OrderBy(l2 => Maybe(l2, () => l2.Name)),
                 expectedIncludes: new List<IExpectedInclude>
@@ -2706,13 +2686,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task SelectMany_with_Include_and_order_by(bool isAsync)
         {
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .SelectMany(l1 => l1.OneToMany_Optional1)
                     .Include(l2 => l2.OneToMany_Optional2)
                     .OrderBy(l2 => l2.Name),
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .SelectMany(l1 => l1.OneToMany_Optional1)
                     .OrderBy(l2 => Maybe(l2, () => l2.Name)),
                 expectedIncludes: new List<IExpectedInclude>
@@ -2741,12 +2721,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task SelectMany_with_navigation_and_Distinct(bool isAsync)
         {
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => from l1 in l1s.Include(l => l.OneToMany_Optional1)
-                       from l2 in l1.OneToMany_Optional1.Distinct()
-                       where l2 != null
-                       select l1,
+                ss => from l1 in ss.Set<Level1>().Include(l => l.OneToMany_Optional1)
+                      from l2 in l1.OneToMany_Optional1.Distinct()
+                      where l2 != null
+                      select l1,
                 expectedIncludes: new List<IExpectedInclude>
                 {
                     new ExpectedInclude<Level1>(l1 => l1.OneToMany_Optional1, "OneToMany_Optional1")
@@ -3422,132 +3402,108 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_with_complex_subquery_with_joins_does_not_get_flattened(bool isAsync)
         {
-            return AssertQueryScalar<Level1, Level2>(
+            return AssertQueryScalar(
                 isAsync,
-                (l1s, l2s) =>
-                    from l1_outer in l1s
-                    join subquery in
-                        (
-                            from l2_inner in l2s
-                            join l1_inner in l1s on l2_inner.Level1_Required_Id equals l1_inner.Id
-                            select l2_inner
-                        )
-                        on l1_outer.Id equals subquery.Level1_Optional_Id into grouping
-                    from subquery in grouping.DefaultIfEmpty()
-                    select (int?)subquery.Id,
-                (l1s, l2s) =>
-                    from l1_outer in l1s
-                    join subquery in
-                        (
-                            from l2_inner in l2s
-                            join l1_inner in l1s on l2_inner.Level1_Required_Id equals l1_inner.Id
-                            select l2_inner
-                        )
-                        on l1_outer.Id equals subquery.Level1_Optional_Id into grouping
-                    from subquery in grouping.DefaultIfEmpty()
-                    select MaybeScalar<int>(subquery, () => subquery.Id));
+                ss => from l1_outer in ss.Set<Level1>()
+                      join subquery in
+                          from l2_inner in ss.Set<Level2>()
+                          join l1_inner in ss.Set<Level1>() on l2_inner.Level1_Required_Id equals l1_inner.Id
+                          select l2_inner
+                      on l1_outer.Id equals subquery.Level1_Optional_Id into grouping
+                      from subquery in grouping.DefaultIfEmpty()
+                      select (int?)subquery.Id,
+                ss => from l1_outer in ss.Set<Level1>()
+                      join subquery in
+                          from l2_inner in ss.Set<Level2>()
+                          join l1_inner in ss.Set<Level1>() on l2_inner.Level1_Required_Id equals l1_inner.Id
+                          select l2_inner
+                      on l1_outer.Id equals subquery.Level1_Optional_Id into grouping
+                      from subquery in grouping.DefaultIfEmpty()
+                      select MaybeScalar<int>(subquery, () => subquery.Id));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_with_complex_subquery_with_joins_does_not_get_flattened2(bool isAsync)
         {
-            return AssertQueryScalar<Level1, Level2>(
+            return AssertQueryScalar(
                 isAsync,
-                (l1s, l2s) =>
-                    from l1_outer in l1s
-                    join subquery in
-                        (
-                            from l2_inner in l2s
-                            join l1_inner in l1s on l2_inner.Level1_Required_Id equals l1_inner.Id
-                            select l2_inner
-                        )
-                        on l1_outer.Id equals subquery.Level1_Optional_Id into grouping
-                    from subquery in grouping.DefaultIfEmpty()
-                    select subquery != null ? (int?)subquery.Id : null,
-                (l1s, l2s) =>
-                    from l1_outer in l1s
-                    join subquery in
-                        (
-                            from l2_inner in l2s
-                            join l1_inner in l1s on l2_inner.Level1_Required_Id equals l1_inner.Id
-                            select l2_inner
-                        )
-                        on l1_outer.Id equals subquery.Level1_Optional_Id into grouping
-                    from subquery in grouping.DefaultIfEmpty()
-                    select MaybeScalar<int>(subquery, () => subquery.Id));
+                ss => from l1_outer in ss.Set<Level1>()
+                      join subquery in
+                          from l2_inner in ss.Set<Level2>()
+                          join l1_inner in ss.Set<Level1>() on l2_inner.Level1_Required_Id equals l1_inner.Id
+                          select l2_inner
+                      on l1_outer.Id equals subquery.Level1_Optional_Id into grouping
+                      from subquery in grouping.DefaultIfEmpty()
+                      select subquery != null ? (int?)subquery.Id : null,
+                ss => from l1_outer in ss.Set<Level1>()
+                      join subquery in
+                          from l2_inner in ss.Set<Level2>()
+                          join l1_inner in ss.Set<Level1>() on l2_inner.Level1_Required_Id equals l1_inner.Id
+                          select l2_inner
+                      on l1_outer.Id equals subquery.Level1_Optional_Id into grouping
+                      from subquery in grouping.DefaultIfEmpty()
+                      select MaybeScalar<int>(subquery, () => subquery.Id));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_with_complex_subquery_with_joins_does_not_get_flattened3(bool isAsync)
         {
-            return AssertQueryScalar<Level1, Level2>(
+            return AssertQueryScalar(
                 isAsync,
-                (l1s, l2s) =>
-                    from l1_outer in l1s
-                    join subquery in
-                        (
-                            from l2_inner in l2s
-                            join l1_inner in l1s on l2_inner.Level1_Required_Id equals l1_inner.Id into grouping_inner
-                            from l1_inner in grouping_inner.DefaultIfEmpty()
-                            select l2_inner
-                        )
-                        on l1_outer.Id equals subquery.Level1_Required_Id into grouping
-                    from subquery in grouping.DefaultIfEmpty()
-                    select (int?)subquery.Id,
-                (l1s, l2s) =>
-                    from l1_outer in l1s
-                    join subquery in
-                        (
-                            from l2_inner in l2s
-                            join l1_inner in l1s on l2_inner.Level1_Required_Id equals l1_inner.Id into grouping_inner
-                            from l1_inner in grouping_inner.DefaultIfEmpty()
-                            select l2_inner
-                        )
-                        on l1_outer.Id equals MaybeScalar<int>(subquery, () => subquery.Level1_Required_Id) into grouping
-                    from subquery in grouping.DefaultIfEmpty()
-                    select MaybeScalar<int>(subquery, () => subquery.Id));
+                ss => from l1_outer in ss.Set<Level1>()
+                      join subquery in
+                          from l2_inner in ss.Set<Level2>()
+                          join l1_inner in ss.Set<Level1>() on l2_inner.Level1_Required_Id equals l1_inner.Id into grouping_inner
+                          from l1_inner in grouping_inner.DefaultIfEmpty()
+                          select l2_inner
+                      on l1_outer.Id equals subquery.Level1_Required_Id into grouping
+                      from subquery in grouping.DefaultIfEmpty()
+                      select (int?)subquery.Id,
+                ss => from l1_outer in ss.Set<Level1>()
+                      join subquery in
+                          from l2_inner in ss.Set<Level2>()
+                          join l1_inner in ss.Set<Level1>() on l2_inner.Level1_Required_Id equals l1_inner.Id into grouping_inner
+                          from l1_inner in grouping_inner.DefaultIfEmpty()
+                          select l2_inner
+                      on l1_outer.Id equals MaybeScalar<int>(subquery, () => subquery.Level1_Required_Id) into grouping
+                      from subquery in grouping.DefaultIfEmpty()
+                      select MaybeScalar<int>(subquery, () => subquery.Id));
         }
 
         [ConditionalTheory(Skip = "Issue #17068")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_with_complex_subquery_with_joins_with_reference_to_grouping1(bool isAsync)
         {
-            return AssertQueryScalar<Level1, Level2>(
+            return AssertQueryScalar(
                 isAsync,
-                (l1s, l2s) =>
-                    from l1_outer in l1s
-                    join subquery in
-                        (
-                            from l2_inner in l2s
-                            join l1_inner in l1s on l2_inner.Level1_Required_Id equals l1_inner.Id
-                            select l2_inner
-                        )
-                        on l1_outer.Id equals subquery.Level1_Optional_Id into grouping
-                    where grouping.Any()
-                    from subquery in grouping.DefaultIfEmpty()
-                    select subquery.Id);
+                ss => from l1_outer in ss.Set<Level1>()
+                      join subquery in
+                          from l2_inner in ss.Set<Level2>()
+                          join l1_inner in ss.Set<Level1>() on l2_inner.Level1_Required_Id equals l1_inner.Id
+                          select l2_inner
+                      on l1_outer.Id equals subquery.Level1_Optional_Id into grouping
+                      where grouping.Any()
+                      from subquery in grouping.DefaultIfEmpty()
+                      select subquery.Id);
         }
 
         [ConditionalTheory(Skip = "Issue #17068")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_with_complex_subquery_with_joins_with_reference_to_grouping2(bool isAsync)
         {
-            return AssertQueryScalar<Level1, Level2>(
+            return AssertQueryScalar(
                 isAsync,
-                (l1s, l2s) =>
-                    from l1_outer in l1s
-                    join subquery in
-                        (
-                            from l2_inner in l2s
-                            join l1_inner in l1s on l2_inner.Level1_Required_Id equals l1_inner.Id
-                            select l2_inner
-                        )
-                        on l1_outer.Id equals subquery.Level1_Optional_Id into grouping
-                    from subquery in grouping.DefaultIfEmpty()
-                    where grouping.Any()
-                    select subquery.Id);
+                ss => from l1_outer in ss.Set<Level1>()
+                      join subquery in
+                          from l2_inner in ss.Set<Level2>()
+                          join l1_inner in ss.Set<Level1>() on l2_inner.Level1_Required_Id equals l1_inner.Id
+                          select l2_inner
+                      on l1_outer.Id equals subquery.Level1_Optional_Id into grouping
+                      from subquery in grouping.DefaultIfEmpty()
+                      where grouping.Any()
+                      select subquery.Id);
         }
 
         [ConditionalTheory]
@@ -3796,14 +3752,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_reference_to_group_in_OrderBy(bool isAsync)
         {
-            return AssertQueryScalar<Level1, Level2>(
+            return AssertQueryScalar(
                 isAsync,
-                (l1s, l2s) =>
-                    from l1 in l1s
-                    join l2 in l2s on l1.Id equals l2.Level1_Optional_Id into groupJoin
-                    from l2 in groupJoin.DefaultIfEmpty()
-                    orderby groupJoin.Count()
-                    select l1.Id,
+                ss => from l1 in ss.Set<Level1>()
+                      join l2 in ss.Set<Level2>() on l1.Id equals l2.Level1_Optional_Id into groupJoin
+                      from l2 in groupJoin.DefaultIfEmpty()
+                      orderby groupJoin.Count()
+                      select l1.Id,
                 assertOrder: true);
         }
 
@@ -3826,14 +3781,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_client_method_in_OrderBy(bool isAsync)
         {
-            return AssertQueryScalar<Level1, Level2>(
+            return AssertQueryScalar(
                 isAsync,
-                (l1s, l2s) =>
-                    from l1 in l1s
-                    join l2 in l2s on l1.Id equals l2.Level1_Optional_Id into groupJoin
-                    from l2 in groupJoin.DefaultIfEmpty()
-                    orderby ClientMethodNullableInt(l1.Id), ClientMethodNullableInt(l2 != null ? l2.Id : (int?)null)
-                    select l1.Id,
+                ss => from l1 in ss.Set<Level1>()
+                      join l2 in ss.Set<Level2>() on l1.Id equals l2.Level1_Optional_Id into groupJoin
+                      from l2 in groupJoin.DefaultIfEmpty()
+                      orderby ClientMethodNullableInt(l1.Id), ClientMethodNullableInt(l2 != null ? l2.Id : (int?)null)
+                      select l1.Id,
                 assertOrder: true);
         }
 
@@ -3846,125 +3800,116 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_without_DefaultIfEmpty(bool isAsync)
         {
-            return AssertQueryScalar<Level1, Level2>(
+            return AssertQueryScalar(
                 isAsync,
-                (l1s, l2s) =>
-                    from l1 in l1s
-                    join l2 in l2s on l1.Id equals l2.Level1_Optional_Id into groupJoin
-                    from l2 in groupJoin.Select(gg => gg)
-                    select l1.Id);
+                ss => from l1 in ss.Set<Level1>()
+                      join l2 in ss.Set<Level2>() on l1.Id equals l2.Level1_Optional_Id into groupJoin
+                      from l2 in groupJoin.Select(gg => gg)
+                      select l1.Id);
         }
 
         [ConditionalTheory(Skip = "Issue #17068")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_with_subquery_on_inner(bool isAsync)
         {
-            return AssertQueryScalar<Level1, Level2>(
+            return AssertQueryScalar(
                 isAsync,
-                (l1s, l2s) =>
-                    from l1 in l1s
-                    join l2 in l2s on l1.Id equals l2.Level1_Optional_Id into groupJoin
-                    from l2 in groupJoin.Where(gg => gg.Id > 0).OrderBy(gg => gg.Id).Take(10).DefaultIfEmpty()
-                    select l1.Id);
+                ss => from l1 in ss.Set<Level1>()
+                      join l2 in ss.Set<Level2>() on l1.Id equals l2.Level1_Optional_Id into groupJoin
+                      from l2 in groupJoin.Where(gg => gg.Id > 0).OrderBy(gg => gg.Id).Take(10).DefaultIfEmpty()
+                      select l1.Id);
         }
 
         [ConditionalTheory(Skip = "Issue #17068")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_with_subquery_on_inner_and_no_DefaultIfEmpty(bool isAsync)
         {
-            return AssertQueryScalar<Level1, Level2>(
+            return AssertQueryScalar(
                 isAsync,
-                (l1s, l2s) =>
-                    from l1 in l1s
-                    join l2 in l2s on l1.Id equals l2.Level1_Optional_Id into groupJoin
-                    from l2 in groupJoin.Where(gg => gg.Id > 0).OrderBy(gg => gg.Id).Take(10)
-                    select l1.Id);
+                ss => from l1 in ss.Set<Level1>()
+                      join l2 in ss.Set<Level2>() on l1.Id equals l2.Level1_Optional_Id into groupJoin
+                      from l2 in groupJoin.Where(gg => gg.Id > 0).OrderBy(gg => gg.Id).Take(10)
+                      select l1.Id);
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Optional_navigation_in_subquery_with_unrelated_projection(bool isAsync)
         {
-            return AssertQueryScalar<Level1, Level2>(
+            return AssertQueryScalar(
                 isAsync,
-                (l1s, l2s) =>
-                    l1s.Where(l1 => l1.OneToOne_Optional_FK1.Name != "Foo")
-                        .OrderBy(l1 => l1.Id)
-                        .Take(15)
-                        .Select(l1 => l1.Id),
-                (l1s, l2s) =>
-                    l1s.Where(l1 => Maybe(l1.OneToOne_Optional_FK1, () => l1.OneToOne_Optional_FK1.Name) != "Foo")
-                        .OrderBy(l1 => l1.Id)
-                        .Take(15)
-                        .Select(l1 => l1.Id));
+                ss => ss.Set<Level1>().Where(l1 => l1.OneToOne_Optional_FK1.Name != "Foo")
+                    .OrderBy(l1 => l1.Id)
+                    .Take(15)
+                    .Select(l1 => l1.Id),
+                ss => ss.Set<Level1>().Where(l1 => Maybe(l1.OneToOne_Optional_FK1, () => l1.OneToOne_Optional_FK1.Name) != "Foo")
+                    .OrderBy(l1 => l1.Id)
+                    .Take(15)
+                    .Select(l1 => l1.Id));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Explicit_GroupJoin_in_subquery_with_unrelated_projection(bool isAsync)
         {
-            return AssertQueryScalar<Level1, Level2>(
+            return AssertQueryScalar(
                 isAsync,
-                (l1s, l2s) =>
-                    from l1 in (from l1 in l1s
-                                join l2 in l2s on l1.Id equals l2.Level1_Optional_Id into grouping
-                                from l2 in grouping.DefaultIfEmpty()
+                ss => from l1 in (from l1 in ss.Set<Level1>()
+                                  join l2 in ss.Set<Level2>() on l1.Id equals l2.Level1_Optional_Id into grouping
+                                  from l2 in grouping.DefaultIfEmpty()
 #pragma warning disable IDE0031 // Use null propagation
-                                where (l2 != null ? l2.Name : null) != "Foo"
+                                  where (l2 != null ? l2.Name : null) != "Foo"
 #pragma warning restore IDE0031 // Use null propagation
-                                select l1).OrderBy(l1 => l1.Id).Take(15)
-                    select l1.Id);
+                                  select l1).OrderBy(l1 => l1.Id).Take(15)
+                      select l1.Id);
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Explicit_GroupJoin_in_subquery_with_unrelated_projection2(bool isAsync)
         {
-            return AssertQueryScalar<Level1, Level2>(
+            return AssertQueryScalar(
                 isAsync,
-                (l1s, l2s) =>
-                    from l1 in (from l1 in l1s
-                                join l2 in l2s on l1.Id equals l2.Level1_Optional_Id into grouping
-                                from l2 in grouping.DefaultIfEmpty()
+                ss => from l1 in (from l1 in ss.Set<Level1>()
+                                  join l2 in ss.Set<Level2>() on l1.Id equals l2.Level1_Optional_Id into grouping
+                                  from l2 in grouping.DefaultIfEmpty()
 #pragma warning disable IDE0031 // Use null propagation
-                                where (l2 != null ? l2.Name : null) != "Foo"
+                                  where (l2 != null ? l2.Name : null) != "Foo"
 #pragma warning restore IDE0031 // Use null propagation
-                                select l1).Distinct()
-                    select l1.Id);
+                                  select l1).Distinct()
+                      select l1.Id);
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Explicit_GroupJoin_in_subquery_with_unrelated_projection3(bool isAsync)
         {
-            return AssertQueryScalar<Level1, Level2>(
+            return AssertQueryScalar(
                 isAsync,
-                (l1s, l2s) =>
-                    from l1 in (from l1 in l1s
-                                join l2 in l2s on l1.Id equals l2.Level1_Optional_Id into grouping
-                                from l2 in grouping.DefaultIfEmpty()
+                ss => from l1 in (from l1 in ss.Set<Level1>()
+                                  join l2 in ss.Set<Level2>() on l1.Id equals l2.Level1_Optional_Id into grouping
+                                  from l2 in grouping.DefaultIfEmpty()
 #pragma warning disable IDE0031 // Use null propagation
-                                where (l2 != null ? l2.Name : null) != "Foo"
+                                  where (l2 != null ? l2.Name : null) != "Foo"
 #pragma warning restore IDE0031 // Use null propagation
-                                select l1.Id).Distinct()
-                    select l1);
+                                  select l1.Id).Distinct()
+                      select l1);
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Explicit_GroupJoin_in_subquery_with_unrelated_projection4(bool isAsync)
         {
-            return AssertQueryScalar<Level1, Level2>(
+            return AssertQueryScalar(
                 isAsync,
-                (l1s, l2s) =>
-                    from l1 in (from l1 in l1s
-                                join l2 in l2s on l1.Id equals l2.Level1_Optional_Id into grouping
-                                from l2 in grouping.DefaultIfEmpty()
+                ss => from l1 in (from l1 in ss.Set<Level1>()
+                                  join l2 in ss.Set<Level2>() on l1.Id equals l2.Level1_Optional_Id into grouping
+                                  from l2 in grouping.DefaultIfEmpty()
 #pragma warning disable IDE0031 // Use null propagation
-                                where (l2 != null ? l2.Name : null) != "Foo"
+                                  where (l2 != null ? l2.Name : null) != "Foo"
 #pragma warning restore IDE0031 // Use null propagation
-                                select l1.Id).Distinct().OrderBy(id => id).Take(20)
-                    select l1);
+                                  select l1.Id).Distinct().OrderBy(id => id).Take(20)
+                      select l1);
         }
 
         [ConditionalTheory]
@@ -4124,47 +4069,45 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Navigation_with_same_navigation_compared_to_null(bool isAsync)
         {
-            return AssertQueryScalar<Level2>(
+            return AssertQueryScalar(
                 isAsync,
-                l2s => from l2 in l2s
-                       where l2.OneToMany_Required_Inverse2.Name != "L1 07" && l2.OneToMany_Required_Inverse2 != null
-                       select l2.Id);
+                ss => from l2 in ss.Set<Level2>()
+                      where l2.OneToMany_Required_Inverse2.Name != "L1 07" && l2.OneToMany_Required_Inverse2 != null
+                      select l2.Id);
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multi_level_navigation_compared_to_null(bool isAsync)
         {
-            return AssertQueryScalar<Level3>(
+            return AssertQueryScalar(
                 isAsync,
-                l3s => from l3 in l3s
-                       where l3.OneToMany_Optional_Inverse3.OneToOne_Required_FK_Inverse2 != null
-                       select l3.Id,
-                l3s => from l3 in l3s
-                       where Maybe(l3.OneToMany_Optional_Inverse3, () => l3.OneToMany_Optional_Inverse3.OneToOne_Required_FK_Inverse2)
-                             != null
-                       select l3.Id);
+                ss => from l3 in ss.Set<Level3>()
+                      where l3.OneToMany_Optional_Inverse3.OneToOne_Required_FK_Inverse2 != null
+                      select l3.Id,
+                ss => from l3 in ss.Set<Level3>()
+                      where Maybe(l3.OneToMany_Optional_Inverse3, () => l3.OneToMany_Optional_Inverse3.OneToOne_Required_FK_Inverse2) != null
+                      select l3.Id);
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multi_level_navigation_with_same_navigation_compared_to_null(bool isAsync)
         {
-            return AssertQueryScalar<Level3>(
+            return AssertQueryScalar(
                 isAsync,
-                l3s => from l3 in l3s
-                       where l3.OneToMany_Optional_Inverse3.OneToOne_Required_FK_Inverse2.Name != "L1 07"
-                       where l3.OneToMany_Optional_Inverse3.OneToOne_Required_FK_Inverse2 != null
-                       select l3.Id,
-                l3s => from l3 in l3s
-                       where Maybe(
-                                 l3.OneToMany_Optional_Inverse3,
-                                 () => Maybe(
-                                     l3.OneToMany_Optional_Inverse3.OneToOne_Required_FK_Inverse2,
-                                     () => l3.OneToMany_Optional_Inverse3.OneToOne_Required_FK_Inverse2.Name)) != "L1 07"
-                       where Maybe(l3.OneToMany_Optional_Inverse3, () => l3.OneToMany_Optional_Inverse3.OneToOne_Required_FK_Inverse2)
-                             != null
-                       select l3.Id);
+                ss => from l3 in ss.Set<Level3>()
+                      where l3.OneToMany_Optional_Inverse3.OneToOne_Required_FK_Inverse2.Name != "L1 07"
+                      where l3.OneToMany_Optional_Inverse3.OneToOne_Required_FK_Inverse2 != null
+                      select l3.Id,
+                ss => from l3 in ss.Set<Level3>()
+                      where Maybe(
+                          l3.OneToMany_Optional_Inverse3,
+                          () => Maybe(
+                              l3.OneToMany_Optional_Inverse3.OneToOne_Required_FK_Inverse2,
+                              () => l3.OneToMany_Optional_Inverse3.OneToOne_Required_FK_Inverse2.Name)) != "L1 07"
+                      where Maybe(l3.OneToMany_Optional_Inverse3, () => l3.OneToMany_Optional_Inverse3.OneToOne_Required_FK_Inverse2) != null
+                      select l3.Id);
         }
 
         [ConditionalTheory]
@@ -4244,9 +4187,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Level4_Include(bool isAsync)
         {
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s.Select(l1 => l1.OneToOne_Required_PK1)
+                ss => ss.Set<Level1>().Select(l1 => l1.OneToOne_Required_PK1)
                     .Where(t => t != null)
                     .Select(l2 => l2.OneToOne_Required_PK2)
                     .Where(t => t != null)
@@ -4265,10 +4208,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Comparing_collection_navigation_on_optional_reference_to_null(bool isAsync)
         {
-            return AssertQueryScalar<Level1>(
+            return AssertQueryScalar(
                 isAsync,
-                l1s => l1s.Where(l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2 == null).Select(l1 => l1.Id),
-                l1s => l1s.Where(l1 => Maybe(l1.OneToOne_Optional_FK1, () => l1.OneToOne_Optional_FK1.OneToMany_Optional2) == null)
+                ss => ss.Set<Level1>().Where(l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2 == null).Select(l1 => l1.Id),
+                ss => ss.Set<Level1>().Where(l1 => Maybe(l1.OneToOne_Optional_FK1, () => l1.OneToOne_Optional_FK1.OneToMany_Optional2) == null)
                     .Select(l1 => l1.Id));
         }
 
@@ -4285,9 +4228,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_subquery_with_client_eval_and_navigation2(bool isAsync)
         {
-            return AssertQueryScalar<Level2>(
+            return AssertQueryScalar(
                 isAsync,
-                l2s => l2s.Select(l2 => l2s.OrderBy(l => l.Id).First().OneToOne_Required_FK_Inverse2.Name == "L1 02"));
+                ss => ss.Set<Level2>().Select(l2 => ss.Set<Level2>().OrderBy(l => l.Id).First().OneToOne_Required_FK_Inverse2.Name == "L1 02"));
         }
 
         [ConditionalTheory]
@@ -4531,9 +4474,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_with_multiple_orderbys_member(bool isAsync)
         {
-            return AssertIncludeQuery<Level2>(
+            return AssertIncludeQuery(
                 isAsync,
-                l2s => l2s
+                ss => ss.Set<Level2>()
                     .Include(l2 => l2.OneToMany_Optional2)
                     .OrderBy(l2 => l2.Name)
                     .ThenBy(l2 => l2.Level1_Required_Id),
@@ -4545,13 +4488,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_with_multiple_orderbys_property(bool isAsync)
         {
-            return AssertIncludeQuery<Level2>(
+            return AssertIncludeQuery(
                 isAsync,
-                l2s => l2s
+                ss => ss.Set<Level2>()
                     .Include(l2 => l2.OneToMany_Optional2)
                     .OrderBy(l2 => EF.Property<int>(l2, "Level1_Required_Id"))
                     .ThenBy(l2 => l2.Name),
-                l2s => l2s
+                ss => ss.Set<Level2>()
                     .OrderBy(l2 => l2.Level1_Required_Id)
                     .ThenBy(l2 => l2.Name),
                 new List<IExpectedInclude> { new ExpectedInclude<Level2>(e => e.OneToMany_Optional2, "OneToMany_Optional2") },
@@ -4562,9 +4505,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_with_multiple_orderbys_methodcall(bool isAsync)
         {
-            return AssertIncludeQuery<Level2>(
+            return AssertIncludeQuery(
                 isAsync,
-                l2s => l2s
+                ss => ss.Set<Level2>()
                     .Include(l2 => l2.OneToMany_Optional2)
                     .OrderBy(l2 => Math.Abs(l2.Level1_Required_Id))
                     .ThenBy(l2 => l2.Name),
@@ -4576,9 +4519,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_with_multiple_orderbys_complex(bool isAsync)
         {
-            return AssertIncludeQuery<Level2>(
+            return AssertIncludeQuery(
                 isAsync,
-                l2s => l2s
+                ss => ss.Set<Level2>()
                     .Include(l2 => l2.OneToMany_Optional2)
                     .OrderBy(l2 => Math.Abs(l2.Level1_Required_Id) + 7)
                     .ThenBy(l2 => l2.Name),
@@ -4590,9 +4533,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_with_multiple_orderbys_complex_repeated(bool isAsync)
         {
-            return AssertIncludeQuery<Level2>(
+            return AssertIncludeQuery(
                 isAsync,
-                l2s => l2s
+                ss => ss.Set<Level2>()
                     .Include(l2 => l2.OneToMany_Optional2)
                     .OrderBy(l2 => -l2.Level1_Required_Id)
                     .ThenBy(l2 => -l2.Level1_Required_Id).ThenBy(l2 => l2.Name),
@@ -4622,9 +4565,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_reference_with_groupby_in_subquery(bool isAsync)
         {
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToOne_Optional_FK1)
                     .GroupBy(g => g.Name)
                     .Select(g => g.OrderBy(e => e.Id).FirstOrDefault()),
@@ -4638,9 +4581,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_with_groupby_in_subquery(bool isAsync)
         {
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToMany_Optional1)
                     .GroupBy(g => g.Name)
                     .Select(g => g.OrderBy(e => e.Id).FirstOrDefault()),
@@ -4660,9 +4603,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Level2>(e => e.OneToMany_Optional2, "OneToMany_Optional2", "OneToOne_Optional_FK1")
             };
 
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2)
                     .GroupBy(g => g.Name)
                     .Select(g => g.OrderBy(e => e.Id).FirstOrDefault()),
@@ -4673,9 +4616,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_with_groupby_in_subquery_and_filter_before_groupby(bool isAsync)
         {
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToMany_Optional1)
                     .Where(l1 => l1.Id > 3)
                     .GroupBy(g => g.Name)
@@ -4690,9 +4633,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_with_groupby_in_subquery_and_filter_after_groupby(bool isAsync)
         {
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToMany_Optional1)
                     .GroupBy(g => g.Name)
                     .Where(g => g.Key != "Foo")
@@ -4713,9 +4656,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<InheritanceDerived2>(e => e.ReferenceSameType, "ReferenceSameType")
             };
 
-            return AssertIncludeQuery<InheritanceBase1>(
+            return AssertIncludeQuery(
                 isAsync,
-                i1s => i1s.Include("ReferenceSameType"),
+                ss => ss.Set<InheritanceBase1>().Include("ReferenceSameType"),
                 expectedIncludes);
         }
 
@@ -4729,9 +4672,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<InheritanceDerived2>(e => e.ReferenceDifferentType, "ReferenceDifferentType")
             };
 
-            return AssertIncludeQuery<InheritanceBase1>(
+            return AssertIncludeQuery(
                 isAsync,
-                i1s => i1s.Include("ReferenceDifferentType"),
+                ss => ss.Set<InheritanceBase1>().Include("ReferenceDifferentType"),
                 expectedIncludes);
         }
 
@@ -4748,9 +4691,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<InheritanceLeaf2>(e => e.BaseCollection, "BaseCollection", "ReferenceDifferentType")
             };
 
-            return AssertIncludeQuery<InheritanceBase1>(
+            return AssertIncludeQuery(
                 isAsync,
-                i1s => i1s.Include("ReferenceDifferentType.BaseCollection"),
+                ss => ss.Set<InheritanceBase1>().Include("ReferenceDifferentType.BaseCollection"),
                 expectedIncludes);
         }
 
@@ -4764,9 +4707,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<InheritanceDerived2>(e => e.CollectionSameType, "CollectionSameType")
             };
 
-            return AssertIncludeQuery<InheritanceBase1>(
+            return AssertIncludeQuery(
                 isAsync,
-                i1s => i1s.Include("CollectionSameType"),
+                ss => ss.Set<InheritanceBase1>().Include("CollectionSameType"),
                 expectedIncludes);
         }
 
@@ -4780,9 +4723,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<InheritanceDerived2>(e => e.CollectionDifferentType, "CollectionDifferentType")
             };
 
-            return AssertIncludeQuery<InheritanceBase1>(
+            return AssertIncludeQuery(
                 isAsync,
-                i1s => i1s.Include("CollectionDifferentType"),
+                ss => ss.Set<InheritanceBase1>().Include("CollectionDifferentType"),
                 expectedIncludes);
         }
 
@@ -4799,9 +4742,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<InheritanceLeaf2>(e => e.BaseCollection, "BaseCollection", "CollectionDifferentType")
             };
 
-            return AssertIncludeQuery<InheritanceBase1>(
+            return AssertIncludeQuery(
                 isAsync,
-                i1s => i1s.Include("CollectionDifferentType.BaseCollection"),
+                ss => ss.Set<InheritanceBase1>().Include("CollectionDifferentType.BaseCollection"),
                 expectedIncludes);
         }
 
@@ -4819,9 +4762,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<InheritanceDerived2>(e => e.ReferenceSameType, "ReferenceSameType", "Collection")
             };
 
-            return AssertIncludeQuery<InheritanceBase2>(
+            return AssertIncludeQuery(
                 isAsync,
-                i2s => i2s.Include("Reference.CollectionDifferentType").Include("Collection.ReferenceSameType"),
+                ss => ss.Set<InheritanceBase2>().Include("Reference.CollectionDifferentType").Include("Collection.ReferenceSameType"),
                 expectedIncludes);
         }
 
@@ -4829,12 +4772,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_reference_collection_order_by_reference_navigation(bool isAsync)
         {
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2)
                     .OrderBy(l1 => (int?)l1.OneToOne_Optional_FK1.Id),
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2)
                     .OrderBy(l1 => MaybeScalar<int>(l1.OneToOne_Optional_FK1, () => l1.OneToOne_Optional_FK1.Id)),
                 expectedIncludes: new List<IExpectedInclude>
@@ -4849,9 +4792,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Nav_rewrite_doesnt_apply_null_protection_for_function_arguments(bool isAsync)
         {
-            return AssertQueryScalar<Level1>(
+            return AssertQueryScalar(
                 isAsync,
-                l1s => l1s.Where(l1 => l1.OneToOne_Optional_PK1 != null)
+                ss => ss.Set<Level1>().Where(l1 => l1.OneToOne_Optional_PK1 != null)
                     .Select(l1 => Math.Max(l1.OneToOne_Optional_PK1.Level1_Required_Id, 7)));
         }
 
@@ -4871,9 +4814,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_after_SelectMany_and_reference_navigation(bool isAsync)
         {
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s.SelectMany(l1 => l1.OneToMany_Required1).Select(l2 => l2.OneToOne_Optional_FK2)
+                ss => ss.Set<Level1>().SelectMany(l1 => l1.OneToMany_Required1).Select(l2 => l2.OneToOne_Optional_FK2)
                     .Include(l3 => l3.OneToMany_Optional3),
                 new List<IExpectedInclude> { new ExpectedInclude<Level3>(l3 => l3.OneToMany_Optional3, "OneToMany_Optional3") });
         }
@@ -4882,9 +4825,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_after_multiple_SelectMany_and_reference_navigation(bool isAsync)
         {
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s.SelectMany(l1 => l1.OneToMany_Required1).SelectMany(l2 => l2.OneToMany_Optional2)
+                ss => ss.Set<Level1>().SelectMany(l1 => l1.OneToMany_Required1).SelectMany(l2 => l2.OneToMany_Optional2)
                     .Select(l3 => l3.OneToOne_Required_FK3).Include(l4 => l4.OneToMany_Required_Self4),
                 new List<IExpectedInclude> { new ExpectedInclude<Level4>(l4 => l4.OneToMany_Required_Self4, "OneToMany_Required_Self4") });
         }
@@ -4893,11 +4836,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_after_SelectMany_and_multiple_reference_navigations(bool isAsync)
         {
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s.SelectMany(l1 => l1.OneToMany_Required1).Select(l2 => l2.OneToOne_Optional_FK2)
+                ss => ss.Set<Level1>().SelectMany(l1 => l1.OneToMany_Required1).Select(l2 => l2.OneToOne_Optional_FK2)
                     .Select(l3 => l3.OneToOne_Required_FK3).Include(l4 => l4.OneToMany_Optional_Self4),
-                l1s => l1s.SelectMany(l1 => l1.OneToMany_Required1).Select(l2 => l2.OneToOne_Optional_FK2)
+                ss => ss.Set<Level1>().SelectMany(l1 => l1.OneToMany_Required1).Select(l2 => l2.OneToOne_Optional_FK2)
                     .Select(l3 => Maybe(l3, () => l3.OneToOne_Required_FK3)),
                 new List<IExpectedInclude> { new ExpectedInclude<Level4>(l4 => l4.OneToMany_Optional_Self4, "OneToMany_Optional_Self4") });
         }
@@ -4906,18 +4849,18 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_after_SelectMany_and_reference_navigation_with_another_SelectMany_with_Distinct(bool isAsync)
         {
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => from lOuter in l1s.SelectMany(l1 => l1.OneToMany_Required1).Select(l2 => l2.OneToOne_Optional_FK2)
+                ss => from lOuter in ss.Set<Level1>().SelectMany(l1 => l1.OneToMany_Required1).Select(l2 => l2.OneToOne_Optional_FK2)
                            .Include(l3 => l3.OneToMany_Optional3)
-                       from lInner in lOuter.OneToMany_Optional3.Distinct()
-                       where lInner != null
-                       select lOuter,
-                l1s => from lOuter in l1s.SelectMany(l1 => l1.OneToMany_Required1).Select(l2 => l2.OneToOne_Optional_FK2)
-                       where lOuter != null
-                       from lInner in lOuter.OneToMany_Optional3.Distinct()
-                       where lInner != null
-                       select lOuter,
+                      from lInner in lOuter.OneToMany_Optional3.Distinct()
+                      where lInner != null
+                      select lOuter,
+                ss => from lOuter in ss.Set<Level1>().SelectMany(l1 => l1.OneToMany_Required1).Select(l2 => l2.OneToOne_Optional_FK2)
+                      where lOuter != null
+                      from lInner in lOuter.OneToMany_Optional3.Distinct()
+                      where lInner != null
+                      select lOuter,
                 new List<IExpectedInclude> { new ExpectedInclude<Level3>(l3 => l3.OneToMany_Optional3, "OneToMany_Optional") });
         }
 
@@ -5035,9 +4978,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include1(bool isAsync)
         {
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s.Include(l1 => l1.OneToOne_Optional_FK1),
+                ss => ss.Set<Level1>().Include(l1 => l1.OneToOne_Optional_FK1),
                 new List<IExpectedInclude> { new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1, "OneToOne_Optional_FK1") });
         }
 
@@ -5051,9 +4994,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1, "OneToOne_Optional_FK1")
             };
 
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s.Include(l1 => l1.OneToOne_Optional_FK1).Include(l1 => l1.OneToOne_Optional_FK1),
+                ss => ss.Set<Level1>().Include(l1 => l1.OneToOne_Optional_FK1).Include(l1 => l1.OneToOne_Optional_FK1),
                 expectedIncludes);
         }
 
@@ -5067,9 +5010,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_PK1, "OneToOne_Optional_PK1")
             };
 
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s.Include(l1 => l1.OneToOne_Optional_FK1).Include(l1 => l1.OneToOne_Optional_PK1),
+                ss => ss.Set<Level1>().Include(l1 => l1.OneToOne_Optional_FK1).Include(l1 => l1.OneToOne_Optional_PK1),
                 expectedIncludes);
         }
 
@@ -5083,9 +5026,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_PK2, "OneToOne_Optional_PK2", "OneToOne_Optional_FK1")
             };
 
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s.Include(l1 => l1.OneToOne_Optional_FK1).ThenInclude(l1 => l1.OneToOne_Optional_PK2),
+                ss => ss.Set<Level1>().Include(l1 => l1.OneToOne_Optional_FK1).ThenInclude(l1 => l1.OneToOne_Optional_PK2),
                 expectedIncludes);
         }
 
@@ -5099,9 +5042,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_PK2, "OneToOne_Optional_PK2", "OneToOne_Optional_FK1")
             };
 
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s.Include(l1 => l1.OneToOne_Optional_FK1.OneToOne_Optional_PK2),
+                ss => ss.Set<Level1>().Include(l1 => l1.OneToOne_Optional_FK1.OneToOne_Optional_PK2),
                 expectedIncludes);
         }
 
@@ -5114,9 +5057,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_PK2, "OneToOne_Optional_PK2")
             };
 
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s.Include(l1 => l1.OneToOne_Optional_FK1.OneToOne_Optional_PK2).Select(l1 => l1.OneToOne_Optional_FK1),
+                ss => ss.Set<Level1>().Include(l1 => l1.OneToOne_Optional_FK1.OneToOne_Optional_PK2).Select(l1 => l1.OneToOne_Optional_FK1),
                 expectedIncludes);
         }
 
@@ -5124,9 +5067,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include7(bool isAsync)
         {
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s.Include(l1 => l1.OneToOne_Optional_FK1.OneToOne_Optional_PK2).Select(l1 => l1.OneToOne_Optional_PK1),
+                ss => ss.Set<Level1>().Include(l1 => l1.OneToOne_Optional_FK1.OneToOne_Optional_PK2).Select(l1 => l1.OneToOne_Optional_PK1),
                 new List<IExpectedInclude>());
         }
 
@@ -5139,10 +5082,10 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK_Inverse2, "OneToOne_Optional_FK_Inverse2")
             };
 
-            return AssertIncludeQuery<Level2>(
+            return AssertIncludeQuery(
                 isAsync,
-                l2s => l2s.Where(l2 => l2.OneToOne_Optional_FK_Inverse2.Name != "Fubar").Include(l2 => l2.OneToOne_Optional_FK_Inverse2),
-                l2s => l2s.Where(l2 => Maybe(l2.OneToOne_Optional_FK_Inverse2, () => l2.OneToOne_Optional_FK_Inverse2.Name) != "Fubar")
+                ss => ss.Set<Level2>().Where(l2 => l2.OneToOne_Optional_FK_Inverse2.Name != "Fubar").Include(l2 => l2.OneToOne_Optional_FK_Inverse2),
+                ss => ss.Set<Level2>().Where(l2 => Maybe(l2.OneToOne_Optional_FK_Inverse2, () => l2.OneToOne_Optional_FK_Inverse2.Name) != "Fubar")
                     .Include(l2 => l2.OneToOne_Optional_FK_Inverse2),
                 expectedIncludes);
         }
@@ -5156,10 +5099,10 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK_Inverse2, "OneToOne_Optional_FK_Inverse2")
             };
 
-            return AssertIncludeQuery<Level2>(
+            return AssertIncludeQuery(
                 isAsync,
-                l2s => l2s.Include(l2 => l2.OneToOne_Optional_FK_Inverse2).Where(l2 => l2.OneToOne_Optional_FK_Inverse2.Name != "Fubar"),
-                l2s => l2s.Include(l2 => l2.OneToOne_Optional_FK_Inverse2).Where(
+                ss => ss.Set<Level2>().Include(l2 => l2.OneToOne_Optional_FK_Inverse2).Where(l2 => l2.OneToOne_Optional_FK_Inverse2.Name != "Fubar"),
+                ss => ss.Set<Level2>().Include(l2 => l2.OneToOne_Optional_FK_Inverse2).Where(
                     l2 => Maybe(l2.OneToOne_Optional_FK_Inverse2, () => l2.OneToOne_Optional_FK_Inverse2.Name) != "Fubar"),
                 expectedIncludes);
         }
@@ -5178,9 +5121,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                     l3 => l3.OneToOne_Optional_PK3, "OneToOne_Optional_PK3", "OneToOne_Optional_FK1.OneToOne_Optional_FK2")
             };
 
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToOne_Optional_FK1.OneToOne_Optional_PK2)
                     .Include(l1 => l1.OneToOne_Optional_PK1.OneToOne_Optional_FK2.OneToOne_Optional_PK3),
                 expectedIncludes);
@@ -5206,9 +5149,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_PK2, "OneToOne_Optional_PK2", "OneToOne_Optional_PK1")
             };
 
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToOne_Optional_FK1.OneToOne_Optional_FK2)
                     .Include(l1 => l1.OneToOne_Optional_FK1.OneToOne_Optional_PK2)
                     .Include(l1 => l1.OneToOne_Optional_PK1.OneToOne_Optional_FK2.OneToOne_Optional_FK3)
@@ -5226,9 +5169,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2, "OneToOne_Optional_FK2")
             };
 
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToOne_Optional_FK1.OneToOne_Optional_FK2)
                     .Select(l1 => l1.OneToOne_Optional_FK1),
                 expectedIncludes);
@@ -5243,9 +5186,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1, "OneToOne_Optional_FK1")
             };
 
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToOne_Optional_FK1)
                     .Select(l1 => new { one = l1, two = l1 }),
                 expectedIncludes,
@@ -5263,9 +5206,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2, "OneToOne_Optional_FK2", "OneToOne_Optional_FK1")
             };
 
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s
+                ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToOne_Optional_FK1).ThenInclude(l2 => l2.OneToOne_Optional_FK2)
                     .Select(l1 => new { one = l1, two = l1.OneToOne_Optional_FK1, three = l1.OneToOne_Optional_PK1 }),
                 expectedIncludes,
@@ -5323,9 +5266,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1, "OneToOne_Optional_FK1")
             };
 
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s.Include(x => x.OneToOne_Optional_FK1).Distinct(),
+                ss => ss.Set<Level1>().Include(x => x.OneToOne_Optional_FK1).Distinct(),
                 expectedIncludes);
         }
 
@@ -5338,10 +5281,10 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1, "OneToOne_Optional_FK1")
             };
 
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s.OrderBy(x => x.OneToOne_Required_FK1.Name).Include(x => x.OneToOne_Optional_FK1).Take(10),
-                l1s => l1s.OrderBy(x => Maybe(x.OneToOne_Required_FK1, () => x.OneToOne_Required_FK1.Name))
+                ss => ss.Set<Level1>().OrderBy(x => x.OneToOne_Required_FK1.Name).Include(x => x.OneToOne_Optional_FK1).Take(10),
+                ss => ss.Set<Level1>().OrderBy(x => Maybe(x.OneToOne_Required_FK1, () => x.OneToOne_Required_FK1.Name))
                     .Include(x => x.OneToOne_Optional_FK1).Take(10),
                 expectedIncludes);
         }
@@ -5355,10 +5298,10 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1, "OneToOne_Optional_FK1")
             };
 
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s.Where(x => x.OneToOne_Required_FK1.Name != "Foo").Include(x => x.OneToOne_Optional_FK1).Distinct(),
-                l1s => l1s.Where(x => Maybe(x.OneToOne_Required_FK1, () => x.OneToOne_Required_FK1.Name) != "Foo").Distinct(),
+                ss => ss.Set<Level1>().Where(x => x.OneToOne_Required_FK1.Name != "Foo").Include(x => x.OneToOne_Optional_FK1).Distinct(),
+                ss => ss.Set<Level1>().Where(x => Maybe(x.OneToOne_Required_FK1, () => x.OneToOne_Required_FK1.Name) != "Foo").Distinct(),
                 expectedIncludes);
         }
 
@@ -5407,9 +5350,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Level2>(l1 => l1.OneToOne_Optional_FK2, "OneToOne_Optional_FK2")
             };
 
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s.Include(x => x.OneToOne_Optional_FK1.OneToOne_Optional_FK2).Select(l1 => l1.OneToOne_Optional_FK1).Distinct(),
+                ss => ss.Set<Level1>().Include(x => x.OneToOne_Optional_FK1.OneToOne_Optional_FK2).Select(l1 => l1.OneToOne_Optional_FK1).Distinct(),
                 expectedIncludes);
         }
 
@@ -5695,9 +5638,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_multiple_collections_on_same_level(bool isAsync)
         {
-            return AssertIncludeQuery<Level1>(
+            return AssertIncludeQuery(
                 isAsync,
-                l1s => l1s.Include(l1 => l1.OneToMany_Optional1).Include(l1 => l1.OneToMany_Required1),
+                ss => ss.Set<Level1>().Include(l1 => l1.OneToMany_Optional1).Include(l1 => l1.OneToMany_Required1),
                 new List<IExpectedInclude>
                 {
                     new ExpectedInclude<Level1>(l1 => l1.OneToMany_Optional1, "OneToMany_Optional1"),

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -56,9 +56,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Officer>(o => o.Weapons, "Weapons", "Gear")
             };
 
-            return AssertIncludeQuery<CogTag>(
+            return AssertIncludeQuery(
                 isAsync,
-                ts => ts.Include(t => t.Gear.Weapons),
+                ss => ss.Set<CogTag>().Include(t => t.Gear.Weapons),
                 expectedIncludes);
         }
 
@@ -104,9 +104,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Officer>(o => o.Squad, "Squad", "Gear")
             };
 
-            return AssertIncludeQuery<CogTag>(
+            return AssertIncludeQuery(
                 isAsync,
-                ts => ts.Include(t => t.Gear.Squad),
+                ss => ss.Set<CogTag>().Include(t => t.Gear.Squad),
                 expectedIncludes);
         }
 
@@ -131,9 +131,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<City>(c => c.StationedGears, "StationedGears", "CityOfBirth")
             };
 
-            return AssertIncludeQuery<Gear>(
+            return AssertIncludeQuery(
                 isAsync,
-                gs => gs.Include(g => g.CityOfBirth.StationedGears),
+                ss => ss.Set<Gear>().Include(g => g.CityOfBirth.StationedGears),
                 expectedIncludes);
         }
 
@@ -148,9 +148,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<City>(c => c.StationedGears, "StationedGears", "CityOfBirth")
             };
 
-            return AssertIncludeQuery<Gear>(
+            return AssertIncludeQuery(
                 isAsync,
-                gs => gs.Include(g => g.CityOfBirth.StationedGears).Where(g => g.Nickname == "Marcus"),
+                ss => ss.Set<Gear>().Include(g => g.CityOfBirth.StationedGears).Where(g => g.Nickname == "Marcus"),
                 expectedIncludes);
         }
 
@@ -164,9 +164,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Officer>(o => o.Weapons, "Weapons")
             };
 
-            return AssertIncludeQuery<Gear>(
+            return AssertIncludeQuery(
                 isAsync,
-                gs => gs.Include(g => g.Weapons).Where(g => g.Nickname == "Marcus"),
+                ss => ss.Set<Gear>().Include(g => g.Weapons).Where(g => g.Nickname == "Marcus"),
                 expectedIncludes);
         }
 
@@ -193,9 +193,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Officer>(o => o.Reports, "Reports")
             };
 
-            return AssertIncludeQuery<Gear>(
+            return AssertIncludeQuery(
                 isAsync,
-                gs => gs.OfType<Officer>().Include(o => o.Reports),
+                ss => ss.Set<Gear>().OfType<Officer>().Include(o => o.Reports),
                 expectedIncludes);
         }
 
@@ -208,9 +208,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Officer>(o => o.Reports, "Reports")
             };
 
-            return AssertIncludeQuery<Gear>(
+            return AssertIncludeQuery(
                 isAsync,
-                gs => gs.OfType<Officer>().Include("Reports"),
+                ss => ss.Set<Gear>().OfType<Officer>().Include("Reports"),
                 expectedIncludes);
         }
 
@@ -223,12 +223,12 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<CogTag>(t => t.Gear, "Gear")
             };
 
-            return AssertIncludeQuery<CogTag>(
+            return AssertIncludeQuery(
                 isAsync,
-                ts => from t in ts.Include(o => o.Gear)
+                ss => from t in ss.Set<CogTag>().Include(o => o.Gear)
                       where t.Gear.Nickname == "Marcus"
                       select t,
-                ts => from t in ts
+                ss => from t in ss.Set<CogTag>()
                       where Maybe(t.Gear, () => t.Gear.Nickname) == "Marcus"
                       select t,
                 expectedIncludes);
@@ -244,22 +244,21 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Officer>(o => o.CityOfBirth, "CityOfBirth")
             };
 
-            return AssertIncludeQuery<Gear, CogTag>(
+            return AssertIncludeQuery(
                 isAsync,
-                (gs, ts) =>
-                    gs.Join(
-                        ts,
-                        g => new
-                        {
-                            SquadId = (int?)g.SquadId,
-                            g.Nickname
-                        },
-                        t => new
-                        {
-                            SquadId = t.GearSquadId,
-                            Nickname = t.GearNickName
-                        },
-                        (g, t) => g).Include(g => g.CityOfBirth),
+                ss => ss.Set<Gear>().Join(
+                    ss.Set<CogTag>(),
+                    g => new
+                    {
+                        SquadId = (int?)g.SquadId,
+                        g.Nickname
+                    },
+                    t => new
+                    {
+                        SquadId = t.GearSquadId,
+                        Nickname = t.GearNickName
+                    },
+                    (g, t) => g).Include(g => g.CityOfBirth),
                 expectedIncludes);
         }
 
@@ -273,22 +272,21 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Officer>(o => o.CityOfBirth, "CityOfBirth")
             };
 
-            return AssertIncludeQuery<CogTag, Gear>(
+            return AssertIncludeQuery(
                 isAsync,
-                (ts, gs) =>
-                    ts.Join(
-                        gs,
-                        t => new
-                        {
-                            SquadId = t.GearSquadId,
-                            Nickname = t.GearNickName
-                        },
-                        g => new
-                        {
-                            SquadId = (int?)g.SquadId,
-                            g.Nickname
-                        },
-                        (t, g) => g).Include(g => g.CityOfBirth),
+                ss => ss.Set<CogTag>().Join(
+                    ss.Set<Gear>(),
+                    t => new
+                    {
+                        SquadId = t.GearSquadId,
+                        Nickname = t.GearNickName
+                    },
+                    g => new
+                    {
+                        SquadId = (int?)g.SquadId,
+                        g.Nickname
+                    },
+                    (t, g) => g).Include(g => g.CityOfBirth),
                 expectedIncludes);
         }
 
@@ -302,22 +300,21 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Officer>(o => o.Weapons, "Weapons")
             };
 
-            return AssertIncludeQuery<Gear, CogTag>(
+            return AssertIncludeQuery(
                 isAsync,
-                (gs, ts) =>
-                    gs.Join(
-                        ts,
-                        g => new
-                        {
-                            SquadId = (int?)g.SquadId,
-                            g.Nickname
-                        },
-                        t => new
-                        {
-                            SquadId = t.GearSquadId,
-                            Nickname = t.GearNickName
-                        },
-                        (g, t) => g).Include(g => g.Weapons),
+                ss => ss.Set<Gear>().Join(
+                    ss.Set<CogTag>(),
+                    g => new
+                    {
+                        SquadId = (int?)g.SquadId,
+                        g.Nickname
+                    },
+                    t => new
+                    {
+                        SquadId = t.GearSquadId,
+                        Nickname = t.GearNickName
+                    },
+                    (g, t) => g).Include(g => g.Weapons),
                 expectedIncludes);
         }
 
@@ -331,22 +328,21 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Officer>(o => o.Weapons, "Weapons")
             };
 
-            return AssertIncludeQuery<CogTag, Gear>(
+            return AssertIncludeQuery(
                 isAsync,
-                (ts, gs) =>
-                    ts.Join(
-                        gs,
-                        t => new
-                        {
-                            SquadId = t.GearSquadId,
-                            Nickname = t.GearNickName
-                        },
-                        g => new
-                        {
-                            SquadId = (int?)g.SquadId,
-                            g.Nickname
-                        },
-                        (t, g) => g).Include(g => g.Weapons),
+                ss => ss.Set<CogTag>().Join(
+                    ss.Set<Gear>(),
+                    t => new
+                    {
+                        SquadId = t.GearSquadId,
+                        Nickname = t.GearNickName
+                    },
+                    g => new
+                    {
+                        SquadId = (int?)g.SquadId,
+                        g.Nickname
+                    },
+                    (t, g) => g).Include(g => g.Weapons),
                 expectedIncludes);
         }
 
@@ -432,22 +428,21 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<City>(c => c.StationedGears, "StationedGears", "CityOfBirth")
             };
 
-            return AssertIncludeQuery<Gear, CogTag>(
+            return AssertIncludeQuery(
                 isAsync,
-                (gs, ts) =>
-                    gs.Join(
-                        ts,
-                        g => new
-                        {
-                            SquadId = (int?)g.SquadId,
-                            g.Nickname
-                        },
-                        t => new
-                        {
-                            SquadId = t.GearSquadId,
-                            Nickname = t.GearNickName
-                        },
-                        (g, t) => g).Include(g => g.CityOfBirth.StationedGears),
+                ss => ss.Set<Gear>().Join(
+                    ss.Set<CogTag>(),
+                    g => new
+                    {
+                        SquadId = (int?)g.SquadId,
+                        g.Nickname
+                    },
+                    t => new
+                    {
+                        SquadId = t.GearSquadId,
+                        Nickname = t.GearNickName
+                    },
+                    (g, t) => g).Include(g => g.CityOfBirth.StationedGears),
                 expectedIncludes);
         }
 
@@ -460,22 +455,21 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Officer>(o => o.CityOfBirth, "CityOfBirth")
             };
 
-            return AssertIncludeQuery<Gear, CogTag>(
+            return AssertIncludeQuery(
                 isAsync,
-                (gs, ts) =>
-                    ts.Join(
-                        gs.OfType<Officer>(),
-                        t => new
-                        {
-                            SquadId = t.GearSquadId,
-                            Nickname = t.GearNickName
-                        },
-                        o => new
-                        {
-                            SquadId = (int?)o.SquadId,
-                            o.Nickname
-                        },
-                        (t, o) => o).Include(o => o.CityOfBirth),
+                ss => ss.Set<CogTag>().Join(
+                    ss.Set<Gear>().OfType<Officer>(),
+                    t => new
+                    {
+                        SquadId = t.GearSquadId,
+                        Nickname = t.GearNickName
+                    },
+                    o => new
+                    {
+                        SquadId = (int?)o.SquadId,
+                        o.Nickname
+                    },
+                    (t, o) => o).Include(o => o.CityOfBirth),
                 expectedIncludes);
         }
 
@@ -488,22 +482,21 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Officer>(o => o.Reports, "Reports")
             };
 
-            return AssertIncludeQuery<Gear, CogTag>(
+            return AssertIncludeQuery(
                 isAsync,
-                (gs, ts) =>
-                    ts.Join(
-                        gs.OfType<Officer>().OrderBy(ee => ee.SquadId),
-                        t => new
-                        {
-                            SquadId = t.GearSquadId,
-                            Nickname = t.GearNickName
-                        },
-                        o => new
-                        {
-                            SquadId = (int?)o.SquadId,
-                            o.Nickname
-                        },
-                        (t, o) => o).OrderBy(ee => ee.FullName).Include(o => o.Reports).OrderBy(oo => oo.HasSoulPatch).ThenByDescending(oo => oo.Nickname),
+                ss => ss.Set<CogTag>().Join(
+                    ss.Set<Gear>().OfType<Officer>().OrderBy(ee => ee.SquadId),
+                    t => new
+                    {
+                        SquadId = t.GearSquadId,
+                        Nickname = t.GearNickName
+                    },
+                    o => new
+                    {
+                        SquadId = (int?)o.SquadId,
+                        o.Nickname
+                    },
+                    (t, o) => o).OrderBy(ee => ee.FullName).Include(o => o.Reports).OrderBy(oo => oo.HasSoulPatch).ThenByDescending(oo => oo.Nickname),
                 expectedIncludes,
                 assertOrder: true);
         }
@@ -517,22 +510,21 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Officer>(o => o.Weapons, "Weapons")
             };
 
-            return AssertIncludeQuery<Gear, CogTag>(
+            return AssertIncludeQuery(
                 isAsync,
-                (gs, ts) =>
-                    gs.OfType<Officer>().Join(
-                        ts,
-                        o => new
-                        {
-                            SquadId = (int?)o.SquadId,
-                            o.Nickname
-                        },
-                        t => new
-                        {
-                            SquadId = t.GearSquadId,
-                            Nickname = t.GearNickName
-                        },
-                        (o, t) => o).Include(g => g.Weapons),
+                ss => ss.Set<Gear>().OfType<Officer>().Join(
+                    ss.Set<CogTag>(),
+                    o => new
+                    {
+                        SquadId = (int?)o.SquadId,
+                        o.Nickname
+                    },
+                    t => new
+                    {
+                        SquadId = t.GearSquadId,
+                        Nickname = t.GearNickName
+                    },
+                    (o, t) => o).Include(g => g.Weapons),
                 expectedIncludes);
         }
 
@@ -545,22 +537,21 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Officer>(o => o.Reports, "Reports")
             };
 
-            return AssertIncludeQuery<Gear, CogTag>(
+            return AssertIncludeQuery(
                 isAsync,
-                (gs, ts) =>
-                    ts.Join(
-                        gs.OfType<Officer>(),
-                        t => new
-                        {
-                            SquadId = t.GearSquadId,
-                            Nickname = t.GearNickName
-                        },
-                        g => new
-                        {
-                            SquadId = (int?)g.SquadId,
-                            g.Nickname
-                        },
-                        (t, o) => o).Include(o => o.Reports),
+                ss => ss.Set<CogTag>().Join(
+                    ss.Set<Gear>().OfType<Officer>(),
+                    t => new
+                    {
+                        SquadId = t.GearSquadId,
+                        Nickname = t.GearNickName
+                    },
+                    g => new
+                    {
+                        SquadId = (int?)g.SquadId,
+                        g.Nickname
+                    },
+                    (t, o) => o).Include(o => o.Reports),
                 expectedIncludes);
         }
 
@@ -573,13 +564,13 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Weapon>(w => w.Owner, "Owner")
             };
 
-            return AssertIncludeQuery<Weapon>(
+            return AssertIncludeQuery(
                 isAsync,
-                ws => ws
+                ss => ss.Set<Weapon>()
                     .Include(w => w.Owner)
                     .Where(w => w.Owner.Nickname != "Paduk")
                     .OrderBy(e => e.Owner.CityOfBirth.Name).ThenBy(e => e.Id),
-                ws => ws
+                ss => ss.Set<Weapon>()
                     .Include(w => w.Owner)
                     .Where(w => Maybe(w.Owner, () => w.Owner.Nickname) != "Paduk")
                     .OrderBy(e => Maybe(e.Owner, () => Maybe(e.Owner.CityOfBirth, () => e.Owner.CityOfBirth.Name)))
@@ -1111,25 +1102,23 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<Gear>().Select(g => g != null ? g.LeaderNickname + g.LeaderNickname : null));
         }
 
-        // issue #18002
-        //[ConditionalTheory]
-        //[MemberData(nameof(IsAsyncData))]
-        //public virtual Task Select_null_propagation_optimization9(bool isAsync)
-        //{
-        //    return AssertQueryTyped(
-        //        isAsync,
-        //        ss => ss.Set<Gear>().Select(g => g != null ? (int?)g.FullName.Length : (int?)null));
-        //}
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Select_null_propagation_optimization9(bool isAsync)
+        {
+            return AssertQueryScalar(
+                isAsync,
+                ss => ss.Set<Gear>().Select(g => g != null ? (int?)g.FullName.Length : (int?)null));
+        }
 
-        // issue #18002
-        //[ConditionalTheory]
-        //[MemberData(nameof(IsAsyncData))]
-        //public virtual Task Select_null_propagation_negative1(bool isAsync)
-        //{
-        //    return AssertQueryTyped(
-        //        isAsync,
-        //        ss => ss.Set<Gear>().Select(g => g.LeaderNickname != null ? (bool?)(g.Nickname.Length == 5) : (bool?)null));
-        //}
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Select_null_propagation_negative1(bool isAsync)
+        {
+            return AssertQueryScalar(
+                isAsync,
+                ss => ss.Set<Gear>().Select(g => g.LeaderNickname != null ? (bool?)(g.Nickname.Length == 5) : (bool?)null));
+        }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
@@ -1219,27 +1208,26 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true);
         }
 
-        // issue #18002
-        //[ConditionalTheory]
-        //[MemberData(nameof(IsAsyncData))]
-        //public virtual Task Select_null_propagation_negative6(bool isAsync)
-        //{
-        //    return AssertQueryTyped(
-        //        isAsync,
-        //        ss => ss.Set<Gear>().Select(
-        //            g => null != g.LeaderNickname
-        //                ? EF.Property<string>(g, "LeaderNickname").Length != EF.Property<string>(g, "LeaderNickname").Length
-        //                : (bool?)null),
-        //        ss => ss.Set<Gear>().Select(g => null != g.LeaderNickname ? g.LeaderNickname.Length != g.LeaderNickname.Length : (bool?)null));
-        //}
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Select_null_propagation_negative6(bool isAsync)
+        {
+            return AssertQueryScalar(
+                isAsync,
+                ss => ss.Set<Gear>().Select(
+                    g => null != g.LeaderNickname
+                        ? EF.Property<string>(g, "LeaderNickname").Length != EF.Property<string>(g, "LeaderNickname").Length
+                        : (bool?)null),
+                ss => ss.Set<Gear>().Select(g => null != g.LeaderNickname ? g.LeaderNickname.Length != g.LeaderNickname.Length : (bool?)null));
+        }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_null_propagation_negative7(bool isAsync)
         {
-            return AssertQueryScalar<Gear>(
+            return AssertQueryScalar(
                 isAsync,
-                gs => gs.Select(g => null != g.LeaderNickname ? g.LeaderNickname == g.LeaderNickname : (bool?)null));
+                ss => ss.Set<Gear>().Select(g => null != g.LeaderNickname ? g.LeaderNickname == g.LeaderNickname : (bool?)null));
         }
 
         [ConditionalTheory]
@@ -1742,8 +1730,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery(
                 isAsync,
                 ss => ss.Set<Gear>().GroupBy(g => g.LeaderNickname).Concat(ss.Set<Gear>().GroupBy(g => g.LeaderNickname)),
-                elementSorter: GroupingSorter<string, Gear>(),
-                elementAsserter: GroupingAsserter<string, Gear>(g => g.Nickname, (e, a) => Assert.Equal(e.Nickname, a.Nickname)));
+                elementSorter: e => e.Key,
+                elementAsserter: (e, a) => AssertGrouping(e, a));
         }
 
         [ConditionalTheory]
@@ -1751,9 +1739,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual async Task Select_navigation_with_concat_and_count(bool isAsync)
         {
             var message = (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => AssertQueryScalar<Gear>(
+                () => AssertQueryScalar(
                 isAsync,
-                gs => gs.Where(g => !g.HasSoulPatch).Select(g => g.Weapons.Concat(g.Weapons).Count())))).Message;
+                ss => ss.Set<Gear>().Where(g => !g.HasSoulPatch).Select(g => g.Weapons.Concat(g.Weapons).Count())))).Message;
 
             Assert.Equal(
                 CoreStrings.QueryFailed("Concat<Weapon>(    source1: AsQueryable<Weapon>(MaterializeCollectionNavigation(Navigation: Gear.Weapons (<Weapons>k__BackingField, ICollection<Weapon>) Collection ToDependent Weapon Inverse: Owner, Where<Weapon>(        source: NavigationExpansionExpression            Source: Where<Weapon>(                source: DbSet<Weapon>,                 predicate: (w) => Property<string>((Unhandled parameter: g), \"FullName\") != null && Property<string>((Unhandled parameter: g), \"FullName\") == Property<string>(w, \"OwnerFullName\"))            PendingSelector: (w) => NavigationTreeExpression                Value: EntityReferenceWeapon                Expression: w        ,         predicate: (i) => Property<string>(NavigationTreeExpression            Value: EntityReferenceGear            Expression: (Unhandled parameter: g), \"FullName\") != null && Property<string>(NavigationTreeExpression            Value: EntityReferenceGear            Expression: (Unhandled parameter: g), \"FullName\") == Property<string>(i, \"OwnerFullName\")))),     source2: MaterializeCollectionNavigation(Navigation: Gear.Weapons (<Weapons>k__BackingField, ICollection<Weapon>) Collection ToDependent Weapon Inverse: Owner, Where<Weapon>(        source: NavigationExpansionExpression            Source: Where<Weapon>(                source: DbSet<Weapon>,                 predicate: (w0) => Property<string>((Unhandled parameter: g), \"FullName\") != null && Property<string>((Unhandled parameter: g), \"FullName\") == Property<string>(w0, \"OwnerFullName\"))            PendingSelector: (w0) => NavigationTreeExpression                Value: EntityReferenceWeapon                Expression: w0        ,         predicate: (i) => Property<string>(NavigationTreeExpression            Value: EntityReferenceGear            Expression: (Unhandled parameter: g), \"FullName\") != null && Property<string>(NavigationTreeExpression            Value: EntityReferenceGear            Expression: (Unhandled parameter: g), \"FullName\") == Property<string>(i, \"OwnerFullName\"))))", "NavigationExpandingExpressionVisitor"),
@@ -1767,8 +1755,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery(
                 isAsync,
                 ss => ss.Set<Gear>().GroupBy(g => g.LeaderNickname).Concat(ss.Set<Gear>().GroupBy(g => g.LeaderNickname)),
-                elementSorter: GroupingSorter<string, Gear>(),
-                elementAsserter: GroupingAsserter<string, Gear>(g => g.Nickname, (e, a) => Assert.Equal(e.Nickname, a.Nickname)));
+                elementSorter: e => e.Key,
+                elementAsserter: (e, a) => AssertGrouping(e, a));
         }
 
         [ConditionalTheory]
@@ -1776,9 +1764,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual async Task Concat_with_collection_navigations(bool isAsync)
         {
             var message = (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => AssertQueryScalar<Gear>(
+                () => AssertQueryScalar(
                 isAsync,
-                gs => gs.Where(g => g.HasSoulPatch).Select(g => g.Weapons.Union(g.Weapons).Count())))).Message;
+                ss => ss.Set<Gear>().Where(g => g.HasSoulPatch).Select(g => g.Weapons.Union(g.Weapons).Count())))).Message;
 
             Assert.Equal(
                 CoreStrings.QueryFailed("Union<Weapon>(    source1: AsQueryable<Weapon>(MaterializeCollectionNavigation(Navigation: Gear.Weapons (<Weapons>k__BackingField, ICollection<Weapon>) Collection ToDependent Weapon Inverse: Owner, Where<Weapon>(        source: NavigationExpansionExpression            Source: Where<Weapon>(                source: DbSet<Weapon>,                 predicate: (w) => Property<string>((Unhandled parameter: g), \"FullName\") != null && Property<string>((Unhandled parameter: g), \"FullName\") == Property<string>(w, \"OwnerFullName\"))            PendingSelector: (w) => NavigationTreeExpression                Value: EntityReferenceWeapon                Expression: w        ,         predicate: (i) => Property<string>(NavigationTreeExpression            Value: EntityReferenceGear            Expression: (Unhandled parameter: g), \"FullName\") != null && Property<string>(NavigationTreeExpression            Value: EntityReferenceGear            Expression: (Unhandled parameter: g), \"FullName\") == Property<string>(i, \"OwnerFullName\")))),     source2: MaterializeCollectionNavigation(Navigation: Gear.Weapons (<Weapons>k__BackingField, ICollection<Weapon>) Collection ToDependent Weapon Inverse: Owner, Where<Weapon>(        source: NavigationExpansionExpression            Source: Where<Weapon>(                source: DbSet<Weapon>,                 predicate: (w0) => Property<string>((Unhandled parameter: g), \"FullName\") != null && Property<string>((Unhandled parameter: g), \"FullName\") == Property<string>(w0, \"OwnerFullName\"))            PendingSelector: (w0) => NavigationTreeExpression                Value: EntityReferenceWeapon                Expression: w0        ,         predicate: (i) => Property<string>(NavigationTreeExpression            Value: EntityReferenceGear            Expression: (Unhandled parameter: g), \"FullName\") != null && Property<string>(NavigationTreeExpression            Value: EntityReferenceGear            Expression: (Unhandled parameter: g), \"FullName\") == Property<string>(i, \"OwnerFullName\"))))", "NavigationExpandingExpressionVisitor"),
@@ -1790,9 +1778,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual async Task Union_with_collection_navigations(bool isAsync)
         {
             var message = (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => AssertQueryScalar<Gear>(
+                () => AssertQueryScalar(
                 isAsync,
-                gs => gs.OfType<Officer>().Select(o => o.Reports.Union(o.Reports).Count())))).Message;
+                ss => ss.Set<Gear>().OfType<Officer>().Select(o => o.Reports.Union(o.Reports).Count())))).Message;
         }
 
         [ConditionalTheory]
@@ -2007,21 +1995,20 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Collection_with_inheritance_and_join_include_joined(bool isAsync)
         {
-            return AssertIncludeQuery<CogTag, Gear>(
+            return AssertIncludeQuery(
                 isAsync,
-                (ts, gs) =>
-                    (from t in ts
-                     join g in gs.OfType<Officer>() on new
-                     {
-                         id1 = t.GearSquadId,
-                         id2 = t.GearNickName
-                     }
-                         equals new
-                         {
-                             id1 = (int?)g.SquadId,
-                             id2 = g.Nickname
-                         }
-                     select g).Include(g => g.Tag),
+                ss => (from t in ss.Set<CogTag>()
+                       join g in ss.Set<Gear>().OfType<Officer>() on new
+                       {
+                           id1 = t.GearSquadId,
+                           id2 = t.GearNickName
+                       }
+                       equals new
+                       {
+                           id1 = (int?)g.SquadId,
+                           id2 = g.Nickname
+                       }
+                       select g).Include(g => g.Tag),
                 new List<IExpectedInclude>
                 {
                     new ExpectedInclude<Officer>(o => o.Tag, "Tag")
@@ -2032,21 +2019,20 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Collection_with_inheritance_and_join_include_source(bool isAsync)
         {
-            return AssertIncludeQuery<Gear, CogTag>(
+            return AssertIncludeQuery(
                 isAsync,
-                (gs, ts) =>
-                    (from g in gs.OfType<Officer>()
-                     join t in ts on new
-                     {
-                         id1 = (int?)g.SquadId,
-                         id2 = g.Nickname
-                     }
-                         equals new
-                         {
-                             id1 = t.GearSquadId,
-                             id2 = t.GearNickName
-                         }
-                     select g).Include(g => g.Tag),
+                ss => (from g in ss.Set<Gear>().OfType<Officer>()
+                       join t in ss.Set<CogTag>() on new
+                       {
+                           id1 = (int?)g.SquadId,
+                           id2 = g.Nickname
+                       }
+                       equals new
+                       {
+                           id1 = t.GearSquadId,
+                           id2 = t.GearNickName
+                       }
+                       select g).Include(g => g.Tag),
                 new List<IExpectedInclude>
                 {
                     new ExpectedInclude<Officer>(o => o.Tag, "Tag")
@@ -2196,10 +2182,10 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Officer>(g => g.Weapons, "Weapons")
             };
 
-            return AssertIncludeQuery<Gear>(
+            return AssertIncludeQuery(
                 isAsync,
-                gs => from g1 in gs.Include(g => g.Weapons)
-                      join g2 in gs.Include(g => g.Weapons)
+                ss => from g1 in ss.Set<Gear>().Include(g => g.Weapons)
+                      join g2 in ss.Set<Gear>().Include(g => g.Weapons)
                           on g1.LeaderNickname equals g2.Nickname into grouping
                       from g2 in grouping.DefaultIfEmpty()
                       select g2 ?? g1,
@@ -2216,10 +2202,10 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Officer>(g => g.Weapons, "Weapons")
             };
 
-            return AssertIncludeQuery<Gear>(
+            return AssertIncludeQuery(
                 isAsync,
-                gs => from g1 in gs.Include(g => g.Weapons)
-                      join g2 in gs.Include(g => g.Weapons)
+                ss => from g1 in ss.Set<Gear>().Include(g => g.Weapons)
+                      join g2 in ss.Set<Gear>().Include(g => g.Weapons)
                           on g1.LeaderNickname equals g2.Nickname into grouping
                       from g2 in grouping.DefaultIfEmpty()
                       select new
@@ -2248,10 +2234,10 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Officer>(g => g.Weapons, "Weapons")
             };
 
-            return AssertIncludeQuery<Gear>(
+            return AssertIncludeQuery(
                 isAsync,
-                gs => from g1 in gs.Include(g => g.Weapons)
-                      join g2 in gs.OfType<Officer>().Include(g => g.Weapons)
+                ss => from g1 in ss.Set<Gear>().Include(g => g.Weapons)
+                      join g2 in ss.Set<Gear>().OfType<Officer>().Include(g => g.Weapons)
                           on g1.LeaderNickname equals g2.Nickname into grouping
                       from g2 in grouping.DefaultIfEmpty()
                       select g2 ?? g1,
@@ -2268,13 +2254,12 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Officer>(g => g.Weapons, "Weapons")
             };
 
-            return AssertIncludeQuery<Gear>(
+            return AssertIncludeQuery(
                 isAsync,
-                gs => from g1 in gs.Include(g => g.Weapons)
-                      join g2 in gs.Include(g => g.Weapons)
+                ss => from g1 in ss.Set<Gear>().Include(g => g.Weapons)
+                      join g2 in ss.Set<Gear>().Include(g => g.Weapons)
                           on g1.LeaderNickname equals g2.Nickname into grouping
                       from g2 in grouping.DefaultIfEmpty()
-                          // ReSharper disable once MergeConditionalExpression
 #pragma warning disable IDE0029 // Use coalesce expression
                       select g2 != null ? g2 : g1,
 #pragma warning restore IDE0029 // Use coalesce expression
@@ -2291,13 +2276,12 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Officer>(g => g.Weapons, "Weapons")
             };
 
-            return AssertIncludeQuery<Gear>(
+            return AssertIncludeQuery(
                 isAsync,
-                gs => from g1 in gs.Include(g => g.Weapons)
-                      join g2 in gs.Include(g => g.Weapons)
+                ss => from g1 in ss.Set<Gear>().Include(g => g.Weapons)
+                      join g2 in ss.Set<Gear>().Include(g => g.Weapons)
                           on g1.LeaderNickname equals g2.Nickname into grouping
                       from g2 in grouping.DefaultIfEmpty()
-                          // ReSharper disable once MergeConditionalExpression
 #pragma warning disable IDE0029 // Use coalesce expression
                       select new
                       {
@@ -2336,15 +2320,14 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<Weapon>().Where(w => w.AmmunitionType == AmmunitionType.Cartridge && ((bool?)w.IsAutomatic ?? false)));
         }
 
-        // #issue 18002
-        //[ConditionalTheory]
-        //[MemberData(nameof(IsAsyncData))]
-        //public virtual Task Coalesce_operator_in_projection_with_other_conditions(bool isAsync)
-        //{
-        //    return AssertQueryTyped(
-        //        isAsync,
-        //        ss => ss.Set<Weapon>().Select(w => w.AmmunitionType == AmmunitionType.Cartridge && ((bool?)w.IsAutomatic ?? false)));
-        //}
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Coalesce_operator_in_projection_with_other_conditions(bool isAsync)
+        {
+            return AssertQueryScalar(
+                isAsync,
+                ss => ss.Set<Weapon>().Select(w => w.AmmunitionType == AmmunitionType.Cartridge && ((bool?)w.IsAutomatic ?? false)));
+        }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
@@ -2421,24 +2404,23 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<CogTag>().Where(t => MaybeScalar<bool>(t.Gear, () => t.Gear.HasSoulPatch) == true || t.Note.Contains("Cole")));
         }
 
-        // issue #18002
-        //[ConditionalTheory]
-        //[MemberData(nameof(IsAsyncData))]
-        //public virtual Task Optional_navigation_type_compensation_works_with_binary_and_expression(bool isAsync)
-        //{
-        //    return AssertQueryTyped(
-        //        isAsync,
-        //        ss => ss.Set<CogTag>().Select(t => t.Gear.HasSoulPatch && t.Note.Contains("Cole")),
-        //        ss => ss.Set<CogTag>().Select(t => MaybeScalar<bool>(t.Gear, () => t.Gear.HasSoulPatch) == true && t.Note.Contains("Cole")));
-        //}
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Optional_navigation_type_compensation_works_with_binary_and_expression(bool isAsync)
+        {
+            return AssertQueryScalar(
+                isAsync,
+                ss => ss.Set<CogTag>().Select(t => t.Gear.HasSoulPatch && t.Note.Contains("Cole")),
+                ss => ss.Set<CogTag>().Select(t => MaybeScalar<bool>(t.Gear, () => t.Gear.HasSoulPatch) == true && t.Note.Contains("Cole")));
+        }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Optional_navigation_type_compensation_works_with_projection(bool isAsync)
         {
-            return AssertQueryScalar<CogTag>(
+            return AssertQueryScalar(
                 isAsync,
-                ts => ts.Where(t => t.Note != "K.I.A.").Select(t => t.Gear.SquadId));
+                ss => ss.Set<CogTag>().Where(t => t.Note != "K.I.A.").Select(t => t.Gear.SquadId));
         }
 
         [ConditionalTheory]
@@ -2511,8 +2493,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery(
                 isAsync,
                 ss => ss.Set<CogTag>().Where(t => t.Note != "K.I.A.").GroupBy(t => t.Gear.SquadId),
-                elementSorter: GroupingSorter<int, CogTag>(),
-                elementAsserter: GroupingAsserter<int, CogTag>(t => t.Id, (e, a) => Assert.Equal(e.Id, a.Id)));
+                elementSorter: e => e.Key,
+                elementAsserter: (e, a) => AssertGrouping(e, a));
         }
 
         [ConditionalTheory]
@@ -2812,9 +2794,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task DateTimeOffset_DateAdd_AddYears(bool isAsync)
         {
-            return AssertQueryScalar<Mission>(
+            return AssertQueryScalar(
                 isAsync,
-                ms => from m in ms
+                ss => from m in ss.Set<Mission>()
                       select m.Timeline.AddYears(1));
         }
 
@@ -2822,9 +2804,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task DateTimeOffset_DateAdd_AddMonths(bool isAsync)
         {
-            return AssertQueryScalar<Mission>(
+            return AssertQueryScalar(
                 isAsync,
-                ms => from m in ms
+                ss => from m in ss.Set<Mission>()
                       select m.Timeline.AddMonths(1));
         }
 
@@ -2832,9 +2814,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task DateTimeOffset_DateAdd_AddDays(bool isAsync)
         {
-            return AssertQueryScalar<Mission>(
+            return AssertQueryScalar(
                 isAsync,
-                ms => from m in ms
+                ss => from m in ss.Set<Mission>()
                       select m.Timeline.AddDays(1));
         }
 
@@ -2842,9 +2824,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task DateTimeOffset_DateAdd_AddHours(bool isAsync)
         {
-            return AssertQueryScalar<Mission>(
+            return AssertQueryScalar(
                 isAsync,
-                ms => from m in ms
+                ss => from m in ss.Set<Mission>()
                       select m.Timeline.AddHours(1));
         }
 
@@ -2852,9 +2834,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task DateTimeOffset_DateAdd_AddMinutes(bool isAsync)
         {
-            return AssertQueryScalar<Mission>(
+            return AssertQueryScalar(
                 isAsync,
-                ms => from m in ms
+                ss => from m in ss.Set<Mission>()
                       select m.Timeline.AddMinutes(1));
         }
 
@@ -2862,9 +2844,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task DateTimeOffset_DateAdd_AddSeconds(bool isAsync)
         {
-            return AssertQueryScalar<Mission>(
+            return AssertQueryScalar(
                 isAsync,
-                ms => from m in ms
+                ss => from m in ss.Set<Mission>()
                       select m.Timeline.AddSeconds(1));
         }
 
@@ -2872,9 +2854,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task DateTimeOffset_DateAdd_AddMilliseconds(bool isAsync)
         {
-            return AssertQueryScalar<Mission>(
+            return AssertQueryScalar(
                 isAsync,
-                ms => from m in ms
+                ss => from m in ss.Set<Mission>()
                       select m.Timeline.AddMilliseconds(300));
         }
 
@@ -2946,12 +2928,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Distinct_with_optional_navigation_is_translated_to_sql(bool isAsync)
         {
-            return AssertQueryScalar<Gear>(
+            return AssertQueryScalar(
                 isAsync,
-                gs => (from g in gs
+                ss => (from g in ss.Set<Gear>()
                        where g.Tag.Note != "Foo"
                        select g.HasSoulPatch).Distinct(),
-                gs => (from g in gs
+                ss => (from g in ss.Set<Gear>()
                        where Maybe(g.Tag, () => g.Tag.Note) != "Foo"
                        select g.HasSoulPatch).Distinct());
         }
@@ -2988,10 +2970,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Distinct_with_unflattened_groupjoin_is_evaluated_on_client(bool isAsync)
         {
-            return AssertQueryScalar<Gear, CogTag>(
+            return AssertQueryScalar(
                 isAsync,
-                (gs, ts) => gs.GroupJoin(
-                        ts,
+                ss => ss.Set<Gear>().GroupJoin(
+                        ss.Set<CogTag>(),
                         g => new
                         {
                             k1 = g.Nickname,
@@ -3067,10 +3049,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Non_flattened_GroupJoin_with_result_operator_evaluates_on_the_client(bool isAsync)
         {
-            return AssertQueryScalar<CogTag, Gear>(
+            return AssertQueryScalar(
                 isAsync,
-                (ts, gs) => ts.GroupJoin(
-                    gs,
+                ss => ss.Set<CogTag>().GroupJoin(
+                    ss.Set<Gear>(),
                     t => new
                     {
                         k1 = t.GearNickName,
@@ -4080,9 +4062,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_reference_on_derived_type_using_string(bool isAsync)
         {
-            return AssertIncludeQuery<LocustLeader>(
+            return AssertIncludeQuery(
                 isAsync,
-                lls => lls.Include("DefeatedBy"),
+                ss => ss.Set<LocustLeader>().Include("DefeatedBy"),
                 new List<IExpectedInclude>
                 {
                     new ExpectedInclude<LocustCommander>(lc => lc.DefeatedBy, "DefeatedBy")
@@ -4099,9 +4081,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Gear>(g => g.Squad, "Squad", "DefeatedBy")
             };
 
-            return AssertIncludeQuery<LocustLeader>(
+            return AssertIncludeQuery(
                 isAsync,
-                lls => lls.Include("DefeatedBy.Squad"),
+                ss => ss.Set<LocustLeader>().Include("DefeatedBy.Squad"),
                 expectedIncludes);
         }
 
@@ -4116,9 +4098,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Gear>(g => g.CityOfBirth, "CityOfBirth", "DefeatedBy.Reports")
             };
 
-            return AssertIncludeQuery<LocustLeader>(
+            return AssertIncludeQuery(
                 isAsync,
-                lls => lls.Include("DefeatedBy.Reports.CityOfBirth"),
+                ss => ss.Set<LocustLeader>().Include("DefeatedBy.Reports.CityOfBirth"),
                 expectedIncludes);
         }
 
@@ -4126,9 +4108,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_reference_on_derived_type_using_lambda(bool isAsync)
         {
-            return AssertIncludeQuery<LocustLeader>(
+            return AssertIncludeQuery(
                 isAsync,
-                lls => lls.Include(ll => ((LocustCommander)ll).DefeatedBy),
+                ss => ss.Set<LocustLeader>().Include(ll => ((LocustCommander)ll).DefeatedBy),
                 new List<IExpectedInclude>
                 {
                     new ExpectedInclude<LocustCommander>(lc => lc.DefeatedBy, "DefeatedBy")
@@ -4139,9 +4121,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_reference_on_derived_type_using_lambda_with_soft_cast(bool isAsync)
         {
-            return AssertIncludeQuery<LocustLeader>(
+            return AssertIncludeQuery(
                 isAsync,
-                lls => lls.Include(ll => (ll as LocustCommander).DefeatedBy),
+                ss => ss.Set<LocustLeader>().Include(ll => (ll as LocustCommander).DefeatedBy),
                 new List<IExpectedInclude>
                 {
                     new ExpectedInclude<LocustCommander>(lc => lc.DefeatedBy, "DefeatedBy")
@@ -4152,9 +4134,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_reference_on_derived_type_using_lambda_with_tracking(bool isAsync)
         {
-            return AssertIncludeQuery<LocustLeader>(
+            return AssertIncludeQuery(
                 isAsync,
-                lls => lls.AsTracking().Include(ll => ((LocustCommander)ll).DefeatedBy),
+                ss => ss.Set<LocustLeader>().AsTracking().Include(ll => ((LocustCommander)ll).DefeatedBy),
                 new List<IExpectedInclude>
                 {
                     new ExpectedInclude<LocustCommander>(lc => lc.DefeatedBy, "DefeatedBy")
@@ -4166,9 +4148,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_on_derived_type_using_string(bool isAsync)
         {
-            return AssertIncludeQuery<Gear>(
+            return AssertIncludeQuery(
                 isAsync,
-                gs => gs.Include("Reports"),
+                ss => ss.Set<Gear>().Include("Reports"),
                 new List<IExpectedInclude>
                 {
                     new ExpectedInclude<Officer>(o => o.Reports, "Reports")
@@ -4179,9 +4161,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_on_derived_type_using_lambda(bool isAsync)
         {
-            return AssertIncludeQuery<Gear>(
+            return AssertIncludeQuery(
                 isAsync,
-                gs => gs.Include(g => ((Officer)g).Reports),
+                ss => ss.Set<Gear>().Include(g => ((Officer)g).Reports),
                 new List<IExpectedInclude>
                 {
                     new ExpectedInclude<Officer>(o => o.Reports, "Reports")
@@ -4192,9 +4174,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_on_derived_type_using_lambda_with_soft_cast(bool isAsync)
         {
-            return AssertIncludeQuery<Gear>(
+            return AssertIncludeQuery(
                 isAsync,
-                gs => gs.Include(g => (g as Officer).Reports),
+                ss => ss.Set<Gear>().Include(g => (g as Officer).Reports),
                 new List<IExpectedInclude>
                 {
                     new ExpectedInclude<Officer>(o => o.Reports, "Reports")
@@ -4211,9 +4193,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Officer>(e => e.Weapons, "Weapons")
             };
 
-            return AssertIncludeQuery<Gear>(
+            return AssertIncludeQuery(
                 isAsync,
-                gs => gs.Include(g => ((Officer)g).Tag).Include(g => ((Officer)g).Weapons),
+                ss => ss.Set<Gear>().Include(g => ((Officer)g).Tag).Include(g => ((Officer)g).Weapons),
                 expectedIncludes);
         }
 
@@ -4227,9 +4209,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Officer>(e => e.Weapons, "Weapons", "Gear")
             };
 
-            return AssertIncludeQuery<CogTag>(
+            return AssertIncludeQuery(
                 isAsync,
-                ts => ts.Include(t => t.Gear).ThenInclude(g => (g as Officer).Weapons),
+                ss => ss.Set<CogTag>().Include(t => t.Gear).ThenInclude(g => (g as Officer).Weapons),
                 expectedIncludes);
         }
 
@@ -4244,9 +4226,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Officer>(e => e.Reports, "Reports", "Commander.DefeatedBy")
             };
 
-            return AssertIncludeQuery<Faction>(
+            return AssertIncludeQuery(
                 isAsync,
-                fs => fs.Include(f => (f as LocustHorde).Commander).ThenInclude(c => (c.DefeatedBy as Officer).Reports),
+                ss => ss.Set<Faction>().Include(f => (f as LocustHorde).Commander).ThenInclude(c => (c.DefeatedBy as Officer).Reports),
                 expectedIncludes);
         }
 
@@ -4260,9 +4242,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Officer>(e => e.Reports, "Reports", "Reports")
             };
 
-            return AssertIncludeQuery<Gear>(
+            return AssertIncludeQuery(
                 isAsync,
-                gs => gs.Include(g => ((Officer)g).Reports).ThenInclude(g => ((Officer)g).Reports),
+                ss => ss.Set<Gear>().Include(g => ((Officer)g).Reports).ThenInclude(g => ((Officer)g).Reports),
                 expectedIncludes);
         }
 
@@ -4276,9 +4258,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<LocustCommander>(e => e.DefeatedBy, "DefeatedBy", "Leaders")
             };
 
-            return AssertIncludeQuery<Faction>(
+            return AssertIncludeQuery(
                 isAsync,
-                fs => fs.Include(f => ((LocustHorde)f).Leaders).ThenInclude(l => ((LocustCommander)l).DefeatedBy),
+                ss => ss.Set<Faction>().Include(f => ((LocustHorde)f).Leaders).ThenInclude(l => ((LocustCommander)l).DefeatedBy),
                 expectedIncludes);
         }
 
@@ -4293,9 +4275,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Officer>(e => e.Reports, "Reports", "Commander.DefeatedBy")
             };
 
-            return AssertIncludeQuery<Faction>(
+            return AssertIncludeQuery(
                 isAsync,
-                fs => fs.Include(f => (((LocustHorde)f).Commander.DefeatedBy as Officer).Reports),
+                ss => ss.Set<Faction>().Include(f => (((LocustHorde)f).Commander.DefeatedBy as Officer).Reports),
                 expectedIncludes);
         }
 
@@ -4310,9 +4292,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Squad>(e => e.Missions, "Missions", "Reports.Squad")
             };
 
-            return AssertIncludeQuery<Gear>(
+            return AssertIncludeQuery(
                 isAsync,
-                gs => gs.Include(g => ((Officer)g).Reports).ThenInclude(g => g.Squad.Missions),
+                ss => ss.Set<Gear>().Include(g => ((Officer)g).Reports).ThenInclude(g => g.Squad.Missions),
                 expectedIncludes);
         }
 
@@ -4379,9 +4361,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collections_naked_navigation_with_ToList_followed_by_projecting_count(bool isAsync)
         {
-            return AssertQueryScalar<Gear>(
+            return AssertQueryScalar(
                 isAsync,
-                gs => (from g in gs
+                ss => (from g in ss.Set<Gear>()
                        where g.Nickname != "Marcus"
                        orderby g.Nickname
                        select g.Weapons.ToList()).Select(e => e.Count),
@@ -4591,64 +4573,65 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        // issue #18002
-        //[ConditionalTheory]
-        //[MemberData(nameof(IsAsyncData))]
-        //public virtual Task Correlated_collections_nested(bool isAsync)
-        //{
-        //    return AssertQueryTyped(
-        //        isAsync,
-        //        ss => from s in ss.Set<Squad>()
-        //              select (from m in s.Missions
-        //                      where m.MissionId < 42
-        //                      select (from ps in m.Mission.ParticipatingSquads
-        //                              where ps.SquadId < 7
-        //                              select ps).ToList()).ToList(),
-        //        elementSorter: CollectionSorter(),
-        //        elementAsserter: (e, a) => AssertCollection(e, a));
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Correlated_collections_nested(bool isAsync)
+        {
+            return AssertQuery(
+                isAsync,
+                ss => from s in ss.Set<Squad>()
+                      select (from m in s.Missions
+                              where m.MissionId < 42
+                              select (from ps in m.Mission.ParticipatingSquads
+                                      where ps.SquadId < 7
+                                      select ps).ToList()).ToList(),
+                elementSorter: e => e.Count(),
+                elementAsserter: (e, a) => AssertCollection(
+                    e,
+                    a,
+                    elementSorter: ee => ee.Count(),
+                    elementAsserter: (ee, aa) => AssertCollection(ee, aa)));
+        }
 
-        //        //CollectionAsserter(
-        //        //    elementSorter: CollectionSorter<SquadMission>(),
-        //        //    elementAsserter: (ee, aa) => AssertCollection<SquadMission>(ee, aa)));
-        //}
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Correlated_collections_nested_mixed_streaming_with_buffer1(bool isAsync)
+        {
+            return AssertQuery(
+                isAsync,
+                ss => from s in ss.Set<Squad>()
+                      select (from m in s.Missions
+                              where m.MissionId < 3
+                              select (from ps in m.Mission.ParticipatingSquads
+                                      where ps.SquadId < 2
+                                      select ps).ToList()),
+                elementSorter: e => e.Count(),
+                elementAsserter: (e, a) => AssertCollection(
+                    e,
+                    a,
+                    elementSorter: ee => ee.Count(),
+                    elementAsserter: (ee, aa) => AssertCollection(ee, aa)));
+        }
 
-        //issue #18002
-        //[ConditionalTheory]
-        //[MemberData(nameof(IsAsyncData))]
-        //public virtual Task Correlated_collections_nested_mixed_streaming_with_buffer1(bool isAsync)
-        //{
-        //    return AssertQuery<Squad>(
-        //        isAsync,
-        //        ss => from s in ss
-        //              select (from m in s.Missions
-        //                      where m.MissionId < 3
-        //                      select (from ps in m.Mission.ParticipatingSquads
-        //                              where ps.SquadId < 2
-        //                              select ps).ToList()),
-        //        elementSorter: CollectionSorter<object>(),
-        //        elementAsserter: CollectionAsserter(
-        //            elementSorter: CollectionSorter<SquadMission>(),
-        //            elementAsserter: (ee, aa) => AssertCollection<SquadMission>(ee, aa)));
-        //}
-
-        // issue #18002
-        //[ConditionalTheory]
-        //[MemberData(nameof(IsAsyncData))]
-        //public virtual Task Correlated_collections_nested_mixed_streaming_with_buffer2(bool isAsync)
-        //{
-        //    return AssertQuery<Squad>(
-        //        isAsync,
-        //        ss => from s in ss
-        //              select (from m in s.Missions
-        //                      where m.MissionId < 42
-        //                      select (from ps in m.Mission.ParticipatingSquads
-        //                              where ps.SquadId < 7
-        //                              select ps)).ToList(),
-        //        elementSorter: CollectionSorter<object>(),
-        //        elementAsserter: CollectionAsserter(
-        //            elementSorter: CollectionSorter<SquadMission>(),
-        //            elementAsserter: (ee, aa) => AssertCollection<SquadMission>(ee, aa)));
-        //}
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Correlated_collections_nested_mixed_streaming_with_buffer2(bool isAsync)
+        {
+            return AssertQuery(
+                isAsync,
+                ss => from s in ss.Set<Squad>()
+                      select (from m in s.Missions
+                              where m.MissionId < 42
+                              select (from ps in m.Mission.ParticipatingSquads
+                                      where ps.SquadId < 7
+                                      select ps)).ToList(),
+                elementSorter: e => e.Count(),
+                elementAsserter: (e, a) => AssertCollection(
+                    e,
+                    a,
+                    elementSorter: ee => ee.Count(),
+                    elementAsserter: (ee, aa) => AssertCollection(ee, aa)));
+        }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
@@ -5759,9 +5742,9 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             return AssertIncludeQuery<LocustLeader>(
                 isAsync,
-                lls => lls.Include(ll => ((LocustCommander)ll).DefeatedBy).ThenInclude(g => g.Weapons)
+                ss => ss.Set<LocustLeader>().Include(ll => ((LocustCommander)ll).DefeatedBy).ThenInclude(g => g.Weapons)
                     .OrderBy(ll => ((LocustCommander)ll).DefeatedBy.Tag.Note).Take(10),
-                lls => lls.Take(10),
+                ss => ss.Set<LocustLeader>().Take(10),
                 expectedIncludes,
                 elementSorter: e => e.Name);
         }
@@ -5812,7 +5795,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                                       select t.Note).ToList()
                     },
                 assertOrder: true,
-                elementAsserter: (e, a) => AssertCollection<string>(e.Collection, a.Collection));
+                elementAsserter: (e, a) => AssertCollection(e.Collection, a.Collection));
         }
 
         [ConditionalTheory]
@@ -5831,7 +5814,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                                       select t.Note).ToList()
                     },
                 assertOrder: true,
-                elementAsserter: (e, a) => AssertCollection<string>(e.Collection, a.Collection));
+                elementAsserter: (e, a) => AssertCollection(e.Collection, a.Collection));
         }
 
         [ConditionalTheory(Skip = "Issue#17068")]
@@ -5850,7 +5833,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                                       select t.Note).ToList()
                     },
                 assertOrder: true,
-                elementAsserter: (e, a) => AssertCollection<string>(e.Collection, a.Collection));
+                elementAsserter: (e, a) => AssertCollection(e.Collection, a.Collection));
         }
 
         [ConditionalTheory]
@@ -5870,7 +5853,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                                       select t.Note).ToList()
                     },
                 assertOrder: true,
-                elementAsserter: (e, a) => AssertCollection<string>(e.Collection, a.Collection));
+                elementAsserter: (e, a) => AssertCollection(e.Collection, a.Collection));
         }
 
         [ConditionalTheory]
@@ -5884,9 +5867,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             };
 
             var message = (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => AssertIncludeQuery<Gear>(
+                () => AssertIncludeQuery(
                 isAsync,
-                gs => gs.Include(g => g.Squad).Concat(gs),
+                ss => ss.Set<Gear>().Include(g => g.Squad).Concat(ss.Set<Gear>()),
                 expectedIncludes))).Message;
 
             Assert.Equal(
@@ -6360,10 +6343,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_with_order_by_constant(bool isAsync)
         {
-            return AssertIncludeQuery<Squad>(
+            return AssertIncludeQuery(
                 isAsync,
-                ss => ss.Include(s => s.Members).OrderBy(s => 42).Select(s => s),
-                expectedQuery: ss => ss,
+                ss => ss.Set<Squad>().Include(s => s.Members).OrderBy(s => 42).Select(s => s),
+                expectedQuery: ss => ss.Set<Squad>(),
                 new List<IExpectedInclude>
                 {
                     new ExpectedInclude<Squad>(s => s.Members, "Members")
@@ -6444,10 +6427,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_with_order_by_constant_null_of_non_mapped_type(bool isAsync)
         {
-            return AssertIncludeQuery<Squad>(
+            return AssertIncludeQuery(
                 isAsync,
-                ss => ss.Include(s => s.Members).OrderBy(s => (MyDTO)null),
-                expectedQuery: ss => ss,
+                ss => ss.Set<Squad>().Include(s => s.Members).OrderBy(s => (MyDTO)null),
+                expectedQuery: ss => ss.Set<Squad>(),
                 new List<IExpectedInclude>
                 {
                     new ExpectedInclude<Squad>(s => s.Members, "Members")
@@ -6524,9 +6507,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_OrderBy_aggregate(bool isAsync)
         {
-            return AssertIncludeQuery<Gear>(
+            return AssertIncludeQuery(
                 isAsync,
-                os => os.OfType<Officer>()
+                ss => ss.Set<Gear>().OfType<Officer>()
                     .Include(o => o.Reports)
                     .OrderBy(o => o.Weapons.Count).ThenBy(o => o.Nickname),
                 new List<IExpectedInclude>
@@ -6540,9 +6523,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_with_complex_OrderBy2(bool isAsync)
         {
-            return AssertIncludeQuery<Gear>(
+            return AssertIncludeQuery(
                 isAsync,
-                os => os.OfType<Officer>()
+                ss => ss.Set<Gear>().OfType<Officer>()
                     .Include(o => o.Reports)
                     .OrderBy(o => o.Weapons.OrderBy(w => w.Id).FirstOrDefault().IsAutomatic).ThenBy(o => o.Nickname),
                 new List<IExpectedInclude>
@@ -6556,9 +6539,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_with_complex_OrderBy3(bool isAsync)
         {
-            return AssertIncludeQuery<Gear>(
+            return AssertIncludeQuery(
                 isAsync,
-                os => os.OfType<Officer>()
+                ss => ss.Set<Gear>().OfType<Officer>()
                     .Include(o => o.Reports)
                     .OrderBy(o => o.Weapons.OrderBy(w => w.Id).Select(w => w.IsAutomatic).FirstOrDefault()).ThenBy(o => o.Nickname),
                 new List<IExpectedInclude>
@@ -6620,103 +6603,103 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_subquery_boolean(bool isAsync)
         {
-            return AssertQueryScalar<Gear>(
+            return AssertQueryScalar(
                 isAsync,
-                gs => gs.Select(g => g.Weapons.OrderBy(w => w.Id).Select(w => w.IsAutomatic).FirstOrDefault()));
+                ss => ss.Set<Gear>().Select(g => g.Weapons.OrderBy(w => w.Id).Select(w => w.IsAutomatic).FirstOrDefault()));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_subquery_boolean_with_pushdown(bool isAsync)
         {
-            return AssertQueryScalar<Gear>(
+            return AssertQueryScalar(
                 isAsync,
-                gs => gs.Select(g => g.Weapons.OrderBy(w => w.Id).FirstOrDefault().IsAutomatic));
+                ss => ss.Set<Gear>().Select(g => g.Weapons.OrderBy(w => w.Id).FirstOrDefault().IsAutomatic));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_subquery_int_with_inside_cast_and_coalesce(bool isAsync)
         {
-            return AssertQueryScalar<Gear>(
+            return AssertQueryScalar(
                 isAsync,
-                gs => gs.Select(g => g.Weapons.OrderBy(w => w.Id).Select(w => (int?)w.Id).FirstOrDefault() ?? 42));
+                ss => ss.Set<Gear>().Select(g => g.Weapons.OrderBy(w => w.Id).Select(w => (int?)w.Id).FirstOrDefault() ?? 42));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_subquery_int_with_outside_cast_and_coalesce(bool isAsync)
         {
-            return AssertQueryScalar<Gear>(
+            return AssertQueryScalar(
                 isAsync,
-                gs => gs.Select(g => (int?)g.Weapons.OrderBy(w => w.Id).Select(w => w.Id).FirstOrDefault() ?? 42));
+                ss => ss.Set<Gear>().Select(g => (int?)g.Weapons.OrderBy(w => w.Id).Select(w => w.Id).FirstOrDefault() ?? 42));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_subquery_int_with_pushdown_and_coalesce(bool isAsync)
         {
-            return AssertQueryScalar<Gear>(
+            return AssertQueryScalar(
                 isAsync,
-                gs => gs.Select(g => (int?)g.Weapons.OrderBy(w => w.Id).FirstOrDefault().Id ?? 42));
+                ss => ss.Set<Gear>().Select(g => (int?)g.Weapons.OrderBy(w => w.Id).FirstOrDefault().Id ?? 42));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_subquery_int_with_pushdown_and_coalesce2(bool isAsync)
         {
-            return AssertQueryScalar<Gear>(
+            return AssertQueryScalar(
                 isAsync,
-                gs => gs.Select(g => (int?)g.Weapons.OrderBy(w => w.Id).FirstOrDefault().Id ?? g.Weapons.OrderBy(w => w.Id).FirstOrDefault().Id));
+                ss => ss.Set<Gear>().Select(g => (int?)g.Weapons.OrderBy(w => w.Id).FirstOrDefault().Id ?? g.Weapons.OrderBy(w => w.Id).FirstOrDefault().Id));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_subquery_boolean_empty(bool isAsync)
         {
-            return AssertQueryScalar<Gear>(
+            return AssertQueryScalar(
                 isAsync,
-                gs => gs.Select(g => g.Weapons.Where(w => w.Name == "BFG").OrderBy(w => w.Id).Select(w => w.IsAutomatic).FirstOrDefault()));
+                ss => ss.Set<Gear>().Select(g => g.Weapons.Where(w => w.Name == "BFG").OrderBy(w => w.Id).Select(w => w.IsAutomatic).FirstOrDefault()));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_subquery_boolean_empty_with_pushdown(bool isAsync)
         {
-            return AssertQueryScalar<Gear>(
+            return AssertQueryScalar(
                 isAsync,
-                gs => gs.Select(g => (bool?)g.Weapons.Where(w => w.Name == "BFG").OrderBy(w => w.Id).FirstOrDefault().IsAutomatic),
-                gs => gs.Select(g => (bool?)null));
+                ss => ss.Set<Gear>().Select(g => (bool?)g.Weapons.Where(w => w.Name == "BFG").OrderBy(w => w.Id).FirstOrDefault().IsAutomatic),
+                ss => ss.Set<Gear>().Select(g => (bool?)null));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_subquery_boolean_empty_with_pushdown_without_convert_to_nullable1(bool isAsync)
         {
-            return AssertQueryScalar<Gear>(
+            return AssertQueryScalar(
                 isAsync,
-                gs => gs.Select(g => g.Weapons.Where(w => w.Name == "BFG").OrderBy(w => w.Id).FirstOrDefault().IsAutomatic),
-                gs => gs.Select(g => false));
+                ss => ss.Set<Gear>().Select(g => g.Weapons.Where(w => w.Name == "BFG").OrderBy(w => w.Id).FirstOrDefault().IsAutomatic),
+                ss => ss.Set<Gear>().Select(g => false));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_subquery_boolean_empty_with_pushdown_without_convert_to_nullable2(bool isAsync)
         {
-            return AssertQueryScalar<Gear>(
+            return AssertQueryScalar(
                 isAsync,
-                gs => gs.Select(g => g.Weapons.Where(w => w.Name == "BFG").OrderBy(w => w.Id).FirstOrDefault().Id),
-                gs => gs.Select(g => 0));
+                ss => ss.Set<Gear>().Select(g => g.Weapons.Where(w => w.Name == "BFG").OrderBy(w => w.Id).FirstOrDefault().Id),
+                ss => ss.Set<Gear>().Select(g => 0));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_subquery_distinct_singleordefault_boolean1(bool isAsync)
         {
-            return AssertQueryScalar<Gear>(
+            return AssertQueryScalar(
                 isAsync,
-                gs => gs.Where(g => g.HasSoulPatch).Select(
-                    g => g.Weapons.Where(w => w.Name.Contains("Lancer")).Distinct().Select(w => w.IsAutomatic).SingleOrDefault()),
+                ss => ss.Set<Gear>().Where(g => g.HasSoulPatch)
+                    .Select(g => g.Weapons.Where(w => w.Name.Contains("Lancer")).Distinct().Select(w => w.IsAutomatic).SingleOrDefault()),
                 assertOrder: true);
         }
 
@@ -6724,10 +6707,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_subquery_distinct_singleordefault_boolean2(bool isAsync)
         {
-            return AssertQueryScalar<Gear>(
+            return AssertQueryScalar(
                 isAsync,
-                gs => gs.Where(g => g.HasSoulPatch).Select(
-                    g => g.Weapons.Where(w => w.Name.Contains("Lancer")).Select(w => w.IsAutomatic).Distinct().SingleOrDefault()),
+                ss => ss.Set<Gear>().Where(g => g.HasSoulPatch)
+                    .Select(g => g.Weapons.Where(w => w.Name.Contains("Lancer")).Select(w => w.IsAutomatic).Distinct().SingleOrDefault()),
                 assertOrder: true);
         }
 
@@ -6735,10 +6718,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_subquery_distinct_singleordefault_boolean_with_pushdown(bool isAsync)
         {
-            return AssertQueryScalar<Gear>(
+            return AssertQueryScalar(
                 isAsync,
-                gs => gs.Where(g => g.HasSoulPatch).Select(
-                    g => g.Weapons.Where(w => w.Name.Contains("Lancer")).Distinct().SingleOrDefault().IsAutomatic),
+                ss => ss.Set<Gear>().Where(g => g.HasSoulPatch)
+                    .Select(g => g.Weapons.Where(w => w.Name.Contains("Lancer")).Distinct().SingleOrDefault().IsAutomatic),
                 assertOrder: true);
         }
 
@@ -6746,31 +6729,31 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_subquery_distinct_singleordefault_boolean_empty1(bool isAsync)
         {
-            return AssertQueryScalar<Gear>(
+            return AssertQueryScalar(
                 isAsync,
-                gs => gs.Where(g => g.HasSoulPatch).Select(
-                    g => g.Weapons.Where(w => w.Name == "BFG").Distinct().Select(w => w.IsAutomatic).SingleOrDefault()));
+                ss => ss.Set<Gear>().Where(g => g.HasSoulPatch)
+                    .Select(g => g.Weapons.Where(w => w.Name == "BFG").Distinct().Select(w => w.IsAutomatic).SingleOrDefault()));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_subquery_distinct_singleordefault_boolean_empty2(bool isAsync)
         {
-            return AssertQueryScalar<Gear>(
+            return AssertQueryScalar(
                 isAsync,
-                gs => gs.Where(g => g.HasSoulPatch).Select(
-                    g => g.Weapons.Where(w => w.Name == "BFG").Select(w => w.IsAutomatic).Distinct().SingleOrDefault()));
+                ss => ss.Set<Gear>().Where(g => g.HasSoulPatch)
+                    .Select(g => g.Weapons.Where(w => w.Name == "BFG").Select(w => w.IsAutomatic).Distinct().SingleOrDefault()));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_subquery_distinct_singleordefault_boolean_empty_with_pushdown(bool isAsync)
         {
-            return AssertQueryScalar<Gear>(
+            return AssertQueryScalar(
                 isAsync,
-                gs => gs.Where(g => g.HasSoulPatch)
+                ss => ss.Set<Gear>().Where(g => g.HasSoulPatch)
                     .Select(g => (bool?)g.Weapons.Where(w => w.Name == "BFG").Distinct().SingleOrDefault().IsAutomatic),
-                gs => gs.Where(g => g.HasSoulPatch).Select(g => (bool?)null),
+                ss => ss.Set<Gear>().Where(g => g.HasSoulPatch).Select(g => (bool?)null),
                 assertOrder: true);
         }
 
@@ -6956,9 +6939,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Time_of_day_datetimeoffset(bool isAsync)
         {
-            return AssertQueryScalar<Mission>(
+            return AssertQueryScalar(
                 isAsync,
-                ms => from m in ms
+                ss => from m in ss.Set<Mission>()
                       select m.Timeline.TimeOfDay);
         }
 
@@ -6966,54 +6949,54 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_Include_Select_Average(bool isAsync)
         {
-            return AssertQueryScalar<Gear>(
+            return AssertQueryScalar(
                 isAsync,
-                gs => gs.Include(g => g.CityOfBirth).GroupBy(g => g.Rank).Select(g => g.Average(gg => gg.SquadId)));
+                ss => ss.Set<Gear>().Include(g => g.CityOfBirth).GroupBy(g => g.Rank).Select(g => g.Average(gg => gg.SquadId)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_Include_Select_Sum(bool isAsync)
         {
-            return AssertQueryScalar<Gear>(
+            return AssertQueryScalar(
                 isAsync,
-                gs => gs.Include(g => g.CityOfBirth).GroupBy(g => g.Rank).Select(g => g.Sum(gg => gg.SquadId)));
+                ss => ss.Set<Gear>().Include(g => g.CityOfBirth).GroupBy(g => g.Rank).Select(g => g.Sum(gg => gg.SquadId)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_Include_Select_Count(bool isAsync)
         {
-            return AssertQueryScalar<Gear>(
+            return AssertQueryScalar(
                 isAsync,
-                gs => gs.Include(g => g.CityOfBirth).GroupBy(g => g.Rank).Select(g => g.Count()));
+                ss => ss.Set<Gear>().Include(g => g.CityOfBirth).GroupBy(g => g.Rank).Select(g => g.Count()));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_Include_Select_LongCount(bool isAsync)
         {
-            return AssertQueryScalar<Gear>(
+            return AssertQueryScalar(
                 isAsync,
-                gs => gs.Include(g => g.CityOfBirth).GroupBy(g => g.Rank).Select(g => g.LongCount()));
+                ss => ss.Set<Gear>().Include(g => g.CityOfBirth).GroupBy(g => g.Rank).Select(g => g.LongCount()));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_Include_Select_Max(bool isAsync)
         {
-            return AssertQueryScalar<Gear>(
+            return AssertQueryScalar(
                 isAsync,
-                gs => gs.Include(g => g.CityOfBirth).GroupBy(g => g.Rank).Select(g => g.Max(gg => gg.SquadId)));
+                ss => ss.Set<Gear>().Include(g => g.CityOfBirth).GroupBy(g => g.Rank).Select(g => g.Max(gg => gg.SquadId)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_Include_Select_Min(bool isAsync)
         {
-            return AssertQueryScalar<Gear>(
+            return AssertQueryScalar(
                 isAsync,
-                gs => gs.Include(g => g.CityOfBirth).GroupBy(g => g.Rank).Select(g => g.Min(gg => gg.SquadId)));
+                ss => ss.Set<Gear>().Include(g => g.CityOfBirth).GroupBy(g => g.Rank).Select(g => g.Min(gg => gg.SquadId)));
         }
 
         [ConditionalTheory]
@@ -7114,9 +7097,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Officer>(e => e.CityOfBirth, "CityOfBirth")
             };
 
-            return AssertIncludeQuery<Gear>(
+            return AssertIncludeQuery(
                 isAsync,
-                gs => gs.Include(g => g.CityOfBirth).GroupBy(g => g.Rank).Select(g => g.FirstOrDefault(gg => gg.HasSoulPatch)),
+                ss => ss.Set<Gear>().Include(g => g.CityOfBirth).GroupBy(g => g.Rank).Select(g => g.FirstOrDefault(gg => gg.HasSoulPatch)),
                 expectedIncludes);
         }
 
@@ -7124,9 +7107,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_with_Cast_to_base(bool isAsync)
         {
-            return AssertIncludeQuery<Gear>(
+            return AssertIncludeQuery(
                 isAsync,
-                gs => gs.OfType<Officer>().Include(o => o.Weapons).Cast<Gear>(),
+                ss => ss.Set<Gear>().OfType<Officer>().Include(o => o.Weapons).Cast<Gear>(),
                 new List<IExpectedInclude> { new ExpectedInclude<Gear>(e => e.Weapons, "Weapons") });
         }
 
@@ -7183,9 +7166,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task OrderBy_same_expression_containing_IsNull_correctly_deduplicates_the_ordering(bool isAsync)
         {
-            return AssertQueryScalar<Gear>(
+            return AssertQueryScalar(
                 isAsync,
-                gs => gs.Select(g => g.LeaderNickname != null ? (bool?)(g.Nickname.Length == 5) : (bool?)null).OrderBy(e => e.HasValue)
+                ss => ss.Set<Gear>().Select(g => g.LeaderNickname != null ? (bool?)(g.Nickname.Length == 5) : (bool?)null)
+                    .OrderBy(e => e.HasValue)
                     .ThenBy(e => e.HasValue).Select(e => e));
         }
 
@@ -7193,9 +7177,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GetValueOrDefault_in_projection(bool isAsync)
         {
-            return AssertQueryScalar<Weapon>(
+            return AssertQueryScalar(
                 isAsync,
-                ws => ws.Select(w => w.SynergyWithId.GetValueOrDefault()));
+                ss => ss.Set<Weapon>().Select(w => w.SynergyWithId.GetValueOrDefault()));
         }
 
         [ConditionalTheory]
@@ -7554,8 +7538,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => from t in ss.Set<CogTag>()
                       where t.Gear is Officer
                       select Maybe(t.Gear, () => ((Officer)t.Gear).Reports.Take(50)),
-                elementSorter: e => ((IEnumerable<Gear>)e)?.Count() ?? 0,
-                elementAsserter: (e, a) => AssertCollection<Gear>(e, a));
+                elementSorter: e => e?.Count() ?? 0,
+                elementAsserter: (e, a) => AssertCollection(e, a));
         }
 
         [ConditionalTheory]
@@ -7570,8 +7554,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => from t in ss.Set<CogTag>()
                       where t.Gear is Officer
                       select Maybe(t.Gear, () => ((Officer)t.Gear).Reports),
-                elementSorter: e => ((IEnumerable<Gear>)e)?.Count() ?? 0,
-                elementAsserter: (e, a) => AssertCollection<Gear>(e, a));
+                elementSorter: e => e?.Count ?? 0,
+                elementAsserter: (e, a) => AssertCollection(e, a));
         }
 
         [ConditionalTheory]
@@ -7592,7 +7576,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.key, a.key);
-                    AssertCollection<Gear>(e.collection, a.collection);
+                    AssertCollection(e.collection, a.collection);
                 });
         }
 
@@ -7715,9 +7699,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_datetimeoffset_comparison_in_projection(bool isAsync)
         {
-            return AssertQueryScalar<Mission>(
+            return AssertQueryScalar(
                 isAsync,
-                ms => ms.Select(m => m.Timeline > DateTimeOffset.Now));
+                ss => ss.Set<Mission>().Select(m => m.Timeline > DateTimeOffset.Now));
         }
 
         [ConditionalTheory]
@@ -7763,23 +7747,16 @@ namespace Microsoft.EntityFrameworkCore.Query
                     })
                 }),
                 assertOrder: true,
-                elementAsserter: (e, a) => CollectionAsserter<dynamic>(
-                    ea => ea.Id,
-                    (ee, aa) =>
-                    {
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.IsAutomatic, aa.IsAutomatic);
-                        Assert.Equal(ee.Name, aa.Name);
-                    })(e.Weapons, a.Weapons));
+                elementAsserter: (e, a) => AssertCollection(e.Weapons, a.Weapons, elementSorter: ee => ee.Id));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Reference_include_chain_loads_correctly_when_middle_is_null(bool isAsync)
         {
-            return AssertIncludeQuery<CogTag>(
+            return AssertIncludeQuery(
                 isAsync,
-                ts => ts.AsTracking().OrderBy(t => t.Note).Include(t => t.Gear).ThenInclude(g => g.Squad),
+                ss => ss.Set<CogTag>().AsTracking().OrderBy(t => t.Note).Include(t => t.Gear).ThenInclude(g => g.Squad),
                 new List<IExpectedInclude>
                 {
                     new ExpectedInclude<CogTag>(t => t.Gear, "Gear"),
@@ -7802,9 +7779,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                             : null
                     }),
                 assertOrder: true,
-                elementAsserter: (e,a) => CollectionAsserter<dynamic>(
-                    ee => ee.Nickname,
-                    (ee, aa) => Assert.Equal(ee.Nickname, aa.Nickname))(e.Items, a.Items));
+                elementAsserter: (e, a) => AssertCollection(e.Items, a.Items, elementSorter: ee => ee.Nickname));
         }
 
         [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
@@ -8,8 +8,6 @@ using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
-// ReSharper disable InconsistentNaming
-
 namespace Microsoft.EntityFrameworkCore.Query
 {
     public abstract class GroupByQueryTestBase<TFixture> : QueryTestBase<TFixture>
@@ -32,18 +30,18 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_Select_Average(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(o => o.CustomerID).Select(g => g.Average(o => o.OrderID)));
+                ss => ss.Set<Order>().GroupBy(o => o.CustomerID).Select(g => g.Average(o => o.OrderID)));
         }
 
         [ConditionalTheory(Skip = "issue #17068")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_Select_Average_with_navigation_expansion(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.Where(o => o.Customer.City != "London")
+                ss => ss.Set<Order>().Where(o => o.Customer.City != "London")
                     .GroupBy(o => o.CustomerID, (k, es) => new { k, es })
                     .Select(g => g.es.Average(o => o.OrderID)));
         }
@@ -52,45 +50,45 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_Select_Count(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(o => o.CustomerID).Select(g => g.Count()));
+                ss => ss.Set<Order>().GroupBy(o => o.CustomerID).Select(g => g.Count()));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_Select_LongCount(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(o => o.CustomerID).Select(g => g.LongCount()));
+                ss => ss.Set<Order>().GroupBy(o => o.CustomerID).Select(g => g.LongCount()));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_Select_Max(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(o => o.CustomerID).Select(g => g.Max(o => o.OrderID)));
+                ss => ss.Set<Order>().GroupBy(o => o.CustomerID).Select(g => g.Max(o => o.OrderID)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_Select_Min(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(o => o.CustomerID).Select(g => g.Min(o => o.OrderID)));
+                ss => ss.Set<Order>().GroupBy(o => o.CustomerID).Select(g => g.Min(o => o.OrderID)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_Select_Sum(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(
+                ss => ss.Set<Order>().GroupBy(
                     o => EF.Property<string>(o, "CustomerID")).Select(g => g.Sum(o => o.OrderID)));
         }
 
@@ -282,9 +280,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_anonymous_Select_Average(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(
+                ss => ss.Set<Order>().GroupBy(
                     o => new { o.CustomerID }).Select(g => g.Average(o => o.OrderID)));
         }
 
@@ -292,9 +290,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_anonymous_Select_Count(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(
+                ss => ss.Set<Order>().GroupBy(
                     o => new { o.CustomerID }).Select(g => g.Count()));
         }
 
@@ -302,9 +300,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_anonymous_Select_LongCount(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(
+                ss => ss.Set<Order>().GroupBy(
                     o => new { o.CustomerID }).Select(g => g.LongCount()));
         }
 
@@ -312,9 +310,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_anonymous_Select_Max(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(
+                ss => ss.Set<Order>().GroupBy(
                     o => new { o.CustomerID }).Select(g => g.Max(o => o.OrderID)));
         }
 
@@ -322,9 +320,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_anonymous_Select_Min(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(
+                ss => ss.Set<Order>().GroupBy(
                     o => new { o.CustomerID }).Select(g => g.Min(o => o.OrderID)));
         }
 
@@ -332,9 +330,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_anonymous_Select_Sum(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(
+                ss => ss.Set<Order>().GroupBy(
                     o => new { o.CustomerID }).Select(g => g.Sum(o => o.OrderID)));
         }
 
@@ -373,9 +371,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Composite_Select_Average(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(
+                ss => ss.Set<Order>().GroupBy(
                     o => new { o.CustomerID, o.EmployeeID }).Select(g => g.Average(o => o.OrderID)));
         }
 
@@ -383,9 +381,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Composite_Select_Count(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(
+                ss => ss.Set<Order>().GroupBy(
                     o => new { o.CustomerID, o.EmployeeID }).Select(g => g.Count()));
         }
 
@@ -393,9 +391,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Composite_Select_LongCount(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(
+                ss => ss.Set<Order>().GroupBy(
                     o => new { o.CustomerID, o.EmployeeID }).Select(g => g.LongCount()));
         }
 
@@ -403,9 +401,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Composite_Select_Max(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(
+                ss => ss.Set<Order>().GroupBy(
                     o => new { o.CustomerID, o.EmployeeID }).Select(g => g.Max(o => o.OrderID)));
         }
 
@@ -413,9 +411,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Composite_Select_Min(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(
+                ss => ss.Set<Order>().GroupBy(
                     o => new { o.CustomerID, o.EmployeeID }).Select(g => g.Min(o => o.OrderID)));
         }
 
@@ -423,9 +421,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Composite_Select_Sum(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(
+                ss => ss.Set<Order>().GroupBy(
                     o => new { o.CustomerID, o.EmployeeID }).Select(g => g.Sum(o => o.OrderID)));
         }
 
@@ -879,54 +877,54 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_scalar_element_selector_Average(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(o => o.CustomerID, o => o.OrderID).Select(g => g.Average()));
+                ss => ss.Set<Order>().GroupBy(o => o.CustomerID, o => o.OrderID).Select(g => g.Average()));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_scalar_element_selector_Count(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(o => o.CustomerID, o => o.OrderID).Select(g => g.Count()));
+                ss => ss.Set<Order>().GroupBy(o => o.CustomerID, o => o.OrderID).Select(g => g.Count()));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_scalar_element_selector_LongCount(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(o => o.CustomerID, o => o.OrderID).Select(g => g.LongCount()));
+                ss => ss.Set<Order>().GroupBy(o => o.CustomerID, o => o.OrderID).Select(g => g.LongCount()));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_scalar_element_selector_Max(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(o => o.CustomerID, o => o.OrderID).Select(g => g.Max()));
+                ss => ss.Set<Order>().GroupBy(o => o.CustomerID, o => o.OrderID).Select(g => g.Max()));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_scalar_element_selector_Min(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(o => o.CustomerID, o => o.OrderID).Select(g => g.Min()));
+                ss => ss.Set<Order>().GroupBy(o => o.CustomerID, o => o.OrderID).Select(g => g.Min()));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_scalar_element_selector_Sum(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(o => o.CustomerID, o => o.OrderID).Select(g => g.Sum()));
+                ss => ss.Set<Order>().GroupBy(o => o.CustomerID, o => o.OrderID).Select(g => g.Sum()));
         }
 
         [ConditionalTheory]
@@ -945,9 +943,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_anonymous_element_selector_Average(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(
+                ss => ss.Set<Order>().GroupBy(
                     o => o.CustomerID, o => new { o.OrderID, o.EmployeeID }).Select(g => g.Average(o => o.OrderID)));
         }
 
@@ -955,9 +953,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_anonymous_element_selector_Count(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(
+                ss => ss.Set<Order>().GroupBy(
                     o => o.CustomerID, o => new { o.OrderID, o.EmployeeID }).Select(g => g.Count()));
         }
 
@@ -965,9 +963,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_anonymous_element_selector_LongCount(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(
+                ss => ss.Set<Order>().GroupBy(
                     o => o.CustomerID, o => new { o.OrderID, o.EmployeeID }).Select(g => g.LongCount()));
         }
 
@@ -975,9 +973,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_anonymous_element_selector_Max(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(
+                ss => ss.Set<Order>().GroupBy(
                     o => o.CustomerID, o => new { o.OrderID, o.EmployeeID }).Select(g => g.Max(o => o.OrderID)));
         }
 
@@ -985,9 +983,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_anonymous_element_selector_Min(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(
+                ss => ss.Set<Order>().GroupBy(
                     o => o.CustomerID, o => new { o.OrderID, o.EmployeeID }).Select(g => g.Min(o => o.OrderID)));
         }
 
@@ -995,9 +993,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Property_anonymous_element_selector_Sum(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(
+                ss => ss.Set<Order>().GroupBy(
                     o => o.CustomerID, o => new { o.OrderID, o.EmployeeID }).Select(g => g.Sum(o => o.OrderID)));
         }
 
@@ -1024,9 +1022,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_element_selector_complex_aggregate(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(o => o.CustomerID, o => new { o.OrderID })
+                ss => ss.Set<Order>().GroupBy(o => o.CustomerID, o => new { o.OrderID })
                     .Select(g => g.Sum(e => e.OrderID + 1)));
         }
 
@@ -1034,9 +1032,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_element_selector_complex_aggregate2(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(o => o.CustomerID, o => new { o.OrderID, o.OrderDate })
+                ss => ss.Set<Order>().GroupBy(o => o.CustomerID, o => new { o.OrderID, o.OrderDate })
                     .Select(g => g.Sum(e => e.OrderID + 1)));
         }
 
@@ -1044,9 +1042,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_element_selector_complex_aggregate3(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(o => o.CustomerID, o => o.OrderID)
+                ss => ss.Set<Order>().GroupBy(o => o.CustomerID, o => o.OrderID)
                     .Select(g => g.Sum(e => e + 1)));
         }
 
@@ -1054,9 +1052,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_element_selector_complex_aggregate4(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(o => o.CustomerID, o => o.OrderID + 1)
+                ss => ss.Set<Order>().GroupBy(o => o.CustomerID, o => o.OrderID + 1)
                     .Select(g => g.Sum(e => e)));
         }
 
@@ -1068,12 +1066,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_empty_key_Aggregate(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os =>
-                    os.GroupBy(
-                            o => new { })
-                        .Select(g => g.Sum(o => o.OrderID)));
+                ss => ss.Set<Order>().GroupBy(o => new { })
+                    .Select(g => g.Sum(o => o.OrderID)));
         }
 
         [ConditionalTheory]
@@ -1090,52 +1086,48 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task OrderBy_GroupBy_Aggregate(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os =>
-                    os.OrderBy(o => o.OrderID)
-                        .GroupBy(o => o.CustomerID)
-                        .Select(g => g.Sum(o => o.OrderID)));
+                ss => ss.Set<Order>().OrderBy(o => o.OrderID)
+                    .GroupBy(o => o.CustomerID)
+                    .Select(g => g.Sum(o => o.OrderID)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task OrderBy_Skip_GroupBy_Aggregate(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os =>
-                    os.OrderBy(o => o.OrderID)
-                        .Skip(80)
-                        .GroupBy(o => o.CustomerID)
-                        .Select(g => g.Average(o => o.OrderID)));
+                ss => ss.Set<Order>().OrderBy(o => o.OrderID)
+                    .Skip(80)
+                    .GroupBy(o => o.CustomerID)
+                    .Select(g => g.Average(o => o.OrderID)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task OrderBy_Take_GroupBy_Aggregate(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os =>
-                    os.OrderBy(o => o.OrderID)
-                        .Take(500)
-                        .GroupBy(o => o.CustomerID)
-                        .Select(g => g.Min(o => o.OrderID)));
+                ss => ss.Set<Order>().OrderBy(o => o.OrderID)
+                    .Take(500)
+                    .GroupBy(o => o.CustomerID)
+                    .Select(g => g.Min(o => o.OrderID)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task OrderBy_Skip_Take_GroupBy_Aggregate(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os =>
-                    os.OrderBy(o => o.OrderID)
-                        .Skip(80)
-                        .Take(500)
-                        .GroupBy(o => o.CustomerID)
-                        .Select(g => g.Max(o => o.OrderID)));
+                ss => ss.Set<Order>().OrderBy(o => o.OrderID)
+                    .Skip(80)
+                    .Take(500)
+                    .GroupBy(o => o.CustomerID)
+                    .Select(g => g.Max(o => o.OrderID)));
         }
 
         [ConditionalTheory]
@@ -1474,9 +1466,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_aggregate_Pushdown_followed_by_projecting_Length(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(e => e.CustomerID)
+                ss => ss.Set<Order>().GroupBy(e => e.CustomerID)
                     .Where(g => g.Count() > 10)
                     .Select(g => g.Key)
                     .OrderBy(t => t)
@@ -1489,9 +1481,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_aggregate_Pushdown_followed_by_projecting_constant(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(e => e.CustomerID)
+                ss => ss.Set<Order>().GroupBy(e => e.CustomerID)
                     .Where(g => g.Count() > 10)
                     .Select(g => g.Key)
                     .OrderBy(t => t)
@@ -1677,18 +1669,18 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Sum_constant(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(o => o.CustomerID).Select(g => g.Sum(e => 1)));
+                ss => ss.Set<Order>().GroupBy(o => o.CustomerID).Select(g => g.Sum(e => 1)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Sum_constant_cast(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.GroupBy(o => o.CustomerID).Select(g => g.Sum(e => 1L)));
+                ss => ss.Set<Order>().GroupBy(o => o.CustomerID).Select(g => g.Sum(e => 1L)));
         }
 
         [ConditionalTheory]
@@ -1750,9 +1742,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Where_in_aggregate(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => from o in os
+                ss => from o in ss.Set<Order>()
                       group o by new { o.CustomerID }
                       into g
                       select g.Where(e => e.OrderID < 10300).Count());
@@ -1793,8 +1785,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery(
                 isAsync,
                 ss => ss.Set<Customer>().Select(c => new { c.City, c.CustomerID }).GroupBy(a => a.City),
-                elementSorter: GroupingSorter<string, object>(),
-                elementAsserter: GroupingAsserter<string, dynamic>(d => d.CustomerID));
+                elementSorter: e => e.Key,
+                elementAsserter: (e, a) => AssertGrouping(e, a));
         }
 
         [ConditionalTheory(Skip = "Issue #17068")]
@@ -1807,8 +1799,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<Customer>().Where(c => countries.Contains(c.Country))
                     .Select(c => new { c.City, c.CustomerID })
                     .GroupBy(a => a.City),
-                elementSorter: GroupingSorter<string, object>(),
-                elementAsserter: GroupingAsserter<string, dynamic>(d => d.CustomerID));
+                elementSorter: e => e.Key,
+                elementAsserter: (e, a) => AssertGrouping(e, a));
         }
 
         [ConditionalTheory(Skip = "Issue #17068")]
@@ -1847,9 +1839,10 @@ namespace Microsoft.EntityFrameworkCore.Query
                      from orderDetail in orderJoin.DefaultIfEmpty()
                      group new { orderDetail.ProductID, orderDetail.Quantity, orderDetail.UnitPrice } by new
                      {
-                         order.OrderID, order.OrderDate
+                         order.OrderID,
+                         order.OrderDate
                      }).Where(x => x.Key.OrderID == 10248),
-                elementAsserter: GroupingAsserter<dynamic, dynamic>(d => d.ProductID));
+                elementAsserter: (e, a) => AssertGrouping(e, a));
         }
 
         [ConditionalTheory(Skip = "Issue #17068")]
@@ -1869,8 +1862,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery(
                 isAsync,
                 ss => ss.Set<Order>().GroupBy(o => o.CustomerID),
-                elementSorter: GroupingSorter<string, Order>(),
-                elementAsserter: GroupingAsserter<string, Order>(o => o.OrderID),
+                elementSorter: e => e.Key,
+                elementAsserter: (e, a) => AssertGrouping(e, a),
                 entryCount: 830);
         }
 
@@ -1881,8 +1874,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery(
                 isAsync,
                 ss => ss.Set<Order>().GroupBy(o => o.CustomerID).Select(g => g),
-                elementSorter: GroupingSorter<string, Order>(),
-                elementAsserter: GroupingAsserter<string, Order>(o => o.OrderID),
+                elementSorter: e => e.Key,
+                elementAsserter: (e, a) => AssertGrouping(e, a),
                 entryCount: 830);
         }
 
@@ -1893,7 +1886,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertFirst(
                 isAsync,
                 ss => ss.Set<Order>().Where(o => o.CustomerID == "ALFKI").GroupBy(o => o.CustomerID).Cast<object>(),
-                asserter: GroupingAsserter<string, Order>(o => o.OrderID),
+                asserter: (e, a) => AssertGrouping((IGrouping<string, Order>)e, (IGrouping<string, Order>)a),
                 entryCount: 6);
         }
 
@@ -1907,7 +1900,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .OrderBy(g => g.Key)
                     .Select(g => g.OrderBy(o => o)),
                 assertOrder: true,
-                elementAsserter: (e, a) => AssertCollection<int>(e, a, ordered: true));
+                elementAsserter: (e, a) => AssertCollection(e, a, ordered: true));
         }
 
         [ConditionalTheory(Skip = "Issue #17068")]
@@ -1920,7 +1913,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .OrderBy(g => g.Key)
                     .Select(g => g.OrderBy(o => o.OrderID)),
                 assertOrder: true,
-                elementAsserter: (e, a) => AssertCollection<Order>(e, a, ordered: true));
+                elementAsserter: (e, a) => AssertCollection(e, a, ordered: true));
         }
 
         [ConditionalTheory(Skip = "Issue #17068")]
@@ -1944,8 +1937,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery(
                 isAsync,
                 ss => ss.Set<Order>().Where(o => o.OrderDate.HasValue).GroupBy(o => o.OrderDate.Value.Month),
-                e => ((IGrouping<int, Order>)e).Key,
-                elementAsserter: GroupingAsserter<int, Order>(o => o.OrderID),
+                e => e.Key,
+                elementAsserter: (e, a) => AssertGrouping(e, a),
                 entryCount: 830);
         }
 
@@ -1981,7 +1974,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 ss => ss.Set<Order>().OrderBy(o => o.OrderID).GroupBy(o => o.CustomerID).OrderBy(g => g.Key),
                 assertOrder: true,
-                elementAsserter: GroupingAsserter<string, Order>(),
+                elementAsserter: (e, a) => AssertGrouping(e, a),
                 entryCount: 830);
         }
 
@@ -1991,13 +1984,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 isAsync,
-                ss => ss.Set<Order>().GroupBy(o => o.CustomerID).OrderBy(g => g.Key).Select(
-                    g => new { Foo = "Foo", Group = g }),
-                e => GroupingSorter<string, object>()(e.Group),
+                ss => ss.Set<Order>().GroupBy(o => o.CustomerID).OrderBy(g => g.Key).Select(g => new { Foo = "Foo", Group = g }),
+                elementSorter: e => e.Group.Key,
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.Foo, a.Foo);
-                    Assert.Equal(e.Group.OrderBy(p => p.OrderID), a.Group.OrderBy(p => p.OrderID));
+                    AssertGrouping(e.Group, a.Group);
                 },
                 entryCount: 830);
         }
@@ -2010,7 +2002,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 ss => ss.Set<Order>().GroupBy(o => o.CustomerID).OrderBy(g => g.Key).Take(5).Skip(3).Distinct(),
                 assertOrder: true,
-                elementAsserter: GroupingAsserter<string, Order>(o => o.OrderID),
+                elementAsserter: (e, a) => AssertGrouping(e, a),
                 entryCount: 31);
         }
 
@@ -2022,7 +2014,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 ss => ss.Set<Order>().GroupBy(o => o.CustomerID).OrderBy(g => g.Key).Take(5).Skip(3).Distinct().Select(g => g.Key),
                 assertOrder: true,
-                elementAsserter: GroupingAsserter<string, Order>(o => o.OrderID),
                 entryCount: 31);
         }
 
@@ -2034,7 +2025,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 ss => ss.Set<Order>().GroupBy(o => o.CustomerID).OrderBy(g => g.Key).Take(5).Skip(3).Distinct().OrderBy(g => g.Key),
                 assertOrder: true,
-                elementAsserter: GroupingAsserter<string, Order>(o => o.OrderID),
+                elementAsserter: (e, a) => AssertGrouping(e, a),
                 entryCount: 31);
         }
 
@@ -2052,7 +2043,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                      {
                          order.OrderID, order.OrderDate
                      }).Where(x => x.Key.OrderID == 10248),
-                elementAsserter: GroupingAsserter<dynamic, dynamic>(d => d.ProductID));
+                elementSorter: e => (e.Key.OrderID, e.Key.OrderDate),
+                elementAsserter: (e, a) => AssertGrouping(e, a));
         }
 
         [ConditionalTheory(Skip = "Issue #17761")]
@@ -2071,8 +2063,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery(
                 isAsync,
                 ss => ss.Set<Order>().OrderBy(o => o.OrderDate).ThenBy(o => o.OrderID).Skip(800).GroupBy(o => o.CustomerID),
-                elementSorter: GroupingSorter<string, object>(),
-                elementAsserter: GroupingAsserter<string, dynamic>(d => d.OrderDate),
+                elementSorter: e => e.Key,
+                elementAsserter: (e, a) => AssertGrouping(e, a),
                 entryCount: 30);
         }
 
@@ -2083,8 +2075,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery(
                 isAsync,
                 ss => ss.Set<Order>().OrderBy(o => o.OrderDate).Take(50).GroupBy(o => o.CustomerID),
-                elementSorter: GroupingSorter<string, object>(),
-                elementAsserter: GroupingAsserter<string, dynamic>(d => d.OrderDate),
+                elementSorter: e => e.Key,
+                elementAsserter: (e, a) => AssertGrouping(e, a),
                 entryCount: 50);
         }
 
@@ -2095,8 +2087,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery(
                 isAsync,
                 ss => ss.Set<Order>().Where(o => o.CustomerID != "SAVEA").OrderBy(o => o.OrderDate).Skip(450).Take(50).GroupBy(o => o.CustomerID),
-                elementSorter: GroupingSorter<string, object>(),
-                elementAsserter: GroupingAsserter<string, dynamic>(d => d.OrderDate),
+                elementSorter: e => e.Key,
+                elementAsserter: (e, a) => AssertGrouping(e, a),
                 entryCount: 50);
         }
 
@@ -2108,8 +2100,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 ss => ss.Set<Order>().Select(
                     o => new { o.CustomerID, o.EmployeeID }).OrderBy(a => a.EmployeeID).Distinct().GroupBy(o => o.CustomerID),
-                elementSorter: GroupingSorter<string, object>(),
-                elementAsserter: GroupingAsserter<string, dynamic>(d => d.EmployeeID));
+                elementSorter: e => e.Key,
+                elementAsserter: (e, a) => AssertGrouping(e, a));
         }
 
         [ConditionalTheory(Skip = "Issue #17068")]
@@ -2182,8 +2174,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<Customer>().GroupBy(c => c.City)
                     .Select(g => g.OrderBy(c => c.CustomerID).First())
                     .GroupBy(c => c.ContactName),
-                elementSorter: GroupingSorter<string, object>(),
-                elementAsserter: GroupingAsserter<string, dynamic>(d => d.CustomerID));
+                elementSorter: e => e.Key,
+                elementAsserter: (e, a) => AssertGrouping(e, a));
         }
 
         [ConditionalTheory(Skip = "Issue #17068")]
@@ -2196,8 +2188,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Select(g => g.OrderBy(c => c.CustomerID).First())
                     .GroupBy(c => c.ContactName)
                     .Select(g => g),
-                elementSorter: GroupingSorter<string, object>(),
-                elementAsserter: GroupingAsserter<string, dynamic>(d => d.CustomerID));
+                elementSorter: e => e.Key,
+                elementAsserter: (e, a) => AssertGrouping(e, a));
         }
 
         #endregion
@@ -2268,23 +2260,23 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Count_after_GroupBy_aggregate(bool isAsync)
         {
-            return AssertSingleResult<Order>(
+            return AssertSingleResult(
                 isAsync,
-                os => os.GroupBy(o => o.CustomerID).Select(g => g.Sum(gg => gg.OrderID)).Count(),
-                os => os.GroupBy(o => o.CustomerID).Select(g => g.Sum(gg => gg.OrderID)).CountAsync());
+                ss => ss.Set<Order>().GroupBy(o => o.CustomerID).Select(g => g.Sum(gg => gg.OrderID)).Count(),
+                ss => ss.Set<Order>().GroupBy(o => o.CustomerID).Select(g => g.Sum(gg => gg.OrderID)).CountAsync());
         }
 
         [ConditionalTheory(Skip = "Issue #17068")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task LongCount_after_client_GroupBy(bool isAsync)
         {
-            return AssertSingleResult<Order>(
+            return AssertSingleResult(
                 isAsync,
-                os => (from o in os
+                ss => (from o in ss.Set<Order>()
                        group o by new { o.CustomerID }
                        into g
                        select g.Where(e => e.OrderID < 10300).Count()).LongCount(),
-                os => (from o in os
+                ss => (from o in ss.Set<Order>()
                        group o by new { o.CustomerID }
                        into g
                        select g.Where(e => e.OrderID < 10300).Count()).LongCountAsync());
@@ -2327,9 +2319,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual async Task Any_after_GroupBy_aggregate(bool isAsync)
         {
-            await AssertAny<Order, int>(
+            await AssertAny(
                 isAsync,
-                os => os.GroupBy(o => o.CustomerID).Select(g => g.Sum(gg => gg.OrderID)));
+                ss => ss.Set<Order>().GroupBy(o => o.CustomerID).Select(g => g.Sum(gg => gg.OrderID)));
         }
 
         [ConditionalTheory(Skip = "Issue#15097")]

--- a/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
@@ -143,16 +143,16 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 ss => ss.Set<OwnedPerson>().Where(p => p.Orders.Count > 0).OrderBy(p => p.Id).Select(p => p.Orders),
                 assertOrder: true,
-                elementAsserter: (e, a) => AssertCollection<Order>(e, a));
+                elementAsserter: (e, a) => AssertCollection(e, a));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Navigation_rewrite_on_owned_collection_with_composition(bool isAsync)
         {
-            return AssertQueryScalar<OwnedPerson>(
+            return AssertQueryScalar(
                 isAsync,
-                ops => ops.OrderBy(p => p.Id).Select(p => p.Orders.OrderBy(o => o.Id).Select(o => o.Id != 42).FirstOrDefault()));
+                ss => ss.Set<OwnedPerson>().OrderBy(p => p.Id).Select(p => p.Orders.OrderBy(o => o.Id).Select(o => o.Id != 42).FirstOrDefault()));
         }
 
         [ConditionalTheory]
@@ -201,7 +201,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 ss => ss.Set<OwnedPerson>().Where(p => p.PersonAddress.Country.Planet.Id != 42).OrderBy(p => p.Id).Select(p => new { p.Orders }),
                 assertOrder: true,
-                elementAsserter: (e, a) => AssertCollection<Order>(e.Orders, a.Orders));
+                elementAsserter: (e, a) => AssertCollection(e.Orders, a.Orders));
         }
 
         [ConditionalTheory]
@@ -214,9 +214,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true,
                 elementAsserter: (e, a) =>
                 {
-                    AssertCollection<Order>(e.Orders, a.Orders);
-                    AssertEqual<OwnedAddress>(e.PersonAddress, a.PersonAddress);
-                    AssertEqual<Planet>(e.Planet, a.Planet);
+                    AssertCollection(e.Orders, a.Orders);
+                    AssertEqual(e.PersonAddress, a.PersonAddress);
+                    AssertEqual(e.Planet, a.Planet);
                 });
         }
 
@@ -248,16 +248,16 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 ss => ss.Set<OwnedPerson>().Where(p => p.PersonAddress.Country.Planet.Id != 7).Select(p => new { p }),
                 elementSorter: e => e.p.Id,
-                elementAsserter: (e, a) => AssertEqual<OwnedPerson>(e.p, a.p));
+                elementAsserter: (e, a) => AssertEqual(e.p, a.p));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_property(bool isAsync)
         {
-            return AssertQueryScalar<OwnedPerson>(
+            return AssertQueryScalar(
                 isAsync,
-                ops => ops.Select(p => p.PersonAddress.Country.Planet.Id));
+                ss => ss.Set<OwnedPerson>().Select(p => p.PersonAddress.Country.Planet.Id));
         }
 
         [ConditionalTheory]
@@ -268,7 +268,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 ss => ss.Set<OwnedPerson>().OrderBy(p => p.Id).Select(p => p.PersonAddress.Country.Planet.Moons),
                 assertOrder: true,
-                elementAsserter: (e, a) => AssertCollection<Moon>(e, a));
+                elementAsserter: (e, a) => AssertCollection(e, a));
         }
 
         [ConditionalTheory]
@@ -293,9 +293,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_collection_count(bool isAsync)
         {
-            return AssertQueryScalar<OwnedPerson>(
+            return AssertQueryScalar(
                 isAsync,
-                ops => ops.Select(p => p.PersonAddress.Country.Planet.Moons.Count));
+                ss => ss.Set<OwnedPerson>().Select(p => p.PersonAddress.Country.Planet.Moons.Count));
         }
 
         [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/QueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/QueryTestBase.cs
@@ -21,727 +21,6 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         public static IEnumerable<object[]> IsAsyncData = new[] { new object[] { false }, new object[] { true } };
 
-        #region AssertAny
-
-        protected Task AssertAny<TItem1>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<object>> query)
-            where TItem1 : class
-            => AssertAny(isAsync, query, query);
-
-        protected Task AssertAny<TItem1>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<object>> actualQuery,
-            Func<IQueryable<TItem1>, IQueryable<object>> expectedQuery)
-            where TItem1 : class
-            => Fixture.QueryAsserter.AssertAny(actualQuery, expectedQuery, isAsync);
-
-        protected Task AssertAny<TItem1, TResult>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<TResult>> query)
-            where TItem1 : class
-            => AssertAny(isAsync, query, query);
-
-        protected Task AssertAny<TItem1, TResult>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<TResult>> actualQuery,
-            Func<IQueryable<TItem1>, IQueryable<TResult>> expectedQuery)
-            where TItem1 : class
-            => Fixture.QueryAsserter.AssertAny(actualQuery, expectedQuery, isAsync);
-
-        protected Task AssertAny<TItem1, TItem2>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> query)
-            where TItem1 : class
-            where TItem2 : class
-            => AssertAny(isAsync, query, query);
-
-        protected Task AssertAny<TItem1, TItem2>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> actualQuery,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> expectedQuery)
-            where TItem1 : class
-            where TItem2 : class
-            => Fixture.QueryAsserter.AssertAny(actualQuery, expectedQuery, isAsync);
-
-        protected Task AssertAny<TItem1, TItem2, TItem3>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<object>> query)
-            where TItem1 : class
-            where TItem2 : class
-            where TItem3 : class
-            => AssertAny(isAsync, query, query);
-
-        protected Task AssertAny<TItem1, TItem2, TItem3>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<object>> actualQuery,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<object>> expectedQuery)
-            where TItem1 : class
-            where TItem2 : class
-            where TItem3 : class
-            => Fixture.QueryAsserter.AssertAny(actualQuery, expectedQuery, isAsync);
-
-        protected Task AssertAny<TItem1, TPredicate>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<TPredicate>> query,
-            Expression<Func<TPredicate, bool>> predicate)
-            where TItem1 : class
-            => AssertAny(isAsync, query, query, predicate, predicate);
-
-        protected Task AssertAny<TItem1, TPredicate>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<TPredicate>> actualQuery,
-            Func<IQueryable<TItem1>, IQueryable<TPredicate>> expectedQuery,
-            Expression<Func<TPredicate, bool>> actualPredicate,
-            Expression<Func<TPredicate, bool>> expectedPredicate)
-            where TItem1 : class
-            => Fixture.QueryAsserter.AssertAny(actualQuery, expectedQuery, actualPredicate, expectedPredicate, isAsync);
-
-        #endregion
-
-        #region AssertAll
-
-        protected Task AssertAll<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> query,
-            Expression<Func<TResult, bool>> predicate)
-            => Fixture.QueryAsserter.AssertAll(
-                query, query, predicate, predicate, isAsync);
-
-        protected Task AssertAll<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> actualQuery,
-            Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Expression<Func<TResult, bool>> actualPredicate,
-            Expression<Func<TResult, bool>> expectedPredicate)
-            => Fixture.QueryAsserter.AssertAll(
-                actualQuery, expectedQuery, actualPredicate, expectedPredicate, isAsync);
-
-        #endregion
-
-        #region AssertFirst
-
-        protected Task AssertFirst<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> query,
-            Action<object, object> asserter = null,
-            int entryCount = 0)
-            => Fixture.QueryAsserter.AssertFirst(
-                query, query, asserter, entryCount, isAsync);
-
-        protected Task AssertFirst<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> actualQuery,
-            Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Action<object, object> asserter = null,
-            int entryCount = 0)
-            => Fixture.QueryAsserter.AssertFirst(
-                actualQuery, expectedQuery, asserter, entryCount, isAsync);
-
-        protected Task AssertFirst<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> query,
-            Expression<Func<TResult, bool>> predicate,
-            Action<object, object> asserter = null,
-            int entryCount = 0)
-            => Fixture.QueryAsserter.AssertFirst(
-                query, query, predicate, predicate, asserter, entryCount, isAsync);
-
-        protected Task AssertFirst<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> actualQuery,
-            Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Expression<Func<TResult, bool>> actualPredicate,
-            Expression<Func<TResult, bool>> expectedPredicate,
-            Action<object, object> asserter = null,
-            int entryCount = 0)
-            => Fixture.QueryAsserter.AssertFirst(
-                actualQuery, expectedQuery, actualPredicate, expectedPredicate, asserter, entryCount, isAsync);
-
-        #endregion
-
-        #region AssertFirstOrDefault
-
-        protected Task AssertFirstOrDefault<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> query,
-            Action<object, object> asserter = null,
-            int entryCount = 0)
-            => Fixture.QueryAsserter.AssertFirstOrDefault(
-                query, query, asserter, entryCount, isAsync);
-
-        protected Task AssertFirstOrDefault<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> actualQuery,
-            Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Action<object, object> asserter = null,
-            int entryCount = 0)
-            => Fixture.QueryAsserter.AssertFirstOrDefault(
-                actualQuery, expectedQuery, asserter, entryCount, isAsync);
-
-        protected Task AssertFirstOrDefault<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> query,
-            Expression<Func<TResult, bool>> predicate,
-            Action<object, object> asserter = null,
-            int entryCount = 0)
-            => Fixture.QueryAsserter.AssertFirstOrDefault(
-                query, query, predicate, predicate, asserter, entryCount, isAsync);
-
-        protected Task AssertFirstOrDefault<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> actualQuery,
-            Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Expression<Func<TResult, bool>> actualPredicate,
-            Expression<Func<TResult, bool>> expectedPredicate,
-            Action<object, object> asserter = null,
-            int entryCount = 0)
-            => Fixture.QueryAsserter.AssertFirstOrDefault(
-                actualQuery, expectedQuery, actualPredicate, expectedPredicate, asserter, entryCount, isAsync);
-
-        #endregion
-
-        #region AssertSingle
-
-        protected Task AssertSingle<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> query,
-            Action<object, object> asserter = null,
-            int entryCount = 0)
-            => Fixture.QueryAsserter.AssertSingle(
-                query, query, asserter, entryCount, isAsync);
-
-        protected Task AssertSingle<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> actualQuery,
-            Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Action<object, object> asserter = null,
-            int entryCount = 0)
-            => Fixture.QueryAsserter.AssertSingle(
-                actualQuery, expectedQuery, asserter, entryCount, isAsync);
-
-        protected Task AssertSingle<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> query,
-            Expression<Func<TResult, bool>> predicate,
-            Action<object, object> asserter = null,
-            int entryCount = 0)
-            => Fixture.QueryAsserter.AssertSingle(
-                query, query, predicate, predicate, asserter, entryCount, isAsync);
-
-        protected Task AssertSingle<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> actualQuery,
-            Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Expression<Func<TResult, bool>> actualPredicate,
-            Expression<Func<TResult, bool>> expectedPredicate,
-            Action<object, object> asserter = null,
-            int entryCount = 0)
-            => Fixture.QueryAsserter.AssertSingle(
-                actualQuery, expectedQuery, actualPredicate, expectedPredicate, asserter, entryCount, isAsync);
-
-        #endregion
-
-        #region AssertSingleOrDefault
-
-        protected Task AssertSingleOrDefault<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> query,
-            Action<object, object> asserter = null,
-            int entryCount = 0)
-            => Fixture.QueryAsserter.AssertSingleOrDefault(
-                query, query, asserter, entryCount, isAsync);
-
-        protected Task AssertSingleOrDefault<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> actualQuery,
-            Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Action<object, object> asserter = null,
-            int entryCount = 0)
-            => Fixture.QueryAsserter.AssertSingleOrDefault(
-                actualQuery, expectedQuery, asserter, entryCount, isAsync);
-
-        protected Task AssertSingleOrDefault<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> query,
-            Expression<Func<TResult, bool>> predicate,
-            Action<object, object> asserter = null,
-            int entryCount = 0)
-            => Fixture.QueryAsserter.AssertSingleOrDefault(
-                query, query, predicate, predicate, asserter, entryCount, isAsync);
-
-        protected Task AssertSingleOrDefault<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> actualQuery,
-            Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Expression<Func<TResult, bool>> actualPredicate,
-            Expression<Func<TResult, bool>> expectedPredicate,
-            Action<object, object> asserter = null,
-            int entryCount = 0)
-            => Fixture.QueryAsserter.AssertSingleOrDefault(
-                actualQuery, expectedQuery, actualPredicate, expectedPredicate, asserter, entryCount, isAsync);
-
-        #endregion
-
-        #region AssertLast
-
-        protected Task AssertLast<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> query,
-            Action<object, object> asserter = null,
-            int entryCount = 0)
-            => Fixture.QueryAsserter.AssertLast(
-                query, query, asserter, entryCount, isAsync);
-
-        protected Task AssertLast<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> actualQuery,
-            Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Action<object, object> asserter = null,
-            int entryCount = 0)
-            => Fixture.QueryAsserter.AssertLast(
-                actualQuery, expectedQuery, asserter, entryCount, isAsync);
-
-        protected Task AssertLast<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> query,
-            Expression<Func<TResult, bool>> predicate,
-            Action<object, object> asserter = null,
-            int entryCount = 0)
-            => Fixture.QueryAsserter.AssertLast(
-                query, query, predicate, predicate, asserter, entryCount, isAsync);
-
-        protected Task AssertLast<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> actualQuery,
-            Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Expression<Func<TResult, bool>> actualPredicate,
-            Expression<Func<TResult, bool>> expectedPredicate,
-            Action<object, object> asserter = null,
-            int entryCount = 0)
-            => Fixture.QueryAsserter.AssertLast(
-                actualQuery, expectedQuery, actualPredicate, expectedPredicate, asserter, entryCount, isAsync);
-
-        #endregion
-
-        #region AssertLastOrDefault
-
-        protected Task AssertLastOrDefault<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> query,
-            Action<object, object> asserter = null,
-            int entryCount = 0)
-            => Fixture.QueryAsserter.AssertLastOrDefault(
-                query, query, asserter, entryCount, isAsync);
-
-        protected Task AssertLastOrDefault<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> actualQuery,
-            Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Action<object, object> asserter = null,
-            int entryCount = 0)
-            => Fixture.QueryAsserter.AssertLastOrDefault(
-                actualQuery, expectedQuery, asserter, entryCount, isAsync);
-
-        protected Task AssertLastOrDefault<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> query,
-            Expression<Func<TResult, bool>> predicate,
-            Action<object, object> asserter = null,
-            int entryCount = 0)
-            => Fixture.QueryAsserter.AssertLastOrDefault(
-                query, query, predicate, predicate, asserter, entryCount, isAsync);
-
-        protected Task AssertLastOrDefault<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> actualQuery,
-            Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Expression<Func<TResult, bool>> actualPredicate,
-            Expression<Func<TResult, bool>> expectedPredicate,
-            Action<object, object> asserter = null,
-            int entryCount = 0)
-            => Fixture.QueryAsserter.AssertLastOrDefault(
-                actualQuery, expectedQuery, actualPredicate, expectedPredicate, asserter, entryCount, isAsync);
-
-        #endregion
-
-        #region AssertCount
-
-        protected Task AssertCount<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> query)
-            => Fixture.QueryAsserter.AssertCount(query, query, isAsync);
-
-        protected Task AssertCount<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> actualQuery,
-            Func<ISetSource, IQueryable<TResult>> expectedQuery)
-            => Fixture.QueryAsserter.AssertCount(actualQuery, expectedQuery, isAsync);
-
-        protected Task AssertCount<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> query,
-            Expression<Func<TResult, bool>> predicate)
-            => Fixture.QueryAsserter.AssertCount(
-                query, query, predicate, predicate, isAsync);
-
-        protected Task AssertCount<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> actualQuery,
-            Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Expression<Func<TResult, bool>> actualPredicate,
-            Expression<Func<TResult, bool>> expectedPredicate)
-            => Fixture.QueryAsserter.AssertCount(
-                actualQuery, expectedQuery, actualPredicate, expectedPredicate, isAsync);
-
-        #endregion
-
-        #region AssertLongCount
-
-        protected Task AssertLongCount<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> query)
-            => Fixture.QueryAsserter.AssertLongCount(query, query, isAsync);
-
-        protected Task AssertLongCount<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> actualQuery,
-            Func<ISetSource, IQueryable<TResult>> expectedQuery)
-            => Fixture.QueryAsserter.AssertLongCount(actualQuery, expectedQuery, isAsync);
-
-        #endregion
-
-        #region AssertMin
-
-        protected Task AssertMin<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> query,
-            Action<object, object> asserter = null,
-            int entryCount = 0)
-            => Fixture.QueryAsserter.AssertMin(
-                query, query, asserter, entryCount, isAsync);
-
-        protected Task AssertMin<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> actualQuery,
-            Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Action<object, object> asserter = null,
-            int entryCount = 0)
-            => Fixture.QueryAsserter.AssertMin(
-                actualQuery, expectedQuery, asserter, entryCount, isAsync);
-
-        protected Task AssertMin<TResult, TSelector>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> query,
-            Expression<Func<TResult, TSelector>> selector,
-            Action<object, object> asserter = null,
-            int entryCount = 0)
-            => Fixture.QueryAsserter.AssertMin(
-                query, query, selector, selector, asserter, entryCount, isAsync);
-
-        protected Task AssertMin<TResult, TSelector>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> actualQuery,
-            Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Expression<Func<TResult, TSelector>> actualSelector,
-            Expression<Func<TResult, TSelector>> expectedSelector,
-            Action<object, object> asserter = null,
-            int entryCount = 0)
-            => Fixture.QueryAsserter.AssertMin(
-                actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, entryCount, isAsync);
-
-        #endregion
-
-        #region AssertMax
-
-        protected Task AssertMax<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> query,
-            Action<object, object> asserter = null,
-            int entryCount = 0)
-            => Fixture.QueryAsserter.AssertMax(
-                query, query, asserter, entryCount, isAsync);
-
-        protected Task AssertMax<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> actualQuery,
-            Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Action<object, object> asserter = null,
-            int entryCount = 0)
-            => Fixture.QueryAsserter.AssertMax(
-                actualQuery, expectedQuery, asserter, entryCount, isAsync);
-
-        protected Task AssertMax<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> query,
-            Expression<Func<TResult, int>> selector,
-            Action<object, object> asserter = null,
-            int entryCount = 0)
-            => Fixture.QueryAsserter.AssertMax(
-                query, query, selector, selector, asserter, entryCount, isAsync);
-
-        protected Task AssertMax<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> actualQuery,
-            Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Expression<Func<TResult, int>> actualSelector,
-            Expression<Func<TResult, int>> expectedSelector,
-            Action<object, object> asserter = null,
-            int entryCount = 0)
-            => Fixture.QueryAsserter.AssertMax(
-                actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, entryCount, isAsync);
-
-        protected Task AssertMax<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> actualQuery,
-            Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Expression<Func<TResult, int?>> actualSelector,
-            Expression<Func<TResult, int?>> expectedSelector,
-            Action<object, object> asserter = null,
-            int entryCount = 0)
-            => Fixture.QueryAsserter.AssertMax(
-                actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, entryCount, isAsync);
-
-        protected Task AssertMax<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> query,
-            Expression<Func<TResult, decimal>> selector,
-            Action<object, object> asserter = null,
-            int entryCount = 0)
-            => Fixture.QueryAsserter.AssertMax(
-                query, query, selector, selector, asserter, entryCount, isAsync);
-
-        #endregion
-
-        #region AssertSum
-
-        protected Task AssertSum(
-            bool isAsync,
-            Func<ISetSource, IQueryable<int>> query,
-            Action<object, object> asserter = null)
-            => Fixture.QueryAsserter.AssertSum(query, query, asserter, isAsync);
-
-        protected Task AssertSum(
-            bool isAsync,
-            Func<ISetSource, IQueryable<int>> actualQuery,
-            Func<ISetSource, IQueryable<int>> expectedQuery,
-            Action<object, object> asserter = null)
-            => Fixture.QueryAsserter.AssertSum(actualQuery, expectedQuery, asserter, isAsync);
-
-        protected Task AssertSum(
-            bool isAsync,
-            Func<ISetSource, IQueryable<int?>> query,
-            Action<object, object> asserter = null)
-            => Fixture.QueryAsserter.AssertSum(query, query, asserter, isAsync);
-
-        protected Task AssertSum(
-            bool isAsync,
-            Func<ISetSource, IQueryable<int?>> actualQuery,
-            Func<ISetSource, IQueryable<int?>> expectedQuery,
-            Action<object, object> asserter = null)
-            => Fixture.QueryAsserter.AssertSum(actualQuery, expectedQuery, asserter, isAsync);
-
-        protected Task AssertSum<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> query,
-            Expression<Func<TResult, int>> selector,
-            Action<object, object> asserter = null)
-            => Fixture.QueryAsserter.AssertSum(
-                query, query, selector, selector, asserter, isAsync);
-
-        protected Task AssertSum<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> actualQuery,
-            Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Expression<Func<TResult, int>> actualSelector,
-            Expression<Func<TResult, int>> expectedSelector,
-            Action<object, object> asserter = null)
-            => Fixture.QueryAsserter.AssertSum(
-                actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
-
-        protected Task AssertSum<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> query,
-            Expression<Func<TResult, int?>> selector,
-            Action<object, object> asserter = null)
-            => Fixture.QueryAsserter.AssertSum(
-                query, query, selector, selector, asserter, isAsync);
-
-        protected Task AssertSum<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> actualQuery,
-            Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Expression<Func<TResult, int?>> actualSelector,
-            Expression<Func<TResult, int?>> expectedSelector,
-            Action<object, object> asserter = null)
-            => Fixture.QueryAsserter.AssertSum(
-                actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
-
-        protected Task AssertSum<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> query,
-            Expression<Func<TResult, long>> selector,
-            Action<object, object> asserter = null)
-            => Fixture.QueryAsserter.AssertSum(
-                query, query, selector, selector, asserter, isAsync);
-
-        protected Task AssertSum<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> query,
-            Expression<Func<TResult, long?>> selector,
-            Action<object, object> asserter = null)
-            => Fixture.QueryAsserter.AssertSum(
-                query, query, selector, selector, asserter, isAsync);
-
-        protected Task AssertSum<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> query,
-            Expression<Func<TResult, decimal>> selector,
-            Action<object, object> asserter = null)
-            => Fixture.QueryAsserter.AssertSum(
-                query, query, selector, selector, asserter, isAsync);
-
-        protected Task AssertSum<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> actualQuery,
-            Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Expression<Func<TResult, decimal>> actualSelector,
-            Expression<Func<TResult, decimal>> expectedSelector,
-            Action<object, object> asserter = null)
-            => Fixture.QueryAsserter.AssertSum(
-                actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
-
-        protected Task AssertSum<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> query,
-            Expression<Func<TResult, float>> selector,
-            Action<object, object> asserter = null)
-            => Fixture.QueryAsserter.AssertSum(
-                query, query, selector, selector, asserter, isAsync);
-
-        protected Task AssertSum<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> actualQuery,
-            Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Expression<Func<TResult, float>> actualSelector,
-            Expression<Func<TResult, float>> expectedSelector,
-            Action<object, object> asserter = null)
-            => Fixture.QueryAsserter.AssertSum(
-                actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
-
-        #endregion
-
-        #region AssertAverage
-
-        protected Task AssertAverage(
-            bool isAsync,
-            Func<ISetSource, IQueryable<int>> query,
-            Action<object, object> asserter = null)
-            => Fixture.QueryAsserter.AssertAverage(query, query, asserter, isAsync);
-
-        protected Task AssertAverage(
-            bool isAsync,
-            Func<ISetSource, IQueryable<int>> actualQuery,
-            Func<ISetSource, IQueryable<int>> expectedQuery,
-            Action<object, object> asserter = null)
-            => Fixture.QueryAsserter.AssertAverage(actualQuery, expectedQuery, asserter, isAsync);
-
-        protected Task AssertAverage(
-            bool isAsync,
-            Func<ISetSource, IQueryable<int?>> actualQuery,
-            Func<ISetSource, IQueryable<int?>> expectedQuery,
-            Action<object, object> asserter = null)
-            => Fixture.QueryAsserter.AssertAverage(actualQuery, expectedQuery, asserter, isAsync);
-
-        protected Task AssertAverage(
-            bool isAsync,
-            Func<ISetSource, IQueryable<long>> query,
-            Action<object, object> asserter = null)
-            => Fixture.QueryAsserter.AssertAverage(query, query, asserter, isAsync);
-
-        protected Task AssertAverage(
-            bool isAsync,
-            Func<ISetSource, IQueryable<long>> actualQuery,
-            Func<ISetSource, IQueryable<long>> expectedQuery,
-            Action<object, object> asserter = null)
-            => Fixture.QueryAsserter.AssertAverage(actualQuery, expectedQuery, asserter, isAsync);
-
-        protected Task AssertAverage<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> query,
-            Expression<Func<TResult, int>> selector,
-            Action<object, object> asserter = null)
-            => Fixture.QueryAsserter.AssertAverage(
-                query, query, selector, selector, asserter, isAsync);
-
-        protected Task AssertAverage<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> actualQuery,
-            Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Expression<Func<TResult, int>> actualSelector,
-            Expression<Func<TResult, int>> expectedSelector,
-            Action<object, object> asserter = null)
-            => Fixture.QueryAsserter.AssertAverage(
-                actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
-
-        protected Task AssertAverage<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> query,
-            Expression<Func<TResult, int?>> selector,
-            Action<object, object> asserter = null)
-            => Fixture.QueryAsserter.AssertAverage(
-                query, query, selector, selector, asserter, isAsync);
-
-        protected Task AssertAverage<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> actualQuery,
-            Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Expression<Func<TResult, int?>> actualSelector,
-            Expression<Func<TResult, int?>> expectedSelector,
-            Action<object, object> asserter = null)
-            => Fixture.QueryAsserter.AssertAverage(
-                actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
-
-        protected Task AssertAverage<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> query,
-            Expression<Func<TResult, decimal>> selector,
-            Action<object, object> asserter = null)
-            => Fixture.QueryAsserter.AssertAverage(
-                query, query, selector, selector, asserter, isAsync);
-
-        protected Task AssertAverage<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> actualQuery,
-            Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Expression<Func<TResult, decimal>> actualSelector,
-            Expression<Func<TResult, decimal>> expectedSelector,
-            Action<object, object> asserter = null)
-            => Fixture.QueryAsserter.AssertAverage(
-                actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
-
-        protected Task AssertAverage<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> query,
-            Expression<Func<TResult, float>> selector,
-            Action<object, object> asserter = null)
-            => Fixture.QueryAsserter.AssertAverage(
-                query, query, selector, selector, asserter, isAsync);
-
-        protected Task AssertAverage<TResult>(
-            bool isAsync,
-            Func<ISetSource, IQueryable<TResult>> actualQuery,
-            Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Expression<Func<TResult, float>> actualSelector,
-            Expression<Func<TResult, float>> expectedSelector,
-            Action<object, object> asserter = null)
-            => Fixture.QueryAsserter.AssertAverage(
-                actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
-
-        #endregion
-
-        #region AssertQuery
-
         public Task AssertQuery<TResult>(
             bool isAsync,
             Func<ISetSource, IQueryable<TResult>> query,
@@ -751,8 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             int entryCount = 0,
             [CallerMemberName] string testMethodName = null)
             where TResult : class
-            => Fixture.QueryAsserter.AssertQuery(
-                query, query, elementSorter, elementAsserter, assertOrder, entryCount, isAsync, testMethodName);
+            => AssertQuery(isAsync, query, query, elementSorter, elementAsserter, assertOrder, entryCount, testMethodName);
 
         public Task AssertQuery<TResult>(
             bool isAsync,
@@ -767,507 +45,698 @@ namespace Microsoft.EntityFrameworkCore.Query
             => Fixture.QueryAsserter.AssertQuery(
                 actualQuery, expectedQuery, elementSorter, elementAsserter, assertOrder, entryCount, isAsync, testMethodName);
 
-        #endregion
-
-        #region AssertQueryScalar
-
-        public Task AssertQueryScalar<TItem1>(
+        public Task AssertQueryScalar<TResult>(
             bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<int>> query,
+            Func<ISetSource, IQueryable<TResult>> query,
             bool assertOrder = false,
             [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
-
-        public Task AssertQueryScalar<TItem1>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<double>> query,
-            bool assertOrder = false,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
-
-        public Task AssertQueryScalar<TItem1>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<int>> actualQuery,
-            Func<IQueryable<TItem1>, IQueryable<int>> expectedQuery,
-            bool assertOrder = false,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            => AssertQueryScalar<TItem1, int>(isAsync, actualQuery, expectedQuery, assertOrder, testMethodName);
-
-        public Task AssertQueryScalar<TItem1>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<uint>> query,
-            bool assertOrder = false,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
-
-        public Task AssertQueryScalar<TItem1>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<uint>> actualQuery,
-            Func<IQueryable<TItem1>, IQueryable<uint>> expectedQuery,
-            bool assertOrder = false,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            => AssertQueryScalar<TItem1, uint>(isAsync, actualQuery, expectedQuery, assertOrder, testMethodName);
-
-        public Task AssertQueryScalar<TItem1>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<long>> query,
-            bool assertOrder = false,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
-
-        public Task AssertQueryScalar<TItem1>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<short>> query,
-            bool assertOrder = false,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
-
-        public Task AssertQueryScalar<TItem1>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<bool>> query,
-            bool assertOrder = false,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
-
-        public Task AssertQueryScalar<TItem1>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<bool>> actualQuery,
-            Func<IQueryable<TItem1>, IQueryable<bool>> expectedQuery,
-            bool assertOrder = false,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            => AssertQueryScalar<TItem1, bool>(isAsync, actualQuery, expectedQuery, assertOrder, testMethodName);
-
-        public Task AssertQueryScalar<TItem1>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<DateTime>> query,
-            bool assertOrder = false,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
-
-        public Task AssertQueryScalar<TItem1>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<DateTimeOffset>> query,
-            bool assertOrder = false,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
-
-        public Task AssertQueryScalar<TItem1>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<TimeSpan>> query,
-            bool assertOrder = false,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
-
-        public Task AssertQueryScalar<TItem1, TResult>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<TResult>> query,
-            bool assertOrder = false,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
             where TResult : struct
             => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
 
-        public Task AssertQueryScalar<TItem1, TResult>(
+        public Task AssertQueryScalar<TResult>(
             bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<TResult>> actualQuery,
-            Func<IQueryable<TItem1>, IQueryable<TResult>> expectedQuery,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
             bool assertOrder = false,
             [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
             where TResult : struct
             => Fixture.QueryAsserter.AssertQueryScalar(actualQuery, expectedQuery, assertOrder, isAsync, testMethodName);
 
-        public Task AssertQueryScalar<TItem1, TItem2>(
+        public Task AssertQueryScalar<TResult>(
             bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<int>> query,
+            Func<ISetSource, IQueryable<TResult?>> query,
             bool assertOrder = false,
             [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            where TItem2 : class
+            where TResult : struct
             => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
 
-        public Task AssertQueryScalar<TItem1, TItem2>(
+        public Task AssertQueryScalar<TResult>(
             bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<int>> actualQuery,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<int>> expectedQuery,
+            Func<ISetSource, IQueryable<TResult?>> actualQuery,
+            Func<ISetSource, IQueryable<TResult?>> expectedQuery,
             bool assertOrder = false,
             [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            where TItem2 : class
-            => AssertQueryScalar<TItem1, TItem2, int>(isAsync, actualQuery, expectedQuery, assertOrder, testMethodName);
-
-        public Task AssertQueryScalar<TItem1, TItem2>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<bool>> query,
-            bool assertOrder = false,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            where TItem2 : class
-            => AssertQueryScalar<TItem1, TItem2, bool>(isAsync, query, query, assertOrder, testMethodName);
-
-        public Task AssertQueryScalar<TItem1, TItem2>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<bool>> actualQuery,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<bool>> expectedQuery,
-            bool assertOrder = false,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            where TItem2 : class
-            => AssertQueryScalar<TItem1, TItem2, bool>(isAsync, actualQuery, expectedQuery, assertOrder, testMethodName);
-
-        public Task AssertQueryScalar<TItem1, TItem2>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<DateTime>> query,
-            bool assertOrder = false,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            where TItem2 : class
-            => AssertQueryScalar<TItem1, TItem2, DateTime>(isAsync, query, query, assertOrder, testMethodName);
-
-        public Task AssertQueryScalar<TItem1, TItem2>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<DateTime>> actualQuery,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<DateTime>> expectedQuery,
-            bool assertOrder = false,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            where TItem2 : class
-            => AssertQueryScalar<TItem1, TItem2, DateTime>(isAsync, actualQuery, expectedQuery, assertOrder, testMethodName);
-
-        public Task AssertQueryScalar<TItem1, TItem2, TResult>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TResult>> actualQuery,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TResult>> expectedQuery,
-            bool assertOrder = false,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            where TItem2 : class
             where TResult : struct
             => Fixture.QueryAsserter.AssertQueryScalar(actualQuery, expectedQuery, assertOrder, isAsync, testMethodName);
 
-        public Task AssertQueryScalar<TItem1, TItem2, TItem3>(
+        public Task<List<TResult>> AssertIncludeQuery<TResult>(
             bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<int>> query,
-            bool assertOrder = false,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            where TItem2 : class
-            where TItem3 : class
-            => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
-
-        public Task AssertQueryScalar<TItem1, TItem2, TItem3, TResult>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<TResult>> actualQuery,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<TResult>> expectedQuery,
-            bool assertOrder = false,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            where TItem2 : class
-            where TItem3 : class
-            where TResult : struct
-            => Fixture.QueryAsserter.AssertQueryScalar(actualQuery, expectedQuery, assertOrder, isAsync, testMethodName);
-
-        #endregion
-
-        #region AssertQueryScalar - nullable
-
-        public Task AssertQueryScalar<TItem1>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<int?>> query,
-            bool assertOrder = false,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
-
-        public Task AssertQueryScalar<TItem1>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<uint?>> query,
-            bool assertOrder = false,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
-
-        public Task AssertQueryScalar<TItem1>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<double?>> query,
-            bool assertOrder = false)
-            where TItem1 : class
-            => AssertQueryScalar(isAsync, query, query, assertOrder);
-
-        public Task AssertQueryScalar<TItem1>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<int?>> actualQuery,
-            Func<IQueryable<TItem1>, IQueryable<int?>> expectedQuery,
-            bool assertOrder = false,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            => AssertQueryScalar<TItem1, int>(isAsync, actualQuery, expectedQuery, assertOrder, testMethodName);
-
-        public Task AssertQueryScalar<TItem1>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<double?>> actualQuery,
-            Func<IQueryable<TItem1>, IQueryable<double?>> expectedQuery,
-            bool assertOrder = false)
-            where TItem1 : class
-            => AssertQueryScalar<TItem1, double>(isAsync, actualQuery, expectedQuery, assertOrder);
-
-        public Task AssertQueryScalar<TItem1>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<bool?>> query,
-            bool assertOrder = false,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
-
-        public Task AssertQueryScalar<TItem1>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<TimeSpan?>> query,
-            bool assertOrder = false,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
-
-        public Task AssertQueryScalar<TItem1>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<DateTime?>> query,
-            bool assertOrder = false,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
-
-        public Task AssertQueryScalar<TItem1>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<bool?>> actualQuery,
-            Func<IQueryable<TItem1>, IQueryable<bool?>> expectedQuery,
-            bool assertOrder = false,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            => AssertQueryScalar<TItem1, bool>(isAsync, actualQuery, expectedQuery, assertOrder, testMethodName);
-
-        public Task AssertQueryScalar<TItem1, TResult>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<TResult?>> actualQuery,
-            Func<IQueryable<TItem1>, IQueryable<TResult?>> expectedQuery,
-            bool assertOrder = false,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            where TResult : struct
-            => Fixture.QueryAsserter.AssertQueryScalar(actualQuery, expectedQuery, assertOrder, isAsync, testMethodName);
-
-        public Task AssertQueryScalar<TItem1, TItem2>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<int?>> query,
-            bool assertOrder = false,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            where TItem2 : class
-            => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
-
-        public Task AssertQueryScalar<TItem1, TItem2>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<int?>> actualQuery,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<int?>> expectedQuery,
-            bool assertOrder = false,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            where TItem2 : class
-            => AssertQueryScalar<TItem1, TItem2, int>(isAsync, actualQuery, expectedQuery, assertOrder, testMethodName);
-
-        public Task AssertQueryScalar<TItem1, TItem2, TResult>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TResult?>> actualQuery,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TResult?>> expectedQuery,
-            bool assertOrder = false,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            where TItem2 : class
-            where TResult : struct
-            => Fixture.QueryAsserter.AssertQueryScalar(actualQuery, expectedQuery, assertOrder, isAsync, testMethodName);
-
-        #endregion
-
-        #region AssertIncludeQuery
-
-        public Task<List<object>> AssertIncludeQuery<TItem1>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<object>> query,
+            Func<ISetSource, IQueryable<TResult>> query,
             List<IExpectedInclude> expectedIncludes,
-            Func<dynamic, object> elementSorter = null,
-            List<Func<dynamic, object>> clientProjections = null,
+            Func<TResult, object> elementSorter = null,
+            List<Func<TResult, object>> clientProjections = null,
             bool assertOrder = false,
             int entryCount = 0,
             [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
             => AssertIncludeQuery(
-                isAsync, query, query, expectedIncludes, elementSorter, clientProjections, assertOrder, entryCount, testMethodName);
-
-        public Task<List<object>> AssertIncludeQuery<TItem1>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<object>> actualQuery,
-            Func<IQueryable<TItem1>, IQueryable<object>> expectedQuery,
-            List<IExpectedInclude> expectedIncludes,
-            Func<dynamic, object> elementSorter = null,
-            List<Func<dynamic, object>> clientProjections = null,
-            bool assertOrder = false,
-            int entryCount = 0,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            => Fixture.QueryAsserter.AssertIncludeQuery(
-                actualQuery, expectedQuery, expectedIncludes, elementSorter, clientProjections, assertOrder, entryCount, isAsync,
+                isAsync,
+                query,
+                query,
+                expectedIncludes,
+                elementSorter,
+                clientProjections,
+                assertOrder,
+                entryCount,
                 testMethodName);
 
-        public Task<List<object>> AssertIncludeQuery<TItem1, TItem2>(
+        public Task<List<TResult>> AssertIncludeQuery<TResult>(
             bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> query,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
             List<IExpectedInclude> expectedIncludes,
-            Func<dynamic, object> elementSorter = null,
-            List<Func<dynamic, object>> clientProjections = null,
+            Func<TResult, object> elementSorter = null,
+            List<Func<TResult, object>> clientProjections = null,
             bool assertOrder = false,
             int entryCount = 0,
             [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            where TItem2 : class
-            => AssertIncludeQuery(
-                isAsync, query, query, expectedIncludes, elementSorter, clientProjections, assertOrder, entryCount, testMethodName);
-
-        public Task<List<object>> AssertIncludeQuery<TItem1, TItem2>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> actualQuery,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> expectedQuery,
-            List<IExpectedInclude> expectedIncludes,
-            Func<dynamic, object> elementSorter = null,
-            List<Func<dynamic, object>> clientProjections = null,
-            bool assertOrder = false,
-            int entryCount = 0,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            where TItem2 : class
             => Fixture.QueryAsserter.AssertIncludeQuery(
-                actualQuery, expectedQuery, expectedIncludes, elementSorter, clientProjections, assertOrder, entryCount, isAsync,
+                actualQuery,
+                expectedQuery,
+                expectedIncludes,
+                elementSorter,
+                clientProjections,
+                assertOrder,
+                entryCount,
+                isAsync,
                 testMethodName);
 
+        protected Task AssertSingleResult<TResult>(
+            bool isAsync,
+            Func<ISetSource, TResult> syncQuery,
+            Func<ISetSource, Task<TResult>> asyncQuery,
+            Action<TResult, TResult> asserter = null,
+            int entryCount = 0,
+            [CallerMemberName] string testMethodName = null)
+            => AssertSingleResult(isAsync, syncQuery, asyncQuery, syncQuery, asserter, entryCount, testMethodName);
+
+        protected Task AssertSingleResult<TResult>(
+            bool isAsync,
+            Func<ISetSource, TResult> actualSyncQuery,
+            Func<ISetSource, Task<TResult>> actualAsyncQuery,
+            Func<ISetSource, TResult> expectedQuery,
+            Action<TResult, TResult> asserter = null,
+            int entryCount = 0,
+            [CallerMemberName] string testMethodName = null)
+            => Fixture.QueryAsserter.AssertSingleResultTyped(actualSyncQuery, actualAsyncQuery, expectedQuery, asserter, entryCount, isAsync, testMethodName);
+
+        #region Assert termination operation methods
+
+        protected Task AssertAny<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query)
+            => AssertAny(isAsync, query, query);
+
+        protected Task AssertAny<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery)
+            => Fixture.QueryAsserter.AssertAny(
+                actualQuery, expectedQuery, isAsync);
+
+        protected Task AssertAny<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Expression<Func<TResult, bool>> predicate)
+            => AssertAny(isAsync, query, query, predicate, predicate);
+
+        protected Task AssertAny<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, bool>> actualPredicate,
+            Expression<Func<TResult, bool>> expectedPredicate)
+            => Fixture.QueryAsserter.AssertAny(
+                actualQuery, expectedQuery, actualPredicate, expectedPredicate, isAsync);
+
+        protected Task AssertAll<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Expression<Func<TResult, bool>> predicate)
+            => AssertAll(isAsync, query, query, predicate, predicate);
+
+        protected Task AssertAll<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, bool>> actualPredicate,
+            Expression<Func<TResult, bool>> expectedPredicate)
+            => Fixture.QueryAsserter.AssertAll(
+                actualQuery, expectedQuery, actualPredicate, expectedPredicate, isAsync);
+
+        protected Task AssertFirst<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Action<TResult, TResult> asserter = null,
+            int entryCount = 0)
+            => AssertFirst(isAsync, query, query, asserter, entryCount);
+
+        protected Task AssertFirst<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Action<TResult, TResult> asserter = null,
+            int entryCount = 0)
+            => Fixture.QueryAsserter.AssertFirst(
+                actualQuery, expectedQuery, asserter, entryCount, isAsync);
+
+        protected Task AssertFirst<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Expression<Func<TResult, bool>> predicate,
+            Action<TResult, TResult> asserter = null,
+            int entryCount = 0)
+            => AssertFirst(isAsync, query, query, predicate, predicate, asserter, entryCount);
+
+        protected Task AssertFirst<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, bool>> actualPredicate,
+            Expression<Func<TResult, bool>> expectedPredicate,
+            Action<TResult, TResult> asserter = null,
+            int entryCount = 0)
+            => Fixture.QueryAsserter.AssertFirst(
+                actualQuery, expectedQuery, actualPredicate, expectedPredicate, asserter, entryCount, isAsync);
+
+        protected Task AssertFirstOrDefault<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Action<TResult, TResult> asserter = null,
+            int entryCount = 0)
+            => AssertFirstOrDefault(isAsync, query, query, asserter, entryCount);
+
+        protected Task AssertFirstOrDefault<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Action<TResult, TResult> asserter = null,
+            int entryCount = 0)
+            => Fixture.QueryAsserter.AssertFirstOrDefault(
+                actualQuery, expectedQuery, asserter, entryCount, isAsync);
+
+        protected Task AssertFirstOrDefault<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Expression<Func<TResult, bool>> predicate,
+            Action<TResult, TResult> asserter = null,
+            int entryCount = 0)
+            => AssertFirstOrDefault(isAsync, query, query, predicate, predicate, asserter, entryCount);
+
+        protected Task AssertFirstOrDefault<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, bool>> actualPredicate,
+            Expression<Func<TResult, bool>> expectedPredicate,
+            Action<TResult, TResult> asserter = null,
+            int entryCount = 0)
+            => Fixture.QueryAsserter.AssertFirstOrDefault(
+                actualQuery, expectedQuery, actualPredicate, expectedPredicate, asserter, entryCount, isAsync);
+
+        protected Task AssertSingle<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Action<TResult, TResult> asserter = null,
+            int entryCount = 0)
+            => AssertSingle(isAsync, query, query, asserter, entryCount);
+
+        protected Task AssertSingle<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Action<TResult, TResult> asserter = null,
+            int entryCount = 0)
+            => Fixture.QueryAsserter.AssertSingle(
+                actualQuery, expectedQuery, asserter, entryCount, isAsync);
+
+        protected Task AssertSingle<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Expression<Func<TResult, bool>> predicate,
+            Action<TResult, TResult> asserter = null,
+            int entryCount = 0)
+            => AssertSingle(isAsync, query, query, predicate, predicate, asserter, entryCount);
+
+        protected Task AssertSingle<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, bool>> actualPredicate,
+            Expression<Func<TResult, bool>> expectedPredicate,
+            Action<TResult, TResult> asserter = null,
+            int entryCount = 0)
+            => Fixture.QueryAsserter.AssertSingle(
+                actualQuery, expectedQuery, actualPredicate, expectedPredicate, asserter, entryCount, isAsync);
+
+        protected Task AssertSingleOrDefault<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Action<TResult, TResult> asserter = null,
+            int entryCount = 0)
+            => AssertSingleOrDefault(isAsync, query, query, asserter, entryCount);
+
+        protected Task AssertSingleOrDefault<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Action<TResult, TResult> asserter = null,
+            int entryCount = 0)
+            => Fixture.QueryAsserter.AssertSingleOrDefault(
+                actualQuery, expectedQuery, asserter, entryCount, isAsync);
+
+        protected Task AssertSingleOrDefault<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Expression<Func<TResult, bool>> predicate,
+            Action<TResult, TResult> asserter = null,
+            int entryCount = 0)
+            => AssertSingleOrDefault(isAsync, query, query, predicate, predicate, asserter, entryCount);
+
+        protected Task AssertSingleOrDefault<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, bool>> actualPredicate,
+            Expression<Func<TResult, bool>> expectedPredicate,
+            Action<TResult, TResult> asserter = null,
+            int entryCount = 0)
+            => Fixture.QueryAsserter.AssertSingleOrDefault(
+                actualQuery, expectedQuery, actualPredicate, expectedPredicate, asserter, entryCount, isAsync);
+
+        protected Task AssertLast<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Action<TResult, TResult> asserter = null,
+            int entryCount = 0)
+            => AssertLast(isAsync, query, query, asserter, entryCount);
+
+        protected Task AssertLast<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Action<TResult, TResult> asserter = null,
+            int entryCount = 0)
+            => Fixture.QueryAsserter.AssertLast(
+                actualQuery, expectedQuery, asserter, entryCount, isAsync);
+
+        protected Task AssertLast<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Expression<Func<TResult, bool>> predicate,
+            Action<TResult, TResult> asserter = null,
+            int entryCount = 0)
+            => AssertLast(isAsync, query, query, predicate, predicate, asserter, entryCount);
+
+        protected Task AssertLast<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, bool>> actualPredicate,
+            Expression<Func<TResult, bool>> expectedPredicate,
+            Action<TResult, TResult> asserter = null,
+            int entryCount = 0)
+            => Fixture.QueryAsserter.AssertLast(
+                actualQuery, expectedQuery, actualPredicate, expectedPredicate, asserter, entryCount, isAsync);
+
+        protected Task AssertLastOrDefault<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Action<TResult, TResult> asserter = null,
+            int entryCount = 0)
+            => AssertLastOrDefault(isAsync, query, query, asserter, entryCount);
+
+        protected Task AssertLastOrDefault<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Action<TResult, TResult> asserter = null,
+            int entryCount = 0)
+            => Fixture.QueryAsserter.AssertLastOrDefault(
+                actualQuery, expectedQuery, asserter, entryCount, isAsync);
+
+        protected Task AssertLastOrDefault<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Expression<Func<TResult, bool>> predicate,
+            Action<TResult, TResult> asserter = null,
+            int entryCount = 0)
+            => AssertLastOrDefault(isAsync, query, query, predicate, predicate, asserter, entryCount);
+
+        protected Task AssertLastOrDefault<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, bool>> actualPredicate,
+            Expression<Func<TResult, bool>> expectedPredicate,
+            Action<TResult, TResult> asserter = null,
+            int entryCount = 0)
+            => Fixture.QueryAsserter.AssertLastOrDefault(
+                actualQuery, expectedQuery, actualPredicate, expectedPredicate, asserter, entryCount, isAsync);
+
+        protected Task AssertCount<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query)
+            => AssertCount(isAsync, query, query);
+
+        protected Task AssertCount<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery)
+            => Fixture.QueryAsserter.AssertCount(actualQuery, expectedQuery, isAsync);
+
+        protected Task AssertCount<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Expression<Func<TResult, bool>> predicate)
+            => AssertCount(isAsync, query, query, predicate, predicate);
+
+        protected Task AssertCount<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, bool>> actualPredicate,
+            Expression<Func<TResult, bool>> expectedPredicate)
+            => Fixture.QueryAsserter.AssertCount(
+                actualQuery, expectedQuery, actualPredicate, expectedPredicate, isAsync);
+
+        protected Task AssertLongCount<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query)
+            => AssertLongCount(isAsync, query, query);
+
+        protected Task AssertLongCount<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery)
+            => Fixture.QueryAsserter.AssertLongCount(actualQuery, expectedQuery, isAsync);
+
+        protected Task AssertMin<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Action<TResult, TResult> asserter = null,
+            int entryCount = 0)
+            => AssertMin(isAsync, query, query, asserter, entryCount);
+
+        protected Task AssertMin<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Action<TResult, TResult> asserter = null,
+            int entryCount = 0)
+            => Fixture.QueryAsserter.AssertMin(
+                actualQuery, expectedQuery, asserter, entryCount, isAsync);
+
+        protected Task AssertMin<TResult, TSelector>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Expression<Func<TResult, TSelector>> selector,
+            Action<TSelector, TSelector> asserter = null,
+            int entryCount = 0)
+            => AssertMin(isAsync, query, query, selector, selector, asserter, entryCount);
+
+        protected Task AssertMin<TResult, TSelector>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, TSelector>> actualSelector,
+            Expression<Func<TResult, TSelector>> expectedSelector,
+            Action<TSelector, TSelector> asserter = null,
+            int entryCount = 0)
+            => Fixture.QueryAsserter.AssertMin(
+                actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, entryCount, isAsync);
+
+        protected Task AssertMax<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Action<TResult, TResult> asserter = null,
+            int entryCount = 0)
+            => AssertMax(isAsync, query, query, asserter, entryCount);
+
+        protected Task AssertMax<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Action<TResult, TResult> asserter = null,
+            int entryCount = 0)
+            => Fixture.QueryAsserter.AssertMax(
+                actualQuery, expectedQuery, asserter, entryCount, isAsync);
+
+        protected Task AssertMax<TResult, TSelector>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Expression<Func<TResult, TSelector>> selector,
+            Action<TSelector, TSelector> asserter = null,
+            int entryCount = 0)
+            => AssertMax(isAsync, query, query, selector, selector, asserter, entryCount);
+
+        protected Task AssertMax<TResult, TSelector>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, TSelector>> actualSelector,
+            Expression<Func<TResult, TSelector>> expectedSelector,
+            Action<TSelector, TSelector> asserter = null,
+            int entryCount = 0)
+            => Fixture.QueryAsserter.AssertMax(
+                actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, entryCount, isAsync);
+
+        protected Task AssertSum(
+            bool isAsync,
+            Func<ISetSource, IQueryable<int>> query,
+            Action<int, int> asserter = null)
+            => AssertSum(isAsync, query, query, asserter);
+
+        protected Task AssertSum(
+            bool isAsync,
+            Func<ISetSource, IQueryable<int>> actualQuery,
+            Func<ISetSource, IQueryable<int>> expectedQuery,
+            Action<int, int> asserter = null)
+            => Fixture.QueryAsserter.AssertSum(actualQuery, expectedQuery, asserter, isAsync);
+
+        protected Task AssertSum(
+            bool isAsync,
+            Func<ISetSource, IQueryable<int?>> query,
+            Action<int?, int?> asserter = null)
+            => AssertSum(isAsync, query, query, asserter);
+
+        protected Task AssertSum(
+            bool isAsync,
+            Func<ISetSource, IQueryable<int?>> actualQuery,
+            Func<ISetSource, IQueryable<int?>> expectedQuery,
+            Action<int?, int?> asserter = null)
+            => Fixture.QueryAsserter.AssertSum(actualQuery, expectedQuery, asserter, isAsync);
+
+        protected Task AssertSum<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Expression<Func<TResult, int>> selector,
+            Action<int, int> asserter = null)
+            => AssertSum(isAsync, query, query, selector, selector, asserter);
+
+        protected Task AssertSum<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, int>> actualSelector,
+            Expression<Func<TResult, int>> expectedSelector,
+            Action<int, int> asserter = null)
+            => Fixture.QueryAsserter.AssertSum(
+                actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
+
+        protected Task AssertSum<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Expression<Func<TResult, int?>> selector,
+            Action<int?, int?> asserter = null)
+            => AssertSum(isAsync, query, query, selector, selector, asserter);
+
+        protected Task AssertSum<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, int?>> actualSelector,
+            Expression<Func<TResult, int?>> expectedSelector,
+            Action<int?, int?> asserter = null)
+            => Fixture.QueryAsserter.AssertSum(
+                actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
+
+        protected Task AssertSum<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Expression<Func<TResult, long>> selector,
+            Action<long, long> asserter = null)
+            => AssertSum(isAsync, query, query, selector, selector, asserter);
+
+        protected Task AssertSum<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, long>> actualSelector,
+            Expression<Func<TResult, long>> expectedSelector,
+            Action<long, long> asserter = null)
+            => Fixture.QueryAsserter.AssertSum(
+                actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
+
+        protected Task AssertSum<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Expression<Func<TResult, long?>> selector,
+            Action<long?, long?> asserter = null)
+            => AssertSum(isAsync, query, query, selector, selector, asserter);
+
+        protected Task AssertSum<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, long?>> actualSelector,
+            Expression<Func<TResult, long?>> expectedSelector,
+            Action<long?, long?> asserter = null)
+            => Fixture.QueryAsserter.AssertSum(
+                actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
+
+        protected Task AssertSum<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Expression<Func<TResult, decimal>> selector,
+            Action<decimal, decimal> asserter = null)
+            => AssertSum(isAsync, query, query, selector, selector, asserter);
+
+        protected Task AssertSum<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, decimal>> actualSelector,
+            Expression<Func<TResult, decimal>> expectedSelector,
+            Action<decimal, decimal> asserter = null)
+            => Fixture.QueryAsserter.AssertSum(
+                actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
+
+        protected Task AssertSum<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Expression<Func<TResult, float>> selector,
+            Action<float, float> asserter = null)
+            => AssertSum(isAsync, query, query, selector, selector, asserter);
+
+        protected Task AssertSum<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, float>> actualSelector,
+            Expression<Func<TResult, float>> expectedSelector,
+            Action<float, float> asserter = null)
+            => Fixture.QueryAsserter.AssertSum(
+                actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
+
+        protected Task AssertAverage(
+            bool isAsync,
+            Func<ISetSource, IQueryable<int>> query,
+            Action<double, double> asserter = null)
+            => AssertAverage(isAsync, query, query, asserter);
+
+        protected Task AssertAverage(
+            bool isAsync,
+            Func<ISetSource, IQueryable<int>> actualQuery,
+            Func<ISetSource, IQueryable<int>> expectedQuery,
+            Action<double, double> asserter = null)
+            => Fixture.QueryAsserter.AssertAverage(actualQuery, expectedQuery, asserter, isAsync);
+
+        protected Task AssertAverage(
+            bool isAsync,
+            Func<ISetSource, IQueryable<int?>> actualQuery,
+            Func<ISetSource, IQueryable<int?>> expectedQuery,
+            Action<double?, double?> asserter = null)
+            => Fixture.QueryAsserter.AssertAverage(actualQuery, expectedQuery, asserter, isAsync);
+
+        protected Task AssertAverage(
+            bool isAsync,
+            Func<ISetSource, IQueryable<long>> query,
+            Action<double, double> asserter = null)
+            => AssertAverage(isAsync, query, query, asserter);
+
+        protected Task AssertAverage(
+            bool isAsync,
+            Func<ISetSource, IQueryable<long>> actualQuery,
+            Func<ISetSource, IQueryable<long>> expectedQuery,
+            Action<double, double> asserter = null)
+            => Fixture.QueryAsserter.AssertAverage(actualQuery, expectedQuery, asserter, isAsync);
+
+        protected Task AssertAverage<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Expression<Func<TResult, int>> selector,
+            Action<double, double> asserter = null)
+            => AssertAverage(isAsync, query, query, selector, selector, asserter);
+
+        protected Task AssertAverage<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, int>> actualSelector,
+            Expression<Func<TResult, int>> expectedSelector,
+            Action<double, double> asserter = null)
+            => Fixture.QueryAsserter.AssertAverage(
+                actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
+
+        protected Task AssertAverage<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Expression<Func<TResult, int?>> selector,
+            Action<double?, double?> asserter = null)
+            => AssertAverage(isAsync, query, query, selector, selector, asserter);
+
+        protected Task AssertAverage<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, int?>> actualSelector,
+            Expression<Func<TResult, int?>> expectedSelector,
+            Action<double?, double?> asserter = null)
+            => Fixture.QueryAsserter.AssertAverage(
+                actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
+
+        protected Task AssertAverage<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Expression<Func<TResult, decimal>> selector,
+            Action<decimal, decimal> asserter = null)
+            => AssertAverage(isAsync, query, query, selector, selector, asserter);
+
+        protected Task AssertAverage<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, decimal>> actualSelector,
+            Expression<Func<TResult, decimal>> expectedSelector,
+            Action<decimal, decimal> asserter = null)
+            => Fixture.QueryAsserter.AssertAverage(
+                actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
+
+        protected Task AssertAverage<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Expression<Func<TResult, float>> selector,
+            Action<float, float> asserter = null)
+            => AssertAverage(isAsync, query, query, selector, selector, asserter);
+
+        protected Task AssertAverage<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, float>> actualSelector,
+            Expression<Func<TResult, float>> expectedSelector,
+            Action<float, float> asserter = null)
+            => Fixture.QueryAsserter.AssertAverage(
+                actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
+
         #endregion
 
-        #region AssertSingleResult
+        #region Helpers
 
-        protected Task AssertSingleResult<TItem1>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, object> syncQuery,
-            Func<IQueryable<TItem1>, Task<object>> asyncQuery,
-            Action<object, object> asserter = null,
-            int entryCount = 0,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            => AssertSingleResult(isAsync, syncQuery, asyncQuery, syncQuery, asserter, entryCount, testMethodName);
-
-        protected Task AssertSingleResult<TItem1>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, object> actualSyncQuery,
-            Func<IQueryable<TItem1>, Task<object>> actualAsyncQuery,
-            Func<IQueryable<TItem1>, object> expectedQuery,
-            Action<object, object> asserter = null,
-            int entryCount = 0,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            => Fixture.QueryAsserter.AssertSingleResult(
-                actualSyncQuery, actualAsyncQuery, expectedQuery, asserter, entryCount, isAsync, testMethodName);
-
-        protected Task AssertSingleResult<TItem1>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, int> syncQuery,
-            Func<IQueryable<TItem1>, Task<int>> asyncQuery,
-            Action<object, object> asserter = null,
-            int entryCount = 0,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            => AssertSingleResult(isAsync, syncQuery, asyncQuery, syncQuery, asserter, entryCount, testMethodName);
-
-        protected Task AssertSingleResult<TItem1>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, int> actualSyncQuery,
-            Func<IQueryable<TItem1>, Task<int>> actualAsyncQuery,
-            Func<IQueryable<TItem1>, int> expectedQuery,
-            Action<object, object> asserter = null,
-            int entryCount = 0,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            => Fixture.QueryAsserter.AssertSingleResult(
-                actualSyncQuery, actualAsyncQuery, expectedQuery, asserter, entryCount, isAsync, testMethodName);
-
-        protected Task AssertSingleResult<TItem1>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, long> syncQuery,
-            Func<IQueryable<TItem1>, Task<long>> asyncQuery,
-            Action<object, object> asserter = null,
-            int entryCount = 0,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            => AssertSingleResult(isAsync, syncQuery, asyncQuery, syncQuery, asserter, entryCount, testMethodName);
-
-        protected Task AssertSingleResult<TItem1>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, long> actualSyncQuery,
-            Func<IQueryable<TItem1>, Task<long>> actualAsyncQuery,
-            Func<IQueryable<TItem1>, long> expectedQuery,
-            Action<object, object> asserter = null,
-            int entryCount = 0,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            => Fixture.QueryAsserter.AssertSingleResult(
-                actualSyncQuery, actualAsyncQuery, expectedQuery, asserter, entryCount, isAsync, testMethodName);
-
-        protected Task AssertSingleResult<TItem1>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, bool> syncQuery,
-            Func<IQueryable<TItem1>, Task<bool>> asyncQuery,
-            Action<object, object> asserter = null,
-            int entryCount = 0,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            => AssertSingleResult(isAsync, syncQuery, asyncQuery, syncQuery, asserter, entryCount, testMethodName);
-
-        protected Task AssertSingleResult<TItem1>(
-            bool isAsync,
-            Func<IQueryable<TItem1>, bool> actualSyncQuery,
-            Func<IQueryable<TItem1>, Task<bool>> actualAsyncQuery,
-            Func<IQueryable<TItem1>, bool> expectedQuery,
-            Action<object, object> asserter = null,
-            int entryCount = 0,
-            [CallerMemberName] string testMethodName = null)
-            where TItem1 : class
-            => Fixture.QueryAsserter.AssertSingleResult(
-                actualSyncQuery, actualAsyncQuery, expectedQuery, asserter, entryCount, isAsync, testMethodName);
-
-        #endregion
-
-        #region Helpers - Sorters
-
-        public static Func<dynamic, dynamic> GroupingSorter<TKey, TElement>()
-            => e => ((IGrouping<TKey, TElement>)e).Key + " " + CollectionSorter<TElement>()(e);
-
-        public static Func<dynamic, dynamic> CollectionSorter<TElement>()
-            => e => ((IEnumerable<TElement>)e).Count();
-
-        #endregion
-
-        #region Helpers - Asserters
-
-        public void AssertEqual<T>(T expected, T actual, Action<dynamic, dynamic> asserter = null)
+        protected void AssertEqual<T>(T expected, T actual, Action<T, T> asserter = null)
             => Fixture.QueryAsserter.AssertEqual(expected, actual, asserter);
 
-        public void AssertCollection<TElement>(
+        protected void AssertCollection<TElement>(
             IEnumerable<TElement> expected,
             IEnumerable<TElement> actual,
             bool ordered = false,
@@ -1275,49 +744,18 @@ namespace Microsoft.EntityFrameworkCore.Query
             Action<TElement, TElement> elementAsserter = null)
             => Fixture.QueryAsserter.AssertCollection(expected, actual, ordered, elementSorter, elementAsserter);
 
-        public static Action<dynamic, dynamic> GroupingAsserter<TKey, TElement>(
+        protected void AssertGrouping<TKey, TElement>(
+            IGrouping<TKey, TElement> expected,
+            IGrouping<TKey, TElement> actual,
+            bool ordered = false,
             Func<TElement, object> elementSorter = null,
+            Action<TKey, TKey> keyAsserter = null,
             Action<TElement, TElement> elementAsserter = null)
         {
-            return (e, a) =>
-            {
-                Assert.Equal(((IGrouping<TKey, TElement>)e).Key, ((IGrouping<TKey, TElement>)a).Key);
-                CollectionAsserter(elementSorter, elementAsserter)(e, a);
-            };
+            keyAsserter ??= Assert.Equal;
+            keyAsserter(expected.Key, actual.Key);
+            AssertCollection(expected, actual, ordered, elementSorter, elementAsserter);
         }
-
-        public static Action<dynamic, dynamic> CollectionAsserter<TElement>(
-            Func<TElement, object> elementSorter = null,
-            Action<TElement, TElement> elementAsserter = null)
-        {
-            return (e, a) =>
-            {
-                if (e == null && a == null)
-                {
-                    return;
-                }
-
-                var actual = elementSorter != null
-                    ? ((IEnumerable<TElement>)a).OrderBy(elementSorter).ToList()
-                    : ((IEnumerable<TElement>)a).ToList();
-
-                var expected = elementSorter != null
-                    ? ((IEnumerable<TElement>)e).OrderBy(elementSorter).ToList()
-                    : ((IEnumerable<TElement>)e).ToList();
-
-                Assert.Equal(expected.Count, actual.Count);
-                elementAsserter ??= Assert.Equal;
-
-                for (var i = 0; i < expected.Count; i++)
-                {
-                    elementAsserter(expected[i], actual[i]);
-                }
-            };
-        }
-
-        #endregion
-
-        #region Helpers - Maybe
 
         protected static TResult Maybe<TResult>(object caller, Func<TResult> expression)
             where TResult : class

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Functions.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Functions.cs
@@ -1195,9 +1195,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Indexof_with_emptystring(bool isAsync)
         {
-            return AssertQueryScalar<Customer>(
+            return AssertQueryScalar(
                 isAsync,
-                cs => cs.Where(c => c.CustomerID == "ALFKI").Select(c => c.ContactName.IndexOf(string.Empty)));
+                ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI").Select(c => c.ContactName.IndexOf(string.Empty)));
         }
 
         [ConditionalTheory]
@@ -1413,7 +1413,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 ss => ss.Set<Customer>().OrderBy(c => c.CustomerID.Length).ThenBy(c => c.CustomerID.Length).ThenBy(c => c.CustomerID).Select(c => c.Orders),
                 assertOrder: true,
-                elementAsserter: (e, a) => AssertCollection<Order>(e, a),
+                elementAsserter: (e, a) => AssertCollection(e, a),
                 entryCount: 830);
         }
 

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.JoinGroupJoin.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.JoinGroupJoin.cs
@@ -239,21 +239,19 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             var ids = new uint[] { 1, 2 };
 
-            await AssertQueryScalar<Employee>(
+            await AssertQueryScalar(
                 isAsync,
-                es =>
-                    from e in es
-                    join id in ids on e.EmployeeID equals id
-                    select e.EmployeeID);
+                ss => from e in ss.Set<Employee>()
+                      join id in ids on e.EmployeeID equals id
+                      select e.EmployeeID);
 
             ids = new uint[] { 3 };
 
-            await AssertQueryScalar<Employee>(
+            await AssertQueryScalar(
                 isAsync,
-                es =>
-                    from e in es
-                    join id in ids on e.EmployeeID equals id
-                    select e.EmployeeID);
+                ss => from e in ss.Set<Employee>()
+                      join id in ids on e.EmployeeID equals id
+                      select e.EmployeeID);
         }
 
         [ConditionalTheory(Skip = "Issue #17068")]
@@ -261,22 +259,18 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual async Task Join_local_string_closure_is_cached_correctly(bool isAsync)
         {
             var ids = "12";
-
-            await AssertQueryScalar<Employee>(
+            await AssertQueryScalar(
                 isAsync,
-                es =>
-                    from e in es
-                    join id in ids on e.EmployeeID equals id
-                    select e.EmployeeID);
+                ss => from e in ss.Set<Employee>()
+                      join id in ids on e.EmployeeID equals id
+                      select e.EmployeeID);
 
             ids = "3";
-
-            await AssertQueryScalar<Employee>(
+            await AssertQueryScalar(
                 isAsync,
-                es =>
-                    from e in es
-                    join id in ids on e.EmployeeID equals id
-                    select e.EmployeeID);
+                ss => from e in ss.Set<Employee>()
+                      join id in ids on e.EmployeeID equals id
+                      select e.EmployeeID);
         }
 
         [ConditionalTheory(Skip = "Issue #17068")]
@@ -284,22 +278,18 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual async Task Join_local_bytes_closure_is_cached_correctly(bool isAsync)
         {
             var ids = new byte[] { 1, 2 };
-
-            await AssertQueryScalar<Employee>(
+            await AssertQueryScalar(
                 isAsync,
-                es =>
-                    from e in es
-                    join id in ids on e.EmployeeID equals id
-                    select e.EmployeeID);
+                ss => from e in ss.Set<Employee>()
+                      join id in ids on e.EmployeeID equals id
+                      select e.EmployeeID);
 
             ids = new byte[] { 3 };
-
-            await AssertQueryScalar<Employee>(
+            await AssertQueryScalar(
                 isAsync,
-                es =>
-                    from e in es
-                    join id in ids on e.EmployeeID equals id
-                    select e.EmployeeID);
+                ss => from e in ss.Set<Employee>()
+                      join id in ids on e.EmployeeID equals id
+                      select e.EmployeeID);
         }
 
         [ConditionalTheory]
@@ -340,8 +330,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.customer.CustomerID,
                 elementAsserter: (e, a) =>
                 {
-                    AssertEqual<Customer>(e.customer, a.customer);
-                    AssertCollection<Order>(e.orders, a.orders);
+                    AssertEqual(e.customer, a.customer);
+                    AssertCollection(e.orders, a.orders);
                 },
                 entryCount: 91);
         }
@@ -477,8 +467,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                     from c in ss.Set<Customer>()
                     join o in ss.Set<Order>() on c.CustomerID equals o.CustomerID into orders
                     select orders,
-                elementSorter: CollectionSorter<Order>(),
-                elementAsserter: (e, a) => AssertCollection<Order>(e, a),
+                elementSorter: e => e.Count(),
+                elementAsserter: (e, a) => AssertCollection(e, a),
                 entryCount: 830);
         }
 
@@ -495,8 +485,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.c.CustomerID,
                 elementAsserter: (e, a) =>
                 {
-                    AssertEqual<Customer>(e.c, a.c);
-                    AssertCollection<Order>(e.orders, a.orders);
+                    AssertEqual(e.c, a.c);
+                    AssertCollection(e.orders, a.orders);
                 },
                 entryCount: 921);
         }
@@ -552,11 +542,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 ss => ss.Set<Customer>().GroupJoin(
                     ss.Set<Order>(), c => c.CustomerID, o => o.CustomerID, (c, o) => new { c.City, o }),
-                elementSorter: e => (e.City, CollectionSorter<Order>()(e.o)),
+                elementSorter: e => (e.City, e.o.Count()),
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.City, a.City);
-                    AssertCollection<Order>(e.o, a.o);
+                    AssertCollection(e.o, a.o);
                 },
                 entryCount: 830);
         }
@@ -569,11 +559,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 ss => ss.Set<Customer>().GroupJoin(
                     ss.Set<Order>(), c => c.CustomerID, o => o.CustomerID, (c, g) => new { c.City, g = g.Select(o => o.CustomerID) }),
-                elementSorter: e => (e.City, CollectionSorter<string>()(e.g)),
+                elementSorter: e => (e.City, e.g.Count()),
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.City, a.City);
-                    AssertCollection<string>(e.g, a.g);
+                    AssertCollection(e.g, a.g);
                 });
         }
 
@@ -585,8 +575,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 ss => ss.Set<Customer>().GroupJoin(
                     ss.Set<Order>(), c => c.CustomerID, o => o.CustomerID, (c, g) => new { g = g.Select(o => o.CustomerID) }),
-                elementSorter: e => CollectionSorter<string>()(e.g),
-                elementAsserter: (e, a) => AssertCollection<string>(e.g, a.g));
+                elementSorter: e => e.g.Count(),
+                elementAsserter: (e, a) => AssertCollection(e.g, a.g));
         }
 
         [ConditionalTheory(Skip = "Issue#17068")]
@@ -596,8 +586,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery(
                 isAsync,
                 ss => ss.Set<Customer>().GroupJoin(ss.Set<Order>(), c => c.CustomerID, o => o.CustomerID, (c, g) => g.Select(o => o.CustomerID)),
-                elementSorter: CollectionSorter<string>(),
-                elementAsserter: (e, a) => AssertCollection<string>(e, a));
+                elementSorter: e => e.Count(),
+                elementAsserter: (e, a) => AssertCollection(e, a));
         }
 
         [ConditionalTheory(Skip = "Issue#17068")]
@@ -612,7 +602,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.CustomerID, a.CustomerID);
-                    AssertCollection<Customer>(e.c, a.c);
+                    AssertCollection(e.c, a.c);
                 },
                 entryCount: 89);
         }
@@ -629,7 +619,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.CustomerID, a.CustomerID);
-                    AssertCollection<string>(e.g, a.g);
+                    AssertCollection(e.g, a.g);
                 });
         }
 
@@ -895,14 +885,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_with_order_by_key_descending1(bool isAsync)
         {
-            return AssertQueryScalar<Customer, Order>(
+            return AssertQueryScalar(
                 isAsync,
-                (cs, os) =>
-                    from c in cs
-                    join o in os on c.CustomerID equals o.CustomerID into grouping
-                    where c.CustomerID.StartsWith("A")
-                    orderby c.CustomerID descending
-                    select grouping.Count(),
+                ss => from c in ss.Set<Customer>()
+                      join o in ss.Set<Order>() on c.CustomerID equals o.CustomerID into grouping
+                      where c.CustomerID.StartsWith("A")
+                      orderby c.CustomerID descending
+                      select grouping.Count(),
                 assertOrder: true);
         }
 
@@ -910,14 +899,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupJoin_with_order_by_key_descending2(bool isAsync)
         {
-            return AssertQueryScalar<Customer, Order>(
+            return AssertQueryScalar(
                 isAsync,
-                (cs, os) =>
-                    from c in cs
-                    orderby c.CustomerID descending
-                    join o in os on c.CustomerID equals o.CustomerID into grouping
-                    where c.CustomerID.StartsWith("A")
-                    select grouping.Count(),
+                ss => from c in ss.Set<Customer>()
+                      orderby c.CustomerID descending
+                      join o in ss.Set<Order>() on c.CustomerID equals o.CustomerID into grouping
+                      where c.CustomerID.StartsWith("A")
+                      select grouping.Count(),
                 assertOrder: true);
         }
 

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
@@ -1016,12 +1016,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multiple_collection_navigation_with_FirstOrDefault_chained_projecting_scalar(bool isAsync)
         {
-            return AssertQueryScalar<Customer>(
+            return AssertQueryScalar(
                 isAsync,
-                cs => cs.OrderBy(c => c.CustomerID).Select(
+                ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Select(
                     c => (int?)c.Orders.OrderBy(o => o.OrderID).FirstOrDefault().OrderDetails.OrderBy(od => od.ProductID).FirstOrDefault()
                         .ProductID),
-                cs => cs.OrderBy(c => c.CustomerID).Select(
+                ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Select(
                     c => MaybeScalar<int>(
                         Maybe(
                             c.Orders.OrderBy(o => o.OrderID).FirstOrDefault(),
@@ -1388,10 +1388,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Contains_top_level(bool isAsync)
         {
-            return AssertSingleResult<Customer>(
+            return AssertSingleResult(
                 isAsync,
-                syncQuery: cs => cs.Select(c => c.CustomerID).Contains("ALFKI"),
-                asyncQuery: cs => cs.Select(c => c.CustomerID).ContainsAsync("ALFKI"));
+                syncQuery: ss => ss.Set<Customer>().Select(c => c.CustomerID).Contains("ALFKI"),
+                asyncQuery: ss => ss.Set<Customer>().Select(c => c.CustomerID).ContainsAsync("ALFKI"));
         }
 
         [ConditionalTheory]
@@ -1763,27 +1763,27 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Cast_before_aggregate_is_preserved(bool isAsync)
         {
-            return AssertQueryScalar<Customer>(
+            return AssertQueryScalar(
                 isAsync,
-                cs => cs.Select(c => c.Orders.Select(o => (double?)o.OrderID).Average()));
+                ss => ss.Set<Customer>().Select(c => c.Orders.Select(o => (double?)o.OrderID).Average()));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Enumerable_min_is_mapped_to_Queryable_1(bool isAsync)
         {
-            return AssertQueryScalar<Customer>(
+            return AssertQueryScalar(
                 isAsync,
-                cs => cs.Select(c => c.Orders.Min(o => (double?)o.OrderID)));
+                ss => ss.Set<Customer>().Select(c => c.Orders.Min(o => (double?)o.OrderID)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Enumerable_min_is_mapped_to_Queryable_2(bool isAsync)
         {
-            return AssertQueryScalar<Customer>(
+            return AssertQueryScalar(
                 isAsync,
-                cs => cs.Select(c => c.Orders.Select(o => (double?)o.OrderID).Min()));
+                ss => ss.Set<Customer>().Select(c => c.Orders.Select(o => (double?)o.OrderID).Min()));
         }
 
         [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
@@ -129,10 +129,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual async Task Select_bool_closure_with_order_parameter_with_cast_to_nullable(bool isAsync)
         {
             var boolean = false;
-
-            await AssertQueryScalar<Customer>(
+            await AssertQueryScalar(
                 isAsync,
-                cs => cs.Select(c => boolean).OrderBy(e => (bool?)e),
+                ss => ss.Set<Customer>().Select(c => boolean).OrderBy(e => (bool?)e),
                 assertOrder: true);
         }
 
@@ -270,9 +269,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_constant_int(bool isAsync)
         {
-            return AssertQueryScalar<Customer>(
+            return AssertQueryScalar(
                 isAsync,
-                cs => cs.Select(c => 0));
+                ss => ss.Set<Customer>().Select(c => 0));
         }
 
         [ConditionalTheory]
@@ -289,28 +288,27 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Select_local(bool isAsync)
         {
             var x = 10;
-
-            return AssertQueryScalar<Customer>(
+            return AssertQueryScalar(
                 isAsync,
-                cs => cs.Select(c => x));
+                ss => ss.Set<Customer>().Select(c => x));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_scalar_primitive(bool isAsync)
         {
-            return AssertQueryScalar<Employee>(
+            return AssertQueryScalar(
                 isAsync,
-                es => es.Select(e => e.EmployeeID));
+                ss => ss.Set<Employee>().Select(e => e.EmployeeID));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_scalar_primitive_after_take(bool isAsync)
         {
-            return AssertQueryScalar<Employee>(
+            return AssertQueryScalar(
                 isAsync,
-                es => es.Take(9).Select(e => e.EmployeeID));
+                ss => ss.Set<Employee>().Take(9).Select(e => e.EmployeeID));
         }
 
         [ConditionalTheory]
@@ -531,9 +529,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                                     orderby o2.OrderID
                                     select o1.OrderID)),
                 assertOrder: true,
-                elementAsserter: (e, a) => CollectionAsserter<dynamic>(
-                    elementAsserter: (ee, aa) => CollectionAsserter<dynamic>(
-                        elementAsserter: (eee, aaa) => AssertCollection<int>(eee, aaa, ordered: true))));
+                elementAsserter: (e, a) => AssertCollection(
+                    e,
+                    a,
+                    ordered: true,
+                    elementAsserter: (ee, aa) => AssertCollection(ee, aa)));
         }
 
         [ConditionalTheory]
@@ -552,9 +552,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_non_matching_value_types_int_to_long_introduces_explicit_cast(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os
+                ss => ss.Set<Order>()
                     .Where(o => o.CustomerID == "ALFKI")
                     .OrderBy(o => o.OrderID)
                     .Select(o => (long)o.OrderID),
@@ -565,9 +565,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_non_matching_value_types_nullable_int_to_long_introduces_explicit_cast(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os
+                ss => ss.Set<Order>()
                     .Where(o => o.CustomerID == "ALFKI")
                     .OrderBy(o => o.OrderID)
                     .Select(o => (long)o.EmployeeID),
@@ -578,9 +578,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_non_matching_value_types_nullable_int_to_int_doesnt_introduce_explicit_cast(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os
+                ss => ss.Set<Order>()
                     .Where(o => o.CustomerID == "ALFKI")
                     .OrderBy(o => o.OrderID)
                     .Select(o => (uint)o.EmployeeID),
@@ -591,9 +591,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_non_matching_value_types_int_to_nullable_int_doesnt_introduce_explicit_cast(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os
+                ss => ss.Set<Order>()
                     .Where(o => o.CustomerID == "ALFKI")
                     .OrderBy(o => o.OrderID)
                     .Select(o => (int?)o.OrderID),
@@ -604,9 +604,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_non_matching_value_types_from_binary_expression_introduces_explicit_cast(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os
+                ss => ss.Set<Order>()
                     .Where(o => o.CustomerID == "ALFKI")
                     .OrderBy(o => o.OrderID)
                     .Select(o => (long)(o.OrderID + o.OrderID)),
@@ -617,9 +617,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_non_matching_value_types_from_binary_expression_nested_introduces_top_level_explicit_cast(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os
+                ss => ss.Set<Order>()
                     .Where(o => o.CustomerID == "ALFKI")
                     .OrderBy(o => o.OrderID)
                     .Select(o => (short)(o.OrderID + (long)o.OrderID)),
@@ -630,9 +630,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_non_matching_value_types_from_unary_expression_introduces_explicit_cast1(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os
+                ss => ss.Set<Order>()
                     .Where(o => o.CustomerID == "ALFKI")
                     .OrderBy(o => o.OrderID)
                     .Select(o => (long)-o.OrderID),
@@ -643,9 +643,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_non_matching_value_types_from_unary_expression_introduces_explicit_cast2(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os
+                ss => ss.Set<Order>()
                     .Where(o => o.CustomerID == "ALFKI")
                     .OrderBy(o => o.OrderID)
                     .Select(o => -((long)o.OrderID)),
@@ -656,9 +656,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_non_matching_value_types_from_length_introduces_explicit_cast(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os
+                ss => ss.Set<Order>()
                     .Where(o => o.CustomerID == "ALFKI")
                     .OrderBy(o => o.OrderID)
                     .Select(o => (long)o.CustomerID.Length),
@@ -669,9 +669,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_non_matching_value_types_from_method_call_introduces_explicit_cast(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os
+                ss => ss.Set<Order>()
                     .Where(o => o.CustomerID == "ALFKI")
                     .OrderBy(o => o.OrderID)
                     .Select(o => (long)Math.Abs(o.OrderID)),
@@ -695,9 +695,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_conditional_with_null_comparison_in_test(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => from o in os
+                ss => from o in ss.Set<Order>()
                       where o.CustomerID == "ALFKI"
                       select o.CustomerID == null ? true : o.OrderID < 100);
         }
@@ -717,9 +717,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Projection_containing_DateTime_subtraction(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.Where(o => o.OrderID < 10300)
+                ss => ss.Set<Order>().Where(o => o.OrderID < 10300)
                     .Select(o => o.OrderDate.Value - new DateTime(1997, 1, 1)));
         }
 
@@ -755,12 +755,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Project_single_element_from_collection_with_OrderBy_Distinct_and_FirstOrDefault_followed_by_projecting_length(
             bool isAsync)
         {
-            return AssertQueryScalar<Customer>(
+            return AssertQueryScalar(
                 isAsync,
-                cs => cs.Select(
-                    c => c.Orders.OrderBy(o => o.OrderID).Select(o => o.CustomerID).Distinct().FirstOrDefault()).Select(e => e.Length),
-                cs => cs.Select(
-                        c => c.Orders.OrderBy(o => o.OrderID).Select(o => o.CustomerID).Distinct().FirstOrDefault())
+                ss => ss.Set<Customer>()
+                    .Select(c => c.Orders.OrderBy(o => o.OrderID).Select(o => o.CustomerID).Distinct().FirstOrDefault())
+                    .Select(e => e.Length),
+                ss => ss.Set<Customer>()
+                    .Select(c => c.Orders.OrderBy(o => o.OrderID).Select(o => o.CustomerID).Distinct().FirstOrDefault())
                     .Select(e => e == null ? 0 : e.Length));
         }
 
@@ -804,9 +805,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault_followed_by_projection_of_length_property(
                 bool isAsync)
         {
-            return AssertQueryScalar<Customer>(
+            return AssertQueryScalar(
                 isAsync,
-                cs => cs.Select(
+                ss => ss.Set<Customer>().Select(
                     c => c.Orders.OrderBy(o => o.OrderID)
                         .ThenByDescending(o => o.OrderDate)
                         .Select(o => o.CustomerID)
@@ -832,11 +833,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.Where(o => o.OrderID < 10300)
-                    .Select(
-                        o => o.OrderDetails.OrderBy(od => od.Product.ProductName).Select(od => od.OrderID).Take(1).FirstOrDefault()));
+                ss => ss.Set<Order>().Where(o => o.OrderID < 10300)
+                    .Select(o => o.OrderDetails.OrderBy(od => od.Product.ProductName).Select(od => od.OrderID).Take(1).FirstOrDefault()));
         }
 
         [ConditionalTheory]
@@ -854,136 +854,135 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_datetime_year_component(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.Select(o => o.OrderDate.Value.Year));
+                ss => ss.Set<Order>().Select(o => o.OrderDate.Value.Year));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_datetime_month_component(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.Select(o => o.OrderDate.Value.Month));
+                ss => ss.Set<Order>().Select(o => o.OrderDate.Value.Month));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_datetime_day_of_year_component(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.Select(o => o.OrderDate.Value.DayOfYear));
+                ss => ss.Set<Order>().Select(o => o.OrderDate.Value.DayOfYear));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_datetime_day_component(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.Select(o => o.OrderDate.Value.Day));
+                ss => ss.Set<Order>().Select(o => o.OrderDate.Value.Day));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_datetime_hour_component(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.Select(o => o.OrderDate.Value.Hour));
+                ss => ss.Set<Order>().Select(o => o.OrderDate.Value.Hour));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_datetime_minute_component(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.Select(o => o.OrderDate.Value.Minute));
+                ss => ss.Set<Order>().Select(o => o.OrderDate.Value.Minute));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_datetime_second_component(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.Select(o => o.OrderDate.Value.Second));
+                ss => ss.Set<Order>().Select(o => o.OrderDate.Value.Second));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_datetime_millisecond_component(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.Select(o => o.OrderDate.Value.Millisecond));
+                ss => ss.Set<Order>().Select(o => o.OrderDate.Value.Millisecond));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_datetime_DayOfWeek_component(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.Select(o => (int)o.OrderDate.Value.DayOfWeek));
+                ss => ss.Set<Order>().Select(o => (int)o.OrderDate.Value.DayOfWeek));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_datetime_Ticks_component(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.Select(o => o.OrderDate.Value.Ticks));
+                ss => ss.Set<Order>().Select(o => o.OrderDate.Value.Ticks));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_datetime_TimeOfDay_component(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.Select(o => o.OrderDate.Value.TimeOfDay));
+                ss => ss.Set<Order>().Select(o => o.OrderDate.Value.TimeOfDay));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_byte_constant(bool isAsync)
         {
-            return AssertQueryScalar<Customer, byte>(
+            return AssertQueryScalar(
                 isAsync,
-                cs => cs.Select(c => c.CustomerID == "ALFKI" ? (byte)1 : (byte)2));
+                ss => ss.Set<Customer>().Select(c => c.CustomerID == "ALFKI" ? (byte)1 : (byte)2));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_short_constant(bool isAsync)
         {
-            return AssertQueryScalar<Customer, short>(
+            return AssertQueryScalar(
                 isAsync,
-                cs => cs.Select(c => c.CustomerID == "ALFKI" ? (short)1 : (short)2));
+                ss => ss.Set<Customer>().Select(c => c.CustomerID == "ALFKI" ? (short)1 : (short)2));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_bool_constant(bool isAsync)
         {
-            return AssertQueryScalar<Customer, bool>(
+            return AssertQueryScalar(
                 isAsync,
-                cs => cs.Select(c => c.CustomerID == "ALFKI" ? true : false));
+                ss => ss.Set<Customer>().Select(c => c.CustomerID == "ALFKI" ? true : false));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Anonymous_projection_AsNoTracking_Selector(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.Select(
-                        o => new { A = o.CustomerID, B = o.OrderDate })
+                ss => ss.Set<Order>().Select(o => new { A = o.CustomerID, B = o.OrderDate })
                     .AsNoTracking() // Just to cause a subquery
                     .Select(e => e.B));
         }
@@ -1014,34 +1013,34 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_GetValueOrDefault_on_DateTime(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.Select(o => o.OrderDate.GetValueOrDefault()));
+                ss => ss.Set<Order>().Select(o => o.OrderDate.GetValueOrDefault()));
         }
 
         [ConditionalTheory(Skip = "issue #13004")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_GetValueOrDefault_on_DateTime_with_null_values(bool isAsync)
         {
-            return AssertQueryScalar<Customer, Order>(
+            return AssertQueryScalar(
                 isAsync,
-                (cs, os) => from c in cs
-                            join o in os on c.CustomerID equals o.CustomerID into grouping
-                            from o in grouping.DefaultIfEmpty()
-                            select o.OrderDate.GetValueOrDefault(new DateTime(1753, 1, 1)),
-                (cs, os) => from c in cs
-                            join o in os on c.CustomerID equals o.CustomerID into grouping
-                            from o in grouping.DefaultIfEmpty()
-                            select o != null ? o.OrderDate.Value : new DateTime(1753, 1, 1));
+                ss => from c in ss.Set<Customer>()
+                      join o in ss.Set<Order>() on c.CustomerID equals o.CustomerID into grouping
+                      from o in grouping.DefaultIfEmpty()
+                      select o.OrderDate.GetValueOrDefault(new DateTime(1753, 1, 1)),
+                ss => from c in ss.Set<Customer>()
+                      join o in ss.Set<Order>() on c.CustomerID equals o.CustomerID into grouping
+                      from o in grouping.DefaultIfEmpty()
+                      select o != null ? o.OrderDate.Value : new DateTime(1753, 1, 1));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Cast_on_top_level_projection_brings_explicit_Cast(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.Select(o => (double?)o.OrderID));
+                ss => ss.Set<Order>().Select(o => (double?)o.OrderID));
         }
 
         [ConditionalTheory]
@@ -1204,10 +1203,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Project_non_nullable_value_after_FirstOrDefault_on_empty_collection(bool isAsync)
         {
-            return AssertQueryScalar<Customer, Order, int>(
+            return AssertQueryScalar(
                 isAsync,
-                (cs, os) => cs.Select(c => os.Where(o => o.CustomerID == "John Doe").Select(o => o.CustomerID).FirstOrDefault().Length),
-                (cs, os) => cs.Select(c => 0));
+                ss => ss.Set<Customer>().Select(c => ss.Set<Order>().Where(o => o.CustomerID == "John Doe").Select(o => o.CustomerID).FirstOrDefault().Length),
+                ss => ss.Set<Customer>().Select(c => 0));
         }
 
         [ConditionalTheory]
@@ -1313,9 +1312,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_with_complex_expression_that_can_be_funcletized(bool isAsync)
         {
-            return AssertQueryScalar<Customer, int>(
+            return AssertQueryScalar(
                 isAsync,
-                cs => cs.Where(c => c.CustomerID == "ALFKI").Select(c => c.ContactName.IndexOf("")),
+                ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI").Select(c => c.ContactName.IndexOf("")),
                 assertOrder: true);
         }
 
@@ -1326,7 +1325,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery(
                 isAsync,
                 ss => ss.Set<Order>().OrderBy(o => o.OrderID).Select(o => o.Customer.Orders),
-                elementAsserter: (e, a) => AssertCollection<Order>(e, a),
+                elementAsserter: (e, a) => AssertCollection(e, a),
                 assertOrder: true,
                 entryCount: 830);
         }
@@ -1335,9 +1334,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_entity_compared_to_null(bool isAsync)
         {
-            return AssertQueryScalar<Order, bool>(
+            return AssertQueryScalar(
                 isAsync,
-                os => from o in os
+                ss => from o in ss.Set<Order>()
                       where o.CustomerID == "ALFKI"
                       select o.Customer == null);
         }
@@ -1346,9 +1345,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Explicit_cast_in_arithmatic_operation_is_preserved(bool isAsync)
         {
-            return AssertQueryScalar<Order, decimal>(
+            return AssertQueryScalar(
                 isAsync,
-                os => from o in os
+                ss => from o in ss.Set<Order>()
                       where o.OrderID == 10243
                       select (decimal)o.OrderID / (decimal)(o.OrderID + 1000));
         }
@@ -1383,9 +1382,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Collection_FirstOrDefault_with_nullable_unsigned_int_column(bool isAsync)
         {
-            return AssertQueryScalar<Customer>(
+            return AssertQueryScalar(
                 isAsync,
-                cs => cs.Select(c => c.Orders.OrderBy(o => o.OrderID).Select(o => o.EmployeeID).FirstOrDefault()));
+                ss => ss.Set<Customer>().Select(c => c.Orders.OrderBy(o => o.OrderID).Select(o => o.EmployeeID).FirstOrDefault()));
         }
 
         [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.SetOperations.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.SetOperations.cs
@@ -63,9 +63,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Except_simple_followed_by_projecting_constant(bool isAsync)
         {
-            return AssertQueryScalar<Customer>(
-                isAsync, cs => cs
-                    .Except(cs)
+            return AssertQueryScalar(
+                isAsync, ss => ss.Set<Customer>()
+                    .Except(ss.Set<Customer>())
                     .Select(e => 1));
         }
 

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
@@ -1194,9 +1194,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_primitive(bool isAsync)
         {
-            return AssertQueryScalar<Employee>(
+            return AssertQueryScalar(
                 isAsync,
-                es => es.Select(e => e.EmployeeID).Take(9).Where(i => i == 5));
+                ss => ss.Set<Employee>().Select(e => e.EmployeeID).Take(9).Where(i => i == 5));
         }
 
         [ConditionalTheory]
@@ -1843,9 +1843,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Time_of_day_datetime(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                o => o.Select(c => c.OrderDate.Value.TimeOfDay));
+                ss => ss.Set<Order>().Select(o => o.OrderDate.Value.TimeOfDay));
         }
 
         [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -875,9 +875,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Skip_Take_Any(bool isAsync)
         {
-            return AssertAny<Customer>(
+            return AssertAny(
                 isAsync,
-                cs => cs.OrderBy(c => c.ContactName).Skip(5).Take(10));
+                ss => ss.Set<Customer>().OrderBy(c => c.ContactName).Skip(5).Take(10));
         }
 
         [ConditionalTheory]
@@ -904,9 +904,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Skip_Take_Any_with_predicate(bool isAsync)
         {
-            return AssertAny<Customer, Customer>(
+            return AssertAny(
                 isAsync,
-                cs => cs.OrderBy(c => c.CustomerID).Skip(5).Take(7),
+                ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Skip(5).Take(7),
                 predicate: p => p.CustomerID.StartsWith("C"));
         }
 
@@ -914,9 +914,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Take_Any_with_predicate(bool isAsync)
         {
-            return AssertAny<Customer, Customer>(
+            return AssertAny(
                 isAsync,
-                cs => cs.OrderBy(c => c.CustomerID).Take(5),
+                ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Take(5),
                 predicate: p => p.CustomerID.StartsWith("B"));
         }
 
@@ -997,9 +997,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Any_simple(bool isAsync)
         {
-            return AssertAny<Customer>(
+            return AssertAny(
                 isAsync,
-                cs => cs);
+                ss => ss.Set<Customer>());
         }
 
         [ConditionalTheory]
@@ -1024,9 +1024,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Any_predicate(bool isAsync)
         {
-            return AssertAny<Customer, Customer>(
+            return AssertAny(
                 isAsync,
-                cs => cs,
+                ss => ss.Set<Customer>(),
                 predicate: c => c.ContactName.StartsWith("A"));
         }
 
@@ -1128,20 +1128,20 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task All_top_level_subquery(bool isAsync)
         {
-            return AssertSingleResult<Customer>(
+            return AssertSingleResult(
                 isAsync,
-                syncQuery: cs => cs.All(c1 => cs.Any(c2 => cs.Any(c3 => c1.CustomerID == c3.CustomerID))),
-                asyncQuery: cs => cs.AllAsync(c1 => cs.Any(c2 => cs.Any(c3 => c1.CustomerID == c3.CustomerID))));
+                syncQuery: ss => ss.Set<Customer>().All(c1 => ss.Set<Customer>().Any(c2 => ss.Set<Customer>().Any(c3 => c1.CustomerID == c3.CustomerID))),
+                asyncQuery: ss => ss.Set<Customer>().AllAsync(c1 => ss.Set<Customer>().Any(c2 => ss.Set<Customer>().Any(c3 => c1.CustomerID == c3.CustomerID))));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task All_top_level_subquery_ef_property(bool isAsync)
         {
-            return AssertSingleResult<Customer>(
+            return AssertSingleResult(
                 isAsync,
-                syncQuery: cs => cs.All(c1 => cs.Any(c2 => cs.Any(c3 => EF.Property<string>(c1, "CustomerID") == c3.CustomerID))),
-                asyncQuery: cs => cs.AllAsync(c1 => cs.Any(c2 => cs.Any(c3 => EF.Property<string>(c1, "CustomerID") == c3.CustomerID))));
+                syncQuery: ss => ss.Set<Customer>().All(c1 => ss.Set<Customer>().Any(c2 => ss.Set<Customer>().Any(c3 => EF.Property<string>(c1, "CustomerID") == c3.CustomerID))),
+                asyncQuery: ss => ss.Set<Customer>().AllAsync(c1 => ss.Set<Customer>().Any(c2 => ss.Set<Customer>().Any(c3 => EF.Property<string>(c1, "CustomerID") == c3.CustomerID))));
         }
 
         [ConditionalTheory]
@@ -1713,8 +1713,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss =>
                     from c in ss.Set<Customer>().OrderBy(c => c.CustomerID).Take(3)
                     select ss.Set<Order>().OrderBy(o => o.OrderID).ThenBy(o => c.CustomerID).Skip(100).Take(2),
-                elementSorter: CollectionSorter<Order>(),
-                elementAsserter: (e, a) => AssertCollection<Order>(e, a, ordered: true));
+                elementSorter: e => e.Count(),
+                elementAsserter: (e, a) => AssertCollection(e, a, ordered: true));
         }
 
         [ConditionalTheory(Skip = "Issue#16314")]
@@ -2118,9 +2118,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task OrderBy_scalar_primitive(bool isAsync)
         {
-            return AssertQueryScalar<Employee>(
+            return AssertQueryScalar(
                 isAsync,
-                es => es.Select(e => e.EmployeeID).OrderBy(i => i),
+                ss => ss.Set<Employee>().Select(e => e.EmployeeID).OrderBy(i => i),
                 assertOrder: true);
         }
 
@@ -2316,10 +2316,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task SelectMany_primitive(bool isAsync)
         {
-            return AssertQueryScalar<Employee>(
+            return AssertQueryScalar(
                 isAsync,
-                es => from e1 in es
-                      from i in es.Select(e2 => e2.EmployeeID)
+                ss => from e1 in ss.Set<Employee>()
+                      from i in ss.Set<Employee>().Select(e2 => e2.EmployeeID)
                       select i);
         }
 
@@ -2327,11 +2327,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task SelectMany_primitive_select_subquery(bool isAsync)
         {
-            return AssertQueryScalar<Employee>(
+            return AssertQueryScalar(
                 isAsync,
-                es => from e1 in es
-                      from i in es.Select(e2 => e2.EmployeeID)
-                      select es.Any());
+                ss => from e1 in ss.Set<Employee>()
+                      from i in ss.Set<Employee>().Select(e2 => e2.EmployeeID)
+                      select ss.Set<Employee>().Any());
         }
 
         [ConditionalTheory]
@@ -2397,14 +2397,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multiple_joins_Where_Order_Any(bool isAsync)
         {
-            return AssertAny<Customer, Order, OrderDetail>(
+            return AssertAny(
                 isAsync,
-                (cs, os, ods) =>
-                    cs.Join(
-                            os, c => c.CustomerID, o => o.CustomerID, (cr, or) => new { cr, or })
-                        .Join(
-                            ods, e => e.or.OrderID, od => od.OrderID, (e, od) => new { e.cr, e.or, od })
-                        .Where(r => r.cr.City == "London").OrderBy(r => r.cr.CustomerID));
+                ss => ss.Set<Customer>().Join(ss.Set<Order>(), c => c.CustomerID, o => o.CustomerID, (cr, or) => new { cr, or })
+                    .Join(ss.Set<OrderDetail>(), e => e.or.OrderID, od => od.OrderID, (e, od) => new { e.cr, e.or, od })
+                    .Where(r => r.cr.City == "London").OrderBy(r => r.cr.CustomerID));
         }
 
         [ConditionalTheory]
@@ -2558,11 +2555,10 @@ namespace Microsoft.EntityFrameworkCore.Query
                     "NavigationExpandingExpressionVisitor"),
                 RemoveNewLines(
                     (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertQueryScalar<Employee>(
+                        () => AssertQueryScalar(
                             isAsync,
-                            es =>
-                                from e in es.Where(c => c.EmployeeID == NonExistentID).DefaultIfEmpty(new Employee())
-                                select 42))).Message));
+                            ss => from e in ss.Set<Employee>().Where(c => c.EmployeeID == NonExistentID).DefaultIfEmpty(new Employee())
+                                  select 42))).Message));
         }
 
         [ConditionalTheory]
@@ -2580,11 +2576,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Default_if_empty_top_level_projection(bool isAsync)
         {
-            return AssertQueryScalar<Employee>(
+            return AssertQueryScalar(
                 isAsync,
-                es =>
-                    from e in es.Where(e => e.EmployeeID == NonExistentID).Select(e => e.EmployeeID).DefaultIfEmpty()
-                    select e);
+                ss => from e in ss.Set<Employee>().Where(e => e.EmployeeID == NonExistentID).Select(e => e.EmployeeID).DefaultIfEmpty()
+                      select e);
         }
 
         [ConditionalTheory]
@@ -2627,13 +2622,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task SelectMany_OrderBy_ThenBy_Any(bool isAsync)
         {
-            return AssertAny<Customer, Order>(
+            return AssertAny(
                 isAsync,
-                (cs, os) =>
-                    from c in cs
-                    from o in os
-                    orderby c.CustomerID, c.City
-                    select c);
+                ss => from c in ss.Set<Customer>()
+                      from o in ss.Set<Order>()
+                      orderby c.CustomerID, c.City
+                      select c);
         }
 
         [ConditionalTheory]
@@ -2878,9 +2872,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task OrderBy_ThenBy_Any(bool isAsync)
         {
-            return AssertAny<Customer>(
+            return AssertAny(
                 isAsync,
-                cs => cs.OrderBy(c => c.CustomerID).ThenBy(c => c.ContactName));
+                ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).ThenBy(c => c.ContactName));
         }
 
         [ConditionalTheory]
@@ -3189,11 +3183,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_Property_when_non_shadow(bool isAsync)
         {
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os =>
-                    from o in os
-                    select EF.Property<int>(o, "OrderID"));
+                ss => from o in ss.Set<Order>()
+                      select EF.Property<int>(o, "OrderID"));
         }
 
         [ConditionalTheory]
@@ -4128,9 +4121,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             var nextYear = 2017;
 
-            return AssertQueryScalar<Order>(
+            return AssertQueryScalar(
                 isAsync,
-                os => os.Where(o => o.OrderDate != null)
+                ss => ss.Set<Order>().Where(o => o.OrderDate != null)
                     .Select(o => o.OrderDate.Value.Year)
                     .Distinct()
                     .Where(x => x < nextYear));
@@ -4486,11 +4479,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Anonymous_member_distinct_result(bool isAsync)
         {
-            return AssertSingleResult<Customer>(
+            return AssertSingleResult(
                 isAsync,
-                syncQuery: cs => cs.Select(
+                syncQuery: ss => ss.Set<Customer>().Select(
                     c => new { c.CustomerID }).Distinct().Count(n => n.CustomerID.StartsWith("A")),
-                asyncQuery: cs => cs.Select(
+                asyncQuery: ss => ss.Set<Customer>().Select(
                     c => new { c.CustomerID }).Distinct().CountAsync(n => n.CustomerID.StartsWith("A")));
         }
 
@@ -4518,10 +4511,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Anonymous_complex_distinct_result(bool isAsync)
         {
-            return AssertSingleResult<Customer>(
+            return AssertSingleResult(
                 isAsync,
-                syncQuery: cs => cs.Select(c => new { A = c.CustomerID + c.City }).Distinct().Count(n => n.A.StartsWith("A")),
-                asyncQuery: cs => cs.Select(c => new { A = c.CustomerID + c.City }).Distinct().CountAsync(n => n.A.StartsWith("A")));
+                syncQuery: ss => ss.Set<Customer>().Select(c => new { A = c.CustomerID + c.City }).Distinct().Count(n => n.A.StartsWith("A")),
+                asyncQuery: ss => ss.Set<Customer>().Select(c => new { A = c.CustomerID + c.City }).Distinct().CountAsync(n => n.A.StartsWith("A")));
         }
 
         [ConditionalTheory]
@@ -4598,11 +4591,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task DTO_member_distinct_result(bool isAsync)
         {
-            return AssertSingleResult<Customer>(
+            return AssertSingleResult(
                 isAsync,
-                syncQuery: cs => cs.Select(
+                syncQuery: ss => ss.Set<Customer>().Select(
                     c => new DTO<string> { Property = c.CustomerID }).Distinct().Count(n => n.Property.StartsWith("A")),
-                asyncQuery: cs => cs.Select(
+                asyncQuery: ss => ss.Set<Customer>().Select(
                     c => new DTO<string> { Property = c.CustomerID }).Distinct().CountAsync(n => n.Property.StartsWith("A")));
         }
 
@@ -4632,11 +4625,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task DTO_complex_distinct_result(bool isAsync)
         {
-            return AssertSingleResult<Customer>(
+            return AssertSingleResult(
                 isAsync,
-                syncQuery: cs => cs.Select(
+                syncQuery: ss => ss.Set<Customer>().Select(
                     c => new DTO<string> { Property = c.CustomerID + c.City }).Distinct().Count(n => n.Property.StartsWith("A")),
-                asyncQuery: cs => cs.Select(
+                asyncQuery: ss => ss.Set<Customer>().Select(
                     c => new DTO<string> { Property = c.CustomerID + c.City }).Distinct().CountAsync(n => n.Property.StartsWith("A")));
         }
 
@@ -5374,9 +5367,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 CoreStrings.TranslationFailed("OrderBy<Customer, string>(    source: DbSet<Customer>,     keySelector: (c) => ClientOrderBy(c))"),
                 RemoveNewLines(
                     (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertQueryScalar<Customer>(
+                        () => AssertQueryScalar(
                             isAsync,
-                            cs => cs.OrderBy(c => ClientOrderBy(c))
+                            ss => ss.Set<Customer>().OrderBy(c => ClientOrderBy(c))
                                 .SelectMany(c => c.Orders)
                                 .Distinct()
                                 .Select(o => o.OrderDate)))).Message));
@@ -5620,9 +5613,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         .Take(1)
                         .Select(o => new { o.OrderDate }).ToList()),
                 assertOrder: true,
-                elementAsserter: (e, a) => CollectionAsserter<dynamic>(
-                    ec => ec.OrderDate,
-                    (ec, ac) => Assert.Equal(ec.OrderDate, ac.OrderDate))(e, a));
+                elementAsserter: (e, a) => AssertCollection(e, a, ordered: true));
         }
 
         private static Expression<Func<Order, bool>> ValidYear => a => a.OrderDate.Value.Year == 1998;

--- a/test/EFCore.Specification.Tests/TestUtilities/QueryAsserterBase.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/QueryAsserterBase.cs
@@ -15,98 +15,14 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
         public virtual ISetSource ExpectedData { get; set; }
 
-        public abstract void AssertEqual<T>(
-            T expected,
-            T actual,
-            Action<dynamic, dynamic> asserter = null);
-
-        public abstract void AssertCollection<TElement>(
-            IEnumerable<TElement> expected,
-            IEnumerable<TElement> actual,
-            bool ordered = false,
-            Func<TElement, object> elementSorter = null,
-            Action<TElement, TElement> elementAsserter = null);
-
-        #region AssertSingleResult
-
         public abstract Task AssertSingleResultTyped<TResult>(
             Func<ISetSource, TResult> actualSyncQuery,
             Func<ISetSource, Task<TResult>> actualAsyncQuery,
             Func<ISetSource, TResult> expectedQuery,
-            Action<object, object> asserter,
+            Action<TResult, TResult> asserter,
             int entryCount,
             bool isAsync,
             string testMethodName);
-
-        public abstract Task AssertSingleResult<TItem1>(
-            Func<IQueryable<TItem1>, object> actualSyncQuery,
-            Func<IQueryable<TItem1>, Task<object>> actualAsyncQuery,
-            Func<IQueryable<TItem1>, object> expectedQuery,
-            Action<object, object> asserter,
-            int entryCount,
-            bool isAsync,
-            string testMethodName)
-            where TItem1 : class;
-
-        public abstract Task AssertSingleResult<TItem1, TResult>(
-            Func<IQueryable<TItem1>, TResult> actualSyncQuery,
-            Func<IQueryable<TItem1>, Task<TResult>> actualAsyncQuery,
-            Func<IQueryable<TItem1>, TResult> expectedQuery,
-            Action<object, object> asserter,
-            int entryCount,
-            bool isAsync,
-            string testMethodName)
-            where TItem1 : class;
-
-        public abstract Task AssertSingleResult<TItem1, TItem2>(
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, object> actualSyncQuery,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, Task<object>> actualAsyncQuery,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, object> expectedQuery,
-            Action<object, object> asserter,
-            int entryCount,
-            bool isAsync,
-            string testMethodName)
-            where TItem1 : class
-            where TItem2 : class;
-
-        public abstract Task AssertSingleResult<TItem1, TItem2, TResult>(
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, TResult> actualSyncQuery,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, Task<TResult>> actualAsyncQuery,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, TResult> expectedQuery,
-            Action<object, object> asserter,
-            int entryCount,
-            bool isAsync,
-            string testMethodName)
-            where TItem1 : class
-            where TItem2 : class;
-
-        public abstract Task AssertSingleResult<TItem1, TItem2, TItem3>(
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, object> actualSyncQuery,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, Task<object>> actualAsyncQuery,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, object> expectedQuery,
-            Action<object, object> asserter,
-            int entryCount,
-            bool isAsync,
-            string testMethodName)
-            where TItem1 : class
-            where TItem2 : class
-            where TItem3 : class;
-
-        public abstract Task AssertSingleResult<TItem1, TItem2, TItem3, TResult>(
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, TResult> actualSyncQuery,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, Task<TResult>> actualAsyncQuery,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, TResult> expectedQuery,
-            Action<object, object> asserter,
-            int entryCount,
-            bool isAsync,
-            string testMethodName)
-            where TItem1 : class
-            where TItem2 : class
-            where TItem3 : class;
-
-        #endregion
-
-        #region AssertQuery
 
         public abstract Task AssertQuery<TResult>(
             Func<ISetSource, IQueryable<TResult>> actualQuery,
@@ -119,146 +35,46 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             string testMethodName)
             where TResult : class;
 
-        #endregion
-
-        #region AssertQueryScalar
-
-        public abstract Task AssertQueryScalar<TItem1, TResult>(
-            Func<IQueryable<TItem1>, IQueryable<TResult>> actualQuery,
-            Func<IQueryable<TItem1>, IQueryable<TResult>> expectedQuery,
+        public abstract Task AssertQueryScalar<TResult>(
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
             bool assertOrder,
             bool isAsync,
             string testMethodName)
-            where TItem1 : class
             where TResult : struct;
 
-        public abstract Task AssertQueryScalar<TItem1, TItem2, TResult>(
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TResult>> actualQuery,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TResult>> expectedQuery,
+        public abstract Task AssertQueryScalar<TResult>(
+            Func<ISetSource, IQueryable<TResult?>> actualQuery,
+            Func<ISetSource, IQueryable<TResult?>> expectedQuery,
             bool assertOrder,
             bool isAsync,
             string testMethodName)
-            where TItem1 : class
-            where TItem2 : class
             where TResult : struct;
 
-        public abstract Task AssertQueryScalar<TItem1, TItem2, TItem3, TResult>(
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<TResult>> actualQuery,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<TResult>> expectedQuery,
-            bool assertOrder,
-            bool isAsync,
-            string testMethodName)
-            where TItem1 : class
-            where TItem2 : class
-            where TItem3 : class
-            where TResult : struct;
-
-        #endregion
-
-        #region AssertQueryScalar - nullable
-
-        public abstract Task AssertQueryScalar<TItem1, TResult>(
-            Func<IQueryable<TItem1>, IQueryable<TResult?>> actualQuery,
-            Func<IQueryable<TItem1>, IQueryable<TResult?>> expectedQuery,
-            bool assertOrder,
-            bool isAsync,
-            string testMethodName)
-            where TItem1 : class
-            where TResult : struct;
-
-        public abstract Task AssertQueryScalar<TItem1, TItem2, TResult>(
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TResult?>> actualQuery,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TResult?>> expectedQuery,
-            bool assertOrder,
-            bool isAsync,
-            string testMethodName)
-            where TItem1 : class
-            where TItem2 : class
-            where TResult : struct;
-
-        #endregion
-
-        #region AssertIncludeQuery
-
-        public abstract Task<List<object>> AssertIncludeQuery<TItem1>(
-            Func<IQueryable<TItem1>, IQueryable<object>> actualQuery,
-            Func<IQueryable<TItem1>, IQueryable<object>> expectedQuery,
+        public abstract Task<List<TResult>> AssertIncludeQuery<TResult>(
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
             List<IExpectedInclude> expectedIncludes,
-            Func<dynamic, object> elementSorter,
-            List<Func<dynamic, object>> clientProjections,
+            Func<TResult, object> elementSorter,
+            List<Func<TResult, object>> clientProjections,
             bool assertOrder,
             int entryCount,
             bool isAsync,
-            string testMethodName)
-            where TItem1 : class;
+            string testMethodName);
 
-        public abstract Task<List<object>> AssertIncludeQuery<TItem1, TItem2>(
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> actualQuery,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> expectedQuery,
-            List<IExpectedInclude> expectedIncludes,
-            Func<dynamic, object> elementSorter,
-            List<Func<dynamic, object>> clientProjections,
-            bool assertOrder,
-            int entryCount,
-            bool isAsync,
-            string testMethodName)
-            where TItem1 : class
-            where TItem2 : class;
+        #region Assert termination operation methods
 
-        #endregion
-
-        #region AssertAny
-
-        public abstract Task AssertAnyTyped<TResult>(
+        public abstract Task AssertAny<TResult>(
             Func<ISetSource, IQueryable<TResult>> actualQuery,
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
             bool isAsync = false);
 
-        public abstract Task AssertAny<TItem1>(
-            Func<IQueryable<TItem1>, IQueryable<object>> actualQuery,
-            Func<IQueryable<TItem1>, IQueryable<object>> expectedQuery,
-            bool isAsync = false)
-            where TItem1 : class;
-
-        public abstract Task AssertAny<TItem1, TResult>(
-            Func<IQueryable<TItem1>, IQueryable<TResult>> actualQuery,
-            Func<IQueryable<TItem1>, IQueryable<TResult>> expectedQuery,
-            bool isAsync = false)
-            where TItem1 : class;
-
-        public abstract Task AssertAny<TItem1, TItem2>(
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> actualQuery,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> expectedQuery,
-            bool isAsync = false)
-            where TItem1 : class
-            where TItem2 : class;
-
-        public abstract Task AssertAny<TItem1, TItem2, TItem3>(
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<object>> actualQuery,
-            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<object>> expectedQuery,
-            bool isAsync = false)
-            where TItem1 : class
-            where TItem2 : class
-            where TItem3 : class;
-
-        public abstract Task AssertAnyTyped<TResult>(
+        public abstract Task AssertAny<TResult>(
             Func<ISetSource, IQueryable<TResult>> actualQuery,
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
             Expression<Func<TResult, bool>> actualPredicate,
             Expression<Func<TResult, bool>> expectedPredicate,
             bool isAsync = false);
-
-        public abstract Task AssertAny<TItem1, TPredicate>(
-            Func<IQueryable<TItem1>, IQueryable<TPredicate>> actualQuery,
-            Func<IQueryable<TItem1>, IQueryable<TPredicate>> expectedQuery,
-            Expression<Func<TPredicate, bool>> actualPredicate,
-            Expression<Func<TPredicate, bool>> expectedPredicate,
-            bool isAsync = false)
-            where TItem1 : class;
-
-        #endregion
-
-        #region AssertAll
 
         public abstract Task AssertAll<TResult>(
             Func<ISetSource, IQueryable<TResult>> actualQuery,
@@ -267,14 +83,10 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Expression<Func<TResult, bool>> expectedPredicate,
             bool isAsync = false);
 
-        #endregion
-
-        #region AssertFirst
-
         public abstract Task AssertFirst<TResult>(
             Func<ISetSource, IQueryable<TResult>> actualQuery,
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Action<object, object> asserter = null,
+            Action<TResult, TResult> asserter = null,
             int entryCount = 0,
             bool isAsync = false);
 
@@ -283,18 +95,14 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
             Expression<Func<TResult, bool>> actualPredicate,
             Expression<Func<TResult, bool>> expectedPredicate,
-            Action<object, object> asserter = null,
+            Action<TResult, TResult> asserter = null,
             int entryCount = 0,
             bool isAsync = false);
-
-        #endregion
-
-        #region AssertFirstOrDefault
 
         public abstract Task AssertFirstOrDefault<TResult>(
             Func<ISetSource, IQueryable<TResult>> actualQuery,
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Action<object, object> asserter = null,
+            Action<TResult, TResult> asserter = null,
             int entryCount = 0,
             bool isAsync = false);
 
@@ -303,18 +111,14 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
             Expression<Func<TResult, bool>> actualPredicate,
             Expression<Func<TResult, bool>> expectedPredicate,
-            Action<object, object> asserter = null,
+            Action<TResult, TResult> asserter = null,
             int entryCount = 0,
             bool isAsync = false);
-
-        #endregion
-
-        #region AssertSingle
 
         public abstract Task AssertSingle<TResult>(
             Func<ISetSource, IQueryable<TResult>> actualQuery,
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Action<object, object> asserter = null,
+            Action<TResult, TResult> asserter = null,
             int entryCount = 0,
             bool isAsync = false);
 
@@ -323,18 +127,14 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
             Expression<Func<TResult, bool>> actualPredicate,
             Expression<Func<TResult, bool>> expectedPredicate,
-            Action<object, object> asserter = null,
+            Action<TResult, TResult> asserter = null,
             int entryCount = 0,
             bool isAsync = false);
-
-        #endregion
-
-        #region AssertSingleOrDefault
 
         public abstract Task AssertSingleOrDefault<TResult>(
             Func<ISetSource, IQueryable<TResult>> actualQuery,
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Action<object, object> asserter = null,
+            Action<TResult, TResult> asserter = null,
             int entryCount = 0,
             bool isAsync = false);
 
@@ -343,18 +143,14 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
             Expression<Func<TResult, bool>> actualPredicate,
             Expression<Func<TResult, bool>> expectedPredicate,
-            Action<object, object> asserter = null,
+            Action<TResult, TResult> asserter = null,
             int entryCount = 0,
             bool isAsync = false);
-
-        #endregion
-
-        #region AssertLast
 
         public abstract Task AssertLast<TResult>(
             Func<ISetSource, IQueryable<TResult>> actualQuery,
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Action<object, object> asserter = null,
+            Action<TResult, TResult> asserter = null,
             int entryCount = 0,
             bool isAsync = false);
 
@@ -363,18 +159,14 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
             Expression<Func<TResult, bool>> actualPredicate,
             Expression<Func<TResult, bool>> expectedPredicate,
-            Action<object, object> asserter = null,
+            Action<TResult, TResult> asserter = null,
             int entryCount = 0,
             bool isAsync = false);
-
-        #endregion
-
-        #region AssertLastOrDefault
 
         public abstract Task AssertLastOrDefault<TResult>(
             Func<ISetSource, IQueryable<TResult>> actualQuery,
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Action<object, object> asserter = null,
+            Action<TResult, TResult> asserter = null,
             int entryCount = 0,
             bool isAsync = false);
 
@@ -383,13 +175,9 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
             Expression<Func<TResult, bool>> actualPredicate,
             Expression<Func<TResult, bool>> expectedPredicate,
-            Action<object, object> asserter = null,
+            Action<TResult, TResult> asserter = null,
             int entryCount = 0,
             bool isAsync = false);
-
-        #endregion
-
-        #region AssertCount
 
         public abstract Task AssertCount<TResult>(
             Func<ISetSource, IQueryable<TResult>> actualQuery,
@@ -403,10 +191,6 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Expression<Func<TResult, bool>> expectedPredicate,
             bool isAsync = false);
 
-        #endregion
-
-        #region AssertLongCount
-
         public abstract Task AssertLongCount<TResult>(
             Func<ISetSource, IQueryable<TResult>> actualQuery,
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
@@ -418,15 +202,11 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Expression<Func<TResult, bool>> actualPredicate,
             Expression<Func<TResult, bool>> expectedPredicate,
             bool isAsync = false);
-
-        #endregion
-
-        #region AssertMin
 
         public abstract Task AssertMin<TResult>(
             Func<ISetSource, IQueryable<TResult>> actualQuery,
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Action<object, object> asserter = null,
+            Action<TResult, TResult> asserter = null,
             int entryCount = 0,
             bool isAsync = false);
 
@@ -435,18 +215,14 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
             Expression<Func<TResult, TSelector>> actualSelector,
             Expression<Func<TResult, TSelector>> expectedSelector,
-            Action<object, object> asserter = null,
+            Action<TSelector, TSelector> asserter = null,
             int entryCount = 0,
             bool isAsync = false);
-
-        #endregion
-
-        #region AssertMax
 
         public abstract Task AssertMax<TResult>(
             Func<ISetSource, IQueryable<TResult>> actualQuery,
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Action<object, object> asserter = null,
+            Action<TResult, TResult> asserter = null,
             int entryCount = 0,
             bool isAsync = false);
 
@@ -455,24 +231,20 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
             Expression<Func<TResult, TSelector>> actualSelector,
             Expression<Func<TResult, TSelector>> expectedSelector,
-            Action<object, object> asserter = null,
+            Action<TSelector, TSelector> asserter = null,
             int entryCount = 0,
             bool isAsync = false);
-
-        #endregion
-
-        #region AssertSum
 
         public abstract Task AssertSum(
             Func<ISetSource, IQueryable<int>> actualQuery,
             Func<ISetSource, IQueryable<int>> expectedQuery,
-            Action<object, object> asserter = null,
+            Action<int, int> asserter = null,
             bool isAsync = false);
 
         public abstract Task AssertSum(
             Func<ISetSource, IQueryable<int?>> actualQuery,
             Func<ISetSource, IQueryable<int?>> expectedQuery,
-            Action<object, object> asserter = null,
+            Action<int?, int?> asserter = null,
             bool isAsync = false);
 
         public abstract Task AssertSum<TResult>(
@@ -480,7 +252,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
             Expression<Func<TResult, int>> actualSelector,
             Expression<Func<TResult, int>> expectedSelector,
-            Action<object, object> asserter = null,
+            Action<int, int> asserter = null,
             bool isAsync = false);
 
         public abstract Task AssertSum<TResult>(
@@ -488,7 +260,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
             Expression<Func<TResult, int?>> actualSelector,
             Expression<Func<TResult, int?>> expectedSelector,
-            Action<object, object> asserter = null,
+            Action<int?, int?> asserter = null,
             bool isAsync = false);
 
         public abstract Task AssertSum<TResult>(
@@ -496,7 +268,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
             Expression<Func<TResult, long>> actualSelector,
             Expression<Func<TResult, long>> expectedSelector,
-            Action<object, object> asserter = null,
+            Action<long, long> asserter = null,
             bool isAsync = false);
 
         public abstract Task AssertSum<TResult>(
@@ -504,7 +276,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
             Expression<Func<TResult, long?>> actualSelector,
             Expression<Func<TResult, long?>> expectedSelector,
-            Action<object, object> asserter = null,
+            Action<long?, long?> asserter = null,
             bool isAsync = false);
 
         public abstract Task AssertSum<TResult>(
@@ -512,7 +284,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
             Expression<Func<TResult, decimal>> actualSelector,
             Expression<Func<TResult, decimal>> expectedSelector,
-            Action<object, object> asserter = null,
+            Action<decimal, decimal> asserter = null,
             bool isAsync = false);
 
         public abstract Task AssertSum<TResult>(
@@ -520,29 +292,25 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
             Expression<Func<TResult, float>> actualSelector,
             Expression<Func<TResult, float>> expectedSelector,
-            Action<object, object> asserter = null,
+            Action<float, float> asserter = null,
             bool isAsync = false);
-
-        #endregion
-
-        #region AssertAverage
 
         public abstract Task AssertAverage(
             Func<ISetSource, IQueryable<int>> actualQuery,
             Func<ISetSource, IQueryable<int>> expectedQuery,
-            Action<object, object> asserter = null,
+            Action<double, double> asserter = null,
             bool isAsync = false);
 
         public abstract Task AssertAverage(
             Func<ISetSource, IQueryable<int?>> actualQuery,
             Func<ISetSource, IQueryable<int?>> expectedQuery,
-            Action<object, object> asserter = null,
+            Action<double?, double?> asserter = null,
             bool isAsync = false);
 
         public abstract Task AssertAverage(
             Func<ISetSource, IQueryable<long>> actualQuery,
             Func<ISetSource, IQueryable<long>> expectedQuery,
-            Action<object, object> asserter = null,
+            Action<double, double> asserter = null,
             bool isAsync = false);
 
         public abstract Task AssertAverage<TResult>(
@@ -550,7 +318,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
             Expression<Func<TResult, int>> actualSelector,
             Expression<Func<TResult, int>> expectedSelector,
-            Action<object, object> asserter = null,
+            Action<double, double> asserter = null,
             bool isAsync = false);
 
         public abstract Task AssertAverage<TResult>(
@@ -558,7 +326,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
             Expression<Func<TResult, int?>> actualSelector,
             Expression<Func<TResult, int?>> expectedSelector,
-            Action<object, object> asserter = null,
+            Action<double?, double?> asserter = null,
             bool isAsync = false);
 
         public abstract Task AssertAverage<TResult>(
@@ -566,7 +334,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
             Expression<Func<TResult, decimal>> actualSelector,
             Expression<Func<TResult, decimal>> expectedSelector,
-            Action<object, object> asserter = null,
+            Action<decimal, decimal> asserter = null,
             bool isAsync = false);
 
         public abstract Task AssertAverage<TResult>(
@@ -574,8 +342,30 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
             Expression<Func<TResult, float>> actualSelector,
             Expression<Func<TResult, float>> expectedSelector,
-            Action<object, object> asserter = null,
+            Action<float, float> asserter = null,
             bool isAsync = false);
+
+        #endregion
+
+        #region Helpers
+
+        public abstract void AssertEqual<T>(
+            T expected,
+            T actual,
+            Action<T, T> asserter = null);
+
+        public abstract void AssertEqual<T>(
+            T? expected,
+            T? actual,
+            Action<T?, T?> asserter = null)
+            where T : struct;
+
+        public abstract void AssertCollection<TElement>(
+            IEnumerable<TElement> expected,
+            IEnumerable<TElement> actual,
+            bool ordered = false,
+            Func<TElement, object> elementSorter = null,
+            Action<TElement, TElement> elementAsserter = null);
 
         #endregion
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -988,33 +988,31 @@ FROM [Gears] AS [g]
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear')");
         }
 
-        // issue #18002
-//        public override async Task Select_null_propagation_optimization9(bool isAsync)
-//        {
-//            await base.Select_null_propagation_optimization9(isAsync);
+        public override async Task Select_null_propagation_optimization9(bool isAsync)
+        {
+            await base.Select_null_propagation_optimization9(isAsync);
 
-//            AssertSql(
-//                @"SELECT CAST(LEN([g].[FullName]) AS int)
-//FROM [Gears] AS [g]
-//WHERE [g].[Discriminator] IN (N'Gear', N'Officer')");
-//        }
+            AssertSql(
+                @"SELECT CAST(LEN([g].[FullName]) AS int)
+FROM [Gears] AS [g]
+WHERE [g].[Discriminator] IN (N'Gear', N'Officer')");
+        }
 
-        // issue #18002
-//        public override async Task Select_null_propagation_negative1(bool isAsync)
-//        {
-//            await base.Select_null_propagation_negative1(isAsync);
+        public override async Task Select_null_propagation_negative1(bool isAsync)
+        {
+            await base.Select_null_propagation_negative1(isAsync);
 
-//            AssertSql(
-//                @"SELECT CASE
-//    WHEN [g].[LeaderNickname] IS NOT NULL THEN CASE
-//        WHEN CAST(LEN([g].[Nickname]) AS int) = 5 THEN CAST(1 AS bit)
-//        ELSE CAST(0 AS bit)
-//    END
-//    ELSE NULL
-//END
-//FROM [Gears] AS [g]
-//WHERE [g].[Discriminator] IN (N'Gear', N'Officer')");
-//        }
+            AssertSql(
+                @"SELECT CASE
+    WHEN [g].[LeaderNickname] IS NOT NULL THEN CASE
+        WHEN CAST(LEN([g].[Nickname]) AS int) = 5 THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END
+    ELSE NULL
+END
+FROM [Gears] AS [g]
+WHERE [g].[Discriminator] IN (N'Gear', N'Officer')");
+        }
 
         public override async Task Select_null_propagation_negative2(bool isAsync)
         {
@@ -1094,22 +1092,21 @@ WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
 ORDER BY [t].[Nickname]");
         }
 
-        // issue #18002
-//        public override async Task Select_null_propagation_negative6(bool isAsync)
-//        {
-//            await base.Select_null_propagation_negative6(isAsync);
+        public override async Task Select_null_propagation_negative6(bool isAsync)
+        {
+            await base.Select_null_propagation_negative6(isAsync);
 
-//            AssertSql(
-//                @"SELECT CASE
-//    WHEN [g].[LeaderNickname] IS NOT NULL THEN CASE
-//        WHEN ((CAST(LEN([g].[LeaderNickname]) AS int) <> CAST(LEN([g].[LeaderNickname]) AS int)) OR (CAST(LEN([g].[LeaderNickname]) AS int) IS NULL OR CAST(LEN([g].[LeaderNickname]) AS int) IS NULL)) AND (CAST(LEN([g].[LeaderNickname]) AS int) IS NOT NULL OR CAST(LEN([g].[LeaderNickname]) AS int) IS NOT NULL) THEN CAST(1 AS bit)
-//        ELSE CAST(0 AS bit)
-//    END
-//    ELSE NULL
-//END
-//FROM [Gears] AS [g]
-//WHERE [g].[Discriminator] IN (N'Gear', N'Officer')");
-//        }
+            AssertSql(
+                @"SELECT CASE
+    WHEN [g].[LeaderNickname] IS NOT NULL THEN CASE
+        WHEN ((CAST(LEN([g].[LeaderNickname]) AS int) <> CAST(LEN([g].[LeaderNickname]) AS int)) OR (CAST(LEN([g].[LeaderNickname]) AS int) IS NULL OR CAST(LEN([g].[LeaderNickname]) AS int) IS NULL)) AND (CAST(LEN([g].[LeaderNickname]) AS int) IS NOT NULL OR CAST(LEN([g].[LeaderNickname]) AS int) IS NOT NULL) THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END
+    ELSE NULL
+END
+FROM [Gears] AS [g]
+WHERE [g].[Discriminator] IN (N'Gear', N'Officer')");
+        }
 
         public override async Task Select_null_propagation_negative7(bool isAsync)
         {
@@ -2123,18 +2120,17 @@ FROM [Weapons] AS [w]
 WHERE (([w].[AmmunitionType] = 1) AND [w].[AmmunitionType] IS NOT NULL) AND (COALESCE([w].[IsAutomatic], CAST(0 AS bit)) = CAST(1 AS bit))");
         }
 
-        // issue #18002
-//        public override async Task Coalesce_operator_in_projection_with_other_conditions(bool isAsync)
-//        {
-//            await base.Coalesce_operator_in_projection_with_other_conditions(isAsync);
+        public override async Task Coalesce_operator_in_projection_with_other_conditions(bool isAsync)
+        {
+            await base.Coalesce_operator_in_projection_with_other_conditions(isAsync);
 
-//            AssertSql(
-//                @"SELECT CASE
-//    WHEN (([w].[AmmunitionType] = 1) AND [w].[AmmunitionType] IS NOT NULL) AND (COALESCE([w].[IsAutomatic], CAST(0 AS bit)) = CAST(1 AS bit)) THEN CAST(1 AS bit)
-//    ELSE CAST(0 AS bit)
-//END
-//FROM [Weapons] AS [w]");
-//        }
+            AssertSql(
+                @"SELECT CASE
+    WHEN (([w].[AmmunitionType] = 1) AND [w].[AmmunitionType] IS NOT NULL) AND (COALESCE([w].[IsAutomatic], CAST(0 AS bit)) = CAST(1 AS bit)) THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END
+FROM [Weapons] AS [w]");
+        }
 
         public override async Task Optional_navigation_type_compensation_works_with_predicate(bool isAsync)
         {
@@ -2250,23 +2246,22 @@ LEFT JOIN (
 WHERE ([t0].[HasSoulPatch] = CAST(1 AS bit)) OR (CHARINDEX(N'Cole', [t].[Note]) > 0)");
         }
 
-        // issue #18002
-//        public override async Task Optional_navigation_type_compensation_works_with_binary_and_expression(bool isAsync)
-//        {
-//            await base.Optional_navigation_type_compensation_works_with_binary_and_expression(isAsync);
+        public override async Task Optional_navigation_type_compensation_works_with_binary_and_expression(bool isAsync)
+        {
+            await base.Optional_navigation_type_compensation_works_with_binary_and_expression(isAsync);
 
-//            AssertSql(
-//                @"SELECT CASE
-//    WHEN ([t0].[HasSoulPatch] = CAST(1 AS bit)) AND (CHARINDEX(N'Cole', [t].[Note]) > 0) THEN CAST(1 AS bit)
-//    ELSE CAST(0 AS bit)
-//END
-//FROM [Tags] AS [t]
-//LEFT JOIN (
-//    SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
-//    FROM [Gears] AS [g]
-//    WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
-//) AS [t0] ON (([t].[GearNickName] = [t0].[Nickname]) AND [t].[GearNickName] IS NOT NULL) AND (([t].[GearSquadId] = [t0].[SquadId]) AND [t].[GearSquadId] IS NOT NULL)");
-//        }
+            AssertSql(
+                @"SELECT CASE
+    WHEN ([t0].[HasSoulPatch] = CAST(1 AS bit)) AND (CHARINDEX(N'Cole', [t].[Note]) > 0) THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END
+FROM [Tags] AS [t]
+LEFT JOIN (
+    SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+    FROM [Gears] AS [g]
+    WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
+) AS [t0] ON (([t].[GearNickName] = [t0].[Nickname]) AND [t].[GearNickName] IS NOT NULL) AND (([t].[GearSquadId] = [t0].[SquadId]) AND [t].[GearSquadId] IS NOT NULL)");
+        }
 
         public override async Task Optional_navigation_type_compensation_works_with_projection(bool isAsync)
         {
@@ -4293,71 +4288,68 @@ WHERE [s].[Id] < 20
 ORDER BY [s].[Id], [t].[Nickname], [t].[SquadId]");
         }
 
-        // issue #18002
-//        public override async Task Correlated_collections_nested(bool isAsync)
-//        {
-//            await base.Correlated_collections_nested(isAsync);
+        public override async Task Correlated_collections_nested(bool isAsync)
+        {
+            await base.Correlated_collections_nested(isAsync);
 
-//            AssertSql(
-//                @"SELECT [s].[Id], [t0].[SquadId], [t0].[MissionId], [t0].[Id], [t0].[SquadId0], [t0].[MissionId0]
-//FROM [Squads] AS [s]
-//LEFT JOIN (
-//    SELECT [s0].[SquadId], [s0].[MissionId], [m].[Id], [t].[SquadId] AS [SquadId0], [t].[MissionId] AS [MissionId0]
-//    FROM [SquadMissions] AS [s0]
-//    INNER JOIN [Missions] AS [m] ON [s0].[MissionId] = [m].[Id]
-//    LEFT JOIN (
-//        SELECT [s1].[SquadId], [s1].[MissionId]
-//        FROM [SquadMissions] AS [s1]
-//        WHERE [s1].[SquadId] < 7
-//    ) AS [t] ON [m].[Id] = [t].[MissionId]
-//    WHERE [s0].[MissionId] < 42
-//) AS [t0] ON [s].[Id] = [t0].[SquadId]
-//ORDER BY [s].[Id], [t0].[SquadId], [t0].[MissionId], [t0].[Id], [t0].[SquadId0], [t0].[MissionId0]");
-//        }
+            AssertSql(
+                @"SELECT [s].[Id], [t0].[SquadId], [t0].[MissionId], [t0].[Id], [t0].[SquadId0], [t0].[MissionId0]
+FROM [Squads] AS [s]
+LEFT JOIN (
+    SELECT [s0].[SquadId], [s0].[MissionId], [m].[Id], [t].[SquadId] AS [SquadId0], [t].[MissionId] AS [MissionId0]
+    FROM [SquadMissions] AS [s0]
+    INNER JOIN [Missions] AS [m] ON [s0].[MissionId] = [m].[Id]
+    LEFT JOIN (
+        SELECT [s1].[SquadId], [s1].[MissionId]
+        FROM [SquadMissions] AS [s1]
+        WHERE [s1].[SquadId] < 7
+    ) AS [t] ON [m].[Id] = [t].[MissionId]
+    WHERE [s0].[MissionId] < 42
+) AS [t0] ON [s].[Id] = [t0].[SquadId]
+ORDER BY [s].[Id], [t0].[SquadId], [t0].[MissionId], [t0].[Id], [t0].[SquadId0], [t0].[MissionId0]");
+        }
 
-        // issue #18002
-//        public override async Task Correlated_collections_nested_mixed_streaming_with_buffer1(bool isAsync)
-//        {
-//            await base.Correlated_collections_nested_mixed_streaming_with_buffer1(isAsync);
+        public override async Task Correlated_collections_nested_mixed_streaming_with_buffer1(bool isAsync)
+        {
+            await base.Correlated_collections_nested_mixed_streaming_with_buffer1(isAsync);
 
-//            AssertSql(
-//                @"SELECT [s].[Id], [t0].[SquadId], [t0].[MissionId], [t0].[Id], [t0].[SquadId0], [t0].[MissionId0]
-//FROM [Squads] AS [s]
-//LEFT JOIN (
-//    SELECT [s0].[SquadId], [s0].[MissionId], [m].[Id], [t].[SquadId] AS [SquadId0], [t].[MissionId] AS [MissionId0]
-//    FROM [SquadMissions] AS [s0]
-//    INNER JOIN [Missions] AS [m] ON [s0].[MissionId] = [m].[Id]
-//    LEFT JOIN (
-//        SELECT [s1].[SquadId], [s1].[MissionId]
-//        FROM [SquadMissions] AS [s1]
-//        WHERE [s1].[SquadId] < 2
-//    ) AS [t] ON [m].[Id] = [t].[MissionId]
-//    WHERE [s0].[MissionId] < 3
-//) AS [t0] ON [s].[Id] = [t0].[SquadId]
-//ORDER BY [s].[Id], [t0].[SquadId], [t0].[MissionId], [t0].[Id], [t0].[SquadId0], [t0].[MissionId0]");
-//        }
+            AssertSql(
+                @"SELECT [s].[Id], [t0].[SquadId], [t0].[MissionId], [t0].[Id], [t0].[SquadId0], [t0].[MissionId0]
+FROM [Squads] AS [s]
+LEFT JOIN (
+    SELECT [s0].[SquadId], [s0].[MissionId], [m].[Id], [t].[SquadId] AS [SquadId0], [t].[MissionId] AS [MissionId0]
+    FROM [SquadMissions] AS [s0]
+    INNER JOIN [Missions] AS [m] ON [s0].[MissionId] = [m].[Id]
+    LEFT JOIN (
+        SELECT [s1].[SquadId], [s1].[MissionId]
+        FROM [SquadMissions] AS [s1]
+        WHERE [s1].[SquadId] < 2
+    ) AS [t] ON [m].[Id] = [t].[MissionId]
+    WHERE [s0].[MissionId] < 3
+) AS [t0] ON [s].[Id] = [t0].[SquadId]
+ORDER BY [s].[Id], [t0].[SquadId], [t0].[MissionId], [t0].[Id], [t0].[SquadId0], [t0].[MissionId0]");
+        }
 
-        // issue 18002
-//        public override async Task Correlated_collections_nested_mixed_streaming_with_buffer2(bool isAsync)
-//        {
-//            await base.Correlated_collections_nested_mixed_streaming_with_buffer2(isAsync);
+        public override async Task Correlated_collections_nested_mixed_streaming_with_buffer2(bool isAsync)
+        {
+            await base.Correlated_collections_nested_mixed_streaming_with_buffer2(isAsync);
 
-//            AssertSql(
-//                @"SELECT [s].[Id], [t0].[SquadId], [t0].[MissionId], [t0].[Id], [t0].[SquadId0], [t0].[MissionId0]
-//FROM [Squads] AS [s]
-//LEFT JOIN (
-//    SELECT [s0].[SquadId], [s0].[MissionId], [m].[Id], [t].[SquadId] AS [SquadId0], [t].[MissionId] AS [MissionId0]
-//    FROM [SquadMissions] AS [s0]
-//    INNER JOIN [Missions] AS [m] ON [s0].[MissionId] = [m].[Id]
-//    LEFT JOIN (
-//        SELECT [s1].[SquadId], [s1].[MissionId]
-//        FROM [SquadMissions] AS [s1]
-//        WHERE [s1].[SquadId] < 7
-//    ) AS [t] ON [m].[Id] = [t].[MissionId]
-//    WHERE [s0].[MissionId] < 42
-//) AS [t0] ON [s].[Id] = [t0].[SquadId]
-//ORDER BY [s].[Id], [t0].[SquadId], [t0].[MissionId], [t0].[Id], [t0].[SquadId0], [t0].[MissionId0]");
-//        }
+            AssertSql(
+                @"SELECT [s].[Id], [t0].[SquadId], [t0].[MissionId], [t0].[Id], [t0].[SquadId0], [t0].[MissionId0]
+FROM [Squads] AS [s]
+LEFT JOIN (
+    SELECT [s0].[SquadId], [s0].[MissionId], [m].[Id], [t].[SquadId] AS [SquadId0], [t].[MissionId] AS [MissionId0]
+    FROM [SquadMissions] AS [s0]
+    INNER JOIN [Missions] AS [m] ON [s0].[MissionId] = [m].[Id]
+    LEFT JOIN (
+        SELECT [s1].[SquadId], [s1].[MissionId]
+        FROM [SquadMissions] AS [s1]
+        WHERE [s1].[SquadId] < 7
+    ) AS [t] ON [m].[Id] = [t].[MissionId]
+    WHERE [s0].[MissionId] < 42
+) AS [t0] ON [s].[Id] = [t0].[SquadId]
+ORDER BY [s].[Id], [t0].[SquadId], [t0].[MissionId], [t0].[Id], [t0].[SquadId0], [t0].[MissionId0]");
+        }
 
         public override async Task Correlated_collections_nested_with_custom_ordering(bool isAsync)
         {

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
@@ -993,9 +993,9 @@ FROM ""Orders"" AS ""o""");
         [MemberData(nameof(IsAsyncData))]
         public virtual async Task Select_datetime_year_component_composed(bool isAsync)
         {
-            await AssertQueryScalar<Order>(
+            await AssertQueryScalar(
                 isAsync,
-                os => os.Select(o => o.OrderDate.Value.AddYears(1).Year));
+                ss => ss.Set<Order>().Select(o => o.OrderDate.Value.AddYears(1).Year));
 
             AssertSql(
                 @"SELECT CAST(strftime('%Y', ""o"".""OrderDate"", CAST(1 AS TEXT) || ' years') AS INTEGER)
@@ -1069,9 +1069,9 @@ FROM ""Orders"" AS ""o""");
         [MemberData(nameof(IsAsyncData))]
         public virtual async Task Select_datetime_millisecond_component_composed(bool isAsync)
         {
-            await AssertQueryScalar<Order>(
+            await AssertQueryScalar(
                 isAsync,
-                os => os.Select(o => o.OrderDate.Value.AddYears(1).Millisecond));
+                ss => ss.Set<Order>().Select(o => o.OrderDate.Value.AddYears(1).Millisecond));
 
             AssertSql(
                 @"SELECT (CAST(strftime('%f', ""o"".""OrderDate"", CAST(1 AS TEXT) || ' years') AS REAL) * 1000.0) % 1000.0
@@ -1109,9 +1109,9 @@ FROM ""Orders"" AS ""o""");
         [MemberData(nameof(IsAsyncData))]
         public virtual async Task Select_datetime_TimeOfDay_component_composed(bool isAsync)
         {
-            await AssertQueryScalar<Order>(
+            await AssertQueryScalar(
                 isAsync,
-                os => os.Select(o => o.OrderDate.Value.AddYears(1).TimeOfDay));
+                ss => ss.Set<Order>().Select(o => o.OrderDate.Value.AddYears(1).TimeOfDay));
 
             AssertSql(
                 @"SELECT rtrim(rtrim(strftime('%H:%M:%f', ""o"".""OrderDate"", CAST(1 AS TEXT) || ' years'), '0'), '.')


### PR DESCRIPTION
Converting remaining assert query methods + final cleanup