### PR TITLE
Add back execution retry for query.

### DIFF
--- a/All.sln.DotSettings
+++ b/All.sln.DotSettings
@@ -198,6 +198,7 @@ Licensed under the Apache License, Version 2.0. See License.txt in the project r
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsWrapperSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EXml_002ECodeStyle_002EFormatSettingsUpgrade_002EXmlMoveToCommonFormatterSettingsUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=annotatable/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=doesnt/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=fallbacks/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=initializers/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=keyless/@EntryIndexedValue">True</s:Boolean>
@@ -207,10 +208,13 @@ Licensed under the Apache License, Version 2.0. See License.txt in the project r
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=pushdown/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=remapper/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=requiredness/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=retriable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=shaper/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=spatialite/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=sproc/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=sqlite/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=subquery/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=unignore/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=fixup/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=attacher/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=attacher/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Xunit/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/EFCore.Relational/Extensions/RelationalDatabaseFacadeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalDatabaseFacadeExtensions.cs
@@ -222,6 +222,7 @@ namespace Microsoft.EntityFrameworkCore
                         new RelationalCommandParameterObject(
                             GetFacadeDependencies(databaseFacade).RelationalConnection,
                             rawSqlCommand.ParameterValues,
+                            null,
                             ((IDatabaseFacadeDependenciesAccessor)databaseFacade).Context,
                             logger));
             }
@@ -388,6 +389,7 @@ namespace Microsoft.EntityFrameworkCore
                         new RelationalCommandParameterObject(
                             facadeDependencies.RelationalConnection,
                             rawSqlCommand.ParameterValues,
+                            null,
                             ((IDatabaseFacadeDependenciesAccessor)databaseFacade).Context,
                             logger),
                         cancellationToken);
@@ -504,6 +506,7 @@ namespace Microsoft.EntityFrameworkCore
                         new RelationalCommandParameterObject(
                             facadeDependencies.RelationalConnection,
                             rawSqlCommand.ParameterValues,
+                            null,
                             ((IDatabaseFacadeDependenciesAccessor)databaseFacade).Context,
                             logger));
             }
@@ -656,6 +659,7 @@ namespace Microsoft.EntityFrameworkCore
                         new RelationalCommandParameterObject(
                             facadeDependencies.RelationalConnection,
                             rawSqlCommand.ParameterValues,
+                            null,
                             ((IDatabaseFacadeDependenciesAccessor)databaseFacade).Context,
                             logger),
                         cancellationToken);

--- a/src/EFCore.Relational/Migrations/HistoryRepository.cs
+++ b/src/EFCore.Relational/Migrations/HistoryRepository.cs
@@ -127,13 +127,14 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         /// <summary>
         ///     Checks whether or not the history table exists.
         /// </summary>
-        /// <returns> <c>True</c> if the table already exists, <c>false</c> otherwise. </returns>
+        /// <returns> <c>true</c> if the table already exists, <c>false</c> otherwise. </returns>
         public virtual bool Exists()
             => Dependencies.DatabaseCreator.Exists()
                 && InterpretExistsResult(
                     Dependencies.RawSqlCommandBuilder.Build(ExistsSql).ExecuteScalar(
                         new RelationalCommandParameterObject(
                             Dependencies.Connection,
+                            null,
                             null,
                             Dependencies.CurrentContext.Context,
                             Dependencies.CommandLogger)));
@@ -144,7 +145,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns>
         ///     A task that represents the asynchronous operation. The task result contains
-        ///     <c>True</c> if the table already exists, <c>false</c> otherwise.
+        ///     <c>true</c> if the table already exists, <c>false</c> otherwise.
         /// </returns>
         public virtual async Task<bool> ExistsAsync(CancellationToken cancellationToken = default)
             => await Dependencies.DatabaseCreator.ExistsAsync(cancellationToken)
@@ -153,6 +154,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                         new RelationalCommandParameterObject(
                             Dependencies.Connection,
                             null,
+                            null,
                             Dependencies.CurrentContext.Context,
                             Dependencies.CommandLogger),
                         cancellationToken));
@@ -160,7 +162,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         /// <summary>
         ///     Interprets the result of executing <see cref="ExistsSql" />.
         /// </summary>
-        /// <returns>true if the table exists; otherwise, false.</returns>
+        /// <returns><c>true</c> if the table already exists, <c>false</c> otherwise.</returns>
         protected abstract bool InterpretExistsResult([NotNull] object value);
 
         /// <summary>
@@ -217,6 +219,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     new RelationalCommandParameterObject(
                         Dependencies.Connection,
                         null,
+                        null,
                         Dependencies.CurrentContext.Context,
                         Dependencies.CommandLogger)))
                 {
@@ -250,6 +253,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 await using (var reader = await command.ExecuteReaderAsync(
                     new RelationalCommandParameterObject(
                         Dependencies.Connection,
+                        null,
                         null,
                         Dependencies.CurrentContext.Context,
                         Dependencies.CommandLogger),

--- a/src/EFCore.Relational/Migrations/Internal/Migrator.cs
+++ b/src/EFCore.Relational/Migrations/Internal/Migrator.cs
@@ -117,6 +117,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     new RelationalCommandParameterObject(
                         _connection,
                         null,
+                        null,
                         _currentContext.Context,
                         _commandLogger));
             }
@@ -153,6 +154,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 await command.ExecuteNonQueryAsync(
                     new RelationalCommandParameterObject(
                         _connection,
+                        null,
                         null,
                         _currentContext.Context,
                         _commandLogger),

--- a/src/EFCore.Relational/Migrations/MigrationCommand.cs
+++ b/src/EFCore.Relational/Migrations/MigrationCommand.cs
@@ -64,6 +64,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 new RelationalCommandParameterObject(
                     connection,
                     parameterValues,
+                    null,
                     _context,
                     _logger));
 
@@ -82,6 +83,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 new RelationalCommandParameterObject(
                     connection,
                     parameterValues,
+                    null,
                     _context,
                     _logger),
                 cancellationToken);

