### PR TITLE
Fix to #17975 - Query/Test: add missing Assert overloads for aggregate operations

### DIFF
--- a/test/EFCore.Specification.Tests/Query/QueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/QueryTestBase.cs
@@ -526,6 +526,110 @@ namespace Microsoft.EntityFrameworkCore.Query
             Action<int?, int?> asserter = null)
             => Fixture.QueryAsserter.AssertSum(actualQuery, expectedQuery, asserter, isAsync);
 
+        protected Task AssertSum(
+            bool isAsync,
+            Func<ISetSource, IQueryable<long>> query,
+            Action<long, long> asserter = null)
+            => AssertSum(isAsync, query, query, asserter);
+
+        protected Task AssertSum(
+            bool isAsync,
+            Func<ISetSource, IQueryable<long>> actualQuery,
+            Func<ISetSource, IQueryable<long>> expectedQuery,
+            Action<long, long> asserter = null)
+            => Fixture.QueryAsserter.AssertSum(actualQuery, expectedQuery, asserter, isAsync);
+
+        protected Task AssertSum(
+            bool isAsync,
+            Func<ISetSource, IQueryable<long?>> query,
+            Action<long?, long?> asserter = null)
+            => AssertSum(isAsync, query, query, asserter);
+
+        protected Task AssertSum(
+            bool isAsync,
+            Func<ISetSource, IQueryable<long?>> actualQuery,
+            Func<ISetSource, IQueryable<long?>> expectedQuery,
+            Action<long?, long?> asserter = null)
+            => Fixture.QueryAsserter.AssertSum(actualQuery, expectedQuery, asserter, isAsync);
+
+        protected Task AssertSum(
+            bool isAsync,
+            Func<ISetSource, IQueryable<decimal>> query,
+            Action<decimal, decimal> asserter = null)
+            => AssertSum(isAsync, query, query, asserter);
+
+        protected Task AssertSum(
+            bool isAsync,
+            Func<ISetSource, IQueryable<decimal>> actualQuery,
+            Func<ISetSource, IQueryable<decimal>> expectedQuery,
+            Action<decimal, decimal> asserter = null)
+            => Fixture.QueryAsserter.AssertSum(actualQuery, expectedQuery, asserter, isAsync);
+
+        protected Task AssertSum(
+            bool isAsync,
+            Func<ISetSource, IQueryable<decimal?>> query,
+            Action<decimal?, decimal?> asserter = null)
+            => AssertSum(isAsync, query, query, asserter);
+
+        protected Task AssertSum(
+            bool isAsync,
+            Func<ISetSource, IQueryable<decimal?>> actualQuery,
+            Func<ISetSource, IQueryable<decimal?>> expectedQuery,
+            Action<decimal?, decimal?> asserter = null)
+            => Fixture.QueryAsserter.AssertSum(actualQuery, expectedQuery, asserter, isAsync);
+
+        protected Task AssertSum(
+            bool isAsync,
+            Func<ISetSource, IQueryable<float>> query,
+            Action<float, float> asserter = null)
+            => AssertSum(isAsync, query, query, asserter);
+
+        protected Task AssertSum(
+            bool isAsync,
+            Func<ISetSource, IQueryable<float>> actualQuery,
+            Func<ISetSource, IQueryable<float>> expectedQuery,
+            Action<float, float> asserter = null)
+            => Fixture.QueryAsserter.AssertSum(actualQuery, expectedQuery, asserter, isAsync);
+
+        protected Task AssertSum(
+            bool isAsync,
+            Func<ISetSource, IQueryable<float?>> query,
+            Action<float?, float?> asserter = null)
+            => AssertSum(isAsync, query, query, asserter);
+
+        protected Task AssertSum(
+            bool isAsync,
+            Func<ISetSource, IQueryable<float?>> actualQuery,
+            Func<ISetSource, IQueryable<float?>> expectedQuery,
+            Action<float?, float?> asserter = null)
+            => Fixture.QueryAsserter.AssertSum(actualQuery, expectedQuery, asserter, isAsync);
+
+        protected Task AssertSum(
+            bool isAsync,
+            Func<ISetSource, IQueryable<double>> query,
+            Action<double, double> asserter = null)
+            => AssertSum(isAsync, query, query, asserter);
+
+        protected Task AssertSum(
+            bool isAsync,
+            Func<ISetSource, IQueryable<double>> actualQuery,
+            Func<ISetSource, IQueryable<double>> expectedQuery,
+            Action<double, double> asserter = null)
+            => Fixture.QueryAsserter.AssertSum(actualQuery, expectedQuery, asserter, isAsync);
+
+        protected Task AssertSum(
+            bool isAsync,
+            Func<ISetSource, IQueryable<double?>> query,
+            Action<double?, double?> asserter = null)
+            => AssertSum(isAsync, query, query, asserter);
+
+        protected Task AssertSum(
+            bool isAsync,
+            Func<ISetSource, IQueryable<double?>> actualQuery,
+            Func<ISetSource, IQueryable<double?>> expectedQuery,
+            Action<double?, double?> asserter = null)
+            => Fixture.QueryAsserter.AssertSum(actualQuery, expectedQuery, asserter, isAsync);
+
         protected Task AssertSum<TResult>(
             bool isAsync,
             Func<ISetSource, IQueryable<TResult>> query,
@@ -614,6 +718,23 @@ namespace Microsoft.EntityFrameworkCore.Query
         protected Task AssertSum<TResult>(
             bool isAsync,
             Func<ISetSource, IQueryable<TResult>> query,
+            Expression<Func<TResult, decimal?>> selector,
+            Action<decimal?, decimal?> asserter = null)
+            => AssertSum(isAsync, query, query, selector, selector, asserter);
+
+        protected Task AssertSum<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, decimal?>> actualSelector,
+            Expression<Func<TResult, decimal?>> expectedSelector,
+            Action<decimal?, decimal?> asserter = null)
+            => Fixture.QueryAsserter.AssertSum(
+                actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
+
+        protected Task AssertSum<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
             Expression<Func<TResult, float>> selector,
             Action<float, float> asserter = null)
             => AssertSum(isAsync, query, query, selector, selector, asserter);
