### PR TITLE
Query: Lift projectionMapping always when pushing down SelectExpressi…

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -13,19 +13,18 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
 {
     public class SelectExpression : TableExpressionBase
     {
-        private IDictionary<ProjectionMember, Expression> _projectionMapping = new Dictionary<ProjectionMember, Expression>();
-        private readonly List<ProjectionExpression> _projection = new List<ProjectionExpression>();
-
         private readonly IDictionary<EntityProjectionExpression, IDictionary<IProperty, int>> _entityProjectionCache
             = new Dictionary<EntityProjectionExpression, IDictionary<IProperty, int>>();
 
+        private readonly List<ProjectionExpression> _projection = new List<ProjectionExpression>();
         private readonly List<TableExpressionBase> _tables = new List<TableExpressionBase>();
         private readonly List<SqlExpression> _groupBy = new List<SqlExpression>();
         private readonly List<OrderingExpression> _orderings = new List<OrderingExpression>();
-
         private readonly List<SqlExpression> _identifier = new List<SqlExpression>();
         private readonly List<SqlExpression> _childIdentifiers = new List<SqlExpression>();
         private readonly List<SelectExpression> _pendingCollections = new List<SelectExpression>();
+
+        private IDictionary<ProjectionMember, Expression> _projectionMapping = new Dictionary<ProjectionMember, Expression>();
 
         public IReadOnlyList<ProjectionExpression> Projection => _projection;
         public IReadOnlyList<TableExpressionBase> Tables => _tables;
@@ -137,7 +136,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             _projectionMapping = result;
         }
 
-        private IEnumerable<IProperty> GetAllPropertiesInHierarchy(IEntityType entityType)
+        private static IEnumerable<IProperty> GetAllPropertiesInHierarchy(IEntityType entityType)
             => entityType.GetTypesInHierarchy().SelectMany(EntityTypeExtensions.GetDeclaredProperties);
 
         public void ReplaceProjectionMapping(IDictionary<ProjectionMember, Expression> projectionMapping)
@@ -660,35 +659,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
 
             var projectionMap = new Dictionary<SqlExpression, ColumnExpression>();
 
-            EntityProjectionExpression liftEntityProjectionFromSubquery(EntityProjectionExpression entityProjection)
-            {
-                var propertyExpressions = new Dictionary<IProperty, ColumnExpression>();
-                foreach (var property in GetAllPropertiesInHierarchy(entityProjection.EntityType))
-                {
-                    var innerColumn = entityProjection.BindProperty(property);
-                    var outerColumn = subquery.GenerateOuterColumn(innerColumn);
-                    projectionMap[innerColumn] = outerColumn;
-                    propertyExpressions[property] = outerColumn;
-                }
-
-                var newEntityProjection = new EntityProjectionExpression(entityProjection.EntityType, propertyExpressions);
-                // Also lift nested entity projections
-                foreach (var navigation in entityProjection.EntityType.GetTypesInHierarchy()
-                    .SelectMany(EntityTypeExtensions.GetDeclaredNavigations))
-                {
-                    var boundEntityShaperExpression = entityProjection.BindNavigation(navigation);
-                    if (boundEntityShaperExpression != null)
-                    {
-                        var innerEntityProjection = (EntityProjectionExpression)boundEntityShaperExpression.ValueBufferExpression;
-                        var newInnerEntityProjection = liftEntityProjectionFromSubquery(innerEntityProjection);
-                        boundEntityShaperExpression = boundEntityShaperExpression.Update(newInnerEntityProjection);
-                        newEntityProjection.AddNavigationBinding(navigation, boundEntityShaperExpression);
-                    }
-                }
-
-                return newEntityProjection;
-            }
-
+            // Projections may be present if added by lifting SingleResult/Enumerable in projection through join
             if (_projection.Any())
             {
                 var projections = _projection.Select(pe => pe.Expression).ToList();
@@ -700,21 +671,26 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                     projectionMap[projection] = outerColumn;
                 }
             }
-            else
+
+            foreach (var mapping in _projectionMapping.ToList())
             {
-                foreach (var mapping in _projectionMapping.ToList())
+                // If projectionMapping's value is ConstantExpression then projection has already been applied
+                // And captured in _projections above so we don't need to process this.
+                if (mapping.Value is ConstantExpression)
                 {
-                    if (mapping.Value is EntityProjectionExpression entityProjection)
-                    {
-                        _projectionMapping[mapping.Key] = liftEntityProjectionFromSubquery(entityProjection);
-                    }
-                    else
-                    {
-                        var innerColumn = (SqlExpression)mapping.Value;
-                        var outerColumn = subquery.GenerateOuterColumn(innerColumn);
-                        projectionMap[innerColumn] = outerColumn;
-                        _projectionMapping[mapping.Key] = outerColumn;
-                    }
+                    break;
+                }
+
+                if (mapping.Value is EntityProjectionExpression entityProjection)
+                {
+                    _projectionMapping[mapping.Key] = LiftEntityProjectionFromSubquery(entityProjection);
+                }
+                else
+                {
+                    var innerColumn = (SqlExpression)mapping.Value;
+                    var outerColumn = subquery.GenerateOuterColumn(innerColumn);
+                    projectionMap[innerColumn] = outerColumn;
+                    _projectionMapping[mapping.Key] = outerColumn;
                 }
             }
 