--- a/src/EFCore.Relational/Query/Internal/BufferedDataReader.cs
+++ b/src/EFCore.Relational/Query/Internal/BufferedDataReader.cs
@@ -1,0 +1,1324 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public class BufferedDataReader : DbDataReader
+    {
+        private DbDataReader _underlyingReader;
+        private List<BufferedDataRecord> _bufferedDataRecords = new List<BufferedDataRecord>();
+        private BufferedDataRecord _currentResultSet;
+        private int _currentResultSetNumber;
+        private int _recordsAffected;
+        private bool _disposed;
+        private bool _isClosed;
+
+        public BufferedDataReader([NotNull] DbDataReader reader)
+        {
+            _underlyingReader = reader;
+        }
+
+        public override int RecordsAffected => _recordsAffected;
+
+        public override object this[string name] => throw new NotSupportedException();
+
+        public override object this[int ordinal] => throw new NotSupportedException();
+
+        public override int Depth => throw new NotSupportedException();
+
+        public override int FieldCount
+        {
+            get
+            {
+                AssertReaderIsOpen();
+                return _currentResultSet.FieldCount;
+            }
+        }
+
+        public override bool HasRows
+        {
+            get
+            {
+                AssertReaderIsOpen();
+                return _currentResultSet.HasRows;
+            }
+        }
+
+        public override bool IsClosed => _isClosed;
+
+        [Conditional("DEBUG")]
+        private void AssertReaderIsOpen()
+        {
+            if (_underlyingReader != null)
+            {
+                throw new InvalidOperationException("The reader wasn't initialized");
+            }
+
+            if (_isClosed)
+            {
+                throw new InvalidOperationException("The reader is closed.");
+            }
+        }
+
+        [Conditional("DEBUG")]
+        private void AssertReaderIsOpenWithData()
+        {
+            AssertReaderIsOpen();
+
+            if (!_currentResultSet.IsDataReady)
+            {
+                throw new InvalidOperationException("The reader doesn't have any data.");
+            }
+        }
+
+        [Conditional("DEBUG")]
+        private void AssertFieldIsReady(int ordinal)
+        {
+            AssertReaderIsOpenWithData();
+
+            if (0 > ordinal
+                || ordinal > _currentResultSet.FieldCount)
+            {
+                throw new IndexOutOfRangeException();
+            }
+        }
+
+        public virtual BufferedDataReader Initialize([NotNull] IReadOnlyList<ReaderColumn> columns)
+        {
+            if (_underlyingReader == null)
+            {
+                return this;
+            }
+
+            try
+            {
+                do
+                {
+                    _bufferedDataRecords.Add(new BufferedDataRecord().Initialize(_underlyingReader, columns));
+                }
+                while (_underlyingReader.NextResult());
+
+                _recordsAffected = _underlyingReader.RecordsAffected;
+                _currentResultSet = _bufferedDataRecords[_currentResultSetNumber];
+
+                return this;
+            }
+            finally
+            {
+                _underlyingReader.Dispose();
+                _underlyingReader = null;
+            }
+        }
+
+        public virtual async Task<BufferedDataReader> InitializeAsync(
+            [NotNull] IReadOnlyList<ReaderColumn> columns, CancellationToken cancellationToken)
+        {
+            if (_underlyingReader == null)
+            {
+                return this;
+            }
+
+            try
+            {
+                do
+                {
+                    _bufferedDataRecords.Add(await new BufferedDataRecord().InitializeAsync(_underlyingReader, columns, cancellationToken));
+                }
+                while (await _underlyingReader.NextResultAsync(cancellationToken));
+
+                _recordsAffected = _underlyingReader.RecordsAffected;
+                _currentResultSet = _bufferedDataRecords[_currentResultSetNumber];
+
+                return this;
+            }
+            finally
+            {
+                _underlyingReader.Dispose();
+                _underlyingReader = null;
+            }
+        }
+
+        public static bool IsSupportedValueType(Type type)
+            => type == typeof(int)
+                || type == typeof(bool)
+                || type == typeof(Guid)
+                || type == typeof(byte)
+                || type == typeof(char)
+                || type == typeof(DateTime)
+                || type == typeof(DateTimeOffset)
+                || type == typeof(decimal)
+                || type == typeof(double)
+                || type == typeof(float)
+                || type == typeof(short)
+                || type == typeof(long)
+                || type == typeof(uint)
+                || type == typeof(ushort)
+                || type == typeof(ulong)
+                || type == typeof(sbyte);
+
+        public override void Close()
+        {
+            _bufferedDataRecords = null;
+            _isClosed = true;
+
+            var reader = _underlyingReader;
+            if (reader != null)
+            {
+                _underlyingReader = null;
+                reader.Dispose();
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (!_disposed
+                && disposing
+                && !IsClosed)
+            {
+                Close();
+            }
+
+            _disposed = true;
+
+            base.Dispose(disposing);
+        }
+
+        public override bool GetBoolean(int ordinal)
+        {
+            AssertFieldIsReady(ordinal);
+            return _currentResultSet.GetBoolean(ordinal);
+        }
+
+        public override byte GetByte(int ordinal)
+        {
+            AssertFieldIsReady(ordinal);
+            return _currentResultSet.GetByte(ordinal);
+        }
+
+        public override long GetBytes(int ordinal, long dataOffset, byte[] buffer, int bufferOffset, int length)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override char GetChar(int ordinal)
+        {
+            AssertFieldIsReady(ordinal);
+            return _currentResultSet.GetChar(ordinal);
+        }
+
+        public override long GetChars(int ordinal, long dataOffset, char[] buffer, int bufferOffset, int length)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override DateTime GetDateTime(int ordinal)
+        {
+            AssertFieldIsReady(ordinal);
+            return _currentResultSet.GetDateTime(ordinal);
+        }
+
+        public override decimal GetDecimal(int ordinal)
+        {
+            AssertFieldIsReady(ordinal);
+            return _currentResultSet.GetDecimal(ordinal);
+        }
+
+        public override double GetDouble(int ordinal)
+        {
+            AssertFieldIsReady(ordinal);
+            return _currentResultSet.GetDouble(ordinal);
+        }
+
+        public override float GetFloat(int ordinal)
+        {
+            AssertFieldIsReady(ordinal);
+            return _currentResultSet.GetFloat(ordinal);
+        }
+
+        public override Guid GetGuid(int ordinal)
+        {
+            AssertFieldIsReady(ordinal);
+            return _currentResultSet.GetGuid(ordinal);
+        }
+
+        public override short GetInt16(int ordinal)
+        {
+            AssertFieldIsReady(ordinal);
+            return _currentResultSet.GetInt16(ordinal);
+        }
+
+        public override int GetInt32(int ordinal)
+        {
+            AssertFieldIsReady(ordinal);
+            return _currentResultSet.GetInt32(ordinal);
+        }
+
+        public override long GetInt64(int ordinal)
+        {
+            AssertFieldIsReady(ordinal);
+            return _currentResultSet.GetInt64(ordinal);
+        }
+
+        public override string GetString(int ordinal)
+        {
+            AssertFieldIsReady(ordinal);
+            return _currentResultSet.GetFieldValue<string>(ordinal);
+        }
+
+        public override T GetFieldValue<T>(int ordinal)
+        {
+            AssertFieldIsReady(ordinal);
+            return _currentResultSet.GetFieldValue<T>(ordinal);
+        }
+
+        public override Task<T> GetFieldValueAsync<T>(int ordinal, CancellationToken cancellationToken)
+        {
+            AssertFieldIsReady(ordinal);
+            return _currentResultSet.GetFieldValueAsync<T>(ordinal, cancellationToken);
+        }
+
+        public override object GetValue(int ordinal)
+        {
+            AssertFieldIsReady(ordinal);
+            return _currentResultSet.GetValue(ordinal);
+        }
+
+        public override int GetValues(object[] values)
+        {
+            AssertReaderIsOpenWithData();
+            return _currentResultSet.GetValues(values);
+        }
+
+        public override string GetDataTypeName(int ordinal)
+        {
+            AssertReaderIsOpen();
+            return _currentResultSet.GetDataTypeName(ordinal);
+        }
+
+        public override Type GetFieldType(int ordinal)
+        {
+            AssertReaderIsOpen();
+            return _currentResultSet.GetFieldType(ordinal);
+        }
+
+        public override string GetName(int ordinal)
+        {
+            AssertReaderIsOpen();
+            return _currentResultSet.GetName(ordinal);
+        }
+
+        public override int GetOrdinal(string name)
+        {
+            Check.NotNull(name, "name");
+            AssertReaderIsOpen();
+            return _currentResultSet.GetOrdinal(name);
+        }
+
+        public override bool IsDBNull(int ordinal)
+        {
+            AssertFieldIsReady(ordinal);
+            return _currentResultSet.IsDBNull(ordinal);
+        }
+
+        public override Task<bool> IsDBNullAsync(int ordinal, CancellationToken cancellationToken)
+        {
+            AssertFieldIsReady(ordinal);
+            return _currentResultSet.IsDBNullAsync(ordinal, cancellationToken);
+        }
+
+        public override IEnumerator GetEnumerator() => throw new NotSupportedException();
+
+        public override DataTable GetSchemaTable() => throw new NotSupportedException();
+
+        public override bool NextResult()
+        {
+            AssertReaderIsOpen();
+            if (++_currentResultSetNumber < _bufferedDataRecords.Count)
+            {
+                _currentResultSet = _bufferedDataRecords[_currentResultSetNumber];
+                return true;
+            }
+
+            _currentResultSet = null;
+            return false;
+        }
+
+        public override Task<bool> NextResultAsync(CancellationToken cancellationToken)
+            => Task.FromResult(NextResult());
+
+        public override bool Read()
+        {
+            AssertReaderIsOpen();
+            return _currentResultSet.Read();
+        }
+
+        public override Task<bool> ReadAsync(CancellationToken cancellationToken)
+        {
+            AssertReaderIsOpen();
+            return _currentResultSet.ReadAsync(cancellationToken);
+        }
+
+        private class BufferedDataRecord
+        {
+            private int _currentRowNumber = -1;
+            private int _rowCount;
+            private string[] _dataTypeNames;
+            private Type[] _fieldTypes;
+            private string[] _columnNames;
+            private Lazy<Dictionary<string, int>> _fieldNameLookup;
+
+            private int _rowCapacity = 1;
+
+            // Resizing bool[] is faster than BitArray, but the latter is more efficient for long-term storage.
+            private BitArray _bools;
+            private bool[] _tempBools;
+            private int _boolCount;
+            private byte[] _bytes;
+            private int _byteCount;
+            private char[] _chars;
+            private int _charCount;
+            private DateTime[] _dateTimes;
+            private int _dateTimeCount;
+            private DateTimeOffset[] _dateTimeOffsets;
+            private int _dateTimeOffsetCount;
+            private decimal[] _decimals;
+            private int _decimalCount;
+            private double[] _doubles;
+            private int _doubleCount;
+            private float[] _floats;
+            private int _floatCount;
+            private Guid[] _guids;
+            private int _guidCount;
+            private short[] _shorts;
+            private int _shortCount;
+            private int[] _ints;
+            private int _intCount;
+            private long[] _longs;
+            private int _longCount;
+            private sbyte[] _sbytes;
+            private int _sbyteCount;
+            private uint[] _uints;
+            private int _uintCount;
+            private ushort[] _ushorts;
+            private int _ushortCount;
+            private ulong[] _ulongs;
+            private int _ulongCount;
+            private object[] _objects;
+            private int _objectCount;
+            private int[] _ordinalToIndexMap;
+
+            private BitArray _nulls;
+            private bool[] _tempNulls;
+            private int _nullCount;
+            private int[] _nullOrdinalToIndexMap;
+
+            private TypeCase[] _columnTypeCases;
+
+            private DbDataReader _underlyingReader;
+            private IReadOnlyList<ReaderColumn> _columns;
+            private int[] _indexMap;
+
+            public bool IsDataReady { get; private set; }
+
+            public bool HasRows => _rowCount > 0;
+
+            public int FieldCount => _fieldTypes.Length;
+
+            public string GetDataTypeName(int ordinal) => _dataTypeNames[ordinal];
+
+            public Type GetFieldType(int ordinal) => _fieldTypes[ordinal];
+
+            public string GetName(int ordinal) => _columnNames[ordinal];
+
+            public int GetOrdinal(string name) => _fieldNameLookup.Value[name];
+
+            public bool GetBoolean(int ordinal)
+                => _columnTypeCases[ordinal] == TypeCase.Bool
+                    ? _bools[_currentRowNumber * _boolCount + _ordinalToIndexMap[ordinal]]
+                    : GetFieldValue<bool>(ordinal);
+
+            public byte GetByte(int ordinal)
+                => _columnTypeCases[ordinal] == TypeCase.Byte
+                    ? _bytes[_currentRowNumber * _byteCount + _ordinalToIndexMap[ordinal]]
+                    : GetFieldValue<byte>(ordinal);
+
+            public char GetChar(int ordinal)
+                => _columnTypeCases[ordinal] == TypeCase.Char
+                    ? _chars[_currentRowNumber * _charCount + _ordinalToIndexMap[ordinal]]
+                    : GetFieldValue<char>(ordinal);
+
+            public DateTime GetDateTime(int ordinal)
+                => _columnTypeCases[ordinal] == TypeCase.DateTime
+                    ? _dateTimes[_currentRowNumber * _dateTimeCount + _ordinalToIndexMap[ordinal]]
+                    : GetFieldValue<DateTime>(ordinal);
+
+            public DateTimeOffset GetDateTimeOffset(int ordinal)
+                => _columnTypeCases[ordinal] == TypeCase.DateTimeOffset
+                    ? _dateTimeOffsets[_currentRowNumber * _dateTimeOffsetCount + _ordinalToIndexMap[ordinal]]
+                    : GetFieldValue<DateTimeOffset>(ordinal);
+
+            public decimal GetDecimal(int ordinal)
+                => _columnTypeCases[ordinal] == TypeCase.Decimal
+                    ? _decimals[_currentRowNumber * _decimalCount + _ordinalToIndexMap[ordinal]]
+                    : GetFieldValue<decimal>(ordinal);
+
+            public double GetDouble(int ordinal)
+                => _columnTypeCases[ordinal] == TypeCase.Double
+                    ? _doubles[_currentRowNumber * _doubleCount + _ordinalToIndexMap[ordinal]]
+                    : GetFieldValue<double>(ordinal);
+
+            public float GetFloat(int ordinal)
+                => _columnTypeCases[ordinal] == TypeCase.Float
+                    ? _floats[_currentRowNumber * _floatCount + _ordinalToIndexMap[ordinal]]
+                    : GetFieldValue<float>(ordinal);
+
+            public Guid GetGuid(int ordinal)
+                => _columnTypeCases[ordinal] == TypeCase.Guid
+                    ? _guids[_currentRowNumber * _guidCount + _ordinalToIndexMap[ordinal]]
+                    : GetFieldValue<Guid>(ordinal);
+
+            public short GetInt16(int ordinal)
+                => _columnTypeCases[ordinal] == TypeCase.Short
+                    ? _shorts[_currentRowNumber * _shortCount + _ordinalToIndexMap[ordinal]]
+                    : GetFieldValue<short>(ordinal);
+
+            public int GetInt32(int ordinal)
+                => _columnTypeCases[ordinal] == TypeCase.Int
+                    ? _ints[_currentRowNumber * _intCount + _ordinalToIndexMap[ordinal]]
+                    : GetFieldValue<int>(ordinal);
+
+            public long GetInt64(int ordinal)
+                => _columnTypeCases[ordinal] == TypeCase.Long
+                    ? _longs[_currentRowNumber * _longCount + _ordinalToIndexMap[ordinal]]
+                    : GetFieldValue<long>(ordinal);
+
+            public sbyte GetSByte(int ordinal)
+                => _columnTypeCases[ordinal] == TypeCase.SByte
+                    ? _sbytes[_currentRowNumber * _sbyteCount + _ordinalToIndexMap[ordinal]]
+                    : GetFieldValue<sbyte>(ordinal);
+
+            public ushort GetUInt16(int ordinal)
+                => _columnTypeCases[ordinal] == TypeCase.UShort
+                    ? _ushorts[_currentRowNumber * _ushortCount + _ordinalToIndexMap[ordinal]]
+                    : GetFieldValue<ushort>(ordinal);
+
+            public uint GetUInt32(int ordinal)
+                => _columnTypeCases[ordinal] == TypeCase.UInt
+                    ? _uints[_currentRowNumber * _uintCount + _ordinalToIndexMap[ordinal]]
+                    : GetFieldValue<uint>(ordinal);
+
+            public ulong GetUInt64(int ordinal)
+                => _columnTypeCases[ordinal] == TypeCase.ULong
+                    ? _ulongs[_currentRowNumber * _ulongCount + _ordinalToIndexMap[ordinal]]
+                    : GetFieldValue<ulong>(ordinal);
+
+            public object GetValue(int ordinal)
+                => GetFieldValue<object>(ordinal);
+
+            public int GetValues(object[] values)
+                => throw new NotSupportedException();
+
+            public T GetFieldValue<T>(int ordinal)
+            {
+                switch (_columnTypeCases[ordinal])
+                {
+                    case TypeCase.Bool:
+                        return (T)(object)GetBoolean(ordinal);
+                    case TypeCase.Byte:
+                        return (T)(object)GetByte(ordinal);
+                    case TypeCase.Char:
+                        return (T)(object)GetChar(ordinal);
+                    case TypeCase.DateTime:
+                        return (T)(object)GetDateTime(ordinal);
+                    case TypeCase.DateTimeOffset:
+                        return (T)(object)GetDateTimeOffset(ordinal);
+                    case TypeCase.Decimal:
+                        return (T)(object)GetDecimal(ordinal);
+                    case TypeCase.Double:
+                        return (T)(object)GetDouble(ordinal);
+                    case TypeCase.Float:
+                        return (T)(object)GetFloat(ordinal);
+                    case TypeCase.Guid:
+                        return (T)(object)GetGuid(ordinal);
+                    case TypeCase.Short:
+                        return (T)(object)GetInt16(ordinal);
+                    case TypeCase.Int:
+                        return (T)(object)GetInt32(ordinal);
+                    case TypeCase.Long:
+                        return (T)(object)GetInt64(ordinal);
+                    case TypeCase.SByte:
+                        return (T)(object)GetSByte(ordinal);
+                    case TypeCase.UShort:
+                        return (T)(object)GetUInt16(ordinal);
+                    case TypeCase.UInt:
+                        return (T)(object)GetUInt32(ordinal);
+                    case TypeCase.ULong:
+                        return (T)(object)GetUInt64(ordinal);
+                    case TypeCase.Empty:
+                        return default;
+                    default:
+                        return (T)_objects[_currentRowNumber * _objectCount + _ordinalToIndexMap[ordinal]];
+                }
+            }
+
+            public Task<T> GetFieldValueAsync<T>(int ordinal, CancellationToken cancellationToken)
+                => Task.FromResult(GetFieldValue<T>(ordinal));
+
+            public bool IsDBNull(int ordinal) => _nulls[_currentRowNumber * _nullCount + _nullOrdinalToIndexMap[ordinal]];
+
+            public Task<bool> IsDBNullAsync(int ordinal, CancellationToken cancellationToken) => Task.FromResult(IsDBNull(ordinal));
+
+            public bool Read() => IsDataReady = ++_currentRowNumber < _rowCount;
+
+            public Task<bool> ReadAsync(CancellationToken cancellationToken) => Task.FromResult(Read());
+
+            public BufferedDataRecord Initialize([NotNull] DbDataReader reader, [NotNull] IReadOnlyList<ReaderColumn> columns)
+            {
+                _underlyingReader = reader;
+                _columns = columns;
+
+                ReadMetadata();
+                InitializeFields();
+
+                while (reader.Read())
+                {
+                    ReadRow();
+                }
+
+                _bools = new BitArray(_tempBools);
+                _tempBools = null;
+                _nulls = new BitArray(_tempNulls);
+                _tempNulls = null;
+                _rowCount = _currentRowNumber + 1;
+                _currentRowNumber = -1;
+                _underlyingReader = null;
+                _columns = null;
+
+                return this;
+            }
+
+            public async Task<BufferedDataRecord> InitializeAsync(
+                [NotNull] DbDataReader reader, [NotNull] IReadOnlyList<ReaderColumn> columns, CancellationToken cancellationToken)
+            {
+                _underlyingReader = reader;
+                _columns = columns;
+
+                ReadMetadata();
+                InitializeFields();
+
+                while (await reader.ReadAsync(cancellationToken))
+                {
+                    ReadRow();
+                }
+
+                _bools = new BitArray(_tempBools);
+                _tempBools = null;
+                _nulls = new BitArray(_tempNulls);
+                _tempNulls = null;
+                _rowCount = _currentRowNumber + 1;
+                _currentRowNumber = -1;
+                _underlyingReader = null;
+                _columns = null;
+
+                return this;
+            }
+
+            private void ReadRow()
+            {
+                _currentRowNumber++;
+
+                if (_rowCapacity == _currentRowNumber)
+                {
+                    DoubleBufferCapacity();
+                }
+
+                for (var i = 0; i < FieldCount; i++)
+                {
+                    var column = _columns[i];
+                    var nullIndex = _nullOrdinalToIndexMap[i];
+                    switch (_columnTypeCases[i])
+                    {
+                        case TypeCase.Bool:
+                            if (nullIndex != -1)
+                            {
+                                if (!(_tempNulls[_currentRowNumber * _nullCount + nullIndex] = _underlyingReader.IsDBNull(i)))
+                                {
+                                    ReadBool(_underlyingReader, i, column);
+                                }
+                            }
+                            else
+                            {
+                                ReadBool(_underlyingReader, i, column);
+                            }
+
+                            break;
+                        case TypeCase.Byte:
+                            if (nullIndex != -1)
+                            {
+                                if (!(_tempNulls[_currentRowNumber * _nullCount + nullIndex] = _underlyingReader.IsDBNull(i)))
+                                {
+                                    ReadByte(_underlyingReader, i, column);
+                                }
+                            }
+                            else
+                            {
+                                ReadByte(_underlyingReader, i, column);
+                            }
+
+                            break;
+                        case TypeCase.Char:
+                            if (nullIndex != -1)
+                            {
+                                if (!(_tempNulls[_currentRowNumber * _nullCount + nullIndex] = _underlyingReader.IsDBNull(i)))
+                                {
+                                    ReadChar(_underlyingReader, i, column);
+                                }
+                            }
+                            else
+                            {
+                                ReadChar(_underlyingReader, i, column);
+                            }
+
+                            break;
+                        case TypeCase.DateTime:
+                            if (nullIndex != -1)
+                            {
+                                if (!(_tempNulls[_currentRowNumber * _nullCount + nullIndex] = _underlyingReader.IsDBNull(i)))
+                                {
+                                    ReadDateTime(_underlyingReader, i, column);
+                                }
+                            }
+                            else
+                            {
+                                ReadDateTime(_underlyingReader, i, column);
+                            }
+
+                            break;
+                        case TypeCase.DateTimeOffset:
+                            if (nullIndex != -1)
+                            {
+                                if (!(_tempNulls[_currentRowNumber * _nullCount + nullIndex] = _underlyingReader.IsDBNull(i)))
+                                {
+                                    ReadDateTimeOffset(_underlyingReader, i, column);
+                                }
+                            }
+                            else
+                            {
+                                ReadDateTimeOffset(_underlyingReader, i, column);
+                            }
+
+                            break;
+                        case TypeCase.Decimal:
+                            if (nullIndex != -1)
+                            {
+                                if (!(_tempNulls[_currentRowNumber * _nullCount + nullIndex] = _underlyingReader.IsDBNull(i)))
+                                {
+                                    ReadDecimal(_underlyingReader, i, column);
+                                }
+                            }
+                            else
+                            {
+                                ReadDecimal(_underlyingReader, i, column);
+                            }
+
+                            break;
+                        case TypeCase.Double:
+                            if (nullIndex != -1)
+                            {
+                                if (!(_tempNulls[_currentRowNumber * _nullCount + nullIndex] = _underlyingReader.IsDBNull(i)))
+                                {
+                                    ReadDouble(_underlyingReader, i, column);
+                                }
+                            }
+                            else
+                            {
+                                ReadDouble(_underlyingReader, i, column);
+                            }
+
+                            break;
+                        case TypeCase.Float:
+                            if (nullIndex != -1)
+                            {
+                                if (!(_tempNulls[_currentRowNumber * _nullCount + nullIndex] = _underlyingReader.IsDBNull(i)))
+                                {
+                                    ReadFloat(_underlyingReader, i, column);
+                                }
+                            }
+                            else
+                            {
+                                ReadFloat(_underlyingReader, i, column);
+                            }
+
+                            break;
+                        case TypeCase.Guid:
+                            if (nullIndex != -1)
+                            {
+                                if (!(_tempNulls[_currentRowNumber * _nullCount + nullIndex] = _underlyingReader.IsDBNull(i)))
+                                {
+                                    ReadGuid(_underlyingReader, i, column);
+                                }
+                            }
+                            else
+                            {
+                                ReadGuid(_underlyingReader, i, column);
+                            }
+
+                            break;
+                        case TypeCase.Short:
+                            if (nullIndex != -1)
+                            {
+                                if (!(_tempNulls[_currentRowNumber * _nullCount + nullIndex] = _underlyingReader.IsDBNull(i)))
+                                {
+                                    ReadShort(_underlyingReader, i, column);
+                                }
+                            }
+                            else
+                            {
+                                ReadShort(_underlyingReader, i, column);
+                            }
+
+                            break;
+                        case TypeCase.Int:
+                            if (nullIndex != -1)
+                            {
+                                if (!(_tempNulls[_currentRowNumber * _nullCount + nullIndex] = _underlyingReader.IsDBNull(i)))
+                                {
+                                    ReadInt(_underlyingReader, i, column);
+                                }
+                            }
+                            else
+                            {
+                                ReadInt(_underlyingReader, i, column);
+                            }
+
+                            break;
+                        case TypeCase.Long:
+                            if (nullIndex != -1)
+                            {
+                                if (!(_tempNulls[_currentRowNumber * _nullCount + nullIndex] = _underlyingReader.IsDBNull(i)))
+                                {
+                                    ReadLong(_underlyingReader, i, column);
+                                }
+                            }
+                            else
+                            {
+                                ReadLong(_underlyingReader, i, column);
+                            }
+
+                            break;
+                        case TypeCase.SByte:
+                            if (nullIndex != -1)
+                            {
+                                if (!(_tempNulls[_currentRowNumber * _nullCount + nullIndex] = _underlyingReader.IsDBNull(i)))
+                                {
+                                    ReadSByte(_underlyingReader, i, column);
+                                }
+                            }
+                            else
+                            {
+                                ReadSByte(_underlyingReader, i, column);
+                            }
+
+                            break;
+                        case TypeCase.UShort:
+                            if (nullIndex != -1)
+                            {
+                                if (!(_tempNulls[_currentRowNumber * _nullCount + nullIndex] = _underlyingReader.IsDBNull(i)))
+                                {
+                                    ReadUShort(_underlyingReader, i, column);
+                                }
+                            }
+                            else
+                            {
+                                ReadUShort(_underlyingReader, i, column);
+                            }
+
+                            break;
+                        case TypeCase.UInt:
+                            if (nullIndex != -1)
+                            {
+                                if (!(_tempNulls[_currentRowNumber * _nullCount + nullIndex] = _underlyingReader.IsDBNull(i)))
+                                {
+                                    ReadUInt(_underlyingReader, i, column);
+                                }
+                            }
+                            else
+                            {
+                                ReadUInt(_underlyingReader, i, column);
+                            }
+
+                            break;
+                        case TypeCase.ULong:
+                            if (nullIndex != -1)
+                            {
+                                if (!(_tempNulls[_currentRowNumber * _nullCount + nullIndex] = _underlyingReader.IsDBNull(i)))
+                                {
+                                    ReadULong(_underlyingReader, i, column);
+                                }
+                            }
+                            else
+                            {
+                                ReadULong(_underlyingReader, i, column);
+                            }
+
+                            break;
+                        case TypeCase.Empty:
+                            break;
+                        default:
+                            if (nullIndex != -1)
+                            {
+                                if (!(_tempNulls[_currentRowNumber * _nullCount + nullIndex] = _underlyingReader.IsDBNull(i)))
+                                {
+                                    ReadObject(_underlyingReader, i, column);
+                                }
+                            }
+                            else
+                            {
+                                ReadObject(_underlyingReader, i, column);
+                            }
+
+                            break;
+                    }
+                }
+            }
+
+            private void ReadMetadata()
+            {
+                var fieldCount = _underlyingReader.FieldCount;
+                var dataTypeNames = new string[fieldCount];
+                var columnTypes = new Type[fieldCount];
+                var columnNames = new string[fieldCount];
+                for (var i = 0; i < fieldCount; i++)
+                {
+                    dataTypeNames[i] = _underlyingReader.GetDataTypeName(i);
+                    columnTypes[i] = _underlyingReader.GetFieldType(i);
+                    columnNames[i] = _underlyingReader.GetName(i);
+                }
+
+                _dataTypeNames = dataTypeNames;
+                _fieldTypes = columnTypes;
+                _columnNames = columnNames;
+                _fieldNameLookup = new Lazy<Dictionary<string, int>>(CreateNameLookup, isThreadSafe: false);
+
+                Dictionary<string, int> CreateNameLookup()
+                {
+                    var index = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+                    for (var i = 0; i < _columnNames.Length; i++)
+                    {
+                        index[_columnNames[i]] = i;
+                    }
+
+                    return index;
+                }
+            }
+
+            private void InitializeFields()
+            {
+                var fieldCount = FieldCount;
+                if (FieldCount < _columns.Count)
+                {
+                    throw new InvalidOperationException("The underlying reader doesn't have as many fields as expected.");
+                }
+
+                _columnTypeCases = Enumerable.Repeat(TypeCase.Empty, fieldCount).ToArray();
+                _ordinalToIndexMap = Enumerable.Repeat(-1, fieldCount).ToArray();
+                if (_columns.Count > 0
+                    && _columns[0].Name != null)
+                {
+                    // Non-Composed FromSql
+                    var readerColumns = _fieldNameLookup.Value;
+
+                    _indexMap = new int[_columns.Count];
+                    var newColumnMap = new ReaderColumn[fieldCount];
+                    for (var i = 0; i < _columns.Count; i++)
+                    {
+                        var column = _columns[i];
+                        if (!readerColumns.TryGetValue(column.Name, out var ordinal))
+                        {
+                            throw new InvalidOperationException(RelationalStrings.FromSqlMissingColumn(column.Name));
+                        }
+
+                        newColumnMap[ordinal] = column;
+                        _indexMap[i] = ordinal;
+                    }
+
+                    _columns = newColumnMap;
+                }
+
+                if (FieldCount != _columns.Count)
+                {
+                    var newColumnMap = new ReaderColumn[fieldCount];
+                    for (var i = 0; i < _columns.Count; i++)
+                    {
+                        newColumnMap[i] = _columns[i];
+                    }
+                    _columns = newColumnMap;
+                }
+
+                for (var i = 0; i < fieldCount; i++)
+                {
+                    var column = _columns[i];
+                    if (column == null)
+                    {
+                        continue;
+                    }
+
+                    var type = column.Type;
+                    if (type == typeof(bool))
+                    {
+                        _columnTypeCases[i] = TypeCase.Bool;
+                        _ordinalToIndexMap[i] = _boolCount;
+                        _boolCount++;
+                    }
+                    else if (type == typeof(byte))
+                    {
+                        _columnTypeCases[i] = TypeCase.Byte;
+                        _ordinalToIndexMap[i] = _byteCount;
+                        _byteCount++;
+                    }
+                    else if (type == typeof(char))
+                    {
+                        _columnTypeCases[i] = TypeCase.Char;
+                        _ordinalToIndexMap[i] = _charCount;
+                        _charCount++;
+                    }
+                    else if (type == typeof(DateTime))
+                    {
+                        _columnTypeCases[i] = TypeCase.DateTime;
+                        _ordinalToIndexMap[i] = _dateTimeCount;
+                        _dateTimeCount++;
+                    }
+                    else if (type == typeof(DateTimeOffset))
+                    {
+                        _columnTypeCases[i] = TypeCase.DateTimeOffset;
+                        _ordinalToIndexMap[i] = _dateTimeOffsetCount;
+                        _dateTimeOffsetCount++;
+                    }
+                    else if (type == typeof(decimal))
+                    {
+                        _columnTypeCases[i] = TypeCase.Decimal;
+                        _ordinalToIndexMap[i] = _decimalCount;
+                        _decimalCount++;
+                    }
+                    else if (type == typeof(double))
+                    {
+                        _columnTypeCases[i] = TypeCase.Double;
+                        _ordinalToIndexMap[i] = _doubleCount;
+                        _doubleCount++;
+                    }
+                    else if (type == typeof(float))
+                    {
+                        _columnTypeCases[i] = TypeCase.Float;
+                        _ordinalToIndexMap[i] = _floatCount;
+                        _floatCount++;
+                    }
+                    else if (type == typeof(Guid))
+                    {
+                        _columnTypeCases[i] = TypeCase.Guid;
+                        _ordinalToIndexMap[i] = _guidCount;
+                        _guidCount++;
+                    }
+                    else if (type == typeof(short))
+                    {
+                        _columnTypeCases[i] = TypeCase.Short;
+                        _ordinalToIndexMap[i] = _shortCount;
+                        _shortCount++;
+                    }
+                    else if (type == typeof(int))
+                    {
+                        _columnTypeCases[i] = TypeCase.Int;
+                        _ordinalToIndexMap[i] = _intCount;
+                        _intCount++;
+                    }
+                    else if (type == typeof(long))
+                    {
+                        _columnTypeCases[i] = TypeCase.Long;
+                        _ordinalToIndexMap[i] = _longCount;
+                        _longCount++;
+                    }
+                    else if (type == typeof(sbyte))
+                    {
+                        _columnTypeCases[i] = TypeCase.SByte;
+                        _ordinalToIndexMap[i] = _sbyteCount;
+                        _sbyteCount++;
+                    }
+                    else if (type == typeof(ushort))
+                    {
+                        _columnTypeCases[i] = TypeCase.UShort;
+                        _ordinalToIndexMap[i] = _ushortCount;
+                        _ushortCount++;
+                    }
+                    else if (type == typeof(uint))
+                    {
+                        _columnTypeCases[i] = TypeCase.UInt;
+                        _ordinalToIndexMap[i] = _uintCount;
+                        _uintCount++;
+                    }
+                    else if (type == typeof(ulong))
+                    {
+                        _columnTypeCases[i] = TypeCase.ULong;
+                        _ordinalToIndexMap[i] = _ulongCount;
+                        _ulongCount++;
+                    }
+                    else
+                    {
+                        _columnTypeCases[i] = TypeCase.Object;
+                        _ordinalToIndexMap[i] = _objectCount;
+                        _objectCount++;
+                    }
+                }
+
+                _tempBools = new bool[_rowCapacity * _boolCount];
+                _bytes = new byte[_rowCapacity * _byteCount];
+                _chars = new char[_rowCapacity * _charCount];
+                _dateTimes = new DateTime[_rowCapacity * _dateTimeCount];
+                _dateTimeOffsets = new DateTimeOffset[_rowCapacity * _dateTimeOffsetCount];
+                _decimals = new decimal[_rowCapacity * _decimalCount];
+                _doubles = new double[_rowCapacity * _doubleCount];
+                _floats = new float[_rowCapacity * _floatCount];
+                _guids = new Guid[_rowCapacity * _guidCount];
+                _shorts = new short[_rowCapacity * _shortCount];
+                _ints = new int[_rowCapacity * _intCount];
+                _longs = new long[_rowCapacity * _longCount];
+                _sbytes = new sbyte[_rowCapacity * _sbyteCount];
+                _ushorts = new ushort[_rowCapacity * _ushortCount];
+                _uints = new uint[_rowCapacity * _uintCount];
+                _ulongs = new ulong[_rowCapacity * _ulongCount];
+                _objects = new object[_rowCapacity * _objectCount];
+
+                _nullOrdinalToIndexMap = Enumerable.Repeat(-1, fieldCount).ToArray();
+                for (var i = 0; i < fieldCount; i++)
+                {
+                    if (_columns[i]?.IsNullable == true)
+                    {
+                        _nullOrdinalToIndexMap[i] = _nullCount;
+                        _nullCount++;
+                    }
+                }
+
+                _tempNulls = new bool[_rowCapacity * _nullCount];
+            }
+
+            private void DoubleBufferCapacity()
+            {
+                _rowCapacity <<= 1;
+
+                var newBools = new bool[_tempBools.Length << 1];
+                Array.Copy(_tempBools, newBools, _tempBools.Length);
+                _tempBools = newBools;
+
+                var newBytes = new byte[_bytes.Length << 1];
+                Array.Copy(_bytes, newBytes, _bytes.Length);
+                _bytes = newBytes;
+
+                var newChars = new char[_chars.Length << 1];
+                Array.Copy(_chars, newChars, _chars.Length);
+                _chars = newChars;
+
+                var newDateTimes = new DateTime[_dateTimes.Length << 1];
+                Array.Copy(_dateTimes, newDateTimes, _dateTimes.Length);
+                _dateTimes = newDateTimes;
+
+                var newDateTimeOffsets = new DateTimeOffset[_dateTimeOffsets.Length << 1];
+                Array.Copy(_dateTimeOffsets, newDateTimeOffsets, _dateTimeOffsets.Length);
+                _dateTimeOffsets = newDateTimeOffsets;
+
+                var newDecimals = new decimal[_decimals.Length << 1];
+                Array.Copy(_decimals, newDecimals, _decimals.Length);
+                _decimals = newDecimals;
+
+                var newDoubles = new double[_doubles.Length << 1];
+                Array.Copy(_doubles, newDoubles, _doubles.Length);
+                _doubles = newDoubles;
+
+                var newFloats = new float[_floats.Length << 1];
+                Array.Copy(_floats, newFloats, _floats.Length);
+                _floats = newFloats;
+
+                var newGuids = new Guid[_guids.Length << 1];
+                Array.Copy(_guids, newGuids, _guids.Length);
+                _guids = newGuids;
+
+                var newShorts = new short[_shorts.Length << 1];
+                Array.Copy(_shorts, newShorts, _shorts.Length);
+                _shorts = newShorts;
+
+                var newInts = new int[_ints.Length << 1];
+                Array.Copy(_ints, newInts, _ints.Length);
+                _ints = newInts;
+
+                var newLongs = new long[_longs.Length << 1];
+                Array.Copy(_longs, newLongs, _longs.Length);
+                _longs = newLongs;
+
+                var newSBytes = new sbyte[_sbytes.Length << 1];
+                Array.Copy(_sbytes, newSBytes, _sbytes.Length);
+                _sbytes = newSBytes;
+
+                var newUShorts = new ushort[_ushorts.Length << 1];
+                Array.Copy(_ushorts, newUShorts, _ushorts.Length);
+                _ushorts = newUShorts;
+
+                var newUInts = new uint[_uints.Length << 1];
+                Array.Copy(_uints, newUInts, _uints.Length);
+                _uints = newUInts;
+
+                var newULongs = new ulong[_ulongs.Length << 1];
+                Array.Copy(_ulongs, newULongs, _ulongs.Length);
+                _ulongs = newULongs;
+
+                var newObjects = new object[_objects.Length << 1];
+                Array.Copy(_objects, newObjects, _objects.Length);
+                _objects = newObjects;
+
+                var newNulls = new bool[_tempNulls.Length << 1];
+                Array.Copy(_tempNulls, newNulls, _tempNulls.Length);
+                _tempNulls = newNulls;
+            }
+
+            private void ReadBool(DbDataReader reader, int ordinal, ReaderColumn column)
+            {
+                _tempBools[_currentRowNumber * _boolCount + _ordinalToIndexMap[ordinal]] =
+                    ((ReaderColumn<bool>)column).GetFieldValue(reader, _indexMap);
+            }
+
+            private void ReadByte(DbDataReader reader, int ordinal, ReaderColumn column)
+            {
+                _bytes[_currentRowNumber * _byteCount + _ordinalToIndexMap[ordinal]] =
+                    ((ReaderColumn<byte>)column).GetFieldValue(reader, _indexMap);
+            }
+
+            private void ReadChar(DbDataReader reader, int ordinal, ReaderColumn column)
+            {
+                _chars[_currentRowNumber * _charCount + _ordinalToIndexMap[ordinal]] =
+                    ((ReaderColumn<char>)column).GetFieldValue(reader, _indexMap);
+            }
+
+            private void ReadDateTime(DbDataReader reader, int ordinal, ReaderColumn column)
+            {
+                _dateTimes[_currentRowNumber * _dateTimeCount + _ordinalToIndexMap[ordinal]] =
+                    ((ReaderColumn<DateTime>)column).GetFieldValue(reader, _indexMap);
+            }
+
+            private void ReadDateTimeOffset(DbDataReader reader, int ordinal, ReaderColumn column)
+            {
+                _dateTimeOffsets[_currentRowNumber * _dateTimeOffsetCount + _ordinalToIndexMap[ordinal]] =
+                    ((ReaderColumn<DateTimeOffset>)column).GetFieldValue(reader, _indexMap);
+            }
+
+            private void ReadDecimal(DbDataReader reader, int ordinal, ReaderColumn column)
+            {
+                _decimals[_currentRowNumber * _decimalCount + _ordinalToIndexMap[ordinal]] =
+                    ((ReaderColumn<decimal>)column).GetFieldValue(reader, _indexMap);
+            }
+
+            private void ReadDouble(DbDataReader reader, int ordinal, ReaderColumn column)
+            {
+                _doubles[_currentRowNumber * _doubleCount + _ordinalToIndexMap[ordinal]] =
+                    ((ReaderColumn<double>)column).GetFieldValue(reader, _indexMap);
+            }
+
+            private void ReadFloat(DbDataReader reader, int ordinal, ReaderColumn column)
+            {
+                _floats[_currentRowNumber * _floatCount + _ordinalToIndexMap[ordinal]] =
+                    ((ReaderColumn<float>)column).GetFieldValue(reader, _indexMap);
+            }
+
+            private void ReadGuid(DbDataReader reader, int ordinal, ReaderColumn column)
+            {
+                _guids[_currentRowNumber * _guidCount + _ordinalToIndexMap[ordinal]] =
+                    ((ReaderColumn<Guid>)column).GetFieldValue(reader, _indexMap);
+            }
+
+            private void ReadShort(DbDataReader reader, int ordinal, ReaderColumn column)
+            {
+                _shorts[_currentRowNumber * _shortCount + _ordinalToIndexMap[ordinal]] =
+                    ((ReaderColumn<short>)column).GetFieldValue(reader, _indexMap);
+            }
+
+            private void ReadInt(DbDataReader reader, int ordinal, ReaderColumn column)
+            {
+                _ints[_currentRowNumber * _intCount + _ordinalToIndexMap[ordinal]] =
+                    ((ReaderColumn<int>)column).GetFieldValue(reader, _indexMap);
+            }
+
+            private void ReadLong(DbDataReader reader, int ordinal, ReaderColumn column)
+            {
+                _longs[_currentRowNumber * _longCount + _ordinalToIndexMap[ordinal]] =
+                    ((ReaderColumn<long>)column).GetFieldValue(reader, _indexMap);
+            }
+
+            private void ReadSByte(DbDataReader reader, int ordinal, ReaderColumn column)
+            {
+                _sbytes[_currentRowNumber * _sbyteCount + _ordinalToIndexMap[ordinal]] =
+                    ((ReaderColumn<sbyte>)column).GetFieldValue(reader, _indexMap);
+            }
+
+            private void ReadUShort(DbDataReader reader, int ordinal, ReaderColumn column)
+            {
+                _ushorts[_currentRowNumber * _ushortCount + _ordinalToIndexMap[ordinal]] =
+                    ((ReaderColumn<ushort>)column).GetFieldValue(reader, _indexMap);
+            }
+
+            private void ReadUInt(DbDataReader reader, int ordinal, ReaderColumn column)
+            {
+                _uints[_currentRowNumber * _uintCount + _ordinalToIndexMap[ordinal]] =
+                    ((ReaderColumn<uint>)column).GetFieldValue(reader, _indexMap);
+            }
+
+            private void ReadULong(DbDataReader reader, int ordinal, ReaderColumn column)
+            {
+                _ulongs[_currentRowNumber * _ulongCount + _ordinalToIndexMap[ordinal]] =
+                    ((ReaderColumn<ulong>)column).GetFieldValue(reader, _indexMap);
+            }
+
+            private void ReadObject(DbDataReader reader, int ordinal, ReaderColumn column)
+            {
+                _objects[_currentRowNumber * _objectCount + _ordinalToIndexMap[ordinal]] =
+                    ((ReaderColumn<object>)column).GetFieldValue(reader, _indexMap);
+            }
+
+            private enum TypeCase
+            {
+                Empty = 0,
+                Object,
+                Bool,
+                Byte,
+                Char,
+                DateTime,
+                DateTimeOffset,
+                Decimal,
+                Double,
+                Float,
+                Guid,
+                SByte,
+                Short,
+                Int,
+                Long,
+                UInt,
+                ULong,
+                UShort
+            }
+        }
+    }
+}