@@ -625,6 +746,57 @@ namespace Microsoft.EntityFrameworkCore.Query
             Expression<Func<TResult, float>> actualSelector,
             Expression<Func<TResult, float>> expectedSelector,
             Action<float, float> asserter = null)
+            => Fixture.QueryAsserter.AssertSum(
+                actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
+
+        protected Task AssertSum<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Expression<Func<TResult, float?>> selector,
+            Action<float?, float?> asserter = null)
+            => AssertSum(isAsync, query, query, selector, selector, asserter);
+
+        protected Task AssertSum<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, float?>> actualSelector,
+            Expression<Func<TResult, float?>> expectedSelector,
+            Action<float?, float?> asserter = null)
+            => Fixture.QueryAsserter.AssertSum(
+                actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
+
+        protected Task AssertSum<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Expression<Func<TResult, double>> selector,
+            Action<double, double> asserter = null)
+            => AssertSum(isAsync, query, query, selector, selector, asserter);
+
+        protected Task AssertSum<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, double>> actualSelector,
+            Expression<Func<TResult, double>> expectedSelector,
+            Action<double, double> asserter = null)
+            => Fixture.QueryAsserter.AssertSum(
+                actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
+
+        protected Task AssertSum<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Expression<Func<TResult, double?>> selector,
+            Action<double?, double?> asserter = null)
+            => AssertSum(isAsync, query, query, selector, selector, asserter);
+
+        protected Task AssertSum<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, double?>> actualSelector,
+            Expression<Func<TResult, double?>> expectedSelector,
+            Action<double?, double?> asserter = null)
             => Fixture.QueryAsserter.AssertSum(
                 actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
 
@@ -640,6 +812,12 @@ namespace Microsoft.EntityFrameworkCore.Query
             Func<ISetSource, IQueryable<int>> expectedQuery,
             Action<double, double> asserter = null)
             => Fixture.QueryAsserter.AssertAverage(actualQuery, expectedQuery, asserter, isAsync);
+
+        protected Task AssertAverage(
+            bool isAsync,
+            Func<ISetSource, IQueryable<int?>> query,
+            Action<double?, double?> asserter = null)
+            => AssertAverage(isAsync, query, query, asserter);
 
         protected Task AssertAverage(
             bool isAsync,
@@ -659,6 +837,97 @@ namespace Microsoft.EntityFrameworkCore.Query
             Func<ISetSource, IQueryable<long>> actualQuery,
             Func<ISetSource, IQueryable<long>> expectedQuery,
             Action<double, double> asserter = null)
