### PR TITLE
Ignore line endings in test assertions

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/Query/QueryNoClientEvalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/QueryNoClientEvalTestBase.cs
@@ -152,7 +152,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         outerKeySelector: i => i, 
         innerKeySelector: (e1, i) => e1)",
                         "NavigationExpandingExpressionVisitor"),
-                    message);
+                    message, ignoreLineEndingDifferences: true);
             }
         }
 
@@ -176,7 +176,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         outerKeySelector: i => i, 
         innerKeySelector: (e1, g) => e1)",
                         "NavigationExpandingExpressionVisitor"),
-                    message);
+                    message, ignoreLineEndingDifferences: true);
             }
         }
 

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -1594,7 +1594,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Expression: g), ""FullName"") != null && EF.Property<string>((NavigationTreeExpression
                 Value: (EntityReference: Gear)
                 Expression: g), ""FullName"") == EF.Property<string>(i, ""OwnerFullName""))))", "NavigationExpandingExpressionVisitor"),
-                message);
+                message, ignoreLineEndingDifferences: true);
         }
 
         [ConditionalTheory(Skip = "Issue #17068")]
@@ -1648,7 +1648,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Expression: g), ""FullName"") != null && EF.Property<string>((NavigationTreeExpression
                 Value: (EntityReference: Gear)
                 Expression: g), ""FullName"") == EF.Property<string>(i, ""OwnerFullName""))))", "NavigationExpandingExpressionVisitor"),
-                message);
+                message, ignoreLineEndingDifferences: true);
         }
 
         [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -2597,7 +2597,7 @@ namespace Microsoft.EntityFrameworkCore.Query
     .Where(c => c.EmployeeID == 4294967295)
     .DefaultIfEmpty(__p_0)",
                     "NavigationExpandingExpressionVisitor"),
-                message);
+                message, ignoreLineEndingDifferences: true);
         }
 
         [ConditionalTheory]
@@ -2616,7 +2616,7 @@ namespace Microsoft.EntityFrameworkCore.Query
     .Where(c => c.EmployeeID == 4294967295)
     .DefaultIfEmpty(__p_0)",
                     "NavigationExpandingExpressionVisitor"),
-                message);
+                message, ignoreLineEndingDifferences: true);
         }
 
         [ConditionalTheory]


### PR DESCRIPTION
Test failures triggered in EFCore.PG (tests are not overridden). Not sure why this doesn't happen on our CI but it doesn't really matter much...