### PR TITLE
Query: Materialize results of FirstOrDefault in subquery only when th…

### DIFF
--- a/test/EFCore.InMemory.FunctionalTests/Query/GearsOfWarQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/GearsOfWarQueryInMemoryTest.cs
@@ -70,5 +70,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return GroupBy_with_boolean_groupin_key_thru_navigation_access(isAsync);
         }
+
+        [ConditionalTheory(Skip = "issue #17260")]
+        public override Task Select_subquery_projecting_single_constant_inside_anonymous(bool isAsync)
+        {
+            return base.Select_subquery_projecting_single_constant_inside_anonymous(isAsync);
+        }
     }
 }

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -5904,8 +5904,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.Id, a.Id);
-                    // See issue#17287
-                    Assert.Equal(e.c1?.Id ?? 0, a.c1?.Id);
+                    Assert.Equal(e.c1?.Id, a.c1?.Id);
                     AssertCollection(e.c2, a.c2, elementSorter: i => i.Id, elementAsserter: (ie, ia) => Assert.Equal(ie.Id, ia.Id));
                 });
         }

--- a/test/EFCore.Specification.Tests/Query/QueryNavigationsTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/QueryNavigationsTestBase.cs
@@ -257,11 +257,25 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 isAsync,
-                ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Take(2).Select(
+                ss => ss.Set<Customer>().Where(e => e.CustomerID.StartsWith("F")).OrderBy(c => c.CustomerID).Take(2).Select(
                     c => c.Orders.OrderBy(o => o.OrderID).Select(
                         o => new { o.CustomerID, o.OrderID }).FirstOrDefault()),
                 assertOrder: true);
         }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Select_collection_FirstOrDefault_project_anonymous_type_client_eval(bool isAsync)
+        {
+            return AssertQuery(
+                isAsync,
+                ss => ss.Set<Customer>().Where(e => e.CustomerID.StartsWith("F")).OrderBy(c => c.CustomerID).Take(2).Select(
+                    c => c.Orders.OrderBy(o => o.OrderID).Select(
+                        o => new { o.CustomerID, OrderID = ClientFunction(o.OrderID, 5) }).FirstOrDefault()),
+                assertOrder: true);
+        }
+
+        private static int ClientFunction(int a, int b) => a + b + 1;
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -4411,15 +4411,15 @@ FROM (
             AssertSql(
                 @"@__p_0='25'
 
-SELECT [t].[Id], [t1].[Id], [l1].[Id]
+SELECT [t].[Id], [t1].[Id], [t1].[c], [l1].[Id]
 FROM (
     SELECT TOP(@__p_0) [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
     FROM [LevelOne] AS [l]
 ) AS [t]
 LEFT JOIN (
-    SELECT [t0].[Id], [t0].[OneToMany_Required_Inverse2Id]
+    SELECT [t0].[Id], [t0].[c], [t0].[OneToMany_Required_Inverse2Id]
     FROM (
-        SELECT [l0].[Id], [l0].[OneToMany_Required_Inverse2Id], ROW_NUMBER() OVER(PARTITION BY [l0].[OneToMany_Required_Inverse2Id] ORDER BY [l0].[Id]) AS [row]
+        SELECT [l0].[Id], 1 AS [c], [l0].[OneToMany_Required_Inverse2Id], ROW_NUMBER() OVER(PARTITION BY [l0].[OneToMany_Required_Inverse2Id] ORDER BY [l0].[Id]) AS [row]
         FROM [LevelTwo] AS [l0]
     ) AS [t0]
     WHERE [t0].[row] <= 1

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryNavigationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryNavigationsSqlServerTest.cs
@@ -167,16 +167,42 @@ ORDER BY [c].[CustomerID]");
             AssertSql(
                 @"@__p_0='2'
 
-SELECT [t1].[CustomerID], [t1].[OrderID]
+SELECT [t1].[CustomerID], [t1].[OrderID], [t1].[c]
 FROM (
     SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'F%'
     ORDER BY [c].[CustomerID]
 ) AS [t]
 LEFT JOIN (
-    SELECT [t0].[CustomerID], [t0].[OrderID]
+    SELECT [t0].[CustomerID], [t0].[OrderID], [t0].[c]
     FROM (
-        SELECT [o].[CustomerID], [o].[OrderID], ROW_NUMBER() OVER(PARTITION BY [o].[CustomerID] ORDER BY [o].[OrderID]) AS [row]
+        SELECT [o].[CustomerID], [o].[OrderID], 1 AS [c], ROW_NUMBER() OVER(PARTITION BY [o].[CustomerID] ORDER BY [o].[OrderID]) AS [row]
+        FROM [Orders] AS [o]
+    ) AS [t0]
+    WHERE [t0].[row] <= 1
+) AS [t1] ON [t].[CustomerID] = [t1].[CustomerID]
+ORDER BY [t].[CustomerID]");
+        }
+
+        public override async Task Select_collection_FirstOrDefault_project_anonymous_type_client_eval(bool isAsync)
+        {
+            await base.Select_collection_FirstOrDefault_project_anonymous_type_client_eval(isAsync);
+
+            AssertSql(
+                @"@__p_0='2'
+
+SELECT [t1].[CustomerID], [t1].[OrderID], [t1].[c]
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'F%'
+    ORDER BY [c].[CustomerID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t0].[CustomerID], [t0].[OrderID], [t0].[c]
+    FROM (
+        SELECT [o].[CustomerID], [o].[OrderID], 1 AS [c], ROW_NUMBER() OVER(PARTITION BY [o].[CustomerID] ORDER BY [o].[OrderID]) AS [row]
         FROM [Orders] AS [o]
     ) AS [t0]
     WHERE [t0].[row] <= 1


### PR DESCRIPTION
…ere are rows

Issue: When we generate translation for subquery.FirstOrDefault() using Left join, we get null in values when there is no associated record.
Then we try to create result with default values rather than returning default of result type.

Fix: Whenever we go through path where we are adding subquery.FirstOrDefault in projection, we inject 1 as dummy column. If we see 1 in result then only we materialize the object else we return default of the type.
- For entityTypes this is not needed because we return null if key values are null.
- For scalar which is server eval (i.e. only 1 column), we generate projectionBinding using resultType so we will get correct default back.
- For scalar result which is client eval, we inject 1 into client projections.
- For non scalar results (anonymous/nominal types), in client/server eval case, we inject 1 into projection/projectionMapping.

Resolves #17287
