### PR TITLE
Solve the 3.0 regression: Cannot use generics w/ interface to construct expression bug

### DIFF
--- a/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
@@ -651,6 +651,16 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
 
         protected override Expression VisitUnary(UnaryExpression unaryExpression)
         {
+
+            // bypass the inner conversion if it is an interface
+            if (unaryExpression.Operand is UnaryExpression operandUnary
+                && operandUnary.NodeType == ExpressionType.Convert
+                && operandUnary.Type.IsInterface)
+            {
+                // update the unaryExpression to use the inner expression
+                return Visit(unaryExpression.Update(operandUnary.Operand));
+            }
+
             var newOperand = Visit(unaryExpression.Operand);
             if (newOperand == null)
             {

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -609,6 +609,15 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         protected override Expression VisitUnary(UnaryExpression unaryExpression)
         {
+            // bypass the inner conversion if it is an interface
+            if (unaryExpression.Operand is UnaryExpression operandUnary
+                && operandUnary.NodeType == ExpressionType.Convert
+                && operandUnary.Type.IsInterface)
+            {
+                // update the unaryExpression to use the inner expression
+                return Visit(unaryExpression.Update(operandUnary.Operand));
+            }
+
             var operand = Visit(unaryExpression.Operand);
 
             if (operand is EntityProjectionExpression)

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -5165,6 +5165,23 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.Id);
         }
 
+        static Expression<Func<T, bool>> HasOrderSince<T>(DateTime since)
+            where T : IOrders
+        {
+            Expression<Func<T, bool>> predicate = oa => oa.Orders.AsQueryable().Any(o=> o.OrderDate > since);
+            return predicate;
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Explicit_cast_to_Interface_bug_17794(bool isAsync)
+        {
+            var expr = HasOrderSince<Customer>(new DateTime(2019,10,30));
+            return AssertQuery(
+                isAsync,
+                ss => ss.Set<Customer>().Where(expr).Select(c => c.CustomerID));
+        }
+
         [ConditionalFact(Skip = "Issue #16314")]
         public virtual void Streaming_chained_sync_query()
         {

--- a/test/EFCore.Specification.Tests/TestModels/Northwind/Customer.cs
+++ b/test/EFCore.Specification.Tests/TestModels/Northwind/Customer.cs
@@ -10,7 +10,16 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.Northwind
 {
-    public class Customer : IComparable<Customer>
+    public interface ICustomerID
+    {
+        string CustomerID { get; }
+    }
+
+    public interface IOrders
+    {
+        List<Order> Orders { get; }
+    }
+    public class Customer : IComparable<Customer>, ICustomerID, IOrders
     {
         public Customer()
         {


### PR DESCRIPTION
This change re-writes an expression to skip over UnaryExpressions where the inner expression is an interface. I am not sure if this is the appropriate way to implement this, however it works for the test case I created. This bug is a blocker on us migrating to 3.x as we use this generic interface, so will be very happy if this is merged.

I have tested and verified these changes on the release/3.0 branch and can make a PR for that instead if that were helpful.

Fixes #17794