### PR TITLE
Add missing Ordinal to {Starts,Ends}With

### DIFF
--- a/src/EFCore.Design/Design/Internal/NamespaceComparer.cs
+++ b/src/EFCore.Design/Design/Internal/NamespaceComparer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.EntityFrameworkCore.Design.Internal
@@ -13,8 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
         /// <inheritdoc />
         public virtual int Compare(string x, string y)
         {
-            var xSystemNamespace = x != null && (string.Equals(x, "System") || x.StartsWith("System."));
-            var ySystemNamespace = y != null && (string.Equals(y, "System") || y.StartsWith("System."));
+            var xSystemNamespace = x != null && (x == "System" || x.StartsWith("System.", StringComparison.Ordinal));
+            var ySystemNamespace = y != null && (y == "System" || y.StartsWith("System.", StringComparison.Ordinal));
 
             return xSystemNamespace && !ySystemNamespace
                 ? -1

--- a/src/EFCore.Relational/Storage/RelationalSqlGenerationHelper.cs
+++ b/src/EFCore.Relational/Storage/RelationalSqlGenerationHelper.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using System.Text;
 using JetBrains.Annotations;
@@ -57,7 +58,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     A valid name based on the candidate name.
         /// </returns>
         public virtual string GenerateParameterName(string name)
-            => name.StartsWith("@")
+            => name.StartsWith("@", StringComparison.Ordinal)
                 ? name
                 : "@" + name;
 

--- a/src/EFCore/Query/Internal/SubqueryMemberPushdownExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/SubqueryMemberPushdownExpressionVisitor.cs
@@ -130,7 +130,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             {
                 var selector = sourceMethodCallExpression.Arguments[1].UnwrapLambdaFromQuote();
                 var selectorBody = selector.Body;
-                var memberAccessExpression = createSelector(selectorBody, methodCallExpression.Method.Name.EndsWith("OrDefault"));
+                var memberAccessExpression = createSelector(selectorBody, methodCallExpression.Method.Name.EndsWith("OrDefault", StringComparison.Ordinal));
 
                 source = Expression.Call(
                     QueryableMethods.Select.MakeGenericMethod(
@@ -143,7 +143,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             else
             {
                 var parameter = Expression.Parameter(queryableType, "s");
-                var memberAccessExpression = createSelector(parameter, methodCallExpression.Method.Name.EndsWith("OrDefault"));
+                var memberAccessExpression = createSelector(parameter, methodCallExpression.Method.Name.EndsWith("OrDefault", StringComparison.Ordinal));
 
                 source = Expression.Call(
                     QueryableMethods.Select.MakeGenericMethod(queryableType, memberAccessExpression.Type),


### PR DESCRIPTION
Fixes #18831. We should also use analyzers (#18870) to make sure it doesn't happen again.

*Mystery:*

Tried to add a test. But mysteriously, the following yields False, True:

```c#
Console.WriteLine("__someName_0".StartsWith("@"));
Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("th-TH");
Console.WriteLine("__someName_0".StartsWith("@"));
```

But the same inside a test returns false for both... There's some environmental thing going on, but don't think it's worth digging into it.