+            => Fixture.QueryAsserter.AssertAverage(actualQuery, expectedQuery, asserter, isAsync);
+
+        protected Task AssertAverage(
+            bool isAsync,
+            Func<ISetSource, IQueryable<long?>> query,
+            Action<double?, double?> asserter = null)
+            => AssertAverage(isAsync, query, query, asserter);
+
+        protected Task AssertAverage(
+            bool isAsync,
+            Func<ISetSource, IQueryable<long?>> actualQuery,
+            Func<ISetSource, IQueryable<long?>> expectedQuery,
+            Action<double?, double?> asserter = null)
+            => Fixture.QueryAsserter.AssertAverage(actualQuery, expectedQuery, asserter, isAsync);
+
+        protected Task AssertAverage(
+            bool isAsync,
+            Func<ISetSource, IQueryable<decimal>> query,
+            Action<decimal, decimal> asserter = null)
+            => AssertAverage(isAsync, query, query, asserter);
+
+        protected Task AssertAverage(
+            bool isAsync,
+            Func<ISetSource, IQueryable<decimal>> actualQuery,
+            Func<ISetSource, IQueryable<decimal>> expectedQuery,
+            Action<decimal, decimal> asserter = null)
+            => Fixture.QueryAsserter.AssertAverage(actualQuery, expectedQuery, asserter, isAsync);
+
+        protected Task AssertAverage(
+            bool isAsync,
+            Func<ISetSource, IQueryable<decimal?>> query,
+            Action<decimal?, decimal?> asserter = null)
+            => AssertAverage(isAsync, query, query, asserter);
+
+        protected Task AssertAverage(
+            bool isAsync,
+            Func<ISetSource, IQueryable<decimal?>> actualQuery,
+            Func<ISetSource, IQueryable<decimal?>> expectedQuery,
+            Action<decimal?, decimal?> asserter = null)
+            => Fixture.QueryAsserter.AssertAverage(actualQuery, expectedQuery, asserter, isAsync);
+
+        protected Task AssertAverage(
+            bool isAsync,
+            Func<ISetSource, IQueryable<float>> query,
+            Action<float, float> asserter = null)
+            => AssertAverage(isAsync, query, query, asserter);
+
+        protected Task AssertAverage(
+            bool isAsync,
+            Func<ISetSource, IQueryable<float>> actualQuery,
+            Func<ISetSource, IQueryable<float>> expectedQuery,
+            Action<float, float> asserter = null)
+            => Fixture.QueryAsserter.AssertAverage(actualQuery, expectedQuery, asserter, isAsync);
+
+        protected Task AssertAverage(
+            bool isAsync,
+            Func<ISetSource, IQueryable<float?>> query,
+            Action<float?, float?> asserter = null)
+            => AssertAverage(isAsync, query, query, asserter);
+
+        protected Task AssertAverage(
+            bool isAsync,
+            Func<ISetSource, IQueryable<float?>> actualQuery,
+            Func<ISetSource, IQueryable<float?>> expectedQuery,
+            Action<float?, float?> asserter = null)
+            => Fixture.QueryAsserter.AssertAverage(actualQuery, expectedQuery, asserter, isAsync);
+
+        protected Task AssertAverage(
+            bool isAsync,
+            Func<ISetSource, IQueryable<double>> query,
+            Action<double, double> asserter = null)
+            => AssertAverage(isAsync, query, query, asserter);
+
+        protected Task AssertAverage(
+            bool isAsync,
+            Func<ISetSource, IQueryable<double>> actualQuery,
+            Func<ISetSource, IQueryable<double>> expectedQuery,
+            Action<double, double> asserter = null)
+            => Fixture.QueryAsserter.AssertAverage(actualQuery, expectedQuery, asserter, isAsync);
+
+        protected Task AssertAverage(
+            bool isAsync,
+            Func<ISetSource, IQueryable<double?>> query,
+            Action<double?, double?> asserter = null)
+            => AssertAverage(isAsync, query, query, asserter);
+
+        protected Task AssertAverage(
+            bool isAsync,
+            Func<ISetSource, IQueryable<double?>> actualQuery,
+            Func<ISetSource, IQueryable<double?>> expectedQuery,
+            Action<double?, double?> asserter = null)
             => Fixture.QueryAsserter.AssertAverage(actualQuery, expectedQuery, asserter, isAsync);
 
         protected Task AssertAverage<TResult>(
@@ -698,6 +967,40 @@ namespace Microsoft.EntityFrameworkCore.Query
         protected Task AssertAverage<TResult>(
             bool isAsync,
             Func<ISetSource, IQueryable<TResult>> query,
+            Expression<Func<TResult, long>> selector,
+            Action<double, double> asserter = null)
+            => AssertAverage(isAsync, query, query, selector, selector, asserter);
+
+        protected Task AssertAverage<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, long>> actualSelector,
+            Expression<Func<TResult, long>> expectedSelector,
+            Action<double, double> asserter = null)
+            => Fixture.QueryAsserter.AssertAverage(
+                actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
+
+        protected Task AssertAverage<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Expression<Func<TResult, long?>> selector,
+            Action<double?, double?> asserter = null)
+            => AssertAverage(isAsync, query, query, selector, selector, asserter);
+
+        protected Task AssertAverage<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, long?>> actualSelector,
+            Expression<Func<TResult, long?>> expectedSelector,
+            Action<double?, double?> asserter = null)
+            => Fixture.QueryAsserter.AssertAverage(
+                actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
+
+        protected Task AssertAverage<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
             Expression<Func<TResult, decimal>> selector,
             Action<decimal, decimal> asserter = null)
             => AssertAverage(isAsync, query, query, selector, selector, asserter);
@@ -715,6 +1018,23 @@ namespace Microsoft.EntityFrameworkCore.Query
         protected Task AssertAverage<TResult>(
             bool isAsync,
             Func<ISetSource, IQueryable<TResult>> query,
+            Expression<Func<TResult, decimal?>> selector,
+            Action<decimal?, decimal?> asserter = null)
+            => AssertAverage(isAsync, query, query, selector, selector, asserter);
+
+        protected Task AssertAverage<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, decimal?>> actualSelector,
+            Expression<Func<TResult, decimal?>> expectedSelector,
+            Action<decimal?, decimal?> asserter = null)
+            => Fixture.QueryAsserter.AssertAverage(
+                actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
+
+        protected Task AssertAverage<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
             Expression<Func<TResult, float>> selector,
             Action<float, float> asserter = null)
             => AssertAverage(isAsync, query, query, selector, selector, asserter);
@@ -726,6 +1046,57 @@ namespace Microsoft.EntityFrameworkCore.Query
             Expression<Func<TResult, float>> actualSelector,
             Expression<Func<TResult, float>> expectedSelector,
             Action<float, float> asserter = null)
+            => Fixture.QueryAsserter.AssertAverage(
+                actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
+
+        protected Task AssertAverage<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Expression<Func<TResult, float?>> selector,
+            Action<float?, float?> asserter = null)
+            => AssertAverage(isAsync, query, query, selector, selector, asserter);
+
+        protected Task AssertAverage<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, float?>> actualSelector,
+            Expression<Func<TResult, float?>> expectedSelector,
+            Action<float?, float?> asserter = null)
+            => Fixture.QueryAsserter.AssertAverage(
+                actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
+
+        protected Task AssertAverage<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Expression<Func<TResult, double>> selector,
+            Action<double, double> asserter = null)
+            => AssertAverage(isAsync, query, query, selector, selector, asserter);
+
+        protected Task AssertAverage<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, double>> actualSelector,
+            Expression<Func<TResult, double>> expectedSelector,
+            Action<double, double> asserter = null)
+            => Fixture.QueryAsserter.AssertAverage(
+                actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
+
+        protected Task AssertAverage<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Expression<Func<TResult, double?>> selector,
+            Action<double?, double?> asserter = null)
+            => AssertAverage(isAsync, query, query, selector, selector, asserter);
+
+        protected Task AssertAverage<TResult>(
+            bool isAsync,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, double?>> actualSelector,
+            Expression<Func<TResult, double?>> expectedSelector,
+            Action<double?, double?> asserter = null)
             => Fixture.QueryAsserter.AssertAverage(
                 actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, isAsync);
 