--- a/src/EFCore.Relational/Query/Internal/RelationalShapedQueryCompilingExpressionVisitorFactory.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalShapedQueryCompilingExpressionVisitorFactory.cs
@@ -29,11 +29,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         }
 
         public virtual ShapedQueryCompilingExpressionVisitor Create(QueryCompilationContext queryCompilationContext)
-        {
-            return new RelationalShapedQueryCompilingExpressionVisitor(
+            => new RelationalShapedQueryCompilingExpressionVisitor(
                 _dependencies,
                 _relationalDependencies,
                 queryCompilationContext);
-        }
     }
 }

--- a/src/EFCore.Relational/Query/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/QuerySqlGenerator.cs
@@ -15,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 {
     public class QuerySqlGenerator : SqlExpressionVisitor
     {
-        private static readonly Regex _composibleSql
+        private static readonly Regex _composableSql
             = new Regex(@"^\s*?SELECT\b", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(value: 1000.0));
 
         private readonly IRelationalCommandBuilderFactory _relationalCommandBuilderFactory;
@@ -319,7 +319,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             _relationalCommandBuilder.AppendLine("(");
 
-            if (!_composibleSql.IsMatch(fromSqlExpression.Sql))
+            if (!_composableSql.IsMatch(fromSqlExpression.Sql))
             {
                 throw new InvalidOperationException(RelationalStrings.FromSqlNonComposable);
             }

--- a/src/EFCore.Relational/Query/RelationalCompiledQueryCacheKeyGenerator.cs
+++ b/src/EFCore.Relational/Query/RelationalCompiledQueryCacheKeyGenerator.cs
@@ -66,7 +66,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         protected new RelationalCompiledQueryCacheKey GenerateCacheKeyCore([NotNull] Expression query, bool async)
             => new RelationalCompiledQueryCacheKey(
                 base.GenerateCacheKeyCore(query, async),
-                RelationalOptionsExtension.Extract(RelationalDependencies.ContextOptions).UseRelationalNulls);
+                RelationalOptionsExtension.Extract(RelationalDependencies.ContextOptions).UseRelationalNulls,
+                shouldBuffer: Dependencies.IsRetryingExecutionStrategy);
 
         /// <summary>
         ///     <para>
@@ -82,17 +83,20 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             private readonly CompiledQueryCacheKey _compiledQueryCacheKey;
             private readonly bool _useRelationalNulls;
+            private readonly bool _shouldBuffer;
 
             /// <summary>
             ///     Initializes a new instance of the <see cref="RelationalCompiledQueryCacheKey" /> class.
             /// </summary>
             /// <param name="compiledQueryCacheKey"> The non-relational cache key. </param>
             /// <param name="useRelationalNulls"> True to use relational null logic. </param>
+            /// <param name="shouldBuffer"> True if the query should be buffered. </param>
             public RelationalCompiledQueryCacheKey(
-                CompiledQueryCacheKey compiledQueryCacheKey, bool useRelationalNulls)
+                CompiledQueryCacheKey compiledQueryCacheKey, bool useRelationalNulls, bool shouldBuffer)
             {
                 _compiledQueryCacheKey = compiledQueryCacheKey;
                 _useRelationalNulls = useRelationalNulls;
+                _shouldBuffer = shouldBuffer;
             }
 
             /// <summary>
@@ -106,12 +110,13 @@ namespace Microsoft.EntityFrameworkCore.Query
             /// </returns>
             public override bool Equals(object obj)
                 => !(obj is null)
-                    && obj is RelationalCompiledQueryCacheKey
-                    && Equals((RelationalCompiledQueryCacheKey)obj);
+                    && obj is RelationalCompiledQueryCacheKey key
+                    && Equals(key);
 
             private bool Equals(RelationalCompiledQueryCacheKey other)
                 => _compiledQueryCacheKey.Equals(other._compiledQueryCacheKey)
-                    && _useRelationalNulls == other._useRelationalNulls;
+                    && _useRelationalNulls == other._useRelationalNulls
+                    && _shouldBuffer == other._shouldBuffer;
 
             /// <summary>
             ///     Gets the hash code for the key.
@@ -119,7 +124,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             /// <returns>
             ///     The hash code for the key.
             /// </returns>
-            public override int GetHashCode() => HashCode.Combine(_compiledQueryCacheKey, _useRelationalNulls);
+            public override int GetHashCode() => HashCode.Combine(_compiledQueryCacheKey, _useRelationalNulls, _shouldBuffer);
         }
     }
 }

--- a/src/EFCore.Relational/Query/RelationalQueryContext.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryContext.cs
@@ -46,14 +46,5 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// </value>
         public virtual IRelationalConnection Connection
             => RelationalDependencies.RelationalConnection;
-
-        /// <summary>
-        ///     The execution strategy factory.
-        /// </summary>
-        /// <value>
-        ///     The execution strategy factory.
-        /// </value>
-        public virtual IExecutionStrategyFactory ExecutionStrategyFactory
-            => RelationalDependencies.ExecutionStrategyFactory;
     }
 }

--- a/src/EFCore.Relational/Query/RelationalQueryContextDependencies.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryContextDependencies.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -62,7 +63,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             Check.NotNull(executionStrategyFactory, nameof(executionStrategyFactory));
 
             RelationalConnection = relationalConnection;
+#pragma warning disable 618
             ExecutionStrategyFactory = executionStrategyFactory;
+#pragma warning restore 618
         }
 
         /// <summary>
@@ -73,6 +76,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <summary>
         ///     The execution strategy.
         /// </summary>
+        [Obsolete("Moved to QueryContextDependencies")]
         public IExecutionStrategyFactory ExecutionStrategyFactory { get; }
 
         /// <summary>
@@ -81,7 +85,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <param name="relationalConnection"> A replacement for the current dependency of this type. </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
         public RelationalQueryContextDependencies With([NotNull] IRelationalConnection relationalConnection)
+#pragma warning disable 618
             => new RelationalQueryContextDependencies(relationalConnection, ExecutionStrategyFactory);
+#pragma warning restore 618
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.RelationalProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.RelationalProjectionBindingRemovingExpressionVisitor.cs
@@ -9,6 +9,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Storage;
 
@@ -23,15 +24,33 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             private readonly SelectExpression _selectExpression;
             private readonly ParameterExpression _dbDataReaderParameter;
+            private readonly ParameterExpression _indexMapParameter;
 
             private readonly IDictionary<ParameterExpression, IDictionary<IProperty, int>> _materializationContextBindings
                 = new Dictionary<ParameterExpression, IDictionary<IProperty, int>>();
 
             public RelationalProjectionBindingRemovingExpressionVisitor(
-                SelectExpression selectExpression, ParameterExpression dbDataReaderParameter)
+                SelectExpression selectExpression,
+                ParameterExpression dbDataReaderParameter,
+                ParameterExpression indexMapParameter,
+                bool buffer)
             {
                 _selectExpression = selectExpression;
                 _dbDataReaderParameter = dbDataReaderParameter;
+                _indexMapParameter = indexMapParameter;
+                if (buffer)
+                {
+                    ProjectionColumns = new ReaderColumn[selectExpression.Projection.Count];
+                }
+            }
+
+            private ReaderColumn[] ProjectionColumns { get; }
+
+            public virtual Expression Visit(Expression node, out IReadOnlyList<ReaderColumn> projectionColumns)
+            {
+                var result = Visit(node);
+                projectionColumns = ProjectionColumns;
+                return result;
             }
 
             protected override Expression VisitBinary(BinaryExpression binaryExpression)
@@ -118,8 +137,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             private static bool IsNullableProjection(ProjectionExpression projection)
                 => !(projection.Expression is ColumnExpression column) || column.IsNullable;
 
-            private static Expression CreateGetValueExpression(
-                Expression dbDataReader,
+            private Expression CreateGetValueExpression(
+                ParameterExpression dbDataReader,
                 int index,
                 bool nullable,
                 RelationalTypeMapping typeMapping,
@@ -127,15 +146,51 @@ namespace Microsoft.EntityFrameworkCore.Query
             {
                 var getMethod = typeMapping.GetDataReaderMethod();
 
-                var indexExpression = Expression.Constant(index);
+                Expression indexExpression = Expression.Constant(index);
+                if (_indexMapParameter != null)
+                {
+                    indexExpression = Expression.ArrayIndex(_indexMapParameter, indexExpression);
+                }
 
                 Expression valueExpression
                     = Expression.Call(
                         getMethod.DeclaringType != typeof(DbDataReader)
                             ? Expression.Convert(dbDataReader, getMethod.DeclaringType)
-                            : dbDataReader,
+                            : (Expression)dbDataReader,
                         getMethod,
                         indexExpression);
+
+                if (ProjectionColumns != null)
+                {
+                    var columnType = valueExpression.Type;
+                    if (!columnType.IsValueType
+                        || !BufferedDataReader.IsSupportedValueType(columnType))
+                    {
+                        columnType = typeof(object);
+                        valueExpression = Expression.Convert(valueExpression, typeof(object));
+                    }
+
+                    if (ProjectionColumns[index] == null)
+                    {
+                        ProjectionColumns[index] = ReaderColumn.Create(
+                            columnType,
+                            nullable,
+                            _indexMapParameter != null ? ((ColumnExpression)_selectExpression.Projection[index].Expression).Name : null,
+                            Expression.Lambda(
+                                valueExpression,
+                                dbDataReader,
+                                _indexMapParameter ?? Expression.Parameter(typeof(int[]))).Compile());
+                    }
+
+                    if (getMethod.DeclaringType != typeof(DbDataReader))
+                    {
+                        valueExpression
+                            = Expression.Call(
+                                dbDataReader,
+                                RelationalTypeMapping.GetDataReaderMethod(columnType),
+                                indexExpression);
+                    }
+                }
 
                 valueExpression = typeMapping.CustomizeDataReaderExpression(valueExpression);
 

--- a/src/EFCore.Relational/Storage/ReaderColumn.cs
+++ b/src/EFCore.Relational/Storage/ReaderColumn.cs
@@ -1,0 +1,52 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Reflection;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Storage
+{
+    /// <summary>
+    ///     <para>
+    ///         An expected column in the relational data reader.
+    ///     </para>
+    ///     <para>
+    ///         This type is typically used by database providers (and other extensions). It is generally
+    ///         not used in application code.
+    ///     </para>
+    /// </summary>
+    public abstract class ReaderColumn
+    {
+        private static readonly ConcurrentDictionary<Type, ConstructorInfo> _constructors
+            = new ConcurrentDictionary<Type, ConstructorInfo>();
+
+        protected ReaderColumn([NotNull] Type type, bool nullable, [CanBeNull] string name)
+        {
+            Type = type;
+            IsNullable = nullable;
+            Name = name;
+        }
+
+        public virtual Type Type { get; }
+        public virtual bool IsNullable { get; }
+        public virtual string Name { get; }
+
+        /// <summary>
+        ///     Creates an instance of <see cref="ReaderColumn{T}"/>.
+        /// </summary>
+        /// <param name="type"> The type of the column. </param>
+        /// <param name="nullable"> Whether the column can contain <c>null</c> values. </param>
+        /// <param name="columnName"> The column name if it is used to access the column values, <c>null</c> otherwise.</param>
+        /// <param name="readFunc">
+        ///     A <see cref="T:System.Func{DbDataReader, Int32[], T}"/> used to get the field value for this column.
+        /// </param>
+        /// <returns> An instance of <see cref="ReaderColumn{T}"/>.</returns>
+        public static ReaderColumn Create([NotNull] Type type, bool nullable, [CanBeNull] string columnName, [NotNull] object readFunc)
+            => (ReaderColumn)GetConstructor(type).Invoke(new[] { nullable, columnName, readFunc });
+
+        private static ConstructorInfo GetConstructor(Type type)
+            => _constructors.GetOrAdd(type, t => typeof(ReaderColumn<>).MakeGenericType(t).GetConstructors()[0]);
+    }
+}

--- a/src/EFCore.Relational/Storage/ReaderColumn`.cs
+++ b/src/EFCore.Relational/Storage/ReaderColumn`.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data.Common;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Storage
+{
+    /// <summary>
+    ///     <para>
+    ///         An expected column in the relational data reader.
+    ///     </para>
+    ///     <para>
+    ///         This type is typically used by database providers (and other extensions). It is generally
+    ///         not used in application code.
+    ///     </para>
+    /// </summary>
+    public class ReaderColumn<T> : ReaderColumn
+    {
+        public ReaderColumn(bool nullable, [CanBeNull] string name, [NotNull] Func<DbDataReader, int[], T> getFieldValue)
+            : base(typeof(T), nullable, name)
+        {
+            GetFieldValue = getFieldValue;
+        }
+
+        public virtual Func<DbDataReader, int[], T> GetFieldValue { get; }
+    }
+}

--- a/src/EFCore.Relational/Storage/RelationalCommand.cs
+++ b/src/EFCore.Relational/Storage/RelationalCommand.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Storage
@@ -375,7 +376,10 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <returns> The result of the command. </returns>
         public virtual RelationalDataReader ExecuteReader(RelationalCommandParameterObject parameterObject)
         {
-            var (connection, context, logger) = (parameterObject.Connection, parameterObject.Context, parameterObject.Logger);
+            var connection = parameterObject.Connection;
+            var context = parameterObject.Context;
+            var readerColumns = parameterObject.ReaderColumns;
+            var logger = parameterObject.Logger;
 
             var commandId = Guid.NewGuid();
             var command = CreateCommand(parameterObject, commandId, DbCommandMethod.ExecuteReader);
@@ -412,6 +416,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
                         reader,
                         startTime,
                         stopwatch.Elapsed);
+                }
+
+                if (readerColumns != null)
+                {
+                    reader = new BufferedDataReader(reader).Initialize(readerColumns);
                 }
 
                 var result = new RelationalDataReader(
@@ -461,7 +470,10 @@ namespace Microsoft.EntityFrameworkCore.Storage
             RelationalCommandParameterObject parameterObject,
             CancellationToken cancellationToken = default)
         {
-            var (connection, context, logger) = (parameterObject.Connection, parameterObject.Context, parameterObject.Logger);
+            var connection = parameterObject.Connection;
+            var context = parameterObject.Context;
+            var readerColumns = parameterObject.ReaderColumns;
+            var logger = parameterObject.Logger;
 
             var commandId = Guid.NewGuid();
             var command = CreateCommand(parameterObject, commandId, DbCommandMethod.ExecuteReader);
@@ -501,6 +513,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
                         startTime,
                         stopwatch.Elapsed,
                         cancellationToken);
+                }
+
+                if (readerColumns != null)
+                {
+                    reader = await new BufferedDataReader(reader).InitializeAsync(readerColumns, cancellationToken);
                 }
 
                 var result = new RelationalDataReader(

--- a/src/EFCore.Relational/Storage/RelationalCommandParameterObject.cs
+++ b/src/EFCore.Relational/Storage/RelationalCommandParameterObject.cs
@@ -30,11 +30,13 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="connection"> The connection on which the command will execute. </param>
         /// <param name="parameterValues"> The SQL parameter values to use, or null if none. </param>
+        /// <param name="readerColumns"> The expected columns if the reader needs to be buffered, or null otherwise. </param>
         /// <param name="context"> The current <see cref="DbContext" /> instance, or null if it is not known. </param>
         /// <param name="logger"> A logger, or null if no logger is available. </param>
         public RelationalCommandParameterObject(
             [NotNull] IRelationalConnection connection,
             [CanBeNull] IReadOnlyDictionary<string, object> parameterValues,
+            [CanBeNull] IReadOnlyList<ReaderColumn> readerColumns,
             [CanBeNull] DbContext context,
             [CanBeNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger)
         {
@@ -42,6 +44,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
             Connection = connection;
             ParameterValues = parameterValues;
+            ReaderColumns = readerColumns;
             Context = context;
             Logger = logger;
         }
@@ -55,6 +58,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     The SQL parameter values to use, or null if none.
         /// </summary>
         public IReadOnlyDictionary<string, object> ParameterValues { get; }
+
+        /// <summary>
+        ///     The expected columns if the reader needs to be buffered, or null otherwise.
+        /// </summary>
+        public IReadOnlyList<ReaderColumn> ReaderColumns { get; }
 
         /// <summary>
         ///     The current <see cref="DbContext" /> instance, or null if it is not known.

--- a/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
@@ -523,10 +523,18 @@ namespace Microsoft.EntityFrameworkCore.Storage
         {
             var type = (Converter?.ProviderClrType ?? ClrType).UnwrapNullableType();
 
-            return _getXMethods.TryGetValue(type, out var method)
+            return GetDataReaderMethod(type);
+        }
+
+        /// <summary>
+        ///     The method to use when reading values of the given type. The method must be defined
+        ///     on <see cref="DbDataReader" />.
+        /// </summary>
+        /// <returns> The method to use to read the value. </returns>
+        public static MethodInfo GetDataReaderMethod([NotNull] Type type)
+            => _getXMethods.TryGetValue(type, out var method)
                 ? method
                 : _getFieldValueMethod.MakeGenericMethod(type);
-        }
 
         /// <summary>
         ///     Gets a custom expression tree for reading the value from the input data reader

--- a/src/EFCore.Relational/Update/Internal/BatchExecutor.cs
+++ b/src/EFCore.Relational/Update/Internal/BatchExecutor.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -37,7 +38,9 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
         public BatchExecutor([NotNull] ICurrentDbContext currentContext, [NotNull] IExecutionStrategyFactory executionStrategyFactory)
         {
             CurrentContext = currentContext;
+#pragma warning disable 618
             ExecutionStrategyFactory = executionStrategyFactory;
+#pragma warning restore 618
         }
 
         /// <summary>
@@ -54,6 +57,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        [Obsolete("This isn't used anymore")]
         protected virtual IExecutionStrategyFactory ExecutionStrategyFactory { get; }
 
         /// <summary>
@@ -65,14 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
         public virtual int Execute(
             IEnumerable<ModificationCommandBatch> commandBatches,
             IRelationalConnection connection)
-            => CurrentContext.Context.Database.AutoTransactionsEnabled
-                ? ExecutionStrategyFactory.Create().Execute((commandBatches, connection), Execute, null)
-                : Execute(CurrentContext.Context, (commandBatches, connection));
-
-        private int Execute(DbContext _, (IEnumerable<ModificationCommandBatch>, IRelationalConnection) parameters)
         {
-            var commandBatches = parameters.Item1;
-            var connection = parameters.Item2;
             var rowsAffected = 0;
             IDbContextTransaction startedTransaction = null;
             try
@@ -118,21 +115,11 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual Task<int> ExecuteAsync(
+        public virtual async Task<int> ExecuteAsync(
             IEnumerable<ModificationCommandBatch> commandBatches,
             IRelationalConnection connection,
             CancellationToken cancellationToken = default)
-            => CurrentContext.Context.Database.AutoTransactionsEnabled
-                ? ExecutionStrategyFactory.Create().ExecuteAsync((commandBatches, connection), ExecuteAsync, null, cancellationToken)
-                : ExecuteAsync(CurrentContext.Context, (commandBatches, connection), cancellationToken);
-
-        private async Task<int> ExecuteAsync(
-            DbContext _,
-            (IEnumerable<ModificationCommandBatch>, IRelationalConnection) parameters,
-            CancellationToken cancellationToken = default)
         {
-            var commandBatches = parameters.Item1;
-            var connection = parameters.Item2;
             var rowsAffected = 0;
             IDbContextTransaction startedTransaction = null;
             try

--- a/src/EFCore.Relational/Update/ReaderModificationCommandBatch.cs
+++ b/src/EFCore.Relational/Update/ReaderModificationCommandBatch.cs
@@ -239,6 +239,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                     new RelationalCommandParameterObject(
                         connection,
                         storeCommand.ParameterValues,
+                        null,
                         Dependencies.CurrentContext.Context,
                         Dependencies.Logger)))
                 {
@@ -276,6 +277,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                     new RelationalCommandParameterObject(
                         connection,
                         storeCommand.ParameterValues,
+                        null,
                         Dependencies.CurrentContext.Context,
                         Dependencies.Logger),
                     cancellationToken))

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerCompiledQueryCacheKeyGenerator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerCompiledQueryCacheKeyGenerator.cs
@@ -64,8 +64,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
 
             public override bool Equals(object obj)
                 => !(obj is null)
-                    && obj is SqlServerCompiledQueryCacheKey
-                    && Equals((SqlServerCompiledQueryCacheKey)obj);
+                    && obj is SqlServerCompiledQueryCacheKey key
+                    && Equals(key);
 
             private bool Equals(SqlServerCompiledQueryCacheKey other)
                 => _relationalCompiledQueryCacheKey.Equals(other._relationalCompiledQueryCacheKey)

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerDatabaseCreator.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerDatabaseCreator.cs
@@ -121,6 +121,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
                                 new RelationalCommandParameterObject(
                                     connection,
                                     null,
+                                    null,
                                     Dependencies.CurrentContext.Context,
                                     Dependencies.CommandLogger))
                         != 0);
