### PR TITLE
Fix to #17236 - Improve readability of expressions in client evaluation exception

### DIFF
--- a/src/EFCore/Metadata/Internal/NavigationExtensions.cs
+++ b/src/EFCore/Metadata/Internal/NavigationExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Runtime.CompilerServices;
 using System.Text;
 using JetBrains.Annotations;
@@ -23,11 +24,26 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        [Obsolete]
+        public static string ToDebugString(
+            [NotNull] this INavigation navigation,
+            bool singleLine,
+            bool includeIndexes,
+            [NotNull] string indent)
+            => ToDebugString(navigation, singleLine, includeIndexes, indent, detailed: true);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public static string ToDebugString(
             [NotNull] this INavigation navigation,
             bool singleLine = true,
             bool includeIndexes = false,
-            [NotNull] string indent = "")
+            [NotNull] string indent = "",
+            bool detailed = true)
         {
             var builder = new StringBuilder();
 
@@ -35,10 +51,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             if (singleLine)
             {
-                builder.Append("Navigation: ").Append(navigation.DeclaringEntityType.DisplayName()).Append(".");
+                builder.Append($"Navigation: {navigation.DeclaringEntityType.DisplayName()}.");
             }
 
             builder.Append(navigation.Name);
+
+            if (!detailed)
+            {
+                return builder.ToString();
+            }
 
             if (navigation.GetFieldName() == null)
             {

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.Expressions.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.Expressions.cs
@@ -189,8 +189,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             public virtual void Print(ExpressionPrinter expressionPrinter)
             {
-                expressionPrinter.Append(nameof(EntityReference));
-                expressionPrinter.Append(EntityType.DisplayName());
+                expressionPrinter.Append($"{nameof(EntityReference)}: {EntityType.DisplayName()}");
                 if (IsOptional)
                 {
                     expressionPrinter.Append("[Optional]");

--- a/src/EFCore/Query/MaterializeCollectionNavigationExpression.cs
+++ b/src/EFCore/Query/MaterializeCollectionNavigationExpression.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
@@ -31,9 +32,13 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         public virtual void Print(ExpressionPrinter expressionPrinter)
         {
-            expressionPrinter.Append($"MaterializeCollectionNavigation({Navigation}, ");
-            expressionPrinter.Visit(Subquery);
-            expressionPrinter.Append(")");
+            expressionPrinter.AppendLine("MaterializeCollectionNavigation(");
+            using (expressionPrinter.Indent())
+            {
+                expressionPrinter.AppendLine($"navigation: {Navigation.ToDebugString(detailed: false)},");
+                expressionPrinter.Append("subquery: ");
+                expressionPrinter.Visit(Subquery);
+            }
         }
     }
 }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.cs
@@ -283,14 +283,9 @@ WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""EmployeeID""] > 0))");
         }
 
         [ConditionalTheory(Skip = "Issue #17246")]
-        public override async Task Default_if_empty_top_level_arg_followed_by_projecting_constant(bool isAsync)
+        public override Task Default_if_empty_top_level_arg_followed_by_projecting_constant(bool isAsync)
         {
-            await base.Default_if_empty_top_level_arg_followed_by_projecting_constant(isAsync);
-
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+            return base.Default_if_empty_top_level_arg_followed_by_projecting_constant(isAsync);
         }
 
         [ConditionalTheory(Skip = "Issue#17246")]
@@ -2197,70 +2192,40 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] > @__p_0))");
         }
 
-        [ConditionalFact(Skip = "Issue #17246")]
-        public override void Random_next_is_not_funcletized_1()
+        [ConditionalTheory(Skip = "Issue #17246")]
+        public override Task Random_next_is_not_funcletized_1(bool isAsync)
         {
-            base.Random_next_is_not_funcletized_1();
-
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+            return base.Random_next_is_not_funcletized_1(isAsync);
         }
 
-        [ConditionalFact(Skip = "Issue #17246")]
-        public override void Random_next_is_not_funcletized_2()
+        [ConditionalTheory(Skip = "Issue #17246")]
+        public override Task Random_next_is_not_funcletized_2(bool isAsync)
         {
-            base.Random_next_is_not_funcletized_2();
-
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+            return base.Random_next_is_not_funcletized_2(isAsync);
         }
 
-        [ConditionalFact(Skip = "Issue #17246")]
-        public override void Random_next_is_not_funcletized_3()
+        [ConditionalTheory(Skip = "Issue #17246")]
+        public override Task Random_next_is_not_funcletized_3(bool isAsync)
         {
-            base.Random_next_is_not_funcletized_3();
-
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+            return base.Random_next_is_not_funcletized_3(isAsync);
         }
 
-        [ConditionalFact(Skip = "Issue #17246")]
-        public override void Random_next_is_not_funcletized_4()
+        [ConditionalTheory(Skip = "Issue #17246")]
+        public override Task Random_next_is_not_funcletized_4(bool isAsync)
         {
-            base.Random_next_is_not_funcletized_4();
-
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+            return base.Random_next_is_not_funcletized_4(isAsync);
         }
 
-        [ConditionalFact(Skip = "Issue #17246")]
-        public override void Random_next_is_not_funcletized_5()
+        [ConditionalTheory(Skip = "Issue #17246")]
+        public override Task Random_next_is_not_funcletized_5(bool isAsync)
         {
-            base.Random_next_is_not_funcletized_5();
-
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+            return base.Random_next_is_not_funcletized_5(isAsync);
         }
 
-        [ConditionalFact(Skip = "Issue #17246")]
-        public override void Random_next_is_not_funcletized_6()
+        [ConditionalTheory(Skip = "Issue #17246")]
+        public override Task Random_next_is_not_funcletized_6(bool isAsync)
         {
-            base.Random_next_is_not_funcletized_6();
-
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+            return base.Random_next_is_not_funcletized_6(isAsync);
         }
 
         [ConditionalTheory(Skip = "Issue #17246")]
@@ -4108,13 +4073,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
         [ConditionalTheory(Skip = "Issue #17246")]
         public override Task Where_query_composition3(bool isAsync) => base.Where_query_composition3(isAsync);
 
-        public override async Task Member_binding_after_ctor_arguments_fails_with_client_eval(bool isAsync)
+        public override Task Member_binding_after_ctor_arguments_fails_with_client_eval(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("OrderBy<Customer, string>(    source: DbSet<Customer>,     keySelector: (c) => new CustomerListItem(        c.CustomerID,         c.City    ).City)"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => base.Member_binding_after_ctor_arguments_fails_with_client_eval(isAsync))).Message));
+            return AssertTranslationFailed(() => base.Member_binding_after_ctor_arguments_fails_with_client_eval(isAsync));
         }
 
         [ConditionalTheory(Skip = "Issue #17246")]

--- a/test/EFCore.InMemory.FunctionalTests/Query/InheritanceInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/InheritanceInMemoryTest.cs
@@ -19,10 +19,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         [ConditionalFact]
         public override void Can_query_all_animal_views()
         {
+            var message = Assert.Throws<InvalidOperationException>(() => base.Can_query_all_animal_views()).Message;
+
             Assert.Equal(
-                CoreStrings.TranslationFailed("OrderBy<AnimalQuery, int>(    source: Select<Bird, AnimalQuery>(        source: DbSet<Bird>,         selector: (b) => MaterializeView(b)),     keySelector: (a) => a.CountryId)"),
-                Assert.Throws<InvalidOperationException>(() => base.Can_query_all_animal_views())
-                    .Message.Replace("\r", "").Replace("\n", ""));
+                CoreStrings.TranslationFailed(@"DbSet<Bird>
+    .Select(b => MaterializeView(b))
+    .OrderBy(a => a.CountryId)"),
+                message);
         }
 
         protected override bool EnforcesFkConstraints => false;

--- a/test/EFCore.InMemory.FunctionalTests/Query/SimpleQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/SimpleQueryInMemoryTest.cs
@@ -109,40 +109,40 @@ namespace Microsoft.EntityFrameworkCore.Query
             return base.OrderBy_multiple_queries(isAsync);
         }
 
-        [ConditionalFact(Skip = "Issue#17386")]
-        public override void Random_next_is_not_funcletized_1()
+        [ConditionalTheory(Skip = "Issue#17386")]
+        public override Task Random_next_is_not_funcletized_1(bool isAsync)
         {
-            base.Random_next_is_not_funcletized_1();
+            return base.Random_next_is_not_funcletized_1(isAsync);
         }
 
-        [ConditionalFact(Skip = "Issue#17386")]
-        public override void Random_next_is_not_funcletized_2()
+        [ConditionalTheory(Skip = "Issue#17386")]
+        public override Task Random_next_is_not_funcletized_2(bool isAsync)
         {
-            base.Random_next_is_not_funcletized_2();
+            return base.Random_next_is_not_funcletized_2(isAsync);
         }
 
-        [ConditionalFact(Skip = "Issue#17386")]
-        public override void Random_next_is_not_funcletized_3()
+        [ConditionalTheory(Skip = "Issue#17386")]
+        public override Task Random_next_is_not_funcletized_3(bool isAsync)
         {
-            base.Random_next_is_not_funcletized_3();
+            return base.Random_next_is_not_funcletized_3(isAsync);
         }
 
-        [ConditionalFact(Skip = "Issue#17386")]
-        public override void Random_next_is_not_funcletized_4()
+        [ConditionalTheory(Skip = "Issue#17386")]
+        public override Task Random_next_is_not_funcletized_4(bool isAsync)
         {
-            base.Random_next_is_not_funcletized_4();
+            return base.Random_next_is_not_funcletized_4(isAsync);
         }
 
-        [ConditionalFact(Skip = "Issue#17386")]
-        public override void Random_next_is_not_funcletized_5()
+        [ConditionalTheory(Skip = "Issue#17386")]
+        public override Task Random_next_is_not_funcletized_5(bool isAsync)
         {
-            base.Random_next_is_not_funcletized_5();
+            return base.Random_next_is_not_funcletized_5(isAsync);
         }
 
-        [ConditionalFact(Skip = "Issue#17386")]
-        public override void Random_next_is_not_funcletized_6()
+        [ConditionalTheory(Skip = "Issue#17386")]
+        public override Task Random_next_is_not_funcletized_6(bool isAsync)
         {
-            base.Random_next_is_not_funcletized_6();
+            return base.Random_next_is_not_funcletized_6(isAsync);
         }
 
         [ConditionalTheory(Skip = "Issue#17386")]

--- a/test/EFCore.Relational.Specification.Tests/Query/UdfDbFunctionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/UdfDbFunctionTestBase.cs
@@ -419,12 +419,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using var context = CreateContext();
 
-            Assert.Equal(
-                CoreStrings.TranslationFailed("Where<Customer>(    source: DbSet<Customer>,     predicate: (c) => 2 == AddOneStatic(c.Id))"),
-                RemoveNewLines(Assert.Throws<InvalidOperationException>(
-                    () => (from c in context.Customers
-                           where 2 == UDFSqlContext.AddOneStatic(c.Id)
-                           select c.Id).Single()).Message));
+            AssertTranslationFailed(
+                () => (from c in context.Customers
+                       where 2 == UDFSqlContext.AddOneStatic(c.Id)
+                       select c.Id).Single());
         }
 
         [ConditionalFact]
@@ -432,12 +430,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using var context = CreateContext();
 
-            Assert.Equal(
-                CoreStrings.TranslationFailed("OrderBy<Customer, int>(    source: DbSet<Customer>,     keySelector: (c) => AddOneStatic(c.Id))"),
-                RemoveNewLines(Assert.Throws<InvalidOperationException>(
-                    () => (from c in context.Customers
-                           orderby UDFSqlContext.AddOneStatic(c.Id)
-                           select c.Id).ToList()).Message));
+            AssertTranslationFailed(
+                () => (from c in context.Customers
+                       orderby UDFSqlContext.AddOneStatic(c.Id)
+                       select c.Id).ToList());
         }
 
         [ConditionalFact]
@@ -458,13 +454,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using var context = CreateContext();
 
-            Assert.Equal(
-                CoreStrings.TranslationFailed(
-                    "Where<Customer>(    source: DbSet<Customer>,     predicate: (c) => 2 == AddOneStatic(Abs(CustomerOrderCountWithClientStatic(c.Id))))"),
-                RemoveNewLines(Assert.Throws<InvalidOperationException>(
-                    () => (from c in context.Customers
-                           where 2 == UDFSqlContext.AddOneStatic(Math.Abs(UDFSqlContext.CustomerOrderCountWithClientStatic(c.Id)))
-                           select c.Id).Single()).Message));
+            AssertTranslationFailed(
+                () => (from c in context.Customers
+                       where 2 == UDFSqlContext.AddOneStatic(Math.Abs(UDFSqlContext.CustomerOrderCountWithClientStatic(c.Id)))
+                       select c.Id).Single());
         }
 
         [ConditionalFact]
@@ -472,13 +465,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using var context = CreateContext();
 
-            Assert.Equal(
-                CoreStrings.TranslationFailed(
-                    "Where<Customer>(    source: DbSet<Customer>,     predicate: (c) => 2 == AddOneStatic(CustomerOrderCountWithClientStatic(Abs(c.Id))))"),
-                RemoveNewLines(Assert.Throws<InvalidOperationException>(
-                    () => (from c in context.Customers
-                           where 2 == UDFSqlContext.AddOneStatic(UDFSqlContext.CustomerOrderCountWithClientStatic(Math.Abs(c.Id)))
-                           select c.Id).Single()).Message));
+            AssertTranslationFailed(
+                () => (from c in context.Customers
+                       where 2 == UDFSqlContext.AddOneStatic(UDFSqlContext.CustomerOrderCountWithClientStatic(Math.Abs(c.Id)))
+                       select c.Id).Single());
         }
 
         [ConditionalFact]
@@ -486,13 +476,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using var context = CreateContext();
 
