### PR TITLE
Fix to #18269 - Query: NRE for query with groupby with Min/Max on entity

### DIFF
--- a/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
@@ -283,6 +283,11 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                     case nameof(Enumerable.Min):
                     case nameof(Enumerable.Sum):
                         var translation = Translate(GetSelector(methodCallExpression, groupByShaperExpression));
+                        if (translation == null)
+                        {
+                            return null;
+                        }
+
                         var selector = Expression.Lambda(translation, groupByShaperExpression.ValueBufferParameter);
                         MethodInfo getMethod()
                             => methodCallExpression.Method.Name switch

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -119,7 +119,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 sqlExpression = Translate(expression);
             }
 
-            return _sqlExpressionFactory.Function("MAX", new[] { sqlExpression }, sqlExpression.Type, sqlExpression.TypeMapping);
+            return sqlExpression != null
+                ? _sqlExpressionFactory.Function("MAX", new[] { sqlExpression }, sqlExpression.Type, sqlExpression.TypeMapping)
+                : null;
         }
 
         public virtual SqlExpression TranslateMin(Expression expression)
@@ -129,7 +131,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 sqlExpression = Translate(expression);
             }
 
-            return _sqlExpressionFactory.Function("MIN", new[] { sqlExpression }, sqlExpression.Type, sqlExpression.TypeMapping);
+            return sqlExpression != null
+                ? _sqlExpressionFactory.Function("MIN", new[] { sqlExpression }, sqlExpression.Type, sqlExpression.TypeMapping)
+                : null;
         }
 
         public virtual SqlExpression TranslateSum(Expression expression)

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlTranslatingExpressionVisitor.cs
@@ -177,10 +177,11 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
         }
 
         private static Type GetProviderType(SqlExpression expression)
-        {
-            return (expression.TypeMapping?.Converter?.ProviderClrType
+            => expression == null
+                ? null
+                : (expression.TypeMapping?.Converter?.ProviderClrType
                     ?? expression.TypeMapping?.ClrType
                     ?? expression.Type).UnwrapNullableType();
-        }
+        
     }
 }

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -7904,6 +7904,22 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Select(g => g.Key));
         }
 
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Group_by_with_aggregate_max_on_entity_type(bool isAsync)
+        {
+            return Assert.ThrowsAsync<InvalidOperationException>(
+                () => AssertQuery(
+                isAsync,
+                ss => ss.Set<Gear>()
+                    .GroupBy(g => g.CityOfBirthName)
+                    .Select(g => new
+                    {
+                        g.Key,
+                        Aggregate = g.Max()
+                    })));
+        }
+
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext();
 
         protected virtual void ClearLog()

--- a/test/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
@@ -2548,7 +2548,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory(Skip = "issue #15279")]
         [MemberData(nameof(IsAsyncData))]
-        public virtual Task Complex_query_with_groupBy_in_subquery(bool isAsync)
+        public virtual Task Complex_query_with_groupBy_in_subquery1(bool isAsync)
         {
             return AssertQuery(
                 isAsync,
@@ -2565,7 +2565,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                             .GroupBy(x => x.First)
                             .Select(g => new
                             {
-                                Count = g.Count(x => x.First.StartsWith("A")),
                                 Sum = g.Sum(x => x.Second),
                             }).ToList()
                     }),
@@ -2587,7 +2586,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Select(c => new
                     {
                         Key = c.CustomerID,
-                        Subquery = ss.Set<Order>()
+                        Subquery = c.Orders
                             .Select(o => new
                             {
                                 First = o.CustomerID,
@@ -2596,7 +2595,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                             .GroupBy(x => x.First)
                             .Select(g => new
                             {
-                                Count = g.Count(x => x.First.StartsWith("A")),
+                                Max = g.Max(x => x.First.Length),
                                 Sum = g.Sum(x => x.Second),
                             }).ToList()
                     }),
@@ -2611,6 +2610,38 @@ namespace Microsoft.EntityFrameworkCore.Query
         [ConditionalTheory(Skip = "issue #15279")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Complex_query_with_groupBy_in_subquery3(bool isAsync)
+        {
+            return AssertQuery(
+                isAsync,
+                ss => ss.Set<Customer>()
+                    .Select(c => new
+                    {
+                        Key = c.CustomerID,
+                        Subquery = ss.Set<Order>()
+                            .Select(o => new
+                            {
+                                First = o.CustomerID,
+                                Second = o.OrderID
+                            })
+                            .GroupBy(x => x.First)
+                            .Select(g => new
+                            {
+                                Max = g.Max(x => x.First.Length),
+                                Sum = g.Sum(x => x.Second),
+                            }).ToList()
+                    }),
+                elementSorter: e => e.Key,
+                elementAsserter: (e, a) =>
+                {
+                    Assert.Equal(e.Key, a.Key);
+                    AssertCollection(e.Subquery, a.Subquery);
+                });
+        }
+
+        // also 15279
+        [ConditionalTheory(Skip = "issue #11711")]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Complex_query_with_groupBy_in_subquery4(bool isAsync)
         {
             return AssertQuery(
                 isAsync,

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -7296,7 +7296,25 @@ GROUP BY [t].[Name], [t].[Count]");
             await base.Complex_GroupBy_after_set_operator_using_result_selector(isAsync);
 
             AssertSql(
-                @"");
+                @"SELECT [t].[Name], [t].[Count], SUM([t].[Count]) AS [Sum]
+FROM (
+    SELECT [c].[Name], (
+        SELECT COUNT(*)
+        FROM [Weapons] AS [w]
+        WHERE ([g].[FullName] = [w].[OwnerFullName]) AND [w].[OwnerFullName] IS NOT NULL) AS [Count]
+    FROM [Gears] AS [g]
+    LEFT JOIN [Cities] AS [c] ON [g].[AssignedCityName] = [c].[Name]
+    WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
+    UNION ALL
+    SELECT [c0].[Name], (
+        SELECT COUNT(*)
+        FROM [Weapons] AS [w0]
+        WHERE ([g0].[FullName] = [w0].[OwnerFullName]) AND [w0].[OwnerFullName] IS NOT NULL) AS [Count]
+    FROM [Gears] AS [g0]
+    INNER JOIN [Cities] AS [c0] ON [g0].[CityOfBirthName] = [c0].[Name]
+    WHERE [g0].[Discriminator] IN (N'Gear', N'Officer')
+) AS [t]
+GROUP BY [t].[Name], [t].[Count]");
         }
 
         public override async Task Left_join_with_GroupBy_with_composite_group_key(bool isAsync)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
@@ -2151,9 +2151,9 @@ FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]");
         }
 
-        public override async Task Complex_query_with_groupBy_in_subquery(bool isAsync)
+        public override async Task Complex_query_with_groupBy_in_subquery1(bool isAsync)
         {
-            await base.Complex_query_with_groupBy_in_subquery(isAsync);
+            await base.Complex_query_with_groupBy_in_subquery1(isAsync);
 
             AssertSql(
                 @"");
@@ -2170,6 +2170,14 @@ GROUP BY [o].[CustomerID]");
         public override async Task Complex_query_with_groupBy_in_subquery3(bool isAsync)
         {
             await base.Complex_query_with_groupBy_in_subquery3(isAsync);
+
+            AssertSql(
+                @"");
+        }
+
+        public override async Task Complex_query_with_groupBy_in_subquery4(bool isAsync)
+        {
+            await base.Complex_query_with_groupBy_in_subquery4(isAsync);
 
             AssertSql(
                 @"");


### PR DESCRIPTION
We we were not checking that argument to the Min/Max method was itself translated.

Resolves #18269