@@ -138,6 +139,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
                         .ExecuteScalarAsync(
                             new RelationalCommandParameterObject(
                                 connection,
+                                null,
                                 null,
                                 Dependencies.CurrentContext.Context,
                                 Dependencies.CommandLogger),
@@ -198,6 +200,7 @@ SELECT 1 ELSE SELECT 0");
                                     new RelationalCommandParameterObject(
                                         _connection,
                                         null,
+                                        null,
                                         Dependencies.CurrentContext.Context,
                                         Dependencies.CommandLogger));
 
@@ -257,6 +260,7 @@ SELECT 1 ELSE SELECT 0");
                                 .ExecuteNonQueryAsync(
                                     new RelationalCommandParameterObject(
                                         _connection,
+                                        null,
                                         null,
                                         Dependencies.CurrentContext.Context,
                                         Dependencies.CommandLogger),

--- a/src/EFCore.SqlServer/ValueGeneration/Internal/SqlServerSequenceHiLoValueGenerator.cs
+++ b/src/EFCore.SqlServer/ValueGeneration/Internal/SqlServerSequenceHiLoValueGenerator.cs
@@ -63,8 +63,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.ValueGeneration.Internal
                     .ExecuteScalar(
                         new RelationalCommandParameterObject(
                             _connection,
-                            null,
-                            null,
+                            parameterValues: null,
+                            readerColumns: null,
+                            context: null,
                             _commandLogger)),
                 typeof(long),
                 CultureInfo.InvariantCulture);
@@ -82,8 +83,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.ValueGeneration.Internal
                     .ExecuteScalarAsync(
                         new RelationalCommandParameterObject(
                             _connection,
-                            null,
-                            null,
+                            parameterValues: null,
+                            readerColumns: null,
+                            context: null,
                             _commandLogger),
                         cancellationToken),
                 typeof(long),

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteDatabaseCreator.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteDatabaseCreator.cs
@@ -64,6 +64,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal
                         Dependencies.Connection,
                         null,
                         null,
+                        null,
                         Dependencies.CommandLogger));
 
             Dependencies.Connection.Close();
@@ -112,6 +113,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal
                 .ExecuteScalar(
                     new RelationalCommandParameterObject(
                         Dependencies.Connection,
+                        null,
                         null,
                         null,
                         Dependencies.CommandLogger));

--- a/src/EFCore/ChangeTracking/Internal/StateManagerDependencies.cs
+++ b/src/EFCore/ChangeTracking/Internal/StateManagerDependencies.cs
@@ -75,6 +75,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             [NotNull] IEntityFinderSource entityFinderSource,
             [NotNull] IDbSetSource setSource,
             [NotNull] IEntityMaterializerSource entityMaterializerSource,
+            [NotNull] IExecutionStrategyFactory executionStrategyFactory,
             [NotNull] ILoggingOptions loggingOptions,
             [NotNull] IDiagnosticsLogger<DbLoggerCategory.Update> updateLogger,
             [NotNull] IDiagnosticsLogger<DbLoggerCategory.ChangeTracking> changeTrackingLogger)
@@ -90,6 +91,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             EntityFinderSource = entityFinderSource;
             SetSource = setSource;
             EntityMaterializerSource = entityMaterializerSource;
+            ExecutionStrategyFactory = executionStrategyFactory;
             LoggingOptions = loggingOptions;
             UpdateLogger = updateLogger;
             ChangeTrackingLogger = changeTrackingLogger;
@@ -189,6 +191,14 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public IExecutionStrategyFactory ExecutionStrategyFactory { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public ILoggingOptions LoggingOptions { get; }
 
         /// <summary>
@@ -225,6 +235,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 EntityFinderSource,
                 SetSource,
                 EntityMaterializerSource,
+                ExecutionStrategyFactory,
                 LoggingOptions,
                 UpdateLogger,
                 ChangeTrackingLogger);
@@ -247,6 +258,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 EntityFinderSource,
                 SetSource,
                 EntityMaterializerSource,
+                ExecutionStrategyFactory,
                 LoggingOptions,
                 UpdateLogger,
                 ChangeTrackingLogger);
@@ -269,6 +281,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 EntityFinderSource,
                 SetSource,
                 EntityMaterializerSource,
+                ExecutionStrategyFactory,
                 LoggingOptions,
                 UpdateLogger,
                 ChangeTrackingLogger);
@@ -291,6 +304,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 EntityFinderSource,
                 SetSource,
                 EntityMaterializerSource,
+                ExecutionStrategyFactory,
                 LoggingOptions,
                 UpdateLogger,
                 ChangeTrackingLogger);
@@ -313,6 +327,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 EntityFinderSource,
                 SetSource,
                 EntityMaterializerSource,
+                ExecutionStrategyFactory,
                 LoggingOptions,
                 UpdateLogger,
                 ChangeTrackingLogger);
@@ -335,6 +350,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 EntityFinderSource,
                 SetSource,
                 EntityMaterializerSource,
+                ExecutionStrategyFactory,
                 LoggingOptions,
                 UpdateLogger,
                 ChangeTrackingLogger);
@@ -357,6 +373,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 EntityFinderSource,
                 SetSource,
                 EntityMaterializerSource,
+                ExecutionStrategyFactory,
                 LoggingOptions,
                 UpdateLogger,
                 ChangeTrackingLogger);
@@ -379,6 +396,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 EntityFinderSource,
                 SetSource,
                 EntityMaterializerSource,
+                ExecutionStrategyFactory,
                 LoggingOptions,
                 UpdateLogger,
                 ChangeTrackingLogger);
@@ -401,6 +419,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 entityFinderSource,
                 SetSource,
                 EntityMaterializerSource,
+                ExecutionStrategyFactory,
                 LoggingOptions,
                 UpdateLogger,
                 ChangeTrackingLogger);
@@ -423,6 +442,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 EntityFinderSource,
                 setSource,
                 EntityMaterializerSource,
+                ExecutionStrategyFactory,
                 LoggingOptions,
                 UpdateLogger,
                 ChangeTrackingLogger);
@@ -445,6 +465,31 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 EntityFinderSource,
                 SetSource,
                 entityMaterializerSource,
+                ExecutionStrategyFactory,
+                LoggingOptions,
+                UpdateLogger,
+                ChangeTrackingLogger);
+
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="executionStrategyFactory"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public StateManagerDependencies With([NotNull] IExecutionStrategyFactory executionStrategyFactory)
+            => new StateManagerDependencies(
+                InternalEntityEntryFactory,
+                InternalEntityEntrySubscriber,
+                InternalEntityEntryNotifier,
+                ValueGenerationManager,
+                Model,
+                Database,
+                ConcurrencyDetector,
+                CurrentContext,
+                EntityFinderSource,
+                SetSource,
+                EntityMaterializerSource,
+                executionStrategyFactory,
                 LoggingOptions,
                 UpdateLogger,
                 ChangeTrackingLogger);
@@ -467,6 +512,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 EntityFinderSource,
                 SetSource,
                 EntityMaterializerSource,
+                ExecutionStrategyFactory,
                 loggingOptions,
                 UpdateLogger,
                 ChangeTrackingLogger);
@@ -489,6 +535,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 EntityFinderSource,
                 SetSource,
                 EntityMaterializerSource,
+                ExecutionStrategyFactory,
                 LoggingOptions,
                 updateLogger,
                 ChangeTrackingLogger);
@@ -511,6 +558,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 EntityFinderSource,
                 SetSource,
                 EntityMaterializerSource,
+                ExecutionStrategyFactory,
                 LoggingOptions,
                 UpdateLogger,
                 changeTrackingLogger);

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
@@ -165,8 +165,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     innerEntityReference.SetIncludePaths(innerIncludeTreeNode);
                 }
 
-                var innerSoureSequenceType = innerSource.Type.GetSequenceType();
-                var innerParameter = Expression.Parameter(innerSoureSequenceType, "i");
+                var innerSourceSequenceType = innerSource.Type.GetSequenceType();
+                var innerParameter = Expression.Parameter(innerSourceSequenceType, "i");
                 Expression outerKey;
                 if (root is NavigationExpansionExpression innerNavigationExpansionExpression
                     && innerNavigationExpansionExpression.CardinalityReducingGenericMethodInfo != null)
