### PR TITLE
Support non-static members in C# generation

### DIFF
--- a/src/EFCore.Design/Design/Internal/CSharpHelper.cs
+++ b/src/EFCore.Design/Design/Internal/CSharpHelper.cs
@@ -893,14 +893,21 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
                     if (memberExpression.Expression == null)
                     {
                         builder
-                            .Append(Reference(memberExpression.Member.DeclaringType, useFullName: true))
-                            .Append('.')
-                            .Append(memberExpression.Member.Name);
-
-                        return true;
+                            .Append(Reference(memberExpression.Member.DeclaringType, useFullName: true));
+                    }
+                    else
+                    {
+                        if (!HandleExpression(memberExpression.Expression, builder))
+                        {
+                            return false;
+                        }
                     }
 
-                    return false;
+                    builder
+                        .Append('.')
+                        .Append(memberExpression.Member.Name);
+
+                    return true;
                 }
             }
 

--- a/test/EFCore.Design.Tests/Design/Internal/CSharpHelperTest.cs
+++ b/test/EFCore.Design.Tests/Design/Internal/CSharpHelperTest.cs
@@ -533,22 +533,35 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
         public void Literal_with_static_field()
         {
             var typeMapping = CreateTypeMappingSource<SimpleTestType>(
-                v => Expression.Field(null, typeof(SimpleTestType).GetField(nameof(SimpleTestType.SomeField))));
+                v => Expression.Field(null, typeof(SimpleTestType).GetField(nameof(SimpleTestType.SomeStaticField))));
 
             Assert.Equal(
-                "Microsoft.EntityFrameworkCore.Design.Internal.SimpleTestType.SomeField",
-                new CSharpHelper(typeMapping).UnknownLiteral(SimpleTestType.SomeField));
+                "Microsoft.EntityFrameworkCore.Design.Internal.SimpleTestType.SomeStaticField",
+                new CSharpHelper(typeMapping).UnknownLiteral(new SimpleTestType()));
         }
 
         [ConditionalFact]
         public void Literal_with_static_property()
         {
             var typeMapping = CreateTypeMappingSource<SimpleTestType>(
-                v => Expression.Property(null, typeof(SimpleTestType).GetProperty(nameof(SimpleTestType.SomeProperty))));
+                v => Expression.Property(null, typeof(SimpleTestType).GetProperty(nameof(SimpleTestType.SomeStaticProperty))));
 
             Assert.Equal(
-                "Microsoft.EntityFrameworkCore.Design.Internal.SimpleTestType.SomeProperty",
-                new CSharpHelper(typeMapping).UnknownLiteral(SimpleTestType.SomeProperty));
+                "Microsoft.EntityFrameworkCore.Design.Internal.SimpleTestType.SomeStaticProperty",
+                new CSharpHelper(typeMapping).UnknownLiteral(new SimpleTestType()));
+        }
+
+        [ConditionalFact]
+        public void Literal_with_instance_property()
+        {
+            var typeMapping = CreateTypeMappingSource<SimpleTestType>(
+                v => Expression.Property(
+                    Expression.New(typeof(SimpleTestType)),
+                    typeof(SimpleTestType).GetProperty(nameof(SimpleTestType.SomeInstanceProperty))));
+
+            Assert.Equal(
+                "new Microsoft.EntityFrameworkCore.Design.Internal.SimpleTestType().SomeInstanceProperty",
+                new CSharpHelper(typeMapping).UnknownLiteral(new SimpleTestType()));
         }
 
         [ConditionalFact]
@@ -672,8 +685,10 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
 
     internal class SimpleTestType
     {
-        public static readonly SimpleTestType SomeField = new SimpleTestType();
-        public static SimpleTestType SomeProperty { get; } = new SimpleTestType();
+        public static readonly int SomeStaticField = 8;
+        public readonly int SomeField = 8;
+        public static int SomeStaticProperty { get; } = 8;
+        public int SomeInstanceProperty { get; } = 8;
 
         public SimpleTestType()
         {


### PR DESCRIPTION
Necessary to unblock some code literal generation for Npgsql.

As this is a design-only low-risk tiny change, I'm hoping we can get this into 3.1.

/cc @bricelam @Pilchie @ajcvickers 