### PR TITLE
Fixed: ArgumentException when Cast IQueryable to an Interface

### DIFF
--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.Expressions.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.Expressions.cs
@@ -139,9 +139,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
         protected class EntityReference : Expression, IPrintableExpression
         {
+            private Type _entityReferenceType;
+
             public EntityReference(IEntityType entityType)
             {
                 EntityType = entityType;
+                _entityReferenceType = entityType.ClrType;
                 IncludePaths = new IncludeTreeNode(entityType, this);
             }
 
@@ -169,6 +172,13 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 result.IncludePaths = IncludePaths.Clone(result);
 
                 return result;
+            }
+
+            public virtual EntityReference Cast(Type castedType)
+            {
+                var clonedEntityReference = Clone();
+                clonedEntityReference._entityReferenceType = castedType;
+                return clonedEntityReference;
             }
 
             public virtual void SetLastInclude(IncludeTreeNode lastIncludeTree)
@@ -200,7 +210,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             public virtual bool IsOptional { get; private set; }
 
             public override ExpressionType NodeType => ExpressionType.Extension;
-            public override Type Type => EntityType.ClrType;
+            public override Type Type => _entityReferenceType;
         }
 
         protected class NavigationTreeNode : Expression

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
@@ -1135,6 +1135,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                     newStructure = newEntityReference;
                 }
+                else
+                {
+                    // If casted type was not found in the types from hierarchy
+                    // (e.g. is an interface), we should cast the entityReference
+                    newStructure = entityReference.Cast(castType);
+                }
             }
             else
             {

--- a/test/EFCore.Specification.Tests/Query/InheritanceTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/InheritanceTestBase.cs
@@ -230,6 +230,19 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
+        public virtual void Can_use_cast_to_ianimal()
+        {
+            using (var context = CreateContext())
+            {
+                var animals = context.Set<Kiwi>().Cast<IAnimal>().ToList();
+
+                Assert.Equal(1, animals.Count);
+                Assert.IsType<Kiwi>(animals[0]);
+                Assert.Equal(1, context.ChangeTracker.Entries().Count());
+            }
+        }
+
+        [ConditionalFact]
         public virtual void Can_query_all_animals()
         {
             using (var context = CreateContext())

--- a/test/EFCore.Specification.Tests/TestModels/Inheritance/Animal.cs
+++ b/test/EFCore.Specification.Tests/TestModels/Inheritance/Animal.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.Inheritance
 {
-    public abstract class Animal
+    public abstract class Animal : IAnimal
     {
         public string Species { get; set; }
         public string Name { get; set; }

--- a/test/EFCore.Specification.Tests/TestModels/Inheritance/IAnimal.cs
+++ b/test/EFCore.Specification.Tests/TestModels/Inheritance/IAnimal.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.Inheritance
+{
+    public interface IAnimal
+    {
+        int CountryId { get; set; }
+        string Name { get; set; }
+        string Species { get; set; }
+    }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceSqlServerTest.cs
@@ -200,6 +200,15 @@ WHERE [a].[Discriminator] IN (N'Eagle', N'Kiwi') AND ([a].[Discriminator] = N'Ki
 FROM [Plant] AS [p]
 WHERE [p].[Genus] IN (1, 0) AND ([p].[Genus] = 0)");
         }
+        public override void Can_use_cast_to_ianimal()
+        {
+            base.Can_use_cast_to_ianimal();
+
+            AssertSql(
+                @"SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[FoundOn]
+FROM [Animal] AS [a]
+WHERE [a].[Discriminator] = N'Kiwi'");
+        }
 
         public override void Can_query_all_animals()
         {


### PR DESCRIPTION
1. I added and used a Cast method for EntityReference as the cast can be to an interface which will not be found in the hierarchy types.

Fixes #18087