### PR TITLE
Enable tests for #16093 - Query: Result mismatch likely due to null semantics

### DIFF
--- a/src/EFCore/Query/ExpressionPrinter.cs
+++ b/src/EFCore/Query/ExpressionPrinter.cs
@@ -593,7 +593,9 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 var argumentNames
                     = !isSimpleMethodOrProperty
-                        ? method.GetParameters().Select(p => p.Name).ToList()
+                        ? extensionMethod
+                            ? method.GetParameters().Skip(1).Select(p => p.Name).ToList()
+                            : method.GetParameters().Select(p => p.Name).ToList()
                         : new List<string>();
 
                 IDisposable indent = null;

--- a/test/EFCore.Relational.Specification.Tests/Query/QueryNoClientEvalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/QueryNoClientEvalTestBase.cs
@@ -147,10 +147,10 @@ namespace Microsoft.EntityFrameworkCore.Query
                     CoreStrings.QueryFailed(
                         @"DbSet<Employee>
     .Join(
-        outer: __p_0, 
-        inner: e1 => e1.EmployeeID, 
-        outerKeySelector: i => i, 
-        innerKeySelector: (e1, i) => e1)",
+        inner: __p_0, 
+        outerKeySelector: e1 => e1.EmployeeID, 
+        innerKeySelector: i => i, 
+        resultSelector: (e1, i) => e1)",
                         "NavigationExpandingExpressionVisitor"),
                     message, ignoreLineEndingDifferences: true);
             }
@@ -171,10 +171,10 @@ namespace Microsoft.EntityFrameworkCore.Query
                     CoreStrings.QueryFailed(
                         @"DbSet<Employee>
     .GroupJoin(
-        outer: __p_0, 
-        inner: e1 => e1.EmployeeID, 
-        outerKeySelector: i => i, 
-        innerKeySelector: (e1, g) => e1)",
+        inner: __p_0, 
+        outerKeySelector: e1 => e1.EmployeeID, 
+        innerKeySelector: i => i, 
+        resultSelector: (e1, g) => e1)",
                         "NavigationExpandingExpressionVisitor"),
                     message, ignoreLineEndingDifferences: true);
             }

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -1797,7 +1797,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         ?? new List<Level3>()));
         }
 
-        [ConditionalTheory(Skip = " Issue#16093")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_navigation_property_to_collection(bool isAsync)
         {
@@ -4109,7 +4109,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       select l2.Name);
         }
 
-        [ConditionalTheory(Skip = "Issue#16093")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Navigations_compared_to_each_other4(bool isAsync)
         {
@@ -4130,7 +4130,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       select l2.Name);
         }
 
-        [ConditionalTheory(Skip = "Issue#16093")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Navigations_compared_to_each_other5(bool isAsync)
         {
@@ -4324,7 +4324,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = " Issue#16093")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Project_collection_navigation_count(bool isAsync)
         {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -1248,14 +1248,13 @@ ORDER BY [l].[Id], [l1].[Id], [t].[Id]");
             await base.Where_navigation_property_to_collection(isAsync);
 
             AssertSql(
-                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_Inverse1Id], [l1].[OneToMany_Required_Self_Inverse1Id], [l1].[OneToOne_Optional_Self1Id]
-FROM [LevelOne] AS [l1]
-LEFT JOIN [LevelTwo] AS [l1.OneToOne_Required_FK1] ON [l1].[Id] = [l1.OneToOne_Required_FK1].[Level1_Required_Id]
+                @"SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
+FROM [LevelOne] AS [l]
+LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Required_Id]
 WHERE (
     SELECT COUNT(*)
-    FROM [LevelThree] AS [l]
-    WHERE [l1.OneToOne_Required_FK1].[Id] = [l].[OneToMany_Optional_Inverse3Id]
-) > 0");
+    FROM [LevelThree] AS [l1]
+    WHERE [l0].[Id] IS NOT NULL AND ([l0].[Id] = [l1].[OneToMany_Optional_Inverse3Id])) > 0");
         }
 
         public override async Task Where_navigation_property_to_collection2(bool isAsync)
