### PR TITLE
Fix to #18492 - Query: inject SearchConditionConvertingExpressionVisitor into ParameterValueBasedSelectExpressionOptimizer

### DIFF
--- a/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
+++ b/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
@@ -89,7 +89,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 { typeof(IRelationalTypeMappingSourcePlugin), new ServiceCharacteristics(ServiceLifetime.Singleton, multipleRegistrations: true) },
                 { typeof(IMethodCallTranslatorPlugin), new ServiceCharacteristics(ServiceLifetime.Singleton, multipleRegistrations: true) },
                 { typeof(IMemberTranslatorPlugin), new ServiceCharacteristics(ServiceLifetime.Singleton, multipleRegistrations: true) },
-
+                { typeof(IRelationalParameterBasedQueryTranslationPostprocessorFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) }
             };
 
         /// <summary>
@@ -166,6 +166,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             TryAdd<IRelationalSqlTranslatingExpressionVisitorFactory, RelationalSqlTranslatingExpressionVisitorFactory>();
             TryAdd<ISqlExpressionFactory, SqlExpressionFactory>();
             TryAdd<IQueryTranslationPreprocessorFactory, RelationalQueryTranslationPreprocessorFactory>();
+            TryAdd<IRelationalParameterBasedQueryTranslationPostprocessorFactory, RelationalParameterBasedQueryTranslationPostprocessorFactory>();
 
             ServiceCollectionMap.GetInfrastructure()
                 .AddDependencySingleton<RelationalSqlGenerationHelperDependencies>()
@@ -187,6 +188,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 .AddDependencySingleton<RelationalQueryTranslationPostprocessorDependencies>()
                 .AddDependencySingleton<RelationalEvaluatableExpressionFilterDependencies>()
                 .AddDependencySingleton<RelationalQueryTranslationPreprocessorDependencies>()
+                .AddDependencySingleton<RelationalParameterBasedQueryTranslationPostprocessorDependencies>()
                 .AddDependencyScoped<MigrationsSqlGeneratorDependencies>()
                 .AddDependencyScoped<RelationalConventionSetBuilderDependencies>()
                 .AddDependencyScoped<ModificationCommandBatchFactoryDependencies>()

--- a/src/EFCore.Relational/Query/IRelationalParameterBasedQueryTranslationPostprocessorFactory.cs
+++ b/src/EFCore.Relational/Query/IRelationalParameterBasedQueryTranslationPostprocessorFactory.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Query.Internal;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    /// <summary>
+    ///     <para>
+    ///         A factory for creating <see cref="RelationalParameterBasedQueryTranslationPostprocessor" /> instances.
+    ///     </para>
+    ///     <para>
+    ///         The service lifetime is <see cref="ServiceLifetime.Singleton" />. This means a single instance
+    ///         is used by many <see cref="DbContext" /> instances. The implementation must be thread-safe.
+    ///         This service cannot depend on services registered as <see cref="ServiceLifetime.Scoped" />.
+    ///     </para>
+    /// </summary>
+    public interface IRelationalParameterBasedQueryTranslationPostprocessorFactory
+    {
+        RelationalParameterBasedQueryTranslationPostprocessor Create(bool useRelationalNulls);
+    }
+}