-            Assert.Equal(
-                CoreStrings.TranslationFailed(
-                    "Where<Customer>(    source: DbSet<Customer>,     predicate: (c) => 2 == Abs(AddOneStatic(CustomerOrderCountWithClientStatic(c.Id))))"),
-                RemoveNewLines(Assert.Throws<InvalidOperationException>(
-                    () => (from c in context.Customers
-                           where 2 == Math.Abs(UDFSqlContext.AddOneStatic(UDFSqlContext.CustomerOrderCountWithClientStatic(c.Id)))
-                           select c.Id).Single()).Message));
+            AssertTranslationFailed(
+                () => (from c in context.Customers
+                       where 2 == Math.Abs(UDFSqlContext.AddOneStatic(UDFSqlContext.CustomerOrderCountWithClientStatic(c.Id)))
+                       select c.Id).Single());
         }
 
         [ConditionalFact]
@@ -500,13 +487,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using var context = CreateContext();
 
-            Assert.Equal(
-                CoreStrings.TranslationFailed(
-                    "Where<Customer>(    source: DbSet<Customer>,     predicate: (c) => 1 == Abs(CustomerOrderCountWithClientStatic(AddOneStatic(c.Id))))"),
-                RemoveNewLines(Assert.Throws<InvalidOperationException>(
-                    () => (from c in context.Customers
-                           where 1 == Math.Abs(UDFSqlContext.CustomerOrderCountWithClientStatic(UDFSqlContext.AddOneStatic(c.Id)))
-                           select c.Id).Single()).Message));
+            AssertTranslationFailed(
+                () => (from c in context.Customers
+                       where 1 == Math.Abs(UDFSqlContext.CustomerOrderCountWithClientStatic(UDFSqlContext.AddOneStatic(c.Id)))
+                       select c.Id).Single());
         }
 
         [ConditionalFact]
@@ -514,13 +498,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using var context = CreateContext();
 
-            Assert.Equal(
-                CoreStrings.TranslationFailed(
-                    "Where<Customer>(    source: DbSet<Customer>,     predicate: (c) => 1 == CustomerOrderCountWithClientStatic(Abs(AddOneStatic(c.Id))))"),
-                RemoveNewLines(Assert.Throws<InvalidOperationException>(
-                    () => (from c in context.Customers
-                           where 1 == UDFSqlContext.CustomerOrderCountWithClientStatic(Math.Abs(UDFSqlContext.AddOneStatic(c.Id)))
-                           select c.Id).Single()).Message));
+            AssertTranslationFailed(
+                () => (from c in context.Customers
+                       where 1 == UDFSqlContext.CustomerOrderCountWithClientStatic(Math.Abs(UDFSqlContext.AddOneStatic(c.Id)))
+                       select c.Id).Single());
         }
 
         [ConditionalFact]
@@ -528,13 +509,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using var context = CreateContext();
 
-            Assert.Equal(
-                CoreStrings.TranslationFailed(
-                    "Where<Customer>(    source: DbSet<Customer>,     predicate: (c) => 1 == CustomerOrderCountWithClientStatic(AddOneStatic(Abs(c.Id))))"),
-                RemoveNewLines(Assert.Throws<InvalidOperationException>(
-                    () => (from c in context.Customers
-                           where 1 == UDFSqlContext.CustomerOrderCountWithClientStatic(UDFSqlContext.AddOneStatic(Math.Abs(c.Id)))
-                           select c.Id).Single()).Message));
+            AssertTranslationFailed(
+                () => (from c in context.Customers
+                       where 1 == UDFSqlContext.CustomerOrderCountWithClientStatic(UDFSqlContext.AddOneStatic(Math.Abs(c.Id)))
+                       select c.Id).Single());
         }
 
         [ConditionalFact]
@@ -542,12 +520,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using var context = CreateContext();
 
-            Assert.Equal(
-                CoreStrings.TranslationFailed("Where<Customer>(    source: DbSet<Customer>,     predicate: (c) => 3 == AddOneStatic(Abs(c.Id)))"),
-                RemoveNewLines(Assert.Throws<InvalidOperationException>(
-                    () => (from c in context.Customers
-                           where 3 == UDFSqlContext.AddOneStatic(Math.Abs(c.Id))
-                           select c.Id).Single()).Message));
+            AssertTranslationFailed(
+                () => (from c in context.Customers
+                       where 3 == UDFSqlContext.AddOneStatic(Math.Abs(c.Id))
+                       select c.Id).Single());
         }
 
         [ConditionalFact]
@@ -555,12 +531,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using var context = CreateContext();
 
-            Assert.Equal(
-                CoreStrings.TranslationFailed("Where<Customer>(    source: DbSet<Customer>,     predicate: (c) => 2 == AddOneStatic(CustomerOrderCountWithClientStatic(c.Id)))"),
-                RemoveNewLines(Assert.Throws<InvalidOperationException>(
-                    () => (from c in context.Customers
-                           where 2 == UDFSqlContext.AddOneStatic(UDFSqlContext.CustomerOrderCountWithClientStatic(c.Id))
-                           select c.Id).Single()).Message));
+            AssertTranslationFailed(
+                () => (from c in context.Customers
+                       where 2 == UDFSqlContext.AddOneStatic(UDFSqlContext.CustomerOrderCountWithClientStatic(c.Id))
+                       select c.Id).Single());
         }
 
         [ConditionalFact]
@@ -568,12 +542,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using var context = CreateContext();
 
-            Assert.Equal(
-                CoreStrings.TranslationFailed("Where<Customer>(    source: DbSet<Customer>,     predicate: (c) => 3 == Abs(AddOneStatic(c.Id)))"),
-                RemoveNewLines(Assert.Throws<InvalidOperationException>(
-                    () => (from c in context.Customers
-                           where 3 == Math.Abs(UDFSqlContext.AddOneStatic(c.Id))
-                           select c.Id).Single()).Message));
+            AssertTranslationFailed(
+                () => (from c in context.Customers
+                       where 3 == Math.Abs(UDFSqlContext.AddOneStatic(c.Id))
+                       select c.Id).Single());
         }
 
         [ConditionalFact]
@@ -593,12 +565,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using var context = CreateContext();
 
-            Assert.Equal(
-                CoreStrings.TranslationFailed("Where<Customer>(    source: DbSet<Customer>,     predicate: (c) => 2 == CustomerOrderCountWithClientStatic(AddOneStatic(c.Id)))"),
-                RemoveNewLines(Assert.Throws<InvalidOperationException>(
-                    () => (from c in context.Customers
-                           where 2 == UDFSqlContext.CustomerOrderCountWithClientStatic(UDFSqlContext.AddOneStatic(c.Id))
-                           select c.Id).Single()).Message));
+            AssertTranslationFailed(
+                () => (from c in context.Customers
+                       where 2 == UDFSqlContext.CustomerOrderCountWithClientStatic(UDFSqlContext.AddOneStatic(c.Id))
+                       select c.Id).Single());
         }
 
         [ConditionalFact]
@@ -876,12 +846,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using var context = CreateContext();
 
-            Assert.Equal(
-                CoreStrings.TranslationFailed("Where<Customer>(    source: DbSet<Customer>,     predicate: (c) => 2 == (Unhandled parameter: __context_0).AddOneInstance(c.Id))"),
-                RemoveNewLines(Assert.Throws<InvalidOperationException>(
-                    () => (from c in context.Customers
-                           where 2 == context.AddOneInstance(c.Id)
-                           select c.Id).Single()).Message));
+            AssertTranslationFailed(
+                () => (from c in context.Customers
+                       where 2 == context.AddOneInstance(c.Id)
+                       select c.Id).Single());
         }
 
         [ConditionalFact]
@@ -889,12 +857,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using var context = CreateContext();
 
-            Assert.Equal(
-                CoreStrings.TranslationFailed("OrderBy<Customer, int>(    source: DbSet<Customer>,     keySelector: (c) => (Unhandled parameter: __context_0).AddOneInstance(c.Id))"),
-                RemoveNewLines(Assert.Throws<InvalidOperationException>(
-                    () => (from c in context.Customers
-                           orderby context.AddOneInstance(c.Id)
-                           select c.Id).ToList()).Message));
+            AssertTranslationFailed(
+                () => (from c in context.Customers
+                       orderby context.AddOneInstance(c.Id)
+                       select c.Id).ToList());
         }
 
         [ConditionalFact]
@@ -915,13 +881,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using var context = CreateContext();
 
-            Assert.Equal(
-                CoreStrings.TranslationFailed(
-                    "Where<Customer>(    source: DbSet<Customer>,     predicate: (c) => 2 == (Unhandled parameter: __context_0).AddOneInstance(Abs((Unhandled parameter: __context_0).CustomerOrderCountWithClientInstance(c.Id))))"),
-                RemoveNewLines(Assert.Throws<InvalidOperationException>(
-                    () => (from c in context.Customers
-                           where 2 == context.AddOneInstance(Math.Abs(context.CustomerOrderCountWithClientInstance(c.Id)))
-                           select c.Id).Single()).Message));
+            AssertTranslationFailed(
+                () => (from c in context.Customers
+                       where 2 == context.AddOneInstance(Math.Abs(context.CustomerOrderCountWithClientInstance(c.Id)))
+                       select c.Id).Single());
         }
 
         [ConditionalFact]
@@ -929,13 +892,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using var context = CreateContext();
 
-            Assert.Equal(
-                CoreStrings.TranslationFailed(
-                    "Where<Customer>(    source: DbSet<Customer>,     predicate: (c) => 2 == (Unhandled parameter: __context_0).AddOneInstance((Unhandled parameter: __context_0).CustomerOrderCountWithClientInstance(Abs(c.Id))))"),
-                RemoveNewLines(Assert.Throws<InvalidOperationException>(
-                    () => (from c in context.Customers
-                           where 2 == context.AddOneInstance(context.CustomerOrderCountWithClientInstance(Math.Abs(c.Id)))
-                           select c.Id).Single()).Message));
+            AssertTranslationFailed(
+                () => (from c in context.Customers
+                       where 2 == context.AddOneInstance(context.CustomerOrderCountWithClientInstance(Math.Abs(c.Id)))
+                       select c.Id).Single());
         }
 
         [ConditionalFact]
@@ -943,12 +903,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using var context = CreateContext();
 
-            Assert.Equal(
-                CoreStrings.TranslationFailed("Where<Customer>(    source: DbSet<Customer>,     predicate: (c) => 2 == Abs((Unhandled parameter: __context_0).AddOneInstance((Unhandled parameter: __context_0).CustomerOrderCountWithClientInstance(c.Id))))"),
-                RemoveNewLines(Assert.Throws<InvalidOperationException>(
-                    () => (from c in context.Customers
-                           where 2 == Math.Abs(context.AddOneInstance(context.CustomerOrderCountWithClientInstance(c.Id)))
-                           select c.Id).Single()).Message));
+            AssertTranslationFailed(
+                () => (from c in context.Customers
+                       where 2 == Math.Abs(context.AddOneInstance(context.CustomerOrderCountWithClientInstance(c.Id)))
+                       select c.Id).Single());
         }
 
         [ConditionalFact]
@@ -956,13 +914,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using var context = CreateContext();
 
-            Assert.Equal(
-                CoreStrings.TranslationFailed(
-                    "Where<Customer>(    source: DbSet<Customer>,     predicate: (c) => 1 == Abs((Unhandled parameter: __context_0).CustomerOrderCountWithClientInstance((Unhandled parameter: __context_0).AddOneInstance(c.Id))))"),
-                RemoveNewLines(Assert.Throws<InvalidOperationException>(
-                    () => (from c in context.Customers
-                           where 1 == Math.Abs(context.CustomerOrderCountWithClientInstance(context.AddOneInstance(c.Id)))
-                           select c.Id).Single()).Message));
+            AssertTranslationFailed(
+                () => (from c in context.Customers
+                       where 1 == Math.Abs(context.CustomerOrderCountWithClientInstance(context.AddOneInstance(c.Id)))
+                       select c.Id).Single());
         }
 
         [ConditionalFact]
@@ -970,13 +925,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using var context = CreateContext();
 
-            Assert.Equal(
-                CoreStrings.TranslationFailed(
-                    "Where<Customer>(    source: DbSet<Customer>,     predicate: (c) => 1 == (Unhandled parameter: __context_0).CustomerOrderCountWithClientInstance(Abs((Unhandled parameter: __context_0).AddOneInstance(c.Id))))"),
-                RemoveNewLines(Assert.Throws<InvalidOperationException>(
-                    () => (from c in context.Customers
-                           where 1 == context.CustomerOrderCountWithClientInstance(Math.Abs(context.AddOneInstance(c.Id)))
-                           select c.Id).Single()).Message));
+            AssertTranslationFailed(
+                () => (from c in context.Customers
+                       where 1 == context.CustomerOrderCountWithClientInstance(Math.Abs(context.AddOneInstance(c.Id)))
+                       select c.Id).Single());
         }
 
         [ConditionalFact]
@@ -984,13 +936,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using var context = CreateContext();
 
-            Assert.Equal(
-                CoreStrings.TranslationFailed(
-                    "Where<Customer>(    source: DbSet<Customer>,     predicate: (c) => 1 == (Unhandled parameter: __context_0).CustomerOrderCountWithClientInstance((Unhandled parameter: __context_0).AddOneInstance(Abs(c.Id))))"),
-                RemoveNewLines(Assert.Throws<InvalidOperationException>(
-                    () => (from c in context.Customers
-                           where 1 == context.CustomerOrderCountWithClientInstance(context.AddOneInstance(Math.Abs(c.Id)))
-                           select c.Id).Single()).Message));
+            AssertTranslationFailed(
+                () => (from c in context.Customers
+                       where 1 == context.CustomerOrderCountWithClientInstance(context.AddOneInstance(Math.Abs(c.Id)))
+                       select c.Id).Single());
         }
 
         [ConditionalFact]
@@ -998,13 +947,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using var context = CreateContext();
 
-            Assert.Equal(
-                CoreStrings.TranslationFailed(
-                    "Where<Customer>(    source: DbSet<Customer>,     predicate: (c) => 3 == (Unhandled parameter: __context_0).AddOneInstance(Abs(c.Id)))"),
-                RemoveNewLines(Assert.Throws<InvalidOperationException>(
-                    () => (from c in context.Customers
-                           where 3 == context.AddOneInstance(Math.Abs(c.Id))
-                           select c.Id).Single()).Message));
+            AssertTranslationFailed(
+                () => (from c in context.Customers
+                       where 3 == context.AddOneInstance(Math.Abs(c.Id))
+                       select c.Id).Single());
         }
 
         [ConditionalFact]
