### PR TITLE
Exclude Object when checking for DbContext in query filters

### DIFF
--- a/src/EFCore/Query/Internal/ParameterExtractingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/ParameterExtractingExpressionVisitor.cs
@@ -349,11 +349,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             public ParameterExpression ContextParameterExpression { get; }
 
             public override Expression Visit(Expression expression)
-            {
-                return expression?.Type.GetTypeInfo().IsAssignableFrom(_contextType) == true
+                => expression?.Type != typeof(object)
+                    && expression?.Type.GetTypeInfo().IsAssignableFrom(_contextType) == true
                     ? ContextParameterExpression
                     : base.Visit(expression);
-            }
         }
 
         private static Expression RemoveConvert(Expression expression)


### PR DESCRIPTION
Fixes #18759

Ports #18761 to 3.1.