### PR TITLE
Another try at simple logging...

### DIFF
--- a/src/EFCore.Cosmos/Diagnostics/Internal/CosmosLoggerExtensions.cs
+++ b/src/EFCore.Cosmos/Diagnostics/Internal/CosmosLoggerExtensions.cs
@@ -44,11 +44,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Diagnostics.Internal
                     CoreEventId.ProviderBaseId,
                     "Executing Sql Query [Parameters=[{parameters}]]{newLine}{commandText}"));
 
-            var warningBehavior = definition.GetLogBehavior(diagnosticsLogger);
-
             definition.Log(
                 diagnosticsLogger,
-                warningBehavior,
                 FormatParameters(cosmosSqlQuery.Parameters),
                 Environment.NewLine,
                 cosmosSqlQuery.Query);

--- a/src/EFCore.Cosmos/Query/Internal/SqlParameterExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/SqlParameterExpression.cs
@@ -14,7 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public class SqlParameterExpression : SqlExpression
+    // Class is sealed because there are no public/protected constructors. Can be unsealed if this is changed.
+    public sealed class SqlParameterExpression : SqlExpression
     {
         private readonly ParameterExpression _parameterExpression;
 

--- a/src/EFCore.Design/Design/DesignTimeServiceCollectionExtensions.cs
+++ b/src/EFCore.Design/Design/DesignTimeServiceCollectionExtensions.cs
@@ -81,6 +81,7 @@ namespace Microsoft.EntityFrameworkCore.Design
                 .AddSingleton<IScaffoldingModelFactory, RelationalScaffoldingModelFactory>()
                 .AddSingleton<IScaffoldingTypeMapper, ScaffoldingTypeMapper>()
                 .AddSingleton<IValueConverterSelector, ValueConverterSelector>()
+                .AddSingleton<ISimpleLogger, NullSimpleLogger>()
                 .AddTransient<MigrationsScaffolderDependencies>()
                 .AddTransient<IMigrationsScaffolder, MigrationsScaffolder>()
                 .AddTransient<ISnapshotModelProcessor, SnapshotModelProcessor>()

--- a/src/EFCore.InMemory/Diagnostics/Internal/InMemoryLoggerExtensions.cs
+++ b/src/EFCore.InMemory/Diagnostics/Internal/InMemoryLoggerExtensions.cs
@@ -28,19 +28,18 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Internal
         {
             var definition = InMemoryResources.LogTransactionsNotSupported(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(diagnostics, warningBehavior);
+                definition.Log(diagnostics);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new EventData(
-                        definition,
-                        (d, _) => ((EventDefinition)d).GenerateMessage()));
+                var eventData = new EventData(
+                    definition,
+                    (d, _) => ((EventDefinition)d).GenerateMessage());
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -57,24 +56,20 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Internal
         {
             var definition = InMemoryResources.LogSavedChanges(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    rowsAffected);
+                definition.Log(diagnostics, rowsAffected);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new SaveChangesEventData(
-                        definition,
-                        ChangesSaved,
-                        entries,
-                        rowsAffected));
+                var eventData = new SaveChangesEventData(
+                    definition,
+                    ChangesSaved,
+                    entries,
+                    rowsAffected);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 

--- a/src/EFCore.Relational/Diagnostics/RelationalLoggerExtensions.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalLoggerExtensions.cs
@@ -62,11 +62,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogCommandCreating(diagnostics, definition, commandMethod);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbCommandInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbCommandInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastCommandCreating(
                     diagnostics,
@@ -78,7 +75,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     false,
                     startTime,
                     definition,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -99,7 +97,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             bool async,
             DateTimeOffset startTime,
             EventDefinition<string> definition,
-            bool diagnosticSourceEnabled)
+            bool diagnosticSourceEnabled,
+            bool simpleLogEnabled)
         {
             var eventData = new CommandCorrelatedEventData(
                 definition,
@@ -112,10 +111,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 async,
                 startTime);
 
-            if (diagnosticSourceEnabled)
-            {
-                diagnostics.DiagnosticSource.Write(definition.EventId.Name, eventData);
-            }
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
 
             return eventData;
         }
@@ -125,10 +121,9 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             EventDefinition<string> definition,
             DbCommandMethod commandMethod)
         {
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(diagnostics, warningBehavior, commandMethod.ToString());
+                definition.Log(diagnostics, commandMethod.ToString());
             }
         }
 
@@ -167,11 +162,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogCommandCreated(diagnostics, definition, commandMethod, duration);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbCommandInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbCommandInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastCommandCreated(
                     diagnostics,
@@ -185,7 +177,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     startTime,
                     duration,
                     definition,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -208,7 +201,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             DateTimeOffset startTime,
             TimeSpan duration,
             EventDefinition<string, int> definition,
-            bool diagnosticSourceEnabled)
+            bool diagnosticSourceEnabled,
+            bool simpleLogEnabled)
         {
             var eventData = new CommandEndEventData(
                 definition,
@@ -224,10 +218,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 startTime,
                 duration);
 
-            if (diagnosticSourceEnabled)
-            {
-                diagnostics.DiagnosticSource.Write(definition.EventId.Name, eventData);
-            }
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
 
             return eventData;
         }
@@ -238,10 +229,9 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             DbCommandMethod commandMethod,
             TimeSpan duration)
         {
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(diagnostics, warningBehavior, commandMethod.ToString(), (int)duration.TotalMilliseconds);
+                definition.Log(diagnostics, commandMethod.ToString(), (int)duration.TotalMilliseconds);
             }
         }
 
@@ -276,11 +266,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogCommandExecuting(diagnostics, command, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbCommandInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbCommandInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastCommandExecuting(
                     diagnostics,
@@ -293,7 +280,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     false,
                     startTime,
                     definition,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -328,11 +316,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogCommandExecuting(diagnostics, command, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbCommandInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbCommandInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastCommandExecuting(
                     diagnostics,
@@ -345,7 +330,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     false,
                     startTime,
                     definition,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -380,11 +366,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogCommandExecuting(diagnostics, command, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbCommandInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbCommandInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastCommandExecuting(
                     diagnostics,
@@ -397,7 +380,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     false,
                     startTime,
                     definition,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -434,11 +418,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogCommandExecuting(diagnostics, command, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbCommandInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbCommandInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastCommandExecuting(
                     diagnostics,
@@ -451,7 +432,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     true,
                     startTime,
                     definition,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -488,11 +470,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogCommandExecuting(diagnostics, command, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbCommandInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbCommandInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastCommandExecuting(
                     diagnostics,
@@ -505,7 +484,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     true,
                     startTime,
                     definition,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -542,11 +522,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogCommandExecuting(diagnostics, command, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbCommandInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbCommandInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastCommandExecuting(
                     diagnostics,
@@ -559,7 +536,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     true,
                     startTime,
                     definition,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -581,7 +559,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             bool async,
             DateTimeOffset startTime,
             EventDefinition<string, CommandType, int, string, string> definition,
-            bool diagnosticSourceEnabled)
+            bool diagnosticSourceEnabled,
+            bool simpleLogEnabled)
         {
             var eventData = new CommandEventData(
                 definition,
@@ -596,12 +575,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 ShouldLogParameterValues(diagnostics, command),
                 startTime);
 
-            if (diagnosticSourceEnabled)
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    eventData);
-            }
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
 
             return eventData;
         }
@@ -611,12 +585,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             DbCommand command,
             EventDefinition<string, CommandType, int, string, string> definition)
         {
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     command.Parameters.FormatParameters(ShouldLogParameterValues(diagnostics, command)),
                     command.CommandType,
                     command.CommandTimeout,
@@ -671,11 +643,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogCommandExecuted(diagnostics, command, duration, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbCommandInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbCommandInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastCommandExecuted(
                     diagnostics,
@@ -690,7 +659,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     startTime,
                     duration,
                     definition,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -729,11 +699,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogCommandExecuted(diagnostics, command, duration, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbCommandInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbCommandInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastCommandExecuted(
                     diagnostics,
@@ -748,7 +715,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     startTime,
                     duration,
                     definition,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -787,11 +755,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogCommandExecuted(diagnostics, command, duration, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbCommandInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbCommandInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastCommandExecuted(
                     diagnostics,
@@ -806,7 +771,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     startTime,
                     duration,
                     definition,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -847,11 +813,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogCommandExecuted(diagnostics, command, duration, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbCommandInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbCommandInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastCommandExecuted(
                     diagnostics,
@@ -866,7 +829,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     startTime,
                     duration,
                     definition,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -907,11 +871,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogCommandExecuted(diagnostics, command, duration, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbCommandInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbCommandInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastCommandExecuted(
                     diagnostics,
@@ -926,7 +887,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     startTime,
                     duration,
                     definition,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -967,11 +929,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogCommandExecuted(diagnostics, command, duration, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbCommandInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbCommandInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastCommandExecuted(
                     diagnostics,
@@ -986,7 +945,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     startTime,
                     duration,
                     definition,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -1010,7 +970,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             DateTimeOffset startTime,
             TimeSpan duration,
             EventDefinition<string, string, CommandType, int, string, string> definition,
-            bool diagnosticSourceEnabled)
+            bool diagnosticSourceEnabled,
+            bool simpleLogEnabled)
         {
             var eventData = new CommandExecutedEventData(
                 definition,
@@ -1027,12 +988,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 startTime,
                 duration);
 
-            if (diagnosticSourceEnabled)
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    eventData);
-            }
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
 
             return eventData;
         }
@@ -1043,12 +999,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             TimeSpan duration,
             EventDefinition<string, string, CommandType, int, string, string> definition)
         {
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     string.Format(CultureInfo.InvariantCulture, "{0:N0}", duration.TotalMilliseconds),
                     command.Parameters.FormatParameters(ShouldLogParameterValues(diagnostics, command)),
                     command.CommandType,
@@ -1100,11 +1054,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogCommandError(diagnostics, command, duration, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbCommandInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbCommandInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastCommandError(
                     diagnostics,
@@ -1119,7 +1070,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     startTime,
                     duration,
                     definition,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 interceptor?.CommandFailed(command, eventData);
             }
@@ -1131,12 +1083,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             TimeSpan duration,
             EventDefinition<string, string, CommandType, int, string, string> definition)
         {
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     string.Format(CultureInfo.InvariantCulture, "{0:N0}", duration.TotalMilliseconds),
                     command.Parameters.FormatParameters(ShouldLogParameterValues(diagnostics, command)),
                     command.CommandType,
@@ -1178,11 +1128,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogCommandError(diagnostics, command, duration, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbCommandInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbCommandInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastCommandError(
                     diagnostics,
@@ -1197,7 +1144,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     startTime,
                     duration,
                     definition,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -1221,7 +1169,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             DateTimeOffset startTime,
             TimeSpan duration,
             EventDefinition<string, string, CommandType, int, string, string> definition,
-            bool diagnosticSourceEnabled)
+            bool diagnosticSourceEnabled,
+            bool simpleLogEnabled)
         {
             var eventData = new CommandErrorEventData(
                 definition,
@@ -1238,12 +1187,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 startTime,
                 duration);
 
-            if (diagnosticSourceEnabled)
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    eventData);
-            }
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
 
             return eventData;
         }
@@ -1277,11 +1221,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogConnectionOpening(diagnostics, connection, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbConnectionInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbConnectionInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastConnectionOpening(
                     diagnostics,
@@ -1289,7 +1230,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     startTime,
                     definition,
                     false,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -1318,11 +1260,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogConnectionOpening(diagnostics, connection, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbConnectionInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbConnectionInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastConnectionOpening(
                     diagnostics,
@@ -1330,7 +1269,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     startTime,
                     definition,
                     true,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -1346,12 +1286,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             IRelationalConnection connection,
             EventDefinition<string, string> definition)
         {
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     connection.DbConnection.Database, connection.DbConnection.DataSource);
             }
         }
@@ -1362,7 +1300,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             DateTimeOffset startTime,
             EventDefinition<string, string> definition,
             bool async,
-            bool diagnosticSourceEnabled)
+            bool diagnosticSourceEnabled,
+            bool simpleLogEnabled)
         {
             var eventData = new ConnectionEventData(
                 definition,
@@ -1373,10 +1312,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 async,
                 startTime);
 
-            if (diagnosticSourceEnabled)
-            {
-                diagnostics.DiagnosticSource.Write(definition.EventId.Name, eventData);
-            }
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
 
             return eventData;
         }
@@ -1407,11 +1343,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogConnectionOpened(diagnostics, connection, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbConnectionInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbConnectionInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastConnectionOpened(
                     diagnostics,
@@ -1420,7 +1353,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     startTime,
                     duration,
                     definition,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 interceptor?.ConnectionOpened(connection.DbConnection, eventData);
             }
@@ -1446,11 +1380,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogConnectionOpened(diagnostics, connection, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbConnectionInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbConnectionInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastConnectionOpened(
                     diagnostics,
@@ -1459,7 +1390,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     startTime,
                     duration,
                     definition,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -1477,7 +1409,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             DateTimeOffset startTime,
             TimeSpan duration,
             EventDefinition<string, string> definition,
-            bool diagnosticSourceEnabled)
+            bool diagnosticSourceEnabled,
+            bool simpleLogEnabled)
         {
             var eventData = new ConnectionEndEventData(
                 definition,
@@ -1489,10 +1422,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 startTime,
                 duration);
 
-            if (diagnosticSourceEnabled)
-            {
-                diagnostics.DiagnosticSource.Write(definition.EventId.Name, eventData);
-            }
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
 
             return eventData;
         }
@@ -1502,12 +1432,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             IRelationalConnection connection,
             EventDefinition<string, string> definition)
         {
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     connection.DbConnection.Database, connection.DbConnection.DataSource);
             }
         }
@@ -1537,11 +1465,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogConnectionClosing(diagnostics, connection, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbConnectionInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbConnectionInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastConnectionClosing(
                     diagnostics,
@@ -1549,7 +1474,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     startTime,
                     false,
                     definition,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -1576,11 +1502,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogConnectionClosing(diagnostics, connection, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbConnectionInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbConnectionInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastConnectionClosing(
                     diagnostics,
@@ -1588,7 +1511,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     startTime,
                     true,
                     definition,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -1605,7 +1529,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             DateTimeOffset startTime,
             bool async,
             EventDefinition<string, string> definition,
-            bool diagnosticSourceEnabled)
+            bool diagnosticSourceEnabled,
+            bool simpleLogEnabled)
         {
             var eventData = new ConnectionEventData(
                 definition,
@@ -1616,10 +1541,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 async,
                 startTime);
 
-            if (diagnosticSourceEnabled)
-            {
-                diagnostics.DiagnosticSource.Write(definition.EventId.Name, eventData);
-            }
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
 
             return eventData;
         }
@@ -1629,12 +1551,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             IRelationalConnection connection,
             EventDefinition<string, string> definition)
         {
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     connection.DbConnection.Database, connection.DbConnection.DataSource);
             }
         }
@@ -1665,11 +1585,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogConnectionClosed(diagnostics, connection, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbConnectionInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbConnectionInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastCollectionClosed(
                     diagnostics,
@@ -1678,7 +1595,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     duration,
                     false,
                     definition,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 interceptor?.ConnectionClosed(connection.DbConnection, eventData);
             }
@@ -1702,11 +1620,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogConnectionClosed(diagnostics, connection, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbConnectionInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbConnectionInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastCollectionClosed(
                     diagnostics,
@@ -1715,7 +1630,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     duration,
                     true,
                     definition,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -1733,7 +1649,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             TimeSpan duration,
             bool async,
             EventDefinition<string, string> definition,
-            bool diagnosticSourceEnabled)
+            bool diagnosticSourceEnabled,
+            bool simpleLogEnabled)
         {
             var eventData = new ConnectionEndEventData(
                 definition,
@@ -1745,10 +1662,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 startTime,
                 duration);
 
-            if (diagnosticSourceEnabled)
-            {
-                diagnostics.DiagnosticSource.Write(definition.EventId.Name, eventData);
-            }
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
 
             return eventData;
         }
@@ -1758,12 +1672,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             IRelationalConnection connection,
             EventDefinition<string, string> definition)
         {
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     connection.DbConnection.Database, connection.DbConnection.DataSource);
             }
         }
@@ -1800,11 +1712,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogConnectionError(diagnostics, connection, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbConnectionInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbConnectionInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastConnectionError(
                     diagnostics,
@@ -1814,7 +1723,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     duration,
                     false,
                     definition,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 interceptor?.ConnectionFailed(connection.DbConnection, eventData);
             }
@@ -1846,11 +1756,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogConnectionError(diagnostics, connection, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbConnectionInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbConnectionInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastConnectionError(
                     diagnostics,
@@ -1860,7 +1767,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     duration,
                     true,
                     definition,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -1879,7 +1787,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             TimeSpan duration,
             bool async,
             EventDefinition<string, string> definition,
-            bool diagnosticSourceEnabled)
+            bool diagnosticSourceEnabled,
+            bool simpleLogEnabled)
         {
             var eventData = new ConnectionErrorEventData(
                 definition,
@@ -1892,10 +1801,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 startTime,
                 duration);
 
-            if (diagnosticSourceEnabled)
-            {
-                diagnostics.DiagnosticSource.Write(definition.EventId.Name, eventData);
-            }
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
 
             return eventData;
         }
@@ -1905,12 +1811,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             IRelationalConnection connection,
             EventDefinition<string, string> definition)
         {
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     connection.DbConnection.Database, connection.DbConnection.DataSource);
             }
         }
@@ -1944,11 +1848,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogTransactionStarting(diagnostics, isolationLevel, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbTransactionInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbTransactionInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastTransactionStarting(
                     diagnostics,
@@ -1958,7 +1859,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     false,
                     startTime,
                     definition,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -1991,11 +1893,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogTransactionStarting(diagnostics, isolationLevel, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbTransactionInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbTransactionInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastTransactionStarting(
                     diagnostics,
@@ -2005,7 +1904,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     true,
                     startTime,
                     definition,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -2024,7 +1924,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             bool async,
             DateTimeOffset startTime,
             EventDefinition<string> definition,
-            bool diagnosticSourceEnabled)
+            bool diagnosticSourceEnabled,
+            bool simpleLogEnabled)
         {
             var eventData = new TransactionStartingEventData(
                 definition,
@@ -2036,10 +1937,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 async,
                 startTime);
 
-            if (diagnosticSourceEnabled)
-            {
-                diagnostics.DiagnosticSource.Write(definition.EventId.Name, eventData);
-            }
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
 
             return eventData;
         }
@@ -2049,13 +1947,9 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             IsolationLevel isolationLevel,
             EventDefinition<string> definition)
         {
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    isolationLevel.ToString("G"));
+                definition.Log(diagnostics, isolationLevel.ToString("G"));
             }
         }
 
@@ -2089,11 +1983,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogTransactionStarted(diagnostics, transaction, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbTransactionInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbTransactionInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastTransactionStarted(
                     diagnostics,
@@ -2104,7 +1995,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     startTime,
                     duration,
                     definition,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -2139,11 +2031,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogTransactionStarted(diagnostics, transaction, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbTransactionInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbTransactionInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastTransactionStarted(
                     diagnostics,
@@ -2154,7 +2043,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     startTime,
                     duration,
                     definition,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -2174,7 +2064,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             DateTimeOffset startTime,
             TimeSpan duration,
             EventDefinition<string> definition,
-            bool diagnosticSourceEnabled)
+            bool diagnosticSourceEnabled,
+            bool simpleLogEnabled)
         {
             var eventData = new TransactionEndEventData(
                 definition,
@@ -2187,10 +2078,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 startTime,
                 duration);
 
-            if (diagnosticSourceEnabled)
-            {
-                diagnostics.DiagnosticSource.Write(definition.EventId.Name, eventData);
-            }
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
 
             return eventData;
         }
@@ -2200,13 +2088,9 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             DbTransaction transaction,
             EventDefinition<string> definition)
         {
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    transaction.IsolationLevel.ToString("G"));
+                definition.Log(diagnostics, transaction.IsolationLevel.ToString("G"));
             }
         }
 
@@ -2237,11 +2121,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogTransactionUsed(diagnostics, transaction, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbTransactionInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbTransactionInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcasstTransactionUsed(
                     diagnostics,
@@ -2251,7 +2132,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     false,
                     startTime,
                     definition,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -2284,11 +2166,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogTransactionUsed(diagnostics, transaction, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbTransactionInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbTransactionInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcasstTransactionUsed(
                     diagnostics,
@@ -2298,7 +2177,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     true,
                     startTime,
                     definition,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -2317,7 +2197,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             bool async,
             DateTimeOffset startTime,
             EventDefinition<string> definition,
-            bool diagnosticSourceEnabled)
+            bool diagnosticSourceEnabled,
+            bool simpleLogEnabled)
         {
             var eventData = new TransactionEventData(
                 definition,
@@ -2334,6 +2215,11 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 diagnostics.DiagnosticSource.Write(definition.EventId.Name, eventData);
             }
 
+            if (simpleLogEnabled)
+            {
+                diagnostics.SimpleLogger.Log(eventData);
+            }
+
             return eventData;
         }
 
@@ -2342,13 +2228,9 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             DbTransaction transaction,
             EventDefinition<string> definition)
         {
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    transaction.IsolationLevel.ToString("G"));
+                definition.Log(diagnostics, transaction.IsolationLevel.ToString("G"));
             }
         }
 
@@ -2380,11 +2262,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogTransactionCommitting(diagnostics, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbTransactionInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbTransactionInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastTransactionCommitting(
                     diagnostics,
@@ -2394,7 +2273,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     startTime,
                     definition,
                     false,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -2427,11 +2307,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogTransactionCommitting(diagnostics, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbTransactionInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbTransactionInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastTransactionCommitting(
                     diagnostics,
@@ -2441,7 +2318,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     startTime,
                     definition,
                     true,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -2460,7 +2338,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             DateTimeOffset startTime,
             EventDefinition definition,
             bool async,
-            bool diagnosticSourceEnabled)
+            bool diagnosticSourceEnabled,
+            bool simpleLogEnabled)
         {
             var eventData = new TransactionEventData(
                 definition,
@@ -2472,10 +2351,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 async,
                 startTime);
 
-            if (diagnosticSourceEnabled)
-            {
-                diagnostics.DiagnosticSource.Write(definition.EventId.Name, eventData);
-            }
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
 
             return eventData;
         }
@@ -2484,10 +2360,9 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> diagnostics,
             EventDefinition definition)
         {
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(diagnostics, warningBehavior);
+                definition.Log(diagnostics);
             }
         }
 
@@ -2512,11 +2387,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogTransactionCommitted(diagnostics, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbTransactionInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbTransactionInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastTransactionCommitted(
                     diagnostics,
@@ -2527,7 +2399,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     duration,
                     definition,
                     false,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 interceptor?.TransactionCommitted(transaction, eventData);
             }
@@ -2557,11 +2430,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogTransactionCommitted(diagnostics, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbTransactionInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbTransactionInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastTransactionCommitted(
                     diagnostics,
@@ -2572,7 +2442,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     duration,
                     definition,
                     true,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -2592,7 +2463,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             TimeSpan duration,
             EventDefinition definition,
             bool async,
-            bool diagnosticSourceEnabled)
+            bool diagnosticSourceEnabled,
+            bool simpleLogEnabled)
         {
             var eventData = new TransactionEndEventData(
                 definition,
@@ -2605,10 +2477,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 startTime,
                 duration);
 
-            if (diagnosticSourceEnabled)
-            {
-                diagnostics.DiagnosticSource.Write(definition.EventId.Name, eventData);
-            }
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
 
             return eventData;
         }
@@ -2617,10 +2486,9 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> diagnostics,
             EventDefinition definition)
         {
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(diagnostics, warningBehavior);
+                definition.Log(diagnostics);
             }
         }
 
@@ -2645,11 +2513,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogTransactionRolledBack(diagnostics, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbTransactionInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbTransactionInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastTransactionRolledBack(
                     diagnostics,
@@ -2660,7 +2525,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     duration,
                     definition,
                     false,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 interceptor?.TransactionRolledBack(transaction, eventData);
             }
@@ -2690,11 +2556,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogTransactionRolledBack(diagnostics, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbTransactionInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbTransactionInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastTransactionRolledBack(
                     diagnostics,
@@ -2705,7 +2568,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     duration,
                     definition,
                     true,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -2725,7 +2589,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             TimeSpan duration,
             EventDefinition definition,
             bool async,
-            bool diagnosticSourceEnabled)
+            bool diagnosticSourceEnabled,
+            bool simpleLogEnabled)
         {
             var eventData = new TransactionEndEventData(
                 definition,
@@ -2738,10 +2603,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 startTime,
                 duration);
 
-            if (diagnosticSourceEnabled)
-            {
-                diagnostics.DiagnosticSource.Write(definition.EventId.Name, eventData);
-            }
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
 
             return eventData;
         }
@@ -2750,10 +2612,9 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> diagnostics,
             EventDefinition definition)
         {
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(diagnostics, warningBehavior);
+                definition.Log(diagnostics);
             }
         }
 
@@ -2777,11 +2638,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogTransactionRollingBack(diagnostics, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbTransactionInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbTransactionInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastTransactionRollingBack(
                     diagnostics,
@@ -2791,7 +2649,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     startTime,
                     definition,
                     false,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -2824,11 +2683,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogTransactionRollingBack(diagnostics, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbTransactionInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbTransactionInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastTransactionRollingBack(
                     diagnostics,
@@ -2838,7 +2694,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     startTime,
                     definition,
                     true,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -2857,7 +2714,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             DateTimeOffset startTime,
             EventDefinition definition,
             bool async,
-            bool diagnosticSourceEnabled)
+            bool diagnosticSourceEnabled,
+            bool simpleLogEnabled)
         {
             var eventData = new TransactionEventData(
                 definition,
@@ -2869,10 +2727,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 async,
                 startTime);
 
-            if (diagnosticSourceEnabled)
-            {
-                diagnostics.DiagnosticSource.Write(definition.EventId.Name, eventData);
-            }
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
 
             return eventData;
         }
@@ -2881,10 +2736,9 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> diagnostics,
             EventDefinition definition)
         {
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(diagnostics, warningBehavior);
+                definition.Log(diagnostics);
             }
         }
 
@@ -2905,25 +2759,24 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = RelationalResources.LogDisposingTransaction(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(diagnostics, warningBehavior);
+                definition.Log(diagnostics);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new TransactionEventData(
-                        definition,
-                        (d, p) => ((EventDefinition)d).GenerateMessage(),
-                        transaction,
-                        connection.Context,
-                        transactionId,
-                        connection.ConnectionId,
-                        false,
-                        startTime));
+                var eventData = new TransactionEventData(
+                    definition,
+                    (d, p) => ((EventDefinition)d).GenerateMessage(),
+                    transaction,
+                    connection.Context,
+                    transactionId,
+                    connection.ConnectionId,
+                    false,
+                    startTime);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -2952,11 +2805,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogTransactionError(diagnostics, exception, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbTransactionInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbTransactionInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastTransactionError(
                     diagnostics,
@@ -2969,7 +2819,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     duration,
                     definition,
                     false,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 interceptor?.TransactionFailed(transaction, eventData);
             }
@@ -3003,11 +2854,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             LogTransactionError(diagnostics, exception, definition);
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbTransactionInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbTransactionInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = BroadcastTransactionError(
                     diagnostics,
@@ -3020,7 +2868,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     duration,
                     definition,
                     true,
-                    diagnosticSourceEnabled);
+                    diagnosticSourceEnabled,
+                    simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -3042,7 +2891,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             TimeSpan duration,
             EventDefinition definition,
             bool async,
-            bool diagnosticSourceEnabled)
+            bool diagnosticSourceEnabled,
+            bool simpleLogEnabled)
         {
             var eventData = new TransactionErrorEventData(
                 definition,
@@ -3057,10 +2907,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 startTime,
                 duration);
 
-            if (diagnosticSourceEnabled)
-            {
-                diagnostics.DiagnosticSource.Write(definition.EventId.Name, eventData);
-            }
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
 
             return eventData;
         }
@@ -3070,10 +2917,9 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             Exception exception,
             EventDefinition definition)
         {
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(diagnostics, warningBehavior, exception);
+                definition.Log(diagnostics);
             }
         }
 