@@ -1012,13 +958,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using var context = CreateContext();
 
-            Assert.Equal(
-                CoreStrings.TranslationFailed(
-                    "Where<Customer>(    source: DbSet<Customer>,     predicate: (c) => 2 == (Unhandled parameter: __context_0).AddOneInstance((Unhandled parameter: __context_0).CustomerOrderCountWithClientInstance(c.Id)))"),
-                RemoveNewLines(Assert.Throws<InvalidOperationException>(
-                    () => (from c in context.Customers
-                           where 2 == context.AddOneInstance(context.CustomerOrderCountWithClientInstance(c.Id))
-                           select c.Id).Single()).Message));
+            AssertTranslationFailed(
+                () => (from c in context.Customers
+                       where 2 == context.AddOneInstance(context.CustomerOrderCountWithClientInstance(c.Id))
+                       select c.Id).Single());
         }
 
         [ConditionalFact]
@@ -1026,12 +969,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using var context = CreateContext();
 
-            Assert.Equal(
-                CoreStrings.TranslationFailed("Where<Customer>(    source: DbSet<Customer>,     predicate: (c) => 3 == Abs((Unhandled parameter: __context_0).AddOneInstance(c.Id)))"),
-                RemoveNewLines(Assert.Throws<InvalidOperationException>(
-                    () => (from c in context.Customers
-                           where 3 == Math.Abs(context.AddOneInstance(c.Id))
-                           select c.Id).Single()).Message));
+            AssertTranslationFailed(
+                () => (from c in context.Customers
+                       where 3 == Math.Abs(context.AddOneInstance(c.Id))
+                       select c.Id).Single());
         }
 
         public static Exception AssertThrows<T>(Func<object> testCode)
@@ -1058,13 +999,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using var context = CreateContext();
 
-            Assert.Equal(
-                CoreStrings.TranslationFailed(
-                    "Where<Customer>(    source: DbSet<Customer>,     predicate: (c) => 2 == (Unhandled parameter: __context_0).CustomerOrderCountWithClientInstance((Unhandled parameter: __context_0).AddOneInstance(c.Id)))"),
-                RemoveNewLines(Assert.Throws<InvalidOperationException>(
-                    () => (from c in context.Customers
-                           where 2 == context.CustomerOrderCountWithClientInstance(context.AddOneInstance(c.Id))
-                           select c.Id).Single()).Message));
+            AssertTranslationFailed(
+                () => (from c in context.Customers
+                       where 2 == context.CustomerOrderCountWithClientInstance(context.AddOneInstance(c.Id))
+                       select c.Id).Single());
         }
 
         [ConditionalFact]
@@ -1083,7 +1021,11 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #endregion
 
-        private string RemoveNewLines(string message)
-            => message.Replace("\n", "").Replace("\r", "");
+        private void AssertTranslationFailed(Action testCode)
+        {
+            Assert.Contains(
+                CoreStrings.TranslationFailed("").Substring(21),
+                Assert.Throws<InvalidOperationException>(testCode).Message);
+        }
     }
 }

--- a/test/EFCore.Specification.Tests/Query/FiltersTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/FiltersTestBase.cs
@@ -51,7 +51,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual void Client_eval()
         {
             Assert.Equal(
-                CoreStrings.TranslationFailed("Where<Product>(    source: DbSet<Product>,     predicate: (p) => ClientMethod(p))"),
+                CoreStrings.TranslationFailed("DbSet<Product>    .Where(p => ClientMethod(p))"),
                 RemoveNewLines(Assert.Throws<InvalidOperationException>(
                     () => _context.Products.ToList()).Message));
         }
@@ -135,7 +135,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual void Included_one_to_many_query_with_client_eval()
         {
             Assert.Equal(
-                CoreStrings.TranslationFailed("Where<Product>(    source: DbSet<Product>,     predicate: (p) => ClientMethod(p))"),
+                CoreStrings.TranslationFailed("DbSet<Product>    .Where(p => ClientMethod(p))"),
                 RemoveNewLines(Assert.Throws<InvalidOperationException>(
                     () => _context.Products.Include(p => p.OrderDetails).ToList()).Message));
         }

--- a/test/EFCore.Specification.Tests/Query/IncludeAsyncTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/IncludeAsyncTestBase.cs
@@ -682,13 +682,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using (var context = CreateContext())
             {
-                Assert.Equal(
-                    CoreStrings.TranslationFailed("Where<Customer>(    source: DbSet<Customer>,     predicate: (c) => c.IsLondon)"),
+                Assert.Contains(
+                    CoreStrings.TranslationFailed("").Substring(21),
                     (await Assert.ThrowsAsync<InvalidOperationException>(
                         () => context.Set<Customer>()
                             .Include(c => c.Orders)
                             .Where(c => c.IsLondon)
-                            .ToListAsync())).Message.Replace("\r", "").Replace("\n",""));
+                            .ToListAsync())).Message);
             }
         }
 

--- a/test/EFCore.Specification.Tests/Query/IncludeTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/IncludeTestBase.cs
@@ -361,14 +361,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using (var context = CreateContext())
             {
-                Assert.Equal(
-                    CoreStrings.TranslationFailed(
-                        "Last<Customer>(Select<Customer, Customer>(    source: DbSet<Customer>,     selector: (c) => IncludeExpression(        c,         MaterializeCollectionNavigation(Navigation: Customer.Orders (<Orders>k__BackingField, List<Order>) Collection ToDependent Order Inverse: Customer PropertyAccessMode.Field, Where<Order>(            source: DbSet<Order>,             predicate: (o) => Property<string>(c, \"CustomerID\") != null && Property<string>(c, \"CustomerID\") == Property<string>(o, \"CustomerID\"))), Orders)))"),
-                    RemoveNewLines(
-                        Assert.Throws<InvalidOperationException>(
-                            () => useString
-                                ? context.Set<Customer>().Include("Orders").Last()
-                                : context.Set<Customer>().Include(c => c.Orders).Last()).Message));
+                Assert.Contains(
+                    CoreStrings.TranslationFailed("").Substring(21),
+                    Assert.Throws<InvalidOperationException>(
+                        () => useString
+                            ? context.Set<Customer>().Include("Orders").Last()
+                            : context.Set<Customer>().Include(c => c.Orders).Last()).Message);
             }
         }
 
@@ -1910,8 +1908,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using (var context = CreateContext())
             {
-                Assert.Equal(
-                    CoreStrings.TranslationFailed("Where<Customer>(    source: DbSet<Customer>,     predicate: (c) => c.IsLondon)"),
+                Assert.Contains(
+                    CoreStrings.TranslationFailed("").Substring(21),
                     Assert.Throws<InvalidOperationException>(
                         () => useString
                             ? context.Set<Customer>()
@@ -4255,8 +4253,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Assert.False(context.Entry(orderDetail.Product).Collection(e => e.OrderDetails).IsLoaded);
             }
         }
-
-        private string RemoveNewLines(string message) => message.Replace("\n", "").Replace("\r", "");
 
         protected virtual void ClearLog()
         {

--- a/test/EFCore.Specification.Tests/Query/QueryNavigationsTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/QueryNavigationsTestBase.cs
@@ -30,20 +30,16 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task Join_with_nav_projected_in_subquery_when_client_eval(bool isAsync)
+        public virtual Task Join_with_nav_projected_in_subquery_when_client_eval(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed(
-                    "Join<Customer, TransparentIdentifier<Order, Customer>, string, TransparentIdentifier<Customer, TransparentIdentifier<Order, Customer>>>(    outer: DbSet<Customer>,     inner: LeftJoin<Order, Customer, string, TransparentIdentifier<Order, Customer>>(        outer: DbSet<Order>,         inner: DbSet<Customer>,         outerKeySelector: (o) => Property<string>(o, \"CustomerID\"),         innerKeySelector: (c0) => Property<string>(c0, \"CustomerID\"),         resultSelector: (o, i) => new TransparentIdentifier<Order, Customer>(            Outer = o,             Inner = i        )),     outerKeySelector: (c) => c.CustomerID,     innerKeySelector: (o) => ClientProjection<Order>(        t: o.Outer,         _: o.Inner).CustomerID,     resultSelector: (c, o) => new TransparentIdentifier<Customer, TransparentIdentifier<Order, Customer>>(        Outer = c,         Inner = o    ))"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertQuery(
-                            isAsync,
-                            ss => from c in ss.Set<Customer>()
-                                  join o in ss.Set<Order>().Select(o => ClientProjection(o, o.Customer)) on c.CustomerID equals o.CustomerID
-                                  join od in ss.Set<OrderDetail>().Select(od => ClientProjection(od, od.Product)) on o.OrderID equals od.OrderID
-                                  select c,
-                            entryCount: 89))).Message));
+            return AssertTranslationFailed(
+                () => AssertQuery(
+                    isAsync,
+                    ss => from c in ss.Set<Customer>()
+                          join o in ss.Set<Order>().Select(o => ClientProjection(o, o.Customer)) on c.CustomerID equals o.CustomerID
+                          join od in ss.Set<OrderDetail>().Select(od => ClientProjection(od, od.Product)) on o.OrderID equals od.OrderID
+                          select c,
+                    entryCount: 89));
         }
 
         [ConditionalTheory(Skip = "Issue #17068")]
@@ -63,19 +59,16 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task Join_with_nav_in_predicate_in_subquery_when_client_eval(bool isAsync)
+        public virtual Task Join_with_nav_in_predicate_in_subquery_when_client_eval(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("Where<TransparentIdentifier<Order, Customer>>(    source: LeftJoin<Order, Customer, string, TransparentIdentifier<Order, Customer>>(        outer: DbSet<Order>,         inner: DbSet<Customer>,         outerKeySelector: (o) => Property<string>(o, \"CustomerID\"),         innerKeySelector: (c0) => Property<string>(c0, \"CustomerID\"),         resultSelector: (o, i) => new TransparentIdentifier<Order, Customer>(            Outer = o,             Inner = i        )),     predicate: (o) => ClientPredicate<Order>(        t: o.Outer,         _: o.Inner))"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertQuery(
-                            isAsync,
-                            ss => from c in ss.Set<Customer>()
-                                  join o in ss.Set<Order>().Where(o => ClientPredicate(o, o.Customer)) on c.CustomerID equals o.CustomerID
-                                  join od in ss.Set<OrderDetail>().Where(od => ClientPredicate(od, od.Product)) on o.OrderID equals od.OrderID
-                                  select c,
-                            entryCount: 89))).Message));
+            return AssertTranslationFailed(
+                () => AssertQuery(
+                    isAsync,
+                    ss => from c in ss.Set<Customer>()
+                          join o in ss.Set<Order>().Where(o => ClientPredicate(o, o.Customer)) on c.CustomerID equals o.CustomerID
+                          join od in ss.Set<OrderDetail>().Where(od => ClientPredicate(od, od.Product)) on o.OrderID equals od.OrderID
+                          select c,
+                    entryCount: 89));
         }
 
         [ConditionalTheory(Skip = "Issue #17068")]
@@ -95,22 +88,17 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task Join_with_nav_in_orderby_in_subquery_when_client_eval(bool isAsync)
+        public virtual Task Join_with_nav_in_orderby_in_subquery_when_client_eval(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("OrderBy<TransparentIdentifier<Order, Customer>, int>(    source: LeftJoin<Order, Customer, string, TransparentIdentifier<Order, Customer>>(        outer: DbSet<Order>,         inner: DbSet<Customer>,         outerKeySelector: (o) => Property<string>(o, \"CustomerID\"),         innerKeySelector: (c0) => Property<string>(c0, \"CustomerID\"),         resultSelector: (o, i) => new TransparentIdentifier<Order, Customer>(            Outer = o,             Inner = i        )),     keySelector: (o) => ClientOrderBy<Order>(        t: o.Outer,         _: o.Inner))"),
-                RemoveNewLines((await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => AssertQuery(
-                        isAsync,
-                        ss => from c in ss.Set<Customer>()
-                              join o in ss.Set<Order>().OrderBy(o => ClientOrderBy(o, o.Customer)) on c.CustomerID equals o.CustomerID
-                              join od in ss.Set<OrderDetail>().OrderBy(od => ClientOrderBy(od, od.Product)) on o.OrderID equals od.OrderID
-                              select c,
-                        entryCount: 89))).Message));
+            return AssertTranslationFailed(
+                () => AssertQuery(
+                    isAsync,
+                    ss => from c in ss.Set<Customer>()
+                          join o in ss.Set<Order>().OrderBy(o => ClientOrderBy(o, o.Customer)) on c.CustomerID equals o.CustomerID
+                          join od in ss.Set<OrderDetail>().OrderBy(od => ClientOrderBy(od, od.Product)) on o.OrderID equals od.OrderID
+                          select c,
+                    entryCount: 89));
         }
-
-        private string RemoveNewLines(string message)
-            => message.Replace("\n", "").Replace("\r", "");
 
         [ConditionalTheory(Skip = "Issue #17068")]
         [MemberData(nameof(IsAsyncData))]
@@ -183,8 +171,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.o1.OrderID + " " + e.o2.OrderID,
                 elementAsserter: (e, a) =>
                 {
-                    AssertEqual<Order>(e.o1, a.o1);
-                    AssertEqual<Order>(e.o2, a.o2);
+                    AssertEqual(e.o1, a.o1);
+                    AssertEqual(e.o2, a.o2);
                 },
                 entryCount: 107);
         }