@@ -2998,14 +2997,13 @@ WHERE EXISTS (
             await base.Navigations_compared_to_each_other4(isAsync);
 
             AssertSql(
-                @"SELECT [l2].[Name]
-FROM [LevelTwo] AS [l2]
-LEFT JOIN [LevelThree] AS [l2.OneToOne_Required_FK2] ON [l2].[Id] = [l2.OneToOne_Required_FK2].[Level2_Required_Id]
+                @"SELECT [l].[Name]
+FROM [LevelTwo] AS [l]
+LEFT JOIN [LevelThree] AS [l0] ON [l].[Id] = [l0].[Level2_Required_Id]
 WHERE EXISTS (
     SELECT 1
-    FROM [LevelFour] AS [l]
-    LEFT JOIN [LevelThree] AS [i.OneToOne_Optional_PK_Inverse4] ON [l].[OneToOne_Optional_PK_Inverse4Id] = [i.OneToOne_Optional_PK_Inverse4].[Id]
-    WHERE [l2.OneToOne_Required_FK2].[Id] = [l].[OneToMany_Optional_Inverse4Id])");
+    FROM [LevelFour] AS [l1]
+    WHERE [l0].[Id] IS NOT NULL AND ([l0].[Id] = [l1].[OneToMany_Optional_Inverse4Id]))");
         }
 
         public override async Task Navigations_compared_to_each_other5(bool isAsync)
@@ -3013,15 +3011,14 @@ WHERE EXISTS (
             await base.Navigations_compared_to_each_other5(isAsync);
 
             AssertSql(
-                @"SELECT [l2].[Name]
-FROM [LevelTwo] AS [l2]
-LEFT JOIN [LevelThree] AS [l2.OneToOne_Required_FK2] ON [l2].[Id] = [l2.OneToOne_Required_FK2].[Level2_Required_Id]
-LEFT JOIN [LevelThree] AS [l2.OneToOne_Required_FK2.OneToOne_Optional_PK2] ON [l2].[Id] = [l2.OneToOne_Required_FK2.OneToOne_Optional_PK2].[OneToOne_Optional_PK_Inverse3Id]
+                @"SELECT [l].[Name]
+FROM [LevelTwo] AS [l]
+LEFT JOIN [LevelThree] AS [l0] ON [l].[Id] = [l0].[Level2_Required_Id]
+LEFT JOIN [LevelThree] AS [l1] ON [l].[Id] = [l1].[OneToOne_Optional_PK_Inverse3Id]
 WHERE EXISTS (
     SELECT 1
-    FROM [LevelFour] AS [l]
-    LEFT JOIN [LevelThree] AS [i.OneToOne_Optional_PK_Inverse4] ON [l].[OneToOne_Optional_PK_Inverse4Id] = [i.OneToOne_Optional_PK_Inverse4].[Id]
-    WHERE [l2.OneToOne_Required_FK2].[Id] = [l].[OneToMany_Optional_Inverse4Id])");
+    FROM [LevelFour] AS [l2]
+    WHERE [l0].[Id] IS NOT NULL AND ([l0].[Id] = [l2].[OneToMany_Optional_Inverse4Id]))");
         }
 
         public override async Task Level4_Include(bool isAsync)
@@ -3175,13 +3172,12 @@ ORDER BY [l].[Id], [l1].[Id]");
             await base.Project_collection_navigation_count(isAsync);
 
             AssertSql(
-                @"SELECT [l1].[Id], (
+                @"SELECT [l0].[Id], (
     SELECT COUNT(*)
     FROM [LevelThree] AS [l]
-    WHERE [l1.OneToOne_Optional_FK1].[Id] = [l].[OneToMany_Optional_Inverse3Id]
-) AS [Count]
-FROM [LevelOne] AS [l1]
-LEFT JOIN [LevelTwo] AS [l1.OneToOne_Optional_FK1] ON [l1].[Id] = [l1.OneToOne_Optional_FK1].[Level1_Optional_Id]");
+    WHERE [l1].[Id] IS NOT NULL AND ([l1].[Id] = [l].[OneToMany_Optional_Inverse3Id])) AS [Count]
+FROM [LevelOne] AS [l0]
+LEFT JOIN [LevelTwo] AS [l1] ON [l0].[Id] = [l1].[Level1_Optional_Id]");
         }
 
         public override async Task Project_collection_navigation_composed(bool isAsync)


### PR DESCRIPTION
Also fixed a minor bug in expression printer, where we would print incorrect argument names for extension methods with 2+ arguments.

Resolves #16093