### PR TITLE
Optimize SQL based on parameter nullability

### DIFF
--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ParameterNullabilityOptimizingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ParameterNullabilityOptimizingExpressionVisitor.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public partial class RelationalShapedQueryCompilingExpressionVisitor
+    {
+        private class ParameterNullabilityBasedSqlExpressionOptimizingExpressionVisitor : SqlExpressionOptimizingExpressionVisitor
+        {
+            private readonly IReadOnlyDictionary<string, object> _parametersValues;
+
+            public ParameterNullabilityBasedSqlExpressionOptimizingExpressionVisitor(
+                ISqlExpressionFactory sqlExpressionFactory,
+                bool useRelationalNulls,
+                IReadOnlyDictionary<string, object> parametersValues)
+                : base(sqlExpressionFactory, useRelationalNulls)
+            {
+                _parametersValues = parametersValues;
+            }
+
+            protected override Expression VisitExtension(Expression extensionExpression)
+            {
+                if (extensionExpression is SelectExpression selectExpression)
+                {
+                    var newSelectExpression = (SelectExpression)base.VisitExtension(extensionExpression);
+
+                    return newSelectExpression.Predicate is SqlConstantExpression newSelectPredicateConstant
+                        && !(selectExpression.Predicate is SqlConstantExpression)
+                        ? newSelectExpression.Update(
+                            newSelectExpression.Projection.ToList(),
+                            newSelectExpression.Tables.ToList(),
+                            SqlExpressionFactory.Equal(
+                                newSelectPredicateConstant,
+                                SqlExpressionFactory.Constant(true, newSelectPredicateConstant.TypeMapping)),
+                            newSelectExpression.GroupBy.ToList(),
+                            newSelectExpression.Having,
+                            newSelectExpression.Orderings.ToList(),
+                            newSelectExpression.Limit,
+                            newSelectExpression.Offset,
+                            newSelectExpression.IsDistinct,
+                            newSelectExpression.Alias)
+                        : newSelectExpression;
+                }
+
+                return base.VisitExtension(extensionExpression);
+            }
+
+            protected override Expression VisitSqlUnaryExpression(SqlUnaryExpression sqlUnaryExpression)
+            {
+                var result = base.VisitSqlUnaryExpression(sqlUnaryExpression);
+                if (result is SqlUnaryExpression newUnaryExpresion
+                    && newUnaryExpresion.Operand is SqlParameterExpression parameterOperand)
+                {
+                    var parameterValue = _parametersValues[parameterOperand.Name];
+                    if (sqlUnaryExpression.OperatorType == ExpressionType.Equal)
+                    {
+                        return SqlExpressionFactory.Constant(parameterValue == null, sqlUnaryExpression.TypeMapping);
+                    }
+
+                    if (sqlUnaryExpression.OperatorType == ExpressionType.NotEqual)
+                    {
+                        return SqlExpressionFactory.Constant(parameterValue != null, sqlUnaryExpression.TypeMapping);
+                    }
+                }
+
+                return result;
+            }
+        }
+    }
+}

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.cs
@@ -7,6 +7,7 @@ using System.Data.Common;
 using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -16,6 +17,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         private readonly Type _contextType;
         private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
         private readonly ISet<string> _tags;
+        private readonly bool _useRelationalNulls;
 
         public RelationalShapedQueryCompilingExpressionVisitor(
             ShapedQueryCompilingExpressionVisitorDependencies dependencies,
@@ -28,6 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             _contextType = queryCompilationContext.ContextType;
             _logger = queryCompilationContext.Logger;
             _tags = queryCompilationContext.Tags;
+            _useRelationalNulls = RelationalOptionsExtension.Extract(queryCompilationContext.ContextOptions).UseRelationalNulls;
         }
 
         protected virtual RelationalShapedQueryCompilingExpressionVisitorDependencies RelationalDependencies { get; }
@@ -68,6 +71,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 RelationalDependencies.SqlExpressionFactory,
                 RelationalDependencies.ParameterNameGeneratorFactory,
                 RelationalDependencies.QuerySqlGeneratorFactory,
+                _useRelationalNulls,
                 selectExpression);
 
             var shaperLambda = (LambdaExpression)shaper;

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -912,6 +912,63 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Select_null_parameter(bool isAsync)
+        {
+            AmmunitionType? ammunitionType = AmmunitionType.Cartridge;
+
+            await AssertQuery(
+                isAsync,
+                ss => ss.Set<Weapon>()
+                    .Select(
+                        w => new
+                        {
+                            w.Id,
+                            AmmoType = ammunitionType
+                        }),
+                elementSorter: e => e.Id);
+
+            ammunitionType = null;
+
+            await AssertQuery(
+                isAsync,
+                ss => ss.Set<Weapon>()
+                    .Select(
+                        w => new
+                        {
+                            w.Id,
+                            AmmoType = ammunitionType
+                        }),
+                elementSorter: e => e.Id);
+
+            ammunitionType = AmmunitionType.Shell;
+
+            await AssertQuery(
+                isAsync,
+                ss => ss.Set<Weapon>()
+                    .Select(
+                        w => new
+                        {
+                            w.Id,
+                            AmmoType = ammunitionType
+                        }),
+                elementSorter: e => e.Id);
+
+            ammunitionType = null;
+
+            await AssertQuery(
+                isAsync,
+                ss => ss.Set<Weapon>()
+                    .Select(
+                        w => new
+                        {
+                            w.Id,
+                            AmmoType = ammunitionType
+                        }),
+                elementSorter: e => e.Id);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_ternary_operation_with_boolean(bool isAsync)
         {
             return AssertQuery(

--- a/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
@@ -90,7 +90,7 @@ WHERE CAST(DATALENGTH([p].[BytesAsImage]) AS int) = 0");
 
 SELECT [m].[Int]
 FROM [MappedNullableDataTypes] AS [m]
-WHERE (([m].[TimeSpanAsTime] = @__timeSpan_0) AND ([m].[TimeSpanAsTime] IS NOT NULL AND @__timeSpan_0 IS NOT NULL)) OR ([m].[TimeSpanAsTime] IS NULL AND @__timeSpan_0 IS NULL)");
+WHERE ([m].[TimeSpanAsTime] = @__timeSpan_0) AND [m].[TimeSpanAsTime] IS NOT NULL");
             }
         }
 
@@ -547,22 +547,15 @@ WHERE (DATEDIFF(NANOSECOND, [m].[TimeSpanAsTime], @__timeSpan_1) = 0) AND DATEDI
                     context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.StringAsNationalCharacterVaryingMax == param29));
 
                 string param30 = null;
-                var message30 = Assert.Throws<SqlException>(
-                    () => context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.StringAsText == param30)).Message;
 
-                // Expect: "The data types text and text are incompatible in the equal to operator."
-                Assert.NotEqual(
-                    message30.IndexOf("text", StringComparison.Ordinal),
-                    message30.LastIndexOf("text", StringComparison.Ordinal));
+                Assert.Same(
+                    entity,
+                    context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.StringAsText == param30));
 
                 string param31 = null;
-                var message31 = Assert.Throws<SqlException>(
-                    () => context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.StringAsNtext == param31)).Message;
-
-                // Expect: "The data types ntext and ntext are incompatible in the equal to operator."
-                Assert.NotEqual(
-                    message31.IndexOf("ntext", StringComparison.Ordinal),
-                    message31.LastIndexOf("ntext", StringComparison.Ordinal));
+                Assert.Same(
+                    entity,
+                    context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.StringAsNtext == param31));
 
                 byte[] param35 = null;
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.BytesAsVarbinaryMax == param35));
@@ -572,13 +565,9 @@ WHERE (DATEDIFF(NANOSECOND, [m].[TimeSpanAsTime], @__timeSpan_1) = 0) AND DATEDI
                     entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.BytesAsBinaryVaryingMax == param36));
 
                 byte[] param37 = null;
-                var message37 = Assert.Throws<SqlException>(
-                    () => context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.BytesAsImage == param37)).Message;
-
-                // Expect: "The data types image and image are incompatible in the equal to operator."
-                Assert.NotEqual(
-                    message37.IndexOf("image", StringComparison.Ordinal),
-                    message37.LastIndexOf("image", StringComparison.Ordinal));
+                Assert.Same(
+                    entity,
+                    context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.BytesAsImage == param37));
 
                 decimal? param38 = null;
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.Decimal == param38));

--- a/test/EFCore.SqlServer.FunctionalTests/FindSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/FindSqlServerTest.cs
@@ -73,7 +73,7 @@ namespace Microsoft.EntityFrameworkCore
 
 SELECT TOP(1) [i].[Id], [i].[Foo]
 FROM [IntKey] AS [i]
-WHERE ([i].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [i].[Id] = @__p_0");
         }
 
         public override void Returns_null_for_int_key_not_in_store()