@@ -3090,24 +2936,23 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = RelationalResources.LogAmbientTransaction(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(diagnostics, warningBehavior);
+                definition.Log(diagnostics);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new ConnectionEventData(
-                        definition,
-                        (d, p) => ((EventDefinition)d).GenerateMessage(),
-                        connection.DbConnection,
-                        connection.Context,
-                        connection.ConnectionId,
-                        false,
-                        startTime));
+                var eventData = new ConnectionEventData(
+                    definition,
+                    (d, p) => ((EventDefinition)d).GenerateMessage(),
+                    connection.DbConnection,
+                    connection.Context,
+                    connection.ConnectionId,
+                    false,
+                    startTime);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -3124,25 +2969,21 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = RelationalResources.LogAmbientTransactionEnlisted(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    transaction.IsolationLevel.ToString("G"));
+                definition.Log(diagnostics, transaction.IsolationLevel.ToString("G"));
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new TransactionEnlistedEventData(
-                        definition,
-                        AmbientTransactionEnlisted,
-                        transaction,
-                        connection.DbConnection,
-                        connection.ConnectionId));
+                var eventData = new TransactionEnlistedEventData(
+                    definition,
+                    AmbientTransactionEnlisted,
+                    transaction,
+                    connection.DbConnection,
+                    connection.ConnectionId);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -3166,25 +3007,21 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = RelationalResources.LogExplicitTransactionEnlisted(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    transaction.IsolationLevel.ToString("G"));
+                definition.Log(diagnostics, transaction.IsolationLevel.ToString("G"));
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new TransactionEnlistedEventData(
-                        definition,
-                        ExplicitTransactionEnlisted,
-                        transaction,
-                        connection.DbConnection,
-                        connection.ConnectionId));
+                var eventData = new TransactionEnlistedEventData(
+                    definition,
+                    ExplicitTransactionEnlisted,
+                    transaction,
+                    connection.DbConnection,
+                    connection.ConnectionId);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -3221,17 +3058,13 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = RelationalResources.LogDisposingDataReader(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(diagnostics, warningBehavior);
+                definition.Log(diagnostics);
             }
 
-            var diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
-            var interceptor = diagnostics.Interceptors?.Aggregate<IDbCommandInterceptor>();
-
-            if (interceptor != null
-                || diagnosticSourceEnabled)
+            if (diagnostics.NeedsEventData<IDbCommandInterceptor>(
+                definition, out var interceptor, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
                 var eventData = new DataReaderDisposingEventData(
                     definition,
@@ -3246,12 +3079,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     startTime,
                     duration);
 
-                if (diagnosticSourceEnabled)
-                {
-                    diagnostics.DiagnosticSource.Write(
-                        definition.EventId.Name,
-                        eventData);
-                }
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
 
                 if (interceptor != null)
                 {
@@ -3275,27 +3103,23 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = RelationalResources.LogMigrating(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 var dbConnection = connection.DbConnection;
 
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    dbConnection.Database, dbConnection.DataSource);
+                definition.Log(diagnostics, dbConnection.Database, dbConnection.DataSource);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new MigratorConnectionEventData(
-                        definition,
-                        MigrateUsingConnection,
-                        migrator,
-                        connection.DbConnection,
-                        connection.ConnectionId));
+                var eventData = new MigratorConnectionEventData(
+                    definition,
+                    MigrateUsingConnection,
+                    migrator,
+                    connection.DbConnection,
+                    connection.ConnectionId);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -3321,24 +3145,20 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = RelationalResources.LogRevertingMigration(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    migration.GetId());
+                definition.Log(diagnostics, migration.GetId());
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new MigrationEventData(
-                        definition,
-                        MigrationReverting,
-                        migrator,
-                        migration));
+                var eventData = new MigrationEventData(
+                    definition,
+                    MigrationReverting,
+                    migrator,
+                    migration);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -3362,24 +3182,20 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = RelationalResources.LogApplyingMigration(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    migration.GetId());
+                definition.Log(diagnostics, migration.GetId());
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new MigrationEventData(
-                        definition,
-                        MigrationApplying,
-                        migrator,
-                        migration));
+                var eventData = new MigrationEventData(
+                    definition,
+                    MigrationApplying,
+                    migrator,
+                    migration);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -3409,27 +3225,23 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = RelationalResources.LogGeneratingDown(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    migration.GetId());
+                definition.Log(diagnostics, migration.GetId());
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new MigrationScriptingEventData(
-                        definition,
-                        MigrationGeneratingDownScript,
-                        migrator,
-                        migration,
-                        fromMigration,
-                        toMigration,
-                        idempotent));
+                var eventData = new MigrationScriptingEventData(
+                    definition,
+                    MigrationGeneratingDownScript,
+                    migrator,
+                    migration,
+                    fromMigration,
+                    toMigration,
+                    idempotent);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -3459,27 +3271,23 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = RelationalResources.LogGeneratingUp(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    migration.GetId());
+                definition.Log(diagnostics, migration.GetId());
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new MigrationScriptingEventData(
-                        definition,
-                        MigrationGeneratingUpScript,
-                        migrator,
-                        migration,
-                        fromMigration,
-                        toMigration,
-                        idempotent));
+                var eventData = new MigrationScriptingEventData(
+                    definition,
+                    MigrationGeneratingUpScript,
+                    migrator,
+                    migration,
+                    fromMigration,
+                    toMigration,
+                    idempotent);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -3501,20 +3309,19 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = RelationalResources.LogNoMigrationsApplied(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(diagnostics, warningBehavior);
+                definition.Log(diagnostics);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new MigratorEventData(
-                        definition,
-                        (d, p) => ((EventDefinition)d).GenerateMessage(),
-                        migrator));
+                var eventData = new MigratorEventData(
+                    definition,
+                    (d, p) => ((EventDefinition)d).GenerateMessage(),
+                    migrator);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -3531,24 +3338,20 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = RelationalResources.LogNoMigrationsFound(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    migrationsAssembly.Assembly.GetName().Name);
+                definition.Log(diagnostics, migrationsAssembly.Assembly.GetName().Name);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new MigrationAssemblyEventData(
-                        definition,
-                        MigrationsNotFound,
-                        migrator,
-                        migrationsAssembly));
+                var eventData = new MigrationAssemblyEventData(
+                    definition,
+                    MigrationsNotFound,
+                    migrator,
+                    migrationsAssembly);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -3570,23 +3373,19 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = RelationalResources.LogMigrationAttributeMissingWarning(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    migrationType.Name);
+                definition.Log(diagnostics, migrationType.Name);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new MigrationTypeEventData(
-                        definition,
-                        MigrationAttributeMissingWarning,
-                        migrationType));
+                var eventData = new MigrationTypeEventData(
+                    definition,
+                    MigrationAttributeMissingWarning,
+                    migrationType);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -3608,23 +3407,19 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = RelationalResources.LogPossibleUnintendedUseOfEquals(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    methodCallExpression);
+                definition.Log(diagnostics, methodCallExpression);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new ExpressionEventData(
-                        definition,
-                        QueryPossibleUnintendedUseOfEqualsWarning,
-                        methodCallExpression));
+                var eventData = new ExpressionEventData(
+                    definition,
+                    QueryPossibleUnintendedUseOfEqualsWarning,
+                    methodCallExpression);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -3644,19 +3439,18 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = RelationalResources.LogQueryPossibleExceptionWithAggregateOperatorWarning(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(diagnostics, warningBehavior);
+                definition.Log(diagnostics);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new EventData(
-                        definition,
-                        (d, p) => ((EventDefinition)d).GenerateMessage()));
+                var eventData = new EventData(
+                    definition,
+                    (d, p) => ((EventDefinition)d).GenerateMessage());
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -3671,24 +3465,19 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = RelationalResources.LogKeyHasDefaultValue(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    property.Name,
-                    property.DeclaringEntityType.DisplayName());
+                definition.Log(diagnostics, property.Name, property.DeclaringEntityType.DisplayName());
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new PropertyEventData(
-                        definition,
-                        ModelValidationKeyDefaultValueWarning,
-                        property));
+                var eventData = new PropertyEventData(
+                    definition,
+                    ModelValidationKeyDefaultValueWarning,
+                    property);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -3712,24 +3501,19 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = RelationalResources.LogBoolWithDefaultWarning(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    property.Name,
-                    property.DeclaringEntityType.DisplayName());
+                definition.Log(diagnostics, property.Name, property.DeclaringEntityType.DisplayName());
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new PropertyEventData(
-                        definition,
-                        BoolWithDefaultWarning,
-                        property));
+                var eventData = new PropertyEventData(
+                    definition,
+                    BoolWithDefaultWarning,
+                    property);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -3753,24 +3537,20 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = RelationalResources.LogBatchReadyForExecution(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    commandCount);
+                definition.Log(diagnostics, commandCount);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new BatchEventData(
-                        definition,
-                        BatchReadyForExecution,
-                        entries,
-                        commandCount));
+                var eventData = new BatchEventData(
+                    definition,
+                    BatchReadyForExecution,
+                    entries,
+                    commandCount);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -3796,25 +3576,21 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = RelationalResources.LogBatchSmallerThanMinBatchSize(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    commandCount, minBatchSize);
+                definition.Log(diagnostics, commandCount, minBatchSize);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new MinBatchSizeEventData(
-                        definition,
-                        BatchSmallerThanMinBatchSize,
-                        entries,
-                        commandCount,
-                        minBatchSize));
+                var eventData = new MinBatchSizeEventData(
+                    definition,
+                    BatchSmallerThanMinBatchSize,
+                    entries,
+                    commandCount,
+                    minBatchSize);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 

--- a/src/EFCore.Relational/Query/RelationalCompiledQueryCacheKeyGenerator.cs
+++ b/src/EFCore.Relational/Query/RelationalCompiledQueryCacheKeyGenerator.cs
@@ -63,7 +63,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <param name="query"> The query to get the cache key for. </param>
         /// <param name="async"> A value indicating whether the query will be executed asynchronously. </param>
         /// <returns> The cache key. </returns>
