### PR TITLE
Re-introduction of GeneratePseudoFromClause for specific "empty" FROM clauses

### DIFF
--- a/src/EFCore.Relational/Query/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/QuerySqlGenerator.cs
@@ -157,6 +157,10 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 GenerateList(selectExpression.Tables, e => Visit(e), sql => sql.AppendLine());
             }
+            else
+            {
+                GeneratePseudoFromClause();
+            }
 
             if (selectExpression.Predicate != null)
             {
@@ -191,6 +195,14 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
 
             return selectExpression;
+        }
+
+        /// <summary>
+        ///     Generates a pseudo FROM clause. Required by some providers
+        ///     when a query has no actual FROM clause.
+        /// </summary>
+        protected virtual void GeneratePseudoFromClause()
+        {
         }
 
         protected override Expression VisitProjection(ProjectionExpression projectionExpression)


### PR DESCRIPTION
For #18926. 

It would really really really help [1] if this would be considered for merge 🙏 and before 3.1 ships 🤞. I don't see any breaking changes here, because in 3.0 this was non-existing and hence nobody could override, hence nothing is/was/will be broken.

[1]: It would help because copying `VisitSelect` and duplicating all the code is impractical because of some private methods usage and also makes no sense when simple plug in point can handle it.


