### PR TITLE
Query: Only match object.Equals with 2 parameter when static method

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/EqualsTranslator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/EqualsTranslator.cs
@@ -47,7 +47,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 left = instance;
                 right = RemoveObjectConvert(arguments[0]);
             }
-            else if (method.Name == nameof(object.Equals)
+            else if (instance == null
+                     && method.Name == nameof(object.Equals)
                      && arguments.Count == 2)
             {
                 left = RemoveObjectConvert(arguments[0]);

--- a/src/EFCore.Relational/Query/Internal/EqualsTranslator.cs
+++ b/src/EFCore.Relational/Query/Internal/EqualsTranslator.cs
@@ -30,7 +30,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 left = instance;
                 right = RemoveObjectConvert(arguments[0]);
             }
-            else if (method.Name == nameof(object.Equals)
+            else if (instance == null
+                     && method.Name == nameof(object.Equals)
                      && arguments.Count == 2)
             {
                 left = RemoveObjectConvert(arguments[0]);

--- a/test/EFCore.InMemory.FunctionalTests/Query/SimpleQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/SimpleQueryInMemoryTest.cs
@@ -163,6 +163,12 @@ namespace Microsoft.EntityFrameworkCore.Query
             return base.Projection_when_arithmetic_mixed_subqueries(isAsync);
         }
 
+        [ConditionalTheory(Skip = "Issue#17386")]
+        public override Task Where_equals_method_string_with_ignore_case(bool isAsync)
+        {
+            return base.Where_equals_method_string_with_ignore_case(isAsync);
+        }
+
         [ConditionalTheory(Skip = "Issue#17536")]
         public override Task SelectMany_correlated_with_outer_3(bool isAsync)
         {

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
@@ -671,6 +671,17 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_equals_method_string_with_ignore_case(bool isAsync)
+        {
+            return Assert.ThrowsAsync<InvalidOperationException>(
+                () => AssertQuery(
+                    isAsync,
+                    ss => ss.Set<Customer>().Where(c => c.City.Equals("London", StringComparison.OrdinalIgnoreCase)),
+                    entryCount: 6));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_equals_method_int(bool isAsync)
         {
             return AssertQuery(


### PR DESCRIPTION
Resolves #18472
