### PR TITLE
Scaffold-DbContext includes "using statement" with model´s namespace

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
@@ -62,9 +62,10 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         /// </summary>
         public virtual string WriteCode(
             IModel model,
-            string @namespace,
             string contextName,
             string connectionString,
+            string contextNamespace,
+            string modelNamespace,
             bool useDataAnnotations,
             bool suppressConnectionStringWarning)
         {
@@ -75,9 +76,17 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             _sb.AppendLine("using System;"); // Guid default values require new Guid() which requires this using
             _sb.AppendLine("using Microsoft.EntityFrameworkCore;");
             _sb.AppendLine("using Microsoft.EntityFrameworkCore.Metadata;");
+
+            var finalContextNamespace = contextNamespace ?? modelNamespace;
+
+            if (finalContextNamespace != modelNamespace)
+            {
+                _sb.AppendLine(String.Concat("using ", modelNamespace, ";"));
+            }
+
             _sb.AppendLine();
 
-            _sb.AppendLine($"namespace {@namespace}");
+            _sb.AppendLine($"namespace {finalContextNamespace}");
             _sb.AppendLine("{");
 
             using (_sb.Indent())

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpModelGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpModelGenerator.cs
@@ -78,9 +78,10 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
             var generatedCode = CSharpDbContextGenerator.WriteCode(
                 model,
-                options.ContextNamespace ?? options.ModelNamespace,
                 options.ContextName,
                 options.ConnectionString,
+                options.ContextNamespace,
+                options.ModelNamespace,
                 options.UseDataAnnotations,
                 options.SuppressConnectionStringWarning);
 

--- a/src/EFCore.Design/Scaffolding/Internal/ICSharpDbContextGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/ICSharpDbContextGenerator.cs
@@ -22,9 +22,10 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         /// </summary>
         string WriteCode(
             [NotNull] IModel model,
-            [NotNull] string @namespace,
             [NotNull] string contextName,
             [NotNull] string connectionString,
+            string contextNamespace,
+            string modelNamespace,
             bool useDataAnnotations,
             bool suppressConnectionStringWarning);
     }

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
@@ -194,6 +194,41 @@ namespace TestNamespace
                     model.FindEntityType("TestNamespace.Vista").FindAnnotation(RelationalAnnotationNames.ViewDefinition)));
         }
 
+        [ConditionalFact]
+        public void ModelInDiferentNamespaceDbContext_works()
+        {
+            var modelGenerationOptions = new ModelCodeGenerationOptions()
+            {
+                ContextNamespace = "TestNamespace",
+                ModelNamespace = "AnotherNamespaceOfModel"
+            };
+
+            const string entityInAnoterNamespaceTypeName = "EntityInAnotherNamespace";
+
+            Test(modelBuilder => modelBuilder.Entity(entityInAnoterNamespaceTypeName)
+                , modelGenerationOptions
+                , code => Assert.Contains(string.Concat("using ", modelGenerationOptions.ModelNamespace, ";"), code.ContextFile.Code)
+                , model => Assert.NotNull(model.FindEntityType(string.Concat(modelGenerationOptions.ModelNamespace, ".", entityInAnoterNamespaceTypeName)))
+            );
+        }
+
+        [ConditionalFact]
+        public void ModelSameNamespaceDbContext_works()
+        {
+            var modelGenerationOptions = new ModelCodeGenerationOptions()
+            {
+                ContextNamespace = "TestNamespace",
+            };
+
+            const string entityInAnoterNamespaceTypeName = "EntityInAnotherNamespace";
+
+            Test(modelBuilder => modelBuilder.Entity(entityInAnoterNamespaceTypeName)
+                , modelGenerationOptions
+                , code => Assert.DoesNotContain(string.Concat("using ", modelGenerationOptions.ModelNamespace, ";"), code.ContextFile.Code)
+                , model => Assert.NotNull(model.FindEntityType(string.Concat(modelGenerationOptions.ModelNamespace, ".", entityInAnoterNamespaceTypeName)))
+            );
+        }
+
         private class TestCodeGeneratorPlugin : ProviderCodeGeneratorPlugin
         {
             public override MethodCallCodeFragment GenerateProviderOptions()

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/ModelCodeGeneratorTestBase.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/ModelCodeGeneratorTestBase.cs
@@ -36,7 +36,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 .BuildServiceProvider()
                 .GetRequiredService<IModelCodeGenerator>();
 
-            options.ModelNamespace = "TestNamespace";
+            options.ModelNamespace ??= "TestNamespace";
             options.ContextName = "TestDbContext";
             options.ConnectionString = "Initial Catalog=TestDatabase";
 


### PR DESCRIPTION
Summary of changes

- Add a new parameter to the WriteCode method of the ICSharpDbContextGenerator interface to pass the namespace of the models
- CSharpDbContextGenerator generates a using statement in the DbContext class if the models are in another namespace
- Add two test on CSharpDbContextGeneratorTest

Fixes #17839