### PR TITLE
Explicit error message when downloading dotnet-install.ps1

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -160,13 +160,26 @@ function InitializeDotNetCli([bool]$install) {
 }
 
 function GetDotNetInstallScript([string] $dotnetRoot) {
-  $installScript = Join-Path $dotnetRoot "dotnet-install.ps1"
+  $installFileName = "dotnet-install.ps1"
+  $installScript = Join-Path $dotnetRoot $installFileName
   if (!(Test-Path $installScript)) {
     Create-Directory $dotnetRoot
     $ProgressPreference = 'SilentlyContinue' # Don't display the console progress UI - it's a huge perf hit
-    Invoke-WebRequest "https://dot.net/$dotnetInstallScriptVersion/dotnet-install.ps1" -OutFile $installScript
-  }
 
+    try {
+      $installFileUrl = "https://dot.net/$dotnetInstallScriptVersion/$installFileName"
+      Invoke-WebRequest $installFileUrl -OutFile $installScript
+    }
+    catch [System.Net.WebException] {
+      Write-Error "Unable to download $($installFileName) from $($installFileUrl)"
+    }
+    catch [System.IO.IOException] {
+      Write-Error "Unable to write $($installFileName) from $($installFileUrl) to $($installScript)"
+    }
+    catch {
+      Write-Error "Something wrong happened while trying to download $($installFileName) from $($installFileUrl) to $($installScript)"
+    }
+  }
   return $installScript
 }
 


### PR DESCRIPTION
Hello,

I tried to build EF Core on my corporate laptop behind a proxy, after cloning the repo I ran `build.cmd` and got the following error : 

![efcore_build_error](https://user-images.githubusercontent.com/5092381/65939927-82279380-e427-11e9-810b-df03bcf66056.jpg)

The blurred part is our corporate page content telling us that we're not allowed to access to this resource if we're not using the proxy settings.

I know that there's many ways to avoid this issue (like setting up PowerShell to use proxy settings, etc) but I think that it would be cool to have a more explicit message than the current one.

When completely unplugging internet connection I got the following error : 

![image](https://user-images.githubusercontent.com/5092381/65940181-1db90400-e428-11e9-93de-85dd366cd3a5.png)

That's better, but shouldn't this be even more explicit ? 

With my "fix" we have something like that instead : 

![image](https://user-images.githubusercontent.com/5092381/65940192-290c2f80-e428-11e9-8433-a01c2afea2b7.png)

## Steps to reproduce
 1. Clone the EF Core repo into your local machine
 2. Unlpug the internet cable/disable Wi-Fi
 3. Run build.cmd
 4. Check the error message

## Idea
If this PR is accepted maybe I could update all calls to `Invoke-WebRequest` ?
