### PR TITLE
Query: Expand navigations in Selector/Include in one pass

### DIFF
--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
@@ -27,6 +27,18 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 _source = source;
             }
 
+            public Expression Expand(Expression expression, bool applyIncludes = false)
+            {
+                expression = Visit(expression);
+                if (applyIncludes)
+                {
+                    expression = new IncludeExpandingExpressionVisitor(_navigationExpandingExpressionVisitor, _source)
+                        .Visit(expression);
+                }
+
+                return expression;
+            }
+
             protected override Expression VisitExtension(Expression expression)
             {
                 switch (expression)
@@ -305,16 +317,15 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             public IncludeExpandingExpressionVisitor(
                 NavigationExpandingExpressionVisitor navigationExpandingExpressionVisitor,
-                NavigationExpansionExpression source,
-                bool tracking)
+                NavigationExpansionExpression source)
                 : base(navigationExpandingExpressionVisitor, source)
             {
-                _isTracking = tracking;
+                _isTracking = navigationExpandingExpressionVisitor._queryCompilationContext.IsTracking;
             }
 
-            public override Expression Visit(Expression expression)
+            protected override Expression VisitExtension(Expression extensionExpression)
             {
-                switch (expression)
+                switch (extensionExpression)
                 {
                     case NavigationTreeExpression navigationTreeExpression:
                         if (navigationTreeExpression.Value is EntityReference entityReference)
@@ -334,9 +345,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                     case OwnedNavigationReference ownedNavigationReference:
                         return ExpandInclude(ownedNavigationReference, ownedNavigationReference.EntityReference);
+
+                    case MaterializeCollectionNavigationExpression _:
+                        return extensionExpression;
                 }
 
-                return base.Visit(expression);
+                return base.VisitExtension(extensionExpression);
             }
 
             protected override Expression VisitMember(MemberExpression memberExpression)
@@ -503,42 +517,16 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
         }
 