@@ -204,19 +192,15 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task Select_Where_Navigation_Client(bool isAsync)
+        public virtual Task Select_Where_Navigation_Client(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed(
-                    "Where<TransparentIdentifier<Order, Customer>>(    source: LeftJoin<Order, Customer, string, TransparentIdentifier<Order, Customer>>(        outer: DbSet<Order>,         inner: DbSet<Customer>,         outerKeySelector: (o) => Property<string>(o, \"CustomerID\"),         innerKeySelector: (c) => Property<string>(c, \"CustomerID\"),         resultSelector: (o, i) => new TransparentIdentifier<Order, Customer>(            Outer = o,             Inner = i        )),     predicate: (o) => o.Inner.IsLondon)"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertQuery(
-                            isAsync,
-                            ss =>from o in ss.Set<Order>()
-                                  where o.Customer.IsLondon
-                                  select o,
-                            entryCount: 46))).Message));
+            return AssertTranslationFailed(
+                () => AssertQuery(
+                    isAsync,
+                    ss => from o in ss.Set<Order>()
+                          where o.Customer.IsLondon
+                          select o,
+                    entryCount: 46));
         }
 
         [ConditionalTheory]
@@ -655,26 +639,24 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task Collection_select_nav_prop_all_client(bool isAsync)
+        public virtual Task Collection_select_nav_prop_all_client(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("All<Order>(    source: Where<Order>(        source: DbSet<Order>,         predicate: (o0) => Property<string>(EntityShaperExpression:             EntityType: Customer            ValueBufferExpression:                 ProjectionBindingExpression: EmptyProjectionMember            IsNullable: False        , \"CustomerID\") != null && Property<string>(EntityShaperExpression:             EntityType: Customer            ValueBufferExpression:                 ProjectionBindingExpression: EmptyProjectionMember            IsNullable: False        , \"CustomerID\") == Property<string>(o0, \"CustomerID\")),     predicate: (o0) => o0.ShipCity == \"London\")"),
-                RemoveNewLines((await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => AssertQuery(
-                        isAsync,
-                        ss => from c in ss.Set<Customer>()
-                              orderby c.CustomerID
-                              select new
-                              {
-                                  All = c.Orders.All(o => o.ShipCity == "London")
-                              },
-                        ss => from c in ss.Set<Customer>()
-                              orderby c.CustomerID
-                              select new
-                              {
-                                  All = (c.Orders ?? new List<Order>()).All(o => false)
-                              },
-                        assertOrder: true))).Message));
+            return AssertTranslationFailed(
+                () => AssertQuery(
+                    isAsync,
+                    ss => from c in ss.Set<Customer>()
+                          orderby c.CustomerID
+                          select new
+                          {
+                              All = c.Orders.All(o => o.ShipCity == "London")
+                          },
+                    ss => from c in ss.Set<Customer>()
+                          orderby c.CustomerID
+                          select new
+                          {
+                              All = (c.Orders ?? new List<Order>()).All(o => false)
+                          },
+                    assertOrder: true));
         }
 
         [ConditionalTheory]
@@ -692,21 +674,17 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 3);
         }
 
-        [ConditionalFact]
-        public virtual void Collection_where_nav_prop_all_client()
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Collection_where_nav_prop_all_client(bool isAsync)
         {
-            using (var context = CreateContext())
-            {
-                Assert.Equal(
-                    CoreStrings.TranslationFailed(
-                        "All<Order>(    source: Where<Order>(        source: DbSet<Order>,         predicate: (o) => Property<string>(EntityShaperExpression:             EntityType: Customer            ValueBufferExpression:                 ProjectionBindingExpression: EmptyProjectionMember            IsNullable: False        , \"CustomerID\") != null && Property<string>(EntityShaperExpression:             EntityType: Customer            ValueBufferExpression:                 ProjectionBindingExpression: EmptyProjectionMember            IsNullable: False        , \"CustomerID\") == Property<string>(o, \"CustomerID\")),     predicate: (o) => o.ShipCity == \"London\")"),
-                    RemoveNewLines(
-                        Assert.Throws<InvalidOperationException>(
-                            () => (from c in context.Set<Customer>()
-                                   orderby c.CustomerID
-                                   where c.Orders.All(o => o.ShipCity == "London")
-                                   select c).ToList()).Message));
-            }
+            return AssertTranslationFailed(
+                () => AssertQuery(
+                    isAsync,
+                    ss => from c in ss.Set<Customer>()
+                          orderby c.CustomerID
+                          where c.Orders.All(o => o.ShipCity == "London")
+                          select c));
         }
 
         [ConditionalTheory]
@@ -1027,21 +1005,17 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task Where_subquery_on_navigation_client_eval(bool isAsync)
+        public virtual Task Where_subquery_on_navigation_client_eval(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed(
-                    "OrderByDescending<Order, int>(    source: DbSet<Order>,     keySelector: (o) => ClientMethod(o.OrderID))"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertQuery(
-                            isAsync,
-                            ss => from c in ss.Set<Customer>()
-                                  orderby c.CustomerID
-                                  where c.Orders.Select(o => o.OrderID).Contains(
-                                      ss.Set<Order>().OrderByDescending(o => ClientMethod(o.OrderID)).Select(o => o.OrderID).FirstOrDefault())
-                                  select c,
-                            entryCount: 1))).Message));
+            return AssertTranslationFailed(
+                () => AssertQuery(
+                    isAsync,
+                    ss => from c in ss.Set<Customer>()
+                          orderby c.CustomerID
+                          where c.Orders.Select(o => o.OrderID).Contains(
+                              ss.Set<Order>().OrderByDescending(o => ClientMethod(o.OrderID)).Select(o => o.OrderID).FirstOrDefault())
+                          select c,
+                    entryCount: 1));
         }
 
         // ReSharper disable once MemberCanBeMadeStatic.Local
@@ -1377,6 +1351,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         private class OrderDTO
         {
             public Customer Customer { get; set; }
+        }
+
+        private async Task AssertTranslationFailed(Func<Task> testCode)
+        {
+            Assert.Contains(
+                CoreStrings.TranslationFailed("").Substring(21),
+                (await Assert.ThrowsAsync<InvalidOperationException>(testCode)).Message);
         }
     }
 }

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
@@ -629,7 +629,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_OrderBy_Count(bool isAsync)
         {
-            return AssertCount<Order>(
+            return AssertCount(
                 isAsync,
                 ss => ss.Set<Order>().Where(o => o.CustomerID == "ALFKI").OrderBy(o => o.OrderID));
         }
@@ -665,104 +665,76 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task Where_OrderBy_Count_client_eval(bool isAsync)
+        public virtual Task Where_OrderBy_Count_client_eval(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed(
-                    "Where<Order>(    source: DbSet<Order>,     predicate: (o) => ClientEvalPredicate(o))"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertCount(
-                            isAsync,
-                            ss => ss.Set<Order>().Where(o => ClientEvalPredicate(o)).OrderBy(o => ClientEvalSelectorStateless())))).Message));
+            return AssertTranslationFailed(
+                () => AssertCount(
+                    isAsync,
+                    ss => ss.Set<Order>().Where(o => ClientEvalPredicate(o)).OrderBy(o => ClientEvalSelectorStateless())));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task OrderBy_Where_Count_client_eval(bool isAsync)
+        public virtual Task OrderBy_Where_Count_client_eval(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed(
-                    "Where<Order>(    source: OrderBy<Order, int>(        source: DbSet<Order>,         keySelector: (o) => 42),     predicate: (o) => ClientEvalPredicate(o))"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertCount(
-                            isAsync,
-                            ss => ss.Set<Order>().OrderBy(o => ClientEvalSelectorStateless()).Where(o => ClientEvalPredicate(o))))).Message));
+            return AssertTranslationFailed(
+                () => AssertCount(
+                    isAsync,
+                    ss => ss.Set<Order>().OrderBy(o => ClientEvalSelectorStateless()).Where(o => ClientEvalPredicate(o))));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task OrderBy_Where_Count_client_eval_mixed(bool isAsync)
+        public virtual Task OrderBy_Where_Count_client_eval_mixed(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed(
-                    "Where<Order>(    source: OrderBy<Order, int>(        source: DbSet<Order>,         keySelector: (o) => o.OrderID),     predicate: (o) => ClientEvalPredicate(o))"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertCount(
-                            isAsync,
-                            ss => ss.Set<Order>().OrderBy(o => o.OrderID).Where(o => ClientEvalPredicate(o))))).Message));
+            return AssertTranslationFailed(
+                () => AssertCount(
+                    isAsync,
+                    ss => ss.Set<Order>().OrderBy(o => o.OrderID).Where(o => ClientEvalPredicate(o))));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task OrderBy_Count_with_predicate_client_eval(bool isAsync)
+        public virtual Task OrderBy_Count_with_predicate_client_eval(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed(
-                    "Count<Order>(    source: OrderBy<Order, int>(        source: DbSet<Order>,         keySelector: (o) => 42),     predicate: (o) => ClientEvalPredicate(o))"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertCount(
-                            isAsync,
-                            ss => ss.Set<Order>().OrderBy(o => ClientEvalSelectorStateless()),
-                            predicate: o => ClientEvalPredicate(o)))).Message));
+            return AssertTranslationFailed(
+                () => AssertCount(
+                    isAsync,
+                    ss => ss.Set<Order>().OrderBy(o => ClientEvalSelectorStateless()),
+                    predicate: o => ClientEvalPredicate(o)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task OrderBy_Count_with_predicate_client_eval_mixed(bool isAsync)
+        public virtual Task OrderBy_Count_with_predicate_client_eval_mixed(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed(
-                    "Count<Order>(    source: OrderBy<Order, int>(        source: DbSet<Order>,         keySelector: (o) => o.OrderID),     predicate: (o) => ClientEvalPredicate(o))"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertCount(
-                            isAsync,
-                            ss => ss.Set<Order>().OrderBy(o => o.OrderID),
-                            predicate: o => ClientEvalPredicate(o)))).Message));
+            return AssertTranslationFailed(
+                () => AssertCount(
+                    isAsync,
+                    ss => ss.Set<Order>().OrderBy(o => o.OrderID),
+                    predicate: o => ClientEvalPredicate(o)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task OrderBy_Where_Count_with_predicate_client_eval(bool isAsync)
+        public virtual Task OrderBy_Where_Count_with_predicate_client_eval(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed(
-                    "Where<Order>(    source: OrderBy<Order, int>(        source: DbSet<Order>,         keySelector: (o) => 42),     predicate: (o) => ClientEvalPredicate(o))"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertCount(
-                            isAsync,
-                            ss => ss.Set<Order>().OrderBy(o => ClientEvalSelectorStateless()).Where(o => ClientEvalPredicate(o)),
-                            predicate: o => ClientEvalPredicate(o)))).Message));
+            return AssertTranslationFailed(
+                () => AssertCount(
+                    isAsync,
+                    ss => ss.Set<Order>().OrderBy(o => ClientEvalSelectorStateless()).Where(o => ClientEvalPredicate(o)),
+                    predicate: o => ClientEvalPredicate(o)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task OrderBy_Where_Count_with_predicate_client_eval_mixed(bool isAsync)
+        public virtual Task OrderBy_Where_Count_with_predicate_client_eval_mixed(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed(
-                    "Where<Order>(    source: OrderBy<Order, int>(        source: DbSet<Order>,         keySelector: (o) => o.OrderID),     predicate: (o) => ClientEvalPredicate(o))"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertCount(
-                            isAsync,
-                            ss => ss.Set<Order>().OrderBy(o => o.OrderID).Where(o => ClientEvalPredicate(o)),
-                            predicate: o => o.CustomerID != "ALFKI"))).Message));
+            return AssertTranslationFailed(
+                () => AssertCount(
+                    isAsync,
+                    ss => ss.Set<Order>().OrderBy(o => o.OrderID).Where(o => ClientEvalPredicate(o)),
+                    predicate: o => o.CustomerID != "ALFKI"));
         }
 
         [ConditionalTheory]
@@ -1052,17 +1024,13 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task Last_when_no_order_by(bool isAsync)
+        public virtual Task Last_when_no_order_by(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed(
-                    @"Last<Customer>(Where<Customer>(    source: DbSet<Customer>,     predicate: (c) => c.CustomerID == ""ALFKI""))"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertLast(
-                            isAsync,
-                            ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI"),
-                            entryCount: 1))).Message));
+            return AssertTranslationFailed(
+                () => AssertLast(
+                    isAsync,
+                    ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI"),
+                    entryCount: 1));
         }
 
         [ConditionalTheory]
@@ -1396,40 +1364,32 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task Contains_with_local_tuple_array_closure(bool isAsync)
+        public virtual Task Contains_with_local_tuple_array_closure(bool isAsync)
         {
             var ids = new[] { Tuple.Create(1, 2), Tuple.Create(10248, 11) };
 
-            Assert.Equal(
-                CoreStrings.TranslationFailed(
-                    "Where<OrderDetail>(    source: DbSet<OrderDetail>,     predicate: (o) => Contains<Tuple<int, int>>(        source: (Unhandled parameter: __ids_0),         value: new Tuple<int, int>(            o.OrderID,             o.ProductID        )))"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertQuery(
-                            isAsync,
-                            ss => ss.Set<OrderDetail>().Where(o => ids.Contains(new Tuple<int, int>(o.OrderID, o.ProductID))),
-                            entryCount: 1))).Message));
+            return AssertTranslationFailed(
+                () => AssertQuery(
+                    isAsync,
+                    ss => ss.Set<OrderDetail>().Where(o => ids.Contains(new Tuple<int, int>(o.OrderID, o.ProductID))),
+                    entryCount: 1));
         }
 
         [ConditionalTheory(Skip = "Issue #15937")]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task Contains_with_local_anonymous_type_array_closure(bool isAsync)
+        public virtual Task Contains_with_local_anonymous_type_array_closure(bool isAsync)
         {
             var ids = new[] { new { Id1 = 1, Id2 = 2 }, new { Id1 = 10248, Id2 = 11 } };
 
-            Assert.Equal(
-                CoreStrings.TranslationFailed(
-                    "(o) => Contains<<>f__AnonymousType0<int, int>>(    source: (Unhandled parameter: __ids_0),     value: new {         Id1 = o.OrderID,         Id2 = o.ProductID     })"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertQuery(
-                            isAsync,
-                            ss => ss.Set<OrderDetail>().Where(o => ids.Contains(new { Id1 = o.OrderID, Id2 = o.ProductID })),
-                            entryCount: 1))).Message));
+            return AssertTranslationFailed(
+                () => AssertQuery(
+                    isAsync,
+                    ss => ss.Set<OrderDetail>().Where(o => ids.Contains(new { Id1 = o.OrderID, Id2 = o.ProductID })),
+                    entryCount: 1));
         }
 
