### PR TITLE
[2.1] Fix to #13285 - UseRelationalNulls does not work with SELECT conditions

### DIFF
--- a/src/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
@@ -489,6 +489,43 @@ namespace Microsoft.EntityFrameworkCore.Query
                 useRelationalNulls: false);
         }
 
+        [Fact]
+        public virtual void Null_comparison_in_selector_with_relational_nulls()
+        {
+            using (var ctx = CreateContext(useRelationalNulls: true))
+            {
+                var query = ctx.Entities1.Select(e => e.NullableStringA != "Foo");
+                var result = query.ToList();
+
+                Assert.Equal(27, result.Count);
+                Assert.Equal(18, result.Where(r => r).Count());
+            }
+        }
+
+        [Fact]
+        public virtual void Null_comparison_in_order_by_with_relational_nulls()
+        {
+            using (var ctx = CreateContext(useRelationalNulls: true))
+            {
+                var query = ctx.Entities1.OrderBy(e => e.NullableStringA != "Foo").ThenBy(e => e.NullableIntB != 10);
+                var result = query.ToList();
+
+                Assert.Equal(27, result.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void Null_comparison_in_join_key_with_relational_nulls()
+        {
+            using (var ctx = CreateContext(useRelationalNulls: true))
+            {
+                var query = ctx.Entities1.Join(ctx.Entities2, e1 => e1.NullableStringA != "Foo", e2 => e2.NullableBoolB != true, (o, i) => new { o, i });
+                var result = query.ToList();
+
+                Assert.Equal(405, result.Count);
+            }
+        }
+
         protected void AssertQuery<TItem>(
             Func<IQueryable<TItem>, IQueryable<TItem>> query,
             bool useDatabaseNullSemantics = false)

--- a/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
@@ -1073,6 +1073,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         /// </summary>
         public virtual void ClearOrderBy() => _orderBy.Clear();
 
+        internal virtual void ClearGroupBy() => _groupBy.Clear();
+
         /// <summary>
         ///     Adds a SQL CROSS JOIN to this SelectExpression.
         /// </summary>

--- a/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -26,6 +26,7 @@ using Remotion.Linq;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Clauses.Expressions;
 using Remotion.Linq.Clauses.ResultOperators;
+using Remotion.Linq.Parsing;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
@@ -381,10 +382,131 @@ namespace Microsoft.EntityFrameworkCore.Query
             var joinEliminator = new JoinEliminator();
             var compositePredicateVisitor = _compositePredicateExpressionVisitorFactory.Create();
 
+            var useRelationalNulls = RelationalOptionsExtension.Extract(ContextOptions).UseRelationalNulls;
             foreach (var selectExpression in QueriesBySource.Values)
             {
                 joinEliminator.EliminateJoins(selectExpression);
                 compositePredicateVisitor.Visit(selectExpression);
+
+                // off by default
+                if (AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue13285", out var isEnabled) && isEnabled)
+                {
+                    if (useRelationalNulls)
+                    {
+                        new RelationalNullsMarkingExpressionVisitor().Visit(selectExpression);
+                    }
+                }
+            }
+        }
+
+        private class RelationalNullsMarkingExpressionVisitor : RelinqExpressionVisitor
+        {
+            protected override Expression VisitBinary(BinaryExpression binaryExpression)
+            {
+                if (binaryExpression.NodeType == ExpressionType.Equal
+                    || binaryExpression.NodeType == ExpressionType.NotEqual)
+                {
+                    return new NullCompensatedExpression(binaryExpression);
+                }
+
+                return base.VisitBinary(binaryExpression);
+            }
+
+            protected override Expression VisitExtension(Expression extensionExpression)
+            {
+                if (extensionExpression is NullCompensatedExpression)
+                {
+                    return extensionExpression;
+                }
+
+                if (extensionExpression is SelectExpression selectExpression)
+                {
+                    if (selectExpression.Projection.Any())
+                    {
+                        var projectionsChanged = default(bool);
+                        var newProjections = new List<Expression>();
+                        foreach (var projection in selectExpression.Projection)
+                        {
+                            var newProjection = Visit(projection);
+                            if (newProjection != projection)
+                            {
+                                projectionsChanged = true;
+                            }
+
+                            newProjections.Add(newProjection);
+                        }
+
+                        if (projectionsChanged)
+                        {
+                            selectExpression.ClearProjection();
+                            foreach (var newProjection in newProjections)
+                            {
+                                selectExpression.AddToProjection(newProjection);
+                            }
+                        }
+                    }
+
+                    if (selectExpression.Predicate != null)
+                    {
+                        selectExpression.Predicate = Visit(selectExpression.Predicate);
+                    }
+
+                    if (selectExpression.GroupBy.Any())
+                    {
+                        var groupByChanged = default(bool);
+                        var newGroupBys = new List<Expression>();
+                        foreach (var groupBy in selectExpression.GroupBy)
+                        {
+                            var newGroupBy = Visit(groupBy);
+                            if (newGroupBy != groupBy)
+                            {
+                                groupByChanged = true;
+                            }
+
+                            newGroupBys.Add(newGroupBy);
+                        }
+
+                        if (groupByChanged)
+                        {
+                            selectExpression.ClearGroupBy();
+                            selectExpression.AddToGroupBy(newGroupBys.ToArray());
+                        }
+                    }
+
+                    if (selectExpression.Having != null)
+                    {
+                        selectExpression.Having = Visit(selectExpression.Having);
+                    }
+
+                    if (selectExpression.OrderBy.Any())
+                    {
+                        var orderByChanged = default(bool);
+                        var newOrderings = new List<Ordering>();
+                        foreach (var ordering in selectExpression.OrderBy)
+                        {
+                            var newOrdering = ordering;
+                            var newOrderBy = Visit(ordering.Expression);
+                            if (newOrderBy != ordering.Expression)
+                            {
+                                orderByChanged = true;
+                                newOrdering = new Ordering(newOrderBy, ordering.OrderingDirection);
+                            }
+
+                            newOrderings.Add(newOrdering);
+                        }
+
+                        if (orderByChanged)
+                        {
+                            selectExpression.ClearOrderBy();
+                            foreach (var newOrdering in newOrderings)
+                            {
+                                selectExpression.AddToOrderBy(newOrdering);
+                            }
+                        }
+                    }
+                }
+
+                return base.VisitExtension(extensionExpression);
             }
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -917,6 +917,50 @@ FROM [Entities1] AS [e]
 WHERE ((CHARINDEX([e].[NullableStringB], [e].[NullableStringA]) > 0) OR ([e].[NullableStringB] = N'')) AND ([e].[BoolA] = 1)");
         }
 
+        public override void Null_comparison_in_selector_with_relational_nulls()
+        {
+            base.Null_comparison_in_selector_with_relational_nulls();
+
+            AssertSql(
+                @"SELECT CASE
+    WHEN ([e].[NullableStringA] <> N'Foo') OR [e].[NullableStringA] IS NULL
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END
+FROM [Entities1] AS [e]");
+        }
+
+        public override void Null_comparison_in_order_by_with_relational_nulls()
+        {
+            base.Null_comparison_in_order_by_with_relational_nulls();
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
+FROM [Entities1] AS [e]
+ORDER BY CASE
+    WHEN ([e].[NullableStringA] <> N'Foo') OR [e].[NullableStringA] IS NULL
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END, CASE
+    WHEN ([e].[NullableIntB] <> 10) OR [e].[NullableIntB] IS NULL
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END");
+        }
+
+        public override void Null_comparison_in_join_key_with_relational_nulls()
+        {
+            base.Null_comparison_in_join_key_with_relational_nulls();
+
+            AssertSql(
+                @"SELECT [e1].[Id], [e1].[BoolA], [e1].[BoolB], [e1].[BoolC], [e1].[IntA], [e1].[IntB], [e1].[IntC], [e1].[NullableBoolA], [e1].[NullableBoolB], [e1].[NullableBoolC], [e1].[NullableIntA], [e1].[NullableIntB], [e1].[NullableIntC], [e1].[NullableStringA], [e1].[NullableStringB], [e1].[NullableStringC], [e1].[StringA], [e1].[StringB], [e1].[StringC], [i].[Id], [i].[BoolA], [i].[BoolB], [i].[BoolC], [i].[IntA], [i].[IntB], [i].[IntC], [i].[NullableBoolA], [i].[NullableBoolB], [i].[NullableBoolC], [i].[NullableIntA], [i].[NullableIntB], [i].[NullableIntC], [i].[NullableStringA], [i].[NullableStringB], [i].[NullableStringC], [i].[StringA], [i].[StringB], [i].[StringC]
+FROM [Entities1] AS [e1]
+INNER JOIN [Entities2] AS [i] ON CASE
+    WHEN ([e1].[NullableStringA] <> N'Foo') OR [e1].[NullableStringA] IS NULL
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END = CASE
+    WHEN ([i].[NullableBoolB] <> 1) OR [i].[NullableBoolB] IS NULL
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END");
+        }
+
         public override void Where_conditional_search_condition_in_result()
         {
             base.Where_conditional_search_condition_in_result();


### PR DESCRIPTION
Problem was that we were only preventing null expansion in predicate, leaving projection and orderings intact.

Fix is to go through entire SelectExpression and prevent null expansion on all encountered comparisons.

Because this changes the result it is switched off by default.