--- a/src/EFCore.Relational/Query/Internal/RelationalParameterBasedQueryTranslationPostprocessorDependencies.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalParameterBasedQueryTranslationPostprocessorDependencies.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Utilities;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal
+{
+    /// <summary>
+    ///     <para>
+    ///         Service dependencies parameter class for <see cref="RelationalParameterBasedQueryTranslationPostprocessorFactory" />
+    ///     </para>
+    ///     <para>
+    ///         This type is typically used by database providers (and other extensions). It is generally
+    ///         not used in application code.
+    ///     </para>
+    ///     <para>
+    ///         Do not construct instances of this class directly from either provider or application code as the
+    ///         constructor signature may change as new dependencies are added. Instead, use this type in
+    ///         your constructor so that an instance will be created and injected automatically by the
+    ///         dependency injection container. To create an instance with some dependent services replaced,
+    ///         first resolve the object from the dependency injection container, then replace selected
+    ///         services using the 'With...' methods. Do not call the constructor at any point in this process.
+    ///     </para>
+    ///     <para>
+    ///         The service lifetime is <see cref="ServiceLifetime.Singleton" />. This means a single instance
+    ///         is used by many <see cref="DbContext" /> instances. The implementation must be thread-safe.
+    ///         This service cannot depend on services registered as <see cref="ServiceLifetime.Scoped" />.
+    ///     </para>
+    /// </summary>
+    public sealed class RelationalParameterBasedQueryTranslationPostprocessorDependencies
+    {
+        /// <summary>
+        ///     <para>
+        ///         Creates the service dependencies parameter object for a <see cref="RelationalParameterBasedQueryTranslationPostprocessorFactory" />.
+        ///     </para>
+        ///     <para>
+        ///         Do not call this constructor directly from either provider or application code as it may change
+        ///         as new dependencies are added. Instead, use this type in your constructor so that an instance
+        ///         will be created and injected automatically by the dependency injection container. To create
+        ///         an instance with some dependent services replaced, first resolve the object from the dependency
+        ///         injection container, then replace selected services using the 'With...' methods. Do not call
+        ///         the constructor at any point in this process.
+        ///     </para>
+        ///     <para>
+        ///         This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///         the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///         any release. You should only use it directly in your code with extreme caution and knowing that
+        ///         doing so can result in application failures when updating to a new Entity Framework Core release.
+        ///     </para>
+        /// </summary>
+        [EntityFrameworkInternal]
+        public RelationalParameterBasedQueryTranslationPostprocessorDependencies(
+            [NotNull] ISqlExpressionFactory sqlExpressionFactory,
+            [NotNull] IParameterNameGeneratorFactory parameterNameGeneratorFactory)
+        {
+            Check.NotNull(sqlExpressionFactory, nameof(sqlExpressionFactory));
+            Check.NotNull(parameterNameGeneratorFactory, nameof(parameterNameGeneratorFactory));
+
+            SqlExpressionFactory = sqlExpressionFactory;
+            ParameterNameGeneratorFactory = parameterNameGeneratorFactory;
+        }
+
+        /// <summary>
+        ///     Sql expression factory.
+        /// </summary>
+        public ISqlExpressionFactory SqlExpressionFactory { get; }
+
+        /// <summary>
+        ///     Parameter name generator factory.
+        /// </summary>
+        public IParameterNameGeneratorFactory ParameterNameGeneratorFactory { get; }
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="sqlExpressionFactory"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public RelationalParameterBasedQueryTranslationPostprocessorDependencies With(ISqlExpressionFactory sqlExpressionFactory)
+            => new RelationalParameterBasedQueryTranslationPostprocessorDependencies(sqlExpressionFactory, ParameterNameGeneratorFactory);
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="parameterNameGeneratorFactory"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public RelationalParameterBasedQueryTranslationPostprocessorDependencies With(IParameterNameGeneratorFactory parameterNameGeneratorFactory)
+            => new RelationalParameterBasedQueryTranslationPostprocessorDependencies(SqlExpressionFactory, parameterNameGeneratorFactory);
+    }
+}

--- a/src/EFCore.Relational/Query/Internal/RelationalParameterBasedQueryTranslationPostprocessorFactory.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalParameterBasedQueryTranslationPostprocessorFactory.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal
+{
+    public class RelationalParameterBasedQueryTranslationPostprocessorFactory : IRelationalParameterBasedQueryTranslationPostprocessorFactory
+    {
+        private readonly RelationalParameterBasedQueryTranslationPostprocessorDependencies _dependencies;
+
+        public RelationalParameterBasedQueryTranslationPostprocessorFactory(RelationalParameterBasedQueryTranslationPostprocessorDependencies dependencies)
+        {
+            _dependencies = dependencies;
+        }
+
+        public virtual RelationalParameterBasedQueryTranslationPostprocessor Create(bool useRelationalNulls)
+            => new RelationalParameterBasedQueryTranslationPostprocessor(_dependencies, useRelationalNulls);
+    }
+}

