### PR TITLE
Correct nullability for set operations

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -508,7 +508,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                 if (joinedMapping.Value1 is EntityProjectionExpression entityProjection1
                     && joinedMapping.Value2 is EntityProjectionExpression entityProjection2)
                 {
-                    handleEntityMapping(joinedMapping.Key, select1, entityProjection1, select2, entityProjection2);
+                    HandleEntityMapping(joinedMapping.Key, select1, entityProjection1, select2, entityProjection2);
                     continue;
                 }
 
@@ -522,15 +522,24 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                         throw new InvalidOperationException("Set operations over different store types are currently unsupported");
                     }
 
-                    var alias = generateUniqueAlias(
+                    var alias = GenerateUniqueAlias(
                         joinedMapping.Key.Last?.Name
                         ?? (innerColumn1 as ColumnExpression)?.Name
                         ?? "c");
 
-                    var innerProjection = new ProjectionExpression(innerColumn1, alias);
-                    select1._projection.Add(innerProjection);
-                    select2._projection.Add(new ProjectionExpression(innerColumn2, alias));
-                    _projectionMapping[joinedMapping.Key] = new ColumnExpression(innerProjection, setExpression);
+                    var innerProjection1 = new ProjectionExpression(innerColumn1, alias);
+                    var innerProjection2 = new ProjectionExpression(innerColumn2, alias);
+                    select1._projection.Add(innerProjection1);
+                    select2._projection.Add(innerProjection2);
+                    var outerProjection = new ColumnExpression(innerProjection1, setExpression);
+
+                    if (IsNullableProjection(innerProjection1)
+                        || IsNullableProjection(innerProjection2))
+                    {
+                        outerProjection = outerProjection.MakeNullable();
+                    }
+
+                    _projectionMapping[joinedMapping.Key] = outerProjection;
                     continue;
                 }
 
@@ -548,7 +557,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             _tables.Clear();
             _tables.Add(setExpression);
 
-            void handleEntityMapping(
+            void HandleEntityMapping(
                 ProjectionMember projectionMember,
                 SelectExpression select1, EntityProjectionExpression projection1,
                 SelectExpression select2, EntityProjectionExpression projection2)
@@ -562,7 +571,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                 var propertyExpressions = new Dictionary<IProperty, ColumnExpression>();
                 foreach (var property in GetAllPropertiesInHierarchy(projection1.EntityType))
                 {
-                    propertyExpressions[property] = addSetOperationColumnProjections(
+                    propertyExpressions[property] = AddSetOperationColumnProjections(
                         select1, projection1.BindProperty(property),
                         select2, projection2.BindProperty(property));
                 }
@@ -570,15 +579,22 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                 _projectionMapping[projectionMember] = new EntityProjectionExpression(projection1.EntityType, propertyExpressions);
             }
 
-            ColumnExpression addSetOperationColumnProjections(
+            ColumnExpression AddSetOperationColumnProjections(
                 SelectExpression select1, ColumnExpression column1,
                 SelectExpression select2, ColumnExpression column2)
             {
-                var alias = generateUniqueAlias(column1.Name);
-                var innerProjection = new ProjectionExpression(column1, alias);
-                select1._projection.Add(innerProjection);
-                select2._projection.Add(new ProjectionExpression(column2, alias));
-                var outerProjection = new ColumnExpression(innerProjection, setExpression);
+                var alias = GenerateUniqueAlias(column1.Name);
+                var innerProjection1 = new ProjectionExpression(column1, alias);
+                var innerProjection2 = new ProjectionExpression(column2, alias);
+                select1._projection.Add(innerProjection1);
+                select2._projection.Add(innerProjection2);
+                var outerProjection = new ColumnExpression(innerProjection1, setExpression);
+                if (IsNullableProjection(innerProjection1)
+                    || IsNullableProjection(innerProjection2))
+                {
+                    outerProjection = outerProjection.MakeNullable();
+                }
+
                 if (select1._identifier.Contains(column1))
                 {
                     _identifier.Add(outerProjection);
@@ -587,7 +603,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                 return outerProjection;
             }
 
-            string generateUniqueAlias(string baseAlias)
+            string GenerateUniqueAlias(string baseAlias)
             {
                 var currentAlias = baseAlias ?? "";
                 var counter = 0;
@@ -598,6 +614,14 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
 
                 return currentAlias;
             }
+
+            static bool IsNullableProjection(ProjectionExpression projectionExpression)
+                => projectionExpression.Expression switch
+                {
+                    ColumnExpression columnExpression => columnExpression.IsNullable,
+                    SqlConstantExpression sqlConstantExpression => sqlConstantExpression.Value == null,
+                    _ => true,
+                };
         }
 
         private ColumnExpression GenerateOuterColumn(SqlExpression projection, string alias = null)

--- a/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.SetOperations.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.SetOperations.cs
@@ -40,6 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         public override Task SubSelect_Union(bool isAsync) => Task.CompletedTask;
         public override Task Client_eval_Union_FirstOrDefault(bool isAsync) => Task.CompletedTask;
         public override Task GroupBy_Select_Union(bool isAsync) => Task.CompletedTask;
+        public override Task Union_over_columns_with_different_nullability(bool isAsync) => Task.CompletedTask;
         public override Task Union_over_different_projection_types(bool isAsync, string leftType, string rightType) => Task.CompletedTask;
     }
 }

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -5709,5 +5709,21 @@ namespace Microsoft.EntityFrameworkCore.Query
                                     ? null
                                     : l1.OneToOne_Optional_FK1.OneToOne_Optional_FK2.OneToOne_Optional_FK3.Name) == "L4 01"));
         }