@@ -85,7 +85,7 @@ WHERE ([i].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT TOP(1) [i].[Id], [i].[Foo]
 FROM [IntKey] AS [i]
-WHERE ([i].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [i].[Id] = @__p_0");
         }
 
         public override void Find_nullable_int_key_tracked()
@@ -104,7 +104,7 @@ WHERE ([i].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT TOP(1) [i].[Id], [i].[Foo]
 FROM [IntKey] AS [i]
-WHERE ([i].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [i].[Id] = @__p_0");
         }
 
         public override void Returns_null_for_nullable_int_key_not_in_store()
@@ -116,7 +116,7 @@ WHERE ([i].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT TOP(1) [i].[Id], [i].[Foo]
 FROM [IntKey] AS [i]
-WHERE ([i].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [i].[Id] = @__p_0");
         }
 
         public override void Find_string_key_tracked()
@@ -135,7 +135,7 @@ WHERE ([i].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT TOP(1) [s].[Id], [s].[Foo]
 FROM [StringKey] AS [s]
-WHERE ([s].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [s].[Id] = @__p_0");
         }
 
         public override void Returns_null_for_string_key_not_in_store()
@@ -147,7 +147,7 @@ WHERE ([s].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT TOP(1) [s].[Id], [s].[Foo]
 FROM [StringKey] AS [s]
-WHERE ([s].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [s].[Id] = @__p_0");
         }
 
         public override void Find_composite_key_tracked()
@@ -167,7 +167,7 @@ WHERE ([s].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT TOP(1) [c].[Id1], [c].[Id2], [c].[Foo]
 FROM [CompositeKey] AS [c]
-WHERE (([c].[Id1] = @__p_0) AND @__p_0 IS NOT NULL) AND (([c].[Id2] = @__p_1) AND @__p_1 IS NOT NULL)");
+WHERE ([c].[Id1] = @__p_0) AND ([c].[Id2] = @__p_1)");
         }
 
         public override void Returns_null_for_composite_key_not_in_store()
@@ -180,7 +180,7 @@ WHERE (([c].[Id1] = @__p_0) AND @__p_0 IS NOT NULL) AND (([c].[Id2] = @__p_1) AN
 
 SELECT TOP(1) [c].[Id1], [c].[Id2], [c].[Foo]
 FROM [CompositeKey] AS [c]
-WHERE (([c].[Id1] = @__p_0) AND @__p_0 IS NOT NULL) AND (([c].[Id2] = @__p_1) AND @__p_1 IS NOT NULL)");
+WHERE ([c].[Id1] = @__p_0) AND ([c].[Id2] = @__p_1)");
         }
 
         public override void Find_base_type_tracked()
@@ -199,7 +199,7 @@ WHERE (([c].[Id1] = @__p_0) AND @__p_0 IS NOT NULL) AND (([c].[Id2] = @__p_1) AN
 
 SELECT TOP(1) [b].[Id], [b].[Discriminator], [b].[Foo], [b].[Boo]
 FROM [BaseType] AS [b]
-WHERE [b].[Discriminator] IN (N'BaseType', N'DerivedType') AND (([b].[Id] = @__p_0) AND @__p_0 IS NOT NULL)");
+WHERE [b].[Discriminator] IN (N'BaseType', N'DerivedType') AND ([b].[Id] = @__p_0)");
         }
 
         public override void Returns_null_for_base_type_not_in_store()
@@ -211,7 +211,7 @@ WHERE [b].[Discriminator] IN (N'BaseType', N'DerivedType') AND (([b].[Id] = @__p
 
 SELECT TOP(1) [b].[Id], [b].[Discriminator], [b].[Foo], [b].[Boo]
 FROM [BaseType] AS [b]
-WHERE [b].[Discriminator] IN (N'BaseType', N'DerivedType') AND (([b].[Id] = @__p_0) AND @__p_0 IS NOT NULL)");
+WHERE [b].[Discriminator] IN (N'BaseType', N'DerivedType') AND ([b].[Id] = @__p_0)");
         }
 
         public override void Find_derived_type_tracked()
@@ -230,7 +230,7 @@ WHERE [b].[Discriminator] IN (N'BaseType', N'DerivedType') AND (([b].[Id] = @__p
 
 SELECT TOP(1) [b].[Id], [b].[Discriminator], [b].[Foo], [b].[Boo]
 FROM [BaseType] AS [b]
-WHERE ([b].[Discriminator] = N'DerivedType') AND (([b].[Id] = @__p_0) AND @__p_0 IS NOT NULL)");
+WHERE ([b].[Discriminator] = N'DerivedType') AND ([b].[Id] = @__p_0)");
         }
 
         public override void Returns_null_for_derived_type_not_in_store()
@@ -242,7 +242,7 @@ WHERE ([b].[Discriminator] = N'DerivedType') AND (([b].[Id] = @__p_0) AND @__p_0
 
 SELECT TOP(1) [b].[Id], [b].[Discriminator], [b].[Foo], [b].[Boo]
 FROM [BaseType] AS [b]
-WHERE ([b].[Discriminator] = N'DerivedType') AND (([b].[Id] = @__p_0) AND @__p_0 IS NOT NULL)");
+WHERE ([b].[Discriminator] = N'DerivedType') AND ([b].[Id] = @__p_0)");
         }
 
         public override void Find_base_type_using_derived_set_tracked()
@@ -254,7 +254,7 @@ WHERE ([b].[Discriminator] = N'DerivedType') AND (([b].[Id] = @__p_0) AND @__p_0
 
 SELECT TOP(1) [b].[Id], [b].[Discriminator], [b].[Foo], [b].[Boo]
 FROM [BaseType] AS [b]
-WHERE ([b].[Discriminator] = N'DerivedType') AND (([b].[Id] = @__p_0) AND @__p_0 IS NOT NULL)");
+WHERE ([b].[Discriminator] = N'DerivedType') AND ([b].[Id] = @__p_0)");
         }
 
         public override void Find_base_type_using_derived_set_from_store()
@@ -266,7 +266,7 @@ WHERE ([b].[Discriminator] = N'DerivedType') AND (([b].[Id] = @__p_0) AND @__p_0
 
 SELECT TOP(1) [b].[Id], [b].[Discriminator], [b].[Foo], [b].[Boo]
 FROM [BaseType] AS [b]
-WHERE ([b].[Discriminator] = N'DerivedType') AND (([b].[Id] = @__p_0) AND @__p_0 IS NOT NULL)");
+WHERE ([b].[Discriminator] = N'DerivedType') AND ([b].[Id] = @__p_0)");
         }
 
         public override void Find_derived_type_using_base_set_tracked()
@@ -285,7 +285,7 @@ WHERE ([b].[Discriminator] = N'DerivedType') AND (([b].[Id] = @__p_0) AND @__p_0
 
 SELECT TOP(1) [b].[Id], [b].[Discriminator], [b].[Foo], [b].[Boo]
 FROM [BaseType] AS [b]
-WHERE [b].[Discriminator] IN (N'BaseType', N'DerivedType') AND (([b].[Id] = @__p_0) AND @__p_0 IS NOT NULL)");
+WHERE [b].[Discriminator] IN (N'BaseType', N'DerivedType') AND ([b].[Id] = @__p_0)");
         }
 
         public override void Find_shadow_key_tracked()
@@ -304,7 +304,7 @@ WHERE [b].[Discriminator] IN (N'BaseType', N'DerivedType') AND (([b].[Id] = @__p
 
 SELECT TOP(1) [s].[Id], [s].[Foo]
 FROM [ShadowKey] AS [s]
-WHERE ([s].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [s].[Id] = @__p_0");
         }
 
         public override void Returns_null_for_shadow_key_not_in_store()
@@ -316,7 +316,7 @@ WHERE ([s].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT TOP(1) [s].[Id], [s].[Foo]
 FROM [ShadowKey] AS [s]
-WHERE ([s].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [s].[Id] = @__p_0");
         }
 
         private string Sql => Fixture.TestSqlLoggerFactory.Sql;

--- a/test/EFCore.SqlServer.FunctionalTests/LoadSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/LoadSqlServerTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore
 
 SELECT [c].[Id], [c].[ParentId]
 FROM [Child] AS [c]
-WHERE (([c].[ParentId] = @__p_0) AND ([c].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([c].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([c].[ParentId] = @__p_0) AND [c].[ParentId] IS NOT NULL");
         }
 
         public override void Lazy_load_many_to_one_reference_to_principal(EntityState state)
@@ -39,7 +39,7 @@ WHERE (([c].[ParentId] = @__p_0) AND ([c].[ParentId] IS NOT NULL AND @__p_0 IS N
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[Id] = @__p_0");
         }
 
         public override void Lazy_load_one_to_one_reference_to_principal(EntityState state)
@@ -51,7 +51,7 @@ WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[Id] = @__p_0");
         }
 
         public override void Lazy_load_one_to_one_reference_to_dependent(EntityState state)
@@ -63,7 +63,7 @@ WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT [s].[Id], [s].[ParentId]
 FROM [Single] AS [s]
-WHERE (([s].[ParentId] = @__p_0) AND ([s].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([s].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([s].[ParentId] = @__p_0) AND [s].[ParentId] IS NOT NULL");
         }
 
         public override void Lazy_load_one_to_one_PK_to_PK_reference_to_principal(EntityState state)
@@ -75,7 +75,7 @@ WHERE (([s].[ParentId] = @__p_0) AND ([s].[ParentId] IS NOT NULL AND @__p_0 IS N
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[Id] = @__p_0");
         }
 
         public override void Lazy_load_one_to_one_PK_to_PK_reference_to_dependent(EntityState state)
@@ -87,7 +87,7 @@ WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT [s].[Id]
 FROM [SinglePkToPk] AS [s]
-WHERE ([s].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [s].[Id] = @__p_0");
         }
 
         public override void Lazy_load_many_to_one_reference_to_principal_null_FK(EntityState state)
@@ -113,7 +113,7 @@ WHERE ([s].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT [c].[Id], [c].[ParentId]
 FROM [Child] AS [c]
-WHERE (([c].[ParentId] = @__p_0) AND ([c].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([c].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([c].[ParentId] = @__p_0) AND [c].[ParentId] IS NOT NULL");
         }
 
         public override void Lazy_load_many_to_one_reference_to_principal_not_found(EntityState state)
@@ -125,7 +125,7 @@ WHERE (([c].[ParentId] = @__p_0) AND ([c].[ParentId] IS NOT NULL AND @__p_0 IS N
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[Id] = @__p_0");
         }
 
         public override void Lazy_load_one_to_one_reference_to_principal_not_found(EntityState state)
@@ -137,7 +137,7 @@ WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[Id] = @__p_0");
         }
 
         public override void Lazy_load_one_to_one_reference_to_dependent_not_found(EntityState state)
@@ -149,7 +149,7 @@ WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT [s].[Id], [s].[ParentId]
 FROM [Single] AS [s]
-WHERE (([s].[ParentId] = @__p_0) AND ([s].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([s].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([s].[ParentId] = @__p_0) AND [s].[ParentId] IS NOT NULL");
         }
 
         public override void Lazy_load_collection_already_loaded(EntityState state, CascadeTiming cascadeDeleteTiming)
@@ -203,7 +203,7 @@ WHERE (([s].[ParentId] = @__p_0) AND ([s].[ParentId] IS NOT NULL AND @__p_0 IS N
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[AlternateId] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[AlternateId] = @__p_0");
         }
 
         public override void Lazy_load_one_to_one_reference_to_principal_alternate_key(EntityState state)
@@ -215,7 +215,7 @@ WHERE ([p].[AlternateId] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[AlternateId] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[AlternateId] = @__p_0");
         }
 
         public override void Lazy_load_one_to_one_reference_to_dependent_alternate_key(EntityState state)
@@ -227,7 +227,7 @@ WHERE ([p].[AlternateId] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT [s].[Id], [s].[ParentId]
 FROM [SingleAk] AS [s]
-WHERE (([s].[ParentId] = @__p_0) AND ([s].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([s].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([s].[ParentId] = @__p_0) AND [s].[ParentId] IS NOT NULL");
         }
 
         public override void Lazy_load_many_to_one_reference_to_principal_null_FK_alternate_key(EntityState state)
@@ -253,7 +253,7 @@ WHERE (([s].[ParentId] = @__p_0) AND ([s].[ParentId] IS NOT NULL AND @__p_0 IS N
 
 SELECT [c].[Id], [c].[ParentId]
 FROM [ChildShadowFk] AS [c]
-WHERE (([c].[ParentId] = @__p_0) AND ([c].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([c].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([c].[ParentId] = @__p_0) AND [c].[ParentId] IS NOT NULL");
         }
 
         public override void Lazy_load_many_to_one_reference_to_principal_shadow_fk(EntityState state)
@@ -265,7 +265,7 @@ WHERE (([c].[ParentId] = @__p_0) AND ([c].[ParentId] IS NOT NULL AND @__p_0 IS N
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[Id] = @__p_0");
         }
 
         public override void Lazy_load_one_to_one_reference_to_principal_shadow_fk(EntityState state)
@@ -277,7 +277,7 @@ WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[Id] = @__p_0");
         }
 
         public override void Lazy_load_one_to_one_reference_to_dependent_shadow_fk(EntityState state)
@@ -289,7 +289,7 @@ WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT [s].[Id], [s].[ParentId]
 FROM [SingleShadowFk] AS [s]
-WHERE (([s].[ParentId] = @__p_0) AND ([s].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([s].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([s].[ParentId] = @__p_0) AND [s].[ParentId] IS NOT NULL");
         }
 
         public override void Lazy_load_many_to_one_reference_to_principal_null_FK_shadow_fk(EntityState state)
@@ -316,7 +316,7 @@ WHERE (([s].[ParentId] = @__p_0) AND ([s].[ParentId] IS NOT NULL AND @__p_0 IS N
 
 SELECT [c].[Id], [c].[ParentAlternateId], [c].[ParentId]
 FROM [ChildCompositeKey] AS [c]
-WHERE ((([c].[ParentAlternateId] = @__p_0) AND ([c].[ParentAlternateId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([c].[ParentAlternateId] IS NULL AND @__p_0 IS NULL)) AND ((([c].[ParentId] = @__p_1) AND ([c].[ParentId] IS NOT NULL AND @__p_1 IS NOT NULL)) OR ([c].[ParentId] IS NULL AND @__p_1 IS NULL))");
+WHERE (([c].[ParentAlternateId] = @__p_0) AND [c].[ParentAlternateId] IS NOT NULL) AND (([c].[ParentId] = @__p_1) AND [c].[ParentId] IS NOT NULL)");
         }
 
         public override void Lazy_load_many_to_one_reference_to_principal_composite_key(EntityState state)
@@ -329,7 +329,7 @@ WHERE ((([c].[ParentAlternateId] = @__p_0) AND ([c].[ParentAlternateId] IS NOT N
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE (([p].[AlternateId] = @__p_0) AND @__p_0 IS NOT NULL) AND (([p].[Id] = @__p_1) AND @__p_1 IS NOT NULL)");
+WHERE ([p].[AlternateId] = @__p_0) AND ([p].[Id] = @__p_1)");
         }
 
         public override void Lazy_load_one_to_one_reference_to_principal_composite_key(EntityState state)
@@ -342,7 +342,7 @@ WHERE (([p].[AlternateId] = @__p_0) AND @__p_0 IS NOT NULL) AND (([p].[Id] = @__
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE (([p].[AlternateId] = @__p_0) AND @__p_0 IS NOT NULL) AND (([p].[Id] = @__p_1) AND @__p_1 IS NOT NULL)");
+WHERE ([p].[AlternateId] = @__p_0) AND ([p].[Id] = @__p_1)");
         }
 
         public override void Lazy_load_one_to_one_reference_to_dependent_composite_key(EntityState state)
@@ -355,7 +355,7 @@ WHERE (([p].[AlternateId] = @__p_0) AND @__p_0 IS NOT NULL) AND (([p].[Id] = @__
 
 SELECT [s].[Id], [s].[ParentAlternateId], [s].[ParentId]
 FROM [SingleCompositeKey] AS [s]
-WHERE ((([s].[ParentAlternateId] = @__p_0) AND ([s].[ParentAlternateId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([s].[ParentAlternateId] IS NULL AND @__p_0 IS NULL)) AND ((([s].[ParentId] = @__p_1) AND ([s].[ParentId] IS NOT NULL AND @__p_1 IS NOT NULL)) OR ([s].[ParentId] IS NULL AND @__p_1 IS NULL))");
+WHERE (([s].[ParentAlternateId] = @__p_0) AND [s].[ParentAlternateId] IS NOT NULL) AND (([s].[ParentId] = @__p_1) AND [s].[ParentId] IS NOT NULL)");
         }
 
         public override void Lazy_load_many_to_one_reference_to_principal_null_FK_composite_key(EntityState state)
@@ -381,7 +381,7 @@ WHERE ((([s].[ParentAlternateId] = @__p_0) AND ([s].[ParentAlternateId] IS NOT N
 
 SELECT [c].[Id], [c].[ParentId]
 FROM [Child] AS [c]
-WHERE (([c].[ParentId] = @__p_0) AND ([c].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([c].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([c].[ParentId] = @__p_0) AND [c].[ParentId] IS NOT NULL");
         }
 
         public override async Task Load_many_to_one_reference_to_principal(EntityState state, bool async)
@@ -393,7 +393,7 @@ WHERE (([c].[ParentId] = @__p_0) AND ([c].[ParentId] IS NOT NULL AND @__p_0 IS N
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[Id] = @__p_0");
         }
 
         public override async Task Load_one_to_one_reference_to_principal(EntityState state, bool async)
@@ -405,7 +405,7 @@ WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[Id] = @__p_0");
         }
 
         public override async Task Load_one_to_one_reference_to_dependent(EntityState state, bool async)
@@ -417,7 +417,7 @@ WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT [s].[Id], [s].[ParentId]
 FROM [Single] AS [s]
-WHERE (([s].[ParentId] = @__p_0) AND ([s].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([s].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([s].[ParentId] = @__p_0) AND [s].[ParentId] IS NOT NULL");
         }
 
         public override async Task Load_one_to_one_PK_to_PK_reference_to_principal(EntityState state, bool async)
@@ -429,7 +429,7 @@ WHERE (([s].[ParentId] = @__p_0) AND ([s].[ParentId] IS NOT NULL AND @__p_0 IS N
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[Id] = @__p_0");
         }
 
         public override async Task Load_one_to_one_PK_to_PK_reference_to_dependent(EntityState state, bool async)
@@ -441,7 +441,7 @@ WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT [s].[Id]
 FROM [SinglePkToPk] AS [s]
-WHERE ([s].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [s].[Id] = @__p_0");
         }
 
         public override async Task Load_collection_using_Query(EntityState state, bool async)
@@ -453,7 +453,7 @@ WHERE ([s].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT [c].[Id], [c].[ParentId]
 FROM [Child] AS [c]
-WHERE (([c].[ParentId] = @__p_0) AND ([c].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([c].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([c].[ParentId] = @__p_0) AND [c].[ParentId] IS NOT NULL");
         }
 
         public override async Task Load_many_to_one_reference_to_principal_using_Query(EntityState state, bool async)
@@ -465,7 +465,7 @@ WHERE (([c].[ParentId] = @__p_0) AND ([c].[ParentId] IS NOT NULL AND @__p_0 IS N
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[Id] = @__p_0");
         }
 
         public override async Task Load_one_to_one_reference_to_principal_using_Query(EntityState state, bool async)
@@ -477,7 +477,7 @@ WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[Id] = @__p_0");
         }
 
         public override async Task Load_one_to_one_reference_to_dependent_using_Query(EntityState state, bool async)
@@ -489,7 +489,7 @@ WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT TOP(2) [s].[Id], [s].[ParentId]
 FROM [Single] AS [s]
-WHERE (([s].[ParentId] = @__p_0) AND ([s].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([s].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([s].[ParentId] = @__p_0) AND [s].[ParentId] IS NOT NULL");
         }
 
         public override async Task Load_one_to_one_PK_to_PK_reference_to_principal_using_Query(EntityState state, bool async)
@@ -501,7 +501,7 @@ WHERE (([s].[ParentId] = @__p_0) AND ([s].[ParentId] IS NOT NULL AND @__p_0 IS N
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[Id] = @__p_0");
         }
 
         public override async Task Load_one_to_one_PK_to_PK_reference_to_dependent_using_Query(EntityState state, bool async)
@@ -513,7 +513,7 @@ WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT TOP(2) [s].[Id]
 FROM [SinglePkToPk] AS [s]
-WHERE ([s].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [s].[Id] = @__p_0");
         }
 
         public override async Task Load_many_to_one_reference_to_principal_null_FK(EntityState state, bool async)
@@ -555,11 +555,11 @@ WHERE CAST(0 AS bit) = CAST(1 AS bit)");
             await base.Load_collection_not_found(state, async);
 
             AssertSql(
-                    @"@__p_0='767' (Nullable = true)
+                @"@__p_0='767' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
 FROM [Child] AS [c]
-WHERE (([c].[ParentId] = @__p_0) AND ([c].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([c].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([c].[ParentId] = @__p_0) AND [c].[ParentId] IS NOT NULL");
         }
 
         public override async Task Load_many_to_one_reference_to_principal_not_found(EntityState state, bool async)
@@ -571,7 +571,7 @@ WHERE (([c].[ParentId] = @__p_0) AND ([c].[ParentId] IS NOT NULL AND @__p_0 IS N
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[Id] = @__p_0");
         }
 
         public override async Task Load_one_to_one_reference_to_principal_not_found(EntityState state, bool async)
@@ -583,7 +583,7 @@ WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[Id] = @__p_0");
         }
 
         public override async Task Load_one_to_one_reference_to_dependent_not_found(EntityState state, bool async)
@@ -595,7 +595,7 @@ WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT [s].[Id], [s].[ParentId]
 FROM [Single] AS [s]
-WHERE (([s].[ParentId] = @__p_0) AND ([s].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([s].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([s].[ParentId] = @__p_0) AND [s].[ParentId] IS NOT NULL");
         }
 
         public override async Task Load_collection_using_Query_not_found(EntityState state, bool async)
@@ -607,7 +607,7 @@ WHERE (([s].[ParentId] = @__p_0) AND ([s].[ParentId] IS NOT NULL AND @__p_0 IS N
 
 SELECT [c].[Id], [c].[ParentId]
 FROM [Child] AS [c]
-WHERE (([c].[ParentId] = @__p_0) AND ([c].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([c].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([c].[ParentId] = @__p_0) AND [c].[ParentId] IS NOT NULL");
         }
 
         public override async Task Load_many_to_one_reference_to_principal_using_Query_not_found(EntityState state, bool async)
@@ -619,7 +619,7 @@ WHERE (([c].[ParentId] = @__p_0) AND ([c].[ParentId] IS NOT NULL AND @__p_0 IS N
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[Id] = @__p_0");
         }
 
         public override async Task Load_one_to_one_reference_to_principal_using_Query_not_found(EntityState state, bool async)
@@ -631,7 +631,7 @@ WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[Id] = @__p_0");
         }
 
         public override async Task Load_one_to_one_reference_to_dependent_using_Query_not_found(EntityState state, bool async)
@@ -643,7 +643,7 @@ WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT TOP(2) [s].[Id], [s].[ParentId]
 FROM [Single] AS [s]
-WHERE (([s].[ParentId] = @__p_0) AND ([s].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([s].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([s].[ParentId] = @__p_0) AND [s].[ParentId] IS NOT NULL");
         }
 
         public override async Task Load_collection_already_loaded(EntityState state, bool async, CascadeTiming cascadeDeleteTiming)
@@ -697,7 +697,7 @@ WHERE (([s].[ParentId] = @__p_0) AND ([s].[ParentId] IS NOT NULL AND @__p_0 IS N
 
 SELECT [c].[Id], [c].[ParentId]
 FROM [Child] AS [c]
-WHERE (([c].[ParentId] = @__p_0) AND ([c].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([c].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([c].[ParentId] = @__p_0) AND [c].[ParentId] IS NOT NULL");
         }
 
         public override async Task Load_many_to_one_reference_to_principal_using_Query_already_loaded(EntityState state, bool async)
@@ -709,7 +709,7 @@ WHERE (([c].[ParentId] = @__p_0) AND ([c].[ParentId] IS NOT NULL AND @__p_0 IS N
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[Id] = @__p_0");
         }
 
         public override async Task Load_one_to_one_reference_to_principal_using_Query_already_loaded(EntityState state, bool async)
@@ -721,7 +721,7 @@ WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[Id] = @__p_0");
         }
 
         public override async Task Load_one_to_one_reference_to_dependent_using_Query_already_loaded(EntityState state, bool async, CascadeTiming cascadeDeleteTiming)
@@ -733,7 +733,7 @@ WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT TOP(2) [s].[Id], [s].[ParentId]
 FROM [Single] AS [s]
-WHERE (([s].[ParentId] = @__p_0) AND ([s].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([s].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([s].[ParentId] = @__p_0) AND [s].[ParentId] IS NOT NULL");
         }
 
         public override async Task Load_one_to_one_PK_to_PK_reference_to_principal_using_Query_already_loaded(EntityState state, bool async)
@@ -745,7 +745,7 @@ WHERE (([s].[ParentId] = @__p_0) AND ([s].[ParentId] IS NOT NULL AND @__p_0 IS N
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[Id] = @__p_0");
         }
 
         public override async Task Load_one_to_one_PK_to_PK_reference_to_dependent_using_Query_already_loaded(EntityState state, bool async)
@@ -757,7 +757,7 @@ WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT TOP(2) [s].[Id]
 FROM [SinglePkToPk] AS [s]
-WHERE ([s].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [s].[Id] = @__p_0");
         }
 
         public override async Task Load_collection_untyped(EntityState state, bool async)
@@ -769,7 +769,7 @@ WHERE ([s].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT [c].[Id], [c].[ParentId]
 FROM [Child] AS [c]
-WHERE (([c].[ParentId] = @__p_0) AND ([c].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([c].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([c].[ParentId] = @__p_0) AND [c].[ParentId] IS NOT NULL");
         }
 
         public override async Task Load_many_to_one_reference_to_principal_untyped(EntityState state, bool async)
@@ -781,7 +781,7 @@ WHERE (([c].[ParentId] = @__p_0) AND ([c].[ParentId] IS NOT NULL AND @__p_0 IS N
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[Id] = @__p_0");
         }
 
         public override async Task Load_one_to_one_reference_to_principal_untyped(EntityState state, bool async)
@@ -793,7 +793,7 @@ WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[Id] = @__p_0");
         }
 
         public override async Task Load_one_to_one_reference_to_dependent_untyped(EntityState state, bool async)
@@ -805,7 +805,7 @@ WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT [s].[Id], [s].[ParentId]
 FROM [Single] AS [s]
-WHERE (([s].[ParentId] = @__p_0) AND ([s].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([s].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([s].[ParentId] = @__p_0) AND [s].[ParentId] IS NOT NULL");
         }
 
         public override async Task Load_collection_using_Query_untyped(EntityState state, bool async)
@@ -817,7 +817,7 @@ WHERE (([s].[ParentId] = @__p_0) AND ([s].[ParentId] IS NOT NULL AND @__p_0 IS N
 
 SELECT [c].[Id], [c].[ParentId]
 FROM [Child] AS [c]
-WHERE (([c].[ParentId] = @__p_0) AND ([c].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([c].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([c].[ParentId] = @__p_0) AND [c].[ParentId] IS NOT NULL");
         }
 
         public override async Task Load_many_to_one_reference_to_principal_using_Query_untyped(EntityState state, bool async)
@@ -829,7 +829,7 @@ WHERE (([c].[ParentId] = @__p_0) AND ([c].[ParentId] IS NOT NULL AND @__p_0 IS N
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[Id] = @__p_0");
         }
 
         public override async Task Load_one_to_one_reference_to_principal_using_Query_untyped(EntityState state, bool async)
@@ -841,7 +841,7 @@ WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[Id] = @__p_0");
         }
 
         public override async Task Load_one_to_one_reference_to_dependent_using_Query_untyped(EntityState state, bool async)
@@ -853,7 +853,7 @@ WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT [s].[Id], [s].[ParentId]
 FROM [Single] AS [s]
-WHERE (([s].[ParentId] = @__p_0) AND ([s].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([s].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([s].[ParentId] = @__p_0) AND [s].[ParentId] IS NOT NULL");
         }
 
         public override async Task Load_collection_not_found_untyped(EntityState state, bool async)
@@ -865,7 +865,7 @@ WHERE (([s].[ParentId] = @__p_0) AND ([s].[ParentId] IS NOT NULL AND @__p_0 IS N
 
 SELECT [c].[Id], [c].[ParentId]
 FROM [Child] AS [c]
-WHERE (([c].[ParentId] = @__p_0) AND ([c].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([c].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([c].[ParentId] = @__p_0) AND [c].[ParentId] IS NOT NULL");
         }
 
         public override async Task Load_many_to_one_reference_to_principal_not_found_untyped(EntityState state, bool async)
@@ -877,7 +877,7 @@ WHERE (([c].[ParentId] = @__p_0) AND ([c].[ParentId] IS NOT NULL AND @__p_0 IS N
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[Id] = @__p_0");
         }
 
         public override async Task Load_one_to_one_reference_to_principal_not_found_untyped(EntityState state, bool async)
@@ -889,7 +889,7 @@ WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[Id] = @__p_0");
         }
 
         public override async Task Load_one_to_one_reference_to_dependent_not_found_untyped(EntityState state, bool async)
@@ -901,7 +901,7 @@ WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT [s].[Id], [s].[ParentId]
 FROM [Single] AS [s]
-WHERE (([s].[ParentId] = @__p_0) AND ([s].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([s].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([s].[ParentId] = @__p_0) AND [s].[ParentId] IS NOT NULL");
         }
 
         public override async Task Load_collection_using_Query_not_found_untyped(EntityState state, bool async)
@@ -913,7 +913,7 @@ WHERE (([s].[ParentId] = @__p_0) AND ([s].[ParentId] IS NOT NULL AND @__p_0 IS N
 
 SELECT [c].[Id], [c].[ParentId]
 FROM [Child] AS [c]
-WHERE (([c].[ParentId] = @__p_0) AND ([c].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([c].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([c].[ParentId] = @__p_0) AND [c].[ParentId] IS NOT NULL");
         }
 
         public override async Task Load_many_to_one_reference_to_principal_using_Query_not_found_untyped(EntityState state, bool async)
@@ -925,7 +925,7 @@ WHERE (([c].[ParentId] = @__p_0) AND ([c].[ParentId] IS NOT NULL AND @__p_0 IS N
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[Id] = @__p_0");
         }
 
         public override async Task Load_one_to_one_reference_to_principal_using_Query_not_found_untyped(EntityState state, bool async)
@@ -937,7 +937,7 @@ WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[Id] = @__p_0");
         }
 
         public override async Task Load_one_to_one_reference_to_dependent_using_Query_not_found_untyped(EntityState state, bool async)
@@ -949,7 +949,7 @@ WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT [s].[Id], [s].[ParentId]
 FROM [Single] AS [s]
-WHERE (([s].[ParentId] = @__p_0) AND ([s].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([s].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([s].[ParentId] = @__p_0) AND [s].[ParentId] IS NOT NULL");
         }
 
         public override async Task Load_collection_already_loaded_untyped(EntityState state, bool async, CascadeTiming cascadeDeleteTiming)
@@ -989,7 +989,7 @@ WHERE (([s].[ParentId] = @__p_0) AND ([s].[ParentId] IS NOT NULL AND @__p_0 IS N
 
 SELECT [c].[Id], [c].[ParentId]
 FROM [Child] AS [c]
-WHERE (([c].[ParentId] = @__p_0) AND ([c].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([c].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([c].[ParentId] = @__p_0) AND [c].[ParentId] IS NOT NULL");
         }
 
         public override async Task Load_many_to_one_reference_to_principal_using_Query_already_loaded_untyped(EntityState state, bool async)
@@ -1001,7 +1001,7 @@ WHERE (([c].[ParentId] = @__p_0) AND ([c].[ParentId] IS NOT NULL AND @__p_0 IS N
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[Id] = @__p_0");
         }
 
         public override async Task Load_one_to_one_reference_to_principal_using_Query_already_loaded_untyped(EntityState state, bool async)
@@ -1013,7 +1013,7 @@ WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[Id] = @__p_0");
         }
 
         public override async Task Load_one_to_one_reference_to_dependent_using_Query_already_loaded_untyped(EntityState state, bool async, CascadeTiming cascadeDeleteTiming)
@@ -1025,7 +1025,7 @@ WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT [s].[Id], [s].[ParentId]
 FROM [Single] AS [s]
-WHERE (([s].[ParentId] = @__p_0) AND ([s].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([s].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([s].[ParentId] = @__p_0) AND [s].[ParentId] IS NOT NULL");
         }
 
         public override async Task Load_collection_alternate_key(EntityState state, bool async)
@@ -1037,7 +1037,7 @@ WHERE (([s].[ParentId] = @__p_0) AND ([s].[ParentId] IS NOT NULL AND @__p_0 IS N
 
 SELECT [c].[Id], [c].[ParentId]
 FROM [ChildAk] AS [c]
-WHERE (([c].[ParentId] = @__p_0) AND ([c].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([c].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([c].[ParentId] = @__p_0) AND [c].[ParentId] IS NOT NULL");
         }
 
         public override async Task Load_many_to_one_reference_to_principal_alternate_key(EntityState state, bool async)
@@ -1049,7 +1049,7 @@ WHERE (([c].[ParentId] = @__p_0) AND ([c].[ParentId] IS NOT NULL AND @__p_0 IS N
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[AlternateId] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[AlternateId] = @__p_0");
         }
 
         public override async Task Load_one_to_one_reference_to_principal_alternate_key(EntityState state, bool async)
@@ -1061,7 +1061,7 @@ WHERE ([p].[AlternateId] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[AlternateId] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[AlternateId] = @__p_0");
         }
 
         public override async Task Load_one_to_one_reference_to_dependent_alternate_key(EntityState state, bool async)
@@ -1073,7 +1073,7 @@ WHERE ([p].[AlternateId] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT [s].[Id], [s].[ParentId]
 FROM [SingleAk] AS [s]
-WHERE (([s].[ParentId] = @__p_0) AND ([s].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([s].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([s].[ParentId] = @__p_0) AND [s].[ParentId] IS NOT NULL");
         }
 
         public override async Task Load_collection_using_Query_alternate_key(EntityState state, bool async)
@@ -1085,7 +1085,7 @@ WHERE (([s].[ParentId] = @__p_0) AND ([s].[ParentId] IS NOT NULL AND @__p_0 IS N
 
 SELECT [c].[Id], [c].[ParentId]
 FROM [ChildAk] AS [c]
-WHERE (([c].[ParentId] = @__p_0) AND ([c].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([c].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([c].[ParentId] = @__p_0) AND [c].[ParentId] IS NOT NULL");
         }
 
         public override async Task Load_many_to_one_reference_to_principal_using_Query_alternate_key(EntityState state, bool async)
@@ -1097,7 +1097,7 @@ WHERE (([c].[ParentId] = @__p_0) AND ([c].[ParentId] IS NOT NULL AND @__p_0 IS N
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[AlternateId] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[AlternateId] = @__p_0");
         }
 
         public override async Task Load_one_to_one_reference_to_principal_using_Query_alternate_key(EntityState state, bool async)
@@ -1109,7 +1109,7 @@ WHERE ([p].[AlternateId] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[AlternateId] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[AlternateId] = @__p_0");
         }
 
         public override async Task Load_one_to_one_reference_to_dependent_using_Query_alternate_key(EntityState state, bool async)
@@ -1121,7 +1121,7 @@ WHERE ([p].[AlternateId] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT TOP(2) [s].[Id], [s].[ParentId]
 FROM [SingleAk] AS [s]
-WHERE (([s].[ParentId] = @__p_0) AND ([s].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([s].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([s].[ParentId] = @__p_0) AND [s].[ParentId] IS NOT NULL");
         }
 
         public override async Task Load_many_to_one_reference_to_principal_null_FK_alternate_key(EntityState state, bool async)
@@ -1163,11 +1163,11 @@ WHERE CAST(0 AS bit) = CAST(1 AS bit)");
             await base.Load_collection_shadow_fk(state, async);
 
             AssertSql(
-                    @"@__p_0='707' (Nullable = true)
+                @"@__p_0='707' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
 FROM [ChildShadowFk] AS [c]
-WHERE (([c].[ParentId] = @__p_0) AND ([c].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([c].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([c].[ParentId] = @__p_0) AND [c].[ParentId] IS NOT NULL");
         }
 
         public override async Task Load_many_to_one_reference_to_principal_shadow_fk(EntityState state, bool async)
@@ -1179,7 +1179,7 @@ WHERE (([c].[ParentId] = @__p_0) AND ([c].[ParentId] IS NOT NULL AND @__p_0 IS N
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[Id] = @__p_0");
         }
 
         public override async Task Load_one_to_one_reference_to_principal_shadow_fk(EntityState state, bool async)
@@ -1191,7 +1191,7 @@ WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[Id] = @__p_0");
         }
 
         public override async Task Load_one_to_one_reference_to_dependent_shadow_fk(EntityState state, bool async)
@@ -1203,7 +1203,7 @@ WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT [s].[Id], [s].[ParentId]
 FROM [SingleShadowFk] AS [s]
-WHERE (([s].[ParentId] = @__p_0) AND ([s].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([s].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([s].[ParentId] = @__p_0) AND [s].[ParentId] IS NOT NULL");
         }
 
         public override async Task Load_collection_using_Query_shadow_fk(EntityState state, bool async)
@@ -1215,7 +1215,7 @@ WHERE (([s].[ParentId] = @__p_0) AND ([s].[ParentId] IS NOT NULL AND @__p_0 IS N
 
 SELECT [c].[Id], [c].[ParentId]
 FROM [ChildShadowFk] AS [c]
-WHERE (([c].[ParentId] = @__p_0) AND ([c].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([c].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([c].[ParentId] = @__p_0) AND [c].[ParentId] IS NOT NULL");
         }
 
         public override async Task Load_many_to_one_reference_to_principal_using_Query_shadow_fk(EntityState state, bool async)
@@ -1227,7 +1227,7 @@ WHERE (([c].[ParentId] = @__p_0) AND ([c].[ParentId] IS NOT NULL AND @__p_0 IS N
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[Id] = @__p_0");
         }
 
         public override async Task Load_one_to_one_reference_to_principal_using_Query_shadow_fk(EntityState state, bool async)
@@ -1239,7 +1239,7 @@ WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [p].[Id] = @__p_0");
         }
 
         public override async Task Load_one_to_one_reference_to_dependent_using_Query_shadow_fk(EntityState state, bool async)
@@ -1251,7 +1251,7 @@ WHERE ([p].[Id] = @__p_0) AND @__p_0 IS NOT NULL");
 
 SELECT TOP(2) [s].[Id], [s].[ParentId]
 FROM [SingleShadowFk] AS [s]
-WHERE (([s].[ParentId] = @__p_0) AND ([s].[ParentId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([s].[ParentId] IS NULL AND @__p_0 IS NULL)");
+WHERE ([s].[ParentId] = @__p_0) AND [s].[ParentId] IS NOT NULL");
         }
 
         public override async Task Load_many_to_one_reference_to_principal_null_FK_shadow_fk(EntityState state, bool async)
@@ -1298,7 +1298,7 @@ WHERE CAST(0 AS bit) = CAST(1 AS bit)");
 
 SELECT [c].[Id], [c].[ParentAlternateId], [c].[ParentId]
 FROM [ChildCompositeKey] AS [c]
-WHERE ((([c].[ParentAlternateId] = @__p_0) AND ([c].[ParentAlternateId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([c].[ParentAlternateId] IS NULL AND @__p_0 IS NULL)) AND ((([c].[ParentId] = @__p_1) AND ([c].[ParentId] IS NOT NULL AND @__p_1 IS NOT NULL)) OR ([c].[ParentId] IS NULL AND @__p_1 IS NULL))");
+WHERE (([c].[ParentAlternateId] = @__p_0) AND [c].[ParentAlternateId] IS NOT NULL) AND (([c].[ParentId] = @__p_1) AND [c].[ParentId] IS NOT NULL)");
         }
 
         public override async Task Load_many_to_one_reference_to_principal_composite_key(EntityState state, bool async)
@@ -1311,7 +1311,7 @@ WHERE ((([c].[ParentAlternateId] = @__p_0) AND ([c].[ParentAlternateId] IS NOT N
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE (([p].[AlternateId] = @__p_0) AND @__p_0 IS NOT NULL) AND (([p].[Id] = @__p_1) AND @__p_1 IS NOT NULL)");
+WHERE ([p].[AlternateId] = @__p_0) AND ([p].[Id] = @__p_1)");
         }
 
         public override async Task Load_one_to_one_reference_to_principal_composite_key(EntityState state, bool async)
@@ -1324,7 +1324,7 @@ WHERE (([p].[AlternateId] = @__p_0) AND @__p_0 IS NOT NULL) AND (([p].[Id] = @__
 
 SELECT [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE (([p].[AlternateId] = @__p_0) AND @__p_0 IS NOT NULL) AND (([p].[Id] = @__p_1) AND @__p_1 IS NOT NULL)");
+WHERE ([p].[AlternateId] = @__p_0) AND ([p].[Id] = @__p_1)");
         }
 
         public override async Task Load_one_to_one_reference_to_dependent_composite_key(EntityState state, bool async)
@@ -1337,7 +1337,7 @@ WHERE (([p].[AlternateId] = @__p_0) AND @__p_0 IS NOT NULL) AND (([p].[Id] = @__
 
 SELECT [s].[Id], [s].[ParentAlternateId], [s].[ParentId]
 FROM [SingleCompositeKey] AS [s]
-WHERE ((([s].[ParentAlternateId] = @__p_0) AND ([s].[ParentAlternateId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([s].[ParentAlternateId] IS NULL AND @__p_0 IS NULL)) AND ((([s].[ParentId] = @__p_1) AND ([s].[ParentId] IS NOT NULL AND @__p_1 IS NOT NULL)) OR ([s].[ParentId] IS NULL AND @__p_1 IS NULL))");
+WHERE (([s].[ParentAlternateId] = @__p_0) AND [s].[ParentAlternateId] IS NOT NULL) AND (([s].[ParentId] = @__p_1) AND [s].[ParentId] IS NOT NULL)");
         }
 
         public override async Task Load_collection_using_Query_composite_key(EntityState state, bool async)
@@ -1350,7 +1350,7 @@ WHERE ((([s].[ParentAlternateId] = @__p_0) AND ([s].[ParentAlternateId] IS NOT N
 
 SELECT [c].[Id], [c].[ParentAlternateId], [c].[ParentId]
 FROM [ChildCompositeKey] AS [c]
-WHERE ((([c].[ParentAlternateId] = @__p_0) AND ([c].[ParentAlternateId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([c].[ParentAlternateId] IS NULL AND @__p_0 IS NULL)) AND ((([c].[ParentId] = @__p_1) AND ([c].[ParentId] IS NOT NULL AND @__p_1 IS NOT NULL)) OR ([c].[ParentId] IS NULL AND @__p_1 IS NULL))");
+WHERE (([c].[ParentAlternateId] = @__p_0) AND [c].[ParentAlternateId] IS NOT NULL) AND (([c].[ParentId] = @__p_1) AND [c].[ParentId] IS NOT NULL)");
         }
 
         public override async Task Load_many_to_one_reference_to_principal_using_Query_composite_key(EntityState state, bool async)
@@ -1363,7 +1363,7 @@ WHERE ((([c].[ParentAlternateId] = @__p_0) AND ([c].[ParentAlternateId] IS NOT N
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE (([p].[AlternateId] = @__p_0) AND @__p_0 IS NOT NULL) AND (([p].[Id] = @__p_1) AND @__p_1 IS NOT NULL)");
+WHERE ([p].[AlternateId] = @__p_0) AND ([p].[Id] = @__p_1)");
         }
 
         public override async Task Load_one_to_one_reference_to_principal_using_Query_composite_key(EntityState state, bool async)
@@ -1376,7 +1376,7 @@ WHERE (([p].[AlternateId] = @__p_0) AND @__p_0 IS NOT NULL) AND (([p].[Id] = @__
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
-WHERE (([p].[AlternateId] = @__p_0) AND @__p_0 IS NOT NULL) AND (([p].[Id] = @__p_1) AND @__p_1 IS NOT NULL)");
+WHERE ([p].[AlternateId] = @__p_0) AND ([p].[Id] = @__p_1)");
         }
 
         public override async Task Load_one_to_one_reference_to_dependent_using_Query_composite_key(EntityState state, bool async)
@@ -1389,7 +1389,7 @@ WHERE (([p].[AlternateId] = @__p_0) AND @__p_0 IS NOT NULL) AND (([p].[Id] = @__
 
 SELECT TOP(2) [s].[Id], [s].[ParentAlternateId], [s].[ParentId]
 FROM [SingleCompositeKey] AS [s]
-WHERE ((([s].[ParentAlternateId] = @__p_0) AND ([s].[ParentAlternateId] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([s].[ParentAlternateId] IS NULL AND @__p_0 IS NULL)) AND ((([s].[ParentId] = @__p_1) AND ([s].[ParentId] IS NOT NULL AND @__p_1 IS NOT NULL)) OR ([s].[ParentId] IS NULL AND @__p_1 IS NULL))");
+WHERE (([s].[ParentAlternateId] = @__p_0) AND [s].[ParentAlternateId] IS NOT NULL) AND (([s].[ParentId] = @__p_1) AND [s].[ParentId] IS NOT NULL)");
         }
 
         public override async Task Load_many_to_one_reference_to_principal_null_FK_composite_key(EntityState state, bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/CompiledQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/CompiledQuerySqlServerTest.cs
@@ -71,7 +71,13 @@ FROM [Customers] AS [c]");
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ([c].[CustomerID] = @__customerID) AND @__customerID IS NOT NULL");
+WHERE [c].[CustomerID] = @__customerID",
+                //
+                @"@__customerID='ANATR' (Size = 5)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = @__customerID");
         }
 
         public override void First_query_with_single_parameter()
@@ -83,7 +89,13 @@ WHERE ([c].[CustomerID] = @__customerID) AND @__customerID IS NOT NULL");
 
 SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ([c].[CustomerID] = @__customerID) AND @__customerID IS NOT NULL");
+WHERE [c].[CustomerID] = @__customerID",
+                //
+                @"@__customerID='ANATR' (Size = 5)
+
+SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = @__customerID");
         }
 
         public override void Query_with_two_parameters()
@@ -95,7 +107,13 @@ WHERE ([c].[CustomerID] = @__customerID) AND @__customerID IS NOT NULL");
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ([c].[CustomerID] = @__customerID) AND @__customerID IS NOT NULL");
+WHERE [c].[CustomerID] = @__customerID",
+                //
+                @"@__customerID='ANATR' (Size = 5)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = @__customerID");
         }
 
         public override void Query_with_three_parameters()
@@ -107,7 +125,13 @@ WHERE ([c].[CustomerID] = @__customerID) AND @__customerID IS NOT NULL");
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ([c].[CustomerID] = @__customerID) AND @__customerID IS NOT NULL");
+WHERE [c].[CustomerID] = @__customerID",
+                //
+                @"@__customerID='ANATR' (Size = 5)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = @__customerID");
         }
 
         public override void Query_with_contains()
@@ -191,7 +215,7 @@ ORDER BY [c].[CompanyName]");
 
 SELECT COUNT(*)
 FROM [Customers] AS [c]
-WHERE ([c].[CustomerID] = @__customerID) AND @__customerID IS NOT NULL");
+WHERE [c].[CustomerID] = @__customerID");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FiltersSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FiltersSqlServerTest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
 SELECT COUNT(*)
 FROM [Customers] AS [c]
-WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL))))");
+WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND ((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL))");
         }
 
         public override void Materialized_query()
@@ -38,7 +38,7 @@ WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS 
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL))))");
+WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND ((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL))");
         }
 
         public override void Find()
@@ -51,7 +51,7 @@ WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS 
 
 SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL))))) AND (([c].[CustomerID] = @__p_0) AND @__p_0 IS NOT NULL)");
+WHERE ((@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND ((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL))) AND ([c].[CustomerID] = @__p_0)");
         }
 
         public override void Materialized_query_parameter()
@@ -63,7 +63,7 @@ WHERE (((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL))))");
+WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND ((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL))");
         }
 
         public override void Materialized_query_parameter_new_context()
@@ -75,13 +75,13 @@ WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS 
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL))))",
+WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND ((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL))",
                 //
                 @"@__ef_filter__TenantPrefix_0='T' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL))))");
+WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND ((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL))");
         }
 
         public override void Projection_query_parameter()
@@ -93,7 +93,7 @@ WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS 
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL))))");
+WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND ((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL))");
         }
 
         public override void Projection_query()
@@ -105,7 +105,7 @@ WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS 
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL))))");
+WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND ((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL))");
         }
 
         public override void Include_query()
@@ -123,11 +123,11 @@ LEFT JOIN (
     LEFT JOIN (
         SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
         FROM [Customers] AS [c0]
-        WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c0].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (((LEFT([c0].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c0].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c0].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL))))
+        WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([c0].[CompanyName] IS NOT NULL AND ((LEFT([c0].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND LEFT([c0].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL))
     ) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
     WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL
 ) AS [t0] ON [c].[CustomerID] = [t0].[CustomerID]
-WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL))))
+WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND ((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL))
 ORDER BY [c].[CustomerID], [t0].[OrderID]");
         }
 
@@ -154,7 +154,7 @@ FROM [Orders] AS [o]
 LEFT JOIN (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
-    WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL))))
+    WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND ((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL))
 ) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
 WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL");
         }
@@ -175,7 +175,7 @@ INNER JOIN (
     LEFT JOIN (
         SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
         FROM [Customers] AS [c]
-        WHERE ((@__ef_filter__TenantPrefix_1 = N'') AND @__ef_filter__TenantPrefix_1 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_1 IS NOT NULL AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_1)) = @__ef_filter__TenantPrefix_1) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_1)) IS NOT NULL AND @__ef_filter__TenantPrefix_1 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_1)) IS NULL AND @__ef_filter__TenantPrefix_1 IS NULL))))
+        WHERE (@__ef_filter__TenantPrefix_1 = N'') OR ([c].[CompanyName] IS NOT NULL AND ((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_1)) = @__ef_filter__TenantPrefix_1) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_1)) IS NOT NULL))
     ) AS [t] ON [o0].[CustomerID] = [t].[CustomerID]
     WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL
 ) AS [t0] ON [o].[OrderID] = [t0].[OrderID]
@@ -198,7 +198,7 @@ INNER JOIN (
     LEFT JOIN (
         SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
         FROM [Customers] AS [c0]
-        WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c0].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (((LEFT([c0].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c0].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c0].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL))))
+        WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([c0].[CompanyName] IS NOT NULL AND ((LEFT([c0].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND LEFT([c0].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL))
     ) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
     WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL
 ) AS [t0] ON [c].[CustomerID] = [t0].[CustomerID]
@@ -207,7 +207,7 @@ INNER JOIN (
     FROM [Order Details] AS [o0]
     WHERE [o0].[Quantity] > @__ef_filter___quantity_1
 ) AS [t1] ON [t0].[OrderID] = [t1].[OrderID]
-WHERE (((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL))))) AND ([t1].[Discount] < CAST(10 AS real))");
+WHERE ((@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND ((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL))) AND ([t1].[Discount] < CAST(10 AS real))");
         }
 
         [ConditionalFact]
@@ -227,7 +227,7 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM (
     select * from Customers
 ) AS [c]
-WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL))))");
+WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND ((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL))");
         }
 
         [ConditionalFact]
@@ -250,7 +250,7 @@ FROM (
 LEFT JOIN (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
-    WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL))))
+    WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND ((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL))
 ) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
 WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL");
         }
@@ -265,14 +265,14 @@ WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL");
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL))))) AND (([c].[CustomerID] = @__customerID) AND @__customerID IS NOT NULL)",
+WHERE ((@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND ((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL))) AND ([c].[CustomerID] = @__customerID)",
                 //
                 @"@__ef_filter__TenantPrefix_0='B' (Size = 4000)
 @__customerID='BLAUS' (Size = 5)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL))))) AND (([c].[CustomerID] = @__customerID) AND @__customerID IS NOT NULL)");
+WHERE ((@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND ((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL))) AND ([c].[CustomerID] = @__customerID)");
         }
 
         public override void Entity_Equality()
@@ -287,7 +287,7 @@ FROM [Orders] AS [o]
 LEFT JOIN (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
-    WHERE ((@__ef_filter__TenantPrefix_0 = N'') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL))))
+    WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND ((LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) IS NOT NULL))
 ) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
 WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL");
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlQuerySqlServerTest.cs
@@ -339,7 +339,7 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM (
     SELECT * FROM ""Customers"" WHERE ""City"" = @p0
 ) AS [c]
-WHERE (([c].[ContactTitle] = @__contactTitle_1) AND ([c].[ContactTitle] IS NOT NULL AND @__contactTitle_1 IS NOT NULL)) OR ([c].[ContactTitle] IS NULL AND @__contactTitle_1 IS NULL)");
+WHERE ([c].[ContactTitle] = @__contactTitle_1) AND [c].[ContactTitle] IS NOT NULL");
         }
 
         public override void FromSqlRaw_queryable_simple_cache_key_includes_query_string()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FunkyDataQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FunkyDataQuerySqlServerTest.cs
@@ -62,49 +62,49 @@ WHERE CHARINDEX(NULL, [f].[FirstName]) <= 0");
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE ((@__prm1_0 = N'') AND @__prm1_0 IS NOT NULL) OR (CHARINDEX(@__prm1_0, [f].[FirstName]) > 0)",
+WHERE (@__prm1_0 = N'') OR (CHARINDEX(@__prm1_0, [f].[FirstName]) > 0)",
                 //
                 @"@__prm2_0='a_' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE ((@__prm2_0 = N'') AND @__prm2_0 IS NOT NULL) OR (CHARINDEX(@__prm2_0, [f].[FirstName]) > 0)",
+WHERE (@__prm2_0 = N'') OR (CHARINDEX(@__prm2_0, [f].[FirstName]) > 0)",
                 //
                 @"@__prm3_0=NULL (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE ((@__prm3_0 = N'') AND @__prm3_0 IS NOT NULL) OR (CHARINDEX(@__prm3_0, [f].[FirstName]) > 0)",
+WHERE CHARINDEX(@__prm3_0, [f].[FirstName]) > 0",
                 //
                 @"@__prm4_0='' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE ((@__prm4_0 = N'') AND @__prm4_0 IS NOT NULL) OR (CHARINDEX(@__prm4_0, [f].[FirstName]) > 0)",
+WHERE (@__prm4_0 = N'') OR (CHARINDEX(@__prm4_0, [f].[FirstName]) > 0)",
                 //
                 @"@__prm5_0='_Ba_' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE ((@__prm5_0 = N'') AND @__prm5_0 IS NOT NULL) OR (CHARINDEX(@__prm5_0, [f].[FirstName]) > 0)",
+WHERE (@__prm5_0 = N'') OR (CHARINDEX(@__prm5_0, [f].[FirstName]) > 0)",
                 //
                 @"@__prm6_0='%B%a%r' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE ((@__prm6_0 <> N'') OR @__prm6_0 IS NULL) AND (CHARINDEX(@__prm6_0, [f].[FirstName]) <= 0)",
+WHERE (@__prm6_0 <> N'') AND (CHARINDEX(@__prm6_0, [f].[FirstName]) <= 0)",
                 //
                 @"@__prm7_0='' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE ((@__prm7_0 <> N'') OR @__prm7_0 IS NULL) AND (CHARINDEX(@__prm7_0, [f].[FirstName]) <= 0)",
+WHERE (@__prm7_0 <> N'') AND (CHARINDEX(@__prm7_0, [f].[FirstName]) <= 0)",
                 //
                 @"@__prm8_0=NULL (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE ((@__prm8_0 <> N'') OR @__prm8_0 IS NULL) AND (CHARINDEX(@__prm8_0, [f].[FirstName]) <= 0)");
+WHERE CHARINDEX(@__prm8_0, [f].[FirstName]) <= 0");
         }
 
         public override async Task String_contains_on_argument_with_wildcard_column(bool isAsync)
@@ -175,49 +175,45 @@ WHERE CAST(0 AS bit) = CAST(1 AS bit)");
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE ((@__prm1_0 = N'') AND @__prm1_0 IS NOT NULL) OR ([f].[FirstName] IS NOT NULL AND (@__prm1_0 IS NOT NULL AND (((LEFT([f].[FirstName], LEN(@__prm1_0)) = @__prm1_0) AND (LEFT([f].[FirstName], LEN(@__prm1_0)) IS NOT NULL AND @__prm1_0 IS NOT NULL)) OR (LEFT([f].[FirstName], LEN(@__prm1_0)) IS NULL AND @__prm1_0 IS NULL))))",
+WHERE (@__prm1_0 = N'') OR ([f].[FirstName] IS NOT NULL AND ((LEFT([f].[FirstName], LEN(@__prm1_0)) = @__prm1_0) AND LEFT([f].[FirstName], LEN(@__prm1_0)) IS NOT NULL))",
                 //
                 @"@__prm2_0='a_' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE ((@__prm2_0 = N'') AND @__prm2_0 IS NOT NULL) OR ([f].[FirstName] IS NOT NULL AND (@__prm2_0 IS NOT NULL AND (((LEFT([f].[FirstName], LEN(@__prm2_0)) = @__prm2_0) AND (LEFT([f].[FirstName], LEN(@__prm2_0)) IS NOT NULL AND @__prm2_0 IS NOT NULL)) OR (LEFT([f].[FirstName], LEN(@__prm2_0)) IS NULL AND @__prm2_0 IS NULL))))",
+WHERE (@__prm2_0 = N'') OR ([f].[FirstName] IS NOT NULL AND ((LEFT([f].[FirstName], LEN(@__prm2_0)) = @__prm2_0) AND LEFT([f].[FirstName], LEN(@__prm2_0)) IS NOT NULL))",
                 //
-                @"@__prm3_0=NULL (Size = 4000)
-
-SELECT [f].[FirstName]
+                @"SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE ((@__prm3_0 = N'') AND @__prm3_0 IS NOT NULL) OR ([f].[FirstName] IS NOT NULL AND (@__prm3_0 IS NOT NULL AND (((LEFT([f].[FirstName], LEN(@__prm3_0)) = @__prm3_0) AND (LEFT([f].[FirstName], LEN(@__prm3_0)) IS NOT NULL AND @__prm3_0 IS NOT NULL)) OR (LEFT([f].[FirstName], LEN(@__prm3_0)) IS NULL AND @__prm3_0 IS NULL))))",
+WHERE CAST(0 AS bit) = CAST(1 AS bit)",
                 //
                 @"@__prm4_0='' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE ((@__prm4_0 = N'') AND @__prm4_0 IS NOT NULL) OR ([f].[FirstName] IS NOT NULL AND (@__prm4_0 IS NOT NULL AND (((LEFT([f].[FirstName], LEN(@__prm4_0)) = @__prm4_0) AND (LEFT([f].[FirstName], LEN(@__prm4_0)) IS NOT NULL AND @__prm4_0 IS NOT NULL)) OR (LEFT([f].[FirstName], LEN(@__prm4_0)) IS NULL AND @__prm4_0 IS NULL))))",
+WHERE (@__prm4_0 = N'') OR ([f].[FirstName] IS NOT NULL AND ((LEFT([f].[FirstName], LEN(@__prm4_0)) = @__prm4_0) AND LEFT([f].[FirstName], LEN(@__prm4_0)) IS NOT NULL))",
                 //
                 @"@__prm5_0='_Ba_' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE ((@__prm5_0 = N'') AND @__prm5_0 IS NOT NULL) OR ([f].[FirstName] IS NOT NULL AND (@__prm5_0 IS NOT NULL AND (((LEFT([f].[FirstName], LEN(@__prm5_0)) = @__prm5_0) AND (LEFT([f].[FirstName], LEN(@__prm5_0)) IS NOT NULL AND @__prm5_0 IS NOT NULL)) OR (LEFT([f].[FirstName], LEN(@__prm5_0)) IS NULL AND @__prm5_0 IS NULL))))",
+WHERE (@__prm5_0 = N'') OR ([f].[FirstName] IS NOT NULL AND ((LEFT([f].[FirstName], LEN(@__prm5_0)) = @__prm5_0) AND LEFT([f].[FirstName], LEN(@__prm5_0)) IS NOT NULL))",
                 //
                 @"@__prm6_0='%B%a%r' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE ((@__prm6_0 <> N'') OR @__prm6_0 IS NULL) AND ([f].[FirstName] IS NOT NULL AND (@__prm6_0 IS NOT NULL AND (((LEFT([f].[FirstName], LEN(@__prm6_0)) <> @__prm6_0) OR (LEFT([f].[FirstName], LEN(@__prm6_0)) IS NULL OR @__prm6_0 IS NULL)) AND (LEFT([f].[FirstName], LEN(@__prm6_0)) IS NOT NULL OR @__prm6_0 IS NOT NULL))))",
+WHERE (@__prm6_0 <> N'') AND ([f].[FirstName] IS NOT NULL AND ((LEFT([f].[FirstName], LEN(@__prm6_0)) <> @__prm6_0) OR LEFT([f].[FirstName], LEN(@__prm6_0)) IS NULL))",
                 //
                 @"@__prm7_0='' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE ((@__prm7_0 <> N'') OR @__prm7_0 IS NULL) AND ([f].[FirstName] IS NOT NULL AND (@__prm7_0 IS NOT NULL AND (((LEFT([f].[FirstName], LEN(@__prm7_0)) <> @__prm7_0) OR (LEFT([f].[FirstName], LEN(@__prm7_0)) IS NULL OR @__prm7_0 IS NULL)) AND (LEFT([f].[FirstName], LEN(@__prm7_0)) IS NOT NULL OR @__prm7_0 IS NOT NULL))))",
+WHERE (@__prm7_0 <> N'') AND ([f].[FirstName] IS NOT NULL AND ((LEFT([f].[FirstName], LEN(@__prm7_0)) <> @__prm7_0) OR LEFT([f].[FirstName], LEN(@__prm7_0)) IS NULL))",
                 //
-                @"@__prm8_0=NULL (Size = 4000)
-
-SELECT [f].[FirstName]
+                @"SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE ((@__prm8_0 <> N'') OR @__prm8_0 IS NULL) AND ([f].[FirstName] IS NOT NULL AND (@__prm8_0 IS NOT NULL AND (((LEFT([f].[FirstName], LEN(@__prm8_0)) <> @__prm8_0) OR (LEFT([f].[FirstName], LEN(@__prm8_0)) IS NULL OR @__prm8_0 IS NULL)) AND (LEFT([f].[FirstName], LEN(@__prm8_0)) IS NOT NULL OR @__prm8_0 IS NOT NULL))))");
+WHERE CAST(0 AS bit) = CAST(1 AS bit)");
         }
 
         public override async Task String_starts_with_on_argument_with_bracket(bool isAsync)
@@ -241,19 +237,19 @@ WHERE [f].[FirstName] IS NOT NULL AND ([f].[FirstName] LIKE N'B\[\[a^%' ESCAPE N
 
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE ((@__prm1_0 = N'') AND @__prm1_0 IS NOT NULL) OR ([f].[FirstName] IS NOT NULL AND (@__prm1_0 IS NOT NULL AND (((LEFT([f].[FirstName], LEN(@__prm1_0)) = @__prm1_0) AND (LEFT([f].[FirstName], LEN(@__prm1_0)) IS NOT NULL AND @__prm1_0 IS NOT NULL)) OR (LEFT([f].[FirstName], LEN(@__prm1_0)) IS NULL AND @__prm1_0 IS NULL))))",
+WHERE (@__prm1_0 = N'') OR ([f].[FirstName] IS NOT NULL AND ((LEFT([f].[FirstName], LEN(@__prm1_0)) = @__prm1_0) AND LEFT([f].[FirstName], LEN(@__prm1_0)) IS NOT NULL))",
                 //
                 @"@__prm2_0='B[' (Size = 4000)
 
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE ((@__prm2_0 = N'') AND @__prm2_0 IS NOT NULL) OR ([f].[FirstName] IS NOT NULL AND (@__prm2_0 IS NOT NULL AND (((LEFT([f].[FirstName], LEN(@__prm2_0)) = @__prm2_0) AND (LEFT([f].[FirstName], LEN(@__prm2_0)) IS NOT NULL AND @__prm2_0 IS NOT NULL)) OR (LEFT([f].[FirstName], LEN(@__prm2_0)) IS NULL AND @__prm2_0 IS NULL))))",
+WHERE (@__prm2_0 = N'') OR ([f].[FirstName] IS NOT NULL AND ((LEFT([f].[FirstName], LEN(@__prm2_0)) = @__prm2_0) AND LEFT([f].[FirstName], LEN(@__prm2_0)) IS NOT NULL))",
                 //
                 @"@__prm3_0='B[[a^' (Size = 4000)
 
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE ((@__prm3_0 = N'') AND @__prm3_0 IS NOT NULL) OR ([f].[FirstName] IS NOT NULL AND (@__prm3_0 IS NOT NULL AND (((LEFT([f].[FirstName], LEN(@__prm3_0)) = @__prm3_0) AND (LEFT([f].[FirstName], LEN(@__prm3_0)) IS NOT NULL AND @__prm3_0 IS NOT NULL)) OR (LEFT([f].[FirstName], LEN(@__prm3_0)) IS NULL AND @__prm3_0 IS NULL))))",
+WHERE (@__prm3_0 = N'') OR ([f].[FirstName] IS NOT NULL AND ((LEFT([f].[FirstName], LEN(@__prm3_0)) = @__prm3_0) AND LEFT([f].[FirstName], LEN(@__prm3_0)) IS NOT NULL))",
                 //
                 @"SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
@@ -328,49 +324,45 @@ WHERE CAST(0 AS bit) = CAST(1 AS bit)");
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE ((@__prm1_0 = N'') AND @__prm1_0 IS NOT NULL) OR ([f].[FirstName] IS NOT NULL AND (@__prm1_0 IS NOT NULL AND (((RIGHT([f].[FirstName], LEN(@__prm1_0)) = @__prm1_0) AND (RIGHT([f].[FirstName], LEN(@__prm1_0)) IS NOT NULL AND @__prm1_0 IS NOT NULL)) OR (RIGHT([f].[FirstName], LEN(@__prm1_0)) IS NULL AND @__prm1_0 IS NULL))))",
+WHERE (@__prm1_0 = N'') OR ([f].[FirstName] IS NOT NULL AND ((RIGHT([f].[FirstName], LEN(@__prm1_0)) = @__prm1_0) AND RIGHT([f].[FirstName], LEN(@__prm1_0)) IS NOT NULL))",
                 //
                 @"@__prm2_0='a_' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE ((@__prm2_0 = N'') AND @__prm2_0 IS NOT NULL) OR ([f].[FirstName] IS NOT NULL AND (@__prm2_0 IS NOT NULL AND (((RIGHT([f].[FirstName], LEN(@__prm2_0)) = @__prm2_0) AND (RIGHT([f].[FirstName], LEN(@__prm2_0)) IS NOT NULL AND @__prm2_0 IS NOT NULL)) OR (RIGHT([f].[FirstName], LEN(@__prm2_0)) IS NULL AND @__prm2_0 IS NULL))))",
+WHERE (@__prm2_0 = N'') OR ([f].[FirstName] IS NOT NULL AND ((RIGHT([f].[FirstName], LEN(@__prm2_0)) = @__prm2_0) AND RIGHT([f].[FirstName], LEN(@__prm2_0)) IS NOT NULL))",
                 //
-                @"@__prm3_0=NULL (Size = 4000)
-
-SELECT [f].[FirstName]
+                @"SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE ((@__prm3_0 = N'') AND @__prm3_0 IS NOT NULL) OR ([f].[FirstName] IS NOT NULL AND (@__prm3_0 IS NOT NULL AND (((RIGHT([f].[FirstName], LEN(@__prm3_0)) = @__prm3_0) AND (RIGHT([f].[FirstName], LEN(@__prm3_0)) IS NOT NULL AND @__prm3_0 IS NOT NULL)) OR (RIGHT([f].[FirstName], LEN(@__prm3_0)) IS NULL AND @__prm3_0 IS NULL))))",
+WHERE CAST(0 AS bit) = CAST(1 AS bit)",
                 //
                 @"@__prm4_0='' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE ((@__prm4_0 = N'') AND @__prm4_0 IS NOT NULL) OR ([f].[FirstName] IS NOT NULL AND (@__prm4_0 IS NOT NULL AND (((RIGHT([f].[FirstName], LEN(@__prm4_0)) = @__prm4_0) AND (RIGHT([f].[FirstName], LEN(@__prm4_0)) IS NOT NULL AND @__prm4_0 IS NOT NULL)) OR (RIGHT([f].[FirstName], LEN(@__prm4_0)) IS NULL AND @__prm4_0 IS NULL))))",
+WHERE (@__prm4_0 = N'') OR ([f].[FirstName] IS NOT NULL AND ((RIGHT([f].[FirstName], LEN(@__prm4_0)) = @__prm4_0) AND RIGHT([f].[FirstName], LEN(@__prm4_0)) IS NOT NULL))",
                 //
                 @"@__prm5_0='_Ba_' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE ((@__prm5_0 = N'') AND @__prm5_0 IS NOT NULL) OR ([f].[FirstName] IS NOT NULL AND (@__prm5_0 IS NOT NULL AND (((RIGHT([f].[FirstName], LEN(@__prm5_0)) = @__prm5_0) AND (RIGHT([f].[FirstName], LEN(@__prm5_0)) IS NOT NULL AND @__prm5_0 IS NOT NULL)) OR (RIGHT([f].[FirstName], LEN(@__prm5_0)) IS NULL AND @__prm5_0 IS NULL))))",
+WHERE (@__prm5_0 = N'') OR ([f].[FirstName] IS NOT NULL AND ((RIGHT([f].[FirstName], LEN(@__prm5_0)) = @__prm5_0) AND RIGHT([f].[FirstName], LEN(@__prm5_0)) IS NOT NULL))",
                 //
                 @"@__prm6_0='%B%a%r' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE ((@__prm6_0 <> N'') OR @__prm6_0 IS NULL) AND ([f].[FirstName] IS NOT NULL AND (@__prm6_0 IS NOT NULL AND (((RIGHT([f].[FirstName], LEN(@__prm6_0)) <> @__prm6_0) OR (RIGHT([f].[FirstName], LEN(@__prm6_0)) IS NULL OR @__prm6_0 IS NULL)) AND (RIGHT([f].[FirstName], LEN(@__prm6_0)) IS NOT NULL OR @__prm6_0 IS NOT NULL))))",
+WHERE (@__prm6_0 <> N'') AND ([f].[FirstName] IS NOT NULL AND ((RIGHT([f].[FirstName], LEN(@__prm6_0)) <> @__prm6_0) OR RIGHT([f].[FirstName], LEN(@__prm6_0)) IS NULL))",
                 //
                 @"@__prm7_0='' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE ((@__prm7_0 <> N'') OR @__prm7_0 IS NULL) AND ([f].[FirstName] IS NOT NULL AND (@__prm7_0 IS NOT NULL AND (((RIGHT([f].[FirstName], LEN(@__prm7_0)) <> @__prm7_0) OR (RIGHT([f].[FirstName], LEN(@__prm7_0)) IS NULL OR @__prm7_0 IS NULL)) AND (RIGHT([f].[FirstName], LEN(@__prm7_0)) IS NOT NULL OR @__prm7_0 IS NOT NULL))))",
+WHERE (@__prm7_0 <> N'') AND ([f].[FirstName] IS NOT NULL AND ((RIGHT([f].[FirstName], LEN(@__prm7_0)) <> @__prm7_0) OR RIGHT([f].[FirstName], LEN(@__prm7_0)) IS NULL))",
                 //
-                @"@__prm8_0=NULL (Size = 4000)
-
-SELECT [f].[FirstName]
+                @"SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE ((@__prm8_0 <> N'') OR @__prm8_0 IS NULL) AND ([f].[FirstName] IS NOT NULL AND (@__prm8_0 IS NOT NULL AND (((RIGHT([f].[FirstName], LEN(@__prm8_0)) <> @__prm8_0) OR (RIGHT([f].[FirstName], LEN(@__prm8_0)) IS NULL OR @__prm8_0 IS NULL)) AND (RIGHT([f].[FirstName], LEN(@__prm8_0)) IS NOT NULL OR @__prm8_0 IS NOT NULL))))");
+WHERE CAST(0 AS bit) = CAST(1 AS bit)");
         }
 
         public override async Task String_ends_with_on_argument_with_wildcard_column(bool isAsync)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -396,7 +396,7 @@ WHERE [w].[AmmunitionType] IS NULL");
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
-WHERE (([w].[AmmunitionType] = @__ammunitionType_0) AND ([w].[AmmunitionType] IS NOT NULL AND @__ammunitionType_0 IS NOT NULL)) OR ([w].[AmmunitionType] IS NULL AND @__ammunitionType_0 IS NULL)");
+WHERE ([w].[AmmunitionType] = @__ammunitionType_0) AND [w].[AmmunitionType] IS NOT NULL");
         }
 
         public override async Task Where_nullable_enum_with_nullable_parameter(bool isAsync)
@@ -408,13 +408,11 @@ WHERE (([w].[AmmunitionType] = @__ammunitionType_0) AND ([w].[AmmunitionType] IS
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
-WHERE (([w].[AmmunitionType] = @__ammunitionType_0) AND ([w].[AmmunitionType] IS NOT NULL AND @__ammunitionType_0 IS NOT NULL)) OR ([w].[AmmunitionType] IS NULL AND @__ammunitionType_0 IS NULL)",
+WHERE ([w].[AmmunitionType] = @__ammunitionType_0) AND [w].[AmmunitionType] IS NOT NULL",
                 //
-                @"@__ammunitionType_0=NULL (DbType = Int32)
-
-SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+                @"SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
-WHERE (([w].[AmmunitionType] = @__ammunitionType_0) AND ([w].[AmmunitionType] IS NOT NULL AND @__ammunitionType_0 IS NOT NULL)) OR ([w].[AmmunitionType] IS NULL AND @__ammunitionType_0 IS NULL)");
+WHERE [w].[AmmunitionType] IS NULL");
         }
 
         public override async Task Where_bitwise_and_enum(bool isAsync)
@@ -718,7 +716,7 @@ WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND (((([g].[Rank] & (
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
-WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND (((([g].[Rank] & @__parameter_0) = @__parameter_0) AND ([g].[Rank] & @__parameter_0 IS NOT NULL AND @__parameter_0 IS NOT NULL)) OR ([g].[Rank] & @__parameter_0 IS NULL AND @__parameter_0 IS NULL))");
+WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND ((([g].[Rank] & @__parameter_0) = @__parameter_0) AND [g].[Rank] & @__parameter_0 IS NOT NULL)");
         }
 
         public override async Task Where_has_flag_with_nullable_parameter(bool isAsync)
@@ -730,7 +728,7 @@ WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND (((([g].[Rank] & @__param
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
-WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND (((([g].[Rank] & @__parameter_0) = @__parameter_0) AND ([g].[Rank] & @__parameter_0 IS NOT NULL AND @__parameter_0 IS NOT NULL)) OR ([g].[Rank] & @__parameter_0 IS NULL AND @__parameter_0 IS NULL))");
+WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND ((([g].[Rank] & @__parameter_0) = @__parameter_0) AND [g].[Rank] & @__parameter_0 IS NOT NULL)");
         }
 
         public override async Task Select_enum_has_flag(bool isAsync)
@@ -799,20 +797,44 @@ WHERE [w].[IsAutomatic] = CAST(1 AS bit)");
                 @"@__ammunitionType_0='1' (Nullable = true)
 
 SELECT [w].[Id], CASE
-    WHEN (([w].[AmmunitionType] = @__ammunitionType_0) AND ([w].[AmmunitionType] IS NOT NULL AND @__ammunitionType_0 IS NOT NULL)) OR ([w].[AmmunitionType] IS NULL AND @__ammunitionType_0 IS NULL) THEN CAST(1 AS bit)
+    WHEN ([w].[AmmunitionType] = @__ammunitionType_0) AND [w].[AmmunitionType] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [Cartridge]
 FROM [Weapons] AS [w]
-WHERE (([w].[AmmunitionType] = @__ammunitionType_0) AND ([w].[AmmunitionType] IS NOT NULL AND @__ammunitionType_0 IS NOT NULL)) OR ([w].[AmmunitionType] IS NULL AND @__ammunitionType_0 IS NULL)",
+WHERE ([w].[AmmunitionType] = @__ammunitionType_0) AND [w].[AmmunitionType] IS NOT NULL",
+                //
+                @"SELECT [w].[Id], CASE
+    WHEN [w].[AmmunitionType] IS NULL THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END AS [Cartridge]
+FROM [Weapons] AS [w]
+WHERE [w].[AmmunitionType] IS NULL");
+        }
+
+        public override async Task Select_null_parameter(bool isAsync)
+        {
+            await base.Select_null_parameter(isAsync);
+
+            AssertSql(
+                @"@__ammunitionType_0='1' (Nullable = true)
+
+SELECT [w].[Id], @__ammunitionType_0 AS [AmmoType]
+FROM [Weapons] AS [w]",
                 //
                 @"@__ammunitionType_0=NULL (DbType = Int32)
 
-SELECT [w].[Id], CASE
-    WHEN (([w].[AmmunitionType] = @__ammunitionType_0) AND ([w].[AmmunitionType] IS NOT NULL AND @__ammunitionType_0 IS NOT NULL)) OR ([w].[AmmunitionType] IS NULL AND @__ammunitionType_0 IS NULL) THEN CAST(1 AS bit)
-    ELSE CAST(0 AS bit)
-END AS [Cartridge]
-FROM [Weapons] AS [w]
-WHERE (([w].[AmmunitionType] = @__ammunitionType_0) AND ([w].[AmmunitionType] IS NOT NULL AND @__ammunitionType_0 IS NOT NULL)) OR ([w].[AmmunitionType] IS NULL AND @__ammunitionType_0 IS NULL)");
+SELECT [w].[Id], @__ammunitionType_0 AS [AmmoType]
+FROM [Weapons] AS [w]",
+                //
+                @"@__ammunitionType_0='2' (Nullable = true)
+
+SELECT [w].[Id], @__ammunitionType_0 AS [AmmoType]
+FROM [Weapons] AS [w]",
+                //
+                @"@__ammunitionType_0=NULL (DbType = Int32)
+
+SELECT [w].[Id], @__ammunitionType_0 AS [AmmoType]
+FROM [Weapons] AS [w]");
         }
 
         public override async Task Select_ternary_operation_with_boolean(bool isAsync)
@@ -1871,7 +1893,7 @@ WHERE ('Unknown' = [c].[Location]) AND [c].[Location] IS NOT NULL");
 
 SELECT [c].[Name], [c].[Location], [c].[Nation]
 FROM [Cities] AS [c]
-WHERE (([c].[Location] = @__value_0) AND ([c].[Location] IS NOT NULL AND @__value_0 IS NOT NULL)) OR ([c].[Location] IS NULL AND @__value_0 IS NULL)");
+WHERE ([c].[Location] = @__value_0) AND [c].[Location] IS NOT NULL");
         }
 
         public override async Task Non_unicode_string_literals_in_contains_is_used_for_non_unicode_column(bool isAsync)
@@ -7027,7 +7049,7 @@ FROM [Gears] AS [g]
 LEFT JOIN (
     SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
     FROM [Weapons] AS [w]
-    WHERE ([w].[IsAutomatic] = @__isAutomatic_0) AND @__isAutomatic_0 IS NOT NULL
+    WHERE [w].[IsAutomatic] = @__isAutomatic_0
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 WHERE [g].[Discriminator] IN (N'Gear', N'Officer')");
         }
@@ -7258,7 +7280,7 @@ SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthNa
 FROM (
     SELECT DISTINCT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
     FROM [Gears] AS [g]
-    WHERE ([g].[Discriminator] IN (N'Gear', N'Officer') AND (([g].[Nickname] <> @__prm_Inner_Nickname_0) OR @__prm_Inner_Nickname_0 IS NULL)) AND (([g].[Nickname] <> @__prm_Inner_Nickname_0) OR @__prm_Inner_Nickname_0 IS NULL)
+    WHERE ([g].[Discriminator] IN (N'Gear', N'Officer') AND ([g].[Nickname] <> @__prm_Inner_Nickname_0)) AND ([g].[Nickname] <> @__prm_Inner_Nickname_0)
 ) AS [t]
 ORDER BY [t].[FullName]");
         }
@@ -7275,10 +7297,10 @@ FROM (
     SELECT DISTINCT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
     FROM [Gears] AS [g]
     INNER JOIN [Squads] AS [s] ON [g].[SquadId] = [s].[Id]
-    WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND (([s].[Id] = @__entity_equality_prm_Inner_Squad_0_Id) AND @__entity_equality_prm_Inner_Squad_0_Id IS NOT NULL)
+    WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND ([s].[Id] = @__entity_equality_prm_Inner_Squad_0_Id)
 ) AS [t]
 INNER JOIN [Squads] AS [s0] ON [t].[SquadId] = [s0].[Id]
-WHERE ([s0].[Id] = @__entity_equality_prm_Inner_Squad_0_Id) AND @__entity_equality_prm_Inner_Squad_0_Id IS NOT NULL
+WHERE [s0].[Id] = @__entity_equality_prm_Inner_Squad_0_Id
 ORDER BY [t].[FullName]");
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -678,11 +678,9 @@ END");
             base.Compare_nullable_with_null_parameter_equal();
 
             AssertSql(
-                @"@__prm_0=NULL (Size = 4000)
-
-SELECT [e].[Id]
+                @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE (([e].[NullableStringA] = @__prm_0) AND ([e].[NullableStringA] IS NOT NULL AND @__prm_0 IS NOT NULL)) OR ([e].[NullableStringA] IS NULL AND @__prm_0 IS NULL)");
+WHERE [e].[NullableStringA] IS NULL");
         }
 
         public override void Compare_nullable_with_non_null_parameter_not_equal()
@@ -694,7 +692,7 @@ WHERE (([e].[NullableStringA] = @__prm_0) AND ([e].[NullableStringA] IS NOT NULL
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE (([e].[NullableStringA] = @__prm_0) AND ([e].[NullableStringA] IS NOT NULL AND @__prm_0 IS NOT NULL)) OR ([e].[NullableStringA] IS NULL AND @__prm_0 IS NULL)");
+WHERE ([e].[NullableStringA] = @__prm_0) AND [e].[NullableStringA] IS NOT NULL");
         }
 
         public override void Join_uses_database_semantics()
@@ -770,11 +768,9 @@ WHERE ((([e].[NullableStringA] <> N'Foo') OR [e].[NullableStringA] IS NULL) AND 
             base.Where_multiple_ors_with_nullable_parameter();
 
             AssertSql(
-                @"@__prm_0=NULL (Size = 4000)
-
-SELECT [e].[Id]
+                @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE (([e].[NullableStringA] = N'Foo') AND [e].[NullableStringA] IS NOT NULL) OR ((([e].[NullableStringA] = @__prm_0) AND ([e].[NullableStringA] IS NOT NULL AND @__prm_0 IS NOT NULL)) OR ([e].[NullableStringA] IS NULL AND @__prm_0 IS NULL))");
+WHERE (([e].[NullableStringA] = N'Foo') AND [e].[NullableStringA] IS NOT NULL) OR [e].[NullableStringA] IS NULL");
         }
 
         public override void Where_multiple_ands_with_nullable_parameter_and_constant()
@@ -782,13 +778,11 @@ WHERE (([e].[NullableStringA] = N'Foo') AND [e].[NullableStringA] IS NOT NULL) O
             base.Where_multiple_ands_with_nullable_parameter_and_constant();
 
             AssertSql(
-                @"@__prm1_0=NULL (Size = 4000)
-@__prm2_1=NULL (Size = 4000)
-@__prm3_2='Blah' (Size = 4000)
+                @"@__prm3_2='Blah' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE (((([e].[NullableStringA] <> N'Foo') OR [e].[NullableStringA] IS NULL) AND ((([e].[NullableStringA] <> @__prm1_0) OR ([e].[NullableStringA] IS NULL OR @__prm1_0 IS NULL)) AND ([e].[NullableStringA] IS NOT NULL OR @__prm1_0 IS NOT NULL))) AND ((([e].[NullableStringA] <> @__prm2_1) OR ([e].[NullableStringA] IS NULL OR @__prm2_1 IS NULL)) AND ([e].[NullableStringA] IS NOT NULL OR @__prm2_1 IS NOT NULL))) AND ((([e].[NullableStringA] <> @__prm3_2) OR ([e].[NullableStringA] IS NULL OR @__prm3_2 IS NULL)) AND ([e].[NullableStringA] IS NOT NULL OR @__prm3_2 IS NOT NULL))");
+WHERE (((([e].[NullableStringA] <> N'Foo') OR [e].[NullableStringA] IS NULL) AND [e].[NullableStringA] IS NOT NULL) AND [e].[NullableStringA] IS NOT NULL) AND (([e].[NullableStringA] <> @__prm3_2) OR [e].[NullableStringA] IS NULL)");
         }
 
         public override void Where_multiple_ands_with_nullable_parameter_and_constant_not_optimized()
@@ -796,13 +790,11 @@ WHERE (((([e].[NullableStringA] <> N'Foo') OR [e].[NullableStringA] IS NULL) AND
             base.Where_multiple_ands_with_nullable_parameter_and_constant_not_optimized();
 
             AssertSql(
-                @"@__prm1_0=NULL (Size = 4000)
-@__prm2_1=NULL (Size = 4000)
-@__prm3_2='Blah' (Size = 4000)
+                @"@__prm3_2='Blah' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE ((([e].[NullableStringB] IS NOT NULL AND (([e].[NullableStringA] <> N'Foo') OR [e].[NullableStringA] IS NULL)) AND ((([e].[NullableStringA] <> @__prm1_0) OR ([e].[NullableStringA] IS NULL OR @__prm1_0 IS NULL)) AND ([e].[NullableStringA] IS NOT NULL OR @__prm1_0 IS NOT NULL))) AND ((([e].[NullableStringA] <> @__prm2_1) OR ([e].[NullableStringA] IS NULL OR @__prm2_1 IS NULL)) AND ([e].[NullableStringA] IS NOT NULL OR @__prm2_1 IS NOT NULL))) AND ((([e].[NullableStringA] <> @__prm3_2) OR ([e].[NullableStringA] IS NULL OR @__prm3_2 IS NULL)) AND ([e].[NullableStringA] IS NOT NULL OR @__prm3_2 IS NOT NULL))");
+WHERE ((([e].[NullableStringB] IS NOT NULL AND (([e].[NullableStringA] <> N'Foo') OR [e].[NullableStringA] IS NULL)) AND [e].[NullableStringA] IS NOT NULL) AND [e].[NullableStringA] IS NOT NULL) AND (([e].[NullableStringA] <> @__prm3_2) OR [e].[NullableStringA] IS NULL)");
         }
 
         public override void Where_coalesce()
@@ -820,11 +812,9 @@ WHERE COALESCE([e].[NullableBoolA], CAST(1 AS bit)) = CAST(1 AS bit)");
             base.Where_equal_nullable_with_null_value_parameter();
 
             AssertSql(
-                @"@__prm_0=NULL (Size = 4000)
-
-SELECT [e].[Id]
+                @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE (([e].[NullableStringA] = @__prm_0) AND ([e].[NullableStringA] IS NOT NULL AND @__prm_0 IS NOT NULL)) OR ([e].[NullableStringA] IS NULL AND @__prm_0 IS NULL)");
+WHERE [e].[NullableStringA] IS NULL");
         }
 
         public override void Where_not_equal_nullable_with_null_value_parameter()
@@ -832,11 +822,9 @@ WHERE (([e].[NullableStringA] = @__prm_0) AND ([e].[NullableStringA] IS NOT NULL
             base.Where_not_equal_nullable_with_null_value_parameter();
 
             AssertSql(
-                @"@__prm_0=NULL (Size = 4000)
-
-SELECT [e].[Id]
+                @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE (([e].[NullableStringA] <> @__prm_0) OR ([e].[NullableStringA] IS NULL OR @__prm_0 IS NULL)) AND ([e].[NullableStringA] IS NOT NULL OR @__prm_0 IS NOT NULL)");
+WHERE [e].[NullableStringA] IS NOT NULL");
         }
 
         public override void Where_equal_with_coalesce()
@@ -1199,11 +1187,9 @@ WHERE @__p_0 = CAST(1 AS bit)");
             base.Where_comparison_null_semantics_optimization_works_with_complex_predicates();
 
             AssertSql(
-                @"@__prm_0=NULL (Size = 4000)
-
-SELECT [e].[Id]
+                @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE (([e].[NullableStringA] = @__prm_0) AND ([e].[NullableStringA] IS NOT NULL AND @__prm_0 IS NOT NULL)) OR ([e].[NullableStringA] IS NULL AND @__prm_0 IS NULL)");
+WHERE [e].[NullableStringA] IS NULL");
         }
 
         public override void Switching_null_semantics_produces_different_cache_entry()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -2254,13 +2254,13 @@ WHERE ([e].[PermissionShort] & CAST(4 AS smallint)) = CAST(4 AS smallint)");
 
 SELECT [e].[Id], [e].[Name]
 FROM [Entities] AS [e]
-WHERE ([e].[Id] = @__id_0) AND @__id_0 IS NOT NULL",
+WHERE [e].[Id] = @__id_0",
                         //
                         @"@__id_0='2'
 
 SELECT [e].[Id], [e].[Name]
 FROM [Entities] AS [e]
-WHERE ([e].[Id] = @__id_0) AND @__id_0 IS NOT NULL");
+WHERE [e].[Id] = @__id_0");
                 }
             }
         }
@@ -2291,13 +2291,13 @@ WHERE ([e].[Id] = @__id_0) AND @__id_0 IS NOT NULL");
 
 SELECT [e].[Id], [e].[Name]
 FROM [Entities] AS [e]
-WHERE ([e].[Id] = @__id_0) AND @__id_0 IS NOT NULL",
+WHERE [e].[Id] = @__id_0",
                         //
                         @"@__id_0='2'
 
 SELECT [e].[Id], [e].[Name]
 FROM [Entities] AS [e]
-WHERE ([e].[Id] = @__id_0) AND @__id_0 IS NOT NULL");
+WHERE [e].[Id] = @__id_0");
                 }
             }
         }
@@ -2333,7 +2333,7 @@ FROM [Entities] AS [e]
 WHERE [e].[Id] IN (
     SELECT [e0].[Id]
     FROM [Entities] AS [e0]
-    WHERE ([e0].[Id] = @__id_0) AND @__id_0 IS NOT NULL
+    WHERE [e0].[Id] = @__id_0
 )",
                         //
                         @"@__id_0='2'
@@ -2343,7 +2343,7 @@ FROM [Entities] AS [e]
 WHERE [e].[Id] IN (
     SELECT [e0].[Id]
     FROM [Entities] AS [e0]
-    WHERE ([e0].[Id] = @__id_0) AND @__id_0 IS NOT NULL
+    WHERE [e0].[Id] = @__id_0
 )");
                 }
             }
@@ -2372,13 +2372,11 @@ WHERE [e].[Id] IN (
 
 SELECT [e].[Id], [e].[Name]
 FROM [Entities] AS [e]
-WHERE (([e].[Name] = @__name_0) AND ([e].[Name] IS NOT NULL AND @__name_0 IS NOT NULL)) OR ([e].[Name] IS NULL AND @__name_0 IS NULL)",
+WHERE ([e].[Name] = @__name_0) AND [e].[Name] IS NOT NULL",
                         //
-                        @"@__name_0=NULL (Size = 4000)
-
-SELECT [e].[Id], [e].[Name]
+                        @"SELECT [e].[Id], [e].[Name]
 FROM [Entities] AS [e]
-WHERE (([e].[Name] = @__name_0) AND ([e].[Name] IS NOT NULL AND @__name_0 IS NOT NULL)) OR ([e].[Name] IS NULL AND @__name_0 IS NULL)");
+WHERE [e].[Name] IS NULL");
                 }
             }
         }
@@ -5886,7 +5884,7 @@ WHERE [r].[IsRemoved] = CAST(1 AS bit)");
 
 SELECT [p].[Id], [p].[RemovableEntityId]
 FROM [Parents] AS [p]
-WHERE ([p].[Id] = @__id_0) AND @__id_0 IS NOT NULL");
+WHERE [p].[Id] = @__id_0");
                 }
             }
         }
@@ -5996,7 +5994,7 @@ WHERE ([f].[String] = N'1337') AND [f].[String] IS NOT NULL");
 
 SELECT [f].[Id], [f].[String]
 FROM [Foos] AS [f]
-WHERE (([f].[String] = @__bar_Value_0) AND ([f].[String] IS NOT NULL AND @__bar_Value_0 IS NOT NULL)) OR ([f].[String] IS NULL AND @__bar_Value_0 IS NULL)");
+WHERE ([f].[String] = @__bar_Value_0) AND [f].[String] IS NOT NULL");
                 }
             }
         }
@@ -6017,7 +6015,7 @@ WHERE (([f].[String] = @__bar_Value_0) AND ([f].[String] IS NOT NULL AND @__bar_
 
 SELECT [f].[Id], [f].[String]
 FROM [Foos] AS [f]
-WHERE (([f].[String] = @__ToString_0) AND ([f].[String] IS NOT NULL AND @__ToString_0 IS NOT NULL)) OR ([f].[String] IS NULL AND @__ToString_0 IS NULL)");
+WHERE ([f].[String] = @__ToString_0) AND [f].[String] IS NOT NULL");
                 }
             }
         }
@@ -6038,7 +6036,7 @@ WHERE (([f].[String] = @__ToString_0) AND ([f].[String] IS NOT NULL AND @__ToStr
 
 SELECT [f].[Id], [f].[String]
 FROM [Foos] AS [f]
-WHERE (([f].[String] = @__p_0) AND ([f].[String] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([f].[String] IS NULL AND @__p_0 IS NULL)");
+WHERE ([f].[String] = @__p_0) AND [f].[String] IS NOT NULL");
                 }
             }
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryFilterFuncletizationSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryFilterFuncletizationSqlServerTest.cs
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
 SELECT [f].[Id], [f].[IsEnabled]
 FROM [FieldFilter] AS [f]
-WHERE (([f].[IsEnabled] = @__ef_filter__Field_0) AND @__ef_filter__Field_0 IS NOT NULL) AND (([f].[IsEnabled] = @__Field_0) AND @__Field_0 IS NOT NULL)");
+WHERE ([f].[IsEnabled] = @__ef_filter__Field_0) AND ([f].[IsEnabled] = @__Field_0)");
         }
 
         public override void DbContext_field_is_parameterized()
@@ -40,13 +40,13 @@ WHERE (([f].[IsEnabled] = @__ef_filter__Field_0) AND @__ef_filter__Field_0 IS NO
 
 SELECT [f].[Id], [f].[IsEnabled]
 FROM [FieldFilter] AS [f]
-WHERE ([f].[IsEnabled] = @__ef_filter__Field_0) AND @__ef_filter__Field_0 IS NOT NULL",
+WHERE [f].[IsEnabled] = @__ef_filter__Field_0",
                 //
                 @"@__ef_filter__Field_0='True'
 
 SELECT [f].[Id], [f].[IsEnabled]
 FROM [FieldFilter] AS [f]
-WHERE ([f].[IsEnabled] = @__ef_filter__Field_0) AND @__ef_filter__Field_0 IS NOT NULL");
+WHERE [f].[IsEnabled] = @__ef_filter__Field_0");
         }
 
         public override void DbContext_property_is_parameterized()
@@ -58,13 +58,13 @@ WHERE ([f].[IsEnabled] = @__ef_filter__Field_0) AND @__ef_filter__Field_0 IS NOT
 
 SELECT [p].[Id], [p].[IsEnabled]
 FROM [PropertyFilter] AS [p]
-WHERE ([p].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL",
+WHERE [p].[IsEnabled] = @__ef_filter__Property_0",
                 //
                 @"@__ef_filter__Property_0='True'
 
 SELECT [p].[Id], [p].[IsEnabled]
 FROM [PropertyFilter] AS [p]
-WHERE ([p].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL");
+WHERE [p].[IsEnabled] = @__ef_filter__Property_0");
         }
 
         public override void DbContext_method_call_is_parameterized()
@@ -76,7 +76,7 @@ WHERE ([p].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 
 
 SELECT [m].[Id], [m].[Tenant]
 FROM [MethodCallFilter] AS [m]
-WHERE ([m].[Tenant] = @__ef_filter__p_0) AND @__ef_filter__p_0 IS NOT NULL");
+WHERE [m].[Tenant] = @__ef_filter__p_0");
         }
 
         public override void DbContext_list_is_parameterized()
@@ -106,13 +106,13 @@ WHERE [l].[Tenant] IN (2, 3)");
 
 SELECT [p].[Id], [p].[IsEnabled]
 FROM [PropertyChainFilter] AS [p]
-WHERE ([p].[IsEnabled] = @__ef_filter__Enabled_0) AND @__ef_filter__Enabled_0 IS NOT NULL",
+WHERE [p].[IsEnabled] = @__ef_filter__Enabled_0",
                 //
                 @"@__ef_filter__Enabled_0='True'
 
 SELECT [p].[Id], [p].[IsEnabled]
 FROM [PropertyChainFilter] AS [p]
-WHERE ([p].[IsEnabled] = @__ef_filter__Enabled_0) AND @__ef_filter__Enabled_0 IS NOT NULL");
+WHERE [p].[IsEnabled] = @__ef_filter__Enabled_0");
         }
 
         public override void DbContext_property_method_call_is_parameterized()
@@ -124,7 +124,7 @@ WHERE ([p].[IsEnabled] = @__ef_filter__Enabled_0) AND @__ef_filter__Enabled_0 IS
 
 SELECT [p].[Id], [p].[Tenant]
 FROM [PropertyMethodCallFilter] AS [p]
-WHERE ([p].[Tenant] = @__ef_filter__p_0) AND @__ef_filter__p_0 IS NOT NULL");
+WHERE [p].[Tenant] = @__ef_filter__p_0");
         }
 
         public override void DbContext_method_call_chain_is_parameterized()
@@ -136,7 +136,7 @@ WHERE ([p].[Tenant] = @__ef_filter__p_0) AND @__ef_filter__p_0 IS NOT NULL");
 
 SELECT [m].[Id], [m].[Tenant]
 FROM [MethodCallChainFilter] AS [m]
-WHERE ([m].[Tenant] = @__ef_filter__p_0) AND @__ef_filter__p_0 IS NOT NULL");
+WHERE [m].[Tenant] = @__ef_filter__p_0");
         }
 
         public override void DbContext_complex_expression_is_parameterized()
@@ -149,21 +149,21 @@ WHERE ([m].[Tenant] = @__ef_filter__p_0) AND @__ef_filter__p_0 IS NOT NULL");
 
 SELECT [c].[Id], [c].[IsEnabled]
 FROM [ComplexFilter] AS [c]
-WHERE (([c].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL) AND (@__ef_filter__p_1 = CAST(1 AS bit))",
+WHERE ([c].[IsEnabled] = @__ef_filter__Property_0) AND (@__ef_filter__p_1 = CAST(1 AS bit))",
                 //
                 @"@__ef_filter__Property_0='True'
 @__ef_filter__p_1='True'
 
 SELECT [c].[Id], [c].[IsEnabled]
 FROM [ComplexFilter] AS [c]
-WHERE (([c].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL) AND (@__ef_filter__p_1 = CAST(1 AS bit))",
+WHERE ([c].[IsEnabled] = @__ef_filter__Property_0) AND (@__ef_filter__p_1 = CAST(1 AS bit))",
                 //
                 @"@__ef_filter__Property_0='True'
 @__ef_filter__p_1='False'
 
 SELECT [c].[Id], [c].[IsEnabled]
 FROM [ComplexFilter] AS [c]
-WHERE (([c].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL) AND (@__ef_filter__p_1 = CAST(1 AS bit))");
+WHERE ([c].[IsEnabled] = @__ef_filter__Property_0) AND (@__ef_filter__p_1 = CAST(1 AS bit))");
         }
 
         public override void DbContext_property_based_filter_does_not_short_circuit()
@@ -176,21 +176,20 @@ WHERE (([c].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0
 
 SELECT [s].[Id], [s].[IsDeleted], [s].[IsModerated]
 FROM [ShortCircuitFilter] AS [s]
-WHERE ([s].[IsDeleted] <> CAST(1 AS bit)) AND ((@__ef_filter__p_0 = CAST(1 AS bit)) OR ((@__ef_filter__IsModerated_1 = [s].[IsModerated]) AND @__ef_filter__IsModerated_1 IS NOT NULL))",
+WHERE ([s].[IsDeleted] <> CAST(1 AS bit)) AND ((@__ef_filter__p_0 = CAST(1 AS bit)) OR (@__ef_filter__IsModerated_1 = [s].[IsModerated]))",
                 //
                 @"@__ef_filter__p_0='False'
 @__ef_filter__IsModerated_1='False' (Nullable = true)
 
 SELECT [s].[Id], [s].[IsDeleted], [s].[IsModerated]
 FROM [ShortCircuitFilter] AS [s]
-WHERE ([s].[IsDeleted] <> CAST(1 AS bit)) AND ((@__ef_filter__p_0 = CAST(1 AS bit)) OR ((@__ef_filter__IsModerated_1 = [s].[IsModerated]) AND @__ef_filter__IsModerated_1 IS NOT NULL))",
+WHERE ([s].[IsDeleted] <> CAST(1 AS bit)) AND ((@__ef_filter__p_0 = CAST(1 AS bit)) OR (@__ef_filter__IsModerated_1 = [s].[IsModerated]))",
                 //
                 @"@__ef_filter__p_0='True'
-@__ef_filter__IsModerated_1=NULL
 
 SELECT [s].[Id], [s].[IsDeleted], [s].[IsModerated]
 FROM [ShortCircuitFilter] AS [s]
-WHERE ([s].[IsDeleted] <> CAST(1 AS bit)) AND ((@__ef_filter__p_0 = CAST(1 AS bit)) OR ((@__ef_filter__IsModerated_1 = [s].[IsModerated]) AND @__ef_filter__IsModerated_1 IS NOT NULL))");
+WHERE ([s].[IsDeleted] <> CAST(1 AS bit)) AND (@__ef_filter__p_0 = CAST(1 AS bit))");
         }
 
         public override void EntityTypeConfiguration_DbContext_field_is_parameterized()
@@ -202,13 +201,13 @@ WHERE ([s].[IsDeleted] <> CAST(1 AS bit)) AND ((@__ef_filter__p_0 = CAST(1 AS bi
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [EntityTypeConfigurationFieldFilter] AS [e]
-WHERE ([e].[IsEnabled] = @__ef_filter__Field_0) AND @__ef_filter__Field_0 IS NOT NULL",
+WHERE [e].[IsEnabled] = @__ef_filter__Field_0",
                 //
                 @"@__ef_filter__Field_0='True'
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [EntityTypeConfigurationFieldFilter] AS [e]
-WHERE ([e].[IsEnabled] = @__ef_filter__Field_0) AND @__ef_filter__Field_0 IS NOT NULL");
+WHERE [e].[IsEnabled] = @__ef_filter__Field_0");
         }
 
         public override void EntityTypeConfiguration_DbContext_property_is_parameterized()
@@ -220,13 +219,13 @@ WHERE ([e].[IsEnabled] = @__ef_filter__Field_0) AND @__ef_filter__Field_0 IS NOT
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [EntityTypeConfigurationPropertyFilter] AS [e]
-WHERE ([e].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL",
+WHERE [e].[IsEnabled] = @__ef_filter__Property_0",
                 //
                 @"@__ef_filter__Property_0='True'
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [EntityTypeConfigurationPropertyFilter] AS [e]
-WHERE ([e].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL");
+WHERE [e].[IsEnabled] = @__ef_filter__Property_0");
         }
 
         public override void EntityTypeConfiguration_DbContext_method_call_is_parameterized()
@@ -238,7 +237,7 @@ WHERE ([e].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 
 
 SELECT [e].[Id], [e].[Tenant]
 FROM [EntityTypeConfigurationMethodCallFilter] AS [e]
-WHERE ([e].[Tenant] = @__ef_filter__p_0) AND @__ef_filter__p_0 IS NOT NULL");
+WHERE [e].[Tenant] = @__ef_filter__p_0");
         }
 
         public override void EntityTypeConfiguration_DbContext_property_chain_is_parameterized()
@@ -250,13 +249,13 @@ WHERE ([e].[Tenant] = @__ef_filter__p_0) AND @__ef_filter__p_0 IS NOT NULL");
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [EntityTypeConfigurationPropertyChainFilter] AS [e]
-WHERE ([e].[IsEnabled] = @__ef_filter__Enabled_0) AND @__ef_filter__Enabled_0 IS NOT NULL",
+WHERE [e].[IsEnabled] = @__ef_filter__Enabled_0",
                 //
                 @"@__ef_filter__Enabled_0='True'
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [EntityTypeConfigurationPropertyChainFilter] AS [e]
-WHERE ([e].[IsEnabled] = @__ef_filter__Enabled_0) AND @__ef_filter__Enabled_0 IS NOT NULL");
+WHERE [e].[IsEnabled] = @__ef_filter__Enabled_0");
         }
 
         public override void Local_method_DbContext_field_is_parameterized()
@@ -268,13 +267,13 @@ WHERE ([e].[IsEnabled] = @__ef_filter__Enabled_0) AND @__ef_filter__Enabled_0 IS
 
 SELECT [l].[Id], [l].[IsEnabled]
 FROM [LocalMethodFilter] AS [l]
-WHERE ([l].[IsEnabled] = @__ef_filter__Field_0) AND @__ef_filter__Field_0 IS NOT NULL",
+WHERE [l].[IsEnabled] = @__ef_filter__Field_0",
                 //
                 @"@__ef_filter__Field_0='True'
 
 SELECT [l].[Id], [l].[IsEnabled]
 FROM [LocalMethodFilter] AS [l]
-WHERE ([l].[IsEnabled] = @__ef_filter__Field_0) AND @__ef_filter__Field_0 IS NOT NULL");
+WHERE [l].[IsEnabled] = @__ef_filter__Field_0");
         }
 
         public override void Local_static_method_DbContext_property_is_parameterized()
@@ -286,13 +285,13 @@ WHERE ([l].[IsEnabled] = @__ef_filter__Field_0) AND @__ef_filter__Field_0 IS NOT
 
 SELECT [l].[Id], [l].[IsEnabled]
 FROM [LocalMethodParamsFilter] AS [l]
-WHERE ([l].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL",
+WHERE [l].[IsEnabled] = @__ef_filter__Property_0",
                 //
                 @"@__ef_filter__Property_0='True'
 
 SELECT [l].[Id], [l].[IsEnabled]
 FROM [LocalMethodParamsFilter] AS [l]
-WHERE ([l].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL");
+WHERE [l].[IsEnabled] = @__ef_filter__Property_0");
         }
 
         public override void Remote_method_DbContext_property_method_call_is_parameterized()
@@ -304,7 +303,7 @@ WHERE ([l].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 
 
 SELECT [r].[Id], [r].[Tenant]
 FROM [RemoteMethodParamsFilter] AS [r]
-WHERE ([r].[Tenant] = @__ef_filter__p_0) AND @__ef_filter__p_0 IS NOT NULL");
+WHERE [r].[Tenant] = @__ef_filter__p_0");
         }
 
         public override void Extension_method_DbContext_field_is_parameterized()
@@ -316,13 +315,13 @@ WHERE ([r].[Tenant] = @__ef_filter__p_0) AND @__ef_filter__p_0 IS NOT NULL");
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [ExtensionBuilderFilter] AS [e]
-WHERE ([e].[IsEnabled] = @__ef_filter__Field_0) AND @__ef_filter__Field_0 IS NOT NULL",
+WHERE [e].[IsEnabled] = @__ef_filter__Field_0",
                 //
                 @"@__ef_filter__Field_0='True'
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [ExtensionBuilderFilter] AS [e]
-WHERE ([e].[IsEnabled] = @__ef_filter__Field_0) AND @__ef_filter__Field_0 IS NOT NULL");
+WHERE [e].[IsEnabled] = @__ef_filter__Field_0");
         }
 
         public override void Extension_method_DbContext_property_chain_is_parameterized()
@@ -334,13 +333,13 @@ WHERE ([e].[IsEnabled] = @__ef_filter__Field_0) AND @__ef_filter__Field_0 IS NOT
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [ExtensionContextFilter] AS [e]
-WHERE ([e].[IsEnabled] = @__ef_filter__Enabled_0) AND @__ef_filter__Enabled_0 IS NOT NULL",
+WHERE [e].[IsEnabled] = @__ef_filter__Enabled_0",
                 //
                 @"@__ef_filter__Enabled_0='True'
 
 SELECT [e].[Id], [e].[IsEnabled]
 FROM [ExtensionContextFilter] AS [e]
-WHERE ([e].[IsEnabled] = @__ef_filter__Enabled_0) AND @__ef_filter__Enabled_0 IS NOT NULL");
+WHERE [e].[IsEnabled] = @__ef_filter__Enabled_0");
         }
 
         public override void Using_DbSet_in_filter_works()
@@ -358,7 +357,7 @@ WHERE EXISTS (
     WHERE EXISTS (
         SELECT 1
         FROM [MultiContextFilter] AS [m]
-        WHERE ((([m].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL) AND ([m].[BossId] = 1)) AND ([m].[BossId] = [d].[PrincipalSetFilterId])) AND ([d].[PrincipalSetFilterId] = [p].[Id]))");
+        WHERE (([m].[IsEnabled] = @__ef_filter__Property_0) AND ([m].[BossId] = 1)) AND ([m].[BossId] = [d].[PrincipalSetFilterId])) AND ([d].[PrincipalSetFilterId] = [p].[Id]))");
         }
 
         public override void Using_Context_set_method_in_filter_works()
@@ -373,7 +372,7 @@ FROM [Dependents] AS [d]
 WHERE EXISTS (
     SELECT 1
     FROM [MultiContextFilter] AS [m]
-    WHERE ((([m].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL) AND ([m].[BossId] = 1)) AND ([m].[BossId] = [d].[PrincipalSetFilterId]))");
+    WHERE (([m].[IsEnabled] = @__ef_filter__Property_0) AND ([m].[BossId] = 1)) AND ([m].[BossId] = [d].[PrincipalSetFilterId]))");
         }
 
         public override void Static_member_from_dbContext_is_inlined()
@@ -425,13 +424,13 @@ WHERE [p].[Tenant] = 0");
 
 SELECT [m].[Id], [m].[BossId], [m].[IsEnabled]
 FROM [MultiContextFilter] AS [m]
-WHERE (([m].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL) AND ([m].[BossId] = 1)",
+WHERE ([m].[IsEnabled] = @__ef_filter__Property_0) AND ([m].[BossId] = 1)",
                 //
                 @"@__ef_filter__Property_0='True'
 
 SELECT [m].[Id], [m].[BossId], [m].[IsEnabled]
 FROM [MultiContextFilter] AS [m]
-WHERE (([m].[IsEnabled] = @__ef_filter__Property_0) AND @__ef_filter__Property_0 IS NOT NULL) AND ([m].[BossId] = 1)");
+WHERE ([m].[IsEnabled] = @__ef_filter__Property_0) AND ([m].[BossId] = 1)");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Functions.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Functions.cs
@@ -1358,7 +1358,7 @@ WHERE [c].[CustomerID] = N'ANATR'");
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE (([o].[OrderDate] = @__arg_0) AND ([o].[OrderDate] IS NOT NULL AND @__arg_0 IS NOT NULL)) OR ([o].[OrderDate] IS NULL AND @__arg_0 IS NULL)");
+WHERE ([o].[OrderDate] = @__arg_0) AND [o].[OrderDate] IS NOT NULL");
         }
 
         public override async Task Static_equals_int_compared_to_long(bool isAsync)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.KeylessEntities.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.KeylessEntities.cs
@@ -58,7 +58,7 @@ SELECT [c].[CompanyName], (
     FROM [Orders] AS [o]
     WHERE ([c].[CustomerID] = [o].[CustomerID]) AND [o].[CustomerID] IS NOT NULL) AS [OrderCount], @__ef_filter___searchTerm_0 AS [SearchTerm]
 FROM [Customers] AS [c]
-WHERE (((@__ef_filter___searchTerm_1 = N'') AND @__ef_filter___searchTerm_1 IS NOT NULL) OR ([c].[CompanyName] IS NOT NULL AND (@__ef_filter___searchTerm_1 IS NOT NULL AND (((LEFT([c].[CompanyName], LEN(@__ef_filter___searchTerm_1)) = @__ef_filter___searchTerm_1) AND (LEFT([c].[CompanyName], LEN(@__ef_filter___searchTerm_1)) IS NOT NULL AND @__ef_filter___searchTerm_1 IS NOT NULL)) OR (LEFT([c].[CompanyName], LEN(@__ef_filter___searchTerm_1)) IS NULL AND @__ef_filter___searchTerm_1 IS NULL))))) AND ((
+WHERE ((@__ef_filter___searchTerm_1 = N'') OR ([c].[CompanyName] IS NOT NULL AND ((LEFT([c].[CompanyName], LEN(@__ef_filter___searchTerm_1)) = @__ef_filter___searchTerm_1) AND LEFT([c].[CompanyName], LEN(@__ef_filter___searchTerm_1)) IS NOT NULL))) AND ((
     SELECT COUNT(*)
     FROM [Orders] AS [o]
     WHERE ([c].[CustomerID] = [o].[CustomerID]) AND [o].[CustomerID] IS NOT NULL) > 0)");

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Where.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Where.cs
@@ -39,7 +39,7 @@ WHERE EXISTS (
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (([c].[City] = @__city_0) AND ([c].[City] IS NOT NULL AND @__city_0 IS NOT NULL)) OR ([c].[City] IS NULL AND @__city_0 IS NULL)");
+WHERE ([c].[City] = @__city_0) AND [c].[City] IS NOT NULL");
         }
 
         public override async Task Where_indexer_closure(bool isAsync)
@@ -51,7 +51,7 @@ WHERE (([c].[City] = @__city_0) AND ([c].[City] IS NOT NULL AND @__city_0 IS NOT
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (([c].[City] = @__p_0) AND ([c].[City] IS NOT NULL AND @__p_0 IS NOT NULL)) OR ([c].[City] IS NULL AND @__p_0 IS NULL)");
+WHERE ([c].[City] = @__p_0) AND [c].[City] IS NOT NULL");
         }
 
         public override async Task Where_dictionary_key_access_closure(bool isAsync)
@@ -63,7 +63,7 @@ WHERE (([c].[City] = @__p_0) AND ([c].[City] IS NOT NULL AND @__p_0 IS NOT NULL)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (([c].[City] = @__get_Item_0) AND ([c].[City] IS NOT NULL AND @__get_Item_0 IS NOT NULL)) OR ([c].[City] IS NULL AND @__get_Item_0 IS NULL)");
+WHERE ([c].[City] = @__get_Item_0) AND [c].[City] IS NOT NULL");
         }
 
         public override async Task Where_tuple_item_closure(bool isAsync)
@@ -75,7 +75,7 @@ WHERE (([c].[City] = @__get_Item_0) AND ([c].[City] IS NOT NULL AND @__get_Item_
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (([c].[City] = @__predicateTuple_Item2_0) AND ([c].[City] IS NOT NULL AND @__predicateTuple_Item2_0 IS NOT NULL)) OR ([c].[City] IS NULL AND @__predicateTuple_Item2_0 IS NULL)");
+WHERE ([c].[City] = @__predicateTuple_Item2_0) AND [c].[City] IS NOT NULL");
         }
 
         public override async Task Where_named_tuple_item_closure(bool isAsync)
@@ -87,7 +87,7 @@ WHERE (([c].[City] = @__predicateTuple_Item2_0) AND ([c].[City] IS NOT NULL AND 
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (([c].[City] = @__predicateTuple_Item2_0) AND ([c].[City] IS NOT NULL AND @__predicateTuple_Item2_0 IS NOT NULL)) OR ([c].[City] IS NULL AND @__predicateTuple_Item2_0 IS NULL)");
+WHERE ([c].[City] = @__predicateTuple_Item2_0) AND [c].[City] IS NOT NULL");
         }
 
         public override async Task Where_simple_closure_constant(bool isAsync)
@@ -111,13 +111,13 @@ WHERE @__predicate_0 = CAST(1 AS bit)");
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (([c].[City] = @__city_0) AND ([c].[City] IS NOT NULL AND @__city_0 IS NOT NULL)) OR ([c].[City] IS NULL AND @__city_0 IS NULL)",
+WHERE ([c].[City] = @__city_0) AND [c].[City] IS NOT NULL",
                 //
                 @"@__city_0='Seattle' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (([c].[City] = @__city_0) AND ([c].[City] IS NOT NULL AND @__city_0 IS NOT NULL)) OR ([c].[City] IS NULL AND @__city_0 IS NULL)");
+WHERE ([c].[City] = @__city_0) AND [c].[City] IS NOT NULL");
         }
 
         public override async Task Where_method_call_nullable_type_closure_via_query_cache(bool isAsync)
@@ -129,13 +129,13 @@ WHERE (([c].[City] = @__city_0) AND ([c].[City] IS NOT NULL AND @__city_0 IS NOT
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE ((CAST([e].[ReportsTo] AS bigint) = @__p_0) AND (CAST([e].[ReportsTo] AS bigint) IS NOT NULL AND @__p_0 IS NOT NULL)) OR (CAST([e].[ReportsTo] AS bigint) IS NULL AND @__p_0 IS NULL)",
+WHERE (CAST([e].[ReportsTo] AS bigint) = @__p_0) AND CAST([e].[ReportsTo] AS bigint) IS NOT NULL",
                 //
                 @"@__p_0='5' (Nullable = true)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE ((CAST([e].[ReportsTo] AS bigint) = @__p_0) AND (CAST([e].[ReportsTo] AS bigint) IS NOT NULL AND @__p_0 IS NOT NULL)) OR (CAST([e].[ReportsTo] AS bigint) IS NULL AND @__p_0 IS NULL)");
+WHERE (CAST([e].[ReportsTo] AS bigint) = @__p_0) AND CAST([e].[ReportsTo] AS bigint) IS NOT NULL");
         }
 
         public override async Task Where_method_call_nullable_type_reverse_closure_via_query_cache(bool isAsync)
@@ -165,13 +165,13 @@ WHERE CAST([e].[EmployeeID] AS bigint) > @__p_0");
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (([c].[City] = @__GetCity_0) AND ([c].[City] IS NOT NULL AND @__GetCity_0 IS NOT NULL)) OR ([c].[City] IS NULL AND @__GetCity_0 IS NULL)",
+WHERE ([c].[City] = @__GetCity_0) AND [c].[City] IS NOT NULL",
                 //
                 @"@__GetCity_0='Seattle' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (([c].[City] = @__GetCity_0) AND ([c].[City] IS NOT NULL AND @__GetCity_0 IS NOT NULL)) OR ([c].[City] IS NULL AND @__GetCity_0 IS NULL)");
+WHERE ([c].[City] = @__GetCity_0) AND [c].[City] IS NOT NULL");
         }
 
         public override async Task Where_field_access_closure_via_query_cache(bool isAsync)
@@ -183,13 +183,13 @@ WHERE (([c].[City] = @__GetCity_0) AND ([c].[City] IS NOT NULL AND @__GetCity_0 
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (([c].[City] = @__city_InstanceFieldValue_0) AND ([c].[City] IS NOT NULL AND @__city_InstanceFieldValue_0 IS NOT NULL)) OR ([c].[City] IS NULL AND @__city_InstanceFieldValue_0 IS NULL)",
+WHERE ([c].[City] = @__city_InstanceFieldValue_0) AND [c].[City] IS NOT NULL",
                 //
                 @"@__city_InstanceFieldValue_0='Seattle' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (([c].[City] = @__city_InstanceFieldValue_0) AND ([c].[City] IS NOT NULL AND @__city_InstanceFieldValue_0 IS NOT NULL)) OR ([c].[City] IS NULL AND @__city_InstanceFieldValue_0 IS NULL)");
+WHERE ([c].[City] = @__city_InstanceFieldValue_0) AND [c].[City] IS NOT NULL");
         }
 
         public override async Task Where_property_access_closure_via_query_cache(bool isAsync)
@@ -201,13 +201,13 @@ WHERE (([c].[City] = @__city_InstanceFieldValue_0) AND ([c].[City] IS NOT NULL A
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (([c].[City] = @__city_InstancePropertyValue_0) AND ([c].[City] IS NOT NULL AND @__city_InstancePropertyValue_0 IS NOT NULL)) OR ([c].[City] IS NULL AND @__city_InstancePropertyValue_0 IS NULL)",
+WHERE ([c].[City] = @__city_InstancePropertyValue_0) AND [c].[City] IS NOT NULL",
                 //
                 @"@__city_InstancePropertyValue_0='Seattle' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (([c].[City] = @__city_InstancePropertyValue_0) AND ([c].[City] IS NOT NULL AND @__city_InstancePropertyValue_0 IS NOT NULL)) OR ([c].[City] IS NULL AND @__city_InstancePropertyValue_0 IS NULL)");
+WHERE ([c].[City] = @__city_InstancePropertyValue_0) AND [c].[City] IS NOT NULL");
         }
 
         public override async Task Where_static_field_access_closure_via_query_cache(bool isAsync)
@@ -219,13 +219,13 @@ WHERE (([c].[City] = @__city_InstancePropertyValue_0) AND ([c].[City] IS NOT NUL
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (([c].[City] = @__StaticFieldValue_0) AND ([c].[City] IS NOT NULL AND @__StaticFieldValue_0 IS NOT NULL)) OR ([c].[City] IS NULL AND @__StaticFieldValue_0 IS NULL)",
+WHERE ([c].[City] = @__StaticFieldValue_0) AND [c].[City] IS NOT NULL",
                 //
                 @"@__StaticFieldValue_0='Seattle' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (([c].[City] = @__StaticFieldValue_0) AND ([c].[City] IS NOT NULL AND @__StaticFieldValue_0 IS NOT NULL)) OR ([c].[City] IS NULL AND @__StaticFieldValue_0 IS NULL)");
+WHERE ([c].[City] = @__StaticFieldValue_0) AND [c].[City] IS NOT NULL");
         }
 
         public override async Task Where_static_property_access_closure_via_query_cache(bool isAsync)
@@ -237,13 +237,13 @@ WHERE (([c].[City] = @__StaticFieldValue_0) AND ([c].[City] IS NOT NULL AND @__S
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (([c].[City] = @__StaticPropertyValue_0) AND ([c].[City] IS NOT NULL AND @__StaticPropertyValue_0 IS NOT NULL)) OR ([c].[City] IS NULL AND @__StaticPropertyValue_0 IS NULL)",
+WHERE ([c].[City] = @__StaticPropertyValue_0) AND [c].[City] IS NOT NULL",
                 //
                 @"@__StaticPropertyValue_0='Seattle' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (([c].[City] = @__StaticPropertyValue_0) AND ([c].[City] IS NOT NULL AND @__StaticPropertyValue_0 IS NOT NULL)) OR ([c].[City] IS NULL AND @__StaticPropertyValue_0 IS NULL)");
+WHERE ([c].[City] = @__StaticPropertyValue_0) AND [c].[City] IS NOT NULL");
         }
 
         public override async Task Where_nested_field_access_closure_via_query_cache(bool isAsync)
@@ -255,13 +255,13 @@ WHERE (([c].[City] = @__StaticPropertyValue_0) AND ([c].[City] IS NOT NULL AND @
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (([c].[City] = @__city_Nested_InstanceFieldValue_0) AND ([c].[City] IS NOT NULL AND @__city_Nested_InstanceFieldValue_0 IS NOT NULL)) OR ([c].[City] IS NULL AND @__city_Nested_InstanceFieldValue_0 IS NULL)",
+WHERE ([c].[City] = @__city_Nested_InstanceFieldValue_0) AND [c].[City] IS NOT NULL",
                 //
                 @"@__city_Nested_InstanceFieldValue_0='Seattle' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (([c].[City] = @__city_Nested_InstanceFieldValue_0) AND ([c].[City] IS NOT NULL AND @__city_Nested_InstanceFieldValue_0 IS NOT NULL)) OR ([c].[City] IS NULL AND @__city_Nested_InstanceFieldValue_0 IS NULL)");
+WHERE ([c].[City] = @__city_Nested_InstanceFieldValue_0) AND [c].[City] IS NOT NULL");
         }
 
         public override async Task Where_nested_property_access_closure_via_query_cache(bool isAsync)
@@ -273,13 +273,13 @@ WHERE (([c].[City] = @__city_Nested_InstanceFieldValue_0) AND ([c].[City] IS NOT
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (([c].[City] = @__city_Nested_InstancePropertyValue_0) AND ([c].[City] IS NOT NULL AND @__city_Nested_InstancePropertyValue_0 IS NOT NULL)) OR ([c].[City] IS NULL AND @__city_Nested_InstancePropertyValue_0 IS NULL)",
+WHERE ([c].[City] = @__city_Nested_InstancePropertyValue_0) AND [c].[City] IS NOT NULL",
                 //
                 @"@__city_Nested_InstancePropertyValue_0='Seattle' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (([c].[City] = @__city_Nested_InstancePropertyValue_0) AND ([c].[City] IS NOT NULL AND @__city_Nested_InstancePropertyValue_0 IS NOT NULL)) OR ([c].[City] IS NULL AND @__city_Nested_InstancePropertyValue_0 IS NULL)");
+WHERE ([c].[City] = @__city_Nested_InstancePropertyValue_0) AND [c].[City] IS NOT NULL");
         }
 
         public override async Task Where_new_instance_field_access_query_cache(bool isAsync)
@@ -291,13 +291,13 @@ WHERE (([c].[City] = @__city_Nested_InstancePropertyValue_0) AND ([c].[City] IS 
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (([c].[City] = @__InstanceFieldValue_0) AND ([c].[City] IS NOT NULL AND @__InstanceFieldValue_0 IS NOT NULL)) OR ([c].[City] IS NULL AND @__InstanceFieldValue_0 IS NULL)",
+WHERE ([c].[City] = @__InstanceFieldValue_0) AND [c].[City] IS NOT NULL",
                 //
                 @"@__InstanceFieldValue_0='Seattle' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (([c].[City] = @__InstanceFieldValue_0) AND ([c].[City] IS NOT NULL AND @__InstanceFieldValue_0 IS NOT NULL)) OR ([c].[City] IS NULL AND @__InstanceFieldValue_0 IS NULL)");
+WHERE ([c].[City] = @__InstanceFieldValue_0) AND [c].[City] IS NOT NULL");
         }
 
         public override async Task Where_new_instance_field_access_closure_via_query_cache(bool isAsync)
@@ -309,13 +309,13 @@ WHERE (([c].[City] = @__InstanceFieldValue_0) AND ([c].[City] IS NOT NULL AND @_
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (([c].[City] = @__InstanceFieldValue_0) AND ([c].[City] IS NOT NULL AND @__InstanceFieldValue_0 IS NOT NULL)) OR ([c].[City] IS NULL AND @__InstanceFieldValue_0 IS NULL)",
+WHERE ([c].[City] = @__InstanceFieldValue_0) AND [c].[City] IS NOT NULL",
                 //
                 @"@__InstanceFieldValue_0='Seattle' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (([c].[City] = @__InstanceFieldValue_0) AND ([c].[City] IS NOT NULL AND @__InstanceFieldValue_0 IS NOT NULL)) OR ([c].[City] IS NULL AND @__InstanceFieldValue_0 IS NULL)");
+WHERE ([c].[City] = @__InstanceFieldValue_0) AND [c].[City] IS NOT NULL");
         }
 
         public override async Task Where_simple_closure_via_query_cache_nullable_type(bool isAsync)
@@ -327,19 +327,17 @@ WHERE (([c].[City] = @__InstanceFieldValue_0) AND ([c].[City] IS NOT NULL AND @_
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE ((CAST([e].[ReportsTo] AS bigint) = @__p_0) AND (CAST([e].[ReportsTo] AS bigint) IS NOT NULL AND @__p_0 IS NOT NULL)) OR (CAST([e].[ReportsTo] AS bigint) IS NULL AND @__p_0 IS NULL)",
+WHERE (CAST([e].[ReportsTo] AS bigint) = @__p_0) AND CAST([e].[ReportsTo] AS bigint) IS NOT NULL",
                 //
                 @"@__p_0='5' (Nullable = true)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE ((CAST([e].[ReportsTo] AS bigint) = @__p_0) AND (CAST([e].[ReportsTo] AS bigint) IS NOT NULL AND @__p_0 IS NOT NULL)) OR (CAST([e].[ReportsTo] AS bigint) IS NULL AND @__p_0 IS NULL)",
+WHERE (CAST([e].[ReportsTo] AS bigint) = @__p_0) AND CAST([e].[ReportsTo] AS bigint) IS NOT NULL",
                 //
-                @"@__p_0=NULL (DbType = Int64)
-
-SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+                @"SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE ((CAST([e].[ReportsTo] AS bigint) = @__p_0) AND (CAST([e].[ReportsTo] AS bigint) IS NOT NULL AND @__p_0 IS NOT NULL)) OR (CAST([e].[ReportsTo] AS bigint) IS NULL AND @__p_0 IS NULL)");
+WHERE CAST([e].[ReportsTo] AS bigint) IS NULL");
         }
 
         public override async Task Where_simple_closure_via_query_cache_nullable_type_reverse(bool isAsync)
@@ -347,23 +345,21 @@ WHERE ((CAST([e].[ReportsTo] AS bigint) = @__p_0) AND (CAST([e].[ReportsTo] AS b
             await base.Where_simple_closure_via_query_cache_nullable_type_reverse(isAsync);
 
             AssertSql(
-                @"@__p_0=NULL (DbType = Int64)
-
-SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+                @"SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE ((CAST([e].[ReportsTo] AS bigint) = @__p_0) AND (CAST([e].[ReportsTo] AS bigint) IS NOT NULL AND @__p_0 IS NOT NULL)) OR (CAST([e].[ReportsTo] AS bigint) IS NULL AND @__p_0 IS NULL)",
+WHERE CAST([e].[ReportsTo] AS bigint) IS NULL",
                 //
                 @"@__p_0='5' (Nullable = true)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE ((CAST([e].[ReportsTo] AS bigint) = @__p_0) AND (CAST([e].[ReportsTo] AS bigint) IS NOT NULL AND @__p_0 IS NOT NULL)) OR (CAST([e].[ReportsTo] AS bigint) IS NULL AND @__p_0 IS NULL)",
+WHERE (CAST([e].[ReportsTo] AS bigint) = @__p_0) AND CAST([e].[ReportsTo] AS bigint) IS NOT NULL",
                 //
                 @"@__p_0='2' (Nullable = true)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE ((CAST([e].[ReportsTo] AS bigint) = @__p_0) AND (CAST([e].[ReportsTo] AS bigint) IS NOT NULL AND @__p_0 IS NOT NULL)) OR (CAST([e].[ReportsTo] AS bigint) IS NULL AND @__p_0 IS NULL)");
+WHERE (CAST([e].[ReportsTo] AS bigint) = @__p_0) AND CAST([e].[ReportsTo] AS bigint) IS NOT NULL");
         }
 
         public override void Where_subquery_closure_via_query_cache()
@@ -378,7 +374,7 @@ FROM [Customers] AS [c]
 WHERE EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE ((([o].[CustomerID] = @__customerID_0) AND ([o].[CustomerID] IS NOT NULL AND @__customerID_0 IS NOT NULL)) OR ([o].[CustomerID] IS NULL AND @__customerID_0 IS NULL)) AND (([o].[CustomerID] = [c].[CustomerID]) AND [o].[CustomerID] IS NOT NULL))",
+    WHERE (([o].[CustomerID] = @__customerID_0) AND [o].[CustomerID] IS NOT NULL) AND (([o].[CustomerID] = [c].[CustomerID]) AND [o].[CustomerID] IS NOT NULL))",
                 //
                 @"@__customerID_0='ANATR' (Size = 5)
 
@@ -387,7 +383,7 @@ FROM [Customers] AS [c]
 WHERE EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE ((([o].[CustomerID] = @__customerID_0) AND ([o].[CustomerID] IS NOT NULL AND @__customerID_0 IS NOT NULL)) OR ([o].[CustomerID] IS NULL AND @__customerID_0 IS NULL)) AND (([o].[CustomerID] = [c].[CustomerID]) AND [o].[CustomerID] IS NOT NULL))");
+    WHERE (([o].[CustomerID] = @__customerID_0) AND [o].[CustomerID] IS NOT NULL) AND (([o].[CustomerID] = [c].[CustomerID]) AND [o].[CustomerID] IS NOT NULL))");
         }
 
         public override async Task Where_bitwise_or(bool isAsync)
@@ -523,7 +519,7 @@ WHERE CAST(0 AS bit) = CAST(1 AS bit)");
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE ([e].[EmployeeID] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [e].[EmployeeID] = @__p_0");
         }
 
         public override async Task Where_equals_on_mismatched_types_nullable_int_long(bool isAsync)
@@ -583,13 +579,13 @@ WHERE CAST(0 AS bit) = CAST(1 AS bit)");
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE (([e].[ReportsTo] = @__intPrm_0) AND ([e].[ReportsTo] IS NOT NULL AND @__intPrm_0 IS NOT NULL)) OR ([e].[ReportsTo] IS NULL AND @__intPrm_0 IS NULL)",
+WHERE ([e].[ReportsTo] = @__intPrm_0) AND [e].[ReportsTo] IS NOT NULL",
                 //
                 @"@__intPrm_0='2'
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE ((@__intPrm_0 = [e].[ReportsTo]) AND (@__intPrm_0 IS NOT NULL AND [e].[ReportsTo] IS NOT NULL)) OR (@__intPrm_0 IS NULL AND [e].[ReportsTo] IS NULL)");
+WHERE (@__intPrm_0 = [e].[ReportsTo]) AND [e].[ReportsTo] IS NOT NULL");
         }
 
         public override async Task Where_equals_on_matched_nullable_int_types(bool isAsync)
@@ -601,13 +597,13 @@ WHERE ((@__intPrm_0 = [e].[ReportsTo]) AND (@__intPrm_0 IS NOT NULL AND [e].[Rep
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE ((@__nullableIntPrm_0 = [e].[ReportsTo]) AND (@__nullableIntPrm_0 IS NOT NULL AND [e].[ReportsTo] IS NOT NULL)) OR (@__nullableIntPrm_0 IS NULL AND [e].[ReportsTo] IS NULL)",
+WHERE (@__nullableIntPrm_0 = [e].[ReportsTo]) AND [e].[ReportsTo] IS NOT NULL",
                 //
                 @"@__nullableIntPrm_0='2' (Nullable = true)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE (([e].[ReportsTo] = @__nullableIntPrm_0) AND ([e].[ReportsTo] IS NOT NULL AND @__nullableIntPrm_0 IS NOT NULL)) OR ([e].[ReportsTo] IS NULL AND @__nullableIntPrm_0 IS NULL)");
+WHERE ([e].[ReportsTo] = @__nullableIntPrm_0) AND [e].[ReportsTo] IS NOT NULL");
         }
 
         public override async Task Where_equals_on_null_nullable_int_types(bool isAsync)
@@ -615,17 +611,13 @@ WHERE (([e].[ReportsTo] = @__nullableIntPrm_0) AND ([e].[ReportsTo] IS NOT NULL 
             await base.Where_equals_on_null_nullable_int_types(isAsync);
 
             AssertSql(
-                @"@__nullableIntPrm_0=NULL (DbType = Int32)
-
-SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+                @"SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE ((@__nullableIntPrm_0 = [e].[ReportsTo]) AND (@__nullableIntPrm_0 IS NOT NULL AND [e].[ReportsTo] IS NOT NULL)) OR (@__nullableIntPrm_0 IS NULL AND [e].[ReportsTo] IS NULL)",
+WHERE [e].[ReportsTo] IS NULL",
                 //
-                @"@__nullableIntPrm_0=NULL (DbType = Int64)
-
-SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+                @"SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE (([e].[ReportsTo] = @__nullableIntPrm_0) AND ([e].[ReportsTo] IS NOT NULL AND @__nullableIntPrm_0 IS NOT NULL)) OR ([e].[ReportsTo] IS NULL AND @__nullableIntPrm_0 IS NULL)");
+WHERE [e].[ReportsTo] IS NULL");
         }
 
         public override async Task Where_comparison_nullable_type_not_null(bool isAsync)
@@ -739,7 +731,7 @@ WHERE CONVERT(date, GETDATE()) = CONVERT(date, GETDATE())");
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE ((CONVERT(date, [o].[OrderDate]) = @__myDatetime_0) AND (CONVERT(date, [o].[OrderDate]) IS NOT NULL AND @__myDatetime_0 IS NOT NULL)) OR (CONVERT(date, [o].[OrderDate]) IS NULL AND @__myDatetime_0 IS NULL)");
+WHERE (CONVERT(date, [o].[OrderDate]) = @__myDatetime_0) AND CONVERT(date, [o].[OrderDate]) IS NOT NULL");
         }
 
         public override async Task Where_date_add_year_constant_component(bool isAsync)
@@ -1167,10 +1159,10 @@ WHERE @__prm_0 = CAST(1 AS bit)");
 
 SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
 FROM [Products] AS [p]
-WHERE (CASE
+WHERE CASE
     WHEN [p].[ProductID] > 50 THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
-END <> @__prm_0) OR @__prm_0 IS NULL");
+END <> @__prm_0");
         }
 
         public override async Task Where_bool_member_and_parameter_compared_to_binary_expression_nested(bool isAsync)
@@ -1183,10 +1175,10 @@ END <> @__prm_0) OR @__prm_0 IS NULL");
 SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
 FROM [Products] AS [p]
 WHERE [p].[Discontinued] = CASE
-    WHEN (CASE
+    WHEN CASE
         WHEN [p].[ProductID] > 50 THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
-    END <> @__prm_0) OR @__prm_0 IS NULL THEN CAST(1 AS bit)
+    END <> @__prm_0 THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END");
         }
@@ -1588,7 +1580,7 @@ WHERE [o0].[OrderID] IN (10643, 10692, 10702, 10835, 10952, 11011)");
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ([c].[CustomerID] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [c].[CustomerID] = @__p_0");
         }
 
         public override async Task Where_multiple_contains_in_subquery_with_or(bool isAsync)
@@ -1722,13 +1714,13 @@ END = CAST(1 AS bit)");
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE ([o].[OrderID] = @__SettableProperty_0) AND @__SettableProperty_0 IS NOT NULL",
+WHERE [o].[OrderID] = @__SettableProperty_0",
                 //
                 @"@__SettableProperty_0='10'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE ([o].[OrderID] = @__SettableProperty_0) AND @__SettableProperty_0 IS NOT NULL");
+WHERE [o].[OrderID] = @__SettableProperty_0");
         }
 
         public override async Task Enclosing_class_readonly_member_generates_parameter(bool isAsync)
@@ -1740,7 +1732,7 @@ WHERE ([o].[OrderID] = @__SettableProperty_0) AND @__SettableProperty_0 IS NOT N
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE ([o].[OrderID] = @__ReadOnlyProperty_0) AND @__ReadOnlyProperty_0 IS NOT NULL");
+WHERE [o].[OrderID] = @__ReadOnlyProperty_0");
         }
 
         public override async Task Enclosing_class_const_member_does_not_generate_parameter(bool isAsync)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -142,7 +142,7 @@ ORDER BY [t0].[CustomerID]");
 
 SELECT TOP(2) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ([c].[CustomerID] = @__p_0) AND @__p_0 IS NOT NULL");
+WHERE [c].[CustomerID] = @__p_0");
         }
 
         public override async Task Entity_equality_self(bool isAsync)
@@ -164,7 +164,7 @@ WHERE [c].[CustomerID] = [c].[CustomerID]");
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE ([c].[CustomerID] = @__entity_equality_local_0_CustomerID) AND @__entity_equality_local_0_CustomerID IS NOT NULL");
+WHERE [c].[CustomerID] = @__entity_equality_local_0_CustomerID");
         }
 
         public override async Task Entity_equality_local_composite_key(bool isAsync)
@@ -177,7 +177,7 @@ WHERE ([c].[CustomerID] = @__entity_equality_local_0_CustomerID) AND @__entity_e
 
 SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
 FROM [Order Details] AS [o]
-WHERE (([o].[OrderID] = @__entity_equality_local_0_OrderID) AND @__entity_equality_local_0_OrderID IS NOT NULL) AND (([o].[ProductID] = @__entity_equality_local_0_ProductID) AND @__entity_equality_local_0_ProductID IS NOT NULL)");
+WHERE ([o].[OrderID] = @__entity_equality_local_0_OrderID) AND ([o].[ProductID] = @__entity_equality_local_0_ProductID)");
         }
 
         public override async Task Entity_equality_local_double_check(bool isAsync)
@@ -189,7 +189,7 @@ WHERE (([o].[OrderID] = @__entity_equality_local_0_OrderID) AND @__entity_equali
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE (([c].[CustomerID] = @__entity_equality_local_0_CustomerID) AND @__entity_equality_local_0_CustomerID IS NOT NULL) AND ((@__entity_equality_local_0_CustomerID = [c].[CustomerID]) AND @__entity_equality_local_0_CustomerID IS NOT NULL)");
+WHERE ([c].[CustomerID] = @__entity_equality_local_0_CustomerID) AND (@__entity_equality_local_0_CustomerID = [c].[CustomerID])");
         }
 
         public override async Task Join_with_entity_equality_local_on_both_sources(bool isAsync)
@@ -204,9 +204,9 @@ FROM [Customers] AS [c]
 INNER JOIN (
     SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
     FROM [Customers] AS [c0]
-    WHERE ([c0].[CustomerID] = @__entity_equality_local_0_CustomerID) AND @__entity_equality_local_0_CustomerID IS NOT NULL
+    WHERE [c0].[CustomerID] = @__entity_equality_local_0_CustomerID
 ) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
-WHERE ([c].[CustomerID] = @__entity_equality_local_0_CustomerID) AND @__entity_equality_local_0_CustomerID IS NOT NULL");
+WHERE [c].[CustomerID] = @__entity_equality_local_0_CustomerID");
         }
 
         public override async Task Entity_equality_local_inline(bool isAsync)
@@ -1622,7 +1622,7 @@ WHERE (((([c].[City] = N'London') AND [c].[City] IS NOT NULL) OR (([c].[City] = 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Customers] AS [c]
 CROSS JOIN [Employees] AS [e]
-WHERE ((((([c].[City] = @__london_0) AND ([c].[City] IS NOT NULL AND @__london_0 IS NOT NULL)) OR ([c].[City] IS NULL AND @__london_0 IS NULL)) OR (([c].[City] = N'Berlin') AND [c].[City] IS NOT NULL)) OR (([c].[City] = N'Seattle') AND [c].[City] IS NOT NULL)) OR ((([c].[City] = @__lisboa_1) AND ([c].[City] IS NOT NULL AND @__lisboa_1 IS NOT NULL)) OR ([c].[City] IS NULL AND @__lisboa_1 IS NULL))");
+WHERE (((([c].[City] = @__london_0) AND [c].[City] IS NOT NULL) OR (([c].[City] = N'Berlin') AND [c].[City] IS NOT NULL)) OR (([c].[City] = N'Seattle') AND [c].[City] IS NOT NULL)) OR (([c].[City] = @__lisboa_1) AND [c].[City] IS NOT NULL)");
         }
 
         public override async Task SelectMany_simple_subquery(bool isAsync)
@@ -2806,7 +2806,7 @@ WHERE [o].[OrderDate] > @__p_0");
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ((@__NewLine_0 = N'') AND @__NewLine_0 IS NOT NULL) OR (CHARINDEX(@__NewLine_0, [c].[CustomerID]) > 0)");
+WHERE (@__NewLine_0 = N'') OR (CHARINDEX(@__NewLine_0, [c].[CustomerID]) > 0)");
         }
 
         public override async Task String_concat_with_navigation1(bool isAsync)
@@ -3023,7 +3023,7 @@ ORDER BY [c].[CustomerID]");
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE ([o].[OrderID] < 10400) AND (([o].[OrderDate] IS NOT NULL AND (((DATEPART(month, [o].[OrderDate]) = @__dateFilter_Value_Month_0) AND (DATEPART(month, [o].[OrderDate]) IS NOT NULL AND @__dateFilter_Value_Month_0 IS NOT NULL)) OR (DATEPART(month, [o].[OrderDate]) IS NULL AND @__dateFilter_Value_Month_0 IS NULL))) AND (((DATEPART(year, [o].[OrderDate]) = @__dateFilter_Value_Year_1) AND (DATEPART(year, [o].[OrderDate]) IS NOT NULL AND @__dateFilter_Value_Year_1 IS NOT NULL)) OR (DATEPART(year, [o].[OrderDate]) IS NULL AND @__dateFilter_Value_Year_1 IS NULL)))",
+WHERE ([o].[OrderID] < 10400) AND (([o].[OrderDate] IS NOT NULL AND ((DATEPART(month, [o].[OrderDate]) = @__dateFilter_Value_Month_0) AND DATEPART(month, [o].[OrderDate]) IS NOT NULL)) AND ((DATEPART(year, [o].[OrderDate]) = @__dateFilter_Value_Year_1) AND DATEPART(year, [o].[OrderDate]) IS NOT NULL))",
                 //
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
@@ -3040,7 +3040,7 @@ WHERE [o].[OrderID] < 10400");
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE ([o].[OrderID] < 10400) AND (([o].[OrderDate] IS NOT NULL AND (((DATEPART(month, [o].[OrderDate]) = @__dateFilter_Value_Month_0) AND (DATEPART(month, [o].[OrderDate]) IS NOT NULL AND @__dateFilter_Value_Month_0 IS NOT NULL)) OR (DATEPART(month, [o].[OrderDate]) IS NULL AND @__dateFilter_Value_Month_0 IS NULL))) AND (((DATEPART(year, [o].[OrderDate]) = @__dateFilter_Value_Year_1) AND (DATEPART(year, [o].[OrderDate]) IS NOT NULL AND @__dateFilter_Value_Year_1 IS NOT NULL)) OR (DATEPART(year, [o].[OrderDate]) IS NULL AND @__dateFilter_Value_Year_1 IS NULL)))",
+WHERE ([o].[OrderID] < 10400) AND (([o].[OrderDate] IS NOT NULL AND ((DATEPART(month, [o].[OrderDate]) = @__dateFilter_Value_Month_0) AND DATEPART(month, [o].[OrderDate]) IS NOT NULL)) AND ((DATEPART(year, [o].[OrderDate]) = @__dateFilter_Value_Year_1) AND DATEPART(year, [o].[OrderDate]) IS NOT NULL))",
                 //
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
@@ -3057,7 +3057,7 @@ WHERE CAST(0 AS bit) = CAST(1 AS bit)");
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE ([o].[OrderID] < 10400) OR (([o].[OrderDate] IS NOT NULL AND (((DATEPART(month, [o].[OrderDate]) = @__dateFilter_Value_Month_0) AND (DATEPART(month, [o].[OrderDate]) IS NOT NULL AND @__dateFilter_Value_Month_0 IS NOT NULL)) OR (DATEPART(month, [o].[OrderDate]) IS NULL AND @__dateFilter_Value_Month_0 IS NULL))) AND (((DATEPART(year, [o].[OrderDate]) = @__dateFilter_Value_Year_1) AND (DATEPART(year, [o].[OrderDate]) IS NOT NULL AND @__dateFilter_Value_Year_1 IS NOT NULL)) OR (DATEPART(year, [o].[OrderDate]) IS NULL AND @__dateFilter_Value_Year_1 IS NULL)))",
+WHERE ([o].[OrderID] < 10400) OR (([o].[OrderDate] IS NOT NULL AND ((DATEPART(month, [o].[OrderDate]) = @__dateFilter_Value_Month_0) AND DATEPART(month, [o].[OrderDate]) IS NOT NULL)) AND ((DATEPART(year, [o].[OrderDate]) = @__dateFilter_Value_Year_1) AND DATEPART(year, [o].[OrderDate]) IS NOT NULL))",
                 //
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]");
@@ -4244,7 +4244,7 @@ FROM (
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE ((@__prefix_0 = N'') AND @__prefix_0 IS NOT NULL) OR (@__prefix_0 IS NOT NULL AND (((LEFT([c].[CustomerID], LEN(@__prefix_0)) = @__prefix_0) AND (LEFT([c].[CustomerID], LEN(@__prefix_0)) IS NOT NULL AND @__prefix_0 IS NOT NULL)) OR (LEFT([c].[CustomerID], LEN(@__prefix_0)) IS NULL AND @__prefix_0 IS NULL)))");
+WHERE (@__prefix_0 = N'') OR ((LEFT([c].[CustomerID], LEN(@__prefix_0)) = @__prefix_0) AND LEFT([c].[CustomerID], LEN(@__prefix_0)) IS NOT NULL)");
         }
 
         public override async Task Comparing_entities_using_Equals(bool isAsync)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/UdfDbFunctionSqlServerTests.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/UdfDbFunctionSqlServerTests.cs
@@ -40,7 +40,7 @@ WHERE (IsDate([c].[FirstName]) = CAST(0 AS bit)) AND IsDate([c].[FirstName]) IS 
 
 SELECT TOP(2) len([c].[LastName])
 FROM [Customers] AS [c]
-WHERE ([c].[Id] = @__customerId_0) AND @__customerId_0 IS NOT NULL");
+WHERE [c].[Id] = @__customerId_0");
         }
 
         public override void Scalar_Function_Constant_Parameter_Static()
@@ -83,7 +83,7 @@ WHERE [c].[Id] = 1");
 
 SELECT TOP(2) [c].[LastName], [dbo].[CustomerOrderCount](@__customerId_0) AS [OrderCount]
 FROM [Customers] AS [c]
-WHERE ([c].[Id] = @__customerId_0) AND @__customerId_0 IS NOT NULL");
+WHERE [c].[Id] = @__customerId_0");
         }
 
         public override void Scalar_Function_Anonymous_Type_Select_Nested_Static()
@@ -96,7 +96,7 @@ WHERE ([c].[Id] = @__customerId_0) AND @__customerId_0 IS NOT NULL");
 
 SELECT TOP(2) [c].[LastName], [dbo].[StarValue](@__starCount_1, [dbo].[CustomerOrderCount](@__customerId_0)) AS [OrderCount]
 FROM [Customers] AS [c]
-WHERE ([c].[Id] = @__customerId_0) AND @__customerId_0 IS NOT NULL");
+WHERE [c].[Id] = @__customerId_0");
         }
 
         public override void Scalar_Function_Where_Correlated_Static()
@@ -172,7 +172,7 @@ WHERE [c].[Id] = 2");
 
 SELECT TOP(2) [c].[LastName], [dbo].[CustomerOrderCount](@__customerId_0) AS [OrderCount]
 FROM [Customers] AS [c]
-WHERE ([c].[Id] = @__customerId_0) AND @__customerId_0 IS NOT NULL");
+WHERE [c].[Id] = @__customerId_0");
         }
 
         public override void Scalar_Function_Let_Nested_Static()
@@ -185,7 +185,7 @@ WHERE ([c].[Id] = @__customerId_0) AND @__customerId_0 IS NOT NULL");
 
 SELECT TOP(2) [c].[LastName], [dbo].[StarValue](@__starCount_0, [dbo].[CustomerOrderCount](@__customerId_1)) AS [OrderCount]
 FROM [Customers] AS [c]
-WHERE ([c].[Id] = @__customerId_1) AND @__customerId_1 IS NOT NULL");
+WHERE [c].[Id] = @__customerId_1");
         }
 
         public override void Scalar_Nested_Function_Unwind_Client_Eval_Select_Static()
@@ -262,7 +262,7 @@ WHERE (IsDate([c].[FirstName]) = CAST(0 AS bit)) AND IsDate([c].[FirstName]) IS 
 
 SELECT TOP(2) len([c].[LastName])
 FROM [Customers] AS [c]
-WHERE ([c].[Id] = @__customerId_0) AND @__customerId_0 IS NOT NULL");
+WHERE [c].[Id] = @__customerId_0");
         }
 
         public override void Scalar_Function_Constant_Parameter_Instance()
@@ -305,7 +305,7 @@ WHERE [c].[Id] = 1");
 
 SELECT TOP(2) [c].[LastName], [dbo].[CustomerOrderCount](@__customerId_0) AS [OrderCount]
 FROM [Customers] AS [c]
-WHERE ([c].[Id] = @__customerId_0) AND @__customerId_0 IS NOT NULL");
+WHERE [c].[Id] = @__customerId_0");
         }
 
         public override void Scalar_Function_Anonymous_Type_Select_Nested_Instance()
@@ -318,7 +318,7 @@ WHERE ([c].[Id] = @__customerId_0) AND @__customerId_0 IS NOT NULL");
 
 SELECT TOP(2) [c].[LastName], [dbo].[StarValue](@__starCount_2, [dbo].[CustomerOrderCount](@__customerId_0)) AS [OrderCount]
 FROM [Customers] AS [c]
-WHERE ([c].[Id] = @__customerId_0) AND @__customerId_0 IS NOT NULL");
+WHERE [c].[Id] = @__customerId_0");
         }
 
         public override void Scalar_Function_Where_Correlated_Instance()
@@ -394,7 +394,7 @@ WHERE [c].[Id] = 2");
 
 SELECT TOP(2) [c].[LastName], [dbo].[CustomerOrderCount](@__customerId_1) AS [OrderCount]
 FROM [Customers] AS [c]
-WHERE ([c].[Id] = @__customerId_1) AND @__customerId_1 IS NOT NULL");
+WHERE [c].[Id] = @__customerId_1");
         }
 
         public override void Scalar_Function_Let_Nested_Instance()
@@ -407,7 +407,7 @@ WHERE ([c].[Id] = @__customerId_1) AND @__customerId_1 IS NOT NULL");
 
 SELECT TOP(2) [c].[LastName], [dbo].[StarValue](@__starCount_1, [dbo].[CustomerOrderCount](@__customerId_2)) AS [OrderCount]
 FROM [Customers] AS [c]
-WHERE ([c].[Id] = @__customerId_2) AND @__customerId_2 IS NOT NULL");
+WHERE [c].[Id] = @__customerId_2");
         }
 
         public override void Scalar_Nested_Function_Unwind_Client_Eval_Select_Instance()

--- a/test/EFCore.SqlServer.FunctionalTests/UpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/UpdatesSqlServerTest.cs
@@ -30,7 +30,7 @@ FROM [Categories] AS [c]",
 
 SELECT [p].[Id], [p].[DependentId], [p].[Name], [p].[Price]
 FROM [Products] AS [p]
-WHERE (([p].[DependentId] = @__category_PrincipalId_0) AND ([p].[DependentId] IS NOT NULL AND @__category_PrincipalId_0 IS NOT NULL)) OR ([p].[DependentId] IS NULL AND @__category_PrincipalId_0 IS NULL)",
+WHERE ([p].[DependentId] = @__category_PrincipalId_0) AND [p].[DependentId] IS NOT NULL",
                 //
                 @"@p1='78'
 @p0='New Category' (Size = 4000)
@@ -47,7 +47,7 @@ FROM [Categories] AS [c]",
 
 SELECT [p].[Id], [p].[DependentId], [p].[Name], [p].[Price]
 FROM [Products] AS [p]
-WHERE (([p].[DependentId] = @__category_PrincipalId_0) AND ([p].[DependentId] IS NOT NULL AND @__category_PrincipalId_0 IS NOT NULL)) OR ([p].[DependentId] IS NULL AND @__category_PrincipalId_0 IS NULL)");
+WHERE ([p].[DependentId] = @__category_PrincipalId_0) AND [p].[DependentId] IS NOT NULL");
         }
 
         public override void Identifiers_are_generated_correctly()

--- a/test/EFCore.Sqlite.FunctionalTests/Query/FiltersSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/FiltersSqliteTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
 SELECT COUNT(*)
 FROM ""Customers"" AS ""c""
-WHERE ((@__ef_filter__TenantPrefix_0 = '') AND @__ef_filter__TenantPrefix_0 IS NOT NULL) OR (""c"".""CompanyName"" IS NOT NULL AND (@__ef_filter__TenantPrefix_0 IS NOT NULL AND (((""c"".""CompanyName"" LIKE ""c"".""CompanyName"" || '%') AND (((substr(""c"".""CompanyName"", 1, length(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND (substr(""c"".""CompanyName"", 1, length(@__ef_filter__TenantPrefix_0)) IS NOT NULL AND @__ef_filter__TenantPrefix_0 IS NOT NULL)) OR (substr(""c"".""CompanyName"", 1, length(@__ef_filter__TenantPrefix_0)) IS NULL AND @__ef_filter__TenantPrefix_0 IS NULL))) OR ((@__ef_filter__TenantPrefix_0 = '') AND @__ef_filter__TenantPrefix_0 IS NOT NULL))))");
+WHERE (@__ef_filter__TenantPrefix_0 = '') OR (""c"".""CompanyName"" IS NOT NULL AND (((""c"".""CompanyName"" LIKE ""c"".""CompanyName"" || '%') AND ((substr(""c"".""CompanyName"", 1, length(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) AND substr(""c"".""CompanyName"", 1, length(@__ef_filter__TenantPrefix_0)) IS NOT NULL)) OR (@__ef_filter__TenantPrefix_0 = '')))");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
@@ -450,7 +450,7 @@ LIMIT -1 OFFSET @__p_1");
 
 SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
 FROM ""Customers"" AS ""c""
-WHERE (rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now', 'localtime'), '0'), '.') <> @__myDatetime_0) OR @__myDatetime_0 IS NULL");
+WHERE rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now', 'localtime'), '0'), '.') <> @__myDatetime_0");
         }
 
         public override async Task Where_datetime_utcnow(bool isAsync)
@@ -462,7 +462,7 @@ WHERE (rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now', 'localtime'), '0'), '.')
 
 SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
 FROM ""Customers"" AS ""c""
-WHERE (rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now'), '0'), '.') <> @__myDatetime_0) OR @__myDatetime_0 IS NULL");
+WHERE rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now'), '0'), '.') <> @__myDatetime_0");
         }
 
         public override async Task Where_datetime_today(bool isAsync)
@@ -484,7 +484,7 @@ WHERE rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now', 'localtime', 'start of da
 
 SELECT ""o"".""OrderID"", ""o"".""CustomerID"", ""o"".""EmployeeID"", ""o"".""OrderDate""
 FROM ""Orders"" AS ""o""
-WHERE ((rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', ""o"".""OrderDate"", 'start of day'), '0'), '.') = @__myDatetime_0) AND (rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', ""o"".""OrderDate"", 'start of day'), '0'), '.') IS NOT NULL AND @__myDatetime_0 IS NOT NULL)) OR (rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', ""o"".""OrderDate"", 'start of day'), '0'), '.') IS NULL AND @__myDatetime_0 IS NULL)");
+WHERE (rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', ""o"".""OrderDate"", 'start of day'), '0'), '.') = @__myDatetime_0) AND rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', ""o"".""OrderDate"", 'start of day'), '0'), '.') IS NOT NULL");
         }
 
         public override async Task Where_datetime_year_component(bool isAsync)


### PR DESCRIPTION
This is part of #17543 - Queries really slow due to null checks

Problem was that at the time we performed null semantics and related optimizations we didn't know the value of parameters, so we always had to assume they can be nullable, which resulted in additional IS NULL checks being created.
However, later in the pipeline we know the parameter values and we can optimize out those checks for parameters whose values are not null.