--- a/src/EFCore.Relational/Query/Internal/SqlExpressionOptimizingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/SqlExpressionOptimizingExpressionVisitor.cs
@@ -413,13 +413,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         {
             if (leftBoolConstant != null && rightBoolConstant != null)
             {
-                // potential optimization:
-                // we can't do it on SqlServer because it reverts search conditions back to values
-                // and we run this visitor after search condition visitor
-                //return operatorType == ExpressionType.Equal
-                //    ? SqlExpressionFactory.Constant((bool)leftBoolConstant.Value == (bool)rightBoolConstant.Value, typeMapping)
-                //    : SqlExpressionFactory.Constant((bool)leftBoolConstant.Value != (bool)rightBoolConstant.Value, typeMapping);
-                return SqlExpressionFactory.MakeBinary(operatorType, left, right, typeMapping);
+                return operatorType == ExpressionType.Equal
+                    ? SqlExpressionFactory.Constant((bool)leftBoolConstant.Value == (bool)rightBoolConstant.Value, typeMapping)
+                    : SqlExpressionFactory.Constant((bool)leftBoolConstant.Value != (bool)rightBoolConstant.Value, typeMapping);
             }
 
             if (rightBoolConstant != null

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.cs
@@ -75,8 +75,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             var relationalCommandCache = new RelationalCommandCache(
                 Dependencies.MemoryCache,
                 RelationalDependencies.SqlExpressionFactory,
-                RelationalDependencies.ParameterNameGeneratorFactory,
                 RelationalDependencies.QuerySqlGeneratorFactory,
+                RelationalDependencies.RelationalParameterBasedQueryTranslationPostprocessorFactory,
                 _useRelationalNulls,
                 selectExpression);
 

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitorDependencies.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitorDependencies.cs
@@ -57,15 +57,18 @@ namespace Microsoft.EntityFrameworkCore.Query
         public RelationalShapedQueryCompilingExpressionVisitorDependencies(
             [NotNull] IQuerySqlGeneratorFactory querySqlGeneratorFactory,
             [NotNull] ISqlExpressionFactory sqlExpressionFactory,
-            [NotNull] IParameterNameGeneratorFactory parameterNameGeneratorFactory)
+            [NotNull] IParameterNameGeneratorFactory parameterNameGeneratorFactory,
+            [NotNull] IRelationalParameterBasedQueryTranslationPostprocessorFactory relationalParameterBasedQueryTranslationPostprocessorFactory)
         {
             Check.NotNull(querySqlGeneratorFactory, nameof(querySqlGeneratorFactory));
             Check.NotNull(sqlExpressionFactory, nameof(sqlExpressionFactory));
             Check.NotNull(parameterNameGeneratorFactory, nameof(parameterNameGeneratorFactory));
+            Check.NotNull(relationalParameterBasedQueryTranslationPostprocessorFactory, nameof(relationalParameterBasedQueryTranslationPostprocessorFactory));
 
             QuerySqlGeneratorFactory = querySqlGeneratorFactory;
             SqlExpressionFactory = sqlExpressionFactory;
             ParameterNameGeneratorFactory = parameterNameGeneratorFactory;
+            RelationalParameterBasedQueryTranslationPostprocessorFactory = relationalParameterBasedQueryTranslationPostprocessorFactory;
         }
 
         /// <summary>
@@ -84,6 +87,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         public IParameterNameGeneratorFactory ParameterNameGeneratorFactory { get; }
 
         /// <summary>
+        ///     The query postprocessor based on parameter values.
+        /// </summary>
+        public IRelationalParameterBasedQueryTranslationPostprocessorFactory RelationalParameterBasedQueryTranslationPostprocessorFactory { get; }
+
+        /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
         /// </summary>
         /// <param name="querySqlGeneratorFactory"> A replacement for the current dependency of this type. </param>
@@ -93,7 +101,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             => new RelationalShapedQueryCompilingExpressionVisitorDependencies(
                 querySqlGeneratorFactory,
                 SqlExpressionFactory,
-                ParameterNameGeneratorFactory);
+                ParameterNameGeneratorFactory,
+                RelationalParameterBasedQueryTranslationPostprocessorFactory);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -104,7 +113,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             => new RelationalShapedQueryCompilingExpressionVisitorDependencies(
                 QuerySqlGeneratorFactory,
                 sqlExpressionFactory,
-                ParameterNameGeneratorFactory);
+                ParameterNameGeneratorFactory,
+                RelationalParameterBasedQueryTranslationPostprocessorFactory);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -116,6 +126,20 @@ namespace Microsoft.EntityFrameworkCore.Query
             => new RelationalShapedQueryCompilingExpressionVisitorDependencies(
                 QuerySqlGeneratorFactory,
                 SqlExpressionFactory,
-                parameterNameGeneratorFactory);
+                parameterNameGeneratorFactory,
+                RelationalParameterBasedQueryTranslationPostprocessorFactory);
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="relationalParameterBasedQueryTranslationPostprocessorFactory"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public RelationalShapedQueryCompilingExpressionVisitorDependencies With(
+            [NotNull] IRelationalParameterBasedQueryTranslationPostprocessorFactory relationalParameterBasedQueryTranslationPostprocessorFactory)
+            => new RelationalShapedQueryCompilingExpressionVisitorDependencies(
+                QuerySqlGeneratorFactory,
+                SqlExpressionFactory,
+                ParameterNameGeneratorFactory,
+                relationalParameterBasedQueryTranslationPostprocessorFactory);
     }
 }

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -1661,7 +1661,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             }
 
             if (!(Having == null && selectExpression.Having == null
-                || Having != null && Predicate.Equals(selectExpression.Having)))
+                || Having != null && Having.Equals(selectExpression.Having)))
             {
                 return false;
             }

