### PR TITLE
Checking for closed state to reduce exceptions

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
@@ -240,7 +240,7 @@ namespace Microsoft.Data.Sqlite
             {
                 try
                 {
-                    while (NextResult())
+                    while (!_closed && NextResult())
                     {
                         _record.Dispose();
                     }


### PR DESCRIPTION
<!--
Please check if the PR fulfills these requirements

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines.
      https://github.com/aspnet/AspNetCore/wiki/Engineering-guidelines

Review the guidelines for CONTRIBUTING.md for more details.
-->

While debugging an application I'm creating I noticed I get a lot of `InvalidOperationException` exceptions thrown and caught internally with the SqliteDataReader. Initially I tried to see if I was doing something incorrectly, but I don't think there is anything I could do differently.

Code that triggers the exception:
```cs
[Fact]
public void BasicTest()
{
    using (var dataContext = new DataContext(_dbContextOptions))
    {
        // throws here
        dataContext.Database.Migrate();
    }

    using (var dataContext = new DataContext(_dbContextOptions))
    {
        var modelObjects = dataContext.Set<ModelObject>();
        modelObjects.Add(new ModelObject
        {
            Value = "asdf"
        });

        // throws here
        dataContext.SaveChanges();
    }

    using (var dataContext = new DataContext(_dbContextOptions))
    {
        var modelObjects = dataContext.Set<ModelObject>();

        // throws here
        var array = modelObjects
            .Select(o => o.Value == "asdf")
            .ToArray();

        array.Should().HaveCount(1);
    }
}
```

The exception is thrown from here:
https://github.com/aspnet/EntityFrameworkCore/blob/f780a3aef9839131aef118cd73dda625e22fb980/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs#L129-L134

The attempt to prevent the exception contained in this pull request:
https://github.com/aspnet/EntityFrameworkCore/blob/a4de941cda2e7a3801124be6430f3a8f10507111/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs#L241-L250

I pushed a test project here: https://github.com/StanleyGoldman/EFCoreUnderstandingProblem
Branch demonstrating using this pull request stops the exception from occurring: https://github.com/StanleyGoldman/EFCoreUnderstandingProblem/tree/fix