### PR TITLE
ExpressionPrinter fixes/cleanup

### DIFF
--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -7301,7 +7301,7 @@ FROM [MockEntities] AS [m]");
                 () => queryBase.Cast<IDummyEntity>().FirstOrDefault(x => x.Id == id)).Message;
 
             Assert.Equal(
-                CoreStrings.TranslationFailed(@"DbSet<MockEntity>    .Cast()    .Where(e => e.Id == __id_0)"),
+                CoreStrings.TranslationFailed(@"DbSet<MockEntity>    .Cast<IDummyEntity>()    .Where(e => e.Id == __id_0)"),
                 message.Replace("\r", "").Replace("\n", ""));
         }
 


### PR DESCRIPTION
Fix to #18709 - Query: expression printer should still print type argument for Cast and OfType
Fix to #18413 - Query: clean-up expression printer when we can do breaking changes

Resolves #18709
Resolves #18413