--- a/src/EFCore.SqlServer/Extensions/SqlServerServiceCollectionExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerServiceCollectionExtensions.cs
@@ -76,6 +76,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .TryAdd<IQuerySqlGeneratorFactory, SqlServerQuerySqlGeneratorFactory>()
                 .TryAdd<IQueryTranslationPostprocessorFactory, SqlServerQueryTranslationPostprocessorFactory>()
                 .TryAdd<IRelationalSqlTranslatingExpressionVisitorFactory, SqlServerSqlTranslatingExpressionVisitorFactory>()
+                .TryAdd<IRelationalParameterBasedQueryTranslationPostprocessorFactory, SqlServerParameterBasedQueryTranslationPostprocessorFactory>()
                 .TryAddProviderSpecificServices(
                     b => b
                         .TryAddSingleton<ISqlServerValueGeneratorCache, SqlServerValueGeneratorCache>()

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerParameterBasedQueryTranslationPostprocessor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerParameterBasedQueryTranslationPostprocessor.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
+{
+    public class SqlServerParameterBasedQueryTranslationPostprocessor : RelationalParameterBasedQueryTranslationPostprocessor
+    {
+        public SqlServerParameterBasedQueryTranslationPostprocessor(
+            RelationalParameterBasedQueryTranslationPostprocessorDependencies dependencies,
+            bool useRelationalNulls)
+            : base(dependencies, useRelationalNulls)
+        {
+        }
+
+        public override (SelectExpression selectExpression, bool canCache) Optimize(
+            SelectExpression selectExpression,
+            IReadOnlyDictionary<string, object> parametersValues)
+        {
+            var (optimizedSelectExpression, canCache) = base.Optimize(selectExpression, parametersValues);
+
+            var searchConditionOptimized = (SelectExpression)new SearchConditionConvertingExpressionVisitor(Dependencies.SqlExpressionFactory)
+                .Visit(optimizedSelectExpression);
+
+            return (searchConditionOptimized, canCache);
+        }
+    }
+}

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerParameterBasedQueryTranslationPostprocessorFactory.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerParameterBasedQueryTranslationPostprocessorFactory.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
+{
+    public class SqlServerParameterBasedQueryTranslationPostprocessorFactory : IRelationalParameterBasedQueryTranslationPostprocessorFactory
+    {
+        private readonly RelationalParameterBasedQueryTranslationPostprocessorDependencies _dependencies;
+
+        public SqlServerParameterBasedQueryTranslationPostprocessorFactory(RelationalParameterBasedQueryTranslationPostprocessorDependencies dependencies)
+        {
+            _dependencies = dependencies;
+        }
+
+        public virtual RelationalParameterBasedQueryTranslationPostprocessor Create(bool useRelationalNulls)
+            => new SqlServerParameterBasedQueryTranslationPostprocessor(_dependencies, useRelationalNulls);
+    }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -2875,7 +2875,7 @@ OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY");
             AssertSql(
                 @"SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
 FROM [LevelOne] AS [l]
-INNER JOIN [LevelTwo] AS [l0] ON (([l].[OneToMany_Optional_Self_Inverse1Id] = [l0].[Level1_Optional_Id]) OR ([l].[OneToMany_Optional_Self_Inverse1Id] IS NULL AND [l0].[Level1_Optional_Id] IS NULL)) AND (CAST(1 AS bit) = CAST(1 AS bit))");
+INNER JOIN [LevelTwo] AS [l0] ON ([l].[OneToMany_Optional_Self_Inverse1Id] = [l0].[Level1_Optional_Id]) OR ([l].[OneToMany_Optional_Self_Inverse1Id] IS NULL AND [l0].[Level1_Optional_Id] IS NULL)");
         }
 
         public override async Task Join_condition_optimizations_applied_correctly_when_anonymous_type_with_multiple_properties(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
@@ -941,7 +941,7 @@ WHERE [c].[CustomerID] IN (N'ALFKI', N'ABC'')); GO; DROP TABLE Orders; GO; --') 
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE CAST(1 AS bit) = CAST(0 AS bit)");
+WHERE CAST(0 AS bit) = CAST(1 AS bit)");
         }
 
         public override async Task Contains_with_local_collection_empty_inline(bool async)
@@ -950,8 +950,7 @@ WHERE CAST(1 AS bit) = CAST(0 AS bit)");
 
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-WHERE CAST(1 AS bit) = CAST(1 AS bit)");
+FROM [Customers] AS [c]");
         }
 
         public override async Task Contains_top_level(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -1436,10 +1436,10 @@ WHERE ((SUBSTRING([e].[NullableStringA], 0 + 1, [e].[IntA]) <> [e].[NullableStri
             AssertSql(
                 @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC], [e0].[Id], [e0].[BoolA], [e0].[BoolB], [e0].[BoolC], [e0].[IntA], [e0].[IntB], [e0].[IntC], [e0].[NullableBoolA], [e0].[NullableBoolB], [e0].[NullableBoolC], [e0].[NullableIntA], [e0].[NullableIntB], [e0].[NullableIntC], [e0].[NullableStringA], [e0].[NullableStringB], [e0].[NullableStringC], [e0].[StringA], [e0].[StringB], [e0].[StringC]
 FROM [Entities1] AS [e]
-INNER JOIN [Entities2] AS [e0] ON ((([e].[NullableStringA] = [e0].[NullableStringB]) OR ([e].[NullableStringA] IS NULL AND [e0].[NullableStringB] IS NULL)) AND (CASE
+INNER JOIN [Entities2] AS [e0] ON (([e].[NullableStringA] = [e0].[NullableStringB]) OR ([e].[NullableStringA] IS NULL AND [e0].[NullableStringB] IS NULL)) AND (CASE
     WHEN (([e].[NullableStringB] <> [e].[NullableStringC]) OR ([e].[NullableStringB] IS NULL OR [e].[NullableStringC] IS NULL)) AND ([e].[NullableStringB] IS NOT NULL OR [e].[NullableStringC] IS NOT NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
-END = COALESCE([e0].[NullableBoolA], [e0].[BoolC]))) AND (CAST(1 AS bit) = CAST(1 AS bit))");
+END = COALESCE([e0].[NullableBoolA], [e0].[BoolC]))");
         }
 
         public override void Null_semantics_contains()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryFilterFuncletizationSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryFilterFuncletizationSqlServerTest.cs
@@ -86,7 +86,7 @@ WHERE [m].[Tenant] = @__ef_filter__p_0");
             AssertSql(
                 @"SELECT [l].[Id], [l].[Tenant]
 FROM [ListFilter] AS [l]
-WHERE CAST(1 AS bit) = CAST(0 AS bit)",
+WHERE CAST(0 AS bit) = CAST(1 AS bit)",
                 //
                 @"SELECT [l].[Id], [l].[Tenant]
 FROM [ListFilter] AS [l]


### PR DESCRIPTION
Using DI to create parameter value based postprocessor, which allows for provider-specific optimizations, including SearchConditionConvertingExpressionVisitor

Resolves #18492
Resolved #18940