--- a/test/EFCore.Specification.Tests/TestUtilities/QueryAsserter.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/QueryAsserter.cs
@@ -783,6 +783,158 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             }
         }
 
+        public override async Task AssertSum(
+            Func<ISetSource, IQueryable<long>> actualQuery,
+            Func<ISetSource, IQueryable<long>> expectedQuery,
+            Action<long, long> asserter = null,
+            bool isAsync = false)
+        {
+            using (var context = _contextCreator())
+            {
+                var actual = isAsync
+                    ? await actualQuery(SetSourceCreator(context)).SumAsync()
+                    : actualQuery(SetSourceCreator(context)).Sum();
+
+                var expected = expectedQuery(ExpectedData).Sum();
+
+                AssertEqual(expected, actual, asserter);
+                Assert.Empty(context.ChangeTracker.Entries());
+            }
+        }
+
+        public override async Task AssertSum(
+            Func<ISetSource, IQueryable<long?>> actualQuery,
+            Func<ISetSource, IQueryable<long?>> expectedQuery,
+            Action<long?, long?> asserter = null,
+            bool isAsync = false)
+        {
+            using (var context = _contextCreator())
+            {
+                var actual = isAsync
+                    ? await actualQuery(SetSourceCreator(context)).SumAsync()
+                    : actualQuery(SetSourceCreator(context)).Sum();
+
+                var expected = expectedQuery(ExpectedData).Sum();
+
+                AssertEqual(expected, actual, asserter);
+                Assert.Empty(context.ChangeTracker.Entries());
+            }
+        }
+
+        public override async Task AssertSum(
+            Func<ISetSource, IQueryable<decimal>> actualQuery,
+            Func<ISetSource, IQueryable<decimal>> expectedQuery,
+            Action<decimal, decimal> asserter = null,
+            bool isAsync = false)
+        {
+            using (var context = _contextCreator())
+            {
+                var actual = isAsync
+                    ? await actualQuery(SetSourceCreator(context)).SumAsync()
+                    : actualQuery(SetSourceCreator(context)).Sum();
+
+                var expected = expectedQuery(ExpectedData).Sum();
+
+                AssertEqual(expected, actual, asserter);
+                Assert.Empty(context.ChangeTracker.Entries());
+            }
+        }
+
+        public override async Task AssertSum(
+            Func<ISetSource, IQueryable<decimal?>> actualQuery,
+            Func<ISetSource, IQueryable<decimal?>> expectedQuery,
+            Action<decimal?, decimal?> asserter = null,
+            bool isAsync = false)
+        {
+            using (var context = _contextCreator())
+            {
+                var actual = isAsync
+                    ? await actualQuery(SetSourceCreator(context)).SumAsync()
+                    : actualQuery(SetSourceCreator(context)).Sum();
+
+                var expected = expectedQuery(ExpectedData).Sum();
+
+                AssertEqual(expected, actual, asserter);
+                Assert.Empty(context.ChangeTracker.Entries());
+            }
+        }
+
+        public override async Task AssertSum(
+            Func<ISetSource, IQueryable<float>> actualQuery,
+            Func<ISetSource, IQueryable<float>> expectedQuery,
+            Action<float, float> asserter = null,
+            bool isAsync = false)
+        {
+            using (var context = _contextCreator())
+            {
+                var actual = isAsync
+                    ? await actualQuery(SetSourceCreator(context)).SumAsync()
+                    : actualQuery(SetSourceCreator(context)).Sum();
+
+                var expected = expectedQuery(ExpectedData).Sum();
+
+                AssertEqual(expected, actual, asserter);
+                Assert.Empty(context.ChangeTracker.Entries());
+            }
+        }
+
+        public override async Task AssertSum(
+            Func<ISetSource, IQueryable<float?>> actualQuery,
+            Func<ISetSource, IQueryable<float?>> expectedQuery,
+            Action<float?, float?> asserter = null,
+            bool isAsync = false)
+        {
+            using (var context = _contextCreator())
+            {
+                var actual = isAsync
+                    ? await actualQuery(SetSourceCreator(context)).SumAsync()
+                    : actualQuery(SetSourceCreator(context)).Sum();
+
+                var expected = expectedQuery(ExpectedData).Sum();
+
+                AssertEqual(expected, actual, asserter);
+                Assert.Empty(context.ChangeTracker.Entries());
+            }
+        }
+
+        public override async Task AssertSum(
+            Func<ISetSource, IQueryable<double>> actualQuery,
+            Func<ISetSource, IQueryable<double>> expectedQuery,
+            Action<double, double> asserter = null,
+            bool isAsync = false)
+        {
+            using (var context = _contextCreator())
+            {
+                var actual = isAsync
+                    ? await actualQuery(SetSourceCreator(context)).SumAsync()
+                    : actualQuery(SetSourceCreator(context)).Sum();
+
+                var expected = expectedQuery(ExpectedData).Sum();
+
+                AssertEqual(expected, actual, asserter);
+                Assert.Empty(context.ChangeTracker.Entries());
+            }
+        }
+
+        public override async Task AssertSum(
+            Func<ISetSource, IQueryable<double?>> actualQuery,
+            Func<ISetSource, IQueryable<double?>> expectedQuery,
+            Action<double?, double?> asserter = null,
+            bool isAsync = false)
+        {
+            using (var context = _contextCreator())
+            {
+                var actual = isAsync
+                    ? await actualQuery(SetSourceCreator(context)).SumAsync()
+                    : actualQuery(SetSourceCreator(context)).Sum();
+
+                var expected = expectedQuery(ExpectedData).Sum();
+
+                AssertEqual(expected, actual, asserter);
+                Assert.Empty(context.ChangeTracker.Entries());
+            }
+        }
+
         public override async Task AssertSum<TResult>(
             Func<ISetSource, IQueryable<TResult>> actualQuery,
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
@@ -891,9 +1043,93 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         public override async Task AssertSum<TResult>(
             Func<ISetSource, IQueryable<TResult>> actualQuery,
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, decimal?>> actualSelector,
+            Expression<Func<TResult, decimal?>> expectedSelector,
+            Action<decimal?, decimal?> asserter = null,
+            bool isAsync = false)
+        {
+            using (var context = _contextCreator())
+            {
+                var actual = isAsync
+                    ? await actualQuery(SetSourceCreator(context)).SumAsync(actualSelector)
+                    : actualQuery(SetSourceCreator(context)).Sum(actualSelector);
+
+                var expected = expectedQuery(ExpectedData).Sum(expectedSelector);
+
+                AssertEqual(expected, actual, asserter);
+                Assert.Empty(context.ChangeTracker.Entries());
+            }
+        }
+
+        public override async Task AssertSum<TResult>(
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
             Expression<Func<TResult, float>> actualSelector,
-            Expression<Func<TResult,  float>> expectedSelector,
+            Expression<Func<TResult, float>> expectedSelector,
             Action<float, float> asserter = null,
+            bool isAsync = false)
+        {
+            using (var context = _contextCreator())
+            {
+                var actual = isAsync
+                    ? await actualQuery(SetSourceCreator(context)).SumAsync(actualSelector)
+                    : actualQuery(SetSourceCreator(context)).Sum(actualSelector);
+
+                var expected = expectedQuery(ExpectedData).Sum(expectedSelector);
+
+                AssertEqual(expected, actual, asserter);
+                Assert.Empty(context.ChangeTracker.Entries());
+            }
+        }
+
+        public override async Task AssertSum<TResult>(
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, float?>> actualSelector,
+            Expression<Func<TResult, float?>> expectedSelector,
+            Action<float?, float?> asserter = null,
+            bool isAsync = false)
+        {
+            using (var context = _contextCreator())
+            {
+                var actual = isAsync
+                    ? await actualQuery(SetSourceCreator(context)).SumAsync(actualSelector)
+                    : actualQuery(SetSourceCreator(context)).Sum(actualSelector);
+
+                var expected = expectedQuery(ExpectedData).Sum(expectedSelector);
+
+                AssertEqual(expected, actual, asserter);
+                Assert.Empty(context.ChangeTracker.Entries());
+            }
+        }
+
+        public override async Task AssertSum<TResult>(
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, double>> actualSelector,
+            Expression<Func<TResult, double>> expectedSelector,
+            Action<double, double> asserter = null,
+            bool isAsync = false)
+        {
+            using (var context = _contextCreator())
+            {
+                var actual = isAsync
+                    ? await actualQuery(SetSourceCreator(context)).SumAsync(actualSelector)
+                    : actualQuery(SetSourceCreator(context)).Sum(actualSelector);
+
+                var expected = expectedQuery(ExpectedData).Sum(expectedSelector);
+
+                AssertEqual(expected, actual, asserter);
+                Assert.Empty(context.ChangeTracker.Entries());
+            }
+        }
+
+        public override async Task AssertSum<TResult>(
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, double?>> actualSelector,
+            Expression<Func<TResult, double?>> expectedSelector,
+            Action<double?, double?> asserter = null,
             bool isAsync = false)
         {
             using (var context = _contextCreator())
@@ -966,6 +1202,139 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             }
         }
 
