### PR TITLE
Query: Deprecate NullConditionalExpression

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
@@ -441,9 +441,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                             .GetMappedProjection(projectionBindingExpression.ProjectionMember)
                         : null;
 
-                case NullConditionalExpression nullConditionalExpression:
-                    return Visit(nullConditionalExpression.AccessOperation);
-
                 default:
                     return null;
             }

--- a/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
@@ -612,14 +612,6 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                         .GetMappedProjection(projectionBindingExpression.ProjectionMember)
                         : null;
 
-                case NullConditionalExpression nullConditionalExpression:
-                {
-                    var translation = Visit(nullConditionalExpression.AccessOperation);
-                    return translation.Type == nullConditionalExpression.Type
-                        ? translation
-                        : Expression.Convert(translation, nullConditionalExpression.Type);
-                }
-
                 default:
                     return null;
             }

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -573,9 +573,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 case SqlExpression _:
                     return extensionExpression;
 
-                case NullConditionalExpression nullConditionalExpression:
-                    return Visit(nullConditionalExpression.AccessOperation);
-
                 case EntityShaperExpression entityShaperExpression:
                     return Visit(entityShaperExpression.ValueBufferExpression);
 

--- a/src/EFCore/Query/Internal/EntityEqualityRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/EntityEqualityRewritingExpressionVisitor.cs
@@ -897,34 +897,13 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 CreateKeyAccessExpression(Unwrap(right), keyProperties));
         }
 
-        protected override Expression VisitExtension(Expression expression)
+        protected override Expression VisitExtension(Expression extensionExpression)
         {
-            switch (expression)
-            {
-                case EntityReferenceExpression _:
-                    // If the expression is an EntityReferenceExpression, simply returns it as all rewriting has already occurred.
-                    // This is necessary when traversing wrapping expressions that have been injected into the lambda for parameters.
-                    return expression;
-
-                case NullConditionalExpression nullConditionalExpression:
-                    return VisitNullConditional(nullConditionalExpression);
-
-                default:
-                    return base.VisitExtension(expression);
-            }
-        }
-
-        private Expression VisitNullConditional(NullConditionalExpression expression)
-        {
-            var newCaller = Visit(expression.Caller);
-            var newAccessOperation = Visit(expression.AccessOperation);
-            var visitedExpression = expression.Update(Unwrap(newCaller), Unwrap(newAccessOperation));
-
-            // TODO: Can the access operation be anything else than a MemberExpression?
-            return newCaller is EntityReferenceExpression wrapper
-                && expression.AccessOperation is MemberExpression memberExpression
-                    ? wrapper.TraverseProperty(memberExpression.Member.Name, visitedExpression)
-                    : visitedExpression;
+            // If the expression is an EntityReferenceExpression, simply returns it as all rewriting has already occurred.
+            // This is necessary when traversing wrapping expressions that have been injected into the lambda for parameters.
+            return extensionExpression is EntityReferenceExpression
+                ? extensionExpression
+                : base.VisitExtension(extensionExpression);
         }
 
         private Expression CreateKeyAccessExpression(

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
@@ -69,9 +69,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     case OwnedNavigationReference ownedNavigationReference:
                         return ownedNavigationReference.EntityReference;
 
-                    case NullConditionalExpression nullConditionalExpression:
-                        return UnwrapEntityReference(nullConditionalExpression.AccessOperation);
-
                     default:
                         return null;
                 }

--- a/src/EFCore/Query/NullConditionalExpression.cs
+++ b/src/EFCore/Query/NullConditionalExpression.cs
@@ -15,6 +15,7 @@ namespace Microsoft.EntityFrameworkCore.Query
     ///     Expression representing null-conditional access.
     ///     Logic in this file is based on https://github.com/bartdesmet/ExpressionFutures
     /// </summary>
+    [Obsolete("Use ConditionalExpression with null check instead")]
     public class NullConditionalExpression : Expression, IPrintableExpression
     {
         /// <summary>

--- a/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.cs
@@ -742,27 +742,6 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""FRANK""))");
         }
 
