### PR TITLE
Fix to #18808 - Query: incorrect results for query with Join where key selector is anonymous type with a single property

### DIFF
--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -520,6 +520,13 @@ namespace Microsoft.EntityFrameworkCore.Query
                         : _sqlExpressionFactory.AndAlso(result, joinPredicate);
                 }
 
+                if (outerNew.Arguments.Count == 1)
+                {
+                    result = _sqlExpressionFactory.AndAlso(
+                        result,
+                        CreateJoinPredicate(Expression.Constant(true), Expression.Constant(true)));
+                }
+
                 return result;
             }
 

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -3919,7 +3919,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Select(l3 => l3.Name));
         }
 
-        [ConditionalTheory(Skip = " Issue#16093")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Join_condition_optimizations_applied_correctly_when_anonymous_type_with_single_property(bool isAsync)
         {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -2876,9 +2876,9 @@ OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY");
             await base.Join_condition_optimizations_applied_correctly_when_anonymous_type_with_single_property(isAsync);
 
             AssertSql(
-                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_Inverse1Id], [l1].[OneToMany_Required_Self_Inverse1Id], [l1].[OneToOne_Optional_Self1Id]
-FROM [LevelOne] AS [l1]
-INNER JOIN [LevelTwo] AS [l2] ON ([l1].[OneToMany_Optional_Self_Inverse1Id] = [l2].[Level1_Optional_Id]) OR ([l1].[OneToMany_Optional_Self_Inverse1Id] IS NULL AND [l2].[Level1_Optional_Id] IS NULL)");
+                @"SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
+FROM [LevelOne] AS [l]
+INNER JOIN [LevelTwo] AS [l0] ON (([l].[OneToMany_Optional_Self_Inverse1Id] = [l0].[Level1_Optional_Id]) OR ([l].[OneToMany_Optional_Self_Inverse1Id] IS NULL AND [l0].[Level1_Optional_Id] IS NULL)) AND (CAST(1 AS bit) = CAST(1 AS bit))");
         }
 
         public override async Task Join_condition_optimizations_applied_correctly_when_anonymous_type_with_multiple_properties(bool isAsync)


### PR DESCRIPTION
Problem was that on c# join predicate behaves differently when it's a regular property (null and null yield false), and where its anonymous type with just a single property (new { A = null } and new { A = null } yields true).
However, we lose that distinction during initial Join predicate translation.

Fix is to add a sentinel true == true condition, if the anonymous type only has one element. This condition can be later optimized out.

Resolves #18808