@@ -788,6 +764,35 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             _groupBy.Clear();
 
             return projectionMap;
+
+            EntityProjectionExpression LiftEntityProjectionFromSubquery(EntityProjectionExpression entityProjection)
+            {
+                var propertyExpressions = new Dictionary<IProperty, ColumnExpression>();
+                foreach (var property in GetAllPropertiesInHierarchy(entityProjection.EntityType))
+                {
+                    var innerColumn = entityProjection.BindProperty(property);
+                    var outerColumn = subquery.GenerateOuterColumn(innerColumn);
+                    projectionMap[innerColumn] = outerColumn;
+                    propertyExpressions[property] = outerColumn;
+                }
+
+                var newEntityProjection = new EntityProjectionExpression(entityProjection.EntityType, propertyExpressions);
+                // Also lift nested entity projections
+                foreach (var navigation in entityProjection.EntityType.GetTypesInHierarchy()
+                    .SelectMany(EntityTypeExtensions.GetDeclaredNavigations))
+                {
+                    var boundEntityShaperExpression = entityProjection.BindNavigation(navigation);
+                    if (boundEntityShaperExpression != null)
+                    {
+                        var innerEntityProjection = (EntityProjectionExpression)boundEntityShaperExpression.ValueBufferExpression;
+                        var newInnerEntityProjection = LiftEntityProjectionFromSubquery(innerEntityProjection);
+                        boundEntityShaperExpression = boundEntityShaperExpression.Update(newInnerEntityProjection);
+                        newEntityProjection.AddNavigationBinding(navigation, boundEntityShaperExpression);
+                    }
+                }
+
+                return newEntityProjection;
+            }
         }
 
         public Expression AddSingleProjection(ShapedQueryExpression shapedQueryExpression)

--- a/test/EFCore.InMemory.FunctionalTests/Query/ComplexNavigationsQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/ComplexNavigationsQueryInMemoryTest.cs
@@ -26,5 +26,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             base.Member_pushdown_chain_3_levels_deep_entity();
         }
+
+        [ConditionalTheory(Skip = "issue #17620")]
+        public override Task Lift_projection_mapping_when_pushing_down_subquery(bool isAsync)
+        {
+            return base.Lift_projection_mapping_when_pushing_down_subquery(isAsync);
+        }
     }
 }

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsWeakQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsWeakQueryTestBase.cs
@@ -178,5 +178,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return base.Include_inside_subquery(isAsync);
         }
+
+        [ConditionalTheory(Skip = "Issue#18519")]
+        public override Task Lift_projection_mapping_when_pushing_down_subquery(bool isAsync)
+        {
+            return base.Lift_projection_mapping_when_pushing_down_subquery(isAsync);
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -4375,6 +4375,30 @@ FROM (
 ) AS [t]");
         }
 
+        public override async Task Lift_projection_mapping_when_pushing_down_subquery(bool isAsync)
+        {
+            await base.Lift_projection_mapping_when_pushing_down_subquery(isAsync);
+
+            AssertSql(
+                @"@__p_0='25'
+
+SELECT [t].[Id], [t1].[Id], [l1].[Id]
+FROM (
+    SELECT TOP(@__p_0) [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
+    FROM [LevelOne] AS [l]
+) AS [t]
+LEFT JOIN (
+    SELECT [t0].[Id], [t0].[OneToMany_Required_Inverse2Id]
+    FROM (
+        SELECT [l0].[Id], [l0].[OneToMany_Required_Inverse2Id], ROW_NUMBER() OVER(PARTITION BY [l0].[OneToMany_Required_Inverse2Id] ORDER BY [l0].[Id]) AS [row]
+        FROM [LevelTwo] AS [l0]
+    ) AS [t0]
+    WHERE [t0].[row] <= 1
+) AS [t1] ON [t].[Id] = [t1].[OneToMany_Required_Inverse2Id]
+LEFT JOIN [LevelTwo] AS [l1] ON [t].[Id] = [l1].[OneToMany_Required_Inverse2Id]
+ORDER BY [t].[Id], [l1].[Id]");
+        }
+
         private void AssertSql(params string[] expected)
         {
             Fixture.TestSqlLoggerFactory.AssertBaseline(expected);


### PR DESCRIPTION
…on into subuquery

Issue: When converting correlation to join, we add the join key columns to projection to make sure they are always available.
We had logic that if projection contains any columns then projection mapping is already applied to projection.
But in above case that is incorrect.
That leaves us with incorrect EntityProjection which fails in further translation as multi-part identifier could not be bound.

We should always lift projectionMapping during Pushdown unless projectionMapping is applied which can be checked through type.

This scenario does not work for owned/weak types due to #18519

Resolves #18514
