### PR TITLE
Handle ListInitExpression in entity equality

### DIFF
--- a/src/EFCore/Query/Internal/EntityEqualityRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/EntityEqualityRewritingExpressionVisitor.cs
@@ -138,6 +138,16 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         protected override Expression VisitNewArray(NewArrayExpression newArrayExpression)
             => newArrayExpression.Update(Visit(newArrayExpression.Expressions).Select(Unwrap));
 
+        // Note that we could bubble up entity type information from the expressions initializing the list. However, EF Core doesn't
+        // actually support doing much further with this list, so it's not worth the complexity (right now). So we simply unwrap.
+        protected override Expression VisitListInit(ListInitExpression listInitExpression)
+            => listInitExpression.Update(
+                (NewExpression)Unwrap(listInitExpression.NewExpression),
+                listInitExpression.Initializers.Select(VisitElementInit));
+
+        protected override ElementInit VisitElementInit(ElementInit elementInit)
+            => Expression.ElementInit(elementInit.AddMethod, Visit(elementInit.Arguments).Select(Unwrap));
+
         protected override Expression VisitMember(MemberExpression memberExpression)
         {
             var visitedExpression = base.Visit(memberExpression.Expression);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.Select.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.Select.cs
@@ -106,6 +106,16 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
+        public override async Task Projection_of_entity_type_into_object_list(bool isAsync)
+        {
+            await base.Projection_of_entity_type_into_object_list(isAsync);
+
+            AssertSql(
+                @"SELECT c
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
         public override async Task Project_to_int_array(bool isAsync)
         {
             await base.Project_to_int_array(isAsync);

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -87,6 +88,17 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<Order>().OrderBy(o => o.OrderID).Where(o => o.OrderID < 10300)
                     .Select(o => new object[] { o, o.Customer }),
                 entryCount: 87,
+                assertOrder: true);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Projection_of_entity_type_into_object_list(bool isAsync)
+        {
+            return AssertQuery(
+                isAsync,
+                ss => ss.Set<Customer>().Select(c => new List<object> { c }),
+                entryCount: 91,
                 assertOrder: true);
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
@@ -102,6 +102,15 @@ WHERE [o].[OrderID] < 10300
 ORDER BY [o].[OrderID]");
         }
 
+        public override async Task Projection_of_entity_type_into_object_list(bool isAsync)
+        {
+            await base.Projection_of_entity_type_into_object_list(isAsync);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]");
+        }
+
         public override async Task Project_to_int_array(bool isAsync)
         {
             await base.Project_to_int_array(isAsync);


### PR DESCRIPTION
Closes #18379

* We lack support for MemberMemberBinding or MemberListBinding as decided in https://github.com/aspnet/EntityFrameworkCore/pull/16791. I think it would be good to at least handle these in top-most projection (not full support with flowing), @smitpatel let me know.
* Theoretically there's IndexExpression which doesn't seem to be actually produced by the C# compiler. The node breaks  elationalSqlTranslatingExpressionVisitor anyway, we can probably forget about it.

Haven't seen anything else but let me know if I've missed anything.