### PR TITLE
Query: Removing Queryable conversion for sources which are not queryable

### DIFF
--- a/src/EFCore/Query/Internal/EnumerableToQueryableMethodConvertingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/EnumerableToQueryableMethodConvertingExpressionVisitor.cs
@@ -35,33 +35,33 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                 var enumerableMethod = methodCallExpression.Method;
                 var enumerableParameters = enumerableMethod.GetParameters();
-                Type[] genericArguments = null;
+                Type[] genericTypeArguments = null;
                 if (enumerableMethod.Name == nameof(Enumerable.Min)
                     || enumerableMethod.Name == nameof(Enumerable.Max))
                 {
-                    genericArguments = new Type[methodCallExpression.Arguments.Count];
+                    genericTypeArguments = new Type[methodCallExpression.Arguments.Count];
 
                     if (!enumerableMethod.IsGenericMethod)
                     {
-                        genericArguments[0] = enumerableMethod.ReturnType;
+                        genericTypeArguments[0] = enumerableMethod.ReturnType;
                     }
                     else
                     {
                         var argumentTypes = enumerableMethod.GetGenericArguments();
-                        if (argumentTypes.Length == genericArguments.Length)
+                        if (argumentTypes.Length == genericTypeArguments.Length)
                         {
-                            genericArguments = argumentTypes;
+                            genericTypeArguments = argumentTypes;
                         }
                         else
                         {
-                            genericArguments[0] = argumentTypes[0];
-                            genericArguments[1] = enumerableMethod.ReturnType;
+                            genericTypeArguments[0] = argumentTypes[0];
+                            genericTypeArguments[1] = enumerableMethod.ReturnType;
                         }
                     }
                 }
                 else if (enumerableMethod.IsGenericMethod)
                 {
-                    genericArguments = enumerableMethod.GetGenericArguments();
+                    genericTypeArguments = enumerableMethod.GetGenericArguments();
                 }
 
                 foreach (var method in typeof(Queryable).GetTypeInfo().GetDeclaredMethods(methodCallExpression.Method.Name))
@@ -69,10 +69,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     var queryableMethod = method;
                     if (queryableMethod.IsGenericMethod)
                     {
-                        if (genericArguments != null
-                            && queryableMethod.GetGenericArguments().Length == genericArguments.Length)
+                        if (genericTypeArguments != null
+                            && queryableMethod.GetGenericArguments().Length == genericTypeArguments.Length)
                         {
-                            queryableMethod = queryableMethod.MakeGenericMethod(genericArguments);
+                            queryableMethod = queryableMethod.MakeGenericMethod(genericTypeArguments);
                         }
                         else
                         {

--- a/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.ResultOperators.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.ResultOperators.cs
@@ -1301,9 +1301,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = 10248))");
         }
 
         [ConditionalTheory(Skip = "Issue#17246 (Contains not implemented)")]
-        public override async Task List_Contains_with_parameter_HashSet(bool isAsync)
+        public override async Task HashSet_Contains_with_parameter(bool isAsync)
         {
-            await base.List_Contains_with_parameter_HashSet(isAsync);
+            await base.HashSet_Contains_with_parameter(isAsync);
 
             AssertSql(
                 @"SELECT c
@@ -1312,9 +1312,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = 10248))");
         }
 
         [ConditionalTheory(Skip = "Issue#17246 (Contains not implemented)")]
-        public override async Task List_Contains_with_parameter_ImmutableHashSet(bool isAsync)
+        public override async Task ImmutableHashSet_Contains_with_parameter(bool isAsync)
         {
-            await base.List_Contains_with_parameter_ImmutableHashSet(isAsync);
+            await base.ImmutableHashSet_Contains_with_parameter(isAsync);
 
             AssertSql(
                 @"SELECT c
@@ -1344,16 +1344,14 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""OrderDetail"") AND ((c[""OrderID""] = 10248) AND (c[""ProductID""] = 42)))");
         }
 