-        protected new RelationalCompiledQueryCacheKey GenerateCacheKeyCore([NotNull] Expression query, bool async)
+        protected new RelationalCompiledQueryCacheKey GenerateCacheKeyCore([NotNull] Expression query, bool async) // Intentionally non-virtual
             => new RelationalCompiledQueryCacheKey(
                 base.GenerateCacheKeyCore(query, async),
                 RelationalOptionsExtension.Extract(RelationalDependencies.ContextOptions).UseRelationalNulls,

--- a/src/EFCore.Relational/Query/SqlExpressions/ColumnExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/ColumnExpression.cs
@@ -11,7 +11,8 @@ using Microsoft.EntityFrameworkCore.Utilities;
 namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
 {
     [DebuggerDisplay("{DebuggerDisplay(),nq}")]
-    public class ColumnExpression : SqlExpression
+    // Class is sealed because there are no public/protected constructors. Can be unsealed if this is changed.
+    public sealed class ColumnExpression : SqlExpression
     {
         internal ColumnExpression(IProperty property, TableExpressionBase table, bool nullable)
             : this(

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -11,7 +11,8 @@ using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
 {
-    public class SelectExpression : TableExpressionBase
+    // Class is sealed because there are no public/protected constructors. Can be unsealed if this is changed.
+    public sealed class SelectExpression : TableExpressionBase
     {
         private readonly IDictionary<EntityProjectionExpression, IDictionary<IProperty, int>> _entityProjectionCache
             = new Dictionary<EntityProjectionExpression, IDictionary<IProperty, int>>();

--- a/src/EFCore.Relational/Query/SqlExpressions/SqlParameterExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlParameterExpression.cs
@@ -7,7 +7,8 @@ using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
 {
-    public class SqlParameterExpression : SqlExpression
+    // Class is sealed because there are no public/protected constructors. Can be unsealed if this is changed.
+    public sealed class SqlParameterExpression : SqlExpression
     {
         private readonly ParameterExpression _parameterExpression;
 

--- a/src/EFCore.Relational/Query/SqlExpressions/TableExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/TableExpression.cs
@@ -6,7 +6,8 @@ using JetBrains.Annotations;
 
 namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
 {
-    public class TableExpression : TableExpressionBase
+    // Class is sealed because there are no public/protected constructors. Can be unsealed if this is changed.
+    public sealed class TableExpression : TableExpressionBase
     {
         internal TableExpression(string name, string schema, [NotNull] string alias)
             : base(alias)

--- a/src/EFCore.SqlServer/Internal/SqlServerLoggerExtensions.cs
+++ b/src/EFCore.SqlServer/Internal/SqlServerLoggerExtensions.cs
@@ -28,23 +28,19 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
         {
             var definition = SqlServerResources.LogDefaultDecimalTypeColumn(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    property.Name, property.DeclaringEntityType.DisplayName());
+                definition.Log(diagnostics, property.Name, property.DeclaringEntityType.DisplayName());
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new PropertyEventData(
-                        definition,
-                        DecimalTypeDefaultWarning,
-                        property));
+                var eventData = new PropertyEventData(
+                    definition,
+                    DecimalTypeDefaultWarning,
+                    property);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -69,23 +65,19 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
         {
             var definition = SqlServerResources.LogByteIdentityColumn(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    property.Name, property.DeclaringEntityType.DisplayName());
+                definition.Log(diagnostics, property.Name, property.DeclaringEntityType.DisplayName());
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new PropertyEventData(
-                        definition,
-                        ByteIdentityColumnWarning,
-                        property));
+                var eventData = new PropertyEventData(
+                    definition,
+                    ByteIdentityColumnWarning,
+                    property);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -120,12 +112,10 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
         {
             var definition = SqlServerResources.LogFoundColumn(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     l => l.LogDebug(
                         definition.EventId,
                         null,
@@ -161,13 +151,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
         {
             var definition = SqlServerResources.LogFoundForeignKey(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    foreignKeyName, tableName, principalTableName, onDeleteAction);
+                definition.Log(diagnostics, foreignKeyName, tableName, principalTableName, onDeleteAction);
             }
 
             // No DiagnosticsSource events because these are purely design-time messages
@@ -185,13 +171,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
         {
             var definition = SqlServerResources.LogFoundDefaultSchema(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    schemaName);
+                definition.Log(diagnostics, schemaName);
             }
 
             // No DiagnosticsSource events because these are purely design-time messages
@@ -210,13 +192,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
         {
             var definition = SqlServerResources.LogFoundTypeAlias(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    typeAliasName, systemTypeName);
+                definition.Log(diagnostics, typeAliasName, systemTypeName);
             }
 
             // No DiagnosticsSource events because these are purely design-time messages
@@ -235,13 +213,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
         {
             var definition = SqlServerResources.LogFoundPrimaryKey(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    primaryKeyName, tableName);
+                definition.Log(diagnostics, primaryKeyName, tableName);
             }
 
             // No DiagnosticsSource events because these are purely design-time messages
@@ -260,13 +234,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
         {
             var definition = SqlServerResources.LogFoundUniqueConstraint(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    uniqueConstraintName, tableName);
+                definition.Log(diagnostics, uniqueConstraintName, tableName);
             }
 
             // No DiagnosticsSource events because these are purely design-time messages
@@ -286,13 +256,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
         {
             var definition = SqlServerResources.LogFoundIndex(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    indexName, tableName, unique);
+                definition.Log(diagnostics, indexName, tableName, unique);
             }
 
             // No DiagnosticsSource events because these are purely design-time messages
@@ -312,13 +278,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
         {
             var definition = SqlServerResources.LogPrincipalTableNotInSelectionSet(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    foreignKeyName, tableName, principalTableName);
+                definition.Log(diagnostics, foreignKeyName, tableName, principalTableName);
             }
 
             // No DiagnosticsSource events because these are purely design-time messages
@@ -339,13 +301,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
         {
             var definition = SqlServerResources.LogPrincipalColumnNotFound(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    foreignKeyName, tableName, principalColumnName, principalTableName);
+                definition.Log(diagnostics, foreignKeyName, tableName, principalColumnName, principalTableName);
             }
 
             // No DiagnosticsSource events because these are purely design-time messages
@@ -363,13 +321,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
         {
             var definition = SqlServerResources.LogMissingSchema(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    schemaName);
+                definition.Log(diagnostics, schemaName);
             }
 
             // No DiagnosticsSource events because these are purely design-time messages
@@ -387,13 +341,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
         {
             var definition = SqlServerResources.LogMissingTable(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    tableName);
+                definition.Log(diagnostics, tableName);
             }
 
             // No DiagnosticsSource events because these are purely design-time messages
@@ -418,12 +368,10 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
             // No DiagnosticsSource events because these are purely design-time messages
             var definition = SqlServerResources.LogFoundSequence(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     l => l.LogDebug(
                         definition.EventId,
                         null,
@@ -450,13 +398,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
         {
             var definition = SqlServerResources.LogFoundTable(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    tableName);
+                definition.Log(diagnostics, tableName);
             }
 
             // No DiagnosticsSource events because these are purely design-time messages
@@ -475,13 +419,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
         {
             var definition = SqlServerResources.LogReflexiveConstraintIgnored(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    foreignKeyName, tableName);
+                definition.Log(diagnostics, foreignKeyName, tableName);
             }
 
             // No DiagnosticsSource events because these are purely design-time messages

--- a/src/EFCore.Sqlite.Core/Internal/SqliteLoggerExtensions.cs
+++ b/src/EFCore.Sqlite.Core/Internal/SqliteLoggerExtensions.cs
@@ -28,24 +28,20 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
         {
             var definition = SqliteResources.LogSchemaConfigured(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    entityType.DisplayName(), schema);
+                definition.Log(diagnostics, entityType.DisplayName(), schema);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new EntityTypeSchemaEventData(
-                        definition,
-                        SchemaConfiguredWarning,
-                        entityType,
-                        schema));
+                var eventData = new EntityTypeSchemaEventData(
+                    definition,
+                    SchemaConfiguredWarning,
+                    entityType,
+                    schema);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -70,23 +66,19 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
         {
             var definition = SqliteResources.LogSequenceConfigured(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    sequence.Name);
+                definition.Log(diagnostics, sequence.Name);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new SequenceEventData(
-                        definition,
-                        SequenceConfiguredWarning,
-                        sequence));
+                var eventData = new SequenceEventData(
+                    definition,
+                    SequenceConfiguredWarning,
+                    sequence);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -113,13 +105,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
         {
             var definition = SqliteResources.LogFoundColumn(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    tableName, columnName, dataTypeName, notNull, defaultValue);
+                definition.Log(diagnostics, tableName, columnName, dataTypeName, notNull, defaultValue);
             }
 
             // No DiagnosticsSource events because these are purely design-time messages
@@ -136,10 +124,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
         {
             var definition = SqliteResources.LogUsingSchemaSelectionsWarning(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(diagnostics, warningBehavior);
+                definition.Log(diagnostics);
             }
 
             // No DiagnosticsSource events because these are purely design-time messages
@@ -157,13 +144,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
         {
             var definition = SqliteResources.LogForeignKeyScaffoldErrorPrincipalTableNotFound(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    foreignKeyName);
+                definition.Log(diagnostics, foreignKeyName);
             }
 
             // No DiagnosticsSource events because these are purely design-time messages
@@ -181,13 +164,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
         {
             var definition = SqliteResources.LogFoundTable(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    tableName);
+                definition.Log(diagnostics, tableName);
             }
 
             // No DiagnosticsSource events because these are purely design-time messages
@@ -205,13 +184,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
         {
             var definition = SqliteResources.LogMissingTable(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    tableName);
+                definition.Log(diagnostics, tableName);
             }
 
             // No DiagnosticsSource events because these are purely design-time messages
@@ -232,13 +207,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
         {
             var definition = SqliteResources.LogPrincipalColumnNotFound(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    foreignKeyName, tableName, principalColumnName, principalTableName);
+                definition.Log(diagnostics, foreignKeyName, tableName, principalColumnName, principalTableName);
             }
 
             // No DiagnosticsSource events because these are purely design-time messages
@@ -258,13 +229,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
         {
             var definition = SqliteResources.LogFoundIndex(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    indexName, tableName, unique);
+                definition.Log(diagnostics, indexName, tableName, unique);
             }
 
             // No DiagnosticsSource events because these are purely design-time messages
@@ -285,13 +252,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
         {
             var definition = SqliteResources.LogFoundForeignKey(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    tableName, id, principalTableName, deleteAction);
+                definition.Log(diagnostics, tableName, id, principalTableName, deleteAction);
             }
 
             // No DiagnosticsSource events because these are purely design-time messages
@@ -310,13 +273,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
         {
             var definition = SqliteResources.LogFoundPrimaryKey(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    primaryKeyName, tableName);
+                definition.Log(diagnostics, primaryKeyName, tableName);
             }
 
             // No DiagnosticsSource events because these are purely design-time messages
@@ -335,13 +294,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
         {
             var definition = SqliteResources.LogFoundUniqueConstraint(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    uniqueConstraintName, tableName);
+                definition.Log(diagnostics, uniqueConstraintName, tableName);
             }
 
             // No DiagnosticsSource events because these are purely design-time messages

--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -1005,7 +1005,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public object this[[NotNull] IPropertyBase propertyBase]
+        public object this[[NotNull] IPropertyBase propertyBase]  // Intentionally non-virtual
         {
             get
             {
@@ -1447,7 +1447,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool HasDefaultValue(IProperty property)
+        public bool HasDefaultValue(IProperty property) // Intentionally non-virtual
         {
             if (!PropertyHasDefaultValue(property))
             {

--- a/src/EFCore/DbContextOptionsBuilder`.cs
+++ b/src/EFCore/DbContextOptionsBuilder`.cs
@@ -2,11 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -81,6 +83,140 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
         public new virtual DbContextOptionsBuilder<TContext> UseLoggerFactory([CanBeNull] ILoggerFactory loggerFactory)
             => (DbContextOptionsBuilder<TContext>)base.UseLoggerFactory(loggerFactory);
+
+        /// <summary>
+        ///     <para>
+        ///         Logs to the supplied sink. For example, use <c>optionsBuilder.LogTo(Console.WriteLine)</c> to
+        ///         log to the console.
+        ///     </para>
+        ///     <para>
+        ///         This overload allows the minimum level of logging and the log formatting to be controlled.
+        ///         Use the <see cref="LogTo(Action{string},IEnumerable{EventId},LogLevel,SimpleLoggerFormatOptions?)" />
+        ///         overload to log only specific events.
+        ///         Use the <see cref="LogTo(Action{string},IEnumerable{string},LogLevel,SimpleLoggerFormatOptions?)" />
+        ///         overload to log only events in specific categories.
+        ///         Use the <see cref="LogTo(Action{string},Func{EventId,LogLevel,bool},SimpleLoggerFormatOptions?)" />
+        ///         overload to use a custom filter for events.
+        ///         Use the <see cref="LogTo(ISimpleLogger)" /> overload to log to a fully custom logger.
+        ///     </para>
+        /// </summary>
+        /// <param name="sink"> The sink to which log messages will be written. </param>
+        /// <param name="minimumLevel"> The minimum level of logging event to log. Defaults to <see cref="LogLevel.Debug" /> </param>
+        /// <param name="formatOptions">
+        ///     Formatting options for log messages. Passing null (the default) means use <see cref="SimpleLoggerFormatOptions.DefaultWithLocalTime" />
+        /// </param>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public new virtual DbContextOptionsBuilder<TContext> LogTo(
+            [NotNull] Action<string> sink,
+            LogLevel minimumLevel = LogLevel.Debug,
+            SimpleLoggerFormatOptions? formatOptions = null)
+            => (DbContextOptionsBuilder<TContext>)base.LogTo(sink, minimumLevel, formatOptions);
+
+        /// <summary>
+        ///     <para>
+        ///         Logs the specified events to the supplied sink. For example, use
+        ///         <c>optionsBuilder.LogTo(Console.WriteLine, new[] { CoreEventId.ContextInitialized })</c> to log the
+        ///         <see cref="CoreEventId.ContextInitialized" /> event to the console.
+        ///     </para>
+        ///     <para>
+        ///         Use the <see cref="LogTo(Action{string},LogLevel,SimpleLoggerFormatOptions?)" /> overload for default logging of
+        ///         all events.
+        ///         Use the <see cref="LogTo(Action{string},IEnumerable{string},LogLevel,SimpleLoggerFormatOptions?)" />
+        ///         overload to log only events in specific categories.
+        ///         Use the <see cref="LogTo(Action{string},Func{EventId,LogLevel,bool},SimpleLoggerFormatOptions?)" />
+        ///         overload to use a custom filter for events.
+        ///         Use the <see cref="LogTo(ISimpleLogger)" /> overload to log to a fully custom logger.
+        ///     </para>
+        /// </summary>
+        /// <param name="sink"> The sink to which log messages will be written. </param>
+        /// <param name="events"> The <see cref="EventId" /> of each event to log. </param>
+        /// <param name="minimumLevel"> The minimum level of logging event to log. Defaults to <see cref="LogLevel.Debug" /> </param>
+        /// <param name="formatOptions">
+        ///     Formatting options for log messages. Passing null (the default) means use <see cref="SimpleLoggerFormatOptions.DefaultWithLocalTime" />
+        /// </param>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public new virtual DbContextOptionsBuilder<TContext> LogTo(
+            [NotNull] Action<string> sink,
+            [NotNull] IEnumerable<EventId> events,
+            LogLevel minimumLevel = LogLevel.Debug,
+            SimpleLoggerFormatOptions? formatOptions = null)
+            => (DbContextOptionsBuilder<TContext>)base.LogTo(sink, events, minimumLevel, formatOptions);
+
+        /// <summary>
+        ///     <para>
+        ///         Logs all events in the specified categories to the supplied sink. For example, use
+        ///         <c>optionsBuilder.LogTo(Console.WriteLine, new[] { DbLoggerCategory.Infrastructure.Name })</c> to log all
+        ///         events in the <see cref="DbLoggerCategory.Infrastructure" /> category.
+        ///     </para>
+        ///     <para>
+        ///         Use the <see cref="LogTo(Action{string},LogLevel,SimpleLoggerFormatOptions?)" /> overload for default logging of
+        ///         all events.
+        ///         Use the <see cref="LogTo(Action{string},IEnumerable{EventId},LogLevel,SimpleLoggerFormatOptions?)" />
+        ///         overload to log only specific events.
+        ///         Use the <see cref="LogTo(Action{string},Func{EventId,LogLevel,bool},SimpleLoggerFormatOptions?)" />
+        ///         overload to use a custom filter for events.
+        ///         Use the <see cref="LogTo(ISimpleLogger)" /> overload to log to a fully custom logger.
+        ///     </para>
+        /// </summary>
+        /// <param name="sink"> The sink to which log messages will be written. </param>
+        /// <param name="categories"> The <see cref="DbLoggerCategory" /> of each event to log. </param>
+        /// <param name="minimumLevel"> The minimum level of logging event to log. Defaults to <see cref="LogLevel.Debug" /> </param>
+        /// <param name="formatOptions">
+        ///     Formatting options for log messages. Passing null (the default) means use <see cref="SimpleLoggerFormatOptions.DefaultWithLocalTime" />
+        /// </param>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public new virtual DbContextOptionsBuilder<TContext> LogTo(
+            [NotNull] Action<string> sink,
+            [NotNull] IEnumerable<string> categories,
+            LogLevel minimumLevel = LogLevel.Debug,
+            SimpleLoggerFormatOptions? formatOptions = null)
+            => (DbContextOptionsBuilder<TContext>)base.LogTo(sink, categories, minimumLevel, formatOptions);
+
+        /// <summary>
+        ///     <para>
+        ///         Logs events filtered by a supplied custom filter delegate. The filter should return true to
+        ///         log a message, or false to filter it out of the log.
+        ///     </para>
+        ///     <para>
+        ///         Use the <see cref="LogTo(Action{string},LogLevel,SimpleLoggerFormatOptions?)" /> overload for default logging of
+        ///         all events.
+        ///         Use the <see cref="LogTo(Action{string},IEnumerable{EventId},LogLevel,SimpleLoggerFormatOptions?)" />
+        ///         Use the <see cref="LogTo(Action{string},IEnumerable{string},LogLevel,SimpleLoggerFormatOptions?)" />
+        ///         overload to log only events in specific categories.
+        ///         Use the <see cref="LogTo(ISimpleLogger)" /> overload to log to a fully custom logger.
+        ///     </para>
+        /// </summary>
+        /// <param name="sink"> The sink to which log messages will be written. </param>
+        /// <param name="filter"> Delegate that returns true to log the message or false to ignore it. </param>
+        /// <param name="formatOptions">
+        ///     Formatting options for log messages. Passing null (the default) means use <see cref="SimpleLoggerFormatOptions.DefaultWithLocalTime" />
+        /// </param>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public new virtual DbContextOptionsBuilder<TContext> LogTo(
+            [NotNull] Action<string> sink,
+            [NotNull] Func<EventId, LogLevel, bool> filter,
+            SimpleLoggerFormatOptions? formatOptions = null)
+            => (DbContextOptionsBuilder<TContext>)base.LogTo(sink, filter, formatOptions);
+
+        /// <summary>
+        ///     <para>
+        ///         Logs to the supplied <see cref="ISimpleLogger" /> implementation.
+        ///     </para>
+        ///     <para>
+        ///         Use this method when the other overloads do not provide enough control over filtering and formatting of the output.
+        ///         Use the <see cref="LogTo(Action{string},LogLevel,SimpleLoggerFormatOptions?)" /> overload for default logging of
+        ///         all events.
+        ///         Use the <see cref="LogTo(Action{string},IEnumerable{EventId},LogLevel,SimpleLoggerFormatOptions?)" />
+        ///         Use the <see cref="LogTo(Action{string},IEnumerable{string},LogLevel,SimpleLoggerFormatOptions?)" />
+        ///         overload to log only events in specific categories.
+        ///         Use the <see cref="LogTo(Action{string},Func{EventId,LogLevel,bool},SimpleLoggerFormatOptions?)" />
+        ///         overload to use a custom filter for events.
+        ///     </para>
+        /// </summary>
+        /// <param name="simpleLogger"> The <see cref="ISimpleLogger" /> to use. </param>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public new virtual DbContextOptionsBuilder<TContext> LogTo([NotNull] ISimpleLogger simpleLogger)
+            => (DbContextOptionsBuilder<TContext>)base.LogTo(simpleLogger);
 
         /// <summary>
         ///     <para>

--- a/src/EFCore/DbFunctions.cs
+++ b/src/EFCore/DbFunctions.cs
@@ -9,7 +9,8 @@ namespace Microsoft.EntityFrameworkCore
     ///     Provides CLR methods that get translated to database functions when used in LINQ to Entities queries.
     ///     The methods on this class are accessed via <see cref="EF.Functions" />.
     /// </summary>
-    public class DbFunctions
+    // Class is sealed because there are no public/protected constructors. Can be unsealed if this is changed.
+    public sealed class DbFunctions
     {
         internal DbFunctions()
         {

--- a/src/EFCore/Diagnostics/CoreLoggerExtensions.cs
+++ b/src/EFCore/Diagnostics/CoreLoggerExtensions.cs
@@ -47,25 +47,23 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogExceptionDuringSaveChanges(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     context.GetType(), Environment.NewLine, exception,
                     exception);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new DbContextErrorEventData(
-                        definition,
-                        SaveChangesFailed,
-                        context,
-                        exception));
+                var eventData = new DbContextErrorEventData(
+                    definition,
+                    SaveChangesFailed,
+                    context,
+                    exception);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -89,24 +87,20 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogOptimisticConcurrencyException(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    exception);
+                definition.Log(diagnostics, exception);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new DbContextErrorEventData(
-                        definition,
-                        OptimisticConcurrencyException,
-                        context,
-                        exception));
+                var eventData = new DbContextErrorEventData(
+                    definition,
+                    OptimisticConcurrencyException,
+                    context,
+                    exception);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -130,24 +124,20 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogDuplicateDependentEntityTypeInstance(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    dependent1.DisplayName(), dependent2.DisplayName());
+                definition.Log(diagnostics,dependent1.DisplayName(), dependent2.DisplayName());
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new SharedDependentEntityEventData(
-                        definition,
-                        DuplicateDependentEntityTypeInstanceWarning,
-                        dependent1,
-                        dependent2));
+                var eventData = new SharedDependentEntityEventData(
+                    definition,
+                    DuplicateDependentEntityTypeInstanceWarning,
+                    dependent1,
+                    dependent2);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -171,25 +161,23 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogExceptionDuringQueryIteration(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     contextType, Environment.NewLine, exception,
                     exception);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new DbContextTypeErrorEventData(
-                        definition,
-                        QueryIterationFailed,
-                        contextType,
-                        exception));
+                var eventData = new DbContextTypeErrorEventData(
+                    definition,
+                    QueryIterationFailed,
+                    contextType,
+                    exception);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -404,24 +392,20 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogQueryExecutionPlanned(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    expressionPrinter.Print(queryExecutorExpression));
+                definition.Log(diagnostics, expressionPrinter.Print(queryExecutorExpression));
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new QueryExpressionEventData(
-                        definition,
-                        QueryExecutionPlanned,
-                        queryExecutorExpression,
-                        expressionPrinter));
+                var eventData = new QueryExpressionEventData(
+                    definition,
+                    QueryExecutionPlanned,
+                    queryExecutorExpression,
+                    expressionPrinter);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -443,19 +427,18 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogSensitiveDataLoggingEnabled(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(diagnostics, warningBehavior);
+                definition.Log(diagnostics);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new EventData(
-                        definition,
-                        (d, p) => ((EventDefinition)d).GenerateMessage()));
+                var eventData = new EventData(
+                    definition,
+                    (d, p) => ((EventDefinition)d).GenerateMessage());
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -508,23 +491,21 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogPossibleUnintendedCollectionNavigationNullComparison(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     $"{navigation.DeclaringEntityType.Name}.{navigation.GetTargetType().Name}");
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new NavigationEventData(
-                        definition,
-                        PossibleUnintendedCollectionNavigationNullComparisonWarning,
-                        navigation));
+                var eventData = new NavigationEventData(
+                    definition,
+                    PossibleUnintendedCollectionNavigationNullComparisonWarning,
+                    navigation);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -548,24 +529,20 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogPossibleUnintendedReferenceComparison(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    left, right);
+                definition.Log(diagnostics,left, right);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new BinaryExpressionEventData(
-                        definition,
-                        PossibleUnintendedReferenceComparisonWarning,
-                        left,
-                        right));
+                var eventData = new BinaryExpressionEventData(
+                    definition,
+                    PossibleUnintendedReferenceComparisonWarning,
+                    left,
+                    right);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -587,20 +564,19 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogServiceProviderCreated(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(diagnostics, warningBehavior);
+                definition.Log(diagnostics);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new ServiceProviderEventData(
-                        definition,
-                        (d, p) => ((EventDefinition)d).GenerateMessage(),
-                        serviceProvider));
+                var eventData = new ServiceProviderEventData(
+                    definition,
+                    (d, p) => ((EventDefinition)d).GenerateMessage(),
+                    serviceProvider);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -615,20 +591,19 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogManyServiceProvidersCreated(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(diagnostics, warningBehavior);
+                definition.Log(diagnostics);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new ServiceProvidersEventData(
-                        definition,
-                        (d, p) => ((EventDefinition)d).GenerateMessage(),
-                        serviceProviders));
+                var eventData = new ServiceProvidersEventData(
+                    definition,
+                    (d, p) => ((EventDefinition)d).GenerateMessage(),
+                    serviceProviders);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -645,24 +620,20 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogServiceProviderDebugInfo(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    GenerateDebugInfoString(newDebugInfo, cachedDebugInfos));
+                definition.Log(diagnostics, GenerateDebugInfoString(newDebugInfo, cachedDebugInfos));
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new ServiceProviderDebugInfoEventData(
-                        definition,
-                        (d, p) => ServiceProviderDebugInfo(d, p),
-                        newDebugInfo,
-                        cachedDebugInfos));
+                var eventData = new ServiceProviderDebugInfoEventData(
+                    definition,
+                    (d, p) => ServiceProviderDebugInfo(d, p),
+                    newDebugInfo,
+                    cachedDebugInfos);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -730,27 +701,25 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogContextInitialized(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     ProductInfo.GetVersion(),
                     context.GetType().ShortDisplayName(),
                     context.Database.ProviderName,
                     contextOptions.BuildOptionsFragment());
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new ContextInitializedEventData(
-                        definition,
-                        ContextInitialized,
-                        context,
-                        contextOptions));
+                var eventData = new ContextInitializedEventData(
+                    definition,
+                    ContextInitialized,
+                    context,
+                    contextOptions);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -780,27 +749,25 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogExecutionStrategyRetrying(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 var lastException = exceptionsEncountered[exceptionsEncountered.Count - 1];
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     (int)delay.TotalMilliseconds, Environment.NewLine, lastException,
                     lastException);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new ExecutionStrategyEventData(
-                        definition,
-                        ExecutionStrategyRetrying,
-                        exceptionsEncountered,
-                        delay,
-                        async));
+                var eventData = new ExecutionStrategyEventData(
+                    definition,
+                    ExecutionStrategyRetrying,
+                    exceptionsEncountered,
+                    delay,
+                    async);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -827,25 +794,21 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogLazyLoadOnDisposedContext(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    navigationName, entityType.GetType().ShortDisplayName());
+                definition.Log(diagnostics,navigationName, entityType.GetType().ShortDisplayName());
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new LazyLoadingEventData(
-                        definition,
-                        LazyLoadOnDisposedContextWarning,
-                        context,
-                        entityType,
-                        navigationName));
+                var eventData = new LazyLoadingEventData(
+                    definition,
+                    LazyLoadOnDisposedContextWarning,
+                    context,
+                    entityType,
+                    navigationName);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -871,25 +834,21 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogNavigationLazyLoading(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    navigationName, entityType.GetType().ShortDisplayName());
+                definition.Log(diagnostics,navigationName, entityType.GetType().ShortDisplayName());
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new LazyLoadingEventData(
-                        definition,
-                        NavigationLazyLoading,
-                        context,
-                        entityType,
-                        navigationName));
+                var eventData = new LazyLoadingEventData(
+                    definition,
+                    NavigationLazyLoading,
+                    context,
+                    entityType,
+                    navigationName);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -915,25 +874,21 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogDetachedLazyLoading(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    navigationName, entityType.GetType().ShortDisplayName());
+                definition.Log(diagnostics,navigationName, entityType.GetType().ShortDisplayName());
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new LazyLoadingEventData(
-                        definition,
-                        DetachedLazyLoadingWarning,
-                        context,
-                        entityType,
-                        navigationName));
+                var eventData = new LazyLoadingEventData(
+                    definition,
+                    DetachedLazyLoadingWarning,
+                    context,
+                    entityType,
+                    navigationName);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -955,23 +910,19 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogShadowPropertyCreated(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    property.Name, property.DeclaringEntityType.DisplayName());
+                definition.Log(diagnostics,property.Name, property.DeclaringEntityType.DisplayName());
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new PropertyEventData(
-                        definition,
-                        ShadowPropertyCreated,
-                        property));
+                var eventData = new PropertyEventData(
+                    definition,
+                    ShadowPropertyCreated,
+                    property);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -993,23 +944,19 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogCollectionWithoutComparer(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    property.Name, property.DeclaringEntityType.DisplayName());
+                definition.Log(diagnostics,property.Name, property.DeclaringEntityType.DisplayName());
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new PropertyEventData(
-                        definition,
-                        CollectionWithoutComparer,
-                        property));
+                var eventData = new PropertyEventData(
+                    definition,
+                    CollectionWithoutComparer,
+                    property);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -1033,24 +980,24 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogRedundantIndexRemoved(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
-                    redundantIndex.Format(), redundantIndex.First().DeclaringType.DisplayName(), otherIndex.Format());
+                    redundantIndex.Format(),
+                    redundantIndex.First().DeclaringType.DisplayName(),
+                    otherIndex.Format());
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new TwoPropertyBaseCollectionsEventData(
-                        definition,
-                        RedundantIndexRemoved,
-                        redundantIndex,
-                        otherIndex));
+                var eventData = new TwoPropertyBaseCollectionsEventData(
+                    definition,
+                    RedundantIndexRemoved,
+                    redundantIndex,
+                    otherIndex);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -1075,23 +1022,22 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogRedundantForeignKey(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
-                    redundantForeignKey.Properties.Format(), redundantForeignKey.DeclaringEntityType.DisplayName());
+                    redundantForeignKey.Properties.Format(),
+                    redundantForeignKey.DeclaringEntityType.DisplayName());
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new ForeignKeyEventData(
-                        definition,
-                        RedundantForeignKeyWarning,
-                        redundantForeignKey));
+                var eventData = new ForeignKeyEventData(
+                    definition,
+                    RedundantForeignKeyWarning,
+                    redundantForeignKey);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -1117,25 +1063,23 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogIncompatibleMatchingForeignKeyProperties(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     foreignKeyProperties.Format(includeTypes: true),
                     principalKeyProperties.Format(includeTypes: true));
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new TwoPropertyBaseCollectionsEventData(
-                        definition,
-                        IncompatibleMatchingForeignKeyProperties,
-                        foreignKeyProperties,
-                        principalKeyProperties));
+                var eventData = new TwoPropertyBaseCollectionsEventData(
+                    definition,
+                    IncompatibleMatchingForeignKeyProperties,
+                    foreignKeyProperties,
+                    principalKeyProperties);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -1159,23 +1103,19 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogRequiredAttributeInverted(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    navigation.Name, navigation.DeclaringEntityType.DisplayName());
+                definition.Log(diagnostics,navigation.Name, navigation.DeclaringEntityType.DisplayName());
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new NavigationEventData(
-                        definition,
-                        RequiredAttributeInverted,
-                        navigation));
+                var eventData = new NavigationEventData(
+                    definition,
+                    RequiredAttributeInverted,
+                    navigation);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -1197,23 +1137,19 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogNonNullableInverted(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    navigation.Name, navigation.DeclaringEntityType.DisplayName());
+                definition.Log(diagnostics,navigation.Name, navigation.DeclaringEntityType.DisplayName());
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new NavigationEventData(
-                        definition,
-                        NonNullableInverted,
-                        navigation));
+                var eventData = new NavigationEventData(
+                    definition,
+                    NonNullableInverted,
+                    navigation);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -1237,27 +1173,25 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogRequiredAttributeOnBothNavigations(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     firstNavigation.DeclaringEntityType.DisplayName(),
                     firstNavigation.Name,
                     secondNavigation.DeclaringEntityType.DisplayName(),
                     secondNavigation.Name);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new TwoPropertyBaseCollectionsEventData(
-                        definition,
-                        RequiredAttributeOnBothNavigations,
-                        new[] { firstNavigation },
-                        new[] { secondNavigation }));
+                var eventData = new TwoPropertyBaseCollectionsEventData(
+                    definition,
+                    RequiredAttributeOnBothNavigations,
+                    new[] { firstNavigation },
+                    new[] { secondNavigation });
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -1287,27 +1221,25 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogNonNullableReferenceOnBothNavigations(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     firstNavigation.DeclaringEntityType.DisplayName(),
                     firstNavigation.Name,
                     secondNavigation.DeclaringEntityType.DisplayName(),
                     secondNavigation.Name);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new TwoPropertyBaseCollectionsEventData(
-                        definition,
-                        NonNullableReferenceOnBothNavigations,
-                        new[] { firstNavigation },
-                        new[] { secondNavigation }));
+                var eventData = new TwoPropertyBaseCollectionsEventData(
+                    definition,
+                    NonNullableReferenceOnBothNavigations,
+                    new[] { firstNavigation },
+                    new[] { secondNavigation });
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -1335,23 +1267,21 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogRequiredAttributeOnDependent(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     navigation.Name, navigation.DeclaringEntityType.DisplayName());
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new NavigationEventData(
-                        definition,
-                        RequiredAttributeOnDependent,
-                        navigation));
+                var eventData = new NavigationEventData(
+                    definition,
+                    RequiredAttributeOnDependent,
+                    navigation);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -1373,23 +1303,22 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogNonNullableReferenceOnDependent(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
-                    navigation.Name, navigation.DeclaringEntityType.DisplayName());
+                    navigation.Name,
+                    navigation.DeclaringEntityType.DisplayName());
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new NavigationEventData(
-                        definition,
-                        NonNullableReferenceOnDependent,
-                        navigation));
+                var eventData = new NavigationEventData(
+                    definition,
+                    NonNullableReferenceOnDependent,
+                    navigation);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -1411,23 +1340,19 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogRequiredAttributeOnCollection(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    navigation.Name, navigation.DeclaringEntityType.DisplayName());
+                definition.Log(diagnostics,navigation.Name,navigation.DeclaringEntityType.DisplayName());
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new NavigationEventData(
-                        definition,
-                        RequiredAttributeOnCollection,
-                        navigation));
+                var eventData = new NavigationEventData(
+                    definition,
+                    RequiredAttributeOnCollection,
+                    navigation);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -1449,26 +1374,24 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogConflictingShadowForeignKeys(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 var declaringTypeName = foreignKey.DeclaringEntityType.DisplayName();
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     declaringTypeName,
                     foreignKey.PrincipalEntityType.DisplayName(),
                     declaringTypeName);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new ForeignKeyEventData(
-                        definition,
-                        ConflictingShadowForeignKeysWarning,
-                        foreignKey));
+                var eventData = new ForeignKeyEventData(
+                    definition,
+                    ConflictingShadowForeignKeysWarning,
+                    foreignKey);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -1495,26 +1418,24 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogMultiplePrimaryKeyCandidates(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     firstProperty.Name,
                     secondProperty.Name,
                     firstProperty.DeclaringEntityType.DisplayName());
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new TwoPropertyBaseCollectionsEventData(
-                        definition,
-                        MultiplePrimaryKeyCandidates,
-                        new[] { firstProperty },
-                        new[] { secondProperty }));
+                var eventData = new TwoPropertyBaseCollectionsEventData(
+                    definition,
+                    MultiplePrimaryKeyCandidates,
+                    new[] { firstProperty },
+                    new[] { secondProperty });
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -1543,27 +1464,25 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogMultipleNavigationProperties(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     firstPropertyCollection.First().Item2.ShortDisplayName(),
                     secondPropertyCollection.First().Item2.ShortDisplayName(),
                     Property.Format(firstPropertyCollection.Select(p => p.Item1?.Name)),
                     Property.Format(secondPropertyCollection.Select(p => p.Item1?.Name)));
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new TwoUnmappedPropertyCollectionsEventData(
-                        definition,
-                        MultipleNavigationProperties,
-                        firstPropertyCollection,
-                        secondPropertyCollection));
+                var eventData = new TwoUnmappedPropertyCollectionsEventData(
+                    definition,
+                    MultipleNavigationProperties,
+                    firstPropertyCollection,
+                    secondPropertyCollection);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -1593,25 +1512,23 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogMultipleInversePropertiesSameTarget(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     string.Join(", ", conflictingNavigations.Select(n => n.Item2.ShortDisplayName() + "." + n.Item1.Name)),
                     inverseNavigation.Name);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new TwoUnmappedPropertyCollectionsEventData(
-                        definition,
-                        MultipleInversePropertiesSameTargetWarning,
-                        conflictingNavigations,
-                        new[] { new Tuple<MemberInfo, Type>(inverseNavigation, targetType) }));
+                var eventData = new TwoUnmappedPropertyCollectionsEventData(
+                    definition,
+                    MultipleInversePropertiesSameTargetWarning,
+                    conflictingNavigations,
+                    new[] { new Tuple<MemberInfo, Type>(inverseNavigation, targetType) });
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -1644,12 +1561,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogNonDefiningInverseNavigation(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     targetType.DisplayName(),
                     inverseNavigation.Name,
                     declaringType.DisplayName(),
@@ -1657,19 +1572,19 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     definingNavigation.Name);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new TwoUnmappedPropertyCollectionsEventData(
-                        definition,
-                        NonDefiningInverseNavigationWarning,
-                        new[] { new Tuple<MemberInfo, Type>(navigation, declaringType.ClrType) },
-                        new[]
-                        {
-                            new Tuple<MemberInfo, Type>(inverseNavigation, targetType.ClrType),
-                            new Tuple<MemberInfo, Type>(definingNavigation, targetType.ClrType)
-                        }));
+                var eventData = new TwoUnmappedPropertyCollectionsEventData(
+                    definition,
+                    NonDefiningInverseNavigationWarning,
+                    new[] { new Tuple<MemberInfo, Type>(navigation, declaringType.ClrType) },
+                    new[]
+                    {
+                        new Tuple<MemberInfo, Type>(inverseNavigation, targetType.ClrType),
+                        new Tuple<MemberInfo, Type>(definingNavigation, targetType.ClrType)
+                    });
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -1707,12 +1622,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogNonOwnershipInverseNavigation(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     targetType.DisplayName(),
                     inverseNavigation.Name,
                     declaringType.DisplayName(),
@@ -1720,19 +1633,19 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     ownershipNavigation.Name);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new TwoUnmappedPropertyCollectionsEventData(
-                        definition,
-                        NonOwnershipInverseNavigationWarning,
-                        new[] { new Tuple<MemberInfo, Type>(navigation, declaringType.ClrType) },
-                        new[]
-                        {
-                            new Tuple<MemberInfo, Type>(inverseNavigation, targetType.ClrType),
-                            new Tuple<MemberInfo, Type>(ownershipNavigation, targetType.ClrType)
-                        }));
+                var eventData = new TwoUnmappedPropertyCollectionsEventData(
+                    definition,
+                    NonOwnershipInverseNavigationWarning,
+                    new[] { new Tuple<MemberInfo, Type>(navigation, declaringType.ClrType) },
+                    new[]
+                    {
+                        new Tuple<MemberInfo, Type>(inverseNavigation, targetType.ClrType),
+                        new Tuple<MemberInfo, Type>(ownershipNavigation, targetType.ClrType)
+                    });
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -1768,12 +1681,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogForeignKeyAttributesOnBothProperties(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     firstNavigation.DeclaringEntityType.ClrType.ShortDisplayName(),
                     firstNavigation.GetIdentifyingMemberInfo().Name,
                     secondNavigation.DeclaringEntityType.ClrType.ShortDisplayName(),
@@ -1782,25 +1693,25 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     secondProperty.Name);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new TwoUnmappedPropertyCollectionsEventData(
-                        definition,
-                        ForeignKeyAttributesOnBothPropertiesWarning,
-                        new[]
-                        {
-                            new Tuple<MemberInfo, Type>(
-                                firstNavigation.GetIdentifyingMemberInfo(), firstNavigation.DeclaringEntityType.ClrType),
-                            new Tuple<MemberInfo, Type>(firstProperty, firstNavigation.DeclaringEntityType.ClrType)
-                        },
-                        new[]
-                        {
-                            new Tuple<MemberInfo, Type>(
-                                secondNavigation.GetIdentifyingMemberInfo(), secondNavigation.DeclaringEntityType.ClrType),
-                            new Tuple<MemberInfo, Type>(secondProperty, secondNavigation.DeclaringEntityType.ClrType)
-                        }));
+                var eventData = new TwoUnmappedPropertyCollectionsEventData(
+                    definition,
+                    ForeignKeyAttributesOnBothPropertiesWarning,
+                    new[]
+                    {
+                        new Tuple<MemberInfo, Type>(
+                            firstNavigation.GetIdentifyingMemberInfo(), firstNavigation.DeclaringEntityType.ClrType),
+                        new Tuple<MemberInfo, Type>(firstProperty, firstNavigation.DeclaringEntityType.ClrType)
+                    },
+                    new[]
+                    {
+                        new Tuple<MemberInfo, Type>(
+                            secondNavigation.GetIdentifyingMemberInfo(), secondNavigation.DeclaringEntityType.ClrType),
+                        new Tuple<MemberInfo, Type>(secondProperty, secondNavigation.DeclaringEntityType.ClrType)
+                    });
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -1834,27 +1745,25 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogForeignKeyAttributesOnBothNavigations(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     firstNavigation.DeclaringEntityType.DisplayName(),
                     firstNavigation.Name,
                     secondNavigation.DeclaringEntityType.DisplayName(),
                     secondNavigation.Name);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new TwoPropertyBaseCollectionsEventData(
-                        definition,
-                        ForeignKeyAttributesOnBothNavigationsWarning,
-                        new[] { firstNavigation },
-                        new[] { secondNavigation }));
+                var eventData = new TwoPropertyBaseCollectionsEventData(
+                    definition,
+                    ForeignKeyAttributesOnBothNavigationsWarning,
+                    new[] { firstNavigation },
+                    new[] { secondNavigation });
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -1884,30 +1793,28 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogConflictingForeignKeyAttributesOnNavigationAndProperty(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     navigation.DeclaringEntityType.ClrType.ShortDisplayName(),
                     navigation.GetIdentifyingMemberInfo()?.Name,
                     property.DeclaringType.ShortDisplayName(),
                     property.Name);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new TwoUnmappedPropertyCollectionsEventData(
-                        definition,
-                        ConflictingForeignKeyAttributesOnNavigationAndPropertyWarning,
-                        new[]
-                        {
-                            new Tuple<MemberInfo, Type>(navigation.GetIdentifyingMemberInfo(), navigation.DeclaringEntityType.ClrType)
-                        },
-                        new[] { new Tuple<MemberInfo, Type>(property, property.DeclaringType) }));
+                var eventData = new TwoUnmappedPropertyCollectionsEventData(
+                    definition,
+                    ConflictingForeignKeyAttributesOnNavigationAndPropertyWarning,
+                    new[]
+                    {
+                        new Tuple<MemberInfo, Type>(navigation.GetIdentifyingMemberInfo(), navigation.DeclaringEntityType.ClrType)
+                    },
+                    new[] { new Tuple<MemberInfo, Type>(property, property.DeclaringType) });
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -1936,23 +1843,19 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogDetectChangesStarting(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    context.GetType().ShortDisplayName());
+                definition.Log(diagnostics, context.GetType().ShortDisplayName());
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new DbContextEventData(
-                        definition,
-                        DetectChangesStarting,
-                        context));
+                var eventData = new DbContextEventData(
+                    definition,
+                    DetectChangesStarting,
+                    context);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -1974,23 +1877,19 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogDetectChangesCompleted(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    context.GetType().ShortDisplayName());
+                definition.Log(diagnostics,context.GetType().ShortDisplayName());
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new DbContextEventData(
-                        definition,
-                        DetectChangesCompleted,
-                        context));
+                var eventData = new DbContextEventData(
+                    definition,
+                    DetectChangesCompleted,
+                    context);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -2018,27 +1917,22 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogPropertyChangeDetected(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    property.DeclaringEntityType.ShortName(),
-                    property.Name);
+                definition.Log(diagnostics,property.DeclaringEntityType.ShortName(),property.Name);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new PropertyChangedEventData(
-                        definition,
-                        PropertyChangeDetected,
-                        new EntityEntry(internalEntityEntry),
-                        property,
-                        oldValue,
-                        newValue));
+                var eventData = new PropertyChangedEventData(
+                    definition,
+                    PropertyChangeDetected,
+                    new EntityEntry(internalEntityEntry),
+                    property,
+                    oldValue,
+                    newValue);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -2068,12 +1962,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogPropertyChangeDetectedSensitive(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     property.DeclaringEntityType.ShortName(),
                     property.Name,
                     oldValue,
@@ -2081,17 +1973,17 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     internalEntityEntry.BuildCurrentValuesString(property.DeclaringEntityType.FindPrimaryKey().Properties));
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new PropertyChangedEventData(
-                        definition,
-                        PropertyChangeDetectedSensitive,
-                        new EntityEntry(internalEntityEntry),
-                        property,
-                        oldValue,
-                        newValue));
+                var eventData = new PropertyChangedEventData(
+                    definition,
+                    PropertyChangeDetectedSensitive,
+                    new EntityEntry(internalEntityEntry),
+                    property,
+                    oldValue,
+                    newValue);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -2124,27 +2016,25 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogForeignKeyChangeDetected(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     property.DeclaringEntityType.ShortName(),
                     property.Name);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new PropertyChangedEventData(
-                        definition,
-                        ForeignKeyChangeDetected,
-                        new EntityEntry(internalEntityEntry),
-                        property,
-                        oldValue,
-                        newValue));
+                var eventData = new PropertyChangedEventData(
+                    definition,
+                    ForeignKeyChangeDetected,
+                    new EntityEntry(internalEntityEntry),
+                    property,
+                    oldValue,
+                    newValue);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -2174,12 +2064,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogForeignKeyChangeDetectedSensitive(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     property.DeclaringEntityType.ShortName(),
                     property.Name,
                     oldValue,
@@ -2187,17 +2075,17 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     internalEntityEntry.BuildCurrentValuesString(property.DeclaringEntityType.FindPrimaryKey().Properties));
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new PropertyChangedEventData(
-                        definition,
-                        ForeignKeyChangeDetectedSensitive,
-                        new EntityEntry(internalEntityEntry),
-                        property,
-                        oldValue,
-                        newValue));
+                var eventData = new PropertyChangedEventData(
+                    definition,
+                    ForeignKeyChangeDetectedSensitive,
+                    new EntityEntry(internalEntityEntry),
+                    property,
+                    oldValue,
+                    newValue);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -2230,29 +2118,27 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogCollectionChangeDetected(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     added.Count,
                     removed.Count,
                     navigation.DeclaringEntityType.ShortName(),
                     navigation.Name);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new CollectionChangedEventData(
-                        definition,
-                        CollectionChangeDetected,
-                        new EntityEntry(internalEntityEntry),
-                        navigation,
-                        added,
-                        removed));
+                var eventData = new CollectionChangedEventData(
+                    definition,
+                    CollectionChangeDetected,
+                    new EntityEntry(internalEntityEntry),
+                    navigation,
+                    added,
+                    removed);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -2284,12 +2170,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogCollectionChangeDetectedSensitive(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     added.Count,
                     removed.Count,
                     navigation.DeclaringEntityType.ShortName(),
@@ -2297,17 +2181,17 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     internalEntityEntry.BuildCurrentValuesString(navigation.DeclaringEntityType.FindPrimaryKey().Properties));
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new CollectionChangedEventData(
-                        definition,
-                        CollectionChangeDetectedSensitive,
-                        new EntityEntry(internalEntityEntry),
-                        navigation,
-                        added,
-                        removed));
+                var eventData = new CollectionChangedEventData(
+                    definition,
+                    CollectionChangeDetectedSensitive,
+                    new EntityEntry(internalEntityEntry),
+                    navigation,
+                    added,
+                    removed);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -2340,27 +2224,22 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogReferenceChangeDetected(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    navigation.DeclaringEntityType.ShortName(),
-                    navigation.Name);
+                definition.Log(diagnostics,navigation.DeclaringEntityType.ShortName(),navigation.Name);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new ReferenceChangedEventData(
-                        definition,
-                        ReferenceChangeDetected,
-                        new EntityEntry(internalEntityEntry),
-                        navigation,
-                        oldValue,
-                        newValue));
+                var eventData = new ReferenceChangedEventData(
+                    definition,
+                    ReferenceChangeDetected,
+                    new EntityEntry(internalEntityEntry),
+                    navigation,
+                    oldValue,
+                    newValue);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -2390,28 +2269,26 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogReferenceChangeDetectedSensitive(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     navigation.DeclaringEntityType.ShortName(),
                     navigation.Name,
                     internalEntityEntry.BuildCurrentValuesString(navigation.DeclaringEntityType.FindPrimaryKey().Properties));
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new ReferenceChangedEventData(
-                        definition,
-                        ReferenceChangeDetectedSensitive,
-                        new EntityEntry(internalEntityEntry),
-                        navigation,
-                        oldValue,
-                        newValue));
+                var eventData = new ReferenceChangedEventData(
+                    definition,
+                    ReferenceChangeDetectedSensitive,
+                    new EntityEntry(internalEntityEntry),
+                    navigation,
+                    oldValue,
+                    newValue);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -2436,24 +2313,22 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogStartedTracking(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     internalEntityEntry.StateManager.Context.GetType().ShortDisplayName(),
                     internalEntityEntry.EntityType.ShortName());
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new EntityEntryEventData(
-                        definition,
-                        StartedTracking,
-                        new EntityEntry(internalEntityEntry)));
+                var eventData = new EntityEntryEventData(
+                    definition,
+                    StartedTracking,
+                    new EntityEntry(internalEntityEntry));
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -2477,25 +2352,23 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogStartedTrackingSensitive(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     internalEntityEntry.StateManager.Context.GetType().ShortDisplayName(),
                     internalEntityEntry.EntityType.ShortName(),
                     internalEntityEntry.BuildCurrentValuesString(internalEntityEntry.EntityType.FindPrimaryKey().Properties));
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new EntityEntryEventData(
-                        definition,
-                        StartedTrackingSensitive,
-                        new EntityEntry(internalEntityEntry)));
+                var eventData = new EntityEntryEventData(
+                    definition,
+                    StartedTrackingSensitive,
+                    new EntityEntry(internalEntityEntry));
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -2524,28 +2397,26 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogStateChanged(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     internalEntityEntry.EntityType.ShortName(),
                     internalEntityEntry.StateManager.Context.GetType().ShortDisplayName(),
                     oldState,
                     newState);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new StateChangedEventData(
-                        definition,
-                        StateChanged,
-                        new EntityEntry(internalEntityEntry),
-                        oldState,
-                        newState));
+                var eventData = new StateChangedEventData(
+                    definition,
+                    StateChanged,
+                    new EntityEntry(internalEntityEntry),
+                    oldState,
+                    newState);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -2575,12 +2446,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogStateChangedSensitive(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     internalEntityEntry.EntityType.ShortName(),
                     internalEntityEntry.BuildCurrentValuesString(internalEntityEntry.EntityType.FindPrimaryKey().Properties),
                     internalEntityEntry.StateManager.Context.GetType().ShortDisplayName(),
@@ -2588,16 +2457,16 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     newState);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new StateChangedEventData(
-                        definition,
-                        StateChangedSensitive,
-                        new EntityEntry(internalEntityEntry),
-                        oldState,
-                        newState));
+                var eventData = new StateChangedEventData(
+                    definition,
+                    StateChangedSensitive,
+                    new EntityEntry(internalEntityEntry),
+                    oldState,
+                    newState);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -2632,27 +2501,25 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 ? CoreResources.LogTempValueGenerated(diagnostics)
                 : CoreResources.LogValueGenerated(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     internalEntityEntry.StateManager.Context.GetType().ShortDisplayName(),
                     property.Name,
                     internalEntityEntry.EntityType.ShortName());
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new PropertyValueEventData(
-                        definition,
-                        ValueGenerated,
-                        new EntityEntry(internalEntityEntry),
-                        property,
-                        value));
+                var eventData = new PropertyValueEventData(
+                    definition,
+                    ValueGenerated,
+                    new EntityEntry(internalEntityEntry),
+                    property,
+                    value);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -2685,28 +2552,26 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 ? CoreResources.LogTempValueGeneratedSensitive(diagnostics)
                 : CoreResources.LogValueGeneratedSensitive(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     internalEntityEntry.StateManager.Context.GetType().ShortDisplayName(),
                     value,
                     property.Name,
                     internalEntityEntry.EntityType.ShortName());
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new PropertyValueEventData(
-                        definition,
-                        ValueGeneratedSensitive,
-                        new EntityEntry(internalEntityEntry),
-                        property,
-                        value));
+                var eventData = new PropertyValueEventData(
+                    definition,
+                    ValueGeneratedSensitive,
+                    new EntityEntry(internalEntityEntry),
+                    property,
+                    value);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -2736,27 +2601,25 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogCascadeDelete(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     internalChildEntry.EntityType.ShortName(),
                     state,
                     internalParentEntry.EntityType.ShortName());
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new CascadeDeleteEventData(
-                        definition,
-                        CascadeDelete,
-                        new EntityEntry(internalChildEntry),
-                        new EntityEntry(internalParentEntry),
-                        state));
+                var eventData = new CascadeDeleteEventData(
+                    definition,
+                    CascadeDelete,
+                    new EntityEntry(internalChildEntry),
+                    new EntityEntry(internalParentEntry),
+                    state);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -2785,12 +2648,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogCascadeDeleteSensitive(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     internalChildEntry.EntityType.ShortName(),
                     internalChildEntry.BuildCurrentValuesString(internalChildEntry.EntityType.FindPrimaryKey().Properties),
                     state,
@@ -2798,16 +2659,16 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                     internalParentEntry.BuildCurrentValuesString(internalParentEntry.EntityType.FindPrimaryKey().Properties));
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new CascadeDeleteEventData(
-                        definition,
-                        CascadeDeleteSensitive,
-                        new EntityEntry(internalChildEntry),
-                        new EntityEntry(internalParentEntry),
-                        state));
+                var eventData = new CascadeDeleteEventData(
+                    definition,
+                    CascadeDeleteSensitive,
+                    new EntityEntry(internalChildEntry),
+                    new EntityEntry(internalParentEntry),
+                    state);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -2838,27 +2699,25 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogCascadeDeleteOrphan(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     internalChildEntry.EntityType.ShortName(),
                     state,
                     parentEntityType.ShortName());
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new CascadeDeleteOrphanEventData(
-                        definition,
-                        CascadeDeleteOrphan,
-                        new EntityEntry(internalChildEntry),
-                        parentEntityType,
-                        state));
+                var eventData = new CascadeDeleteOrphanEventData(
+                    definition,
+                    CascadeDeleteOrphan,
+                    new EntityEntry(internalChildEntry),
+                    parentEntityType,
+                    state);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -2887,28 +2746,26 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogCascadeDeleteOrphanSensitive(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
                 definition.Log(
                     diagnostics,
-                    warningBehavior,
                     internalChildEntry.EntityType.ShortName(),
                     internalChildEntry.BuildCurrentValuesString(internalChildEntry.EntityType.FindPrimaryKey().Properties),
                     state,
                     parentEntityType.ShortName());
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new CascadeDeleteOrphanEventData(
-                        definition,
-                        CascadeDeleteOrphanSensitive,
-                        new EntityEntry(internalChildEntry),
-                        parentEntityType,
-                        state));
+                var eventData = new CascadeDeleteOrphanEventData(
+                    definition,
+                    CascadeDeleteOrphanSensitive,
+                    new EntityEntry(internalChildEntry),
+                    parentEntityType,
+                    state);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -2934,23 +2791,19 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogSaveChangesStarting(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    context.GetType().ShortDisplayName());
+                definition.Log(diagnostics,context.GetType().ShortDisplayName());
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new DbContextEventData(
-                        definition,
-                        SaveChangesStarting,
-                        context));
+                var eventData = new DbContextEventData(
+                    definition,
+                    SaveChangesStarting,
+                    context);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -2974,25 +2827,19 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogSaveChangesCompleted(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    context.GetType().ShortDisplayName(),
-                    entitiesSavedCount);
+                definition.Log(diagnostics,context.GetType().ShortDisplayName(), entitiesSavedCount);
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new SaveChangesCompletedEventData(
-                        definition,
-                        SaveChangesCompleted,
-                        context,
-                        entitiesSavedCount));
+                var eventData = new SaveChangesCompletedEventData(
+                    definition,
+                    SaveChangesCompleted,
+                    context,
+                    entitiesSavedCount);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 
@@ -3016,23 +2863,19 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var definition = CoreResources.LogContextDisposed(diagnostics);
 