-        protected string RemoveNewLines(string message)
-            => message.Replace("\n", "").Replace("\r", "");
+        //protected string RemoveNewLines(string message)
+        //    => message.Replace("\n", "").Replace("\r", "");
 
         [ConditionalFact]
         public virtual void OfType_Select()
@@ -1628,13 +1588,16 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using (var context = CreateContext())
             {
+                var message = Assert.Throws<InvalidOperationException>(() => context.Customers.Select(c => c.CustomerID.FirstOrDefault()).ToList()).Message;
+
                 Assert.Equal(
                     CoreStrings.QueryFailed(
-                        "AsQueryable<char>(NavigationTreeExpression    Value: EntityReferenceCustomer    Expression: (Unhandled parameter: c).CustomerID)",
+                        @"(NavigationTreeExpression
+    Value: (EntityReference: Customer)
+    Expression: c).CustomerID
+    .AsQueryable()",
                         "NavigationExpandingExpressionVisitor"),
-                    RemoveNewLines(
-                        Assert.Throws<InvalidOperationException>(
-                            () => context.Customers.Select(c => c.CustomerID.FirstOrDefault()).ToList()).Message));
+                        message);
             }
         }
 

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
@@ -134,18 +134,15 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task Select_bool_closure_with_order_by_property_with_cast_to_nullable(bool isAsync)
+        public virtual Task Select_bool_closure_with_order_by_property_with_cast_to_nullable(bool isAsync)
         {
             var boolean = false;
 
-            Assert.Equal(
-                CoreStrings.TranslationFailed("OrderBy<Customer, Nullable<bool>>(    source: DbSet<Customer>,     keySelector: (c) => (Nullable<bool>)(Unhandled parameter: __p_0).f)"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertQuery(
-                            isAsync,
-                            ss => ss.Set<Customer>().Select(c => new { f = boolean }).OrderBy(e => (bool?)e.f),
-                            assertOrder: true))).Message));
+            return AssertTranslationFailed(
+                () => AssertQuery(
+                    isAsync,
+                    ss => ss.Set<Customer>().Select(c => new { f = boolean }).OrderBy(e => (bool?)e.f),
+                    assertOrder: true));
         }
 
         [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
@@ -581,16 +581,13 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task Where_client(bool isAsync)
+        public virtual Task Where_client(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("Where<Customer>(    source: DbSet<Customer>,     predicate: (c) => c.IsLondon)"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertQuery(
-                            isAsync,
-                            ss => ss.Set<Customer>().Where(c => c.IsLondon),
-                            entryCount: 6))).Message));
+            return AssertTranslationFailed(
+                () => AssertQuery(
+                    isAsync,
+                    ss => ss.Set<Customer>().Where(c => c.IsLondon),
+                    entryCount: 6));
         }
 
         [ConditionalTheory]
@@ -605,74 +602,61 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task Where_subquery_correlated_client_eval(bool isAsync)
+        public virtual Task Where_subquery_correlated_client_eval(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("Any<Customer>(    source: DbSet<Customer>,     predicate: (c0) => EntityShaperExpression:         EntityType: Customer        ValueBufferExpression:             ProjectionBindingExpression: EmptyProjectionMember        IsNullable: False    .CustomerID == c0.CustomerID && c0.IsLondon)"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertQuery(
-                            isAsync,
-                            ss => ss.Set<Customer>().OrderBy(c1 => c1.CustomerID).Take(5)
-                                .Where(c1 => ss.Set<Customer>().Any(c2 => c1.CustomerID == c2.CustomerID && c2.IsLondon)),
-                            entryCount: 1))).Message));
+            return AssertTranslationFailed(
+                () => AssertQuery(
+                    isAsync,
+                    ss => ss.Set<Customer>()
+                        .OrderBy(c1 => c1.CustomerID)
+                        .Take(5)
+                        .Where(c1 => ss.Set<Customer>().Any(c2 => c1.CustomerID == c2.CustomerID && c2.IsLondon)),
+                    entryCount: 1));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task Where_client_and_server_top_level(bool isAsync)
+        public virtual Task Where_client_and_server_top_level(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("Where<Customer>(    source: DbSet<Customer>,     predicate: (c) => c.IsLondon && c.CustomerID != \"AROUT\")"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertQuery(
-                            isAsync,
-                            ss => ss.Set<Customer>().Where(c => c.IsLondon && c.CustomerID != "AROUT"),
-                            entryCount: 5))).Message));
+            return AssertTranslationFailed(
+                () => AssertQuery(
+                    isAsync,
+                    ss => ss.Set<Customer>().Where(c => c.IsLondon && c.CustomerID != "AROUT"),
+                    entryCount: 5));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task Where_client_or_server_top_level(bool isAsync)
+        public virtual Task Where_client_or_server_top_level(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("Where<Customer>(    source: DbSet<Customer>,     predicate: (c) => c.IsLondon || c.CustomerID == \"ALFKI\")"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertQuery(
-                            isAsync,
-                            ss => ss.Set<Customer>().Where(c => c.IsLondon || c.CustomerID == "ALFKI"),
-                            entryCount: 7))).Message));
+            return AssertTranslationFailed(
+                () => AssertQuery(
+                    isAsync,
+                    ss => ss.Set<Customer>().Where(c => c.IsLondon || c.CustomerID == "ALFKI"),
+                    entryCount: 7));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task Where_client_and_server_non_top_level(bool isAsync)
+        public virtual Task Where_client_and_server_non_top_level(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("Where<Customer>(    source: DbSet<Customer>,     predicate: (c) => c.CustomerID != \"ALFKI\" == c.IsLondon && c.CustomerID != \"AROUT\")"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertQuery(
-                            isAsync,
-                            ss => ss.Set<Customer>().Where(c => c.CustomerID != "ALFKI" == (c.IsLondon && c.CustomerID != "AROUT")),
-                            entryCount: 6))).Message));
+            return AssertTranslationFailed(
+                () => AssertQuery(
+                    isAsync,
+                    ss => ss.Set<Customer>().Where(c => c.CustomerID != "ALFKI" == (c.IsLondon && c.CustomerID != "AROUT")),
+                    entryCount: 6));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task Where_client_deep_inside_predicate_and_server_top_level(bool isAsync)
+        public virtual Task Where_client_deep_inside_predicate_and_server_top_level(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("Where<Customer>(    source: DbSet<Customer>,     predicate: (c) => c.CustomerID != \"ALFKI\" && c.CustomerID == \"MAUMAR\" || c.CustomerID != \"AROUT\" && c.IsLondon)"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertQuery(
-                            isAsync,
-                            ss => ss.Set<Customer>().Where(
-                                c => c.CustomerID != "ALFKI" && (c.CustomerID == "MAUMAR" || (c.CustomerID != "AROUT" && c.IsLondon))),
-                            entryCount: 5))).Message));
+            return AssertTranslationFailed(
+                () => AssertQuery(
+                    isAsync,
+                    ss => ss.Set<Customer>()
+                        .Where(c => c.CustomerID != "ALFKI" && (c.CustomerID == "MAUMAR" || (c.CustomerID != "AROUT" && c.IsLondon))),
+                    entryCount: 5));
         }
 
         [ConditionalTheory]
@@ -1240,15 +1224,12 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task Where_bool_client_side_negated(bool isAsync)
+        public virtual Task Where_bool_client_side_negated(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("Where<Product>(    source: DbSet<Product>,     predicate: (p) => !(ClientFunc(p.ProductID)) && p.Discontinued)"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertQuery(
-                            isAsync,
-                            ss => ss.Set<Product>().Where(p => !ClientFunc(p.ProductID) && p.Discontinued), entryCount: 8))).Message));
+            return AssertTranslationFailed(
+                () => AssertQuery(
+                    isAsync,
+                    ss => ss.Set<Product>().Where(p => !ClientFunc(p.ProductID) && p.Discontinued), entryCount: 8));
         }
 
         private static bool ClientFunc(int id)

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -605,16 +605,13 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task Queryable_reprojection(bool isAsync)
+        public virtual Task Queryable_reprojection(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("Where<Customer>(    source: DbSet<Customer>,     predicate: (c) => c.IsLondon)"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertQuery(
-                            isAsync,
-                            ss => ss.Set<Customer>().Where(c => c.IsLondon)
-                                .Select(c => new Customer { CustomerID = "Foo", City = c.City })))).Message));
+            return AssertTranslationFailed(
+                () => AssertQuery(
+                    isAsync,
+                    ss => ss.Set<Customer>().Where(c => c.IsLondon)
+                        .Select(c => new Customer { CustomerID = "Foo", City = c.City })));
         }
 
         [ConditionalTheory]
@@ -1146,44 +1143,35 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task All_client(bool isAsync)
+        public virtual Task All_client(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("All<Customer>(    source: DbSet<Customer>,     predicate: (c) => c.IsLondon)"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertAll(
-                            isAsync,
-                            ss => ss.Set<Customer>(),
-                            predicate: c => c.IsLondon))).Message));
+            return AssertTranslationFailed(
+                () => AssertAll(
+                    isAsync,
+                    ss => ss.Set<Customer>(),
+                    predicate: c => c.IsLondon));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task All_client_and_server_top_level(bool isAsync)
+        public virtual Task All_client_and_server_top_level(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("All<Customer>(    source: DbSet<Customer>,     predicate: (c) => c.CustomerID != \"Foo\" && c.IsLondon)"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertAll(
-                            isAsync,
-                            ss => ss.Set<Customer>(),
-                            predicate: c => c.CustomerID != "Foo" && c.IsLondon))).Message));
+            return AssertTranslationFailed(
+                () => AssertAll(
+                    isAsync,
+                    ss => ss.Set<Customer>(),
+                    predicate: c => c.CustomerID != "Foo" && c.IsLondon));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task All_client_or_server_top_level(bool isAsync)
+        public virtual Task All_client_or_server_top_level(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("All<Customer>(    source: DbSet<Customer>,     predicate: (c) => c.CustomerID != \"Foo\" || c.IsLondon)"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertAll(
-                            isAsync,
-                            ss => ss.Set<Customer>(),
-                            predicate: c => c.CustomerID != "Foo" || c.IsLondon))).Message));
+            return AssertTranslationFailed(
+                () => AssertAll(
+                    isAsync,
+                    ss => ss.Set<Customer>(),
+                    predicate: c => c.CustomerID != "Foo" || c.IsLondon));
         }
 
         [ConditionalTheory]
@@ -1235,26 +1223,25 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             Assert.Equal(
                 "Unsupported Binary operator type specified.",
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertQuery(
-                            isAsync,
-                            ss =>
-                                from o in ss.Set<Order>().OrderBy(o => o.OrderID).Take(3).Select(
-                                    o2 => new { o2, Mod = o2.OrderID % 2 })
-                                from e in ss.Set<Employee>().OrderBy(e => e.EmployeeID).Take(2).Select(
-                                    e2 => new { e2, Square = e2.EmployeeID ^ 2 })
-                                select new
-                                {
-                                    Add = e.e2.EmployeeID + o.o2.OrderID,
-                                    e.Square,
-                                    e.e2,
-                                    Literal = 42,
-                                    o.o2,
-                                    o.Mod
-                                },
-                            elementSorter: e => (e.e2.EmployeeID, e.o2.OrderID),
-                            entryCount: 3))).Message));
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => AssertQuery(
+                        isAsync,
+                        ss =>
+                            from o in ss.Set<Order>().OrderBy(o => o.OrderID).Take(3).Select(
+                                o2 => new { o2, Mod = o2.OrderID % 2 })
+                            from e in ss.Set<Employee>().OrderBy(e => e.EmployeeID).Take(2).Select(
+                                e2 => new { e2, Square = e2.EmployeeID ^ 2 })
+                            select new
+                            {
+                                Add = e.e2.EmployeeID + o.o2.OrderID,
+                                e.Square,
+                                e.e2,
+                                Literal = 42,
+                                o.o2,
+                                o.Mod
+                            },
+                        elementSorter: e => (e.e2.EmployeeID, e.o2.OrderID),
+                        entryCount: 3))).Message);
         }
 
         [ConditionalTheory]
@@ -1293,17 +1280,14 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task First_client_predicate(bool isAsync)
+        public virtual Task First_client_predicate(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("Where<Customer>(    source: OrderBy<Customer, string>(        source: DbSet<Customer>,         keySelector: (c) => c.CustomerID),     predicate: (c) => c.IsLondon)"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertFirst(
-                            isAsync,
-                            ss => ss.Set<Customer>().OrderBy(c => c.CustomerID),
-                            predicate: c => c.IsLondon,
-                            entryCount: 1))).Message));
+            return AssertTranslationFailed(
+                () => AssertFirst(
+                    isAsync,
+                    ss => ss.Set<Customer>().OrderBy(c => c.CustomerID),
+                    predicate: c => c.IsLondon,
+                    entryCount: 1));
         }
 
         [ConditionalTheory]