@@ -228,7 +228,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         : Expression.Equal(outerKey, innerKey);
 
                     var subquery = Expression.Call(
-                        QueryableMethods.Where.MakeGenericMethod(innerSoureSequenceType),
+                        QueryableMethods.Where.MakeGenericMethod(innerSourceSequenceType),
                         innerSource,
                         Expression.Quote(
                             Expression.Lambda(

--- a/src/EFCore/Query/QueryCompilationContext.cs
+++ b/src/EFCore/Query/QueryCompilationContext.cs
@@ -36,6 +36,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             IsAsync = async;
             IsTracking = context.ChangeTracker.QueryTrackingBehavior == QueryTrackingBehavior.TrackAll;
+            IsBuffering = dependencies.IsRetryingExecutionStrategy;
             Model = dependencies.Model;
             ContextOptions = dependencies.ContextOptions;
             ContextType = context.GetType();
@@ -51,6 +52,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual IModel Model { get; }
         public virtual IDbContextOptions ContextOptions { get; }
         public virtual bool IsTracking { get; internal set; }
+        public virtual bool IsBuffering { get; }
         public virtual bool IgnoreQueryFilters { get; internal set; }
         public virtual ISet<string> Tags { get; } = new HashSet<string>();
         public virtual IDiagnosticsLogger<DbLoggerCategory.Query> Logger { get; }

--- a/src/EFCore/Query/QueryContext.cs
+++ b/src/EFCore/Query/QueryContext.cs
@@ -77,6 +77,15 @@ namespace Microsoft.EntityFrameworkCore.Query
             => Dependencies.QueryProvider;
 
         /// <summary>
+        ///     The execution strategy factory.
+        /// </summary>
+        /// <value>
+        ///     The execution strategy factory.
+        /// </value>
+        public virtual IExecutionStrategyFactory ExecutionStrategyFactory
+            => Dependencies.ExecutionStrategyFactory;
+
+        /// <summary>
         ///     Gets the concurrency detector.
         /// </summary>
         /// <value>

--- a/src/EFCore/Query/QueryContextDependencies.cs
+++ b/src/EFCore/Query/QueryContextDependencies.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -59,16 +60,19 @@ namespace Microsoft.EntityFrameworkCore.Query
         [EntityFrameworkInternal]
         public QueryContextDependencies(
             [NotNull] ICurrentDbContext currentContext,
+            [NotNull] IExecutionStrategyFactory executionStrategyFactory,
             [NotNull] IConcurrencyDetector concurrencyDetector,
             [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> commandLogger,
             [NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> queryLogger)
         {
             Check.NotNull(currentContext, nameof(currentContext));
+            Check.NotNull(executionStrategyFactory, nameof(executionStrategyFactory));
             Check.NotNull(concurrencyDetector, nameof(concurrencyDetector));
             Check.NotNull(commandLogger, nameof(commandLogger));
             Check.NotNull(queryLogger, nameof(queryLogger));
 
             CurrentContext = currentContext;
+            ExecutionStrategyFactory = executionStrategyFactory;
             ConcurrencyDetector = concurrencyDetector;
             CommandLogger = commandLogger;
             QueryLogger = queryLogger;
@@ -94,6 +98,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         public IQueryProvider QueryProvider => CurrentContext.GetDependencies().QueryProvider;
 
         /// <summary>
+        ///     The execution strategy.
+        /// </summary>
+        public IExecutionStrategyFactory ExecutionStrategyFactory { get; }
+
+        /// <summary>
         ///     Gets the concurrency detector.
         /// </summary>
         public IConcurrencyDetector ConcurrencyDetector { get; }
@@ -114,7 +123,14 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <param name="currentContext"> A replacement for the current dependency of this type. </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
         public QueryContextDependencies With([NotNull] ICurrentDbContext currentContext)
-            => new QueryContextDependencies(currentContext, ConcurrencyDetector, CommandLogger, QueryLogger);
+            => new QueryContextDependencies(currentContext, ExecutionStrategyFactory, ConcurrencyDetector, CommandLogger, QueryLogger);
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="executionStrategyFactor"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public QueryContextDependencies With([NotNull] IExecutionStrategyFactory executionStrategyFactor)
+            => new QueryContextDependencies(CurrentContext, executionStrategyFactor, ConcurrencyDetector, CommandLogger, QueryLogger);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -122,7 +138,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <param name="concurrencyDetector"> A replacement for the current dependency of this type. </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
         public QueryContextDependencies With([NotNull] IConcurrencyDetector concurrencyDetector)
-            => new QueryContextDependencies(CurrentContext, concurrencyDetector, CommandLogger, QueryLogger);
+            => new QueryContextDependencies(CurrentContext, ExecutionStrategyFactory, concurrencyDetector, CommandLogger, QueryLogger);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -130,7 +146,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <param name="commandLogger"> A replacement for the current dependency of this type. </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
         public QueryContextDependencies With([NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> commandLogger)
-            => new QueryContextDependencies(CurrentContext, ConcurrencyDetector, commandLogger, QueryLogger);
+            => new QueryContextDependencies(CurrentContext, ExecutionStrategyFactory, ConcurrencyDetector, commandLogger, QueryLogger);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -138,6 +154,6 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <param name="queryLogger"> A replacement for the current dependency of this type. </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
         public QueryContextDependencies With([NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> queryLogger)
-            => new QueryContextDependencies(CurrentContext, ConcurrencyDetector, CommandLogger, queryLogger);
+            => new QueryContextDependencies(CurrentContext, ExecutionStrategyFactory, ConcurrencyDetector, CommandLogger, queryLogger);
     }
 }

--- a/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
@@ -41,6 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             _constantVerifyingExpressionVisitor = new ConstantVerifyingExpressionVisitor(dependencies.TypeMappingSource);
 
+            IsBuffering = queryCompilationContext.IsBuffering;
             IsAsync = queryCompilationContext.IsAsync;
 
             if (queryCompilationContext.IsAsync)
@@ -54,6 +55,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         protected virtual ShapedQueryCompilingExpressionVisitorDependencies Dependencies { get; }
 
         protected virtual bool IsTracking { get; }
+
+        public virtual bool IsBuffering { get; internal set; }
 
         protected virtual bool IsAsync { get; }
 

--- a/src/EFCore/Storage/ExecutionStrategyExtensions.cs
+++ b/src/EFCore/Storage/ExecutionStrategyExtensions.cs
@@ -283,7 +283,7 @@ namespace Microsoft.EntityFrameworkCore
             [NotNull] this IExecutionStrategy strategy,
             [CanBeNull] TState state,
             [NotNull] Func<TState, TResult> operation)
-            => strategy.Execute(operation, verifySucceeded: null, state: state);
+            => strategy.Execute(state, operation,  verifySucceeded: null);
 
         /// <summary>
         ///     Executes the specified asynchronous operation and returns the result.
@@ -330,13 +330,39 @@ namespace Microsoft.EntityFrameworkCore
         /// </exception>
         public static TResult Execute<TState, TResult>(
             [NotNull] this IExecutionStrategy strategy,
+            [CanBeNull] TState state,
             [NotNull] Func<TState, TResult> operation,
-            [CanBeNull] Func<TState, ExecutionResult<TResult>> verifySucceeded,
-            [CanBeNull] TState state)
+            [CanBeNull] Func<TState, ExecutionResult<TResult>> verifySucceeded)
             => Check.NotNull(strategy, nameof(strategy)).Execute(
                 state,
                 (c, s) => operation(s),
                 verifySucceeded == null ? (Func<DbContext, TState, ExecutionResult<TResult>>)null : (c, s) => verifySucceeded(s));
+
+        /// <summary>
+        ///     Executes the specified operation and returns the result.
+        /// </summary>
+        /// <param name="strategy">The strategy that will be used for the execution.</param>
+        /// <param name="operation">
+        ///     A delegate representing an executable operation that returns the result of type <typeparamref name="TResult" />.
+        /// </param>
+        /// <param name="verifySucceeded"> A delegate that tests whether the operation succeeded even though an exception was thrown. </param>
+        /// <param name="state"> The state that will be passed to the operation. </param>
+        /// <typeparam name="TState"> The type of the state. </typeparam>
+        /// <typeparam name="TResult"> The return type of <paramref name="operation" />. </typeparam>
+        /// <returns> The result from the operation. </returns>
+        /// <exception cref="RetryLimitExceededException">
+        ///     The operation has not succeeded after the configured number of retries.
+        /// </exception>
+        [Obsolete("Use overload that takes the state first")]
+        public static TResult Execute<TState, TResult>(
+            [NotNull] this IExecutionStrategy strategy,
+            [NotNull] Func<TState, TResult> operation,
+            [CanBeNull] Func<TState, ExecutionResult<TResult>> verifySucceeded,
+            [CanBeNull] TState state)
+            => strategy.Execute(
+                state,
+                operation,
+                verifySucceeded);
 
         /// <summary>
         ///     Executes the specified asynchronous operation and returns the result.

--- a/test/EFCore.Cosmos.FunctionalTests/TestUtilities/TestCosmosExecutionStrategy.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/TestUtilities/TestCosmosExecutionStrategy.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Cosmos.TestUtilities;
 using Microsoft.EntityFrameworkCore.Storage;
 
+// ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore.TestUtilities
 {
     public class TestCosmosExecutionStrategy : CosmosExecutionStrategy

--- a/test/EFCore.Relational.Specification.Tests/CommandInterceptionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/CommandInterceptionTestBase.cs
@@ -14,6 +14,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 using Xunit;
 
+// ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore
 {
     public abstract class CommandInterceptionTestBase : InterceptionTestBase
@@ -78,7 +79,7 @@ namespace Microsoft.EntityFrameworkCore
                 var connection = context.GetService<IRelationalConnection>();
                 var logger = context.GetService<IDiagnosticsLogger<DbLoggerCategory.Database.Command>>();
 
-                var commandParameterObject = new RelationalCommandParameterObject(connection, null, context, logger);
+                var commandParameterObject = new RelationalCommandParameterObject(connection, null, null, context, logger);
 
                 using (var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId))
                 {
@@ -292,7 +293,7 @@ namespace Microsoft.EntityFrameworkCore
                 var connection = context.GetService<IRelationalConnection>();
                 var logger = context.GetService<IDiagnosticsLogger<DbLoggerCategory.Database.Command>>();
 
-                var commandParameterObject = new RelationalCommandParameterObject(connection, null, context, logger);
+                var commandParameterObject = new RelationalCommandParameterObject(connection, null, null, context, logger);
 
                 using (var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId))
                 {
@@ -483,7 +484,7 @@ namespace Microsoft.EntityFrameworkCore
                 var connection = context.GetService<IRelationalConnection>();
                 var logger = context.GetService<IDiagnosticsLogger<DbLoggerCategory.Database.Command>>();
 
-                var commandParameterObject = new RelationalCommandParameterObject(connection, null, context, logger);
+                var commandParameterObject = new RelationalCommandParameterObject(connection, null, null, context, logger);
 
                 using (var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId))
                 {
@@ -683,7 +684,7 @@ namespace Microsoft.EntityFrameworkCore
                 var connection = context.GetService<IRelationalConnection>();
                 var logger = context.GetService<IDiagnosticsLogger<DbLoggerCategory.Database.Command>>();
 
-                var commandParameterObject = new RelationalCommandParameterObject(connection, null, context, logger);
+                var commandParameterObject = new RelationalCommandParameterObject(connection, null, null, context, logger);
 
                 using (var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId))
                 {
@@ -891,6 +892,20 @@ namespace Microsoft.EntityFrameworkCore
                 _secondReader = secondReader;
             }
 
+            public override int FieldCount => _firstReader.FieldCount;
+            public override int RecordsAffected => _firstReader.RecordsAffected + _secondReader.RecordsAffected;
+            public override bool HasRows => _firstReader.HasRows || _secondReader.HasRows;
+            public override bool IsClosed => _firstReader.IsClosed;
+            public override int Depth => _firstReader.Depth;
+
+            public override string GetDataTypeName(int ordinal) => _firstReader.GetDataTypeName(ordinal);
+            public override Type GetFieldType(int ordinal) => _firstReader.GetFieldType(ordinal);
+            public override string GetName(int ordinal) => _firstReader.GetName(ordinal);
+            public override bool NextResult() => _firstReader.NextResult() || _secondReader.NextResult();
+
+            public override async Task<bool> NextResultAsync(CancellationToken cancellationToken)
+                => await _firstReader.NextResultAsync(cancellationToken) || await _secondReader.NextResultAsync(cancellationToken);
+
             public override void Close()
             {
                 _firstReader.Close();
@@ -948,7 +963,7 @@ namespace Microsoft.EntityFrameworkCore
                 var connection = context.GetService<IRelationalConnection>();
                 var logger = context.GetService<IDiagnosticsLogger<DbLoggerCategory.Database.Command>>();
 
-                var commandParameterObject = new RelationalCommandParameterObject(connection, null, context, logger);
+                var commandParameterObject = new RelationalCommandParameterObject(connection, null, null, context, logger);
 
                 using (var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId))
                 {
@@ -1104,7 +1119,7 @@ namespace Microsoft.EntityFrameworkCore
                 var connection = context.GetService<IRelationalConnection>();
                 var logger = context.GetService<IDiagnosticsLogger<DbLoggerCategory.Database.Command>>();
 
-                var commandParameterObject = new RelationalCommandParameterObject(connection, null, context, logger);
+                var commandParameterObject = new RelationalCommandParameterObject(connection, null, null, context, logger);
 
                 try
                 {
@@ -1188,7 +1203,7 @@ namespace Microsoft.EntityFrameworkCore
                 var connection = context.GetService<IRelationalConnection>();
                 var logger = context.GetService<IDiagnosticsLogger<DbLoggerCategory.Database.Command>>();
 
-                var commandParameterObject = new RelationalCommandParameterObject(connection, null, context, logger);
+                var commandParameterObject = new RelationalCommandParameterObject(connection, null, null, context, logger);
 
                 var exception = async
                     ? await Assert.ThrowsAsync<Exception>(() => command.ExecuteScalarAsync(commandParameterObject))
@@ -1323,7 +1338,7 @@ namespace Microsoft.EntityFrameworkCore
             var connection = context.GetService<IRelationalConnection>();
             var logger = context.GetService<IDiagnosticsLogger<DbLoggerCategory.Database.Command>>();
 
-            var commandParameterObject = new RelationalCommandParameterObject(connection, null, context, logger);
+            var commandParameterObject = new RelationalCommandParameterObject(connection, null, null, context, logger);
 
             Assert.Equal(
                 ResultReplacingScalarCommandInterceptor.InterceptedResult,
@@ -1520,6 +1535,11 @@ namespace Microsoft.EntityFrameworkCore
             private readonly int[] _ints = { 977, 988, 999 };
 
             private readonly string[] _strings = { "<977>", "<988>", "<999>" };
+            public override int FieldCount { get; }
+            public override int RecordsAffected { get; }
+            public override bool HasRows { get; }
+            public override bool IsClosed { get; }
+            public override int Depth { get; }
 
             public override bool Read()
                 => _index++ < _ints.Length;
@@ -1557,14 +1577,9 @@ namespace Microsoft.EntityFrameworkCore
             public override int GetOrdinal(string name) => throw new NotImplementedException();
             public override object GetValue(int ordinal) => throw new NotImplementedException();
             public override int GetValues(object[] values) => throw new NotImplementedException();
-            public override int FieldCount { get; }
             public override object this[int ordinal] => throw new NotImplementedException();
             public override object this[string name] => throw new NotImplementedException();
-            public override int RecordsAffected { get; }
-            public override bool HasRows { get; }
-            public override bool IsClosed { get; }
             public override bool NextResult() => throw new NotImplementedException();
-            public override int Depth { get; }
             public override IEnumerator GetEnumerator() => throw new NotImplementedException();
         }
 

--- a/test/EFCore.Relational.Specification.Tests/Query/AsyncFromSqlQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/AsyncFromSqlQueryTestBase.cs
@@ -30,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var context = CreateContext())
             {
                 var actual = await context.Set<Customer>()
-                    .FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [ContactName] LIKE '%z%'"))
+                    .FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Customers] WHERE [ContactName] LIKE '%z%'"))
                     .ToArrayAsync();
 
                 Assert.Equal(14, actual.Length);
@@ -44,7 +44,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var context = CreateContext())
             {
                 var actual = await context.Set<Customer>().FromSqlRaw(
-                        NormalizeDelimetersInRawString(
+                        NormalizeDelimitersInRawString(
                             "SELECT [Region], [PostalCode], [Phone], [Fax], [CustomerID], [Country], [ContactTitle], [ContactName], [CompanyName], [City], [Address] FROM [Customers]"))
                     .ToArrayAsync();
 
@@ -59,7 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var context = CreateContext())
             {
                 var actual = await context.Set<Customer>().FromSqlRaw(
-                        NormalizeDelimetersInRawString(
+                        NormalizeDelimitersInRawString(
                             "SELECT [Region], [PostalCode], [PostalCode] AS [Foo], [Phone], [Fax], [CustomerID], [Country], [ContactTitle], [ContactName], [CompanyName], [City], [Address] FROM [Customers]"))
                     .ToArrayAsync();
 
@@ -73,7 +73,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using (var context = CreateContext())
             {
-                var actual = await context.Set<Customer>().FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Customers]"))
+                var actual = await context.Set<Customer>().FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Customers]"))
                     .Where(c => c.ContactName.Contains("z"))
                     .ToArrayAsync();
 
@@ -87,8 +87,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var context = CreateContext())
             {
                 var actual
-                    = await (from c in context.Set<Customer>().FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Customers]"))
-                             from o in context.Set<Order>().FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Orders]"))
+                    = await (from c in context.Set<Customer>().FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Customers]"))
+                             from o in context.Set<Order>().FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Orders]"))
                              where c.CustomerID == o.CustomerID
                              select new { c, o })
                         .ToArrayAsync();
@@ -106,9 +106,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var context = CreateContext())
             {
                 var actual
-                    = await (from c in context.Set<Customer>().FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Customers]"))
+                    = await (from c in context.Set<Customer>().FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Customers]"))
                              from o in context.Set<Order>().FromSqlRaw(
-                                 NormalizeDelimetersInRawString("SELECT * FROM [Orders] WHERE [OrderDate] BETWEEN {0} AND {1}"), startDate,
+                                 NormalizeDelimitersInRawString("SELECT * FROM [Orders] WHERE [OrderDate] BETWEEN {0} AND {1}"), startDate,
                                  endDate)
                              where c.CustomerID == o.CustomerID
                              select new { c, o })
@@ -129,9 +129,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             {
                 var actual
                     = await (from c in context.Set<Customer>().FromSqlRaw(
-                                 NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [City] = {0}"), city)
+                                 NormalizeDelimitersInRawString("SELECT * FROM [Customers] WHERE [City] = {0}"), city)
                              from o in context.Set<Order>().FromSqlRaw(
-                                 NormalizeDelimetersInRawString("SELECT * FROM [Orders] WHERE [OrderDate] BETWEEN {0} AND {1}"), startDate,
+                                 NormalizeDelimitersInRawString("SELECT * FROM [Orders] WHERE [OrderDate] BETWEEN {0} AND {1}"), startDate,
                                  endDate)
                              where c.CustomerID == o.CustomerID
                              select new { c, o })
@@ -147,7 +147,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var context = CreateContext())
             {
                 var actual = await context.Set<Customer>().FromSqlRaw(
-                        NormalizeDelimetersInRawString(
+                        NormalizeDelimitersInRawString(
                             @"SELECT *
 FROM [Customers]
 WHERE [City] = 'London'"))
@@ -164,7 +164,7 @@ WHERE [City] = 'London'"))
             using (var context = CreateContext())
             {
                 var actual = await context.Set<Customer>().FromSqlRaw(
-                        NormalizeDelimetersInRawString(
+                        NormalizeDelimitersInRawString(
                             @"SELECT *
 FROM [Customers]"))
                     .Where(c => c.City == "London")
@@ -184,7 +184,7 @@ FROM [Customers]"))
             using (var context = CreateContext())
             {
                 var actual = await context.Set<Customer>().FromSqlRaw(
-                        NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [City] = {0} AND [ContactTitle] = {1}"), city,
+                        NormalizeDelimitersInRawString("SELECT * FROM [Customers] WHERE [City] = {0} AND [ContactTitle] = {1}"), city,
                         contactTitle)
                     .ToArrayAsync();
 
@@ -203,7 +203,7 @@ FROM [Customers]"))
             using (var context = CreateContext())
             {
                 var actual = await context.Set<Customer>().FromSqlRaw(
-                        NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [City] = {0}"), city)
+                        NormalizeDelimitersInRawString("SELECT * FROM [Customers] WHERE [City] = {0}"), city)
                     .Where(c => c.ContactTitle == contactTitle)
                     .ToArrayAsync();
 
@@ -219,14 +219,14 @@ FROM [Customers]"))
             using (var context = CreateContext())
             {
                 var actual = await context.Set<Customer>()
-                    .FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [City] = 'London'"))
+                    .FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Customers] WHERE [City] = 'London'"))
                     .ToArrayAsync();
 
                 Assert.Equal(6, actual.Length);
                 Assert.True(actual.All(c => c.City == "London"));
 
                 actual = await context.Set<Customer>()
-                    .FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [City] = 'Seattle'"))
+                    .FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Customers] WHERE [City] = 'Seattle'"))
                     .ToArrayAsync();
 
                 Assert.Single(actual);
@@ -243,7 +243,7 @@ FROM [Customers]"))
 
             using (var context = CreateContext())
             {
-                var actual = await context.Set<Customer>().FromSqlRaw(NormalizeDelimetersInRawString(sql), city, contactTitle)
+                var actual = await context.Set<Customer>().FromSqlRaw(NormalizeDelimitersInRawString(sql), city, contactTitle)
                     .ToArrayAsync();
 
                 Assert.Equal(3, actual.Length);
@@ -253,7 +253,7 @@ FROM [Customers]"))
                 city = "Madrid";
                 contactTitle = "Accounting Manager";
 
-                actual = await context.Set<Customer>().FromSqlRaw(NormalizeDelimetersInRawString(sql), city, contactTitle)
+                actual = await context.Set<Customer>().FromSqlRaw(NormalizeDelimitersInRawString(sql), city, contactTitle)
                     .ToArrayAsync();
 
                 Assert.Equal(2, actual.Length);
@@ -267,7 +267,7 @@ FROM [Customers]"))
         {
             using (var context = CreateContext())
             {
-                var actual = await context.Set<Customer>().FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Customers]"))
+                var actual = await context.Set<Customer>().FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Customers]"))
                     .AsNoTracking()
                     .ToArrayAsync();
 
@@ -281,7 +281,7 @@ FROM [Customers]"))
         {
             using (var context = CreateContext())
             {
-                var actual = await context.Set<Customer>().FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Customers]"))
+                var actual = await context.Set<Customer>().FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Customers]"))
                     .Select(
                         c => new { c.CustomerID, c.City })
                     .AsNoTracking()
@@ -297,7 +297,7 @@ FROM [Customers]"))
         {
             using (var context = CreateContext())
             {
-                var actual = await context.Set<Customer>().FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Customers]"))
+                var actual = await context.Set<Customer>().FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Customers]"))
                     .Include(c => c.Orders)
                     .ToArrayAsync();
 
@@ -310,7 +310,7 @@ FROM [Customers]"))
         {
             using (var context = CreateContext())
             {
-                var actual = await context.Set<Customer>().FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Customers]"))
+                var actual = await context.Set<Customer>().FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Customers]"))
                     .Include(c => c.Orders)
                     .Where(c => c.City == "London")
                     .ToArrayAsync();
@@ -325,7 +325,7 @@ FROM [Customers]"))
             using (var context = CreateContext())
             {
                 var actual = await context.Customers
-                    .FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [ContactName] LIKE '%z%'"))
+                    .FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Customers] WHERE [ContactName] LIKE '%z%'"))
                     .ToArrayAsync();
 
                 Assert.Equal(14, actual.Length);
@@ -342,7 +342,7 @@ FROM [Customers]"))
         {
             using (var context = CreateContext())
             {
-                var actual = await context.Set<Customer>().FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Customers]"))
+                var actual = await context.Set<Customer>().FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Customers]"))
                     .Where(c => c.ContactName == c.CompanyName)
                     .ToArrayAsync();
 
@@ -400,11 +400,11 @@ FROM [Customers]"))
             }
         }
 
-        private string NormalizeDelimetersInRawString(string sql)
-            => Fixture.TestStore.NormalizeDelimetersInRawString(sql);
+        private string NormalizeDelimitersInRawString(string sql)
+            => Fixture.TestStore.NormalizeDelimitersInRawString(sql);
 
-        private FormattableString NormalizeDelimetersInInterpolatedString(FormattableString sql)
-            => Fixture.TestStore.NormalizeDelimetersInInterpolatedString(sql);
+        private FormattableString NormalizeDelimitersInInterpolatedString(FormattableString sql)
+            => Fixture.TestStore.NormalizeDelimitersInInterpolatedString(sql);
 
         protected NorthwindContext CreateContext() => Fixture.CreateContext();
     }

--- a/test/EFCore.Relational.Specification.Tests/Query/FromSqlQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/FromSqlQueryTestBase.cs
@@ -42,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     Assert.Throws<InvalidOperationException>(
                         () =>
                             context.Set<Product>().FromSqlRaw(
-                                    NormalizeDelimetersInRawString(
+                                    NormalizeDelimitersInRawString(
                                         @"SELECT [ProductID] AS [ProductName], [ProductName] AS [ProductID], [SupplierID], [UnitPrice], [UnitsInStock], [Discontinued]
                                FROM [Products]"))
                                 .ToList()).Message);
@@ -59,7 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     Assert.Throws<InvalidOperationException>(
                         () =>
                             context.Set<Product>().FromSqlRaw(
-                                    NormalizeDelimetersInRawString(
+                                    NormalizeDelimitersInRawString(
                                         @"SELECT [ProductID], [SupplierID] AS [UnitPrice], [ProductName], [SupplierID], [UnitsInStock], [Discontinued]
                                FROM [Products]"))
                                 .ToList()).Message);
@@ -76,7 +76,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     Assert.Throws<InvalidOperationException>(
                         () =>
                             context.Set<Product>().FromSqlRaw(
-                                    NormalizeDelimetersInRawString(
+                                    NormalizeDelimitersInRawString(
                                         @"SELECT [ProductID], [SupplierID] AS [UnitPrice], [ProductName], [UnitsInStock], [Discontinued]
                                FROM [Products]"))
                                 .Select(p => p.UnitPrice)
@@ -95,7 +95,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         () =>
                             context.Set<Product>()
                                 .FromSqlRaw(
-                                    NormalizeDelimetersInRawString(
+                                    NormalizeDelimitersInRawString(
                                         @"SELECT [ProductID] AS [ProductName], [ProductName] AS [ProductID], [SupplierID], [UnitPrice], [UnitsInStock], [Discontinued]
                                FROM [Products]")).AsNoTracking()
                                 .ToList()).Message);
@@ -108,7 +108,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var context = CreateContext())
             {
                 context.Set<Product>().FromSqlRaw(
-                        NormalizeDelimetersInRawString(
+                        NormalizeDelimitersInRawString(
                             @"SELECT [ProductID], [ProductName], [SupplierID], [UnitPrice], [UnitsInStock], NULL AS [Discontinued]
                                FROM [Products]"))
                     .ToList();
@@ -117,7 +117,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     Assert.Throws<InvalidOperationException>(
                         () =>
                             context.Set<Product>().FromSqlRaw(
-                                    NormalizeDelimetersInRawString(
+                                    NormalizeDelimitersInRawString(
                                         @"SELECT [ProductID], [ProductName], [SupplierID], [UnitPrice], [UnitsInStock], NULL AS [Discontinued]
                                FROM [Products]"))
                                 .ToList()).Message);
@@ -134,7 +134,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     Assert.Throws<InvalidOperationException>(
                         () =>
                             context.Set<Product>().FromSqlRaw(
-                                    NormalizeDelimetersInRawString(
+                                    NormalizeDelimitersInRawString(
                                         @"SELECT [ProductID], [ProductName], [SupplierID], [UnitPrice], [UnitsInStock], NULL AS [Discontinued]
                                FROM [Products]"))
                                 .Select(p => p.Discontinued)
@@ -153,7 +153,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         () =>
                             context.Set<Product>()
                                 .FromSqlRaw(
-                                    NormalizeDelimetersInRawString(
+                                    NormalizeDelimitersInRawString(
                                         @"SELECT [ProductID], [ProductName], [SupplierID], [UnitPrice], [UnitsInStock], NULL AS [Discontinued]
                                FROM [Products]")).AsNoTracking()
                                 .ToList()).Message);
@@ -166,7 +166,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var context = CreateContext())
             {
                 var actual = context.Set<Customer>()
-                    .FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [ContactName] LIKE '%z%'"))
+                    .FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Customers] WHERE [ContactName] LIKE '%z%'"))
                     .ToArray();
 
                 Assert.Equal(14, actual.Length);
@@ -180,7 +180,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var context = CreateContext())
             {
                 var actual = context.Set<Customer>().FromSqlRaw(
-                        NormalizeDelimetersInRawString(
+                        NormalizeDelimitersInRawString(
                             "SELECT [Region], [PostalCode], [Phone], [Fax], [CustomerID], [Country], [ContactTitle], [ContactName], [CompanyName], [City], [Address] FROM [Customers]"))
                     .ToArray();
 
@@ -195,7 +195,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var context = CreateContext())
             {
                 var actual = context.Set<Customer>().FromSqlRaw(
-                        NormalizeDelimetersInRawString(
+                        NormalizeDelimitersInRawString(
                             "SELECT [Region], [PostalCode], [PostalCode] AS [Foo], [Phone], [Fax], [CustomerID], [Country], [ContactTitle], [ContactName], [CompanyName], [City], [Address] FROM [Customers]"))
                     .ToArray();
 
@@ -213,7 +213,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     RelationalStrings.FromSqlMissingColumn("Region"),
                     Assert.Throws<InvalidOperationException>(
                         () => context.Set<Customer>().FromSqlRaw(
-                                NormalizeDelimetersInRawString(
+                                NormalizeDelimitersInRawString(
                                     "SELECT [PostalCode], [Phone], [Fax], [CustomerID], [Country], [ContactTitle], [ContactName], [CompanyName], [City], [Address] FROM [Customers]"))
                             .ToArray()
                     ).Message);
@@ -225,7 +225,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using (var context = CreateContext())
             {
-                var actual = context.Set<Customer>().FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Customers]"))
+                var actual = context.Set<Customer>().FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Customers]"))
                     .Where(c => c.ContactName.Contains("z"))
                     .ToArray();
 
@@ -239,7 +239,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var context = CreateContext())
             {
                 var actual = context.Set<Customer>().FromSqlRaw(
-                        NormalizeDelimetersInRawString(
+                        NormalizeDelimitersInRawString(
                             _eol + "    " + _eol + _eol + _eol + "SELECT" + _eol + "* FROM [Customers]"))
                     .Where(c => c.ContactName.Contains("z"))
                     .ToArray();
@@ -253,7 +253,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             var query = EF.CompileQuery(
                 (NorthwindContext context) => context.Set<Customer>()
-                    .FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Customers]"))
+                    .FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Customers]"))
                     .Where(c => c.ContactName.Contains("z")));
 
             using (var context = CreateContext())
@@ -270,7 +270,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             var query = EF.CompileQuery(
                 (NorthwindContext context) => context.Set<Customer>()
                     .FromSqlRaw(
-                        NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [CustomerID] = {0}"), "CONSH")
+                        NormalizeDelimitersInRawString("SELECT * FROM [Customers] WHERE [CustomerID] = {0}"), "CONSH")
                     .Where(c => c.ContactName.Contains("z")));
 
             using (var context = CreateContext())
@@ -287,7 +287,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             var query = EF.CompileQuery(
                 (NorthwindContext context) => context.Set<Customer>()
                     .FromSqlRaw(
-                        NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [CustomerID] = @customer"),
+                        NormalizeDelimitersInRawString("SELECT * FROM [Customers] WHERE [CustomerID] = @customer"),
                         CreateDbParameter("customer", "CONSH"))
                     .Where(c => c.ContactName.Contains("z")));
 
@@ -305,7 +305,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             var query = EF.CompileQuery(
                 (NorthwindContext context) => context.Set<Customer>()
                     .FromSqlRaw(
-                        NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [CustomerID] = {0}"),
+                        NormalizeDelimitersInRawString("SELECT * FROM [Customers] WHERE [CustomerID] = {0}"),
                         CreateDbParameter(null, "CONSH"))
                     .Where(c => c.ContactName.Contains("z")));
 
@@ -324,7 +324,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             {
                 var actual
                     = (from c in context.Set<Customer>()
-                       where context.Orders.FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Orders]"))
+                       where context.Orders.FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Orders]"))
                            .Select(o => o.CustomerID)
                            .Contains(c.CustomerID)
                        select c)
@@ -343,7 +343,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     = (from c in context.Set<Customer>()
                        where
                            c.CustomerID == "ALFKI"
-                           && context.Orders.FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Orders]"))
+                           && context.Orders.FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Orders]"))
                                .Select(o => o.CustomerID)
                                .Contains(c.CustomerID)
                        select c)
@@ -359,8 +359,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var context = CreateContext())
             {
                 var actual
-                    = (from c in context.Set<Customer>().FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Customers]"))
-                       from o in context.Set<Order>().FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Orders]"))
+                    = (from c in context.Set<Customer>().FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Customers]"))
+                       from o in context.Set<Order>().FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Orders]"))
                        where c.CustomerID == o.CustomerID
                        select new { c, o })
                     .ToArray();
@@ -378,9 +378,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var context = CreateContext())
             {
                 var actual
-                    = (from c in context.Set<Customer>().FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Customers]"))
+                    = (from c in context.Set<Customer>().FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Customers]"))
                        from o in context.Set<Order>().FromSqlRaw(
-                           NormalizeDelimetersInRawString("SELECT * FROM [Orders] WHERE [OrderDate] BETWEEN {0} AND {1}"),
+                           NormalizeDelimitersInRawString("SELECT * FROM [Orders] WHERE [OrderDate] BETWEEN {0} AND {1}"),
                            startDate,
                            endDate)
                        where c.CustomerID == o.CustomerID
@@ -402,9 +402,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             {
                 var actual
                     = (from c in context.Set<Customer>().FromSqlRaw(
-                           NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [City] = {0}"), city)
+                           NormalizeDelimitersInRawString("SELECT * FROM [Customers] WHERE [City] = {0}"), city)
                        from o in context.Set<Order>().FromSqlRaw(
-                           NormalizeDelimetersInRawString("SELECT * FROM [Orders] WHERE [OrderDate] BETWEEN {0} AND {1}"),
+                           NormalizeDelimitersInRawString("SELECT * FROM [Orders] WHERE [OrderDate] BETWEEN {0} AND {1}"),
                            startDate,
                            endDate)
                        where c.CustomerID == o.CustomerID
@@ -419,9 +419,9 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 actual
                     = (from c in context.Set<Customer>().FromSqlRaw(
-                           NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [City] = {0}"), city)
+                           NormalizeDelimitersInRawString("SELECT * FROM [Customers] WHERE [City] = {0}"), city)
                        from o in context.Set<Order>().FromSqlRaw(
-                           NormalizeDelimetersInRawString("SELECT * FROM [Orders] WHERE [OrderDate] BETWEEN {0} AND {1}"),
+                           NormalizeDelimitersInRawString("SELECT * FROM [Orders] WHERE [OrderDate] BETWEEN {0} AND {1}"),
                            startDate,
                            endDate)
                        where c.CustomerID == o.CustomerID
@@ -438,7 +438,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var context = CreateContext())
             {
                 var actual = context.Set<Customer>().FromSqlRaw(
-                        NormalizeDelimetersInRawString(
+                        NormalizeDelimitersInRawString(
                             @"SELECT *
 FROM [Customers]
 WHERE [City] = 'London'"))
@@ -455,7 +455,7 @@ WHERE [City] = 'London'"))
             using (var context = CreateContext())
             {
                 var actual = context.Set<Customer>().FromSqlRaw(
-                        NormalizeDelimetersInRawString(
+                        NormalizeDelimitersInRawString(
                             @"SELECT *
 FROM [Customers]"))
                     .Where(c => c.City == "London")
@@ -475,7 +475,7 @@ FROM [Customers]"))
             using (var context = CreateContext())
             {
                 var actual = context.Set<Customer>().FromSqlRaw(
-                        NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [City] = {0} AND [ContactTitle] = {1}"), city,
+                        NormalizeDelimitersInRawString("SELECT * FROM [Customers] WHERE [City] = {0} AND [ContactTitle] = {1}"), city,
                         contactTitle)
                     .ToArray();
 
@@ -491,7 +491,7 @@ FROM [Customers]"))
             using (var context = CreateContext())
             {
                 var actual = context.Set<Customer>().FromSqlRaw(
-                        NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [City] = {0} AND [ContactTitle] = {1}"), "London",
+                        NormalizeDelimitersInRawString("SELECT * FROM [Customers] WHERE [City] = {0} AND [ContactTitle] = {1}"), "London",
                         "Sales Representative")
                     .ToArray();
 
@@ -510,7 +510,7 @@ FROM [Customers]"))
             using (var context = CreateContext())
             {
                 var actual = context.Set<Customer>().FromSqlInterpolated(
-                        NormalizeDelimetersInInterpolatedString(
+                        NormalizeDelimitersInInterpolatedString(
                             $"SELECT * FROM [Customers] WHERE [City] = {city} AND [ContactTitle] = {contactTitle}"))
                     .ToArray();
 
@@ -526,7 +526,7 @@ FROM [Customers]"))
             using (var context = CreateContext())
             {
                 var actual = context.Set<Customer>().FromSqlInterpolated(
-                        NormalizeDelimetersInInterpolatedString(
+                        NormalizeDelimitersInInterpolatedString(
                             $"SELECT * FROM [Customers] WHERE [City] = {"London"} AND [ContactTitle] = {"Sales Representative"}"))
                     .ToArray();
 
@@ -547,9 +547,9 @@ FROM [Customers]"))
             {
                 var actual
                     = (from c in context.Set<Customer>().FromSqlRaw(
-                           NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [City] = {0}"), city)
+                           NormalizeDelimitersInRawString("SELECT * FROM [Customers] WHERE [City] = {0}"), city)
                        from o in context.Set<Order>().FromSqlInterpolated(
-                           NormalizeDelimetersInInterpolatedString(
+                           NormalizeDelimitersInInterpolatedString(
                                $"SELECT * FROM [Orders] WHERE [OrderDate] BETWEEN {startDate} AND {endDate}"))
                        where c.CustomerID == o.CustomerID
                        select new { c, o })
@@ -563,9 +563,9 @@ FROM [Customers]"))
 
                 actual
                     = (from c in context.Set<Customer>().FromSqlRaw(
-                           NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [City] = {0}"), city)
+                           NormalizeDelimitersInRawString("SELECT * FROM [Customers] WHERE [City] = {0}"), city)
                        from o in context.Set<Order>().FromSqlInterpolated(
-                           NormalizeDelimetersInInterpolatedString(
+                           NormalizeDelimitersInInterpolatedString(
                                $"SELECT * FROM [Orders] WHERE [OrderDate] BETWEEN {startDate} AND {endDate}"))
                        where c.CustomerID == o.CustomerID
                        select new { c, o })
@@ -583,7 +583,7 @@ FROM [Customers]"))
             using (var context = CreateContext())
             {
                 var actual = context.Set<Employee>().FromSqlRaw(
-                        NormalizeDelimetersInRawString(
+                        NormalizeDelimitersInRawString(
                             // ReSharper disable once ExpressionIsAlwaysNull
                             "SELECT * FROM [Employees] WHERE [ReportsTo] = {0} OR ([ReportsTo] IS NULL AND {0} IS NULL)"), reportsTo)
                     .ToArray();
@@ -601,7 +601,7 @@ FROM [Customers]"))
             using (var context = CreateContext())
             {
                 var actual = context.Set<Customer>().FromSqlRaw(
-                        NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [City] = {0}"), city)
+                        NormalizeDelimitersInRawString("SELECT * FROM [Customers] WHERE [City] = {0}"), city)
                     .Where(c => c.ContactTitle == contactTitle)
                     .ToArray();
 
@@ -617,14 +617,14 @@ FROM [Customers]"))
             using (var context = CreateContext())
             {
                 var actual = context.Set<Customer>()
-                    .FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [City] = 'London'"))
+                    .FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Customers] WHERE [City] = 'London'"))
                     .ToArray();
 
                 Assert.Equal(6, actual.Length);
                 Assert.True(actual.All(c => c.City == "London"));
 
                 actual = context.Set<Customer>()
-                    .FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [City] = 'Seattle'"))
+                    .FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Customers] WHERE [City] = 'Seattle'"))
                     .ToArray();
 
                 Assert.Single(actual);
@@ -641,7 +641,7 @@ FROM [Customers]"))
 
             using (var context = CreateContext())
             {
-                var actual = context.Set<Customer>().FromSqlRaw(NormalizeDelimetersInRawString(sql), city, contactTitle)
+                var actual = context.Set<Customer>().FromSqlRaw(NormalizeDelimitersInRawString(sql), city, contactTitle)
                     .ToArray();
 
                 Assert.Equal(3, actual.Length);
@@ -651,7 +651,7 @@ FROM [Customers]"))
                 city = "Madrid";
                 contactTitle = "Accounting Manager";
 
-                actual = context.Set<Customer>().FromSqlRaw(NormalizeDelimetersInRawString(sql), city, contactTitle)
+                actual = context.Set<Customer>().FromSqlRaw(NormalizeDelimitersInRawString(sql), city, contactTitle)
                     .ToArray();
 
                 Assert.Equal(2, actual.Length);
@@ -665,7 +665,7 @@ FROM [Customers]"))
         {
             using (var context = CreateContext())
             {
-                var actual = context.Set<Customer>().FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Customers]"))
+                var actual = context.Set<Customer>().FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Customers]"))
                     .AsNoTracking()
                     .ToArray();
 
@@ -681,7 +681,7 @@ FROM [Customers]"))
             {
                 var boolMapping = (RelationalTypeMapping)context.GetService<ITypeMappingSource>().FindMapping(typeof(bool));
                 var actual = context.Set<Product>().FromSqlRaw(
-                        NormalizeDelimetersInRawString(
+                        NormalizeDelimitersInRawString(
                             @"SELECT *
 FROM [Products]
 WHERE [Discontinued] <> "
@@ -700,7 +700,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
         {
             using (var context = CreateContext())
             {
-                var actual = context.Set<Customer>().FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Customers]"))
+                var actual = context.Set<Customer>().FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Customers]"))
                     .Include(c => c.Orders)
                     .ToArray();
 
@@ -713,7 +713,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
         {
             using (var context = CreateContext())
             {
-                var actual = context.Set<Customer>().FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Customers]"))
+                var actual = context.Set<Customer>().FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Customers]"))
                     .Include(c => c.Orders)
                     .Where(c => c.City == "London")
                     .ToArray();
@@ -728,7 +728,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
             using (var context = CreateContext())
             {
                 var actual = context.Customers
-                    .FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [ContactName] LIKE '%z%'"))
+                    .FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Customers] WHERE [ContactName] LIKE '%z%'"))
                     .ToArray();
 
                 Assert.Equal(14, actual.Length);
@@ -745,7 +745,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
         {
             using (var context = CreateContext())
             {
-                var actual = context.Set<Customer>().FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Customers]"))
+                var actual = context.Set<Customer>().FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Customers]"))
                     .Where(c => c.ContactName == c.CompanyName)
                     .ToArray();
 
@@ -761,7 +761,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
                 var parameter = CreateDbParameter("@city", "London");
 
                 var actual = context.Customers.FromSqlRaw(
-                        NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [City] = @city"), parameter)
+                        NormalizeDelimitersInRawString("SELECT * FROM [Customers] WHERE [City] = @city"), parameter)
                     .ToArray();
 
                 Assert.Equal(6, actual.Length);
@@ -777,7 +777,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
                 var parameter = CreateDbParameter("city", "London");
 
                 var actual = context.Customers.FromSqlRaw(
-                        NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [City] = @city"), parameter)
+                        NormalizeDelimitersInRawString("SELECT * FROM [Customers] WHERE [City] = @city"), parameter)
                     .ToArray();
 
                 Assert.Equal(6, actual.Length);
@@ -796,7 +796,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
                 var titleParameter = CreateDbParameter("@title", title);
 
                 var actual = context.Customers.FromSqlRaw(
-                        NormalizeDelimetersInRawString(
+                        NormalizeDelimitersInRawString(
                             "SELECT * FROM [Customers] WHERE [City] = {0} AND [ContactTitle] = @title"), city, titleParameter)
                     .ToArray();
 
@@ -807,7 +807,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
                 var cityParameter = CreateDbParameter("@city", city);
 
                 actual = context.Customers.FromSqlRaw(
-                        NormalizeDelimetersInRawString(
+                        NormalizeDelimitersInRawString(
                             "SELECT * FROM [Customers] WHERE [City] = @city AND [ContactTitle] = {1}"), cityParameter, title)
                     .ToArray();
 
@@ -855,7 +855,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
                 var parameter = CreateDbParameter("@id", "ALFKI");
 
                 var query = context.Customers.FromSqlRaw(
-                    NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [CustomerID] = @id"), parameter);
+                    NormalizeDelimitersInRawString("SELECT * FROM [Customers] WHERE [CustomerID] = @id"), parameter);
 
                 // ReSharper disable PossibleMultipleEnumeration
                 var result1 = query.ToList();
@@ -875,9 +875,9 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
             using (var context = CreateContext())
             {
                 var query = from c1 in context.Set<Customer>()
-                                .FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [CustomerID] = 'ALFKI'"))
+                                .FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Customers] WHERE [CustomerID] = 'ALFKI'"))
                             from c2 in context.Set<Customer>().FromSqlRaw(
-                                    NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [CustomerID] = 'AROUT'"))
+                                    NormalizeDelimitersInRawString("SELECT * FROM [Customers] WHERE [CustomerID] = 'AROUT'"))
                                 .Include(c => c.Orders)
                             select new { c1, c2 };
 
@@ -904,9 +904,9 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
             using (var context = CreateContext())
             {
                 var query = from c in context.Set<Customer>()
-                                .FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [CustomerID] = 'ALFKI'"))
+                                .FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Customers] WHERE [CustomerID] = 'ALFKI'"))
                             join o in context.Set<Order>().FromSqlRaw(
-                                        NormalizeDelimetersInRawString("SELECT * FROM [Orders] WHERE [OrderID] <> 1"))
+                                        NormalizeDelimitersInRawString("SELECT * FROM [Orders] WHERE [OrderID] <> 1"))
                                     .Include(o => o.OrderDetails)
                                 on c.CustomerID equals o.CustomerID
                             select new { c, o };
@@ -952,7 +952,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
 
                 var actual = context.Customers
                     .FromSqlInterpolated(
-                        NormalizeDelimetersInInterpolatedString($"SELECT * FROM [Customers] WHERE [CustomerID] = {parameter}"))
+                        NormalizeDelimitersInInterpolatedString($"SELECT * FROM [Customers] WHERE [CustomerID] = {parameter}"))
                     .ToList();
 
                 Assert.Single(actual);
@@ -969,7 +969,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
 
                 var actual = context.Customers
                     .FromSqlInterpolated(
-                        NormalizeDelimetersInInterpolatedString($"SELECT * FROM [Customers] WHERE [CustomerID] = {parameter}"))
+                        NormalizeDelimitersInInterpolatedString($"SELECT * FROM [Customers] WHERE [CustomerID] = {parameter}"))
                     .ToList();
 
                 Assert.Single(actual);
@@ -986,7 +986,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
                 var max = 10400;
 
                 var query1 = context.Orders
-                    .FromSqlInterpolated(NormalizeDelimetersInInterpolatedString($"SELECT * FROM [Orders] WHERE [OrderID] >= {min}"))
+                    .FromSqlInterpolated(NormalizeDelimitersInInterpolatedString($"SELECT * FROM [Orders] WHERE [OrderID] >= {min}"))
                     .Select(i => i.OrderID);
                 query1.ToList();
 
@@ -1000,7 +1000,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
                         o => o.OrderID <= max
                             && context.Orders
                                 .FromSqlInterpolated(
-                                    NormalizeDelimetersInInterpolatedString($"SELECT * FROM [Orders] WHERE [OrderID] >= {min}"))
+                                    NormalizeDelimitersInInterpolatedString($"SELECT * FROM [Orders] WHERE [OrderID] >= {min}"))
                                 .Select(i => i.OrderID)
                                 .Contains(o.OrderID))
                     .Select(o => o.OrderID);
@@ -1016,7 +1016,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
                 var tableName = "Orders";
                 var max = 10250;
                 var query = context.Orders.FromSqlRaw(
-                        NormalizeDelimetersInRawString($"SELECT * FROM [{tableName}] WHERE [OrderID] < {{0}}"), max)
+                        NormalizeDelimitersInRawString($"SELECT * FROM [{tableName}] WHERE [OrderID] < {{0}}"), max)
                     .ToList();
 
                 Assert.Equal(2, query.Count);
@@ -1029,7 +1029,7 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
             using (var context = CreateContext())
             {
                 var actual = context.Set<Order>()
-                    .FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Orders]"))
+                    .FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Orders]"))
                     .Where(o => o.Customer == new Customer { CustomerID = "VINET" })
                     .ToArray();
 
@@ -1043,20 +1043,20 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
             using var context = CreateContext();
 
             var actual = context.Set<Customer>()
-                .FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [City] = 'London'"))
+                .FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Customers] WHERE [City] = 'London'"))
                 .Concat(
                     context.Set<Customer>()
-                        .FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Customers] WHERE [City] = 'Berlin'")))
+                        .FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Customers] WHERE [City] = 'Berlin'")))
                 .ToArray();
 
             Assert.Equal(7, actual.Length);
         }
 
-        protected string NormalizeDelimetersInRawString(string sql)
-            => Fixture.TestStore.NormalizeDelimetersInRawString(sql);
+        protected string NormalizeDelimitersInRawString(string sql)
+            => Fixture.TestStore.NormalizeDelimitersInRawString(sql);
 
-        protected FormattableString NormalizeDelimetersInInterpolatedString(FormattableString sql)
-            => Fixture.TestStore.NormalizeDelimetersInInterpolatedString(sql);
+        protected FormattableString NormalizeDelimitersInInterpolatedString(FormattableString sql)
+            => Fixture.TestStore.NormalizeDelimitersInInterpolatedString(sql);
 
         protected abstract DbParameter CreateDbParameter(string name, object value);
 

--- a/test/EFCore.Relational.Specification.Tests/Query/FromSqlSprocQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/FromSqlSprocQueryTestBase.cs
@@ -370,7 +370,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             var query = from mep in context.Set<MostExpensiveProduct>()
                             .FromSqlRaw(TenMostExpensiveProductsSproc, GetTenMostExpensiveProductsParameters())
                         from p in context.Set<Product>()
-                            .FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Products]"))
+                            .FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Products]"))
                         where mep.TenMostExpensiveProducts == p.ProductName
                         select new { mep, p };
 
@@ -390,7 +390,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             var query1 = context.Set<MostExpensiveProduct>()
                 .FromSqlRaw(TenMostExpensiveProductsSproc, GetTenMostExpensiveProductsParameters());
             var query2 = context.Set<Product>()
-                .FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Products]"));
+                .FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Products]"));
 
             var results1 = async ? await query1.ToListAsync() : query1.ToList();
             var results2 = async ? await query2.ToListAsync() : query2.ToList();
@@ -409,7 +409,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual async Task From_sql_queryable_select_and_stored_procedure(bool async)
         {
             using var context = CreateContext();
-            var query = from p in context.Set<Product>().FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Products]"))
+            var query = from p in context.Set<Product>().FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Products]"))
                         from mep in context.Set<MostExpensiveProduct>()
                             .FromSqlRaw(TenMostExpensiveProductsSproc, GetTenMostExpensiveProductsParameters())
                         where mep.TenMostExpensiveProducts == p.ProductName
@@ -430,7 +430,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             using var context = CreateContext();
 
             var query1 = context.Set<Product>()
-                .FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Products]"));
+                .FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Products]"));
             var query2 = context.Set<MostExpensiveProduct>()
                 .FromSqlRaw(TenMostExpensiveProductsSproc, GetTenMostExpensiveProductsParameters());
 
@@ -445,8 +445,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             Assert.Equal(10, actual.Length);
         }
 
-        private string NormalizeDelimetersInRawString(string sql)
-            => Fixture.TestStore.NormalizeDelimetersInRawString(sql);
+        private string NormalizeDelimitersInRawString(string sql)
+            => Fixture.TestStore.NormalizeDelimitersInRawString(sql);
 
         protected virtual object[] GetTenMostExpensiveProductsParameters()
             => Array.Empty<object>();

--- a/test/EFCore.Relational.Specification.Tests/Query/GearsOfWarFromSqlQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/GearsOfWarFromSqlQueryTestBase.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var context = CreateContext())
             {
                 var actual = context.Set<Weapon>().FromSqlRaw(
-                        NormalizeDelimetersInRawString(
+                        NormalizeDelimitersInRawString(
                             "SELECT [Id], [Name], [IsAutomatic], [AmmunitionType], [OwnerFullName], [SynergyWithId] FROM [Weapons] ORDER BY [Name]"))
                     .ToArray();
 
@@ -35,11 +35,11 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        private string NormalizeDelimetersInRawString(string sql)
-            => Fixture.TestStore.NormalizeDelimetersInRawString(sql);
+        private string NormalizeDelimitersInRawString(string sql)
+            => Fixture.TestStore.NormalizeDelimitersInRawString(sql);
 
-        private FormattableString NormalizeDelimetersInInterpolatedString(FormattableString sql)
-            => Fixture.TestStore.NormalizeDelimetersInInterpolatedString(sql);
+        private FormattableString NormalizeDelimitersInInterpolatedString(FormattableString sql)
+            => Fixture.TestStore.NormalizeDelimitersInInterpolatedString(sql);
 
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext();
 

--- a/test/EFCore.Relational.Specification.Tests/Query/InheritanceRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/InheritanceRelationalTestBase.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using (var context = CreateContext())
             {
-                context.Set<Animal>().FromSqlRaw(NormalizeDelimetersInRawString("select * from [Animal]")).ToList();
+                context.Set<Animal>().FromSqlRaw(NormalizeDelimitersInRawString("select * from [Animal]")).ToList();
             }
         }
 
@@ -32,14 +32,14 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using (var context = CreateContext())
             {
-                context.Set<Eagle>().FromSqlRaw(NormalizeDelimetersInRawString("select * from [Animal]")).ToList();
+                context.Set<Eagle>().FromSqlRaw(NormalizeDelimitersInRawString("select * from [Animal]")).ToList();
             }
         }
 
-        private string NormalizeDelimetersInRawString(string sql)
-            => ((RelationalTestStore)Fixture.TestStore).NormalizeDelimetersInRawString(sql);
+        private string NormalizeDelimitersInRawString(string sql)
+            => ((RelationalTestStore)Fixture.TestStore).NormalizeDelimitersInRawString(sql);
 
-        private FormattableString NormalizeDelimetersInInterpolatedString(FormattableString sql)
-            => ((RelationalTestStore)Fixture.TestStore).NormalizeDelimetersInInterpolatedString(sql);
+        private FormattableString NormalizeDelimitersInInterpolatedString(FormattableString sql)
+            => ((RelationalTestStore)Fixture.TestStore).NormalizeDelimitersInInterpolatedString(sql);
     }
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
@@ -745,7 +745,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var context = CreateContext(useRelationalNulls: true))
             {
                 var actual = context.Entities1
-                    .FromSqlRaw(NormalizeDelimetersInRawString("SELECT * FROM [Entities1]"))
+                    .FromSqlRaw(NormalizeDelimitersInRawString("SELECT * FROM [Entities1]"))
                     .Where(c => c.StringA == c.StringB)
                     .ToArray();
 
@@ -1065,11 +1065,11 @@ namespace Microsoft.EntityFrameworkCore.Query
             return caller == null ? null : expression();
         }
 
-        private string NormalizeDelimetersInRawString(string sql)
-            => Fixture.TestStore.NormalizeDelimetersInRawString(sql);
+        private string NormalizeDelimitersInRawString(string sql)
+            => Fixture.TestStore.NormalizeDelimitersInRawString(sql);
 
         private FormattableString NormalizeDelimetersInInterpolatedString(FormattableString sql)
-            => Fixture.TestStore.NormalizeDelimetersInInterpolatedString(sql);
+            => Fixture.TestStore.NormalizeDelimitersInInterpolatedString(sql);
 
         protected abstract NullSemanticsContext CreateContext(bool useRelationalNulls = false);
 

--- a/test/EFCore.Relational.Specification.Tests/Query/QueryNoClientEvalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/QueryNoClientEvalTestBase.cs
@@ -80,7 +80,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             {
                 AssertTranslationFailed(
                     () => context.Customers
-                        .FromSqlRaw(NormalizeDelimetersInRawString("select * from [Customers]"))
+                        .FromSqlRaw(NormalizeDelimitersInRawString("select * from [Customers]"))
                         .Where(c => c.IsLondon)
                         .ToList());
             }
@@ -93,7 +93,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             {
                 var customers
                     = context.Customers
-                        .FromSqlRaw(NormalizeDelimetersInRawString("select * from [Customers]"))
+                        .FromSqlRaw(NormalizeDelimitersInRawString("select * from [Customers]"))
                         .ToList();
 
                 Assert.Equal(91, customers.Count);
@@ -232,8 +232,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        private string NormalizeDelimetersInRawString(string sql)
-            => Fixture.TestStore.NormalizeDelimetersInRawString(sql);
+        private string NormalizeDelimitersInRawString(string sql)
+            => Fixture.TestStore.NormalizeDelimitersInRawString(sql);
 
         private void AssertTranslationFailed(Action testCode)
         {

--- a/test/EFCore.Relational.Specification.Tests/TestUtilities/RelationalDatabaseCleaner.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestUtilities/RelationalDatabaseCleaner.cs
@@ -129,7 +129,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 }
 
                 sqlBuilder.Build(batches[i])
-                    .ExecuteNonQuery(new RelationalCommandParameterObject(connection, null, null, null));
+                    .ExecuteNonQuery(new RelationalCommandParameterObject(connection, null, null, null, null));
             }
         }
 

--- a/test/EFCore.Relational.Specification.Tests/TestUtilities/RelationalTestStore.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestUtilities/RelationalTestStore.cs
@@ -43,14 +43,14 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             base.Dispose();
         }
 
-        public virtual string NormalizeDelimetersInRawString(string sql)
-            => sql.Replace("[", OpenDelimeter).Replace("]", CloseDelimeter);
+        public virtual string NormalizeDelimitersInRawString(string sql)
+            => sql.Replace("[", OpenDelimiter).Replace("]", CloseDelimiter);
 
-        public virtual FormattableString NormalizeDelimetersInInterpolatedString(FormattableString sql)
-            => new TestFormattableString(NormalizeDelimetersInRawString(sql.Format), sql.GetArguments());
+        public virtual FormattableString NormalizeDelimitersInInterpolatedString(FormattableString sql)
+            => new TestFormattableString(NormalizeDelimitersInRawString(sql.Format), sql.GetArguments());
 
-        protected virtual string OpenDelimeter => "\"";
+        protected virtual string OpenDelimiter => "\"";
 
-        protected virtual string CloseDelimeter => "\"";
+        protected virtual string CloseDelimiter => "\"";
     }
 }

--- a/test/EFCore.Relational.Tests/Query/Internal/BufferedDataReaderTest.cs
+++ b/test/EFCore.Relational.Tests/Query/Internal/BufferedDataReaderTest.cs
@@ -1,0 +1,217 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider;
+using Xunit;
+
+// ReSharper disable InconsistentNaming
+namespace Microsoft.EntityFrameworkCore.Query.Internal
+{
+    public class BufferedDataReaderTest
+    {
+        public static IEnumerable<object[]> IsAsyncData = new[] { new object[] { false }, new object[] { true } };
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task Metadata_methods_return_expected_results(bool async)
+        {
+            var reader = new FakeDbDataReader(new[] { "columnName" }, new[] { new[] { new object() }, new[] { new object() } });
+            var columns = new ReaderColumn[] { new ReaderColumn<object>(true, null, (r, _) => r.GetValue(0)) };
+            var bufferedDataReader = new BufferedDataReader(reader);
+            if (async)
+            {
+                await bufferedDataReader.InitializeAsync(columns, CancellationToken.None);
+            }
+            else
+            {
+                bufferedDataReader.Initialize(columns);
+            }
+
+            Assert.Equal(1, bufferedDataReader.FieldCount);
+            Assert.Equal(0, bufferedDataReader.GetOrdinal("columnName"));
+            Assert.Equal(typeof(object).Name, bufferedDataReader.GetDataTypeName(0));
+            Assert.Equal(typeof(object), bufferedDataReader.GetFieldType(0));
+            Assert.Equal("columnName", bufferedDataReader.GetName(0));
+            Assert.Equal(2, bufferedDataReader.RecordsAffected);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task Manipulation_methods_perform_expected_actions(bool async)
+        {
+            var reader = new FakeDbDataReader(
+                new[] { "id", "name" },
+                new List<IList<object[]>> { new[] { new object[] { 1, "a" } }, new object[0][] });
+            var columns = new ReaderColumn[]
+            {
+                new ReaderColumn<int>(false, null, (r, _) => r.GetInt32(0)), new ReaderColumn<object>(true, null, (r, _) => r.GetValue(1))
+            };
+
+            var bufferedDataReader = new BufferedDataReader(reader);
+
+            Assert.False(bufferedDataReader.IsClosed);
+            if (async)
+            {
+                await bufferedDataReader.InitializeAsync(columns, CancellationToken.None);
+            }
+            else
+            {
+                bufferedDataReader.Initialize(columns);
+            }
+
+            Assert.False(bufferedDataReader.IsClosed);
+
+            Assert.True(bufferedDataReader.HasRows);
+
+            if (async)
+            {
+                Assert.True(await bufferedDataReader.ReadAsync());
+                Assert.False(await bufferedDataReader.ReadAsync());
+            }
+            else
+            {
+                Assert.True(bufferedDataReader.Read());
+                Assert.False(bufferedDataReader.Read());
+            }
+
+            Assert.True(bufferedDataReader.HasRows);
+
+            if (async)
+            {
+                Assert.True(await bufferedDataReader.NextResultAsync());
+            }
+            else
+            {
+                Assert.True(bufferedDataReader.NextResult());
+            }
+
+            Assert.False(bufferedDataReader.HasRows);
+
+            if (async)
+            {
+                Assert.False(await bufferedDataReader.ReadAsync());
+                Assert.False(await bufferedDataReader.NextResultAsync());
+            }
+            else
+            {
+                Assert.False(bufferedDataReader.Read());
+                Assert.False(bufferedDataReader.NextResult());
+            }
+
+            Assert.False(bufferedDataReader.IsClosed);
+            bufferedDataReader.Close();
+            Assert.True(bufferedDataReader.IsClosed);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task Initialize_is_idempotent(bool isAsync)
+        {
+            var reader = new FakeDbDataReader(new[] { "name" }, new[] { new[] { new object() } });
+            var columns = new ReaderColumn[] { new ReaderColumn<object>(true, null, (r, _) => r.GetValue(0)) };
+            var bufferedReader = new BufferedDataReader(reader);
+
+            Assert.False(reader.IsClosed);
+            if (isAsync)
+            {
+                await bufferedReader.InitializeAsync(columns, CancellationToken.None);
+            }
+            else
+            {
+                bufferedReader.Initialize(columns);
+            }
+
+            Assert.True(reader.IsClosed);
+
+            if (isAsync)
+            {
+                await bufferedReader.InitializeAsync(columns, CancellationToken.None);
+            }
+            else
+            {
+                bufferedReader.Initialize(columns);
+            }
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task Data_methods_return_expected_results(bool async)
+        {
+            await Verify_get_method_returns_supplied_value(true, async);
+            await Verify_get_method_returns_supplied_value((byte)1, async);
+            await Verify_get_method_returns_supplied_value((short)1, async);
+            await Verify_get_method_returns_supplied_value(1, async);
+            await Verify_get_method_returns_supplied_value(1L, async);
+            await Verify_get_method_returns_supplied_value(1F, async);
+            await Verify_get_method_returns_supplied_value(1D, async);
+            await Verify_get_method_returns_supplied_value(1M, async);
+            await Verify_get_method_returns_supplied_value('a', async);
+            await Verify_get_method_returns_supplied_value("a", async);
+            await Verify_get_method_returns_supplied_value(DateTime.Now, async);
+            await Verify_get_method_returns_supplied_value(Guid.NewGuid(), async);
+            var obj = new object();
+            await Verify_method_result(r => r.GetValue(0), async, obj, new[] { obj });
+            await Verify_method_result(r => r.GetFieldValue<object>(0), async, obj, new[] { obj });
+            await Verify_method_result(r => r.GetFieldValueAsync<object>(0).Result, async, obj, new[] { obj });
+            await Verify_method_result(r => r.IsDBNull(0), async, true, new object[] { DBNull.Value });
+            await Verify_method_result(r => r.IsDBNull(0), async, false, new object[] { true });
+            await Verify_method_result(r => r.IsDBNullAsync(0).Result, async, true, new object[] { DBNull.Value });
+            await Verify_method_result(r => r.IsDBNullAsync(0).Result, async, false, new object[] { true });
+
+            await Assert.ThrowsAsync<NotSupportedException>(
+                () => Verify_method_result(r => r.GetBytes(0, 0, new byte[0], 0, 0), async, 0, new object[] { 1L }));
+            await Assert.ThrowsAsync<NotSupportedException>(
+                () => Verify_method_result(r => r.GetChars(0, 0, new char[0], 0, 0), async, 0, new object[] { 1L }));
+        }
+
+        private async Task Verify_method_result<T>(
+            Func<BufferedDataReader, T> method, bool async, T expectedResult,
+            params object[][] dataReaderContents)
+        {
+            var reader = new FakeDbDataReader(new[] { "name" }, dataReaderContents);
+            var columnType = typeof(T);
+            if (!columnType.IsValueType)
+            {
+                columnType = typeof(object);
+            }
+
+            var columns = new[]
+            {
+                ReaderColumn.Create(columnType, true, null, (Func<DbDataReader, int[], T>)((r, _) => r.GetFieldValue<T>(0)))
+            };
+
+            var bufferedReader = new BufferedDataReader(reader);
+            if (async)
+            {
+                await bufferedReader.InitializeAsync(columns, CancellationToken.None);
+
+                Assert.True(await bufferedReader.ReadAsync());
+            }
+            else
+            {
+                bufferedReader.Initialize(columns);
+
+                Assert.True(bufferedReader.Read());
+            }
+
+            Assert.Equal(expectedResult, method(bufferedReader));
+        }
+
+        private Task Verify_get_method_returns_supplied_value<T>(T value, bool async)
+        {
+            // use the specific reader.GetXXX method
+            var readerMethod = GetReaderMethod(typeof(T));
+            return Verify_method_result(
+                r => (T)readerMethod.Invoke(r, new object[] { 0 }), async, value, new object[] { value });
+        }
+
+        private static MethodInfo GetReaderMethod(Type type) => RelationalTypeMapping.GetDataReaderMethod(type);
+    }
+}

--- a/test/EFCore.Relational.Tests/Storage/RelationalCommandTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalCommandTest.cs
@@ -44,7 +44,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             var relationalCommand = CreateRelationalCommand(commandText: "CommandText");
 
             relationalCommand.ExecuteNonQuery(
-                new RelationalCommandParameterObject(fakeConnection, null, null, null));
+                new RelationalCommandParameterObject(fakeConnection, null, null, null, null));
 
             Assert.Equal(1, fakeConnection.DbConnections.Count);
             Assert.Equal(1, fakeConnection.DbConnections[0].DbCommands.Count);
@@ -66,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             var relationalCommand = CreateRelationalCommand();
 
             relationalCommand.ExecuteNonQuery(
-                new RelationalCommandParameterObject(fakeConnection, null, null, null));
+                new RelationalCommandParameterObject(fakeConnection, null, null, null, null));
 
             Assert.Equal(1, fakeConnection.DbConnections.Count);
             Assert.Equal(1, fakeConnection.DbConnections[0].DbCommands.Count);
@@ -88,7 +88,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             var relationalCommand = CreateRelationalCommand();
 
             relationalCommand.ExecuteNonQuery(
-                new RelationalCommandParameterObject(fakeConnection, null, null, null));
+                new RelationalCommandParameterObject(fakeConnection, null, null, null, null));
 
             Assert.Equal(1, fakeConnection.DbConnections.Count);
             Assert.Equal(1, fakeConnection.DbConnections[0].DbCommands.Count);
@@ -122,7 +122,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
             var result = relationalCommand.ExecuteNonQuery(
                 new RelationalCommandParameterObject(
-                    new FakeRelationalConnection(options), null, null, null));
+                    new FakeRelationalConnection(options), null, null, null, null));
 
             Assert.Equal(1, result);
 
@@ -162,7 +162,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
             var result = await relationalCommand.ExecuteNonQueryAsync(
                 new RelationalCommandParameterObject(
-                    new FakeRelationalConnection(options), null, null, null));
+                    new FakeRelationalConnection(options), null, null, null, null));
 
             Assert.Equal(1, result);
 
@@ -202,7 +202,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
             var result = (string)relationalCommand.ExecuteScalar(
                 new RelationalCommandParameterObject(
-                    new FakeRelationalConnection(options), null, null, null));
+                    new FakeRelationalConnection(options), null, null, null, null));
 
             Assert.Equal("ExecuteScalar Result", result);
 
@@ -242,7 +242,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
             var result = (string)await relationalCommand.ExecuteScalarAsync(
                 new RelationalCommandParameterObject(
-                    new FakeRelationalConnection(options), null, null, null));
+                    new FakeRelationalConnection(options), null, null, null, null));
 
             Assert.Equal("ExecuteScalar Result", result);
 
@@ -284,7 +284,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
             var result = relationalCommand.ExecuteReader(
                 new RelationalCommandParameterObject(
-                    new FakeRelationalConnection(options), null, null, null));
+                    new FakeRelationalConnection(options), null, null, null, null));
 
             Assert.Same(dbDataReader, result.DbDataReader);
             Assert.Equal(0, fakeDbConnection.CloseCount);
@@ -333,7 +333,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
             var result = await relationalCommand.ExecuteReaderAsync(
                 new RelationalCommandParameterObject(
-                    new FakeRelationalConnection(options), null, null, null));
+                    new FakeRelationalConnection(options), null, null, null, null));
 
             Assert.Same(dbDataReader, result.DbDataReader);
             Assert.Equal(0, fakeDbConnection.CloseCount);
@@ -363,42 +363,42 @@ namespace Microsoft.EntityFrameworkCore.Storage
                     new CommandAction(
                         (connection, command, parameterValues, logger)
                             => command.ExecuteNonQuery(
-                                new RelationalCommandParameterObject(connection, parameterValues, null, logger))),
+                                new RelationalCommandParameterObject(connection, parameterValues, null, null, logger))),
                     DbCommandMethod.ExecuteNonQuery, false
                 },
                 {
                     new CommandAction(
                         (connection, command, parameterValues, logger)
                             => command.ExecuteScalar(
-                                new RelationalCommandParameterObject(connection, parameterValues, null, logger))),
+                                new RelationalCommandParameterObject(connection, parameterValues, null, null, logger))),
                     DbCommandMethod.ExecuteScalar, false
                 },
                 {
                     new CommandAction(
                         (connection, command, parameterValues, logger)
                             => command.ExecuteReader(
-                                new RelationalCommandParameterObject(connection, parameterValues, null, logger))),
+                                new RelationalCommandParameterObject(connection, parameterValues, null, null, logger))),
                     DbCommandMethod.ExecuteReader, false
                 },
                 {
                     new CommandFunc(
                         (connection, command, parameterValues, logger)
                             => command.ExecuteNonQueryAsync(
-                                new RelationalCommandParameterObject(connection, parameterValues, null, logger))),
+                                new RelationalCommandParameterObject(connection, parameterValues, null, null, logger))),
                     DbCommandMethod.ExecuteNonQuery, true
                 },
                 {
                     new CommandFunc(
                         (connection, command, parameterValues, logger)
                             => command.ExecuteScalarAsync(
-                                new RelationalCommandParameterObject(connection, parameterValues, null, logger))),
+                                new RelationalCommandParameterObject(connection, parameterValues, null, null, logger))),
                     DbCommandMethod.ExecuteScalar, true
                 },
                 {
                     new CommandFunc(
                         (connection, command, parameterValues, logger)
                             => command.ExecuteReaderAsync(
-                                new RelationalCommandParameterObject(connection, parameterValues, null, logger))),
+                                new RelationalCommandParameterObject(connection, parameterValues, null, null, logger))),
                     DbCommandMethod.ExecuteReader, true
                 }
             };