+        public override async Task AssertAverage(
+            Func<ISetSource, IQueryable<long?>> actualQuery,
+            Func<ISetSource, IQueryable<long?>> expectedQuery,
+            Action<double?, double?> asserter = null,
+            bool isAsync = false)
+        {
+            using (var context = _contextCreator())
+            {
+                var actual = isAsync
+                    ? await actualQuery(SetSourceCreator(context)).AverageAsync()
+                    : actualQuery(SetSourceCreator(context)).Average();
+
+                var expected = expectedQuery(ExpectedData).Average();
+
+                AssertEqual(expected, actual, asserter);
+                Assert.Empty(context.ChangeTracker.Entries());
+            }
+        }
+
+        public override async Task AssertAverage(
+            Func<ISetSource, IQueryable<decimal>> actualQuery,
+            Func<ISetSource, IQueryable<decimal>> expectedQuery,
+            Action<decimal, decimal> asserter = null,
+            bool isAsync = false)
+        {
+            using (var context = _contextCreator())
+            {
+                var actual = isAsync
+                    ? await actualQuery(SetSourceCreator(context)).AverageAsync()
+                    : actualQuery(SetSourceCreator(context)).Average();
+
+                var expected = expectedQuery(ExpectedData).Average();
+
+                AssertEqual(expected, actual, asserter);
+                Assert.Empty(context.ChangeTracker.Entries());
+            }
+        }
+
+        public override async Task AssertAverage(
+            Func<ISetSource, IQueryable<decimal?>> actualQuery,
+            Func<ISetSource, IQueryable<decimal?>> expectedQuery,
+            Action<decimal?, decimal?> asserter = null,
+            bool isAsync = false)
+        {
+            using (var context = _contextCreator())
+            {
+                var actual = isAsync
+                    ? await actualQuery(SetSourceCreator(context)).AverageAsync()
+                    : actualQuery(SetSourceCreator(context)).Average();
+
+                var expected = expectedQuery(ExpectedData).Average();
+
+                AssertEqual(expected, actual, asserter);
+                Assert.Empty(context.ChangeTracker.Entries());
+            }
+        }
+
+        public override async Task AssertAverage(
+            Func<ISetSource, IQueryable<float>> actualQuery,
+            Func<ISetSource, IQueryable<float>> expectedQuery,
+            Action<float, float> asserter = null,
+            bool isAsync = false)
+        {
+            using (var context = _contextCreator())
+            {
+                var actual = isAsync
+                    ? await actualQuery(SetSourceCreator(context)).AverageAsync()
+                    : actualQuery(SetSourceCreator(context)).Average();
+
+                var expected = expectedQuery(ExpectedData).Average();
+
+                AssertEqual(expected, actual, asserter);
+                Assert.Empty(context.ChangeTracker.Entries());
+            }
+        }
+
+        public override async Task AssertAverage(
+            Func<ISetSource, IQueryable<float?>> actualQuery,
+            Func<ISetSource, IQueryable<float?>> expectedQuery,
+            Action<float?, float?> asserter = null,
+            bool isAsync = false)
+        {
+            using (var context = _contextCreator())
+            {
+                var actual = isAsync
+                    ? await actualQuery(SetSourceCreator(context)).AverageAsync()
+                    : actualQuery(SetSourceCreator(context)).Average();
+
+                var expected = expectedQuery(ExpectedData).Average();
+
+                AssertEqual(expected, actual, asserter);
+                Assert.Empty(context.ChangeTracker.Entries());
+            }
+        }
+
+        public override async Task AssertAverage(
+            Func<ISetSource, IQueryable<double>> actualQuery,
+            Func<ISetSource, IQueryable<double>> expectedQuery,
+            Action<double, double> asserter = null,
+            bool isAsync = false)
+        {
+            using (var context = _contextCreator())
+            {
+                var actual = isAsync
+                    ? await actualQuery(SetSourceCreator(context)).AverageAsync()
+                    : actualQuery(SetSourceCreator(context)).Average();
+
+                var expected = expectedQuery(ExpectedData).Average();
+
+                AssertEqual(expected, actual, asserter);
+                Assert.Empty(context.ChangeTracker.Entries());
+            }
+        }
+
+        public override async Task AssertAverage(
+            Func<ISetSource, IQueryable<double?>> actualQuery,
+            Func<ISetSource, IQueryable<double?>> expectedQuery,
+            Action<double?, double?> asserter = null,
+            bool isAsync = false)
+        {
+            using (var context = _contextCreator())
+            {
+                var actual = isAsync
+                    ? await actualQuery(SetSourceCreator(context)).AverageAsync()
+                    : actualQuery(SetSourceCreator(context)).Average();
+
+                var expected = expectedQuery(ExpectedData).Average();
+
+                AssertEqual(expected, actual, asserter);
+                Assert.Empty(context.ChangeTracker.Entries());
+            }
+        }
+
         public override async Task AssertAverage<TResult>(
             Func<ISetSource, IQueryable<TResult>> actualQuery,
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
@@ -1011,6 +1380,48 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         public override async Task AssertAverage<TResult>(
             Func<ISetSource, IQueryable<TResult>> actualQuery,
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, long>> actualSelector,
+            Expression<Func<TResult, long>> expectedSelector,
+            Action<double, double> asserter = null,
+            bool isAsync = false)
+        {
+            using (var context = _contextCreator())
+            {
+                var actual = isAsync
+                    ? await actualQuery(SetSourceCreator(context)).AverageAsync(actualSelector)
+                    : actualQuery(SetSourceCreator(context)).Average(actualSelector);
+
+                var expected = expectedQuery(ExpectedData).Average(expectedSelector);
+
+                AssertEqual(expected, actual, asserter);
+                Assert.Empty(context.ChangeTracker.Entries());
+            }
+        }
+
+        public override async Task AssertAverage<TResult>(
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, long?>> actualSelector,
+            Expression<Func<TResult, long?>> expectedSelector,
+            Action<double?, double?> asserter = null,
+            bool isAsync = false)
+        {
+            using (var context = _contextCreator())
+            {
+                var actual = isAsync
+                    ? await actualQuery(SetSourceCreator(context)).AverageAsync(actualSelector)
+                    : actualQuery(SetSourceCreator(context)).Average(actualSelector);
+
+                var expected = expectedQuery(ExpectedData).Average(expectedSelector);
+
+                AssertEqual(expected, actual, asserter);
+                Assert.Empty(context.ChangeTracker.Entries());
+            }
+        }
+
+        public override async Task AssertAverage<TResult>(
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
             Expression<Func<TResult, decimal>> actualSelector,
             Expression<Func<TResult, decimal>> expectedSelector,
             Action<decimal, decimal> asserter = null,
@@ -1032,9 +1443,93 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         public override async Task AssertAverage<TResult>(
             Func<ISetSource, IQueryable<TResult>> actualQuery,
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, decimal?>> actualSelector,
+            Expression<Func<TResult, decimal?>> expectedSelector,
+            Action<decimal?, decimal?> asserter = null,
+            bool isAsync = false)
+        {
+            using (var context = _contextCreator())
+            {
+                var actual = isAsync
+                    ? await actualQuery(SetSourceCreator(context)).AverageAsync(actualSelector)
+                    : actualQuery(SetSourceCreator(context)).Average(actualSelector);
+
+                var expected = expectedQuery(ExpectedData).Average(expectedSelector);
+
+                AssertEqual(expected, actual, asserter);
+                Assert.Empty(context.ChangeTracker.Entries());
+            }
+        }
+
+        public override async Task AssertAverage<TResult>(
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
             Expression<Func<TResult, float>> actualSelector,
             Expression<Func<TResult, float>> expectedSelector,
             Action<float, float> asserter = null,
+            bool isAsync = false)
+        {
+            using (var context = _contextCreator())
+            {
+                var actual = isAsync
+                    ? await actualQuery(SetSourceCreator(context)).AverageAsync(actualSelector)
+                    : actualQuery(SetSourceCreator(context)).Average(actualSelector);
+
+                var expected = expectedQuery(ExpectedData).Average(expectedSelector);
+
+                AssertEqual(expected, actual, asserter);
+                Assert.Empty(context.ChangeTracker.Entries());
+            }
+        }
+
+        public override async Task AssertAverage<TResult>(
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, float?>> actualSelector,
+            Expression<Func<TResult, float?>> expectedSelector,
+            Action<float?, float?> asserter = null,
+            bool isAsync = false)
+        {
+            using (var context = _contextCreator())
+            {
+                var actual = isAsync
+                    ? await actualQuery(SetSourceCreator(context)).AverageAsync(actualSelector)
+                    : actualQuery(SetSourceCreator(context)).Average(actualSelector);
+
+                var expected = expectedQuery(ExpectedData).Average(expectedSelector);
+
+                AssertEqual(expected, actual, asserter);
+                Assert.Empty(context.ChangeTracker.Entries());
+            }
+        }
+
+        public override async Task AssertAverage<TResult>(
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, double>> actualSelector,
+            Expression<Func<TResult, double>> expectedSelector,
+            Action<double, double> asserter = null,
+            bool isAsync = false)
+        {
+            using (var context = _contextCreator())
+            {
+                var actual = isAsync
+                    ? await actualQuery(SetSourceCreator(context)).AverageAsync(actualSelector)
+                    : actualQuery(SetSourceCreator(context)).Average(actualSelector);
+
+                var expected = expectedQuery(ExpectedData).Average(expectedSelector);
+
+                AssertEqual(expected, actual, asserter);
+                Assert.Empty(context.ChangeTracker.Entries());
+            }
+        }
+
+        public override async Task AssertAverage<TResult>(
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, double?>> actualSelector,
+            Expression<Func<TResult, double?>> expectedSelector,
+            Action<double?, double?> asserter = null,
             bool isAsync = false)
         {
             using (var context = _contextCreator())

--- a/test/EFCore.Specification.Tests/TestUtilities/QueryAsserterBase.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/QueryAsserterBase.cs
@@ -247,6 +247,54 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Action<int?, int?> asserter = null,
             bool isAsync = false);
 
+        public abstract Task AssertSum(
+            Func<ISetSource, IQueryable<long>> actualQuery,
+            Func<ISetSource, IQueryable<long>> expectedQuery,
+            Action<long, long> asserter = null,
+            bool isAsync = false);
+
+        public abstract Task AssertSum(
+            Func<ISetSource, IQueryable<long?>> actualQuery,
+            Func<ISetSource, IQueryable<long?>> expectedQuery,
+            Action<long?, long?> asserter = null,
+            bool isAsync = false);
+
+        public abstract Task AssertSum(
+            Func<ISetSource, IQueryable<decimal>> actualQuery,
+            Func<ISetSource, IQueryable<decimal>> expectedQuery,
+            Action<decimal, decimal> asserter = null,
+            bool isAsync = false);
+
+        public abstract Task AssertSum(
+            Func<ISetSource, IQueryable<decimal?>> actualQuery,
+            Func<ISetSource, IQueryable<decimal?>> expectedQuery,
+            Action<decimal?, decimal?> asserter = null,
+            bool isAsync = false);
+
+        public abstract Task AssertSum(
+            Func<ISetSource, IQueryable<float>> actualQuery,
+            Func<ISetSource, IQueryable<float>> expectedQuery,
+            Action<float, float> asserter = null,
+            bool isAsync = false);
+
+        public abstract Task AssertSum(
+            Func<ISetSource, IQueryable<float?>> actualQuery,
+            Func<ISetSource, IQueryable<float?>> expectedQuery,
+            Action<float?, float?> asserter = null,
+            bool isAsync = false);
+
+        public abstract Task AssertSum(
+            Func<ISetSource, IQueryable<double>> actualQuery,
+            Func<ISetSource, IQueryable<double>> expectedQuery,
+            Action<double, double> asserter = null,
+            bool isAsync = false);
+
+        public abstract Task AssertSum(
+            Func<ISetSource, IQueryable<double?>> actualQuery,
+            Func<ISetSource, IQueryable<double?>> expectedQuery,
+            Action<double?, double?> asserter = null,
+            bool isAsync = false);
+
         public abstract Task AssertSum<TResult>(
             Func<ISetSource, IQueryable<TResult>> actualQuery,
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
@@ -290,9 +338,41 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         public abstract Task AssertSum<TResult>(
             Func<ISetSource, IQueryable<TResult>> actualQuery,
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, decimal?>> actualSelector,
+            Expression<Func<TResult, decimal?>> expectedSelector,
+            Action<decimal?, decimal?> asserter = null,
+            bool isAsync = false);
+
+        public abstract Task AssertSum<TResult>(
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
             Expression<Func<TResult, float>> actualSelector,
             Expression<Func<TResult, float>> expectedSelector,
             Action<float, float> asserter = null,
+            bool isAsync = false);
+
+        public abstract Task AssertSum<TResult>(
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, float?>> actualSelector,
+            Expression<Func<TResult, float?>> expectedSelector,
+            Action<float?, float?> asserter = null,
+            bool isAsync = false);
+
+        public abstract Task AssertSum<TResult>(
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, double>> actualSelector,
+            Expression<Func<TResult, double>> expectedSelector,
+            Action<double, double> asserter = null,
+            bool isAsync = false);
+
+        public abstract Task AssertSum<TResult>(
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, double?>> actualSelector,
+            Expression<Func<TResult, double?>> expectedSelector,
+            Action<double?, double?> asserter = null,
             bool isAsync = false);
 
         public abstract Task AssertAverage(
@@ -311,6 +391,48 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Func<ISetSource, IQueryable<long>> actualQuery,
             Func<ISetSource, IQueryable<long>> expectedQuery,
             Action<double, double> asserter = null,
+            bool isAsync = false);
+
+        public abstract Task AssertAverage(
+            Func<ISetSource, IQueryable<long?>> actualQuery,
+            Func<ISetSource, IQueryable<long?>> expectedQuery,
+            Action<double?, double?> asserter = null,
+            bool isAsync = false);
+
+        public abstract Task AssertAverage(
+            Func<ISetSource, IQueryable<decimal>> actualQuery,
+            Func<ISetSource, IQueryable<decimal>> expectedQuery,
+            Action<decimal, decimal> asserter = null,
+            bool isAsync = false);
+
+        public abstract Task AssertAverage(
+            Func<ISetSource, IQueryable<decimal?>> actualQuery,
+            Func<ISetSource, IQueryable<decimal?>> expectedQuery,
+            Action<decimal?, decimal?> asserter = null,
+            bool isAsync = false);
+
+        public abstract Task AssertAverage(
+            Func<ISetSource, IQueryable<float>> actualQuery,
+            Func<ISetSource, IQueryable<float>> expectedQuery,
+            Action<float, float> asserter = null,
+            bool isAsync = false);
+
+        public abstract Task AssertAverage(
+            Func<ISetSource, IQueryable<float?>> actualQuery,
+            Func<ISetSource, IQueryable<float?>> expectedQuery,
+            Action<float?, float?> asserter = null,
+            bool isAsync = false);
+
+        public abstract Task AssertAverage(
+            Func<ISetSource, IQueryable<double>> actualQuery,
+            Func<ISetSource, IQueryable<double>> expectedQuery,
+            Action<double, double> asserter = null,
+            bool isAsync = false);
+
+        public abstract Task AssertAverage(
+            Func<ISetSource, IQueryable<double?>> actualQuery,
+            Func<ISetSource, IQueryable<double?>> expectedQuery,
+            Action<double?, double?> asserter = null,
             bool isAsync = false);
 
         public abstract Task AssertAverage<TResult>(
@@ -332,6 +454,22 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         public abstract Task AssertAverage<TResult>(
             Func<ISetSource, IQueryable<TResult>> actualQuery,
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, long>> actualSelector,
+            Expression<Func<TResult, long>> expectedSelector,
+            Action<double, double> asserter = null,
+            bool isAsync = false);
+
+        public abstract Task AssertAverage<TResult>(
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, long?>> actualSelector,
+            Expression<Func<TResult, long?>> expectedSelector,
+            Action<double?, double?> asserter = null,
+            bool isAsync = false);
+
+        public abstract Task AssertAverage<TResult>(
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
             Expression<Func<TResult, decimal>> actualSelector,
             Expression<Func<TResult, decimal>> expectedSelector,
             Action<decimal, decimal> asserter = null,
@@ -340,9 +478,41 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         public abstract Task AssertAverage<TResult>(
             Func<ISetSource, IQueryable<TResult>> actualQuery,
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, decimal?>> actualSelector,
+            Expression<Func<TResult, decimal?>> expectedSelector,
+            Action<decimal?, decimal?> asserter = null,
+            bool isAsync = false);
+
+        public abstract Task AssertAverage<TResult>(
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
             Expression<Func<TResult, float>> actualSelector,
             Expression<Func<TResult, float>> expectedSelector,
             Action<float, float> asserter = null,
+            bool isAsync = false);
+
+        public abstract Task AssertAverage<TResult>(
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, float?>> actualSelector,
+            Expression<Func<TResult, float?>> expectedSelector,
+            Action<float?, float?> asserter = null,
+            bool isAsync = false);
+
+        public abstract Task AssertAverage<TResult>(
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, double>> actualSelector,
+            Expression<Func<TResult, double>> expectedSelector,
+            Action<double, double> asserter = null,
+            bool isAsync = false);
+
+        public abstract Task AssertAverage<TResult>(
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, double?>> actualSelector,
+            Expression<Func<TResult, double?>> expectedSelector,
+            Action<double?, double?> asserter = null,
             bool isAsync = false);
 
         #endregion


### PR DESCRIPTION
We were missing some overloads, this could be confusing when trying to write tests that needed those overloads.

Fixes #17975