-        public override async Task Null_conditional_simple(bool isAsync)
-        {
-            await base.Null_conditional_simple(isAsync);
-
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
-        }
-
-        [ConditionalTheory(Skip = "Issue #17246")]
-        public override async Task Null_conditional_deep(bool isAsync)
-        {
-            await base.Null_conditional_deep(isAsync);
-
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
-        }
-
         public override async Task Queryable_simple(bool isAsync)
         {
             await base.Queryable_simple(isAsync);

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -520,52 +520,6 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual Task Null_conditional_simple(bool isAsync)
-        {
-            var c = Expression.Parameter(typeof(Customer));
-
-            var predicate
-                = Expression.Lambda<Func<Customer, bool>>(
-                    Expression.Equal(
-                        new NullConditionalExpression(c, Expression.Property(c, "CustomerID")),
-                        Expression.Constant("ALFKI")),
-                    c);
-
-            return AssertQuery(
-                isAsync,
-                ss => ss.Set<Customer>().Where(predicate),
-                entryCount: 1);
-        }
-
-        [ConditionalTheory]
-        [MemberData(nameof(IsAsyncData))]
-        public virtual Task Null_conditional_deep(bool isAsync)
-        {
-            var c = Expression.Parameter(typeof(Customer));
-
-            var nullConditionalExpression
-                = new NullConditionalExpression(c, Expression.Property(c, "CustomerID"));
-
-            nullConditionalExpression
-                = new NullConditionalExpression(
-                    nullConditionalExpression,
-                    Expression.Property(nullConditionalExpression, "Length"));
-
-            var predicate
-                = Expression.Lambda<Func<Customer, bool>>(
-                    Expression.Equal(
-                        nullConditionalExpression,
-                        Expression.Constant(5, typeof(int?))),
-                    c);
-
-            return AssertQuery(
-                isAsync,
-                ss => ss.Set<Customer>().Where(predicate),
-                entryCount: 91);
-        }
-
-        [ConditionalTheory]
-        [MemberData(nameof(IsAsyncData))]
         public virtual Task Queryable_simple(bool isAsync)
         {
             return AssertQuery(

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -1234,26 +1234,6 @@ FROM (
 ) AS [t0]");
         }
 
-        public override async Task Null_conditional_simple(bool isAsync)
-        {
-            await base.Null_conditional_simple(isAsync);
-
-            AssertSql(
-                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = N'ALFKI'");
-        }
-
-        public override async Task Null_conditional_deep(bool isAsync)
-        {
-            await base.Null_conditional_deep(isAsync);
-
-            AssertSql(
-                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-WHERE CAST(LEN([c].[CustomerID]) AS int) = 5");
-        }
-
         public override async Task Queryable_simple(bool isAsync)
         {
             await base.Queryable_simple(isAsync);

--- a/test/EFCore.Tests/Query/ExpressionPrinterTest.cs
+++ b/test/EFCore.Tests/Query/ExpressionPrinterTest.cs
@@ -165,7 +165,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public void Complex_MethodCall_printed_correctly()
         {
             Assert.Equal(
-                @"""Foobar"".Substring(
+                "\"Foobar\""
++ @".Substring(
     startIndex: 0, 
     length: 4)",
                 _expressionPrinter.Print(
@@ -194,16 +195,6 @@ namespace Microsoft.EntityFrameworkCore.Query
     .AsEnumerable()
     .Where(x => x.Length > 1)",
                 _expressionPrinter.Print(expr.Body));
-        }
-
-        [ConditionalFact]
-        public void Use_Print_method_when_printing_extension_expression()
-        {
-            var expr = new NullConditionalExpression(
-                Expression.Constant("caller"),
-                Expression.Constant("accessOperation"));
-
-            Assert.Equal(expr.Print(), _expressionPrinter.Print(expr));
         }
     }
 }


### PR DESCRIPTION
We flow nullability information through joins. And InMemory works with nullable values from database differently.
Hence we no longer need it. It creates unnecessary wrapper expression complicating things.

Looking for a quick review. It is required for #18670