--- a/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeDbDataReader.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeDbDataReader.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Data.Common;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -13,15 +14,26 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider
     public class FakeDbDataReader : DbDataReader
     {
         private readonly string[] _columnNames;
-        private readonly IList<object[]> _results;
+        private IList<object[]> _results;
+        private readonly IList<IList<object[]>> _resultSets;
 
+        private int _currentResultSet;
         private object[] _currentRow;
         private int _rowIndex;
+        private bool _closed;
 
         public FakeDbDataReader(string[] columnNames = null, IList<object[]> results = null)
         {
             _columnNames = columnNames ?? Array.Empty<string>();
             _results = results ?? new List<object[]>();
+            _resultSets = new List<IList<object[]>> { _results };
+        }
+
+        public FakeDbDataReader(string[] columnNames, IList<IList<object[]>> resultSets)
+        {
+            _columnNames = columnNames ?? Array.Empty<string>();
+            _resultSets = resultSets ?? new List<IList<object[]>> { new List<object[]>() };
+            _results = _resultSets[0];
         }
 
         public override bool Read()
@@ -51,6 +63,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider
         public override void Close()
         {
             CloseCount++;
+            _closed = true;
         }
 
         public int DisposeCount { get; private set; }
@@ -63,6 +76,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider
 
                 base.Dispose(true);
             }
