### PR TITLE
Catch exceptions in CanConnect and return false

### DIFF
--- a/src/EFCore.Relational/Storage/RelationalDatabaseCreator.cs
+++ b/src/EFCore.Relational/Storage/RelationalDatabaseCreator.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;
@@ -314,7 +315,16 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <returns> <c>True</c> if the database is available; <c>false</c> otherwise. </returns>
         public virtual bool CanConnect()
-            => Exists();
+        {
+            try
+            {
+                return Exists();
+            }
+            catch
+            {
+                return false;
+            }
+        }
 
         /// <summary>
         ///     <para>
@@ -327,7 +337,16 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns> <c>True</c> if the database is available; <c>false</c> otherwise. </returns>
-        public virtual Task<bool> CanConnectAsync(CancellationToken cancellationToken = default)
-            => ExistsAsync(cancellationToken);
+        public virtual async Task<bool> CanConnectAsync(CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return await ExistsAsync(cancellationToken);
+            }
+            catch
+            {
+                return false;
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #18355

We can consider logging the exceptions, although I'm not sure that would be the right thing to do - this method is purely about checking whether we can connect or not, and it could be said there's no actual "failing operation" warranting a log message. It would also likely cause lots of spurious log messages as automated health checks fail while networking is down etc.

Note that I don't think this is a breaking change, as applications are already expected to check for false. 