-            var warningBehavior = definition.GetLogBehavior(diagnostics);
-            if (warningBehavior != WarningBehavior.Ignore)
+            if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(
-                    diagnostics,
-                    warningBehavior,
-                    context.GetType().ShortDisplayName());
+                definition.Log(diagnostics,context.GetType().ShortDisplayName());
             }
 
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
             {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new DbContextEventData(
-                        definition,
-                        ContextDisposed,
-                        context));
+                var eventData = new DbContextEventData(
+                    definition,
+                    ContextDisposed,
+                    context);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
             }
         }
 

--- a/src/EFCore/Diagnostics/DiagnosticsLoggerExtensions.cs
+++ b/src/EFCore/Diagnostics/DiagnosticsLoggerExtensions.cs
@@ -1,0 +1,128 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using JetBrains.Annotations;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     <para>
+    ///         Extensions on <see cref="IDiagnosticsLogger" /> for use by database providers when logging events.
+    ///     </para>
+    ///     <para>
+    ///         This type is typically used by database providers. It is generally not used in application code.
+    ///     </para>
+    /// </summary>
+    public static class DiagnosticsLoggerExtensions
+    {
+        /// <summary>
+        ///     Checks whether or not the message should be sent to the <see cref="ILogger"/>.
+        /// </summary>
+        /// <param name="diagnostics"> The <see cref="IDiagnosticsLogger" /> being used. </param>
+        /// <param name="definition"> The definition of the event to log. </param>
+        /// <returns> True if <see cref="ILogger"/> logging is enabled and the event should not be ignored; false otherwise. </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] // Because hot path for logging
+        public static bool ShouldLog(
+                [NotNull] this IDiagnosticsLogger diagnostics,
+                [NotNull] EventDefinitionBase definition)
+            // No null checks; low-level code in hot path for logging.
+            => definition.WarningBehavior == WarningBehavior.Throw
+                || (diagnostics.Logger.IsEnabled(definition.Level)
+                    && definition.WarningBehavior != WarningBehavior.Ignore);
+
+        /// <summary>
+        ///     Dispatches the given <see cref="EventData" /> to a <see cref="DiagnosticSource" />, if enabled, and
+        ///     a <see cref="ISimpleLogger" />, if enabled.
+        /// </summary>
+        /// <param name="diagnostics"> The <see cref="IDiagnosticsLogger" /> being used. </param>
+        /// <param name="definition"> The definition of the event to log. </param>
+        /// <param name="eventData"> The event data. </param>
+        /// <param name="diagnosticSourceEnabled"> True to dispatch to a <see cref="DiagnosticSource" />; false otherwise. </param>
+        /// <param name="simpleLogEnabled"> True to dispatch to a <see cref="ISimpleLogger" />; false otherwise. </param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] // Because hot path for logging
+        public static void DispatchEventData(
+            [NotNull] this IDiagnosticsLogger diagnostics,
+            [NotNull] EventDefinitionBase definition,
+            [NotNull] EventData eventData,
+            bool diagnosticSourceEnabled,
+            bool simpleLogEnabled)
+        {
+            // No null checks; low-level code in hot path for logging.
+
+            if (diagnosticSourceEnabled)
+            {
+                diagnostics.DiagnosticSource.Write(definition.EventId.Name, eventData);
+            }
+
+            if (simpleLogEnabled)
+            {
+                diagnostics.SimpleLogger.Log(eventData);
+            }
+        }
+
+        /// <summary>
+        ///     Determines whether or not an <see cref="EventData" /> instance is needed based on whether or
+        ///     not there is a <see cref="DiagnosticSource" /> or an <see cref="ISimpleLogger" /> enabled for
+        ///     the given event.
+        /// </summary>
+        /// <param name="diagnostics"> The <see cref="IDiagnosticsLogger" /> being used. </param>
+        /// <param name="definition"> The definition of the event. </param>
+        /// <param name="diagnosticSourceEnabled"> Set to true if a <see cref="DiagnosticSource" /> is enabled; false otherwise. </param>
+        /// <param name="simpleLogEnabled"> True to true if a <see cref="ISimpleLogger" /> is enabled; false otherwise. </param>
+        /// <returns> True if either a diagnostic source or a simple logger is enabled; false otherwise. </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] // Because hot path for logging
+        public static bool NeedsEventData(
+            [NotNull] this IDiagnosticsLogger diagnostics,
+            [NotNull] EventDefinitionBase definition,
+            out bool diagnosticSourceEnabled,
+            out bool simpleLogEnabled)
+        {
+            // No null checks; low-level code in hot path for logging.
+
+            diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
+
+            simpleLogEnabled = definition.WarningBehavior == WarningBehavior.Log
+                && diagnostics.SimpleLogger.ShouldLog(definition.EventId, definition.Level);
+
+            return diagnosticSourceEnabled
+                || simpleLogEnabled;
+        }
+
+        /// <summary>
+        ///     Determines whether or not an <see cref="EventData" /> instance is needed based on whether or
+        ///     not there is a <see cref="DiagnosticSource" />, an <see cref="ISimpleLogger" />, or an <see cref="IInterceptor" /> enabled for
+        ///     the given event.
+        /// </summary>
+        /// <param name="diagnostics"> The <see cref="IDiagnosticsLogger" /> being used. </param>
+        /// <param name="definition"> The definition of the event. </param>
+        /// <param name="interceptor"> The <see cref="IInterceptor" /> to use if enabled; otherwise null. </param>
+        /// <param name="diagnosticSourceEnabled"> Set to true if a <see cref="DiagnosticSource" /> is enabled; false otherwise. </param>
+        /// <param name="simpleLogEnabled"> True to true if a <see cref="ISimpleLogger" /> is enabled; false otherwise. </param>
+        /// <returns> True if either a diagnostic source, a simple logger, or an interceptor is enabled; false otherwise. </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] // Because hot path for logging
+        public static bool NeedsEventData<TInterceptor>(
+            [NotNull] this IDiagnosticsLogger diagnostics,
+            [NotNull] EventDefinitionBase definition,
+            [CanBeNull] out TInterceptor interceptor,
+            out bool diagnosticSourceEnabled,
+            out bool simpleLogEnabled)
+            where TInterceptor : class, IInterceptor
+        {
+            // No null checks; low-level code in hot path for logging.
+
+            diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
+
+            interceptor = diagnostics.Interceptors?.Aggregate<TInterceptor>();
+
+            simpleLogEnabled = definition.WarningBehavior == WarningBehavior.Log
+                && diagnostics.SimpleLogger.ShouldLog(definition.EventId, definition.Level);
+
+            return diagnosticSourceEnabled
+                || simpleLogEnabled
+                || interceptor != null;
+        }
+    }
+}