@@ -2028,72 +2012,59 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task Where_query_composition3(bool isAsync)
+        public virtual Task Where_query_composition3(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("Where<Customer>(    source: OrderBy<Customer, string>(        source: DbSet<Customer>,         keySelector: (c0) => c0.CustomerID),     predicate: (c0) => c0.IsLondon)"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertQuery(
-                            isAsync,
-                            ss => from c1 in ss.Set<Customer>()
-                                  where c1.City == ss.Set<Customer>().OrderBy(c => c.CustomerID).First(c => c.IsLondon).City
-                                  select c1,
-                            entryCount: 6))).Message));
+            return AssertTranslationFailed(
+                () => AssertQuery(
+                    isAsync,
+                    ss => from c1 in ss.Set<Customer>()
+                          where c1.City == ss.Set<Customer>().OrderBy(c => c.CustomerID).First(c => c.IsLondon).City
+                          select c1,
+                    entryCount: 6));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task Where_query_composition4(bool isAsync)
+        public virtual Task Where_query_composition4(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("OrderBy<Customer, bool>(    source: DbSet<Customer>,     keySelector: (c1) => c1.IsLondon)"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertQuery(
-                            isAsync,
-                            ss => from c1 in ss.Set<Customer>().OrderBy(c => c.CustomerID).Take(2)
-                                  where c1.City == (from c2 in ss.Set<Customer>().OrderBy(c => c.CustomerID)
-                                                    from c3 in ss.Set<Customer>().OrderBy(c => c.IsLondon).ThenBy(c => c.CustomerID)
-                                                    select new { c3 }).First().c3.City
-                                  select c1,
-                            entryCount: 1))).Message));
+            return AssertTranslationFailed(
+                () => AssertQuery(
+                    isAsync,
+                    ss => from c1 in ss.Set<Customer>().OrderBy(c => c.CustomerID).Take(2)
+                          where c1.City == (from c2 in ss.Set<Customer>().OrderBy(c => c.CustomerID)
+                                            from c3 in ss.Set<Customer>().OrderBy(c => c.IsLondon).ThenBy(c => c.CustomerID)
+                                            select new { c3 }).First().c3.City
+                          select c1,
+                    entryCount: 1));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task Where_query_composition5(bool isAsync)
+        public virtual Task Where_query_composition5(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed(
-                    "Where<Customer>(    source: DbSet<Customer>,     predicate: (c) => c.IsLondon == First<bool>(Select<Customer, bool>(        source: OrderBy<Customer, string>(            source: DbSet<Customer>,             keySelector: (c0) => c0.CustomerID),         selector: (c0) => c0.IsLondon)))"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertQuery(
-                            isAsync,
-                            ss => from c1 in ss.Set<Customer>()
-                                  where c1.IsLondon == ss.Set<Customer>().OrderBy(c => c.CustomerID).First().IsLondon
-                                  select c1,
-                            entryCount: 85))).Message));
+            return AssertTranslationFailed(
+                () => AssertQuery(
+                    isAsync,
+                    ss => from c1 in ss.Set<Customer>()
+                          where c1.IsLondon == ss.Set<Customer>().OrderBy(c => c.CustomerID).First().IsLondon
+                          select c1,
+                    entryCount: 85));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task Where_query_composition6(bool isAsync)
+        public virtual Task Where_query_composition6(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("Where<Customer>(    source: DbSet<Customer>,     predicate: (c) => c.IsLondon == First<bool>(Select<Customer, bool>(        source: OrderBy<Customer, string>(            source: DbSet<Customer>,             keySelector: (c0) => c0.CustomerID),         selector: (c0) => c0.IsLondon)))"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertQuery(
-                            isAsync,
-                            ss => from c1 in ss.Set<Customer>()
-                                  where c1.IsLondon
-                                      == ss.Set<Customer>().OrderBy(c => c.CustomerID)
-                                          .Select(c => new { Foo = c })
-                                          .First().Foo.IsLondon
-                                  select c1,
-                            entryCount: 85))).Message));
+            return AssertTranslationFailed(
+                () => AssertQuery(
+                    isAsync,
+                    ss => from c1 in ss.Set<Customer>()
+                          where c1.IsLondon
+                                == ss.Set<Customer>().OrderBy(c => c.CustomerID)
+                                    .Select(c => new { Foo = c })
+                                    .First().Foo.IsLondon
+                          select c1,
+                    entryCount: 85));
         }
 
         [ConditionalTheory]
@@ -2129,18 +2100,16 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual async Task SelectMany_mixed(bool isAsync)
         {
             Assert.Equal(
-                CoreStrings.QueryFailed("(e1) => string[] { \"a\", \"b\", }", "NavigationExpandingExpressionVisitor"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertQuery(
-                            isAsync,
-                            ss =>
-                                from e1 in ss.Set<Employee>().OrderBy(e => e.EmployeeID).Take(2)
-                                from s in new[] { "a", "b" }
-                                from c in ss.Set<Customer>().OrderBy(c => c.CustomerID).Take(2)
-                                select new { e1, s, c },
-                            e => (e.e1.EmployeeID, e.c.CustomerID),
-                            entryCount: 4))).Message));
+                CoreStrings.QueryFailed("e1 => string[] { \"a\", \"b\", }", "NavigationExpandingExpressionVisitor"),
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => AssertQuery(
+                        isAsync,
+                        ss => from e1 in ss.Set<Employee>().OrderBy(e => e.EmployeeID).Take(2)
+                              from s in new[] { "a", "b" }
+                              from c in ss.Set<Customer>().OrderBy(c => c.CustomerID).Take(2)
+                              select new { e1, s, c },
+                        e => (e.e1.EmployeeID, e.c.CustomerID),
+                        entryCount: 4))).Message);
         }
 
         [ConditionalTheory]
@@ -2532,33 +2501,39 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual async Task Default_if_empty_top_level_arg(bool isAsync)
         {
+            var message = (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => AssertQuery(
+                    isAsync,
+                    ss => from e in ss.Set<Employee>().Where(c => c.EmployeeID == NonExistentID).DefaultIfEmpty(new Employee())
+                          select e,
+                    entryCount: 1))).Message;
+
             Assert.Equal(
                 CoreStrings.QueryFailed(
-                    "DefaultIfEmpty<Employee>(    source: Where<Employee>(        source: DbSet<Employee>,         predicate: (c) => c.EmployeeID == 4294967295),     defaultValue: (Unhandled parameter: __p_0))",
+                    @"DbSet<Employee>
+    .Where(c => c.EmployeeID == 4294967295)
+    .DefaultIfEmpty(__p_0)",
                     "NavigationExpandingExpressionVisitor"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertQuery(
-                            isAsync,
-                            ss => from e in ss.Set<Employee>().Where(c => c.EmployeeID == NonExistentID).DefaultIfEmpty(new Employee())
-                                  select e,
-                            entryCount: 1))).Message));
+                    message);
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual async Task Default_if_empty_top_level_arg_followed_by_projecting_constant(bool isAsync)
         {
+            var message = (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => AssertQueryScalar(
+                    isAsync,
+                    ss => from e in ss.Set<Employee>().Where(c => c.EmployeeID == NonExistentID).DefaultIfEmpty(new Employee())
+                          select 42))).Message;
+
             Assert.Equal(
                 CoreStrings.QueryFailed(
-                    "DefaultIfEmpty<Employee>(    source: Where<Employee>(        source: DbSet<Employee>,         predicate: (c) => c.EmployeeID == 4294967295),     defaultValue: (Unhandled parameter: __p_0))",
+                    @"DbSet<Employee>
+    .Where(c => c.EmployeeID == 4294967295)
+    .DefaultIfEmpty(__p_0)",
                     "NavigationExpandingExpressionVisitor"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertQueryScalar(
-                            isAsync,
-                            ss => from e in ss.Set<Employee>().Where(c => c.EmployeeID == NonExistentID).DefaultIfEmpty(new Employee())
-                                  select 42))).Message));
+                    message);
         }
 
         [ConditionalTheory]
@@ -2702,34 +2677,27 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task OrderBy_client_mixed(bool isAsync)
+        public virtual Task OrderBy_client_mixed(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("OrderBy<Customer, bool>(    source: DbSet<Customer>,     keySelector: (c) => c.IsLondon)"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertQuery(
-                            isAsync,
-                            ss => ss.Set<Customer>().OrderBy(c => c.IsLondon).ThenBy(c => c.CompanyName),
-                            assertOrder: true,
-                            entryCount: 91))).Message));
+            return AssertTranslationFailed(
+                () => AssertQuery(
+                    isAsync,
+                    ss => ss.Set<Customer>().OrderBy(c => c.IsLondon).ThenBy(c => c.CompanyName),
+                    assertOrder: true,
+                    entryCount: 91));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task OrderBy_multiple_queries(bool isAsync)
+        public virtual Task OrderBy_multiple_queries(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("Join<Customer, Order, Foo, TransparentIdentifier<Customer, Order>>(    outer: DbSet<Customer>,     inner: DbSet<Order>,     outerKeySelector: (c) => new Foo{ Bar = c.CustomerID }    ,     innerKeySelector: (o) => new Foo{ Bar = o.CustomerID }    ,     resultSelector: (c, o) => new TransparentIdentifier<Customer, Order>(        Outer = c,         Inner = o    ))"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertQuery(
-                            isAsync,
-                            ss =>
-                                from c in ss.Set<Customer>()
-                                join o in ss.Set<Order>() on new Foo { Bar = c.CustomerID } equals new Foo { Bar = o.CustomerID }
-                                orderby c.IsLondon, o.OrderDate
-                                select new { c, o }))).Message));
+            return AssertTranslationFailed(
+                () => AssertQuery(
+                    isAsync,
+                    ss => from c in ss.Set<Customer>()
+                          join o in ss.Set<Order>() on new Foo { Bar = c.CustomerID } equals new Foo { Bar = o.CustomerID }
+                          orderby c.IsLondon, o.OrderDate
+                          select new { c, o }));
         }
 
         [ConditionalTheory]
@@ -3547,94 +3515,64 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 267);
         }
 
-        [ConditionalFact]
-        public virtual void Random_next_is_not_funcletized_1()
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Random_next_is_not_funcletized_1(bool isAsync)
         {
-            using (var context = CreateContext())
-            {
-                Assert.Equal(
-                    CoreStrings.TranslationFailed("Where<Order>(    source: DbSet<Order>,     predicate: (o) => o.OrderID > new Random().Next())"),
-                    RemoveNewLines(
-                        Assert.Throws<InvalidOperationException>(
-                            () => context.Orders
-                                .Where(o => o.OrderID > new Random().Next())
-                                .ToList()).Message));
-            }
+            return AssertTranslationFailed(
+                () => AssertQuery(
+                    isAsync,
+                    ss => ss.Set<Order>().Where(o => o.OrderID > new Random().Next())));
         }
 
-        [ConditionalFact]
-        public virtual void Random_next_is_not_funcletized_2()
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Random_next_is_not_funcletized_2(bool isAsync)
         {
-            using (var context = CreateContext())
-            {
-                Assert.Equal(
-                    CoreStrings.TranslationFailed("Where<Order>(    source: DbSet<Order>,     predicate: (o) => o.OrderID > new Random().Next(5))"),
-                    RemoveNewLines(
-                        Assert.Throws<InvalidOperationException>(
-                            () => context.Orders
-                                .Where(o => o.OrderID > new Random().Next(5))
-                                .ToList()).Message));
-            }
+            return AssertTranslationFailed(
+                () => AssertQuery(
+                    isAsync,
+                    ss => ss.Set<Order>().Where(o => o.OrderID > new Random().Next(5))));
         }
 
-        [ConditionalFact]
-        public virtual void Random_next_is_not_funcletized_3()
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Random_next_is_not_funcletized_3(bool isAsync)
         {
-            using (var context = CreateContext())
-            {
-                Assert.Equal(
-                    CoreStrings.TranslationFailed("Where<Order>(    source: DbSet<Order>,     predicate: (o) => o.OrderID > new Random().Next(        minValue: 0,         maxValue: 10))"),
-                    RemoveNewLines(
-                        Assert.Throws<InvalidOperationException>(
-                            () => context.Orders
-                                .Where(o => o.OrderID > new Random().Next(0, 10))
-                                .ToList()).Message));
-            }
+            return AssertTranslationFailed(
+                () => AssertQuery(
+                    isAsync,
+                    ss => ss.Set<Order>().Where(o => o.OrderID > new Random().Next(0, 10))));
         }
 
-        [ConditionalFact]
-        public virtual void Random_next_is_not_funcletized_4()
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Random_next_is_not_funcletized_4(bool isAsync)
         {
-            using (var context = CreateContext())
-            {
-                Assert.Equal(
-                    CoreStrings.TranslationFailed("Where<Order>(    source: DbSet<Order>,     predicate: (o) => o.OrderID > new Random(15).Next())"),
-                    RemoveNewLines(
-                        Assert.Throws<InvalidOperationException>(
-                            () => context.Orders
-                                .Where(o => o.OrderID > new Random(15).Next())
-                                .ToList()).Message));
-            }
+            return AssertTranslationFailed(
+                () => AssertQuery(
+                    isAsync,
+                    ss => ss.Set<Order>().Where(o => o.OrderID > new Random(15).Next())));
         }
 
-        [ConditionalFact]
-        public virtual void Random_next_is_not_funcletized_5()
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Random_next_is_not_funcletized_5(bool isAsync)
         {
-            using (var context = CreateContext())
-            {
-                Assert.Equal(
-                    CoreStrings.TranslationFailed("Where<Order>(    source: DbSet<Order>,     predicate: (o) => o.OrderID > new Random(15).Next(5))"),
-                    RemoveNewLines(
-                        Assert.Throws<InvalidOperationException>(
-                            () => context.Orders
-                                .Where(o => o.OrderID > new Random(15).Next(5))
-                                .ToList()).Message));
-            }
+            return AssertTranslationFailed(
+                () => AssertQuery(
+                    isAsync,
+                    ss => ss.Set<Order>().Where(o => o.OrderID > new Random(15).Next(5))));
         }
 
-        [ConditionalFact]
-        public virtual void Random_next_is_not_funcletized_6()
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Random_next_is_not_funcletized_6(bool isAsync)
         {
-            using (var context = CreateContext())
-            {
-                Assert.Equal(
-                    CoreStrings.TranslationFailed("Where<Order>(    source: DbSet<Order>,     predicate: (o) => o.OrderID > new Random(15).Next(        minValue: 0,         maxValue: 10))"),
-                    RemoveNewLines(
-                        Assert.Throws<InvalidOperationException>(
-                            () => context.Orders
-                                .Where(o => o.OrderID > new Random(15).Next(0, 10))
-                                .ToList()).Message));
-            }
+            return AssertTranslationFailed(
+                () => AssertQuery(
+                    isAsync,
+                    ss => ss.Set<Order>().Where(o => o.OrderID > new Random(15).Next(0, 10))));
         }
 
         [ConditionalTheory]
