### PR TITLE
Apply element sorter in AssertIncludeQuery

### DIFF
--- a/test/EFCore.Specification.Tests/TestUtilities/QueryAsserter.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/QueryAsserter.cs
@@ -243,6 +243,12 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                     elementSorter = (Func<TResult, object>)sorter;
                 }
 
+                if (elementSorter != null)
+                {
+                    actual = actual.OrderBy(elementSorter).ToList();
+                    expected = expected.OrderBy(elementSorter).ToList();
+                }
+
                 if (clientProjections != null)
                 {
                     foreach (var clientProjection in clientProjections)


### PR DESCRIPTION
AssertIncludeQuery currently ignores the provided element sorter.

I don't have all the context so I'm not sure I did the right thing here. It's fine to punt this after 3.1 if we want to, I have two affected test failures in Npgsql which I can skip.