--- a/src/EFCore/Diagnostics/EventData.cs
+++ b/src/EFCore/Diagnostics/EventData.cs
@@ -40,6 +40,11 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public virtual LogLevel LogLevel => _eventDefinition.Level;
 
         /// <summary>
+        ///     A string representing the code where this event is defined.
+        /// </summary>
+        public virtual string EventIdCode => _eventDefinition.EventIdCode;
+
+        /// <summary>
         ///     A logger message describing this event.
         /// </summary>
         /// <returns> A logger message describing this event. </returns>

--- a/src/EFCore/Diagnostics/EventDefinition.cs
+++ b/src/EFCore/Diagnostics/EventDefinition.cs
@@ -56,18 +56,16 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <typeparam name="TLoggerCategory"> The <see cref="DbLoggerCategory" />. </typeparam>
         /// <param name="logger"> The logger to which the event should be logged. </param>
-        /// <param name="warningBehavior"> Whether the event should be logged, thrown as an exception or ignored. </param>
         /// <param name="exception"> Optional exception associated with the event. </param>
         public virtual void Log<TLoggerCategory>(
             [NotNull] IDiagnosticsLogger<TLoggerCategory> logger,
-            WarningBehavior warningBehavior,
             [CanBeNull] Exception exception = null)
             where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
         {
-            switch (warningBehavior)
+            switch (WarningBehavior)
             {
                 case WarningBehavior.Log:
-                    _logAction(logger.Logger, null);
+                    _logAction(logger.Logger, exception);
                     break;
                 case WarningBehavior.Throw:
                     throw WarningAsError(GenerateMessage());

--- a/src/EFCore/Diagnostics/EventDefinitionBase.cs
+++ b/src/EFCore/Diagnostics/EventDefinitionBase.cs
@@ -14,8 +14,6 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     /// </summary>
     public abstract class EventDefinitionBase
     {
-        private readonly WarningBehavior _warningBehavior;
-
         /// <summary>
         ///     Creates an event definition instance.
         /// </summary>
@@ -48,7 +46,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 }
 
                 var behavior = warningsConfiguration.GetBehavior(eventId);
-                _warningBehavior = behavior
+                WarningBehavior = behavior
                     ?? (level == LogLevel.Warning
                         && warningsConfiguration.DefaultBehavior == WarningBehavior.Throw
                             ? WarningBehavior.Throw
@@ -56,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             }
             else
             {
-                _warningBehavior = WarningBehavior.Log;
+                WarningBehavior = WarningBehavior.Log;
             }
 
             Level = level;
@@ -87,17 +85,9 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 CoreStrings.WarningAsErrorTemplate(EventId.ToString(), message, EventIdCode));
 
         /// <summary>
-        ///     Gets the log behavior for this event. This determines whether it should be logged, thrown as an exception or ignored.
+        ///     The configured <see cref="WarningBehavior"/>.
         /// </summary>
-        /// <typeparam name="TLoggerCategory"> The <see cref="DbLoggerCategory" />. </typeparam>
-        /// <param name="logger"> The logger to which the event would be logged. </param>
-        /// <returns> Whether the event should be logged, thrown as an exception or ignored. </returns>
-        public virtual WarningBehavior GetLogBehavior<TLoggerCategory>(
-            [NotNull] IDiagnosticsLogger<TLoggerCategory> logger)
-            where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
-            => _warningBehavior == WarningBehavior.Log
-                ? logger.Logger.IsEnabled(Level) ? WarningBehavior.Log : WarningBehavior.Ignore
-                : _warningBehavior;
+        public virtual WarningBehavior WarningBehavior { get;  }
 
         internal sealed class MessageExtractingLogger : ILogger
         {

--- a/src/EFCore/Diagnostics/EventDefinition`.cs
+++ b/src/EFCore/Diagnostics/EventDefinition`.cs
@@ -58,15 +58,13 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <typeparam name="TLoggerCategory"> The <see cref="DbLoggerCategory" />. </typeparam>
         /// <param name="logger"> The logger to which the event should be logged. </param>
-        /// <param name="warningBehavior"> Whether the event should be logged, thrown as an exception or ignored. </param>
         /// <param name="arg"> Message argument. </param>
         public virtual void Log<TLoggerCategory>(
             [NotNull] IDiagnosticsLogger<TLoggerCategory> logger,
-            WarningBehavior warningBehavior,
             [CanBeNull] TParam arg)
             where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
         {
-            switch (warningBehavior)
+            switch (WarningBehavior)
             {
                 case WarningBehavior.Log:
                     _logAction(logger.Logger, arg, null);

--- a/src/EFCore/Diagnostics/EventDefinition``.cs
+++ b/src/EFCore/Diagnostics/EventDefinition``.cs
@@ -60,17 +60,15 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <typeparam name="TLoggerCategory"> The <see cref="DbLoggerCategory" />. </typeparam>
         /// <param name="logger"> The logger to which the event should be logged. </param>
-        /// <param name="warningBehavior"> Whether the event should be logged, thrown as an exception or ignored. </param>
         /// <param name="arg1"> The first message argument. </param>
         /// <param name="arg2"> The second message argument. </param>
         public virtual void Log<TLoggerCategory>(
             [NotNull] IDiagnosticsLogger<TLoggerCategory> logger,
-            WarningBehavior warningBehavior,
             [CanBeNull] TParam1 arg1,
             [CanBeNull] TParam2 arg2)
             where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
         {
-            switch (warningBehavior)
+            switch (WarningBehavior)
             {
                 case WarningBehavior.Log:
                     _logAction(logger.Logger, arg1, arg2, null);

--- a/src/EFCore/Diagnostics/EventDefinition```.cs
+++ b/src/EFCore/Diagnostics/EventDefinition```.cs
@@ -64,21 +64,19 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <typeparam name="TLoggerCategory"> The <see cref="DbLoggerCategory" />. </typeparam>
         /// <param name="logger"> The logger to which the event should be logged. </param>
-        /// <param name="warningBehavior"> Whether the event should be logged, thrown as an exception or ignored. </param>
         /// <param name="arg1"> The first message argument. </param>
         /// <param name="arg2"> The second message argument. </param>
         /// <param name="arg3"> The third message argument. </param>
         /// <param name="exception"> Optional exception associated with the event. </param>
         public virtual void Log<TLoggerCategory>(
             [NotNull] IDiagnosticsLogger<TLoggerCategory> logger,
-            WarningBehavior warningBehavior,
             [CanBeNull] TParam1 arg1,
             [CanBeNull] TParam2 arg2,
             [CanBeNull] TParam3 arg3,
             [CanBeNull] Exception exception = null)
             where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
         {
-            switch (warningBehavior)
+            switch (WarningBehavior)
             {
                 case WarningBehavior.Log:
                     _logAction(logger.Logger, arg1, arg2, arg3, exception);

--- a/src/EFCore/Diagnostics/EventDefinition````.cs
+++ b/src/EFCore/Diagnostics/EventDefinition````.cs
@@ -64,21 +64,19 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <typeparam name="TLoggerCategory"> The <see cref="DbLoggerCategory" />. </typeparam>
         /// <param name="logger"> The logger to which the event should be logged. </param>
-        /// <param name="warningBehavior"> Whether the event should be logged, thrown as an exception or ignored. </param>
         /// <param name="arg1"> The first message argument. </param>
         /// <param name="arg2"> The second message argument. </param>
         /// <param name="arg3"> The third message argument. </param>
         /// <param name="arg4"> The fourth message argument. </param>
         public virtual void Log<TLoggerCategory>(
             [NotNull] IDiagnosticsLogger<TLoggerCategory> logger,
-            WarningBehavior warningBehavior,
             [CanBeNull] TParam1 arg1,
             [CanBeNull] TParam2 arg2,
             [CanBeNull] TParam3 arg3,
             [CanBeNull] TParam4 arg4)
             where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
         {
-            switch (warningBehavior)
+            switch (WarningBehavior)
             {
                 case WarningBehavior.Log:
                     _logAction(logger.Logger, arg1, arg2, arg3, arg4, null);

--- a/src/EFCore/Diagnostics/EventDefinition`````.cs
+++ b/src/EFCore/Diagnostics/EventDefinition`````.cs
@@ -66,7 +66,6 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <typeparam name="TLoggerCategory"> The <see cref="DbLoggerCategory" />. </typeparam>
         /// <param name="logger"> The logger to which the event should be logged. </param>
-        /// <param name="warningBehavior"> Whether the event should be logged, thrown as an exception or ignored. </param>
         /// <param name="arg1"> The first message argument. </param>
         /// <param name="arg2"> The second message argument. </param>
         /// <param name="arg3"> The third message argument. </param>
@@ -74,7 +73,6 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="arg5"> The fifth message argument. </param>
         public virtual void Log<TLoggerCategory>(
             [NotNull] IDiagnosticsLogger<TLoggerCategory> logger,
-            WarningBehavior warningBehavior,
             [CanBeNull] TParam1 arg1,
             [CanBeNull] TParam2 arg2,
             [CanBeNull] TParam3 arg3,
@@ -82,7 +80,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             [CanBeNull] TParam5 arg5)
             where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
         {
-            switch (warningBehavior)
+            switch (WarningBehavior)
             {
                 case WarningBehavior.Log:
                     _logAction(logger.Logger, arg1, arg2, arg3, arg4, arg5, null);

--- a/src/EFCore/Diagnostics/EventDefinition``````.cs
+++ b/src/EFCore/Diagnostics/EventDefinition``````.cs
@@ -68,7 +68,6 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <typeparam name="TLoggerCategory"> The <see cref="DbLoggerCategory" />. </typeparam>
         /// <param name="logger"> The logger to which the event should be logged. </param>
-        /// <param name="warningBehavior"> Whether the event should be logged, thrown as an exception or ignored. </param>
         /// <param name="arg1"> The first message argument. </param>
         /// <param name="arg2"> The second message argument. </param>
         /// <param name="arg3"> The third message argument. </param>
@@ -77,7 +76,6 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="arg6"> The sixth message argument. </param>
         public virtual void Log<TLoggerCategory>(
             [NotNull] IDiagnosticsLogger<TLoggerCategory> logger,
-            WarningBehavior warningBehavior,
             [CanBeNull] TParam1 arg1,
             [CanBeNull] TParam2 arg2,
             [CanBeNull] TParam3 arg3,
@@ -86,7 +84,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             [CanBeNull] TParam6 arg6)
             where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
         {
-            switch (warningBehavior)
+            switch (WarningBehavior)
             {
                 case WarningBehavior.Log:
                     _logAction(logger.Logger, arg1, arg2, arg3, arg4, arg5, arg6, null);

--- a/src/EFCore/Diagnostics/FallbackEventDefinition.cs
+++ b/src/EFCore/Diagnostics/FallbackEventDefinition.cs
@@ -57,15 +57,13 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         /// <typeparam name="TLoggerCategory"> The <see cref="DbLoggerCategory" />. </typeparam>
         /// <param name="logger"> The logger to which the event should be logged. </param>
-        /// <param name="warningBehavior"> Whether the event should be logged, thrown as an exception or ignored. </param>
         /// <param name="logAction"> A delegate that will log the message to an <see cref="ILogger" />. </param>
         public virtual void Log<TLoggerCategory>(
             [NotNull] IDiagnosticsLogger<TLoggerCategory> logger,
-            WarningBehavior warningBehavior,
             [NotNull] Action<ILogger> logAction)
             where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
         {
-            switch (warningBehavior)
+            switch (WarningBehavior)
             {
                 case WarningBehavior.Log:
                     logAction(logger.Logger);

--- a/src/EFCore/Diagnostics/IDiagnosticsLogger.cs
+++ b/src/EFCore/Diagnostics/IDiagnosticsLogger.cs
@@ -47,5 +47,15 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     The <see cref="DiagnosticSource" />.
         /// </summary>
         DiagnosticSource DiagnosticSource { get; }
+
+        /// <summary>
+        ///     The <see cref="ISimpleLogger" />.
+        /// </summary>
+        ISimpleLogger SimpleLogger { get; }
+
+        /// <summary>
+        ///     Holds registered interceptors, if any.
+        /// </summary>
+        IInterceptors Interceptors { get; }
     }
 }

--- a/src/EFCore/Diagnostics/IDiagnosticsLogger`.cs
+++ b/src/EFCore/Diagnostics/IDiagnosticsLogger`.cs
@@ -28,9 +28,5 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     public interface IDiagnosticsLogger<TLoggerCategory> : IDiagnosticsLogger
         where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
     {
-        /// <summary>
-        ///     Holds registered interceptors, if any.
-        /// </summary>
-        IInterceptors Interceptors { get; }
     }
 }

--- a/src/EFCore/Diagnostics/ISimpleLogger.cs
+++ b/src/EFCore/Diagnostics/ISimpleLogger.cs
@@ -1,0 +1,39 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     A simple logging interface for Entity Framework events.
+    ///     Used by <see cref="DbContextOptionsBuilder.LogTo(Action{string},LogLevel,SimpleLoggerFormatOptions?)" />
+    /// </summary>
+    public interface ISimpleLogger
+    {
+        /// <summary>
+        ///     <para>
+        ///         Logs the given <see cref="EventData" />.
+        ///     </para>
+        ///     <para>
+        ///         This method is only called if <see cref="ShouldLog" /> returns true.
+        ///     </para>
+        ///     <para>
+        ///         The specific subtype of the <see cref="EventData" /> argument is dependent on the event
+        ///         being logged. See <see cref="CoreEventId" /> for the type of event data used for each core event.
+        ///     </para>
+        /// </summary>
+        /// <param name="eventData"> The event to log. </param>
+        void Log([NotNull] EventData eventData);
+
+        /// <summary>
+        ///     Determines whether or not the given event should be logged.
+        /// </summary>
+        /// <param name="eventId"> The ID of the event. </param>
+        /// <param name="logLevel"> The level of the event. </param>
+        /// <returns> Returns true if the event should be logged; false if it should be filtered out. </returns>
+        bool ShouldLog(EventId eventId, LogLevel logLevel);
+    }
+}

--- a/src/EFCore/Diagnostics/Internal/NullSimpleLogger.cs
+++ b/src/EFCore/Diagnostics/Internal/NullSimpleLogger.cs
@@ -1,11 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
+using Microsoft.Extensions.Logging;
 
-namespace Microsoft.EntityFrameworkCore.Internal
+namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
 {
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -13,8 +11,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public sealed class ReferenceEnumerableEqualityComparer<TEnumerable, TValue> : IEqualityComparer<TEnumerable>
-        where TEnumerable : IEnumerable<TValue>
+    public class NullSimpleLogger : ISimpleLogger
     {
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -22,7 +19,9 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public bool Equals(TEnumerable x, TEnumerable y) => x.SequenceEqual(y);
+        public virtual void Log(EventData eventData)
+        {
+        }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -30,15 +29,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public int GetHashCode(TEnumerable obj)
-        {
-            var hash = new HashCode();
-            foreach (var value in obj)
-            {
-                hash.Add(value);
-            }
-
-            return hash.ToHashCode();
-        }
+        public virtual bool ShouldLog(EventId eventId, LogLevel logLevel) => false;
     }
 }

--- a/src/EFCore/Diagnostics/SimpleLogger.cs
+++ b/src/EFCore/Diagnostics/SimpleLogger.cs
@@ -1,0 +1,136 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Utilities;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     An implementation of <see cref="ISimpleLogger" /> that will log filtered events to a given sink
+    ///     with some control over formatting.
+    /// </summary>
+    public class SimpleLogger : ISimpleLogger
+    {
+        /// <summary>
+        ///     Creates a new <see cref="SimpleLogger" /> instance.
+        /// </summary>
+        /// <param name="sink"> The sink to which messages will be logged. </param>
+        /// <param name="filter"> A delegate that returns true to log the message; false to filter it out. </param>
+        /// <param name="formatOptions"> Formatting options for log messages. </param>
+        public SimpleLogger(
+            [NotNull] Action<string> sink,
+            [NotNull] Func<EventId, LogLevel, bool> filter,
+            SimpleLoggerFormatOptions formatOptions)
+        {
+            FormatOptions = formatOptions;
+            Sink = sink;
+            Filter = filter;
+        }
+
+        /// <summary>
+        ///     The <see cref="FormatOptions" /> to used when formatting messages to log.
+        /// </summary>
+        public SimpleLoggerFormatOptions FormatOptions { get; } // Intentionally not virtual for perf
+
+        /// <summary>
+        ///     The sink to which messages are being logged.
+        /// </summary>
+        public Action<string> Sink { get; } // Intentionally not virtual for perf
+
+        /// <summary>
+        ///     A delegate that returns true to log the message; false to filter it out.
+        /// </summary>
+        public Func<EventId, LogLevel, bool> Filter { get; } // Intentionally not virtual for perf
+
+        /// <inheritdoc />
+        public virtual void Log(EventData eventData)
+        {
+            Check.NotNull(eventData, nameof(eventData));
+
+            var message = eventData.ToString();
+            var logLevel = eventData.LogLevel;
+            var eventId = eventData.EventId;
+
+            if (FormatOptions != SimpleLoggerFormatOptions.None)
+            {
+                var messageBuilder = new StringBuilder();
+
+                if ((FormatOptions & SimpleLoggerFormatOptions.Level) != 0)
+                {
+                    messageBuilder.Append(GetLogLevelString(logLevel));
+                }
+
+                if ((FormatOptions & SimpleLoggerFormatOptions.LocalTime) != 0)
+                {
+                    messageBuilder.Append(DateTime.Now.ToShortDateString()).Append(DateTime.Now.ToString(" HH:mm:ss.fff "));
+                }
+
+                if ((FormatOptions & SimpleLoggerFormatOptions.UtcTime) != 0)
+                {
+                    messageBuilder.Append(DateTime.UtcNow.ToString("o")).Append(' ');
+                }
+
+                if ((FormatOptions & SimpleLoggerFormatOptions.Id) != 0)
+                {
+                    messageBuilder.Append(eventData.EventIdCode).Append('[').Append(eventId.Id).Append("] ");
+                }
+
+                if ((FormatOptions & SimpleLoggerFormatOptions.Category) != 0)
+                {
+                    var lastDot = eventId.Name.LastIndexOf('.');
+                    if (lastDot > 0)
+                    {
+                        messageBuilder.Append('(').Append(eventId.Name.Substring(0, lastDot)).Append(") ");
+                    }
+                }
+
+                const string padding = "      ";
+                var preambleLength = messageBuilder.Length;
+
+                if (FormatOptions == SimpleLoggerFormatOptions.SingleLine) // Single line ONLY
+                {
+                    message = messageBuilder
+                        .Append(message)
+                        .Replace(Environment.NewLine, "")
+                        .ToString();
+                }
+                else
+                {
+                    message = (FormatOptions & SimpleLoggerFormatOptions.SingleLine) != 0
+                        ? messageBuilder
+                            .Append("-> ")
+                            .Append(message)
+                            .Replace(Environment.NewLine, "", preambleLength, messageBuilder.Length - preambleLength)
+                            .ToString()
+                        : messageBuilder
+                            .AppendLine()
+                            .Append(message)
+                            .Replace(Environment.NewLine, Environment.NewLine + padding, preambleLength, messageBuilder.Length - preambleLength)
+                            .ToString();
+                }
+            }
+
+            Sink(message);
+        }
+
+        /// <inheritdoc />
+        public virtual bool ShouldLog(EventId eventId, LogLevel logLevel)
+            => Filter(eventId, logLevel);
+
+        private static string GetLogLevelString(LogLevel logLevel)
+            => logLevel switch
+            {
+                LogLevel.Trace => "trce: ",
+                LogLevel.Debug => "dbug: ",
+                LogLevel.Information => "info: ",
+                LogLevel.Warning => "warn: ",
+                LogLevel.Error => "fail: ",
+                LogLevel.Critical => "crit: ",
+                _ => "none",
+            };
+    }
+}

--- a/src/EFCore/Diagnostics/SimpleLoggerFormatOptions.cs
+++ b/src/EFCore/Diagnostics/SimpleLoggerFormatOptions.cs
@@ -1,0 +1,73 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     Formatting options for use with <see cref="SimpleLogger" />
+    ///     and <see cref="DbContextOptionsBuilder.LogTo(Action{string},LogLevel,SimpleLoggerFormatOptions?)" />.
+    /// </summary>
+    [Flags]
+    public enum SimpleLoggerFormatOptions
+    {
+        /// <summary>
+        ///     The raw log message with no additional metadata or formatting.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        ///     Each event will only occupy a single line in the log. Multiple lines are used by default.
+        /// </summary>
+        SingleLine = 1,
+
+        /// <summary>
+        ///     Include the event <see cref="LogLevel" /> in each log message. The level is included by default.
+        /// </summary>
+        Level = 1 << 1,
+
+        /// <summary>
+        ///     Includes the event <see cref="DbLoggerCategory" /> in each message. The category is included by default.
+        /// </summary>
+        Category = 1 << 2,
+
+        /// <summary>
+        ///     Includes the <see cref="EventId" /> in each message. The event ID is included by default.
+        /// </summary>
+        Id = 1 << 3,
+
+        /// <summary>
+        ///     Includes a UTC timestamp in each message. The local time is included by default. Use <see cref="DefaultWithUtcTime" />
+        ///     to include all default options but change timestamps to UTC.
+        /// </summary>
+        UtcTime = 1 << 4,
+
+        /// <summary>
+        ///     Includes a local time timestamp in each message. The local time is included by default.
+        /// </summary>
+        LocalTime = 1 << 5,
+
+        /// <summary>
+        ///     <para>
+        ///         The default used by <see cref="DbContextOptionsBuilder.LogTo(Action{string},LogLevel,SimpleLoggerFormatOptions?)" />.
+        ///     </para>
+        ///     <para>
+        ///         Includes <see cref="Level" />, <see cref="Category" />, <see cref="Id" />, <see cref="LocalTime" />.
+        ///     </para>
+        /// </summary>
+        DefaultWithLocalTime = Level | Category | Id | LocalTime,
+
+        /// <summary>
+        ///     <para>
+        ///         The same defaults as used by <see cref="DbContextOptionsBuilder.LogTo(Action{string},LogLevel,SimpleLoggerFormatOptions?)" />,
+        ///         but with UTC timestamps.
+        ///     </para>
+        ///     <para>
+        ///         Includes <see cref="Level" />, <see cref="Category" />, <see cref="Id" />, <see cref="UtcTime" />.
+        ///     </para>
+        /// </summary>
+        DefaultWithUtcTime = Level | Category | Id | UtcTime
+    }
+}

--- a/src/EFCore/Infrastructure/CoreOptionsExtension.cs
+++ b/src/EFCore/Infrastructure/CoreOptionsExtension.cs
@@ -33,6 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         private IServiceProvider _applicationServiceProvider;
         private IModel _model;
         private ILoggerFactory _loggerFactory;
+        private ISimpleLogger _simpleLogger;
         private IMemoryCache _memoryCache;
         private bool _sensitiveDataLoggingEnabled;
         private bool _detailedErrorsEnabled;
@@ -66,6 +67,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             _applicationServiceProvider = copyFrom.ApplicationServiceProvider;
             _model = copyFrom.Model;
             _loggerFactory = copyFrom.LoggerFactory;
+            _simpleLogger = copyFrom.SimpleLogger;
             _memoryCache = copyFrom.MemoryCache;
             _sensitiveDataLoggingEnabled = copyFrom.IsSensitiveDataLoggingEnabled;
             _detailedErrorsEnabled = copyFrom.DetailedErrorsEnabled;
@@ -164,6 +166,21 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             var clone = Clone();
 
             clone._loggerFactory = loggerFactory;
+
+            return clone;
+        }
+
+        /// <summary>
+        ///     Creates a new instance with all options the same as for this instance, but with the given option changed.
+        ///     It is unusual to call this method directly. Instead use <see cref="DbContextOptionsBuilder" />.
+        /// </summary>
+        /// <param name="simpleLogger"> The option to change. </param>
+        /// <returns> A new instance with the option changed. </returns>
+        public virtual CoreOptionsExtension WithSimpleLogger([CanBeNull] ISimpleLogger simpleLogger)
+        {
+            var clone = Clone();
+
+            clone._simpleLogger = simpleLogger;
 
             return clone;
         }
@@ -317,6 +334,11 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     The option set from the <see cref="DbContextOptionsBuilder.UseLoggerFactory" /> method.
         /// </summary>
         public virtual ILoggerFactory LoggerFactory => _loggerFactory;
+
+        /// <summary>
+        ///     The option set from the <see cref="DbContextOptionsBuilder.LogTo(Action{string},LogLevel,SimpleLoggerFormatOptions?)" /> method.
+        /// </summary>
+        public virtual ISimpleLogger SimpleLogger => _simpleLogger;
 
         /// <summary>
         ///     The option set from the <see cref="DbContextOptionsBuilder.UseMemoryCache" /> method.

--- a/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
+++ b/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
@@ -130,6 +130,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 { typeof(IDbContextTransactionManager), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IQueryContextFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IQueryCompilationContextFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
+                { typeof(ISimpleLogger), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(ILazyLoader), new ServiceCharacteristics(ServiceLifetime.Transient) },
                 {
                     typeof(IParameterBindingFactory), new ServiceCharacteristics(ServiceLifetime.Singleton, multipleRegistrations: true)
@@ -264,6 +265,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             TryAdd<IQueryCompilationContextFactory, QueryCompilationContextFactory>();
             TryAdd<IQueryTranslationPreprocessorFactory, QueryTranslationPreprocessorFactory>();
             TryAdd<IQueryTranslationPostprocessorFactory, QueryTranslationPostprocessorFactory>();
+
+            TryAdd(p => p.GetService<IDbContextOptions>()?.FindExtension<CoreOptionsExtension>()?.SimpleLogger ?? new NullSimpleLogger());
 
             // This has to be lazy to avoid creating instances that are not disposed
             ServiceCollectionMap

--- a/src/EFCore/Internal/DiagnosticsLogger.cs
+++ b/src/EFCore/Internal/DiagnosticsLogger.cs
@@ -37,10 +37,12 @@ namespace Microsoft.EntityFrameworkCore.Internal
             [NotNull] ILoggingOptions loggingOptions,
             [NotNull] DiagnosticSource diagnosticSource,
             [NotNull] LoggingDefinitions loggingDefinitions,
+            [NotNull] ISimpleLogger simpleLogger,
             [CanBeNull] IInterceptors interceptors = null)
         {
             DiagnosticSource = diagnosticSource;
             Definitions = loggingDefinitions;
+            SimpleLogger = simpleLogger;
             Logger = loggerFactory.CreateLogger(new TLoggerCategory());
             Options = loggingOptions;
             Interceptors = interceptors;
@@ -85,6 +87,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual LoggingDefinitions Definitions { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual ISimpleLogger SimpleLogger { get; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Internal/ReferenceEqualityComparer.cs
+++ b/src/EFCore/Internal/ReferenceEqualityComparer.cs
@@ -12,6 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    // Sealed for perf
     public sealed class ReferenceEqualityComparer : IEqualityComparer<object>
     {
         private ReferenceEqualityComparer()

--- a/src/EFCore/Internal/ServiceProviderCache.cs
+++ b/src/EFCore/Internal/ServiceProviderCache.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -119,7 +120,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
                             ScopedLoggerFactory.Create(scopedProvider, options),
                             scopedProvider.GetService<ILoggingOptions>(),
                             scopedProvider.GetService<DiagnosticSource>(),
-                            loggingDefinitions);
+                            loggingDefinitions,
+                            new NullSimpleLogger());
 
                         if (_configurations.Count == 0)
                         {

--- a/src/EFCore/Metadata/Conventions/ForeignKeyIndexConvention.cs
+++ b/src/EFCore/Metadata/Conventions/ForeignKeyIndexConvention.cs
@@ -365,7 +365,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         public virtual void ProcessModelFinalized(IConventionModelBuilder modelBuilder, IConventionContext<IConventionModelBuilder> context)
         {
             var definition = CoreResources.LogRedundantIndexRemoved(Dependencies.Logger);
-            if (definition.GetLogBehavior(Dependencies.Logger) == WarningBehavior.Ignore
+            if (!Dependencies.Logger.ShouldLog(definition)
                 && !Dependencies.Logger.DiagnosticSource.IsEnabled(definition.EventId.Name))
             {
                 return;

--- a/src/EFCore/Metadata/Internal/ClrPropertyGetter.cs
+++ b/src/EFCore/Metadata/Internal/ClrPropertyGetter.cs
@@ -13,6 +13,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    // Sealed for perf
     public sealed class ClrPropertyGetter<TEntity, TValue> : IClrPropertyGetter
         where TEntity : class
     {

--- a/src/EFCore/Metadata/Internal/ClrPropertySetter.cs
+++ b/src/EFCore/Metadata/Internal/ClrPropertySetter.cs
@@ -13,6 +13,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    // Sealed for perf
     public sealed class ClrPropertySetter<TEntity, TValue> : IClrPropertySetter
         where TEntity : class
     {

--- a/src/EFCore/Metadata/Internal/EntityTypePathComparer.cs
+++ b/src/EFCore/Metadata/Internal/EntityTypePathComparer.cs
@@ -12,7 +12,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public class EntityTypePathComparer : IComparer<IEntityType>, IEqualityComparer<IEntityType>
+    // Sealed for perf
+    public sealed class EntityTypePathComparer : IComparer<IEntityType>, IEqualityComparer<IEntityType>
     {
         private EntityTypePathComparer()
         {
@@ -32,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual int Compare(IEntityType x, IEntityType y)
+        public int Compare(IEntityType x, IEntityType y)
         {
             if (ReferenceEquals(x, y))
             {
@@ -99,7 +100,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual int GetHashCode(IEntityType entityType)
+        public int GetHashCode(IEntityType entityType)
         {
             var hash = new HashCode();
             while (true)

--- a/src/EFCore/Metadata/Internal/PropertyAccessors.cs
+++ b/src/EFCore/Metadata/Internal/PropertyAccessors.cs
@@ -13,6 +13,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    // Sealed for perf
     public sealed class PropertyAccessors
     {
         /// <summary>

--- a/src/EFCore/Metadata/Internal/PropertyListComparer.cs
+++ b/src/EFCore/Metadata/Internal/PropertyListComparer.cs
@@ -12,7 +12,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public class PropertyListComparer : IComparer<IReadOnlyList<IProperty>>, IEqualityComparer<IReadOnlyList<IProperty>>
+    // Sealed for perf
+    public sealed class PropertyListComparer : IComparer<IReadOnlyList<IProperty>>, IEqualityComparer<IReadOnlyList<IProperty>>
     {
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Query/CompiledQueryCacheKeyGenerator.cs
+++ b/src/EFCore/Query/CompiledQueryCacheKeyGenerator.cs
@@ -60,7 +60,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <param name="query"> The query to get the cache key for. </param>
         /// <param name="async"> A value indicating whether the query will be executed asynchronously. </param>
         /// <returns> The cache key. </returns>
-        protected CompiledQueryCacheKey GenerateCacheKeyCore([NotNull] Expression query, bool async)
+        protected CompiledQueryCacheKey GenerateCacheKeyCore([NotNull] Expression query, bool async) // Intentionally non-virtual
             => new CompiledQueryCacheKey(
                 Check.NotNull(query, nameof(query)),
                 Dependencies.Model,

--- a/test/EFCore.InMemory.Tests/InMemoryTransactionManagerTest.cs
+++ b/test/EFCore.InMemory.Tests/InMemoryTransactionManagerTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.InMemory.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.InMemory.Internal;
 using Microsoft.EntityFrameworkCore.InMemory.Storage.Internal;
@@ -66,7 +67,8 @@ namespace Microsoft.EntityFrameworkCore
                 new ListLoggerFactory(l => false),
                 options,
                 new DiagnosticListener("Fake"),
-                new InMemoryLoggingDefinitions());
+                new InMemoryLoggingDefinitions(),
+                new NullSimpleLogger());
             return logger;
         }
     }

--- a/test/EFCore.Relational.Tests/ApiConsistencyTest.cs
+++ b/test/EFCore.Relational.Tests/ApiConsistencyTest.cs
@@ -3,10 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
+using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -14,6 +16,16 @@ namespace Microsoft.EntityFrameworkCore
 {
     public class ApiConsistencyTest : ApiConsistencyTestBase
     {
+        public ApiConsistencyTest()
+            : base(
+                typeof(RelationalCompiledQueryCacheKeyGenerator)
+                    .GetRuntimeMethods()
+                    .Single(
+                        m => m.Name == "GenerateCacheKeyCore"
+                            && m.DeclaringType == typeof(RelationalCompiledQueryCacheKeyGenerator)))
+        {
+        }
+
         private static readonly Type[] _fluentApiTypes =
         {
             typeof(RelationalForeignKeyBuilderExtensions),
@@ -30,9 +42,6 @@ namespace Microsoft.EntityFrameworkCore
         };
 
         protected override IEnumerable<Type> FluentApiTypes => _fluentApiTypes;
-
-        protected override bool ShouldHaveVirtualMethods(Type type)
-            => type.Name != "EntityShaper";
 
         protected override void AddServices(ServiceCollection serviceCollection)
         {

--- a/test/EFCore.Relational.Tests/Storage/RelationalCommandTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalCommandTest.cs
@@ -939,7 +939,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 logFactory,
                 new FakeLoggingOptions(false),
                 new DiagnosticListener("Fake"),
-                new TestRelationalLoggingDefinitions());
+                new TestRelationalLoggingDefinitions(),
+                new NullSimpleLogger());
 
             var relationalCommand = CreateRelationalCommand(
                 commandText: "Logged Command",
@@ -996,7 +997,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 logFactory,
                 new FakeLoggingOptions(true),
                 new DiagnosticListener("Fake"),
-                new TestRelationalLoggingDefinitions());
+                new TestRelationalLoggingDefinitions(),
+                new NullSimpleLogger());
 
             var relationalCommand = CreateRelationalCommand(
                 commandText: "Logged Command",
@@ -1053,7 +1055,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 new ListLoggerFactory(),
                 new FakeLoggingOptions(false),
                 new ListDiagnosticSource(diagnostic),
-                new TestRelationalLoggingDefinitions());
+                new TestRelationalLoggingDefinitions(),
+                new NullSimpleLogger());
 
             var relationalCommand = CreateRelationalCommand(
                 parameters: new[]
@@ -1123,7 +1126,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 new ListLoggerFactory(),
                 new FakeLoggingOptions(false),
                 new ListDiagnosticSource(diagnostic),
-                new TestRelationalLoggingDefinitions());
+                new TestRelationalLoggingDefinitions(),
+                new NullSimpleLogger());
 
             var relationalCommand = CreateRelationalCommand(
                 parameters: new[]

--- a/test/EFCore.Relational.Tests/Storage/RelationalTransactionExtensionsTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalTransactionExtensionsTest.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -36,7 +37,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                     loggerFactory,
                     new LoggingOptions(),
                     new DiagnosticListener("Fake"),
-                    new TestRelationalLoggingDefinitions()),
+                    new TestRelationalLoggingDefinitions(),
+                    new NullSimpleLogger()),
                 false);
 
             Assert.Equal(dbTransaction, transaction.GetDbTransaction());

--- a/test/EFCore.Relational.Tests/TestUtilities/FakeDiagnosticsLogger.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/FakeDiagnosticsLogger.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.Extensions.Logging;
 
@@ -19,6 +20,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         public ILogger Logger => this;
 
         public DiagnosticSource DiagnosticSource { get; } = new DiagnosticListener("Fake");
+
+        public ISimpleLogger SimpleLogger { get; } = new NullSimpleLogger();
 
         public void Log<TState>(
             LogLevel logLevel,

--- a/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalConnection.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalConnection.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Diagnostics;
+using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -26,12 +27,14 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider
                         new LoggerFactory(),
                         new LoggingOptions(),
                         new DiagnosticListener("FakeDiagnosticListener"),
-                        new TestRelationalLoggingDefinitions()),
+                        new TestRelationalLoggingDefinitions(),
+                        new NullSimpleLogger()),
                     new DiagnosticsLogger<DbLoggerCategory.Database.Connection>(
                         new LoggerFactory(),
                         new LoggingOptions(),
                         new DiagnosticListener("FakeDiagnosticListener"),
-                        new TestRelationalLoggingDefinitions()),
+                        new TestRelationalLoggingDefinitions(),
+                        new NullSimpleLogger()),
                     new NamedConnectionStringResolver(options ?? CreateOptions()),
                     new RelationalTransactionFactory(new RelationalTransactionFactoryDependencies()),
                     new CurrentDbContext(new FakeDbContext())))

--- a/test/EFCore.Specification.Tests/TestUtilities/TestLogger.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/TestLogger.cs
@@ -32,5 +32,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         public ILogger Logger => this;
 
         public virtual LoggingDefinitions Definitions { get; } = new TDefinitions();
+
+        public IInterceptors Interceptors { get; }
     }
 }

--- a/test/EFCore.Specification.Tests/TestUtilities/TestLoggerBase.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/TestLoggerBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Diagnostics;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities
@@ -12,6 +13,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         public LogLevel? LoggedAt { get; set; }
         public EventId LoggedEvent { get; set; }
         public string Message { get; set; }
+
+        public ISimpleLogger SimpleLogger { get; } = new TestSimpleLogger();
 
         public DiagnosticSource DiagnosticSource { get; } = new TestDiagnosticSource();
     }

--- a/test/EFCore.Specification.Tests/TestUtilities/TestLogger`.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/TestLogger`.cs
@@ -9,6 +9,5 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         where TCategory : LoggerCategory<TCategory>, new()
         where TDefinitions : LoggingDefinitions, new()
     {
-        public IInterceptors Interceptors { get; }
     }
 }

--- a/test/EFCore.Specification.Tests/TestUtilities/TestSimpleLogger.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/TestSimpleLogger.cs
@@ -1,0 +1,22 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities
+{
+    public class TestSimpleLogger : ISimpleLogger
+    {
+        public LogLevel? LoggedAt { get; set; }
+        public EventId LoggedEvent { get; set; }
+
+        public void Log(EventData eventData)
+        {
+            LoggedAt = eventData.LogLevel;
+            LoggedEvent = eventData.EventId;
+        }
+
+        public bool ShouldLog(EventId eventId, LogLevel logLevel) => true;
+    }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Scaffolding/SqlServerDatabaseModelFactoryTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Scaffolding/SqlServerDatabaseModelFactoryTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -2201,7 +2202,8 @@ DROP TABLE PrincipalTable;");
                         Fixture.ListLoggerFactory,
                         new LoggingOptions(),
                         new DiagnosticListener("Fake"),
-                        new SqlServerLoggingDefinitions()));
+                        new SqlServerLoggingDefinitions(),
+                        new NullSimpleLogger()));
 
                 var databaseModel = databaseModelFactory.Create(
                     Fixture.TestStore.ConnectionString,

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerDatabaseCleaner.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerDatabaseCleaner.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Diagnostics;
+using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Scaffolding;
@@ -21,7 +22,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                     loggerFactory,
                     new LoggingOptions(),
                     new DiagnosticListener("Fake"),
-                    new SqlServerLoggingDefinitions()));
+                    new SqlServerLoggingDefinitions(),
+                    new NullSimpleLogger()));
 
         protected override bool AcceptTable(DatabaseTable table) => !(table is DatabaseView);
 

--- a/test/EFCore.SqlServer.Tests/SqlServerConnectionTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerConnectionTest.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
@@ -71,12 +72,14 @@ namespace Microsoft.EntityFrameworkCore
                     new LoggerFactory(),
                     new LoggingOptions(),
                     new DiagnosticListener("FakeDiagnosticListener"),
-                    new SqlServerLoggingDefinitions()),
+                    new SqlServerLoggingDefinitions(),
+                    new NullSimpleLogger()),
                 new DiagnosticsLogger<DbLoggerCategory.Database.Connection>(
                     new LoggerFactory(),
                     new LoggingOptions(),
                     new DiagnosticListener("FakeDiagnosticListener"),
-                    new SqlServerLoggingDefinitions()),
+                    new SqlServerLoggingDefinitions(),
+                    new NullSimpleLogger()),
                 new NamedConnectionStringResolver(options),
                 new RelationalTransactionFactory(new RelationalTransactionFactoryDependencies()),
                 new CurrentDbContext(new FakeDbContext()));

