### PR TITLE
Query: Unwrap convert nodes around entity before doing member lookup

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
@@ -95,57 +95,44 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         protected override Expression VisitMember(MemberExpression memberExpression)
-        {
-            var innerExpression = Visit(memberExpression.Expression);
-
-            if (TryBindMember(innerExpression, MemberIdentity.Create(memberExpression.Member), out var result))
-            {
-                return result;
-            }
-
-            return TranslationFailed(memberExpression.Expression, innerExpression)
-                ? null
-                : _memberTranslatorProvider.Translate((SqlExpression)innerExpression, memberExpression.Member, memberExpression.Type);
-        }
+            => TryBindMember(memberExpression.Expression, MemberIdentity.Create(memberExpression.Member), out var result)
+                ? result
+                : TranslationFailed(memberExpression.Expression, Visit(memberExpression.Expression), out var sqlInnerExpression)
+                    ? null
+                    : _memberTranslatorProvider.Translate(sqlInnerExpression, memberExpression.Member, memberExpression.Type);
 
         private bool TryBindMember(Expression source, MemberIdentity member, out Expression expression)
         {
-            Type convertedType = null;
-            if (source is UnaryExpression unaryExpression
-                && unaryExpression.NodeType == ExpressionType.Convert)
+            source = source.UnwrapTypeConversion(out var convertedType);
+            Expression visitedExpression;
+            switch (source)
             {
-                if (unaryExpression.Type != typeof(object))
-                {
-                    convertedType = unaryExpression.Type;
-                }
+                case EntityShaperExpression entityShaperExpression:
+                    visitedExpression = Visit(entityShaperExpression.ValueBufferExpression);
+                    break;
 
-                source = unaryExpression.Operand;
+                case MemberExpression memberExpression:
+                    TryBindMember(memberExpression.Expression, MemberIdentity.Create(memberExpression.Member), out visitedExpression);
+                    break;
+
+                case MethodCallExpression methodCallExpression
+                    when methodCallExpression.TryGetEFPropertyArguments(out var innerSource, out var innerPropertyName):
+                    TryBindMember(innerSource, MemberIdentity.Create(innerPropertyName), out visitedExpression);
+                    break;
+
+                default:
+                    visitedExpression = null;
+                    break;
             }
 
-            if (source is EntityProjectionExpression entityProjectionExpression)
+            if (visitedExpression is EntityProjectionExpression entityProjectionExpression)
             {
-                if (convertedType != null
-                    && convertedType.IsInterface
-                    && convertedType.IsAssignableFrom(entityProjectionExpression.Type))
-                {
-                    convertedType = entityProjectionExpression.Type;
-                }
-
+                convertedType ??= entityProjectionExpression.Type;
                 expression = member.MemberInfo != null
                     ? entityProjectionExpression.BindMember(member.MemberInfo, convertedType, clientEval: false, out _)
                     : entityProjectionExpression.BindMember(member.Name, convertedType, clientEval: false, out _);
+
                 return expression != null;
-            }
-
-            if (source is MemberExpression innerMemberExpression
-                && TryBindMember(innerMemberExpression, MemberIdentity.Create(innerMemberExpression.Member), out var innerResult))
-            {
-                if (convertedType != null)
-                {
-                    innerResult = Expression.Convert(innerResult, convertedType);
-                }
-
-                return TryBindMember(innerResult, member, out expression);
             }
 
             expression = null;
@@ -162,13 +149,12 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         {
             if (methodCallExpression.TryGetEFPropertyArguments(out var source, out var propertyName))
             {
-                return TryBindMember(Visit(source), MemberIdentity.Create(propertyName), out var result)
+                return TryBindMember(source, MemberIdentity.Create(propertyName), out var result)
                     ? result
                     : null;
             }
 
-            var @object = Visit(methodCallExpression.Object);
-            if (TranslationFailed(methodCallExpression.Object, @object))
+            if (TranslationFailed(methodCallExpression.Object, Visit(methodCallExpression.Object), out var sqlObject))
             {
                 return null;
             }
@@ -176,16 +162,16 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
             var arguments = new SqlExpression[methodCallExpression.Arguments.Count];
             for (var i = 0; i < arguments.Length; i++)
             {
-                var argument = Visit(methodCallExpression.Arguments[i]);
-                if (TranslationFailed(methodCallExpression.Arguments[i], argument))
+                var argument = methodCallExpression.Arguments[i];
+                if (TranslationFailed(argument, Visit(argument), out var sqlArgument))
                 {
                     return null;
                 }
 
-                arguments[i] = (SqlExpression)argument;
+                arguments[i] = sqlArgument;
             }
 
-            return _methodCallTranslatorProvider.Translate(_model, (SqlExpression)@object, methodCallExpression.Method, arguments);
+            return _methodCallTranslatorProvider.Translate(_model, sqlObject, methodCallExpression.Method, arguments);
         }
 
         private static Expression TryRemoveImplicitConvert(Expression expression)
@@ -240,17 +226,14 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
             left = Visit(left);
             right = Visit(right);
 
-            if (TranslationFailed(binaryExpression.Left, left)
-                || TranslationFailed(binaryExpression.Right, right))
-            {
-                return null;
-            }
-
-            return _sqlExpressionFactory.MakeBinary(
-                binaryExpression.NodeType,
-                (SqlExpression)left,
-                (SqlExpression)right,
-                null);
+            return TranslationFailed(binaryExpression.Left, left, out var sqlLeft)
+                || TranslationFailed(binaryExpression.Right, right, out var sqlRight)
+                ? null
+                : _sqlExpressionFactory.MakeBinary(
+                    binaryExpression.NodeType,
+                    sqlLeft,
+                    sqlRight,
+                    null);
         }
 
         /// <summary>
