### PR TITLE
[3.1] Cosmos: Use the execution strategy to retry transient failures

### DIFF
--- a/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
@@ -25,38 +25,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
             => GetString("CosmosNotInUse");
 
         /// <summary>
-        ///     Create container failed. Status code: {statusCode}. Message: '{errorMessage}'
-        /// </summary>
-        public static string CreateContainerFailed([CanBeNull] object statusCode, [CanBeNull] object errorMessage)
-            => string.Format(
-                GetString("CreateContainerFailed", nameof(statusCode), nameof(errorMessage)),
-                statusCode, errorMessage);
-
-        /// <summary>
-        ///     Create item failed. Status code: {statusCode}. Message: '{errorMessage}'
-        /// </summary>
-        public static string CreateItemFailed([CanBeNull] object statusCode, [CanBeNull] object errorMessage)
-            => string.Format(
-                GetString("CreateItemFailed", nameof(statusCode), nameof(errorMessage)),
-                statusCode, errorMessage);
-
-        /// <summary>
-        ///     Delete database failed. Status code: {statusCode}. Message: '{errorMessage}'
-        /// </summary>
-        public static string DeleteDatabaseFailed([CanBeNull] object statusCode, [CanBeNull] object errorMessage)
-            => string.Format(
-                GetString("DeleteDatabaseFailed", nameof(statusCode), nameof(errorMessage)),
-                statusCode, errorMessage);
-
-        /// <summary>
-        ///     Delete item failed. Status code: {statusCode}. Message: '{errorMessage}'
-        /// </summary>
-        public static string DeleteItemFailed([CanBeNull] object statusCode, [CanBeNull] object errorMessage)
-            => string.Format(
-                GetString("DeleteItemFailed", nameof(statusCode), nameof(errorMessage)),
-                statusCode, errorMessage);
-
-        /// <summary>
         ///     The discriminator value for '{entityType1}' is '{discriminatorValue}' which is the same for '{entityType2}'. Every concrete entity type mapped to the container '{container}' needs to have a unique discriminator value.
         /// </summary>
         public static string DuplicateDiscriminatorValue([CanBeNull] object entityType1, [CanBeNull] object discriminatorValue, [CanBeNull] object entityType2, [CanBeNull] object container)
@@ -127,22 +95,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
             => string.Format(
                 GetString("PartitionKeyStoreNameMismatch", nameof(property1), nameof(entityType1), nameof(storeName1), nameof(property2), nameof(entityType2), nameof(storeName2)),
                 property1, entityType1, storeName1, property2, entityType2, storeName2);