--- a/test/EFCore.Sqlite.FunctionalTests/Scaffolding/SqliteDatabaseModelFactoryTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Scaffolding/SqliteDatabaseModelFactoryTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
@@ -49,8 +50,11 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
                     .AddSingleton<LoggingDefinitions, SqliteLoggingDefinitions>()
                     .AddSingleton(typeof(IDiagnosticsLogger<>), typeof(DiagnosticsLogger<>))
                     .AddSingleton<IValueConverterSelector, ValueConverterSelector>()
-                    .AddSingleton<ILoggerFactory>(Fixture.ListLoggerFactory);
+                    .AddSingleton<ILoggerFactory>(Fixture.ListLoggerFactory)
+                    .AddSingleton<ISimpleLogger, NullSimpleLogger>();
+
                 new SqliteDesignTimeServices().ConfigureDesignTimeServices(services);
+
                 var databaseModelFactory = services
                     .BuildServiceProvider()
                     .GetRequiredService<IDatabaseModelFactory>();

--- a/test/EFCore.Sqlite.FunctionalTests/TestUtilities/SqliteDatabaseCleaner.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/TestUtilities/SqliteDatabaseCleaner.cs
@@ -28,6 +28,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 .AddSingleton<ValueConverterSelectorDependencies>()
                 .AddSingleton<DiagnosticSource>(new DiagnosticListener(DbLoggerCategory.Name))
                 .AddSingleton<ILoggingOptions, LoggingOptions>()
