### PR TITLE
[TINY] Enable sql verification for #16086 - Query: subquery with order by but without Skip/Take gets the orderby removed

### DIFF
--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -1963,10 +1963,22 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 isAsync,
-                ss =>
-                    from g in ss.Set<Gear>()
-                    join w in ss.Set<Weapon>().OrderBy(ww => ww.Name) on g.FullName equals w.OwnerFullName
-                    select new { w.Name, g.FullName },
+                ss => from g in ss.Set<Gear>()
+                      join w in ss.Set<Weapon>().OrderBy(ww => ww.Name) on g.FullName equals w.OwnerFullName
+                      select new { w.Name, g.FullName },
+                elementSorter: w => w.Name);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Join_with_order_by_without_skip_or_take_nested(bool isAsync)
+        {
+            return AssertQuery(
+                isAsync,
+                ss => from s in ss.Set<Squad>()
+                      join g in ss.Set<Gear>().OrderByDescending(gg => gg.SquadId) on s.Id equals g.SquadId
+                      join w in ss.Set<Weapon>().OrderBy(ww => ww.Name) on g.FullName equals w.OwnerFullName
+                      select new { w.Name, g.FullName },
                 elementSorter: w => w.Name);
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -1787,17 +1787,32 @@ WHERE [g].[Discriminator] IN (N'Gear', N'Officer')");
         {
             await base.Join_with_order_by_without_skip_or_take(isAsync);
 
-            // issue #16086
-            //            AssertSql(
-            //                @"SELECT [t].[Name], [g].[FullName]
-            //FROM [Gears] AS [g]
-            //INNER JOIN (
-            //    SELECT [ww].*
-            //    FROM [Weapons] AS [ww]
-            //    ORDER BY [ww].[Name]
-            //    OFFSET 0 ROWS
-            //) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
-            //WHERE [g].[Discriminator] IN (N'Officer', N'Gear')");
+            AssertSql(
+                @"SELECT [t].[Name], [g].[FullName]
+FROM [Gears] AS [g]
+INNER JOIN (
+    SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+    FROM [Weapons] AS [w]
+) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
+WHERE [g].[Discriminator] IN (N'Gear', N'Officer')");
+        }
+
+        public override async Task Join_with_order_by_without_skip_or_take_nested(bool isAsync)
+        {
+            await base.Join_with_order_by_without_skip_or_take_nested(isAsync);
+
+            AssertSql(
+                @"SELECT [t0].[Name], [t].[FullName]
+FROM [Squads] AS [s]
+INNER JOIN (
+    SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+    FROM [Gears] AS [g]
+    WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
+) AS [t] ON [s].[Id] = [t].[SquadId]
+INNER JOIN (
+    SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+    FROM [Weapons] AS [w]
+) AS [t0] ON [t].[FullName] = [t0].[OwnerFullName]");
         }
 
         public override async Task Collection_with_inheritance_and_join_include_joined(bool isAsync)


### PR DESCRIPTION
Sql we generate is not perfect (ordering on the joined set is not preserved) but there is not much we can do in the general case. We could improve this for some cases (outer set it's unambiguously sorted or is entity which we can sort ourselves).
Probably not worth given the marginal benefit.