-        public override void Paging_operation_on_string_doesnt_issue_warning()
+        public override async Task String_FirstOrDefault_in_projection_does_client_eval(bool isAsync)
         {
-            base.Paging_operation_on_string_doesnt_issue_warning();
+            await base.String_FirstOrDefault_in_projection_does_client_eval(isAsync);
 
-            Assert.DoesNotContain(
-#pragma warning disable CS0612 // Type or member is obsolete
-                CoreResources.LogFirstWithoutOrderByAndFilter(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
-#pragma warning restore CS0612 // Type or member is obsolete
-                    "(from char <generated>_1 in [c].CustomerID select [<generated>_1]).FirstOrDefault()"),
-                Fixture.TestSqlLoggerFactory.Log.Select(l => l.Message));
+            AssertSql(
+                @"SELECT c[""CustomerID""]
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
         [ConditionalTheory(Skip = "Issue #17246")]

--- a/test/EFCore.InMemory.FunctionalTests/CustomConvertersInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/CustomConvertersInMemoryTest.cs
@@ -31,6 +31,12 @@ namespace Microsoft.EntityFrameworkCore
         {
         }
 
+        [ConditionalFact(Skip = "Issue#17050")]
+        public override void Collection_property_as_scalar()
+        {
+            base.Collection_property_as_scalar();
+        }
+
         public class CustomConvertersInMemoryFixture : CustomConvertersFixtureBase
         {
             public override bool StrictEquality => true;

--- a/test/EFCore.SqlServer.FunctionalTests/CustomConvertersSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/CustomConvertersSqlServerTest.cs
@@ -148,6 +148,8 @@ BuiltInNullableDataTypesShadow.TestNullableUnsignedInt16 ---> [nullable int] [Pr
 BuiltInNullableDataTypesShadow.TestNullableUnsignedInt32 ---> [nullable bigint] [Precision = 19 Scale = 0]
 BuiltInNullableDataTypesShadow.TestNullableUnsignedInt64 ---> [nullable decimal] [Precision = 20 Scale = 0]
 BuiltInNullableDataTypesShadow.TestString ---> [nullable nvarchar] [MaxLength = -1]
+CollectionScalar.Id ---> [int] [Precision = 10 Scale = 0]
+CollectionScalar.Tags ---> [nullable nvarchar] [MaxLength = -1]
 EmailTemplate.Id ---> [uniqueidentifier]
 EmailTemplate.TemplateType ---> [int] [Precision = 10 Scale = 0]
 EntityWithValueWrapper.Id ---> [int] [Precision = 10 Scale = 0]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.ResultOperators.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.ResultOperators.cs
@@ -1147,9 +1147,9 @@ FROM [Orders] AS [o]
 WHERE [o].[OrderID] IN (10248, 10249)");
         }
 
-        public override async Task List_Contains_with_parameter_HashSet(bool isAsync)
+        public override async Task HashSet_Contains_with_parameter(bool isAsync)
         {
-            await base.List_Contains_with_parameter_HashSet(isAsync);
+            await base.HashSet_Contains_with_parameter(isAsync);
 
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
@@ -1157,9 +1157,9 @@ FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (N'ALFKI')");
         }
 
-        public override async Task List_Contains_with_parameter_ImmutableHashSet(bool isAsync)
+        public override async Task ImmutableHashSet_Contains_with_parameter(bool isAsync)
         {
-            await base.List_Contains_with_parameter_ImmutableHashSet(isAsync);
+            await base.ImmutableHashSet_Contains_with_parameter(isAsync);
 
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
@@ -1185,16 +1185,13 @@ SELECT CASE
 END");
         }
 
-        public override void Paging_operation_on_string_doesnt_issue_warning()
+        public override async Task String_FirstOrDefault_in_projection_does_client_eval(bool isAsync)
         {
-            base.Paging_operation_on_string_doesnt_issue_warning();
+            await base.String_FirstOrDefault_in_projection_does_client_eval(isAsync);
 
-            Assert.DoesNotContain(
-#pragma warning disable CS0612 // Type or member is obsolete
-                CoreResources.LogFirstWithoutOrderByAndFilter(new TestLogger<SqlServerLoggingDefinitions>()).GenerateMessage(
-#pragma warning restore CS0612 // Type or member is obsolete
-                    "(from char <generated>_1 in [c].CustomerID select [<generated>_1]).FirstOrDefault()"),
-                Fixture.TestSqlLoggerFactory.Log.Select(l => l.Message));
+            AssertSql(
+                @"SELECT [c].[CustomerID]
+FROM [Customers] AS [c]");
         }
 
         public override async Task Project_constant_Sum(bool isAsync)


### PR DESCRIPTION
Our EnumerableToQueryable converter works on all the methods. But during nav expansion, we actually inject query sources.
If item is not a query source (like postgre arrays or collection property mapped as scalar via value conversion), then we convert it to enumerable again to be handled by provider.

Resolves #17374