+                .AddSingleton<ISimpleLogger, NullSimpleLogger>()
                 .AddSingleton<LoggingDefinitions, SqliteLoggingDefinitions>()
                 .AddSingleton(typeof(IDiagnosticsLogger<>), typeof(DiagnosticsLogger<>))
                 .AddSingleton<IValueConverterSelector, ValueConverterSelector>()

--- a/test/EFCore.Tests/Infrastructure/DiagnosticsLoggerTest.cs
+++ b/test/EFCore.Tests/Infrastructure/DiagnosticsLoggerTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
+using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.Logging;
@@ -45,11 +46,11 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             var loggerFactory = new ListLoggerFactory(filter);
 
             var dbLogger = new DiagnosticsLogger<DbLoggerCategory.Database>(
-                loggerFactory, new LoggingOptions(), new DiagnosticListener("Fake"), new TestLoggingDefinitions());
+                loggerFactory, new LoggingOptions(), new DiagnosticListener("Fake"), new TestLoggingDefinitions(), new NullSimpleLogger());
             var sqlLogger = new DiagnosticsLogger<DbLoggerCategory.Database.Command>(
-                loggerFactory, new LoggingOptions(), new DiagnosticListener("Fake"), new TestLoggingDefinitions());
+                loggerFactory, new LoggingOptions(), new DiagnosticListener("Fake"), new TestLoggingDefinitions(), new NullSimpleLogger());
             var queryLogger = new DiagnosticsLogger<DbLoggerCategory.Query>(
-                loggerFactory, new LoggingOptions(), new DiagnosticListener("Fake"), new TestLoggingDefinitions());
+                loggerFactory, new LoggingOptions(), new DiagnosticListener("Fake"), new TestLoggingDefinitions(), new NullSimpleLogger());
             var randomLogger = loggerFactory.CreateLogger("Random");
 
             dbLogger.Logger.LogInformation(1, "DB1");