@@ -5361,18 +5299,15 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task SelectMany_after_client_method(bool isAsync)
+        public virtual Task SelectMany_after_client_method(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("OrderBy<Customer, string>(    source: DbSet<Customer>,     keySelector: (c) => ClientOrderBy(c))"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertQueryScalar(
-                            isAsync,
-                            ss => ss.Set<Customer>().OrderBy(c => ClientOrderBy(c))
-                                .SelectMany(c => c.Orders)
-                                .Distinct()
-                                .Select(o => o.OrderDate)))).Message));
+            return AssertTranslationFailed(
+                () => AssertQueryScalar(
+                    isAsync,
+                    ss => ss.Set<Customer>().OrderBy(c => ClientOrderBy(c))
+                        .SelectMany(c => c.Orders)
+                        .Distinct()
+                        .Select(o => o.OrderDate)));
         }
 
         private static string ClientOrderBy(Customer c)
@@ -5420,23 +5355,18 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task Client_OrderBy_GroupBy_Group_ordering_works(bool isAsync)
+        public virtual Task Client_OrderBy_GroupBy_Group_ordering_works(bool isAsync)
         {
-            Assert.StartsWith(
-                "The LINQ expression ",
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => AssertQuery(
-                            isAsync,
-                            ss => from o in ss.Set<Order>()
-                                  orderby ClientEvalSelector(o)
-                                  group o by o.CustomerID
-                                  into g
-                                  orderby g.Key
-                                  select g.OrderByDescending(x => x.OrderID),
-                            assertOrder: true,
-                            elementAsserter: (e, a) => AssertCollection(e, a, ordered: true))))
-                    .Message));
+            return AssertTranslationFailed(
+                () => AssertQuery(
+                    isAsync,
+                    ss => from o in ss.Set<Order>()
+                          orderby ClientEvalSelector(o)
+                          group o by o.CustomerID into g
+                          orderby g.Key
+                          select g.OrderByDescending(x => x.OrderID),
+                    assertOrder: true,
+                    elementAsserter: (e, a) => AssertCollection(e, a, ordered: true)));
         }
 
         [ConditionalTheory]
@@ -5614,6 +5544,13 @@ namespace Microsoft.EntityFrameworkCore.Query
                         .Select(o => new { o.OrderDate }).ToList()),
                 assertOrder: true,
                 elementAsserter: (e, a) => AssertCollection(e, a, ordered: true));
+        }
+
+        protected async Task AssertTranslationFailed(Func<Task> testCode)
+        {
+            Assert.Contains(
+                CoreStrings.TranslationFailed("").Substring(21),
+                (await Assert.ThrowsAsync<InvalidOperationException>(testCode)).Message);
         }
 
         private static Expression<Func<Order, bool>> ValidYear => a => a.OrderDate.Value.Year == 1998;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryLoggingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryLoggingSqlServerTest.cs
@@ -38,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 Assert.NotNull(customers);
                 Assert.StartsWith(
-                    "(queryContext) => new QueryingEnumerable<Customer>(",
+                    "queryContext => new QueryingEnumerable<Customer>(",
                     Fixture.TestSqlLoggerFactory.Log[0].Message);
             }
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
@@ -1048,13 +1048,9 @@ FROM [Customers] AS [c]
 WHERE [c].[CustomerID] = N'FISSA'");
         }
 
-        public override async Task Member_binding_after_ctor_arguments_fails_with_client_eval(bool isAsync)
+        public override Task Member_binding_after_ctor_arguments_fails_with_client_eval(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("OrderBy<Customer, string>(    source: DbSet<Customer>,     keySelector: (c) => new CustomerListItem(        c.CustomerID,         c.City    ).City)"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => base.Member_binding_after_ctor_arguments_fails_with_client_eval(isAsync))).Message));
+            return AssertTranslationFailed(() => base.Member_binding_after_ctor_arguments_fails_with_client_eval(isAsync));
         }
 
         public override async Task Filtered_collection_projection_is_tracked(bool isAsync)

--- a/test/EFCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
@@ -884,40 +884,25 @@ LIMIT 1");
                         .Select(g => g.Min(e => e.TestNullableDecimal))
                         .ToList());
 
-                Assert.Equal(
-                    CoreStrings.TranslationFailed(
-                        "Min<BuiltInNullableDataTypes>(    source: GroupByShaperExpression:    KeySelector: 1,     ElementSelector:EntityShaperExpression:         EntityType: BuiltInNullableDataTypes        ValueBufferExpression:             ProjectionBindingExpression: EmptyProjectionMember        IsNullable: False    ,     selector: (e) => e.TestNullableDecimal)"),
-                    RemoveNewLines(ex.Message));
+                AssertTranslationFailed(
+                    () => query
+                        .Select(g => g.Min(e => e.TestNullableDecimal))
+                        .ToList());
 
-                ex = Assert.Throws<InvalidOperationException>(
+                AssertTranslationFailed(
                     () => query
                         .Select(g => g.Min(e => e.TestNullableDateTimeOffset))
                         .ToList());
 
-                Assert.Equal(
-                    CoreStrings.TranslationFailed(
-                        "Min<BuiltInNullableDataTypes, Nullable<DateTimeOffset>>(    source: GroupByShaperExpression:    KeySelector: 1,     ElementSelector:EntityShaperExpression:         EntityType: BuiltInNullableDataTypes        ValueBufferExpression:             ProjectionBindingExpression: EmptyProjectionMember        IsNullable: False    ,     selector: (e) => e.TestNullableDateTimeOffset)"),
-                    RemoveNewLines(ex.Message));
-
-                ex = Assert.Throws<InvalidOperationException>(
+                AssertTranslationFailed(
                     () => query
                         .Select(g => g.Min(e => e.TestNullableTimeSpan))
                         .ToList());
 
-                Assert.Equal(
-                    CoreStrings.TranslationFailed(
-                        "Min<BuiltInNullableDataTypes, Nullable<TimeSpan>>(    source: GroupByShaperExpression:    KeySelector: 1,     ElementSelector:EntityShaperExpression:         EntityType: BuiltInNullableDataTypes        ValueBufferExpression:             ProjectionBindingExpression: EmptyProjectionMember        IsNullable: False    ,     selector: (e) => e.TestNullableTimeSpan)"),
-                    RemoveNewLines(ex.Message));
-
-                ex = Assert.Throws<InvalidOperationException>(
+                AssertTranslationFailed(
                     () => query
                         .Select(g => g.Min(e => e.TestNullableUnsignedInt64))
                         .ToList());
-
-                Assert.Equal(
-                    CoreStrings.TranslationFailed(
-                        "Min<BuiltInNullableDataTypes, Nullable<ulong>>(    source: GroupByShaperExpression:    KeySelector: 1,     ElementSelector:EntityShaperExpression:         EntityType: BuiltInNullableDataTypes        ValueBufferExpression:             ProjectionBindingExpression: EmptyProjectionMember        IsNullable: False    ,     selector: (e) => e.TestNullableUnsignedInt64)"),
-                    RemoveNewLines(ex.Message));
             }
         }
 
@@ -954,45 +939,25 @@ LIMIT 1");
                     .Where(e => e.PartitionId == 201)
                     .GroupBy(_ => true);
 
-                var ex = Assert.Throws<InvalidOperationException>(
+                AssertTranslationFailed(
                     () => query
                         .Select(g => g.Max(e => e.TestNullableDecimal))
                         .ToList());
 
-                Assert.Equal(
-                    CoreStrings.TranslationFailed(
-                        "Max<BuiltInNullableDataTypes>(    source: GroupByShaperExpression:    KeySelector: 1,     ElementSelector:EntityShaperExpression:         EntityType: BuiltInNullableDataTypes        ValueBufferExpression:             ProjectionBindingExpression: EmptyProjectionMember        IsNullable: False    ,     selector: (e) => e.TestNullableDecimal)"),
-                    RemoveNewLines(ex.Message));
-
-                ex = Assert.Throws<InvalidOperationException>(
+                AssertTranslationFailed(
                     () => query
                         .Select(g => g.Max(e => e.TestNullableDateTimeOffset))
                         .ToList());
 
-                Assert.Equal(
-                    CoreStrings.TranslationFailed(
-                        "Max<BuiltInNullableDataTypes, Nullable<DateTimeOffset>>(    source: GroupByShaperExpression:    KeySelector: 1,     ElementSelector:EntityShaperExpression:         EntityType: BuiltInNullableDataTypes        ValueBufferExpression:             ProjectionBindingExpression: EmptyProjectionMember        IsNullable: False    ,     selector: (e) => e.TestNullableDateTimeOffset)"),
-                    RemoveNewLines(ex.Message));
-
-                ex = Assert.Throws<InvalidOperationException>(
+                AssertTranslationFailed(
                     () => query
                         .Select(g => g.Max(e => e.TestNullableTimeSpan))
                         .ToList());
 
-                Assert.Equal(
-                    CoreStrings.TranslationFailed(
-                        "Max<BuiltInNullableDataTypes, Nullable<TimeSpan>>(    source: GroupByShaperExpression:    KeySelector: 1,     ElementSelector:EntityShaperExpression:         EntityType: BuiltInNullableDataTypes        ValueBufferExpression:             ProjectionBindingExpression: EmptyProjectionMember        IsNullable: False    ,     selector: (e) => e.TestNullableTimeSpan)"),
-                    RemoveNewLines(ex.Message));
-
-                ex = Assert.Throws<InvalidOperationException>(
+                AssertTranslationFailed(
                     () => query
                         .Select(g => g.Max(e => e.TestNullableUnsignedInt64))
                         .ToList());
-
-                Assert.Equal(
-                    CoreStrings.TranslationFailed(
-                        "Max<BuiltInNullableDataTypes, Nullable<ulong>>(    source: GroupByShaperExpression:    KeySelector: 1,     ElementSelector:EntityShaperExpression:         EntityType: BuiltInNullableDataTypes        ValueBufferExpression:             ProjectionBindingExpression: EmptyProjectionMember        IsNullable: False    ,     selector: (e) => e.TestNullableUnsignedInt64)"),
-                    RemoveNewLines(ex.Message));
             }
         }
 
@@ -1009,14 +974,10 @@ LIMIT 1");
 
                 context.SaveChanges();
 
-                var ex = Assert.Throws<InvalidOperationException>(
+                AssertTranslationFailed(
                     () => context.Set<BuiltInNullableDataTypes>()
                         .Where(e => e.PartitionId == 202)
                         .Average(e => e.TestNullableDecimal));
-                Assert.Equal(
-                    CoreStrings.TranslationFailed(
-                        "Average<BuiltInNullableDataTypes>(    source: Where<BuiltInNullableDataTypes>(        source: DbSet<BuiltInNullableDataTypes>,         predicate: (b) => b.PartitionId == 202),     selector: (b) => b.TestNullableDecimal)"),
-                    RemoveNewLines(ex.Message));
             }
         }
 
@@ -1033,19 +994,19 @@ LIMIT 1");
 
                 context.SaveChanges();
 
-                var ex = Assert.Throws<InvalidOperationException>(
+                AssertTranslationFailed(
                     () => context.Set<BuiltInDataTypes>()
                         .Where(e => e.PartitionId == 203)
                         .Sum(e => e.TestDecimal));
-                Assert.Equal(
-                    CoreStrings.TranslationFailed(
-                        "Sum<BuiltInDataTypes>(    source: Where<BuiltInDataTypes>(        source: DbSet<BuiltInDataTypes>,         predicate: (b) => b.PartitionId == 203),     selector: (b) => b.TestDecimal)"),
-                    RemoveNewLines(ex.Message));
             }
         }
 
-        private string RemoveNewLines(string message)
-            => message.Replace("\n", "").Replace("\r", "");
+        private void AssertTranslationFailed(Action testCode)
+        {
+            Assert.Contains(
+                CoreStrings.TranslationFailed("").Substring(21),
+                Assert.Throws<InvalidOperationException>(testCode).Message);
+        }
 
         [ConditionalFact]
         public virtual void Can_query_negation_of_converted_types()

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -17,129 +17,76 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         // SQLite client-eval
-        public override async Task Where_datetimeoffset_date_component(bool isAsync)
+        public override Task Where_datetimeoffset_date_component(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("Where<Mission>(    source: DbSet<Mission>,     predicate: (m) => m.Timeline.Date > (Unhandled parameter: __Date_0))"),
-                RemoveNewLines((await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => base.Where_datetimeoffset_date_component(isAsync)))
-                .Message));
+            return AssertTranslationFailed(() => base.Where_datetimeoffset_date_component(isAsync));
         }
 
         // SQLite client-eval
-        public override async Task Where_datetimeoffset_day_component(bool isAsync)
+        public override Task Where_datetimeoffset_day_component(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("Where<Mission>(    source: DbSet<Mission>,     predicate: (m) => m.Timeline.Day == 2)"),
-                RemoveNewLines((await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => base.Where_datetimeoffset_day_component(isAsync)))
-                .Message));
+            return AssertTranslationFailed(() => base.Where_datetimeoffset_date_component(isAsync));
         }
 
         // SQLite client-eval
-        public override async Task Where_datetimeoffset_dayofyear_component(bool isAsync)
+        public override Task Where_datetimeoffset_dayofyear_component(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("Where<Mission>(    source: DbSet<Mission>,     predicate: (m) => m.Timeline.DayOfYear == 2)"),
-                RemoveNewLines((await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => base.Where_datetimeoffset_dayofyear_component(isAsync)))
-                .Message));
+            return AssertTranslationFailed(() => base.Where_datetimeoffset_dayofyear_component(isAsync));
         }
 
         // SQLite client-eval
-        public override async Task Where_datetimeoffset_hour_component(bool isAsync)
+        public override Task Where_datetimeoffset_hour_component(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("Where<Mission>(    source: DbSet<Mission>,     predicate: (m) => m.Timeline.Hour == 10)"),
-                RemoveNewLines((await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => base.Where_datetimeoffset_hour_component(isAsync)))
-                .Message));
+            return AssertTranslationFailed(() => base.Where_datetimeoffset_hour_component(isAsync));
         }
 
         // SQLite client-eval
