### PR TITLE
Fix to #18916 - Query: regression in EFCore 3.1 Preview 2 and Preview3 for query with conditional expression whose element is a comparison containing null-value parameter

### DIFF
--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -7547,6 +7547,36 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Where(f => f.Capital == ss.Set<Gear>().OrderBy(s => s.Nickname).FirstOrDefault().CityOfBirth));
         }
 
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Conditional_expression_with_test_being_simplified_to_constant_simple(bool isAsync)
+        {
+            var prm = true;
+            var prm2 = (string)null;
+
+            return AssertQuery(
+                isAsync,
+                ss => ss.Set<Gear>().Where(g => g.HasSoulPatch == prm
+                    ? true
+                    : g.CityOfBirthName == prm2));
+        }
+
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Conditional_expression_with_test_being_simplified_to_constant_complex(bool isAsync)
+        {
+            var prm = true;
+            var prm2 = "Dom's Lancer";
+            var prm3 = (string)null;
+
+            return AssertQuery(
+                isAsync,
+                ss => ss.Set<Gear>().Where(g => g.HasSoulPatch == prm
+                    ? ss.Set<Weapon>().Where(w => w.Id == g.SquadId).Single().Name == prm2
+                    : g.CityOfBirthName == prm3));
+        }
+
         protected async Task AssertTranslationFailed(Func<Task> testCode)
         {
             Assert.Contains(

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -7504,6 +7504,52 @@ WHERE ([f].[Discriminator] = N'LocustHorde') AND (([c].[Name] = (
     ORDER BY [g].[Nickname]) IS NULL))");
         }
 
+        public override async Task Conditional_expression_with_test_being_simplified_to_constant_simple(bool isAsync)
+        {
+            await base.Conditional_expression_with_test_being_simplified_to_constant_simple(isAsync);
+
+            AssertSql(
+                @"@__prm_0='True'
+
+SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+FROM [Gears] AS [g]
+WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND (CASE
+    WHEN [g].[HasSoulPatch] = @__prm_0 THEN CAST(1 AS bit)
+    ELSE CASE
+        WHEN CAST(0 AS bit) = CAST(1 AS bit) THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END
+END = CAST(1 AS bit))");
+        }
+
+        public override async Task Conditional_expression_with_test_being_simplified_to_constant_complex(bool isAsync)
+        {
+            await base.Conditional_expression_with_test_being_simplified_to_constant_complex(isAsync);
+
+            AssertSql(
+                @"@__prm_0='True'
+@__prm2_1='Dom's Lancer' (Size = 4000)
+
+SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+FROM [Gears] AS [g]
+WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND (CASE
+    WHEN [g].[HasSoulPatch] = @__prm_0 THEN CASE
+        WHEN ((
+            SELECT TOP(1) [w].[Name]
+            FROM [Weapons] AS [w]
+            WHERE [w].[Id] = [g].[SquadId]) = @__prm2_1) AND (
+            SELECT TOP(1) [w].[Name]
+            FROM [Weapons] AS [w]
+            WHERE [w].[Id] = [g].[SquadId]) IS NOT NULL THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END
+    ELSE CASE
+        WHEN CAST(0 AS bit) = CAST(1 AS bit) THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END
+END = CAST(1 AS bit))");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }


### PR DESCRIPTION
Problem was that now we are peeking into parameter values and simplifying the queries. As a result comparisons of non-nullable expressions with null-value parameter are optimized out to a simple constant false. Sql server expects search condition in some places (e.g. WHERE, HAVING or WHEN parts of CASE statements).
Before we look into parameter values we run SearchConditionConvertingExpressionVisitor which fixes those cases. However, this visitor is currently sql server specific, and the part of the pipeline that looks into parameter values is not provider specific, so we can't re-run it.

Fix is to manually convert constants encountered in those areas into conditions. We used to do it already for WHERE and HAVING but we missed WHEN.

Resolves #18916