### PR TITLE
Don't leak connections in CrossStore tests

### DIFF
--- a/test/EFCore.CrossStore.FunctionalTests/ConfigurationPatternsTest.cs
+++ b/test/EFCore.CrossStore.FunctionalTests/ConfigurationPatternsTest.cs
@@ -14,7 +14,7 @@ using Xunit;
 namespace Microsoft.EntityFrameworkCore
 {
     [SqlServerConfiguredCondition]
-    public class ConfigurationPatternsTest : IClassFixture<CrossStoreFixture>
+    public class ConfigurationPatternsTest : IClassFixture<CrossStoreFixture>, IDisposable
     {
         public ConfigurationPatternsTest(CrossStoreFixture fixture)
         {
@@ -219,7 +219,7 @@ namespace Microsoft.EntityFrameworkCore
 #pragma warning restore xUnit1013 // Public method should be marked as test
 
         [SqlServerConfiguredCondition]
-        public class NestedContextDifferentStores : IClassFixture<CrossStoreFixture>
+        public class NestedContextDifferentStores : IClassFixture<CrossStoreFixture>, IDisposable
         {
             public NestedContextDifferentStores(CrossStoreFixture fixture)
             {

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerTestStore.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerTestStore.cs
@@ -157,16 +157,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         }
 
         private static void WaitForExists(SqlConnection connection)
-        {
-            if (TestEnvironment.IsSqlAzure)
-            {
-                new TestSqlServerRetryingExecutionStrategy().Execute(connection, WaitForExistsImplementation);
-            }
-            else
-            {
-                WaitForExistsImplementation(connection);
-            }
-        }
+            => new TestSqlServerRetryingExecutionStrategy().Execute(connection, WaitForExistsImplementation);
 
         private static void WaitForExistsImplementation(SqlConnection connection)
         {
@@ -242,21 +233,10 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         }
 
         public override void OpenConnection()
-        {
-            if (TestEnvironment.IsSqlAzure)
-            {
-                new TestSqlServerRetryingExecutionStrategy().Execute(Connection, connection => connection.Open());
-            }
-            else
-            {
-                Connection.Open();
-            }
-        }
+            => new TestSqlServerRetryingExecutionStrategy().Execute(Connection, connection => connection.Open());
 
         public override Task OpenConnectionAsync()
-            => TestEnvironment.IsSqlAzure
-                ? new TestSqlServerRetryingExecutionStrategy().ExecuteAsync(Connection, connection => connection.OpenAsync())
-                : Connection.OpenAsync();
+            => new TestSqlServerRetryingExecutionStrategy().ExecuteAsync(Connection, connection => connection.OpenAsync());
 
         public T ExecuteScalar<T>(string sql, params object[] parameters)
             => ExecuteScalar<T>(Connection, sql, parameters);
@@ -371,8 +351,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         private static Task<T> ExecuteAsync<T>(
             DbConnection connection, Func<DbCommand, Task<T>> executeAsync, string sql,
             bool useTransaction = false, IReadOnlyList<object> parameters = null)
-            => TestEnvironment.IsSqlAzure
-                ? new TestSqlServerRetryingExecutionStrategy().ExecuteAsync(
+            => new TestSqlServerRetryingExecutionStrategy().ExecuteAsync(
                     new
                     {
                         connection,
@@ -381,8 +360,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                         useTransaction,
                         parameters
                     },
-                    state => ExecuteCommandAsync(state.connection, state.executeAsync, state.sql, state.useTransaction, state.parameters))
-                : ExecuteCommandAsync(connection, executeAsync, sql, useTransaction, parameters);
+                    state => ExecuteCommandAsync(state.connection, state.executeAsync, state.sql, state.useTransaction, state.parameters));
 
         private static async Task<T> ExecuteCommandAsync<T>(
             DbConnection connection, Func<DbCommand, Task<T>> executeAsync, string sql, bool useTransaction,


### PR DESCRIPTION
Always use the ExecutionStrategy in SQL Server tests
