### PR TITLE
Exit Dispose early if reader is already disposed

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
@@ -227,7 +227,7 @@ namespace Microsoft.Data.Sqlite
         /// </param>
         protected override void Dispose(bool disposing)
         {
-            if (!disposing)
+            if (!disposing || _closed)
             {
                 return;
             }


### PR DESCRIPTION
Otherwise calling Close followed by Dispose generates an exception internally, bad for perf and for the debugging experience.

Fixes #18307