-        private class IncludeApplyingExpressionVisitor : ExpressionVisitor
-        {
-            private readonly NavigationExpandingExpressionVisitor _visitor;
-            private readonly bool _isTracking;
-
-            public IncludeApplyingExpressionVisitor(NavigationExpandingExpressionVisitor visitor, bool tracking)
-            {
-                _visitor = visitor;
-                _isTracking = tracking;
-            }
-
-            public override Expression Visit(Expression expression)
-            {
-                if (expression is NavigationExpansionExpression navigationExpansionExpression)
-                {
-                    var innerVisitor = new IncludeExpandingExpressionVisitor(_visitor, navigationExpansionExpression, _isTracking);
-                    var pendingSelector = innerVisitor.Visit(navigationExpansionExpression.PendingSelector);
-                    pendingSelector = _visitor.Visit(pendingSelector);
-                    pendingSelector = Visit(pendingSelector);
-
-                    navigationExpansionExpression.ApplySelector(pendingSelector);
-
-                    return navigationExpansionExpression;
-                }
-
-                return base.Visit(expression);
-            }
-        }
-
         private class PendingSelectorExpandingExpressionVisitor : ExpressionVisitor
         {
             private readonly NavigationExpandingExpressionVisitor _visitor;
+            private readonly bool _applyIncludes;
 
-            public PendingSelectorExpandingExpressionVisitor(NavigationExpandingExpressionVisitor visitor)
+            public PendingSelectorExpandingExpressionVisitor(
+                NavigationExpandingExpressionVisitor visitor, bool applyIncludes = false)
             {
                 _visitor = visitor;
+                _applyIncludes = applyIncludes;
             }
 
             public override Expression Visit(Expression expression)
@@ -547,11 +535,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 {
                     _visitor.ApplyPendingOrderings(navigationExpansionExpression);
 
-                    var pendingSelector = _visitor.ExpandNavigationsInExpression(
-                        navigationExpansionExpression, navigationExpansionExpression.PendingSelector);
-
+                    var pendingSelector = new ExpandingExpressionVisitor(_visitor, navigationExpansionExpression)
+                        .Expand(navigationExpansionExpression.PendingSelector, _applyIncludes);
+                    pendingSelector = _visitor._subqueryMemberPushdownExpressionVisitor.Visit(pendingSelector);
+                    pendingSelector = _visitor.Visit(pendingSelector);
                     pendingSelector = Visit(pendingSelector);
-
                     navigationExpansionExpression.ApplySelector(pendingSelector);
 
                     return navigationExpansionExpression;

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
@@ -67,7 +67,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
         public virtual Expression Expand(Expression query)
         {
-            var result = ExpandAndReduce(query, applyInclude: true);
+            var result = ExpandAndReduce(query, applyIncludes: true);
 
             var dbContextOnQueryContextPropertyAccess =
                 Expression.Convert(
@@ -96,15 +96,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             return result;
         }
 
-        private Expression ExpandAndReduce(Expression query, bool applyInclude)
+        private Expression ExpandAndReduce(Expression query, bool applyIncludes)
         {
             var result = Visit(query);
-            result = _pendingSelectorExpandingExpressionVisitor.Visit(result);
-            if (applyInclude)
-            {
-                result = new IncludeApplyingExpressionVisitor(this, _queryCompilationContext.IsTracking).Visit(result);
-            }
-
+            result = new PendingSelectorExpandingExpressionVisitor(this, applyIncludes: applyIncludes).Visit(result);
             result = Reduce(result);
 
             return result;
@@ -131,7 +126,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                     navigationExpansionExpression = (NavigationExpansionExpression)Visit(processedDefiningQueryBody);
 
-                    var expanded = ExpandAndReduce(navigationExpansionExpression, applyInclude: false);
+                    var expanded = ExpandAndReduce(navigationExpansionExpression, applyIncludes: false);
                     navigationExpansionExpression = CreateNavigationExpansionExpression(expanded, entityType);
                 }
                 else
@@ -949,9 +944,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             else
             {
                 source = (NavigationExpansionExpression)ProcessSelect(source, elementSelector);
-                source = (NavigationExpansionExpression)_pendingSelectorExpandingExpressionVisitor.Visit(source);
-                source = (NavigationExpansionExpression)new IncludeApplyingExpressionVisitor(
-                    this, _queryCompilationContext.IsTracking).Visit(source);
+                source = (NavigationExpansionExpression)new PendingSelectorExpandingExpressionVisitor(this, applyIncludes: true)
+                    .Visit(source);
                 keySelector = GenerateLambda(keySelectorBody, source.CurrentParameter);
                 elementSelector = GenerateLambda(source.PendingSelector, source.CurrentParameter);
                 if (resultSelector == null)
@@ -1335,7 +1329,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     && selector.ReturnType.GetGenericTypeDefinition() == typeof(IGrouping<,>)))
             {
                 var selectorLambda = GenerateLambda(ExpandNavigationsInLambdaExpression(source, selector), source.CurrentParameter);
-
                 var newSource = Expression.Call(
                     QueryableMethods.Select.MakeGenericMethod(source.SourceElementType, selectorLambda.ReturnType),
                     source.Source,
@@ -1419,15 +1412,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             return _reducingExpressionVisitor.Visit(source);
         }
 
-        private Expression ExpandNavigationsInExpression(NavigationExpansionExpression source, Expression expression)
-        {
-            expression = new ExpandingExpressionVisitor(this, source).Visit(expression);
-            expression = _subqueryMemberPushdownExpressionVisitor.Visit(expression);
-            expression = Visit(expression);
-
-            return expression;
-        }
-
         private Expression ExpandNavigationsInLambdaExpression(
             NavigationExpansionExpression source,
             LambdaExpression lambdaExpression)
@@ -1437,7 +1421,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 source.PendingSelector,
                 lambdaExpression.Body);
 
-            return ExpandNavigationsInExpression(source, lambdaBody);
+            lambdaBody = new ExpandingExpressionVisitor(this, source).Visit(lambdaBody);
+            lambdaBody = _subqueryMemberPushdownExpressionVisitor.Visit(lambdaBody);
+            lambdaBody = Visit(lambdaBody);
+            lambdaBody = _pendingSelectorExpandingExpressionVisitor.Visit(lambdaBody);
+
+            return lambdaBody;
         }
 
         private class Parameters : IParameterValues

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsWeakQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsWeakQueryTestBase.cs
@@ -173,9 +173,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
         }
 