-        public override async Task Where_datetimeoffset_millisecond_component(bool isAsync)
+        public override Task Where_datetimeoffset_millisecond_component(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("Where<Mission>(    source: DbSet<Mission>,     predicate: (m) => m.Timeline.Millisecond == 0)"),
-                RemoveNewLines((await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => base.Where_datetimeoffset_millisecond_component(isAsync)))
-                .Message));
+            return AssertTranslationFailed(() => base.Where_datetimeoffset_millisecond_component(isAsync));
         }
 
         // SQLite client-eval
-        public override async Task Where_datetimeoffset_minute_component(bool isAsync)
+        public override Task Where_datetimeoffset_minute_component(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("Where<Mission>(    source: DbSet<Mission>,     predicate: (m) => m.Timeline.Minute == 0)"),
-                RemoveNewLines((await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => base.Where_datetimeoffset_minute_component(isAsync)))
-                .Message));
+            return AssertTranslationFailed(() => base.Where_datetimeoffset_minute_component(isAsync));
         }
 
         // SQLite client-eval
-        public override async Task Where_datetimeoffset_month_component(bool isAsync)
+        public override Task Where_datetimeoffset_month_component(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("Where<Mission>(    source: DbSet<Mission>,     predicate: (m) => m.Timeline.Month == 1)"),
-                RemoveNewLines((await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => base.Where_datetimeoffset_month_component(isAsync)))
-                .Message));
+            return AssertTranslationFailed(() => base.Where_datetimeoffset_month_component(isAsync));
         }
 
         // SQLite client-eval
-        public override async Task Where_datetimeoffset_now(bool isAsync)
+        public override Task Where_datetimeoffset_now(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("Where<Mission>(    source: DbSet<Mission>,     predicate: (m) => m.Timeline != DateTimeOffset.Now)"),
-                RemoveNewLines((await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => base.Where_datetimeoffset_now(isAsync)))
-                .Message));
+            return AssertTranslationFailed(() => base.Where_datetimeoffset_now(isAsync));
         }
 
         // SQLite client-eval
-        public override async Task Where_datetimeoffset_second_component(bool isAsync)
+        public override Task Where_datetimeoffset_second_component(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("Where<Mission>(    source: DbSet<Mission>,     predicate: (m) => m.Timeline.Second == 0)"),
-                RemoveNewLines((await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => base.Where_datetimeoffset_second_component(isAsync)))
-                .Message));
+            return AssertTranslationFailed(() => base.Where_datetimeoffset_second_component(isAsync));
         }
 
         // SQLite client-eval
-        public override async Task Where_datetimeoffset_utcnow(bool isAsync)
+        public override Task Where_datetimeoffset_utcnow(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("Where<Mission>(    source: DbSet<Mission>,     predicate: (m) => m.Timeline != DateTimeOffset.UtcNow)"),
-                RemoveNewLines((await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => base.Where_datetimeoffset_utcnow(isAsync)))
-                .Message));
+            return AssertTranslationFailed(() => base.Where_datetimeoffset_utcnow(isAsync));
         }
 
         // SQLite client-eval
-        public override async Task Where_datetimeoffset_year_component(bool isAsync)
+        public override Task Where_datetimeoffset_year_component(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("Where<Mission>(    source: DbSet<Mission>,     predicate: (m) => m.Timeline.Year == 2)"),
-                RemoveNewLines((await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => base.Where_datetimeoffset_year_component(isAsync)))
-                .Message));
+            return AssertTranslationFailed(() => base.Where_datetimeoffset_year_component(isAsync));
         }
 
         // SQLite client-eval
-        public override async Task DateTimeOffset_Contains_Less_than_Greater_than(bool isAsync)
+        public override Task DateTimeOffset_Contains_Less_than_Greater_than(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed(
-                    "Where<Mission>(    source: DbSet<Mission>,     predicate: (m) => (Unhandled parameter: __start_0) <= (DateTimeOffset)m.Timeline.Date && m.Timeline < (Unhandled parameter: __end_1) && Contains<DateTimeOffset>(        source: (Unhandled parameter: __dates_2),         value: m.Timeline))"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => base.DateTimeOffset_Contains_Less_than_Greater_than(isAsync)))
-                    .Message));
+            return AssertTranslationFailed(() => base.DateTimeOffset_Contains_Less_than_Greater_than(isAsync));
         }
-
-        private string RemoveNewLines(string message)
-            => message.Replace("\n", "").Replace("\r", "");
 
         // Sqlite does not support cross/outer apply
         public override Task Correlated_collections_inner_subquery_predicate_references_outer_qsre(bool isAsync) => null;

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
@@ -1332,13 +1332,9 @@ FROM (
             return base.Like_with_non_string_column_using_ToString(isAsync);
         }
 
-        public override async Task Member_binding_after_ctor_arguments_fails_with_client_eval(bool isAsync)
+        public override Task Member_binding_after_ctor_arguments_fails_with_client_eval(bool isAsync)
         {
-            Assert.Equal(
-                CoreStrings.TranslationFailed("OrderBy<Customer, string>(    source: DbSet<Customer>,     keySelector: (c) => new CustomerListItem(        c.CustomerID,         c.City    ).City)"),
-                RemoveNewLines(
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => base.Member_binding_after_ctor_arguments_fails_with_client_eval(isAsync))).Message));
+            return AssertTranslationFailed(() => base.Member_binding_after_ctor_arguments_fails_with_client_eval(isAsync));
         }
 
         [ConditionalTheory(Skip = "Issue#17230")]

--- a/test/EFCore.Tests/Query/ExpressionPrinterTest.cs
+++ b/test/EFCore.Tests/Query/ExpressionPrinterTest.cs
@@ -1,0 +1,169 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public class ExpressionPrinterTest
+    {
+        private readonly ExpressionPrinter _expressionPrinter = new ExpressionPrinter();
+
+        [ConditionalFact]
+        public void UnaryExpression_printed_correctly()
+        {
+            Assert.Equal("(decimal)42", _expressionPrinter.Print(Expression.Convert(Expression.Constant(42), typeof(decimal))));
+            Assert.Equal("throw \"Some exception\"", _expressionPrinter.Print(Expression.Throw(Expression.Constant("Some exception"))));
+            Assert.Equal("!(True)", _expressionPrinter.Print(Expression.Not(Expression.Constant(true))));
+            Assert.Equal("(BaseClass as DerivedClass)", _expressionPrinter.Print(Expression.TypeAs(Expression.Constant(new BaseClass()), typeof(DerivedClass))));
+        }
+
+        private class BaseClass
+        {
+        }
+
+        private class DerivedClass : BaseClass
+        {
+        }
+
+        [ConditionalFact]
+        public void BinaryExpression_printed_correctly()
+        {
+            Assert.Equal("7 == 42", _expressionPrinter.Print(Expression.MakeBinary(ExpressionType.Equal, Expression.Constant(7), Expression.Constant(42))));
+            Assert.Equal("7 != 42", _expressionPrinter.Print(Expression.MakeBinary(ExpressionType.NotEqual, Expression.Constant(7), Expression.Constant(42))));
+            Assert.Equal("7 > 42", _expressionPrinter.Print(Expression.MakeBinary(ExpressionType.GreaterThan, Expression.Constant(7), Expression.Constant(42))));
+            Assert.Equal("7 >= 42", _expressionPrinter.Print(Expression.MakeBinary(ExpressionType.GreaterThanOrEqual, Expression.Constant(7), Expression.Constant(42))));
+            Assert.Equal("7 < 42", _expressionPrinter.Print(Expression.MakeBinary(ExpressionType.LessThan, Expression.Constant(7), Expression.Constant(42))));
+            Assert.Equal("7 <= 42", _expressionPrinter.Print(Expression.MakeBinary(ExpressionType.LessThanOrEqual, Expression.Constant(7), Expression.Constant(42))));
+            Assert.Equal("True && True", _expressionPrinter.Print(Expression.MakeBinary(ExpressionType.AndAlso, Expression.Constant(true), Expression.Constant(true))));
+            Assert.Equal("True || True", _expressionPrinter.Print(Expression.MakeBinary(ExpressionType.OrElse, Expression.Constant(true), Expression.Constant(true))));
+            Assert.Equal("7 & 42", _expressionPrinter.Print(Expression.MakeBinary(ExpressionType.And, Expression.Constant(7), Expression.Constant(42))));
+            Assert.Equal("7 | 42", _expressionPrinter.Print(Expression.MakeBinary(ExpressionType.Or, Expression.Constant(7), Expression.Constant(42))));
+            Assert.Equal("7 ^ 42", _expressionPrinter.Print(Expression.MakeBinary(ExpressionType.ExclusiveOr, Expression.Constant(7), Expression.Constant(42))));
+            Assert.Equal("7 + 42", _expressionPrinter.Print(Expression.MakeBinary(ExpressionType.Add, Expression.Constant(7), Expression.Constant(42))));
+            Assert.Equal("7 - 42", _expressionPrinter.Print(Expression.MakeBinary(ExpressionType.Subtract, Expression.Constant(7), Expression.Constant(42))));
+            Assert.Equal("7 * 42", _expressionPrinter.Print(Expression.MakeBinary(ExpressionType.Multiply, Expression.Constant(7), Expression.Constant(42))));
+            Assert.Equal("7 / 42", _expressionPrinter.Print(Expression.MakeBinary(ExpressionType.Divide, Expression.Constant(7), Expression.Constant(42))));
+            Assert.Equal("7 % 42", _expressionPrinter.Print(Expression.MakeBinary(ExpressionType.Modulo, Expression.Constant(7), Expression.Constant(42))));
+        }
+
+        [ConditionalFact]
+        public void ConditionalExpression_printed_correctly()
+        {
+            Assert.Equal(
+                "True ? \"Foo\" : \"Bar\"",
+                _expressionPrinter.Print(
+                    Expression.Condition(
+                        Expression.Constant(true),
+                        Expression.Constant("Foo"),
+                        Expression.Constant("Bar"))));
+        }
+
+        [ConditionalFact]
+        public void Simple_lambda_printed_correctly()
+        {
+            Assert.Equal(
+                "prm => 42",
+                _expressionPrinter.Print(
+                    Expression.Lambda(
+                        Expression.Constant(42),
+                        Expression.Parameter(typeof(int), "prm"))));
+        }
+
+        [ConditionalFact]
+        public void Multi_parameter_lambda_printed_correctly()
+        {
+            Assert.Equal(
+                "(prm1, prm2) => 42",
+                _expressionPrinter.Print(
+                    Expression.Lambda(
+                        Expression.Constant(42),
+                        Expression.Parameter(typeof(int), "prm1"),
+                        Expression.Parameter(typeof(int), "prm2"))));
+        }
+
+        [ConditionalFact]
+        public void Unhandled_parameter_in_lambda_detected()
+        {
+            Assert.Equal(
+                "prm1{0} => (Unhandled parameter: prm2){1}",
+                _expressionPrinter.PrintDebug(
+                    Expression.Lambda(
+                        Expression.Parameter(typeof(int), "prm2"),
+                        Expression.Parameter(typeof(int), "prm1"))));
+        }
+
+        [ConditionalFact]
+        public void MemberAccess_after_BinaryExpression_adds_parentheses()
+        {
+            Assert.Equal(
+                @"(7 + 42).Value",
+                _expressionPrinter.Print(
+                    Expression.Property(
+                        Expression.Add(
+                            Expression.Constant(7, typeof(int?)),
+                            Expression.Constant(42, typeof(int?))),
+                        "Value")));
+        }
+
+        [ConditionalFact]
+        public void Simple_MethodCall_printed_correctly()
+        {
+            Assert.Equal(
+                @"""Foo"".ToUpper()",
+                _expressionPrinter.Print(
+                    Expression.Call(
+                        Expression.Constant("Foo"),
+                        typeof(string).GetMethods().Single(m => m.Name == nameof(string.ToUpper) && m.GetParameters().Count() == 0))));
+        }
+
+        [ConditionalFact]
+        public void Complex_MethodCall_printed_correctly()
+        {
+            Assert.Equal(
+                @"""Foobar"".Substring(
+    startIndex: 0, 
+    length: 4)",
+                _expressionPrinter.Print(
+                    Expression.Call(
+                        Expression.Constant("Foobar"),
+                        typeof(string).GetMethods().Single(m => m.Name == nameof(string.Substring) && m.GetParameters().Count() == 2),
+                        Expression.Constant(0),
+                        Expression.Constant(4))));
+        }
+
+        [ConditionalFact]
+        public void Linq_methods_printed_as_extensions()
+        {
+            Expression<Func<object, object>> expr =
+                _ => new[] { 1, 2, 3 }.AsQueryable().Select(x => x.ToString()).AsEnumerable().Where(x => x.Length > 1);
+
+            Assert.Equal(
+                @"new int[]
+{ 
+    1, 
+    2, 
+    3 
+}
+    .AsQueryable()
+    .Select(x => x.ToString())
+    .AsEnumerable()
+    .Where(x => x.Length > 1)",
+                _expressionPrinter.Print(expr.Body));
+        }
+
+        [ConditionalFact]
+        public void Use_Print_method_when_printing_extension_expression()
+        {
+            var expr = new NullConditionalExpression(
+                Expression.Constant("caller"),
+                Expression.Constant("accessOperation"));
+
+            Assert.Equal(expr.Print(), _expressionPrinter.Print(expr));
+        }
+    }
+}


### PR DESCRIPTION
Adding a new switch to ExpressionPrinter that creates simplified output for Print and verbose (i.e. what we had before this change) for PrintDebug.
Simplified output means:
- displaying Enumerable/Queryable methods (e.g. Where, Select, Join) as extension methods
- simplifying display of Navigation object

Also fixed minor display bugs in expression printer.

Also some changes in testing:
- added unit tests for ExpressionPrinter,
- DRY the "translation failed" tests,
- "translation failed" tests no longer verify expression in the exception message and instead just make sure that right exception is thrown.

Resolves #17236 