### PR TITLE
Fix Cosmos tests on CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -113,16 +113,22 @@ stages:
             pool:
               vmImage: ubuntu-16.04
             variables:
-              - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['system.pullrequest.isfork'], false), notin(variables['Build.Reason'], 'PullRequest', 'Schedule', 'BuildCompletion'), or(endsWith(variables['Build.BuildId'], '0'), endsWith(variables['Build.BuildId'], '2'), endsWith(variables['Build.BuildId'], '4'), endsWith(variables['Build.BuildId'], '6'), endsWith(variables['Build.BuildId'], '8'))) }}:
-                - _CosmosConnectionUrl: https://ef-nightly-test.documents.azure.com:443/
-                - _CosmosToken: $(ef-nightly-cosmos-key)
-              - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['system.pullrequest.isfork'], false), notin(variables['Build.Reason'], 'PullRequest', 'Schedule', 'BuildCompletion'), or(endsWith(variables['Build.BuildId'], '1'), endsWith(variables['Build.BuildId'], '3'), endsWith(variables['Build.BuildId'], '5'), endsWith(variables['Build.BuildId'], '7'), endsWith(variables['Build.BuildId'], '9'))) }}:
-                - _CosmosConnectionUrl: https://ef-pr-test.documents.azure.com:443/
-                - _CosmosToken: $(ef-pr-cosmos-test)
+              - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['system.pullrequest.isfork'], false), notin(variables['Build.Reason'], 'PullRequest', 'Schedule', 'BuildCompletion')) }}:
+                - _CosmosConnectionUrl: 'true'
             steps:
               - bash: sudo apt-get install -y libsqlite3-mod-spatialite
                 displayName: Install SpatiaLite
                 continueOnError: true
+              - bash: |
+                    echo "##vso[task.setvariable variable=_CosmosConnectionUrl]https://ef-nightly-test.documents.azure.com:443/"
+                    echo "##vso[task.setvariable variable=_CosmosToken]$(ef-nightly-cosmos-key)"
+                displayName: Prepare to run Cosmos tests on ef-nightly-test
+                condition: and(eq(variables['_CosmosConnectionUrl'], 'true'), or(endsWith(variables['Build.BuildId'], '0'), endsWith(variables['Build.BuildId'], '2'), endsWith(variables['Build.BuildId'], '4'), endsWith(variables['Build.BuildId'], '6'), endsWith(variables['Build.BuildId'], '8')))
+              - bash: |
+                    echo "##vso[task.setvariable variable=_CosmosConnectionUrl]https://ef-pr-test.documents.azure.com:443/"
+                    echo "##vso[task.setvariable variable=_CosmosToken]$(ef-pr-cosmos-test)"
+                displayName: Prepare to run Cosmos tests on ef-pr-test
+                condition: and(eq(variables['_CosmosConnectionUrl'], 'true'), or(endsWith(variables['Build.BuildId'], '1'), endsWith(variables['Build.BuildId'], '3'), endsWith(variables['Build.BuildId'], '5'), endsWith(variables['Build.BuildId'], '7'), endsWith(variables['Build.BuildId'], '9')))
               - script: eng/common/cibuild.sh --configuration $(_BuildConfig) --prepareMachine
                 env:
                   Test__Cosmos__DefaultConnection: $(_CosmosConnectionUrl)


### PR DESCRIPTION
__Problem__
The ${{ }} expressions evaluate at compile-time and `Build.BuildId` variable is not set at that point
And $[ ] can't be used in variable conditions

__Solution__
Move the `Build.BuildId` expression to a task condition so it can be evaluated at run-time