### PR TITLE
Exclude Object when checking for DbContext in query filters

### DIFF
--- a/src/EFCore/Query/Internal/ParameterExtractingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/ParameterExtractingExpressionVisitor.cs
@@ -349,11 +349,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             public ParameterExpression ContextParameterExpression { get; }
 
             public override Expression Visit(Expression expression)
-            {
-                return expression?.Type.GetTypeInfo().IsAssignableFrom(_contextType) == true
+                => expression?.Type != typeof(object)
+                    && expression?.Type.GetTypeInfo().IsAssignableFrom(_contextType) == true
                     ? ContextParameterExpression
                     : base.Visit(expression);
-            }
         }
 
         private static Expression RemoveConvert(Expression expression)


### PR DESCRIPTION
Fixes #18759

@smitpatel if we really want to avoid QueryBugsTest we can simply remove the equality operator from Customer and the bug should repro in FiltersQueryBase.Entity_Equality. But this seems subtle enough that a query bug test makes sense (i.e. to avoid someone defining an operator again in the future). Let me know what you prefer.