### PR TITLE
Query: Don't expose ICurrentDbContext on QCCD

### DIFF
--- a/src/EFCore/Query/QueryCompilationContext.cs
+++ b/src/EFCore/Query/QueryCompilationContext.cs
@@ -32,14 +32,12 @@ namespace Microsoft.EntityFrameworkCore.Query
             QueryCompilationContextDependencies dependencies,
             bool async)
         {
-            var context = dependencies.CurrentContext.Context;
-
             IsAsync = async;
-            IsTracking = context.ChangeTracker.QueryTrackingBehavior == QueryTrackingBehavior.TrackAll;
+            IsTracking = dependencies.IsTracking;
             IsBuffering = dependencies.IsRetryingExecutionStrategy;
             Model = dependencies.Model;
             ContextOptions = dependencies.ContextOptions;
-            ContextType = context.GetType();
+            ContextType = dependencies.ContextType;
             Logger = dependencies.Logger;
 
             _queryTranslationPreprocessorFactory = dependencies.QueryTranslationPreprocessorFactory;

--- a/src/EFCore/Query/QueryCompilationContextDependencies.cs
+++ b/src/EFCore/Query/QueryCompilationContextDependencies.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -37,6 +38,7 @@ namespace Microsoft.EntityFrameworkCore.Query
     public sealed class QueryCompilationContextDependencies
     {
         private readonly IExecutionStrategyFactory _executionStrategyFactory;
+        private readonly ICurrentDbContext _currentContext;
 
         /// <summary>
         ///     <para>
@@ -79,7 +81,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Check.NotNull(contextOptions, nameof(contextOptions));
             Check.NotNull(logger, nameof(logger));
 
-            CurrentContext = currentContext;
+            _currentContext = currentContext;
             Model = model;
             QueryTranslationPreprocessorFactory = queryTranslationPreprocessorFactory;
             QueryableMethodTranslatingExpressionVisitorFactory = queryableMethodTranslatingExpressionVisitorFactory;
@@ -92,9 +94,14 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         /// <summary>
-        ///     The cache being used to store value generator instances.
+        ///     The CLR type of DbContext.
         /// </summary>
-        public ICurrentDbContext CurrentContext { get; }
+        public Type ContextType => _currentContext.Context.GetType();
+
+        /// <summary>
+        ///     The flag indicating if default query tracking behavior is tracking.
+        /// </summary>
+        public bool IsTracking => _currentContext.Context.ChangeTracker.QueryTrackingBehavior == QueryTrackingBehavior.TrackAll;
 
         /// <summary>
         ///     The model.
@@ -149,7 +156,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 QueryTranslationPostprocessorFactory,
                 ShapedQueryCompilingExpressionVisitorFactory,
                 _executionStrategyFactory,
-                CurrentContext,
+                _currentContext,
                 ContextOptions,
                 Logger);
 
@@ -166,7 +173,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 QueryTranslationPostprocessorFactory,
                 ShapedQueryCompilingExpressionVisitorFactory,
                 _executionStrategyFactory,
-                CurrentContext,
+                _currentContext,
                 ContextOptions,
                 Logger);
 
@@ -184,7 +191,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 QueryTranslationPostprocessorFactory,
                 ShapedQueryCompilingExpressionVisitorFactory,
                 _executionStrategyFactory,
-                CurrentContext,
+                _currentContext,
                 ContextOptions,
                 Logger);
 
@@ -202,7 +209,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 queryTranslationPostprocessorFactory,
                 ShapedQueryCompilingExpressionVisitorFactory,
                 _executionStrategyFactory,
-                CurrentContext,
+                _currentContext,
                 ContextOptions,
                 Logger);
 
@@ -220,7 +227,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 QueryTranslationPostprocessorFactory,
                 shapedQueryCompilingExpressionVisitorFactory,
                 _executionStrategyFactory,
-                CurrentContext,
+                _currentContext,
                 ContextOptions,
                 Logger);
 
@@ -237,7 +244,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 QueryTranslationPostprocessorFactory,
                 ShapedQueryCompilingExpressionVisitorFactory,
                 executionStrategyFactory,
-                CurrentContext,
+                _currentContext,
                 ContextOptions,
                 Logger);
 
@@ -271,7 +278,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 QueryTranslationPostprocessorFactory,
                 ShapedQueryCompilingExpressionVisitorFactory,
                 _executionStrategyFactory,
-                CurrentContext,
+                _currentContext,
                 contextOptions,
                 Logger);
 
@@ -288,7 +295,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 QueryTranslationPostprocessorFactory,
                 ShapedQueryCompilingExpressionVisitorFactory,
                 _executionStrategyFactory,
-                CurrentContext,
+                _currentContext,
                 ContextOptions,
                 logger);
     }

--- a/test/EFCore.Specification.Tests/TestUtilities/TestHelpers.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/TestHelpers.cs
@@ -55,9 +55,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 .First();
             var constructorParameters = constructor.GetParameters().Where(p => !obsoleteTypes.Contains(p.ParameterType)).ToList();
 
-            Assert.Equal(constructorParameters.Count, serviceProperties.Count);
-
-            foreach (var serviceType in constructorParameters.Where(p => !ignoreProperties.Contains(p.Name)).Select(p => p.ParameterType))
+            foreach (var serviceType in constructorParameters.Select(p => p.ParameterType))
             {
                 var withMethod = typeof(TDependencies).GetTypeInfo().DeclaredMethods
                     .Single(

--- a/test/EFCore.Tests/Query/QueryCompilationContextDependenciesTest.cs
+++ b/test/EFCore.Tests/Query/QueryCompilationContextDependenciesTest.cs
@@ -12,7 +12,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [ConditionalFact]
         public void Can_use_With_methods_to_clone_and_replace_service()
         {
-            InMemoryTestHelpers.Instance.TestDependenciesClone<QueryCompilationContextDependencies>();
+            InMemoryTestHelpers.Instance.TestDependenciesClone<QueryCompilationContextDependencies>(
+                nameof(QueryCompilationContextDependencies.IsTracking),
+                nameof(QueryCompilationContextDependencies.ContextType));
         }
     }
 }


### PR DESCRIPTION
Resolves #17845