+
+            _closed = true;
         }
 
         public override int FieldCount => _columnNames.Length;
@@ -88,11 +103,11 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider
 
         public override int Depth => throw new NotImplementedException();
 
-        public override bool HasRows => throw new NotImplementedException();
+        public override bool HasRows => _results.Count != 0;
 
-        public override bool IsClosed => throw new NotImplementedException();
+        public override bool IsClosed => _closed;
 
-        public override int RecordsAffected => 0;
+        public override int RecordsAffected => _resultSets.Aggregate(0, (a, r) => a + r.Count);
 
         public override bool GetBoolean(int ordinal) => (bool)_currentRow[ordinal];
 
@@ -110,10 +125,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider
             throw new NotImplementedException();
         }
 
-        public override string GetDataTypeName(int ordinal)
-        {
-            throw new NotImplementedException();
-        }
+        public override string GetDataTypeName(int ordinal) => GetFieldType(ordinal).Name;
 
         public override DateTime GetDateTime(int ordinal) => (DateTime)_currentRow[ordinal];
 
@@ -127,9 +139,9 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider
         }
 
         public override Type GetFieldType(int ordinal)
-        {
-            throw new NotImplementedException();
-        }
+            => _results.Count > 0
+                ? _results[0][ordinal]?.GetType() ?? typeof(object)
+                : typeof(object);
 
         public override float GetFloat(int ordinal) => (float)_currentRow[ordinal];
 
@@ -153,7 +165,13 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider
 
         public override bool NextResult()
         {
-            throw new NotImplementedException();
+            var hasResult = _resultSets.Count > ++_currentResultSet;
+            if (hasResult)
+            {
+                _results = _resultSets[_currentResultSet];
+            }
+
+            return hasResult;
         }
     }
 }

--- a/test/EFCore.Specification.Tests/InterceptionTestBase.cs
+++ b/test/EFCore.Specification.Tests/InterceptionTestBase.cs
@@ -177,7 +177,7 @@ namespace Microsoft.EntityFrameworkCore
             public virtual DbContextOptions CreateOptions(
                 IEnumerable<IInterceptor> appInterceptors,
                 IEnumerable<IInterceptor> injectedInterceptors)
-                => base.AddOptions(
+                => AddOptions(
                         TestStore
                             .AddProviderOptions(
                                 new DbContextOptionsBuilder()

--- a/test/EFCore.Specification.Tests/TestUtilities/DataGenerator.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/DataGenerator.cs
@@ -1,0 +1,47 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities
+{
+    public static class DataGenerator
+    {
+        private static readonly ConcurrentDictionary<int, object[][]> _boolCombinations
+            = new ConcurrentDictionary<int, object[][]>();
+
+        public static object[][] GetBoolCombinations(int length)
+            => _boolCombinations.GetOrAdd(length, l => GetCombinations(new object[] { false, true }, l));
+
+        public static object[][] GetCombinations(object[] set, int length)
+        {
+            var sets = new object[length][];
+            Array.Fill(sets, set);
+            return GetCombinations(sets);
+        }
+
+        public static object[][] GetCombinations(object[][] sets)
+        {
+            var numberOfCombinations = sets.Aggregate(1L, (current, set) => current * set.Length);
+            var combinations = new object[numberOfCombinations][];
+
+            for (var i = 0L; i < numberOfCombinations; i++)
+            {
+                var combination = new object[sets.Length];
+                var temp = i;
+                for (var j = 0; j < sets.Length; j++)
+                {
+                    var set = sets[j];
+                    combination[j] = set[(int)(temp % set.Length)];
+                    temp /= set.Length;
+                }
+
+                combinations[i] = combination;
+            }
+
+            return combinations;
+        }
+    }
+}

--- a/test/EFCore.Specification.Tests/TestUtilities/TestHelpers.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/TestHelpers.cs
@@ -75,7 +75,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                     }
                     else
                     {
-                        Assert.Same(property.GetValue(clone), property.GetValue(dependencies));
+                        Assert.Equal(property.GetValue(clone), property.GetValue(dependencies));
                     }
                 }
             }

--- a/test/EFCore.SqlServer.FunctionalTests/CommandInterceptionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/CommandInterceptionSqlServerTest.cs
@@ -4,6 +4,8 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -66,6 +68,13 @@ namespace Microsoft.EntityFrameworkCore
             public class InterceptionSqlServerFixture : InterceptionSqlServerFixtureBase
             {
                 protected override bool ShouldSubscribeToDiagnosticListener => false;
+
+                public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+                {
+                    new SqlServerDbContextOptionsBuilder(base.AddOptions(builder))
+                        .ExecutionStrategy(d => new SqlServerExecutionStrategy(d));
+                    return builder;
+                }
             }
         }
 
@@ -81,6 +90,13 @@ namespace Microsoft.EntityFrameworkCore
             public class InterceptionSqlServerFixture : InterceptionSqlServerFixtureBase
             {
                 protected override bool ShouldSubscribeToDiagnosticListener => true;
+
+                public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+                {
+                    new SqlServerDbContextOptionsBuilder(base.AddOptions(builder))
+                        .ExecutionStrategy(d => new SqlServerExecutionStrategy(d));
+                    return builder;
+                }
             }
         }
     }

--- a/test/EFCore.SqlServer.FunctionalTests/ExecutionStrategyTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ExecutionStrategyTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using System.Threading;
@@ -31,65 +32,56 @@ namespace Microsoft.EntityFrameworkCore
 
         protected ExecutionStrategyFixture Fixture { get; }
 
-        [ConditionalFact]
-        public void Does_not_throw_or_retry_on_false_commit_failure()
+        [ConditionalTheory]
+        [MemberData(nameof(DataGenerator.GetBoolCombinations), 1, MemberType = typeof(DataGenerator))]
+        public void Handles_commit_failure(bool realFailure)
         {
-            Test_commit_failure(false);
-        }
-
-        [ConditionalFact]
-        public void Retries_on_true_commit_failure()
-        {
-            Test_commit_failure(true);
-        }
-
-        private void Test_commit_failure(bool realFailure)
-        {
+            // Use all overloads of ExecuteInTransaction
             Test_commit_failure(
                 realFailure, (e, db) => e.ExecuteInTransaction(
-                    () => db.SaveChanges(acceptAllChangesOnSuccess: false),
+                    () => { db.SaveChanges(false); },
                     () => db.Products.AsNoTracking().Any()));
 
             Test_commit_failure(
                 realFailure, (e, db) => e.ExecuteInTransaction(
-                    () => db.SaveChanges(acceptAllChangesOnSuccess: false),
+                    () => db.SaveChanges(false),
                     () => db.Products.AsNoTracking().Any()));
 
             Test_commit_failure(
                 realFailure, (e, db) => e.ExecuteInTransaction(
                     db,
-                    c => c.SaveChanges(acceptAllChangesOnSuccess: false),
+                    c => { c.SaveChanges(false); },
                     c => c.Products.AsNoTracking().Any()));
 
             Test_commit_failure(
                 realFailure, (e, db) => e.ExecuteInTransaction(
                     db,
-                    c => c.SaveChanges(acceptAllChangesOnSuccess: false),
+                    c => c.SaveChanges(false),
                     c => c.Products.AsNoTracking().Any()));
 
             Test_commit_failure(
                 realFailure, (e, db) => e.ExecuteInTransaction(
-                    () => db.SaveChanges(acceptAllChangesOnSuccess: false),
+                    () => { db.SaveChanges(false); },
                     () => db.Products.AsNoTracking().Any(),
                     IsolationLevel.Serializable));
 
             Test_commit_failure(
                 realFailure, (e, db) => e.ExecuteInTransaction(
-                    () => db.SaveChanges(acceptAllChangesOnSuccess: false),
+                    () => db.SaveChanges(false),
                     () => db.Products.AsNoTracking().Any(),
                     IsolationLevel.Serializable));
 
             Test_commit_failure(
                 realFailure, (e, db) => e.ExecuteInTransaction(
                     db,
-                    c => c.SaveChanges(acceptAllChangesOnSuccess: false),
+                    c => { c.SaveChanges(false); },
                     c => c.Products.AsNoTracking().Any(),
                     IsolationLevel.Serializable));
 
             Test_commit_failure(
                 realFailure, (e, db) => e.ExecuteInTransaction(
                     db,
-                    c => c.SaveChanges(acceptAllChangesOnSuccess: false),
+                    c => c.SaveChanges(false),
                     c => c.Products.AsNoTracking().Any(),
                     IsolationLevel.Serializable));
         }