--- a/test/EFCore.Tests/Infrastructure/EventIdTestBase.cs
+++ b/test/EFCore.Tests/Infrastructure/EventIdTestBase.cs
@@ -70,6 +70,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                     var testLogger =
                         (TestLoggerBase)Activator.CreateInstance(typeof(TestLogger<,>).MakeGenericType(category, loggerDefinitionsType));
                     var testDiagnostics = (TestDiagnosticSource)testLogger.DiagnosticSource;
+                    var simpleLogger = (TestSimpleLogger)testLogger.SimpleLogger;
 
                     var args = new object[loggerParameters.Length];
                     args[0] = testLogger;
@@ -112,6 +113,12 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                             {
                                 Assert.Equal(logLevel, testLogger.LoggedAt);
                                 logged = true;
+
+                                if (categoryName != DbLoggerCategory.Scaffolding.Name)
+                                {
+                                    Assert.Equal(logLevel, simpleLogger.LoggedAt);
+                                    Assert.Equal(eventId, simpleLogger.LoggedEvent);
+                                }
                             }
 
                             if (enableFor == eventId.Name

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTestBase.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTestBase.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Diagnostics;
 using System.Linq;
+using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
@@ -220,7 +221,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 LoggerFactory,
                 options,
                 new DiagnosticListener("Fake"),
-                TestHelpers.LoggingDefinitions);
+                TestHelpers.LoggingDefinitions,
+                new NullSimpleLogger());
         }
 
         protected DiagnosticsLogger<DbLoggerCategory.Model> CreateModelLogger(bool sensitiveDataLoggingEnabled = false)
@@ -231,7 +233,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 LoggerFactory,
                 options,
                 new DiagnosticListener("Fake"),
-                TestHelpers.LoggingDefinitions);
+                TestHelpers.LoggingDefinitions,
+                new NullSimpleLogger());
         }
 
         protected virtual ModelBuilder CreateConventionalModelBuilder(bool sensitiveDataLoggingEnabled = false)

--- a/test/EFCore.Tests/Metadata/Conventions/ForeignKeyPropertyDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/ForeignKeyPropertyDiscoveryConventionTest.cs
@@ -1154,7 +1154,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 ListLoggerFactory,
                 options,
                 new DiagnosticListener("Fake"),
-                new TestLoggingDefinitions());
+                new TestLoggingDefinitions(),
+                new NullSimpleLogger());
             return modelLogger;
         }
 

--- a/test/EFCore.Tests/Metadata/Conventions/KeyDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/KeyDiscoveryConventionTest.cs
@@ -169,7 +169,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 ListLoggerFactory,
                 options,
                 new DiagnosticListener("Fake"),
-                new TestLoggingDefinitions());
+                new TestLoggingDefinitions(),
+                new NullSimpleLogger());
             return modelLogger;
         }
 

--- a/test/EFCore.Tests/Metadata/Conventions/NavigationAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/NavigationAttributeConventionTest.cs
@@ -896,7 +896,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 ListLoggerFactory,
                 options,
                 new DiagnosticListener("Fake"),
-                new TestLoggingDefinitions());
+                new TestLoggingDefinitions(),
+                new NullSimpleLogger());
             return modelLogger;
         }
 

--- a/test/EFCore.Tests/Metadata/Conventions/NonNullableNavigationConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/NonNullableNavigationConventionTest.cs
@@ -226,7 +226,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 ListLoggerFactory,
                 options,
                 new DiagnosticListener("Fake"),
-                new TestLoggingDefinitions());
+                new TestLoggingDefinitions(),
+                new NullSimpleLogger());
             return modelLogger;
         }
 

--- a/test/EFCore.Tests/Metadata/Conventions/RelationshipDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/RelationshipDiscoveryConventionTest.cs
@@ -991,7 +991,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 ListLoggerFactory,
                 options,
                 new DiagnosticListener("Fake"),
-                new TestLoggingDefinitions());
+                new TestLoggingDefinitions(),
+                new NullSimpleLogger());
             return modelLogger;
         }
 

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderTestBase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -122,14 +123,16 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                     ValidationLoggerFactory,
                     options,
                     new DiagnosticListener("Fake"),
-                    testHelpers.LoggingDefinitions);
+                    testHelpers.LoggingDefinitions,
+                    new NullSimpleLogger());
 
                 ModelLoggerFactory = new ListLoggerFactory(l => l == DbLoggerCategory.Model.Name);
                 var modelLogger = new DiagnosticsLogger<DbLoggerCategory.Model>(
                     ModelLoggerFactory,
                     options,
                     new DiagnosticListener("Fake"),
-                    testHelpers.LoggingDefinitions);
+                    testHelpers.LoggingDefinitions,
+                    new NullSimpleLogger());
 
                 ModelBuilder = testHelpers.CreateConventionBuilder(modelLogger, validationLogger);
             }

--- a/test/EFCore.Tests/SimpleLoggerTests.cs
+++ b/test/EFCore.Tests/SimpleLoggerTests.cs
@@ -1,0 +1,470 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public class SimpleLoggerTests
+    {
+        private const string ContextInitialized =
+            @"info: <Local Date> HH:mm:ss.fff CoreEventId.ContextInitialized[10403] (Microsoft.EntityFrameworkCore.Infrastructure) 
+      Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory' with options: StoreName=SimpleLoggerTests ";
+
+        private const string SaveChangesStarting =
+            @"dbug: <Local Date> HH:mm:ss.fff CoreEventId.SaveChangesStarting[10004] (Microsoft.EntityFrameworkCore.Update) 
+      SaveChanges starting for 'LoggingContext'.";
+
+        private const string SaveChangesCompleted =
+            @"dbug: <Local Date> HH:mm:ss.fff CoreEventId.SaveChangesCompleted[10005] (Microsoft.EntityFrameworkCore.Update) 
+      SaveChanges completed for 'LoggingContext' with 0 entities written to the database.";
+
+        private const string ContextDisposed =
+            @"dbug: <Local Date> HH:mm:ss.fff CoreEventId.ContextDisposed[10407] (Microsoft.EntityFrameworkCore.Infrastructure) 
+      'LoggingContext' disposed.";
+
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Log_with_default_options(bool async)
+        {
+            var stream = new StringWriter();
+            var actual = await LogTest(async, stream, b => b.LogTo(stream.WriteLine));
+
+            AssertLog(actual, ContextInitialized, SaveChangesStarting, SaveChangesCompleted, ContextDisposed);
+        }
+
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Log_with_minimum_level(bool async)
+        {
+            var stream = new StringWriter();
+            var actual = await LogTest(async, stream, b => b.LogTo(stream.WriteLine, LogLevel.Information));
+
+            AssertLog(actual, ContextInitialized);
+        }
+
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Log_for_multiple_categories(bool async)
+        {
+            var stream = new StringWriter();
+            var actual = await LogTest(
+                async,
+                stream,
+                b => b.LogTo(
+                    stream.WriteLine,
+                    new[] { DbLoggerCategory.Infrastructure.Name, DbLoggerCategory.Update.Name }));
+
+            AssertLog(actual, ContextInitialized, SaveChangesStarting, SaveChangesCompleted, ContextDisposed);
+        }
+
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Log_for_single_category(bool async)
+        {
+            var stream = new StringWriter();
+            var actual = await LogTest(
+                async,
+                stream,
+                b => b.LogTo(
+                    stream.WriteLine,
+                    new[] { DbLoggerCategory.Infrastructure.Name }));
+
+            AssertLog(actual, ContextInitialized, ContextDisposed);
+        }
+
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Log_for_single_category_and_minimum_level(bool async)
+        {
+            var stream = new StringWriter();
+            var actual = await LogTest(
+                async,
+                stream,
+                b => b.LogTo(
+                    stream.WriteLine,
+                    new[] { DbLoggerCategory.Infrastructure.Name },
+                    LogLevel.Information));
+
+            AssertLog(actual, ContextInitialized);
+
+            stream = new StringWriter();
+            actual = await LogTest(
+                async,
+                stream,
+                b => b.LogTo(
+                    stream.WriteLine,
+                    new[] { DbLoggerCategory.Update.Name },
+                    LogLevel.Information));
+
+            Assert.Equal("", actual);
+        }
+
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Log_for_single_event(bool async)
+        {
+            var stream = new StringWriter();
+            var actual = await LogTest(
+                async,
+                stream,
+                b => b.LogTo(
+                    stream.WriteLine,
+                    new[] { CoreEventId.ContextInitialized }));
+
+            AssertLog(actual, ContextInitialized);
+        }
+
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Log_for_multiple_events(bool async)
+        {
+            var stream = new StringWriter();
+            var actual = await LogTest(
+                async,
+                stream,
+                b => b.LogTo(
+                    stream.WriteLine,
+                    new[] { CoreEventId.ContextInitialized, CoreEventId.ContextDisposed }));
+
+            AssertLog(actual, ContextInitialized, ContextDisposed);
+        }
+
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Log_for_many_events(bool async) // Hits HashCode usage
+        {
+            var stream = new StringWriter();
+            var actual = await LogTest(
+                async,
+                stream,
+                b => b.LogTo(
+                    stream.WriteLine,
+                    new[]
+                    {
+                        CoreEventId.ContextInitialized,
+                        CoreEventId.ContextDisposed,
+                        CoreEventId.StartedTracking,
+                        CoreEventId.StateChanged,
+                        CoreEventId.ValueGenerated,
+                        CoreEventId.CascadeDelete
+                    }));
+
+            AssertLog(actual, ContextInitialized, ContextDisposed);
+        }
+
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Log_for_single_event_and_minimum_level(bool async)
+        {
+            var stream = new StringWriter();
+            var actual = await LogTest(
+                async,
+                stream,
+                b => b.LogTo(
+                    stream.WriteLine,
+                    new[] { CoreEventId.ContextInitialized },
+                    LogLevel.Information));
+
+            AssertLog(actual, ContextInitialized);
+
+            stream = new StringWriter();
+            actual = await LogTest(
+                async,
+                stream,
+                b => b.LogTo(
+                    stream.WriteLine,
+                    new[] { CoreEventId.ContextDisposed },
+                    LogLevel.Information));
+
+            Assert.Equal("", actual);
+        }
+
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Log_with_custom_filter(bool async)
+        {
+            var stream = new StringWriter();
+            var actual = await LogTest(
+                async, stream, b => b.LogTo(stream.WriteLine, (e, l) => e == CoreEventId.SaveChangesCompleted));
+
+            AssertLog(actual, SaveChangesCompleted);
+        }
+
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Log_with_custom_logger(bool async)
+        {
+            var stream = new StringWriter();
+            var actual = await LogTest(async, stream, b => b.LogTo(new CustomSimpleLogger(stream.Write)));
+
+            Assert.Equal(@"Initialized LoggingContext" + Environment.NewLine, actual);
+        }
+
+        private class CustomSimpleLogger : ISimpleLogger
+        {
+            public CustomSimpleLogger([NotNull] Action<string> sink)
+            {
+                Sink = sink;
+            }
+
+            public virtual Action<string> Sink { get; }
+
+            public void Log(EventData eventData)
+                => Sink("Initialized " + ((ContextInitializedEventData)eventData).Context.GetType().Name);
+
+            public bool ShouldLog(EventId eventId, LogLevel logLevel)
+                => eventId == CoreEventId.ContextInitialized;
+        }
+
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Log_with_raw_message(bool async)
+        {
+            var stream = new StringWriter();
+            var actual = await LogTest(
+                async, stream, b => b.LogTo(stream.WriteLine, LogLevel.Information, SimpleLoggerFormatOptions.None));
+
+            AssertLog(
+                actual,
+                @"Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory' with options: StoreName=SimpleLoggerTests ");
+        }
+
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Log_raw_single_line(bool async)
+        {
+            var stream = new StringWriter();
+            var actual = await LogTest(
+                async, stream, b => b.LogTo(stream.WriteLine, LogLevel.Information, SimpleLoggerFormatOptions.SingleLine));
+
+            AssertLog(
+                actual,
+                @"Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory' with options: StoreName=SimpleLoggerTests ");
+        }
+
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Log_default_single_line(bool async)
+        {
+            var stream = new StringWriter();
+            var actual = await LogTest(
+                async, stream, b => b.LogTo(
+                    stream.WriteLine,
+                    LogLevel.Information,
+                    SimpleLoggerFormatOptions.SingleLine | SimpleLoggerFormatOptions.DefaultWithLocalTime));
+
+            AssertLog(
+                actual,
+                @"info: <Local Date> HH:mm:ss.fff CoreEventId.ContextInitialized[10403] (Microsoft.EntityFrameworkCore.Infrastructure) -> Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory' with options: StoreName=SimpleLoggerTests ");
+        }
+
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Log_only_level(bool async)
+        {
+            var stream = new StringWriter();
+            var actual = await LogTest(
+                async, stream, b => b.LogTo(stream.WriteLine, LogLevel.Information, SimpleLoggerFormatOptions.Level));
+
+            AssertLog(
+                actual,
+                @"info: 
+      Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory' with options: StoreName=SimpleLoggerTests ");
+        }
+
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Log_only_local_time(bool async)
+        {
+            var stream = new StringWriter();
+            var actual = await LogTest(
+                async, stream, b => b.LogTo(stream.WriteLine, LogLevel.Information, SimpleLoggerFormatOptions.LocalTime), 0);
+
+            AssertLog(
+                actual,
+                @"<Local Date> HH:mm:ss.fff 
+      Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory' with options: StoreName=SimpleLoggerTests ");
+        }
+
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Log_only_UTC_time(bool async)
+        {
+            var stream = new StringWriter();
+            var actual = await LogTest(
+                async, stream, b => b.LogTo(stream.WriteLine, LogLevel.Information, SimpleLoggerFormatOptions.UtcTime), 0, true);
+
+            AssertLog(
+                actual,
+                @"YYYY-MM-DDTHH:MM:SS.MMMMMMTZ 
+      Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory' with options: StoreName=SimpleLoggerTests ");
+        }
+
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Log_only_ID(bool async)
+        {
+            var stream = new StringWriter();
+            var actual = await LogTest(
+                async, stream, b => b.LogTo(stream.WriteLine, LogLevel.Information, SimpleLoggerFormatOptions.Id));
+
+            AssertLog(
+                actual,
+                @"CoreEventId.ContextInitialized[10403] 
+      Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory' with options: StoreName=SimpleLoggerTests ");
+        }
+
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Log_only_category(bool async)
+        {
+            var stream = new StringWriter();
+            var actual = await LogTest(
+                async, stream, b => b.LogTo(stream.WriteLine, LogLevel.Information, SimpleLoggerFormatOptions.Category));
+
+            AssertLog(
+                actual,
+                @"(Microsoft.EntityFrameworkCore.Infrastructure) 
+      Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory' with options: StoreName=SimpleLoggerTests ");
+        }
+
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Log_level_and_ID(bool async)
+        {
+            var stream = new StringWriter();
+            var actual = await LogTest(
+                async, stream, b => b.LogTo(
+                    stream.WriteLine, LogLevel.Information, SimpleLoggerFormatOptions.Id | SimpleLoggerFormatOptions.Level));
+
+            AssertLog(
+                actual,
+                @"info: CoreEventId.ContextInitialized[10403] 
+      Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory' with options: StoreName=SimpleLoggerTests ");
+        }
+
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Log_level_and_UTC(bool async)
+        {
+            var stream = new StringWriter();
+            var actual = await LogTest(
+                async, stream, b => b.LogTo(
+                    stream.WriteLine,
+                    LogLevel.Information,
+                    SimpleLoggerFormatOptions.UtcTime | SimpleLoggerFormatOptions.Level),
+                6, true);
+
+            AssertLog(
+                actual,
+                @"info: YYYY-MM-DDTHH:MM:SS.MMMMMMTZ 
+      Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory' with options: StoreName=SimpleLoggerTests ");
+        }
+
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Log_default_UTC(bool async)
+        {
+            var stream = new StringWriter();
+            var actual = await LogTest(
+                async, stream, b => b.LogTo(
+                    stream.WriteLine, LogLevel.Information, SimpleLoggerFormatOptions.DefaultWithUtcTime),6, true);
+
+            AssertLog(
+                actual,
+                @"info: YYYY-MM-DDTHH:MM:SS.MMMMMMTZ CoreEventId.ContextInitialized[10403] (Microsoft.EntityFrameworkCore.Infrastructure) 
+      Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory' with options: StoreName=SimpleLoggerTests ");
+        }
+
+        private static void AssertLog(string actual, params string[] lines)
+            => Assert.Equal(
+                string.Join(Environment.NewLine, lines) + Environment.NewLine,
+                actual,
+                ignoreLineEndingDifferences: true,
+                ignoreWhiteSpaceDifferences: true);
+
+        private static async Task<string> LogTest(
+            bool async,
+            TextWriter writer,
+            Func<DbContextOptionsBuilder<LoggingContext>, DbContextOptionsBuilder<LoggingContext>> configureLogging,
+            int dateAt = 6,
+            bool utc = false)
+        {
+            var options = configureLogging(
+                    new DbContextOptionsBuilder<LoggingContext>()
+                        .UseInMemoryDatabase("SimpleLoggerTests"))
+                .Options;
+
+            string productVersion;
+
+            using (var context = new LoggingContext(options))
+            {
+                Assert.Equal(0, async ? await context.SaveChangesAsync() : context.SaveChanges());
+
+                productVersion = context.Model.GetProductVersion();
+            }
+
+            var lines = writer.ToString()
+                .Replace(productVersion, "X.X.X-any")
+                .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+
+            var builder = new StringBuilder();
+            foreach (var line in lines)
+            {
+                var normalized = line;
+
+                if (!normalized.StartsWith("Init", StringComparison.Ordinal))
+                {
+                    if (normalized.Contains("20", StringComparison.Ordinal))
+                    {
+                        var end = (utc ? 28 : 23) + dateAt;
+                        normalized = normalized.Substring(0, dateAt)
+                            + (utc ? "YYYY-MM-DDTHH:MM:SS.MMMMMMTZ" : "<Local Date> HH:mm:ss.fff") + normalized.Substring(end);
+                    }
+                }
+
+                builder.AppendLine(normalized);
+            }
+
+            return builder.ToString();
+        }
+
+        private class LoggingContext : DbContext
+        {
+            public LoggingContext([NotNull] DbContextOptions options)
+                : base(options)
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #16200
Fixes #1199

Examples:

Log to the Console:

```C#
protected override void OnConfiguring(DbContextOptionsBuilder options)
    => options
	    .UseMyProvider("...")
            .LogTo(Console.WriteLine);
```

Log to the Console for a given level:

```C#
protected override void OnConfiguring(DbContextOptionsBuilder options)
    => options
	    .UseMyProvider("...")
            .LogTo(Console.WriteLine, LogLevel.Information));
```

Log to the Console for specific events:

```C#
protected override void OnConfiguring(DbContextOptionsBuilder options)
    => options
	    .UseMyProvider("...")
            .LogTo(Console.WriteLine, new[] { CoreEventId.ContextInitialized, CoreEventId.ContextDisposed }));
```

Log to the Console for specific categories:

```C#
protected override void OnConfiguring(DbContextOptionsBuilder options)
    => options
	    .UseMyProvider("...")
            .LogTo(Console.WriteLine, new[] { DbLoggerCategory.Infrastructure.Name, DbLoggerCategory.Update.Name }));
```

Log to the Console with custom filter:

```C#
protected override void OnConfiguring(DbContextOptionsBuilder options)
    => options
	    .UseMyProvider("...")
            .LogTo(Console.WriteLine, (e, l) => e == CoreEventId.SaveChangesCompleted)));
```

Log to the Console for events in specific categories and a given level formatted as a single line using UTC timestamps:

```C#
protected override void OnConfiguring(DbContextOptionsBuilder options)
    => options
	    .UseMyProvider("...")
            .LogTo(
                Console.WriteLine,
                new[] { DbLoggerCategory.Infrastructure.Name, DbLoggerCategory.Update.Name },
                LogLevel.Information,
                SimpleLoggerFormatOptions.SingleLine | SimpleLoggerFormatOptions.DefaultWithUtcTime ));
```