-
-        /// <summary>
-        ///     Query failed. Status code: {statusCode}. Message: '{errorMessage}'
-        /// </summary>
-        public static string QueryFailed([CanBeNull] object statusCode, [CanBeNull] object errorMessage)
-            => string.Format(
-                GetString("QueryFailed", nameof(statusCode), nameof(errorMessage)),
-                statusCode, errorMessage);
-
-        /// <summary>
-        ///     Replace item failed. Status code: {statusCode}. Message: '{errorMessage}'
-        /// </summary>
-        public static string ReplaceItemFailed([CanBeNull] object statusCode, [CanBeNull] object errorMessage)
-            => string.Format(
-                GetString("ReplaceItemFailed", nameof(statusCode), nameof(errorMessage)),
-                statusCode, errorMessage);
 
         private static string GetString(string name, params string[] formatterNames)
         {

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.resx
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.resx
@@ -120,18 +120,6 @@
   <data name="CosmosNotInUse" xml:space="preserve">
     <value>Cosmos-specific methods can only be used when the context is using the Cosmos provider.</value>
   </data>
-  <data name="CreateContainerFailed" xml:space="preserve">
-    <value>Create container failed. Status code: {statusCode}. Message: '{errorMessage}'</value>
-  </data>
-  <data name="CreateItemFailed" xml:space="preserve">
-    <value>Create item failed. Status code: {statusCode}. Message: '{errorMessage}'</value>
-  </data>
-  <data name="DeleteDatabaseFailed" xml:space="preserve">
-    <value>Delete database failed. Status code: {statusCode}. Message: '{errorMessage}'</value>
-  </data>
-  <data name="DeleteItemFailed" xml:space="preserve">
-    <value>Delete item failed. Status code: {statusCode}. Message: '{errorMessage}'</value>
-  </data>
   <data name="DuplicateDiscriminatorValue" xml:space="preserve">
     <value>The discriminator value for '{entityType1}' is '{discriminatorValue}' which is the same for '{entityType2}'. Every concrete entity type mapped to the container '{container}' needs to have a unique discriminator value.</value>
   </data>
@@ -158,11 +146,5 @@
   </data>
   <data name="PartitionKeyStoreNameMismatch" xml:space="preserve">
     <value>The partition key property '{property1}' on '{entityType1}' is mapped as '{storeName1}', but the partition key property '{property2}' on '{entityType2}' is mapped as '{storeName2}'. All partition key properties need to be mapped to the same store property.</value>
-  </data>
-  <data name="QueryFailed" xml:space="preserve">
-    <value>Query failed. Status code: {statusCode}. Message: '{errorMessage}'</value>
-  </data>
-  <data name="ReplaceItemFailed" xml:space="preserve">
-    <value>Replace item failed. Status code: {statusCode}. Message: '{errorMessage}'</value>
   </data>
 </root>

--- a/test/EFCore.Cosmos.FunctionalTests/EndToEndCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/EndToEndCosmosTest.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore.Cosmos.Internal;
+using Microsoft.Azure.Cosmos;
 using Microsoft.EntityFrameworkCore.Cosmos.TestUtilities;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -457,30 +457,30 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
             {
                 context.Add(customer);
 
-                Assert.StartsWith(CosmosStrings.CreateItemFailed("NotFound", "Message: {\"Errors\":[\"Resource Not Found\"]}")[..^1],
-                    (await Assert.ThrowsAsync<InvalidOperationException>(() => context.SaveChangesAsync())).Message);
+                Assert.StartsWith("Response status code does not indicate success: 404 Substatus: 0",
+                    (await Assert.ThrowsAsync<CosmosException>(() => context.SaveChangesAsync())).Message);
             }
 
             using (var context = new CustomerContext(options))
             {
                 context.Add(customer).State = EntityState.Modified;
 
-                Assert.StartsWith(CosmosStrings.ReplaceItemFailed("NotFound", "Message: {\"Errors\":[\"Resource Not Found\"]}")[..^1],
-                    (await Assert.ThrowsAsync<InvalidOperationException>(() => context.SaveChangesAsync())).Message);
+                Assert.StartsWith("Response status code does not indicate success: 404 Substatus: 0",
+                    (await Assert.ThrowsAsync<CosmosException>(() => context.SaveChangesAsync())).Message);
             }
 
             using (var context = new CustomerContext(options))
             {
                 context.Add(customer).State = EntityState.Deleted;
 
-                Assert.StartsWith(CosmosStrings.DeleteItemFailed("NotFound", "Message: {\"Errors\":[\"Resource Not Found\"]}")[..^1],
-                    (await Assert.ThrowsAsync<InvalidOperationException>(() => context.SaveChangesAsync())).Message);
+                Assert.StartsWith("Response status code does not indicate success: 404 Substatus: 0",
+                    (await Assert.ThrowsAsync<CosmosException>(() => context.SaveChangesAsync())).Message);
             }
 
             using (var context = new CustomerContext(options))
             {
-                Assert.StartsWith(CosmosStrings.QueryFailed("NotFound", "Message: {\"Errors\":[\"Resource Not Found\"]}")[..^1],
-                    (await Assert.ThrowsAsync<InvalidOperationException>(() => context.Set<Customer>().SingleAsync())).Message);
+                Assert.StartsWith("Response status code does not indicate success: 404 Substatus: 0",
+                    (await Assert.ThrowsAsync<CosmosException>(() => context.Set<Customer>().SingleAsync())).Message);
             }
         }
 


### PR DESCRIPTION
### Description
Use the SDK exception type when a store error occurs
Remove the exception messages introduced in https://github.com/aspnet/EntityFrameworkCore/pull/17903 as they didn't add much value

Part of #17925

#### Customer impact
With these changes store failures will be presented as `CosmosException` instead of `InvalidOperationException`, so they can be retried

#### Regression
N/A, 3.0 is the first RTM release for the Cosmos provider

#### Risk
Low