@@ -133,87 +125,77 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [ConditionalFact]
-        public Task Does_not_throw_or_retry_on_false_commit_failure_async()
+        [ConditionalTheory]
+        [MemberData(nameof(DataGenerator.GetBoolCombinations), 1, MemberType = typeof(DataGenerator))]
+        public async Task Handles_commit_failure_async(bool realFailure)
         {
-            return Test_commit_failure_async(false);
-        }
-
-        [ConditionalFact]
-        public Task Retries_on_true_commit_failure_async()
-        {
-            return Test_commit_failure_async(true);
-        }
-
-        private async Task Test_commit_failure_async(bool realFailure)
-        {
+            // Use all overloads of ExecuteInTransactionAsync
             await Test_commit_failure_async(
                 realFailure, (e, db) => e.ExecuteInTransactionAsync(
-                    () => db.SaveChangesAsync(acceptAllChangesOnSuccess: false),
+                    () => db.SaveChangesAsync(false),
                     () => db.Products.AsNoTracking().AnyAsync()));
 
-            var cancellationToken = CancellationToken.None;
             await Test_commit_failure_async(
                 realFailure, (e, db) => e.ExecuteInTransactionAsync(
-                    async ct => await db.SaveChangesAsync(acceptAllChangesOnSuccess: false),
+                    async ct => { await db.SaveChangesAsync(false); },
                     ct => db.Products.AsNoTracking().AnyAsync(),
-                    cancellationToken));
+                    CancellationToken.None));
 
             await Test_commit_failure_async(
                 realFailure, (e, db) => e.ExecuteInTransactionAsync(
-                    ct => db.SaveChangesAsync(acceptAllChangesOnSuccess: false),
+                    ct => db.SaveChangesAsync(false, ct),
                     ct => db.Products.AsNoTracking().AnyAsync(),
-                    cancellationToken));
+                    CancellationToken.None));
 
             await Test_commit_failure_async(
                 realFailure, (e, db) => e.ExecuteInTransactionAsync(
                     db,
-                    async (c, ct) => await c.SaveChangesAsync(acceptAllChangesOnSuccess: false),
+                    async (c, ct) => { await c.SaveChangesAsync(false, ct); },
                     (c, ct) => c.Products.AsNoTracking().AnyAsync(),
-                    cancellationToken));
+                    CancellationToken.None));
 
             await Test_commit_failure_async(
                 realFailure, (e, db) => e.ExecuteInTransactionAsync(
                     db,
-                    (c, ct) => c.SaveChangesAsync(acceptAllChangesOnSuccess: false),
+                    (c, ct) => c.SaveChangesAsync(false, ct),
                     (c, ct) => c.Products.AsNoTracking().AnyAsync(),
-                    cancellationToken));
+                    CancellationToken.None));
 
             await Test_commit_failure_async(
                 realFailure, (e, db) => e.ExecuteInTransactionAsync(
-                    () => db.SaveChangesAsync(acceptAllChangesOnSuccess: false),
+                    () => db.SaveChangesAsync(false),
                     () => db.Products.AsNoTracking().AnyAsync(),
                     IsolationLevel.Serializable));
 
             await Test_commit_failure_async(
                 realFailure, (e, db) => e.ExecuteInTransactionAsync(
-                    async ct => await db.SaveChangesAsync(acceptAllChangesOnSuccess: false),
-                    ct => db.Products.AsNoTracking().AnyAsync(),
+                    async ct => { await db.SaveChangesAsync(false, ct); },
+                    ct => db.Products.AsNoTracking().AnyAsync(ct),
                     IsolationLevel.Serializable,
-                    cancellationToken));
+                    CancellationToken.None));
 
             await Test_commit_failure_async(
                 realFailure, (e, db) => e.ExecuteInTransactionAsync(
-                    ct => db.SaveChangesAsync(acceptAllChangesOnSuccess: false),
-                    ct => db.Products.AsNoTracking().AnyAsync(),
+                    ct => db.SaveChangesAsync(false, ct),
+                    ct => db.Products.AsNoTracking().AnyAsync(ct),
                     IsolationLevel.Serializable,
-                    cancellationToken));
-
-            await Test_commit_failure_async(
-                realFailure, (e, db) => e.ExecuteInTransactionAsync(
-                    db,
-                    async (c, ct) => await c.SaveChangesAsync(acceptAllChangesOnSuccess: false),
-                    (c, ct) => c.Products.AsNoTracking().AnyAsync(),
-                    IsolationLevel.Serializable,
-                    cancellationToken));
+                    CancellationToken.None));
 
             await Test_commit_failure_async(
                 realFailure, (e, db) => e.ExecuteInTransactionAsync(
                     db,
-                    (c, ct) => c.SaveChangesAsync(acceptAllChangesOnSuccess: false),
-                    (c, ct) => c.Products.AsNoTracking().AnyAsync(),
+                    async (c, ct) => { await c.SaveChangesAsync(false, ct); },
+                    (c, ct) => c.Products.AsNoTracking().AnyAsync(ct),
                     IsolationLevel.Serializable,
-                    cancellationToken));
+                    CancellationToken.None));
+
+            await Test_commit_failure_async(
+                realFailure, (e, db) => e.ExecuteInTransactionAsync(
+                    db,
+                    (c, ct) => c.SaveChangesAsync(false, ct),
+                    (c, ct) => c.Products.AsNoTracking().AnyAsync(ct),
+                    IsolationLevel.Serializable,
+                    CancellationToken.None));
         }
 
         private async Task Test_commit_failure_async(
@@ -226,10 +208,26 @@ namespace Microsoft.EntityFrameworkCore
                 var connection = (TestSqlServerConnection)context.GetService<ISqlServerConnection>();
 
                 connection.CommitFailures.Enqueue(new bool?[] { realFailure });
+                Fixture.TestSqlLoggerFactory.Clear();
 
                 context.Products.Add(new Product());
                 await execute(new TestSqlServerRetryingExecutionStrategy(context), context);
                 context.ChangeTracker.AcceptAllChanges();
+
+                var retryMessage =
+                    "A transient exception has been encountered during execution and the operation will be retried after 0ms."
+                    + Environment.NewLine
+                    + "Microsoft.Data.SqlClient.SqlException (0x80131904): Bang!";
+                if (realFailure)
+                {
+                    var logEntry = Fixture.TestSqlLoggerFactory.Log.Single(l => l.Id == CoreEventId.ExecutionStrategyRetrying);
+                    Assert.Contains(retryMessage, logEntry.Message);
+                    Assert.Equal(LogLevel.Information, logEntry.Level);
+                }
+                else
+                {
+                    Assert.Empty(Fixture.TestSqlLoggerFactory.Log.Where(l => l.Id == CoreEventId.ExecutionStrategyRetrying));
+                }
 
                 Assert.Equal(realFailure ? 3 : 2, connection.OpenCount);
             }
@@ -240,19 +238,9 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [ConditionalFact]
-        public void Does_not_throw_or_retry_on_false_commit_failure_multiple_SaveChanges()
-        {
-            Test_commit_failure_multiple_SaveChanges(false);
-        }
-
-        [ConditionalFact]
-        public void Retries_on_true_commit_failure_multiple_SaveChanges()
-        {
-            Test_commit_failure_multiple_SaveChanges(true);
-        }
-
-        private void Test_commit_failure_multiple_SaveChanges(bool realFailure)
+        [ConditionalTheory]
+        [MemberData(nameof(DataGenerator.GetBoolCombinations), 1, MemberType = typeof(DataGenerator))]
+        public void Handles_commit_failure_multiple_SaveChanges(bool realFailure)
         {
             CleanContext();
 
@@ -274,9 +262,9 @@ namespace Microsoft.EntityFrameworkCore
                             context2.Database.UseTransaction(null);
                             context2.Database.UseTransaction(context1.Database.CurrentTransaction.GetDbTransaction());
 
-                            c1.SaveChanges(acceptAllChangesOnSuccess: false);
+                            c1.SaveChanges(false);
 
-                            return context2.SaveChanges(acceptAllChangesOnSuccess: false);
+                            return context2.SaveChanges(false);
                         },
                         c => c.Products.AsNoTracking().Any());
 
@@ -292,15 +280,9 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalTheory]
-        [InlineData(false, false, false)]
-        [InlineData(true, false, false)]
-        [InlineData(false, true, false)]
-        [InlineData(true, true, false)]
-        [InlineData(false, false, true)]
-        [InlineData(true, false, true)]
-        [InlineData(false, true, true)]
-        [InlineData(true, true, true)]
-        public async Task Retries_only_on_true_execution_failure(bool realFailure, bool openConnection, bool async)
+        [MemberData(nameof(DataGenerator.GetBoolCombinations), 4, MemberType = typeof(DataGenerator))]
+        public async Task Retries_SaveChanges_on_execution_failure(
+            bool realFailure, bool externalStrategy, bool openConnection, bool async)
         {
             CleanContext();
 
@@ -331,30 +313,44 @@ namespace Microsoft.EntityFrameworkCore
 
                 if (async)
                 {
-                    await new TestSqlServerRetryingExecutionStrategy(context).ExecuteInTransactionAsync(
-                        context,
-                        (c, _) => c.SaveChangesAsync(acceptAllChangesOnSuccess: false),
-                        (c, _) =>
-                        {
-                            // This shouldn't be called if SaveChanges failed
-                            Assert.True(false);
-                            return Task.FromResult(false);
-                        });
+                    if (externalStrategy)
+                    {
+                        await new TestSqlServerRetryingExecutionStrategy(context).ExecuteInTransactionAsync(
+                            context,
+                            (c, ct) => c.SaveChangesAsync(false, ct),
+                            (c, _) =>
+                            {
+                                Assert.True(false);
+                                return Task.FromResult(false);
+                            });
+
+                        context.ChangeTracker.AcceptAllChanges();
+                    }
+                    else
+                    {
+                        await context.SaveChangesAsync();
+                    }
                 }
                 else
                 {
-                    new TestSqlServerRetryingExecutionStrategy(context).ExecuteInTransaction(
-                        context,
-                        c => c.SaveChanges(acceptAllChangesOnSuccess: false),
-                        c =>
-                        {
-                            // This shouldn't be called if SaveChanges failed
-                            Assert.True(false);
-                            return false;
-                        });
-                }
+                    if (externalStrategy)
+                    {
+                        new TestSqlServerRetryingExecutionStrategy(context).ExecuteInTransaction(
+                            context,
+                            c => c.SaveChanges(false),
+                            c =>
+                            {
+                                Assert.True(false);
+                                return false;
+                            });
 
-                context.ChangeTracker.AcceptAllChanges();
+                        context.ChangeTracker.AcceptAllChanges();
+                    }
+                    else
+                    {
+                        context.SaveChanges();
+                    }
+                }
 
                 Assert.Equal(2, connection.OpenCount);
                 Assert.Equal(4, connection.ExecutionCount);
@@ -386,9 +382,8 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalTheory]
-        [InlineData(false)]
-        //[InlineData(true)]
-        public async Task Retries_query_on_execution_failure(bool async)
+        [MemberData(nameof(DataGenerator.GetBoolCombinations), 2, MemberType = typeof(DataGenerator))]
+        public async Task Retries_query_on_execution_failure(bool externalStrategy, bool async)
         {
             CleanContext();
 
@@ -408,36 +403,34 @@ namespace Microsoft.EntityFrameworkCore
 
                 Assert.Equal(ConnectionState.Closed, context.Database.GetDbConnection().State);
 
+                List<Product> list;
                 if (async)
                 {
-                    var list = await new TestSqlServerRetryingExecutionStrategy(context).ExecuteInTransactionAsync(
-                        context,
-                        (c, _) => context.Products.ToListAsync(),
-                        (c, _) =>
-                        {
-                            // This shouldn't be called if query failed
-                            Assert.True(false);
-                            return Task.FromResult(false);
-                        });
-
-                    Assert.Equal(2, list.Count);
+                    if (externalStrategy)
+                    {
+                        list = await new TestSqlServerRetryingExecutionStrategy(context)
+                            .ExecuteAsync(context, (c, ct) => c.Products.ToListAsync(ct), null);
+                    }
+                    else
+                    {
+                        list = await context.Products.ToListAsync();
+                    }
                 }
                 else
                 {
-                    var list = new TestSqlServerRetryingExecutionStrategy(context).ExecuteInTransaction(
-                        context,
-                        c => context.Products.ToList(),
-                        c =>
-                        {
-                            // This shouldn't be called if query failed
-                            Assert.True(false);
-                            return false;
-                        });
-
-                    Assert.Equal(2, list.Count);
+                    if (externalStrategy)
+                    {
+                        list = new TestSqlServerRetryingExecutionStrategy(context)
+                            .Execute(context, c => c.Products.ToList(), null);
+                    }
+                    else
+                    {
+                        list = context.Products.ToList();
+                    }
                 }
 
-                Assert.Equal(2, connection.OpenCount);
+                Assert.Equal(2, list.Count);
+                Assert.Equal(1, connection.OpenCount);
                 Assert.Equal(2, connection.ExecutionCount);
 
                 Assert.Equal(ConnectionState.Closed, context.Database.GetDbConnection().State);
@@ -445,9 +438,74 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalTheory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Retries_OpenConnection_on_execution_failure(bool async)
+        [MemberData(nameof(DataGenerator.GetBoolCombinations), 2, MemberType = typeof(DataGenerator))]
+        public async Task Retries_FromSqlRaw_on_execution_failure(bool externalStrategy, bool async)
+        {
+            CleanContext();
+
+            using (var context = CreateContext())
+            {
+                context.Products.Add(new Product());
+                context.Products.Add(new Product());
+
+                context.SaveChanges();
+            }
+
+            using (var context = CreateContext())
+            {
+                var connection = (TestSqlServerConnection)context.GetService<ISqlServerConnection>();
+
+                connection.ExecutionFailures.Enqueue(new bool?[] { true });
+
+                Assert.Equal(ConnectionState.Closed, context.Database.GetDbConnection().State);
+
+                List<Product> list;
+                if (async)
+                {
+                    if (externalStrategy)
+                    {
+                        list = await new TestSqlServerRetryingExecutionStrategy(context)
+                            .ExecuteAsync(
+                                context, (c, ct) => c.Set<Product>().FromSqlRaw(
+                                    @"SELECT [ID], [name]
+                              FROM [Products]").ToListAsync(ct), null);
+                    }
+                    else
+                    {
+                        list = await context.Set<Product>().FromSqlRaw(
+                            @"SELECT [ID], [name]
+                              FROM [Products]").ToListAsync();
+                    }
+                }
+                else
+                {
+                    if (externalStrategy)
+                    {
+                        list = new TestSqlServerRetryingExecutionStrategy(context)
+                            .Execute(
+                                context, c => c.Set<Product>().FromSqlRaw(
+                                    @"SELECT [ID], [name]
+                              FROM [Products]").ToList(), null);
+                    }
+                    else
+                    {
+                        list = context.Set<Product>().FromSqlRaw(
+                            @"SELECT [ID], [name]
+                              FROM [Products]").ToList();
+                    }
+                }
+
+                Assert.Equal(2, list.Count);
+                Assert.Equal(1, connection.OpenCount);
+                Assert.Equal(2, connection.ExecutionCount);
+
+                Assert.Equal(ConnectionState.Closed, context.Database.GetDbConnection().State);
+            }
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(DataGenerator.GetBoolCombinations), 2, MemberType = typeof(DataGenerator))]
+        public async Task Retries_OpenConnection_on_execution_failure(bool externalStrategy, bool async)
         {
             using (var context = CreateContext())
             {
@@ -459,15 +517,29 @@ namespace Microsoft.EntityFrameworkCore
 
                 if (async)
                 {
-                    await new TestSqlServerRetryingExecutionStrategy(context).ExecuteAsync(
-                        context,
-                        c => context.Database.OpenConnectionAsync());
+                    if (externalStrategy)
+                    {
+                        await new TestSqlServerRetryingExecutionStrategy(context).ExecuteAsync(
+                            context,
+                            c => c.Database.OpenConnectionAsync());
+                    }
+                    else
+                    {
+                        await context.Database.OpenConnectionAsync();
+                    }
                 }
                 else
                 {
-                    new TestSqlServerRetryingExecutionStrategy(context).Execute(
-                        context,
-                        c => context.Database.OpenConnection());
+                    if (externalStrategy)
+                    {
+                        new TestSqlServerRetryingExecutionStrategy(context).Execute(
+                            context,
+                            c => c.Database.OpenConnection());
+                    }
+                    else
+                    {
+                        context.Database.OpenConnection();
+                    }
                 }
 
                 Assert.Equal(2, connection.OpenCount);
@@ -539,7 +611,7 @@ namespace Microsoft.EntityFrameworkCore
                         new TestSqlServerRetryingExecutionStrategy(context, TimeSpan.FromMilliseconds(100))
                             .ExecuteInTransaction(
                                 context,
-                                c => c.SaveChanges(acceptAllChangesOnSuccess: false),
+                                c => c.SaveChanges(false),
                                 c => false));
                 context.ChangeTracker.AcceptAllChanges();
 
@@ -594,12 +666,10 @@ namespace Microsoft.EntityFrameworkCore
             protected override Type ContextType { get; } = typeof(ExecutionStrategyContext);
 
             protected override IServiceCollection AddServices(IServiceCollection serviceCollection)
-            {
-                return base.AddServices(serviceCollection)
+                => base.AddServices(serviceCollection)
                     .AddSingleton<IRelationalTransactionFactory, TestRelationalTransactionFactory>()
                     .AddScoped<ISqlServerConnection, TestSqlServerConnection>()
                     .AddSingleton<IRelationalCommandBuilderFactory, TestRelationalCommandBuilderFactory>();
-            }
 
             public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
             {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AsyncSimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AsyncSimpleQuerySqlServerTest.cs
@@ -124,22 +124,10 @@ namespace Microsoft.EntityFrameworkCore.Query
                 {
                     while (await asyncEnumerator.MoveNextAsync())
                     {
-                        if (!context.GetService<IRelationalConnection>().IsMultipleActiveResultSetsEnabled)
-                        {
-                            // Not supported, we could make it work by triggering buffering
-                            // from RelationalCommand.
-
-                            await Assert.ThrowsAsync<InvalidOperationException>(
-                                () => context.Database.ExecuteSqlRawAsync(
-                                    "[dbo].[CustOrderHist] @CustomerID = {0}",
-                                    asyncEnumerator.Current.CustomerID));
-                        }
-                        else
-                        {
-                            await context.Database.ExecuteSqlRawAsync(
-                                "[dbo].[CustOrderHist] @CustomerID = {0}",
-                                asyncEnumerator.Current.CustomerID);
-                        }
+                        // Outer query is buffered by default
+                        await context.Database.ExecuteSqlRawAsync(
+                            "[dbo].[CustOrderHist] @CustomerID = {0}",
+                            asyncEnumerator.Current.CustomerID);
                     }
                 }
             }

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestSqlServerRetryingExecutionStrategy.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestSqlServerRetryingExecutionStrategy.cs
@@ -66,9 +66,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             }
 
             return exception is InvalidOperationException invalidOperationException
-                && invalidOperationException.Message == "Internal .Net Framework Data Provider error 6."
-                    ? true
-                    : false;
+                && invalidOperationException.Message == "Internal .Net Framework Data Provider error 6.";
         }
 
         public new virtual TimeSpan? GetNextDelay(Exception lastException)

--- a/test/EFCore.SqlServer.Tests/Storage/SqlServerRetryingExecutionStrategyTests.cs
+++ b/test/EFCore.SqlServer.Tests/Storage/SqlServerRetryingExecutionStrategyTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
+// ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     public class SqlServerRetryingExecutionStrategyTests
@@ -14,13 +15,13 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public void GetNextDelay_returns_shorter_delay_for_InMemory_transient_errors()
         {
             var strategy = new TestSqlServerRetryingExecutionStrategy(CreateContext());
-            var inMemoryOltpError = SqlExceptionFactory.CreateSqlException(41302);
+            var inMemoryError = SqlExceptionFactory.CreateSqlException(41302);
             var delays = new List<TimeSpan>();
-            var delay = strategy.GetNextDelay(inMemoryOltpError);
+            var delay = strategy.GetNextDelay(inMemoryError);
             while (delay != null)
             {
                 delays.Add(delay.Value);
-                delay = strategy.GetNextDelay(inMemoryOltpError);
+                delay = strategy.GetNextDelay(inMemoryError);
             }
 
             var expectedDelays = new List<TimeSpan>
@@ -39,7 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 Assert.True(
                     Math.Abs((delays[i] - expectedDelays[i]).TotalMilliseconds)
                     <= expectedDelays[i].TotalMilliseconds * 0.1 + 1,
-                    string.Format("Expected: {0}; Actual: {1}", expectedDelays[i], delays[i]));
+                    $"Expected: {expectedDelays[i]}; Actual: {delays[i]}");
             }
         }
 

--- a/test/EFCore.Tests/Query/CompiledQueryCacheKeyGeneratorDependenciesTest.cs
+++ b/test/EFCore.Tests/Query/CompiledQueryCacheKeyGeneratorDependenciesTest.cs
@@ -4,6 +4,7 @@
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
+// ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Query
 {
     public class CompiledQueryCacheKeyGeneratorDependenciesTest

--- a/test/EFCore.Tests/Query/QueryCompilationContextDependenciesTest.cs
+++ b/test/EFCore.Tests/Query/QueryCompilationContextDependenciesTest.cs
@@ -4,6 +4,7 @@
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
+// ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Query
 {
     public class QueryCompilationContextDependenciesTest

--- a/test/EFCore.Tests/Storage/ExecutionStrategyTest.cs
+++ b/test/EFCore.Tests/Storage/ExecutionStrategyTest.cs
@@ -65,7 +65,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 Assert.True(
                     Math.Abs((delays[i] - expectedDelays[i]).TotalMilliseconds)
                     <= expectedDelays[i].TotalMilliseconds * 0.1 + 1,
-                    string.Format("Expected: {0}; Actual: {1}", expectedDelays[i], delays[i]));
+                    $"Expected: {expectedDelays[i]}; Actual: {delays[i]}");
             }
         }
 
@@ -281,18 +281,18 @@ namespace Microsoft.EntityFrameworkCore.Storage
         }
 
         [ConditionalFact]
-        public void Execute_Action_retries_until_not_retrieable_exception_is_thrown()
+        public void Execute_Action_retries_until_not_retriable_exception_is_thrown()
         {
-            Execute_retries_until_not_retrieable_exception_is_thrown((e, f) => e.Execute(() => f()));
+            Execute_retries_until_not_retriable_exception_is_thrown((e, f) => e.Execute(() => f()));
         }
 
         [ConditionalFact]
-        public void Execute_Func_retries_until_not_retrieable_exception_is_thrown()
+        public void Execute_Func_retries_until_not_retriable_exception_is_thrown()
         {
-            Execute_retries_until_not_retrieable_exception_is_thrown((e, f) => e.Execute(f));
+            Execute_retries_until_not_retriable_exception_is_thrown((e, f) => e.Execute(f));
         }
 
-        private void Execute_retries_until_not_retrieable_exception_is_thrown(Action<ExecutionStrategy, Func<int>> execute)
+        private void Execute_retries_until_not_retriable_exception_is_thrown(Action<ExecutionStrategy, Func<int>> execute)
         {
             var executionStrategyMock = new TestExecutionStrategy(
                 Context,


### PR DESCRIPTION
__Issue__:
We lacked tests for implicit usage of the execution strategy, so when the query pipeline was rewritten the lack of this feature wasn't detected.

__Solution__:
Add execution retry for query with a buffering data reader.
Move the retry scope for SaveChanges to properly reset the state before retrying.
Add tests for implicit usage of the execution strategy.

Fixes #18628