-        public override void Union_over_entities_with_different_nullability()
-        {
-        }
+        public override Task Union_over_entities_with_different_nullability(bool isAsync) => Task.CompletedTask;
 
         [ConditionalTheory(Skip = "Issue#16752")]
         public override Task Include_inside_subquery(bool isAsync)

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -7202,7 +7202,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             public Squad Squad { get; set; }
         }
 
-        [ConditionalTheory(Skip = "issue #17852")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Project_entity_and_collection_element(bool isAsync)
         {
@@ -7499,6 +7499,16 @@ namespace Microsoft.EntityFrameworkCore.Query
             await AssertQuery(
                 isAsync,
                 ss => ss.Set<Gear>().Where(g => (g.Rank | rank) != rank));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task FirstOrDefault_navigation_access_entity_equality_in_where_predicate_apply_peneding_selector(bool isAsync)
+        {
+            return AssertQuery(
+                isAsync,
+                ss => ss.Set<Faction>()
+                    .Where(f => f.Capital == ss.Set<Gear>().OrderBy(s => s.Nickname).FirstOrDefault().CityOfBirth));
         }
 
         protected async Task AssertTranslationFailed(Func<Task> testCode)

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -5511,7 +5511,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 2);
         }
 
-        [ConditionalTheory(Skip = "Issue#17756")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Dependent_to_principal_navigation_equal_to_null_for_subquery(bool isAsync)
         {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -2344,14 +2344,17 @@ WHERE [l2].[Id] = 7");
             await base.Required_navigation_on_a_subquery_with_First_in_predicate(isAsync);
 
             AssertSql(
-                @"SELECT [l2o].[Id], [l2o].[Date], [l2o].[Level1_Optional_Id], [l2o].[Level1_Required_Id], [l2o].[Name], [l2o].[OneToMany_Optional_Inverse2Id], [l2o].[OneToMany_Optional_Self_Inverse2Id], [l2o].[OneToMany_Required_Inverse2Id], [l2o].[OneToMany_Required_Self_Inverse2Id], [l2o].[OneToOne_Optional_PK_Inverse2Id], [l2o].[OneToOne_Optional_Self2Id]
-FROM [LevelTwo] AS [l2o]
-WHERE [l2o].[Id] = 7",
-                //
-                @"SELECT TOP(1) [l2i.OneToOne_Required_FK_Inverse20].[Name]
-FROM [LevelTwo] AS [l2i0]
-INNER JOIN [LevelOne] AS [l2i.OneToOne_Required_FK_Inverse20] ON [l2i0].[Level1_Required_Id] = [l2i.OneToOne_Required_FK_Inverse20].[Id]
-ORDER BY [l2i0].[Id]");
+                @"SELECT [l].[Id], [l].[Date], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Name], [l].[OneToMany_Optional_Inverse2Id], [l].[OneToMany_Optional_Self_Inverse2Id], [l].[OneToMany_Required_Inverse2Id], [l].[OneToMany_Required_Self_Inverse2Id], [l].[OneToOne_Optional_PK_Inverse2Id], [l].[OneToOne_Optional_Self2Id]
+FROM [LevelTwo] AS [l]
+WHERE ([l].[Id] = 7) AND (((
+    SELECT TOP(1) [l1].[Name]
+    FROM [LevelTwo] AS [l0]
+    INNER JOIN [LevelOne] AS [l1] ON [l0].[Level1_Required_Id] = [l1].[Id]
+    ORDER BY [l0].[Id]) = N'L1 02') AND (
+    SELECT TOP(1) [l1].[Name]
+    FROM [LevelTwo] AS [l0]
+    INNER JOIN [LevelOne] AS [l1] ON [l0].[Level1_Required_Id] = [l1].[Id]
+    ORDER BY [l0].[Id]) IS NOT NULL)");
         }
 
         public override async Task Manually_created_left_join_propagates_nullability_to_navigations(bool isAsync)
@@ -4383,9 +4386,9 @@ END = N'L4 01') AND CASE
 END IS NOT NULL");
         }
 
