### PR TITLE
Add missed icon metadata

### DIFF
--- a/src/EFCore.Analyzers/EFCore.Analyzers.nuspec
+++ b/src/EFCore.Analyzers/EFCore.Analyzers.nuspec
@@ -5,6 +5,7 @@
     <dependencies>
       <group targetFramework=".NETStandard1.3" />
     </dependencies>
+    <icon>packageIcon.png</icon>
   </metadata>
 
   <files>

--- a/src/EFCore.Tools/EFCore.Tools.nuspec
+++ b/src/EFCore.Tools/EFCore.Tools.nuspec
@@ -8,6 +8,7 @@
         <dependency id="Microsoft.EntityFrameworkCore.Design" version="$version$" />
       </group>
     </dependencies>
+    <icon>packageIcon.png</icon>
   </metadata>
   <files>
     <file src="lib\**\*" target="lib/" />


### PR DESCRIPTION
Add `icon` metadata to 2 manual `.nuspec`s that I missed previously