@@ -265,14 +248,11 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
             var ifTrue = Visit(conditionalExpression.IfTrue);
             var ifFalse = Visit(conditionalExpression.IfFalse);
 
-            if (TranslationFailed(conditionalExpression.Test, test)
-                || TranslationFailed(conditionalExpression.IfTrue, ifTrue)
-                || TranslationFailed(conditionalExpression.IfFalse, ifFalse))
-            {
-                return null;
-            }
-
-            return _sqlExpressionFactory.Condition((SqlExpression)test, (SqlExpression)ifTrue, (SqlExpression)ifFalse);
+            return TranslationFailed(conditionalExpression.Test, test, out var sqlTest)
+                || TranslationFailed(conditionalExpression.IfTrue, ifTrue, out var sqlIfTrue)
+                || TranslationFailed(conditionalExpression.IfFalse, ifFalse, out var sqlIfFalse)
+                ? null
+                : _sqlExpressionFactory.Condition(sqlTest, sqlIfTrue, sqlIfFalse);
         }
 
         /// <summary>
@@ -285,17 +265,10 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         {
             var operand = Visit(unaryExpression.Operand);
 
-            if (operand is EntityProjectionExpression)
-            {
-                return unaryExpression.Update(operand);
-            }
-
-            if (TranslationFailed(unaryExpression.Operand, operand))
+            if (TranslationFailed(unaryExpression.Operand, operand, out var sqlOperand))
             {
                 return null;
             }
-
-            var sqlOperand = (SqlExpression)operand;
 
             switch (unaryExpression.NodeType)
             {
@@ -334,7 +307,9 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
 
         private static bool CanEvaluate(Expression expression)
         {
+#pragma warning disable IDE0066 // Convert switch statement to expression
             switch (expression)
+#pragma warning restore IDE0066 // Convert switch statement to expression
             {
                 case ConstantExpression constantExpression:
                     return true;
@@ -447,7 +422,17 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         }
 
         [DebuggerStepThrough]
-        private bool TranslationFailed(Expression original, Expression translation)
-            => original != null && !(translation is SqlExpression);
+        private bool TranslationFailed(Expression original, Expression translation, out SqlExpression castTranslation)
+        {
+            if (original != null
+                && !(translation is SqlExpression))
+            {
+                castTranslation = null;
+                return true;
+            }
+
+            castTranslation = translation as SqlExpression;
+            return false;
+        }
     }
 }

--- a/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
@@ -828,19 +828,8 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
             {
                 var innerExpression = Visit(memberExpression.Expression);
 
-                if (innerExpression is EntityShaperExpression
-                    || (innerExpression is UnaryExpression innerUnaryExpression
-                        && innerUnaryExpression.NodeType == ExpressionType.Convert
-                        && innerUnaryExpression.Operand is EntityShaperExpression))
-                {
-                    var collectionNavigation = Expand(innerExpression, MemberIdentity.Create(memberExpression.Member));
-                    if (collectionNavigation != null)
-                    {
-                        return collectionNavigation;
-                    }
-                }
-
-                return memberExpression.Update(innerExpression);
+                return TryExpand(innerExpression, MemberIdentity.Create(memberExpression.Member))
+                    ?? memberExpression.Update(innerExpression);
             }
 
             protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
@@ -848,19 +837,9 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                 if (methodCallExpression.TryGetEFPropertyArguments(out var source, out var navigationName))
                 {
                     source = Visit(source);
-                    if (source is EntityShaperExpression
-                        || (source is UnaryExpression innerUnaryExpression
-                            && innerUnaryExpression.NodeType == ExpressionType.Convert
-                            && innerUnaryExpression.Operand is EntityShaperExpression))
-                    {
-                        var collectionNavigation = Expand(source, MemberIdentity.Create(navigationName));
-                        if (collectionNavigation != null)
-                        {
-                            return collectionNavigation;
-                        }
-                    }
 
-                    return methodCallExpression.Update(null, new[] { source, methodCallExpression.Arguments[1] });
+                    return TryExpand(source, MemberIdentity.Create(navigationName))
+                        ?? methodCallExpression.Update(null, new[] { source, methodCallExpression.Arguments[1] });
                 }
 
                 return base.VisitMethodCall(methodCallExpression);
@@ -871,19 +850,9 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                     ? extensionExpression
                     : base.VisitExtension(extensionExpression);
 
-            private Expression Expand(Expression source, MemberIdentity member)
+            private Expression TryExpand(Expression source, MemberIdentity member)
             {
-                Type convertedType = null;
-                if (source is UnaryExpression unaryExpression
-                    && unaryExpression.NodeType == ExpressionType.Convert)
-                {
-                    source = unaryExpression.Operand;
-                    if (unaryExpression.Type != typeof(object))
-                    {
-                        convertedType = unaryExpression.Type;
-                    }
-                }
-
+                source = source.UnwrapTypeConversion(out var convertedType);
                 if (!(source is EntityShaperExpression entityShaperExpression))
                 {
                     return null;
@@ -1016,17 +985,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                 return null;
             }
 
-            MethodInfo getMethod()
-                => methodName switch
-                {
-                    nameof(Enumerable.Average) => EnumerableMethods.GetAverageWithSelector(selector.ReturnType),
-                    nameof(Enumerable.Max) => EnumerableMethods.GetMaxWithSelector(selector.ReturnType),
-                    nameof(Enumerable.Min) => EnumerableMethods.GetMinWithSelector(selector.ReturnType),
-                    nameof(Enumerable.Sum) => EnumerableMethods.GetSumWithSelector(selector.ReturnType),
-                    _ => throw new InvalidOperationException("Invalid Aggregate Operator encountered."),
-                };
-
-            var method = getMethod();
+            var method = GetMethod();
             method = method.GetGenericArguments().Length == 2
                 ? method.MakeGenericMethod(typeof(ValueBuffer), selector.ReturnType)
                 : method.MakeGenericMethod(typeof(ValueBuffer));
@@ -1040,6 +999,16 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
             source.ShaperExpression = inMemoryQueryExpression.GetSingleScalarProjection();
 
             return source;
+
+            MethodInfo GetMethod()
+                => methodName switch
+                {
+                    nameof(Enumerable.Average) => EnumerableMethods.GetAverageWithSelector(selector.ReturnType),
+                    nameof(Enumerable.Max) => EnumerableMethods.GetMaxWithSelector(selector.ReturnType),
+                    nameof(Enumerable.Min) => EnumerableMethods.GetMinWithSelector(selector.ReturnType),
+                    nameof(Enumerable.Sum) => EnumerableMethods.GetSumWithSelector(selector.ReturnType),
+                    _ => throw new InvalidOperationException("Invalid Aggregate Operator encountered."),
+                };
         }
 
         private ShapedQueryExpression TranslateSingleResultOperator(

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -986,19 +986,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             {
                 var innerExpression = Visit(memberExpression.Expression);
 
-                if (innerExpression is EntityShaperExpression
-                    || (innerExpression is UnaryExpression innerUnaryExpression
-                        && innerUnaryExpression.NodeType == ExpressionType.Convert
-                        && innerUnaryExpression.Operand is EntityShaperExpression))
-                {
-                    var collectionNavigation = Expand(innerExpression, MemberIdentity.Create(memberExpression.Member));
-                    if (collectionNavigation != null)
-                    {
-                        return collectionNavigation;
-                    }
-                }
-
-                return memberExpression.Update(innerExpression);
+                return TryExpand(innerExpression, MemberIdentity.Create(memberExpression.Member))
+                    ?? memberExpression.Update(innerExpression);
             }
 
             protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
@@ -1006,19 +995,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 if (methodCallExpression.TryGetEFPropertyArguments(out var source, out var navigationName))
                 {
                     source = Visit(source);
-                    if (source is EntityShaperExpression
-                        || (source is UnaryExpression innerUnaryExpression
-                            && innerUnaryExpression.NodeType == ExpressionType.Convert
-                            && innerUnaryExpression.Operand is EntityShaperExpression))
-                    {
-                        var collectionNavigation = Expand(source, MemberIdentity.Create(navigationName));
-                        if (collectionNavigation != null)
-                        {
-                            return collectionNavigation;
-                        }
-                    }
 
-                    return methodCallExpression.Update(null, new[] { source, methodCallExpression.Arguments[1] });
+                    return TryExpand(source, MemberIdentity.Create(navigationName))
+                        ?? methodCallExpression.Update(null, new[] { source, methodCallExpression.Arguments[1] });
                 }
 
                 return base.VisitMethodCall(methodCallExpression);
@@ -1029,19 +1008,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                     ? extensionExpression
                     : base.VisitExtension(extensionExpression);
 
-            private Expression Expand(Expression source, MemberIdentity member)
+            private Expression TryExpand(Expression source, MemberIdentity member)
             {
-                Type convertedType = null;
-                if (source is UnaryExpression unaryExpression
-                    && unaryExpression.NodeType == ExpressionType.Convert)
-                {
-                    source = unaryExpression.Operand;
-                    if (unaryExpression.Type != typeof(object))
-                    {
-                        convertedType = unaryExpression.Type;
-                    }
-                }
-
+                source = source.UnwrapTypeConversion(out var convertedType);
                 if (!(source is EntityShaperExpression entityShaperExpression))
                 {
                     return null;

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -186,43 +186,20 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         protected override Expression VisitMember(MemberExpression memberExpression)
-        {
-            var innerExpression = Visit(memberExpression.Expression);
-
-            if ((innerExpression is EntityProjectionExpression
-                    || (innerExpression is UnaryExpression innerUnaryExpression
-                        && innerUnaryExpression.NodeType == ExpressionType.Convert
-                        && innerUnaryExpression.Operand is EntityProjectionExpression))
-                && TryBindMember(innerExpression, MemberIdentity.Create(memberExpression.Member), out var result))
-            {
-                return result;
-            }
-
-            return TranslationFailed(memberExpression.Expression, innerExpression, out var sqlInnerExpression)
-                ? null
-                : Dependencies.MemberTranslatorProvider.Translate(sqlInnerExpression, memberExpression.Member, memberExpression.Type);
-        }
+            => TryBindMember(memberExpression.Expression, MemberIdentity.Create(memberExpression.Member), out var result)
+                ? result
+                : TranslationFailed(memberExpression.Expression, base.Visit(memberExpression.Expression), out var sqlInnerExpression)
+                    ? null
+                    : Dependencies.MemberTranslatorProvider.Translate(sqlInnerExpression, memberExpression.Member, memberExpression.Type);
 
         private bool TryBindMember(Expression source, MemberIdentity member, out Expression expression)
         {
+            source = source.UnwrapTypeConversion(out var convertedType);
             expression = null;
-            Type convertedType = null;
-            if (source is UnaryExpression unaryExpression
-                && unaryExpression.NodeType == ExpressionType.Convert)
+            if (source is EntityShaperExpression entityShaperExpression)
             {
-                source = unaryExpression.Operand;
-                if (unaryExpression.Type != typeof(object))
-                {
-                    convertedType = unaryExpression.Type;
-                }
-            }
-
-            if (source is EntityProjectionExpression entityProjectionExpression)
-            {
-                var entityType = entityProjectionExpression.EntityType;
-                if (convertedType != null
-                    && !(convertedType.IsInterface
-                        && convertedType.IsAssignableFrom(entityType.ClrType)))
+                var entityType = entityShaperExpression.EntityType;
+                if (convertedType != null)
                 {
                     entityType = entityType.GetRootType().GetDerivedTypesInclusive()
                         .FirstOrDefault(et => et.ClrType == convertedType);
@@ -235,7 +212,10 @@ namespace Microsoft.EntityFrameworkCore.Query
                 var property = member.MemberInfo != null
                     ? entityType.FindProperty(member.MemberInfo)
                     : entityType.FindProperty(member.Name);
-                if (property != null)
+                if (property != null
+                    && Visit(entityShaperExpression.ValueBufferExpression) is EntityProjectionExpression entityProjectionExpression
+                    && (entityProjectionExpression.EntityType.IsAssignableFrom(property.DeclaringEntityType)
+                        || property.DeclaringEntityType.IsAssignableFrom(entityProjectionExpression.EntityType)))
                 {
                     expression = entityProjectionExpression.BindProperty(property);
                     return true;
@@ -321,7 +301,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             // EF.Property case
             if (methodCallExpression.TryGetEFPropertyArguments(out var source, out var propertyName))
             {
-                if (TryBindMember(Visit(source), MemberIdentity.Create(propertyName), out var result))
+                if (TryBindMember(source, MemberIdentity.Create(propertyName), out var result))
                 {
                     return result;
                 }
@@ -389,7 +369,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                     return null;
                 }
 
+#pragma warning disable IDE0046 // Convert to conditional expression
                 if (subquery.Tables.Count == 0
+#pragma warning restore IDE0046 // Convert to conditional expression
                     && methodCallExpression.Method.IsGenericMethod
                     && methodCallExpression.Method.GetGenericMethodDefinition() is MethodInfo genericMethod
                     && (genericMethod == QueryableMethods.AnyWithoutPredicate
@@ -457,18 +439,6 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         private Expression ConvertAnonymousObjectEqualityComparison(BinaryExpression binaryExpression)
         {
-            static Expression removeObjectConvert(Expression expression)
-            {
-                if (expression is UnaryExpression unaryExpression
-                    && expression.Type == typeof(object)
-                    && expression.NodeType == ExpressionType.Convert)
-                {
-                    return unaryExpression.Operand;
-                }
-
-                return expression;
-            }
-
             var leftExpressions = ((NewArrayExpression)((NewExpression)binaryExpression.Left).Arguments[0]).Expressions;
             var rightExpressions = ((NewArrayExpression)((NewExpression)binaryExpression.Right).Arguments[0]).Expressions;
 
@@ -476,8 +446,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                     rightExpressions,
                     (l, r) =>
                     {
-                        l = removeObjectConvert(l);
-                        r = removeObjectConvert(r);
+                        l = RemoveObjectConvert(l);
+                        r = RemoveObjectConvert(r);
                         if (l.Type.IsNullableType())
                         {
                             r = r.Type.IsNullableType() ? r : Expression.Convert(r, l.Type);
@@ -490,6 +460,13 @@ namespace Microsoft.EntityFrameworkCore.Query
                         return Expression.Equal(l, r);
                     })
                 .Aggregate((a, b) => Expression.AndAlso(a, b));
+
+            static Expression RemoveObjectConvert(Expression expression)
+                => expression is UnaryExpression unaryExpression
+                    && expression.Type == typeof(object)
+                    && expression.NodeType == ExpressionType.Convert
+                    ? unaryExpression.Operand
+                    : expression;
         }
 
         protected override Expression VisitBinary(BinaryExpression binaryExpression)
@@ -503,17 +480,14 @@ namespace Microsoft.EntityFrameworkCore.Query
             var left = TryRemoveImplicitConvert(binaryExpression.Left);
             var right = TryRemoveImplicitConvert(binaryExpression.Right);
 
-            if (TranslationFailed(binaryExpression.Left, Visit(left), out var sqlLeft)
-                || TranslationFailed(binaryExpression.Right, Visit(right), out var sqlRight))
-            {
-                return null;
-            }
-
-            return _sqlExpressionFactory.MakeBinary(
-                binaryExpression.NodeType,
-                sqlLeft,
-                sqlRight,
-                null);
+            return TranslationFailed(binaryExpression.Left, Visit(left), out var sqlLeft)
+                || TranslationFailed(binaryExpression.Right, Visit(right), out var sqlRight)
+                ? null
+                : _sqlExpressionFactory.MakeBinary(
+                    binaryExpression.NodeType,
+                    sqlLeft,
+                    sqlRight,
+                    null);
         }
 
         private SqlConstantExpression GetConstantOrNull(Expression expression)
@@ -529,7 +503,9 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         private static bool CanEvaluate(Expression expression)
         {
+#pragma warning disable IDE0066 // Convert switch statement to expression
             switch (expression)
+#pragma warning restore IDE0066 // Convert switch statement to expression
             {
                 case ConstantExpression constantExpression:
                     return true;
@@ -593,24 +569,16 @@ namespace Microsoft.EntityFrameworkCore.Query
             var ifTrue = Visit(conditionalExpression.IfTrue);
             var ifFalse = Visit(conditionalExpression.IfFalse);
 
-            if (TranslationFailed(conditionalExpression.Test, test, out var sqlTest)
+            return TranslationFailed(conditionalExpression.Test, test, out var sqlTest)
                 || TranslationFailed(conditionalExpression.IfTrue, ifTrue, out var sqlIfTrue)
-                || TranslationFailed(conditionalExpression.IfFalse, ifFalse, out var sqlIfFalse))
-            {
-                return null;
-            }
-
-            return _sqlExpressionFactory.Case(new[] { new CaseWhenClause(sqlTest, sqlIfTrue) }, sqlIfFalse);
+                || TranslationFailed(conditionalExpression.IfFalse, ifFalse, out var sqlIfFalse)
+                ? null
+                : _sqlExpressionFactory.Case(new[] { new CaseWhenClause(sqlTest, sqlIfTrue) }, sqlIfFalse);
         }
 
         protected override Expression VisitUnary(UnaryExpression unaryExpression)
         {
             var operand = Visit(unaryExpression.Operand);
-
-            if (operand is EntityProjectionExpression)
-            {
-                return unaryExpression.Update(operand);
-            }
 
             if (TranslationFailed(unaryExpression.Operand, operand, out var sqlOperand))
             {

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
@@ -95,25 +95,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             private Expression TryExpandNavigation(Expression root, MemberIdentity memberIdentity)
             {
-                Type convertedType = null;
-                var innerExpression = root;
-                if (innerExpression is UnaryExpression unaryExpression
-                    && unaryExpression.NodeType == ExpressionType.Convert)
-                {
-                    innerExpression = unaryExpression.Operand;
-                    if (unaryExpression.Type != typeof(object)
-                        && unaryExpression.Type != innerExpression.Type)
-                    {
-                        convertedType = unaryExpression.Type;
-                    }
-                }
-
+                var innerExpression = root.UnwrapTypeConversion(out var convertedType);
                 if (UnwrapEntityReference(innerExpression) is EntityReference entityReference)
                 {
                     var entityType = entityReference.EntityType;
-                    if (convertedType != null
-                        && !(convertedType.IsInterface
-                            && convertedType.IsAssignableFrom(entityType.ClrType)))
+                    if (convertedType != null)
                     {
                         entityType = entityType.GetTypesInHierarchy()
                             .FirstOrDefault(et => et.ClrType == convertedType);

--- a/src/Shared/ExpressionExtensions.cs
+++ b/src/Shared/ExpressionExtensions.cs
@@ -13,5 +13,22 @@ namespace System.Linq.Expressions
             => (LambdaExpression)(expression is UnaryExpression unary && expression.NodeType == ExpressionType.Quote
                 ? unary.Operand
                 : expression);
+
+        public static Expression UnwrapTypeConversion(this Expression expression, out Type convertedType)
+        {
+            convertedType = null;
+            while (expression is UnaryExpression unaryExpression
+                && unaryExpression.NodeType == ExpressionType.Convert)
+            {
+                expression = unaryExpression.Operand;
+                if (unaryExpression.Type != typeof(object) // Ignore object conversion
+                    && !unaryExpression.Type.IsAssignableFrom(expression.Type)) // Ignore casting to base type/interface
+                {
+                    convertedType = unaryExpression.Type;
+                }
+            }
+
+            return expression;
+        }
     }
 }


### PR DESCRIPTION
Resolves #17794