+
+        [ConditionalFact]
+        public virtual void Union_over_entities_with_different_nullability()
+        {
+            using var ctx = CreateContext();
+
+            var query = ctx.Set<Level1>()
+                .GroupJoin(ctx.Set<Level2>(), l1 => l1.Id, l2 => l2.Level1_Optional_Id, (l1, l2s) => new { l1, l2s })
+                .SelectMany(g => g.l2s.DefaultIfEmpty(), (g, l2) => new { g.l1, l2 })
+                .Concat(ctx.Set<Level2>().GroupJoin(ctx.Set<Level1>(), l2 => l2.Level1_Optional_Id, l1 => l1.Id, (l2, l1s) => new { l2, l1s })
+                    .SelectMany(g => g.l1s.DefaultIfEmpty(), (g, l1) => new { l1, g.l2 })
+                    .Where(e => e.l1.Equals(null)))
+                .Select(e => e.l1.Id);
+
+            var result = query.ToList();
+        }
     }
 }

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsWeakQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsWeakQueryTestBase.cs
@@ -169,6 +169,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
         }
 
+        public override void Union_over_entities_with_different_nullability()
+        {
+        }
+
         [ConditionalTheory(Skip = "Issue#16752")]
         public override Task Include_inside_subquery(bool isAsync)
         {

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.SetOperations.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.SetOperations.cs
@@ -445,6 +445,17 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Union_over_columns_with_different_nullability(bool isAsync)
+        {
+            return AssertQuery(
+                isAsync, ss => ss.Set<Customer>()
+                    .Select(c => "NonNullableConstant")
+                    .Concat(ss.Set<Customer>()
+                        .Select(c => (string)null)));
+        }
+
+        [ConditionalTheory]
 #pragma warning disable xUnit1016 // MemberData must reference a public member
         [MemberData(nameof(GetSetOperandTestCases))]
 #pragma warning restore xUnit1016 // MemberData must reference a public member

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -4357,6 +4357,24 @@ END = N'L4 01') AND CASE
 END IS NOT NULL");
         }
 
+        public override void Union_over_entities_with_different_nullability()
+        {
+            base.Union_over_entities_with_different_nullability();
+
+            AssertSql(
+                @"SELECT [t].[Id]
+FROM (
+    SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l0].[Id] AS [Id0], [l0].[Date] AS [Date0], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name] AS [Name0], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id]
+    FROM [LevelOne] AS [l]
+    LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
+    UNION ALL
+    SELECT [l2].[Id], [l2].[Date], [l2].[Name], [l2].[OneToMany_Optional_Self_Inverse1Id], [l2].[OneToMany_Required_Self_Inverse1Id], [l2].[OneToOne_Optional_Self1Id], [l1].[Id] AS [Id0], [l1].[Date] AS [Date0], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[Name] AS [Name0], [l1].[OneToMany_Optional_Inverse2Id], [l1].[OneToMany_Optional_Self_Inverse2Id], [l1].[OneToMany_Required_Inverse2Id], [l1].[OneToMany_Required_Self_Inverse2Id], [l1].[OneToOne_Optional_PK_Inverse2Id], [l1].[OneToOne_Optional_Self2Id]
+    FROM [LevelTwo] AS [l1]
+    LEFT JOIN [LevelOne] AS [l2] ON [l1].[Level1_Optional_Id] = [l2].[Id]
+    WHERE [l2].[Id] IS NULL
+) AS [t]");
+        }
+
         private void AssertSql(params string[] expected)
         {
             Fixture.TestSqlLoggerFactory.AssertBaseline(expected);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.SetOperations.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.SetOperations.cs
@@ -380,6 +380,18 @@ WHERE ([c0].[City] = N'London') AND [c0].[City] IS NOT NULL
 GROUP BY [c0].[CustomerID]");
         }
 
+        public override async Task Union_over_columns_with_different_nullability(bool isAsync)
+        {
+            await base.Union_over_columns_with_different_nullability(isAsync);
+
+            AssertSql(
+                @"SELECT N'NonNullableConstant' AS [c]
+FROM [Customers] AS [c]
+UNION ALL
+SELECT NULL AS [c]
+FROM [Customers] AS [c0]");
+        }
+
         public override async Task Union_over_different_projection_types(bool isAsync, string leftType, string rightType)
         {
             await base.Union_over_different_projection_types(isAsync, leftType, rightType);


### PR DESCRIPTION
Fixes #18135

@smitpatel some minor comments:

* Technically we should also make [the outer EntityProjectionExpression itself](https://github.com/aspnet/EntityFrameworkCore/blob/3a87d7e12884f0706581a9d3b3547cb54b378851/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs#L579) nullable when one of the inner ones is nullable, but we currently can't check if an EntityProjectionExpression is nullable or not - we could expose IsNullable for this purpose. This doesn't seem to matter in practice since EntityProjectionExpression's nullability is only consulted in BindProperty, but for set operations _propertyExpressionsCache is already populated correctly. Let me know if you want me to do this and expose IsNullable.
* In a perfect world, isNullableProjection should drill down into the expression to really understand whether it's nullable or not. Currently we just assume nullable except for some very basic cases.
* I currently duplicated isNullableProjection from ColumnExpression, we should DRY this at some point.
