### PR TITLE
Use AssemblyQualifiedName to distinguish db functions.  Fix issue #18425

### DIFF
--- a/src/EFCore.Relational/Metadata/Internal/DbFunction.cs
+++ b/src/EFCore.Relational/Metadata/Internal/DbFunction.cs
@@ -121,7 +121,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         private static string BuildAnnotationName(MethodBase methodBase)
             =>
                 // ReSharper disable once AssignNullToNotNullAttribute
-                $"{RelationalAnnotationNames.DbFunction}{methodBase.DeclaringType.ShortDisplayName()}{methodBase.Name}({string.Join(",", methodBase.GetParameters().Select(p => p.ParameterType.Name))})";
+                // ReSharper disable once PossibleNullReferenceException
+                $"{RelationalAnnotationNames.DbFunction}{methodBase.DeclaringType.FullName}{methodBase.Name}({string.Join(",", methodBase.GetParameters().Select(p => p.ParameterType.FullName))})";
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/test/EFCore.Relational.Tests/Metadata/DbFunctionMetadataTests.cs
+++ b/test/EFCore.Relational.Tests/Metadata/DbFunctionMetadataTests.cs
@@ -213,6 +213,27 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             }
         }
 
+        public static class OuterA
+        {
+            public static class Inner
+            {
+                public static decimal? Min(decimal? a, decimal? b)
+                {
+                    throw new Exception();
+                }
+            }
+        }
+        public static class OuterB
+        {
+            public static class Inner
+            {
+                public static decimal? Min(decimal? a, decimal? b)
+                {
+                    throw new Exception();
+                }
+            }
+        }
+
         [ConditionalFact]
         public virtual void DbFunctions_with_duplicate_names_and_parameters_on_different_types_dont_collide()
         {
@@ -599,6 +620,24 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
             Assert.Equal("d", dbFunc.Parameters[1].Name);
             Assert.Equal(typeof(int), dbFunc.Parameters[1].ClrType);
+        }
+
+        [ConditionalFact]
+        public void DbFunction_Annotation_FullName()
+        {
+            var modelBuilder = GetModelBuilder();
+
+            var methodA = typeof(OuterA.Inner).GetMethod(nameof(OuterA.Inner.Min));
+            var methodB = typeof(OuterB.Inner).GetMethod(nameof(OuterB.Inner.Min));
+
+            var funcA = modelBuilder.HasDbFunction(methodA);
+            var funcB = modelBuilder.HasDbFunction(methodB);
+
+            funcA.HasName("MinA");
+
+            Assert.Equal("MinA", funcA.Metadata.Name);
+            Assert.Equal("Min", funcB.Metadata.Name);
+            Assert.NotEqual(funcA.Metadata.Name, funcB.Metadata.Name);
         }
 
         private ModelBuilder GetModelBuilder(DbContext dbContext = null)


### PR DESCRIPTION
Update dbfunctions to use the AssemblyQualifiedName in their annotation name.  This will prevent nested, and cross assembly, class functions from having name collisions.  

Fixes #18425