-        public override void Union_over_entities_with_different_nullability()
+        public override async Task Union_over_entities_with_different_nullability(bool isAsync)
         {
-            base.Union_over_entities_with_different_nullability();
+            await base.Union_over_entities_with_different_nullability(isAsync);
 
             AssertSql(
                 @"SELECT [t].[Id]
@@ -4423,6 +4426,39 @@ LEFT JOIN (
 ) AS [t1] ON [t].[Id] = [t1].[OneToMany_Required_Inverse2Id]
 LEFT JOIN [LevelTwo] AS [l1] ON [t].[Id] = [l1].[OneToMany_Required_Inverse2Id]
 ORDER BY [t].[Id], [l1].[Id]");
+        }
+
+        public override async Task Including_reference_navigation_and_projecting_collection_navigation(bool isAsync)
+        {
+            await base.Including_reference_navigation_and_projecting_collection_navigation(isAsync);
+
+            AssertSql(
+                @"SELECT [l].[Id], [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id], [l1].[Id], [l1].[Level2_Optional_Id], [l1].[Level2_Required_Id], [l1].[Name], [l1].[OneToMany_Optional_Inverse3Id], [l1].[OneToMany_Optional_Self_Inverse3Id], [l1].[OneToMany_Required_Inverse3Id], [l1].[OneToMany_Required_Self_Inverse3Id], [l1].[OneToOne_Optional_PK_Inverse3Id], [l1].[OneToOne_Optional_Self3Id], [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Optional_Self_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToMany_Required_Self_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id], [l2].[OneToOne_Optional_Self2Id]
+FROM [LevelOne] AS [l]
+LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Required_Id]
+LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[Level2_Optional_Id]
+LEFT JOIN [LevelTwo] AS [l2] ON [l].[Id] = [l2].[OneToMany_Required_Inverse2Id]
+ORDER BY [l].[Id], [l2].[Id]");
+        }
+
+        public override async Task Including_reference_navigation_and_projecting_collection_navigation_2(bool isAsync)
+        {
+            await base.Including_reference_navigation_and_projecting_collection_navigation_2(isAsync);
+
+            AssertSql(
+                @"SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id], [t0].[Id], [t0].[Date], [t0].[Level1_Optional_Id], [t0].[Level1_Required_Id], [t0].[Name], [t0].[OneToMany_Optional_Inverse2Id], [t0].[OneToMany_Optional_Self_Inverse2Id], [t0].[OneToMany_Required_Inverse2Id], [t0].[OneToMany_Required_Self_Inverse2Id], [t0].[OneToOne_Optional_PK_Inverse2Id], [t0].[OneToOne_Optional_Self2Id], [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Optional_Self_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToMany_Required_Self_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id], [l2].[OneToOne_Optional_Self2Id]
+FROM [LevelOne] AS [l]
+LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Required_Id]
+LEFT JOIN (
+    SELECT [t].[Id], [t].[Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Name], [t].[OneToMany_Optional_Inverse2Id], [t].[OneToMany_Optional_Self_Inverse2Id], [t].[OneToMany_Required_Inverse2Id], [t].[OneToMany_Required_Self_Inverse2Id], [t].[OneToOne_Optional_PK_Inverse2Id], [t].[OneToOne_Optional_Self2Id]
+    FROM (
+        SELECT [l1].[Id], [l1].[Date], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[Name], [l1].[OneToMany_Optional_Inverse2Id], [l1].[OneToMany_Optional_Self_Inverse2Id], [l1].[OneToMany_Required_Inverse2Id], [l1].[OneToMany_Required_Self_Inverse2Id], [l1].[OneToOne_Optional_PK_Inverse2Id], [l1].[OneToOne_Optional_Self2Id], ROW_NUMBER() OVER(PARTITION BY [l1].[OneToMany_Required_Inverse2Id] ORDER BY [l1].[Id] DESC) AS [row]
+        FROM [LevelTwo] AS [l1]
+    ) AS [t]
+    WHERE [t].[row] <= 1
+) AS [t0] ON [l].[Id] = [t0].[OneToMany_Required_Inverse2Id]
+LEFT JOIN [LevelTwo] AS [l2] ON [l].[Id] = [l2].[OneToMany_Required_Inverse2Id]
+ORDER BY [l].[Id], [l2].[Id]");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -7503,6 +7503,32 @@ FROM [Gears] AS [g]
 WHERE CAST(0 AS bit) = CAST(1 AS bit)");
         }
 
+        public override async Task FirstOrDefault_navigation_access_entity_equality_in_where_predicate_apply_peneding_selector(bool isAsync)
+        {
+            await base.FirstOrDefault_navigation_access_entity_equality_in_where_predicate_apply_peneding_selector(isAsync);
+
+            AssertSql(
+                @"SELECT [f].[Id], [f].[CapitalName], [f].[Discriminator], [f].[Name], [f].[CommanderName], [f].[Eradicated]
+FROM [Factions] AS [f]
+LEFT JOIN [Cities] AS [c] ON [f].[CapitalName] = [c].[Name]
+WHERE ([f].[Discriminator] = N'LocustHorde') AND ((([c].[Name] = (
+    SELECT TOP(1) [c0].[Name]
+    FROM [Gears] AS [g]
+    INNER JOIN [Cities] AS [c0] ON [g].[CityOfBirthName] = [c0].[Name]
+    WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
+    ORDER BY [g].[Nickname])) AND ([c].[Name] IS NOT NULL AND (
+    SELECT TOP(1) [c0].[Name]
+    FROM [Gears] AS [g]
+    INNER JOIN [Cities] AS [c0] ON [g].[CityOfBirthName] = [c0].[Name]
+    WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
+    ORDER BY [g].[Nickname]) IS NOT NULL)) OR ([c].[Name] IS NULL AND (
+    SELECT TOP(1) [c0].[Name]
+    FROM [Gears] AS [g]
+    INNER JOIN [Cities] AS [c0] ON [g].[CityOfBirthName] = [c0].[Name]
+    WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
+    ORDER BY [g].[Nickname]) IS NULL))");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -4628,12 +4628,11 @@ WHERE (
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE (
-    SELECT TOP(1) [o.Customer].[CustomerID]
+    SELECT TOP(1) [c0].[CustomerID]
     FROM [Orders] AS [o]
-    LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
-    WHERE [c].[CustomerID] = [o].[CustomerID]
-    ORDER BY [o].[OrderID]
-) IS NULL");
+    LEFT JOIN [Customers] AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
+    WHERE ([c].[CustomerID] = [o].[CustomerID]) AND [o].[CustomerID] IS NOT NULL
+    ORDER BY [o].[OrderID]) IS NULL");
         }
 
         public override async Task Collection_navigation_equality_rewrite_for_subquery(bool isAsync)


### PR DESCRIPTION
Issue: Earlier we expanded navigation in selector and include in separate phase. This causes issue because if the latter visitor expands a reference navigation then former visitor's collection expansions have incorrect references.
Fix: Fix is to make include expansion part of selector expansion as next phase. So by the time we apply include, the correlation predicate in collection hasn't been converted to actual reference. So when it gets converted, it takes correct reference.

Also apply pending selector inside lambda expression since it is a subquery. This caused issue when subquery has a projection which has navigation to expand, which we never visited.

Resolves #18127
Resolves #18090
Resolves #17852
Resolves #17756
