### PR TITLE
Seal private nested classes to avoid unneeded virtual methods

### DIFF
--- a/benchmark/EF6.SqlServer.Benchmarks/Initialization/InitializationTests.cs
+++ b/benchmark/EF6.SqlServer.Benchmarks/Initialization/InitializationTests.cs
@@ -67,9 +67,9 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Initialization
             builder.Build(new SqlConnection(AdventureWorksFixture.ConnectionString));
         }
 
-        private class ColdStartEnabledTests : MarshalByRefObject
+        private sealed class ColdStartEnabledTests : MarshalByRefObject
         {
-            public virtual void CreateAndDisposeUnusedContext(int count)
+            public void CreateAndDisposeUnusedContext(int count)
             {
                 for (var i = 0; i < count; i++)
                 {
@@ -80,7 +80,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Initialization
                 }
             }
 
-            public virtual void InitializeAndQuery_AdventureWorks(int count)
+            public void InitializeAndQuery_AdventureWorks(int count)
             {
                 for (var i = 0; i < count; i++)
                 {
@@ -91,7 +91,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Initialization
                 }
             }
 
-            public virtual void InitializeAndSaveChanges_AdventureWorks(int count)
+            public void InitializeAndSaveChanges_AdventureWorks(int count)
             {
                 for (var i = 0; i < count; i++)
                 {

--- a/src/EFCore.Abstractions/Properties/AbstractionsStrings.Designer.cs
+++ b/src/EFCore.Abstractions/Properties/AbstractionsStrings.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     public static class AbstractionsStrings
     {
         private static readonly ResourceManager _resourceManager
-            = new ResourceManager("Microsoft.EntityFrameworkCore.Properties.AbstractionsStrings", typeof(AbstractionsStrings).GetTypeInfo().Assembly);
+            = new ResourceManager("Microsoft.EntityFrameworkCore.Properties.AbstractionsStrings", typeof(AbstractionsStrings).Assembly);
 
         /// <summary>
         ///     The string argument '{argumentName}' cannot be empty.

--- a/src/EFCore.Cosmos/Extensions/CosmosDatabaseFacadeExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosDatabaseFacadeExtensions.cs
@@ -57,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns> <c>true</c> if the Cosmos provider is being used. </returns>
         public static bool IsCosmos([NotNull] this DatabaseFacade database)
             => database.ProviderName.Equals(
-                typeof(CosmosOptionsExtension).GetTypeInfo().Assembly.GetName().Name,
+                typeof(CosmosOptionsExtension).Assembly.GetName().Name,
                 StringComparison.Ordinal);
     }
 }

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
     public static class CosmosStrings
     {
         private static readonly ResourceManager _resourceManager
-            = new ResourceManager("Microsoft.EntityFrameworkCore.Cosmos.Properties.CosmosStrings", typeof(CosmosStrings).GetTypeInfo().Assembly);
+            = new ResourceManager("Microsoft.EntityFrameworkCore.Cosmos.Properties.CosmosStrings", typeof(CosmosStrings).Assembly);
 
         /// <summary>
         ///     Cosmos-specific methods can only be used when the context is using the Cosmos provider.

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitor.cs
@@ -21,23 +21,23 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
 {
     public partial class CosmosShapedQueryCompilingExpressionVisitor
     {
-        private class CosmosProjectionBindingRemovingExpressionVisitor : ExpressionVisitor
+        private sealed class CosmosProjectionBindingRemovingExpressionVisitor : ExpressionVisitor
         {
             private static readonly MethodInfo _getItemMethodInfo
-                = typeof(JObject).GetTypeInfo().GetRuntimeProperties()
+                = typeof(JObject).GetRuntimeProperties()
                     .Single(pi => pi.Name == "Item" && pi.GetIndexParameters()[0].ParameterType == typeof(string))
                     .GetMethod;
 
             private static readonly PropertyInfo _jTokenTypePropertyInfo
-                = typeof(JToken).GetTypeInfo().GetRuntimeProperties()
+                = typeof(JToken).GetRuntimeProperties()
                     .Single(mi => mi.Name == nameof(JToken.Type));
 
             private static readonly MethodInfo _jTokenToObjectMethodInfo
-                = typeof(JToken).GetTypeInfo().GetRuntimeMethods()
+                = typeof(JToken).GetRuntimeMethods()
                     .Single(mi => mi.Name == nameof(JToken.ToObject) && mi.GetParameters().Length == 0);
 
             private static readonly MethodInfo _toObjectMethodInfo
-                = typeof(CosmosProjectionBindingRemovingExpressionVisitor).GetTypeInfo().GetRuntimeMethods()
+                = typeof(CosmosProjectionBindingRemovingExpressionVisitor).GetRuntimeMethods()
                     .Single(mi => mi.Name == nameof(SafeToObject));
 
             private static readonly MethodInfo _collectionAccessorAddMethodInfo

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.InExpressionValuesExpandingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.InExpressionValuesExpandingExpressionVisitor.cs
@@ -10,7 +10,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
 {
     public partial class CosmosShapedQueryCompilingExpressionVisitor
     {
-        private class InExpressionValuesExpandingExpressionVisitor : ExpressionVisitor
+        private sealed class InExpressionValuesExpandingExpressionVisitor : ExpressionVisitor
         {
             private readonly ISqlExpressionFactory _sqlExpressionFactory;
             private readonly IReadOnlyDictionary<string, object> _parametersValues;

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.JObjectInjectingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.JObjectInjectingExpressionVisitor.cs
@@ -10,7 +10,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
 {
     public partial class CosmosShapedQueryCompilingExpressionVisitor
     {
-        private class JObjectInjectingExpressionVisitor : ExpressionVisitor
+        private sealed class JObjectInjectingExpressionVisitor : ExpressionVisitor
         {
             private int _currentEntityIndex;
 

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
 {
     public partial class CosmosShapedQueryCompilingExpressionVisitor
     {
-        private class QueryingEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>
+        private sealed class QueryingEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>
         {
             private readonly CosmosQueryContext _cosmosQueryContext;
             private readonly ISqlExpressionFactory _sqlExpressionFactory;

--- a/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
@@ -74,7 +74,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
             return null;
         }
 
-        private class SqlTypeMappingVerifyingExpressionVisitor : ExpressionVisitor
+        private sealed class SqlTypeMappingVerifyingExpressionVisitor : ExpressionVisitor
         {
             protected override Expression VisitExtension(Expression node)
             {

--- a/src/EFCore.Cosmos/Storage/Internal/CosmosClientWrapper.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosClientWrapper.cs
@@ -452,7 +452,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
             return container.GetItemQueryStreamIterator(queryDefinition);
         }
 
-        private class DocumentEnumerable : IEnumerable<JObject>
+        private sealed class DocumentEnumerable : IEnumerable<JObject>
         {
             private readonly CosmosClientWrapper _cosmosClient;
             private readonly string _containerId;
@@ -472,7 +472,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
 
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-            private class Enumerator : IEnumerator<JObject>
+            private sealed class Enumerator : IEnumerator<JObject>
             {
                 private FeedIterator _query;
                 private ResponseMessage _responseMessage;
@@ -570,7 +570,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
             }
         }
 
-        private class DocumentAsyncEnumerable : IAsyncEnumerable<JObject>
+        private sealed class DocumentAsyncEnumerable : IAsyncEnumerable<JObject>
         {
             private readonly CosmosClientWrapper _cosmosClient;
             private readonly string _containerId;
@@ -589,7 +589,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
             public IAsyncEnumerator<JObject> GetAsyncEnumerator(CancellationToken cancellationToken = default)
                 => new AsyncEnumerator(this, cancellationToken);
 
-            private class AsyncEnumerator : IAsyncEnumerator<JObject>
+            private sealed class AsyncEnumerator : IAsyncEnumerator<JObject>
             {
                 private FeedIterator _query;
                 private ResponseMessage _responseMessage;

--- a/src/EFCore.Design/Design/Internal/DbContextOperations.cs
+++ b/src/EFCore.Design/Design/Internal/DbContextOperations.cs
@@ -152,13 +152,13 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             // Look for IDesignTimeDbContextFactory implementations
             _reporter.WriteVerbose(DesignStrings.FindingContextFactories);
             var contextFactories = _startupAssembly.GetConstructibleTypes()
-                .Where(t => typeof(IDesignTimeDbContextFactory<DbContext>).GetTypeInfo().IsAssignableFrom(t));
+                .Where(t => typeof(IDesignTimeDbContextFactory<DbContext>).IsAssignableFrom(t));
             foreach (var factory in contextFactories)
             {
                 _reporter.WriteVerbose(DesignStrings.FoundContextFactory(factory.ShortDisplayName()));
                 var manufacturedContexts =
                     from i in factory.ImplementedInterfaces
-                    where i.GetTypeInfo().IsGenericType
+                    where i.IsGenericType
                           && i.GetGenericTypeDefinition() == typeof(IDesignTimeDbContextFactory<>)
                     select i.GenericTypeArguments[0];
                 foreach (var context in manufacturedContexts)
@@ -188,10 +188,10 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             var types = _startupAssembly.GetConstructibleTypes()
                 .Concat(_assembly.GetConstructibleTypes())
                 .ToList();
-            var contextTypes = types.Where(t => typeof(DbContext).GetTypeInfo().IsAssignableFrom(t)).Select(
+            var contextTypes = types.Where(t => typeof(DbContext).IsAssignableFrom(t)).Select(
                     t => t.AsType())
                 .Concat(
-                    types.Where(t => typeof(Migration).GetTypeInfo().IsAssignableFrom(t))
+                    types.Where(t => typeof(Migration).IsAssignableFrom(t))
                         .Select(t => t.GetCustomAttribute<DbContextAttribute>()?.ContextType)
                         .Where(t => t != null))
                 .Distinct();
@@ -242,8 +242,8 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
 
         private Func<DbContext> FindContextFactory(Type contextType)
         {
-            var factoryInterface = typeof(IDesignTimeDbContextFactory<>).MakeGenericType(contextType).GetTypeInfo();
-            var factory = contextType.GetTypeInfo().Assembly.GetConstructibleTypes()
+            var factoryInterface = typeof(IDesignTimeDbContextFactory<>).MakeGenericType(contextType);
+            var factory = contextType.Assembly.GetConstructibleTypes()
                 .FirstOrDefault(t => factoryInterface.IsAssignableFrom(t));
             return factory == null ? (Func<DbContext>)null : (() => CreateContextFromFactory(factory.AsType()));
         }

--- a/src/EFCore.Design/Design/Internal/DesignTimeServicesBuilder.cs
+++ b/src/EFCore.Design/Design/Internal/DesignTimeServicesBuilder.cs
@@ -93,7 +93,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             _reporter.WriteVerbose(DesignStrings.FindingDesignTimeServices(_startupAssembly.GetName().Name));
 
             var designTimeServicesType = _startupAssembly.GetLoadableDefinedTypes()
-                .Where(t => typeof(IDesignTimeServices).GetTypeInfo().IsAssignableFrom(t)).Select(t => t.AsType())
+                .Where(t => typeof(IDesignTimeServices).IsAssignableFrom(t)).Select(t => t.AsType())
                 .FirstOrDefault();
             if (designTimeServicesType == null)
             {

--- a/src/EFCore.Design/Design/Internal/MigrationsOperations.cs
+++ b/src/EFCore.Design/Design/Internal/MigrationsOperations.cs
@@ -225,7 +225,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             var options = services.GetRequiredService<IDbContextOptions>();
             var contextType = services.GetRequiredService<ICurrentDbContext>().Context.GetType();
             var migrationsAssemblyName = RelationalOptionsExtension.Extract(options).MigrationsAssembly
-                                         ?? contextType.GetTypeInfo().Assembly.GetName().Name;
+                                         ?? contextType.Assembly.GetName().Name;
             if (assemblyName.Name != migrationsAssemblyName
                 && assemblyName.FullName != migrationsAssemblyName)
             {

--- a/src/EFCore.Design/Migrations/Internal/SnapshotModelProcessor.cs
+++ b/src/EFCore.Design/Migrations/Internal/SnapshotModelProcessor.cs
@@ -36,7 +36,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             _operationReporter = operationReporter;
             _relationalNames = new HashSet<string>(
                 typeof(RelationalAnnotationNames)
-                    .GetTypeInfo()
                     .GetRuntimeFields()
                     .Where(p => p.Name != nameof(RelationalAnnotationNames.Prefix))
                     .Select(p => ((string)p.GetValue(null)).Substring(RelationalAnnotationNames.Prefix.Length - 1)));

--- a/src/EFCore.Design/Properties/DesignStrings.Designer.cs
+++ b/src/EFCore.Design/Properties/DesignStrings.Designer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
     public static class DesignStrings
     {
         private static readonly ResourceManager _resourceManager
-            = new ResourceManager("Microsoft.EntityFrameworkCore.Properties.DesignStrings", typeof(DesignStrings).GetTypeInfo().Assembly);
+            = new ResourceManager("Microsoft.EntityFrameworkCore.Properties.DesignStrings", typeof(DesignStrings).Assembly);
 
         /// <summary>
         ///     The name '{migrationName}' is used by an existing migration.

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
@@ -375,7 +375,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             }
         }
 
-        private class AttributeWriter
+        private sealed class AttributeWriter
         {
             private readonly string _attributeName;
             private readonly List<string> _parameters = new List<string>();

--- a/src/EFCore.InMemory/Extensions/InMemoryDatabaseFacadeExtensions.cs
+++ b/src/EFCore.InMemory/Extensions/InMemoryDatabaseFacadeExtensions.cs
@@ -30,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns> <c>true</c> if the in-memory database is being used. </returns>
         public static bool IsInMemory([NotNull] this DatabaseFacade database)
             => database.ProviderName.Equals(
-                typeof(InMemoryOptionsExtension).GetTypeInfo().Assembly.GetName().Name,
+                typeof(InMemoryOptionsExtension).Assembly.GetName().Name,
                 StringComparison.Ordinal);
     }
 }

--- a/src/EFCore.InMemory/Properties/InMemoryStrings.Designer.cs
+++ b/src/EFCore.InMemory/Properties/InMemoryStrings.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Internal
     public static class InMemoryStrings
     {
         private static readonly ResourceManager _resourceManager
-            = new ResourceManager("Microsoft.EntityFrameworkCore.InMemory.Properties.InMemoryStrings", typeof(InMemoryStrings).GetTypeInfo().Assembly);
+            = new ResourceManager("Microsoft.EntityFrameworkCore.InMemory.Properties.InMemoryStrings", typeof(InMemoryStrings).Assembly);
 
         /// <summary>
         ///     Attempted to update or delete an entity that does not exist in the store.
@@ -67,7 +67,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Internal
     public static class InMemoryResources
     {
         private static readonly ResourceManager _resourceManager
-            = new ResourceManager("Microsoft.EntityFrameworkCore.InMemory.Properties.InMemoryStrings", typeof(InMemoryResources).GetTypeInfo().Assembly);
+            = new ResourceManager("Microsoft.EntityFrameworkCore.InMemory.Properties.InMemoryStrings", typeof(InMemoryResources).Assembly);
 
         /// <summary>
         ///     Saved {count} entities to in-memory store.

--- a/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
             _entityProjectionFindingExpressionVisitor = new EntityProjectionFindingExpressionVisitor();
         }
 
-        private class EntityProjectionFindingExpressionVisitor : ExpressionVisitor
+        private sealed class EntityProjectionFindingExpressionVisitor : ExpressionVisitor
         {
             private bool _found;
 

--- a/src/EFCore.InMemory/Query/Internal/InMemoryQueryExpression.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryQueryExpression.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
             = typeof(ValueBuffer).GetConstructors().Single(ci => ci.GetParameters().Length == 1);
 
         private static readonly PropertyInfo _valueBufferCountMemberInfo
-            = typeof(ValueBuffer).GetTypeInfo().GetProperty(nameof(ValueBuffer.Count));
+            = typeof(ValueBuffer).GetProperty(nameof(ValueBuffer.Count));
 
         private readonly List<Expression> _valueBufferSlots = new List<Expression>();
 
@@ -157,7 +157,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
             return AddToProjection(serverQueryExpression);
         }
 
-        private class ShaperRemappingExpressionVisitor : ExpressionVisitor
+        private sealed class ShaperRemappingExpressionVisitor : ExpressionVisitor
         {
             private readonly IDictionary<ProjectionMember, Expression> _projectionMapping;
 
@@ -941,7 +941,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
             }
         }
 
-        private class NullableReadValueExpressionVisitor : ExpressionVisitor
+        private sealed class NullableReadValueExpressionVisitor : ExpressionVisitor
         {
             protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
             {

--- a/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
@@ -629,7 +629,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
             return null;
         }
 
-        private class DefaultIfEmptyFindingExpressionVisitor : ExpressionVisitor
+        private sealed class DefaultIfEmptyFindingExpressionVisitor : ExpressionVisitor
         {
             private bool _defaultIfEmpty;
 
@@ -801,7 +801,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
         internal Expression ExpandWeakEntities(InMemoryQueryExpression queryExpression, Expression lambdaBody)
             => _weakEntityExpandingExpressionVisitor.Expand(queryExpression, lambdaBody);
 
-        private class WeakEntityExpandingExpressionVisitor : ExpressionVisitor
+        private sealed class WeakEntityExpandingExpressionVisitor : ExpressionVisitor
         {
             private InMemoryQueryExpression _queryExpression;
             private readonly InMemoryExpressionTranslatingExpressionVisitor _expressionTranslator;
@@ -811,7 +811,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                 _expressionTranslator = expressionTranslator;
             }
 
-            public virtual Expression Expand(InMemoryQueryExpression queryExpression, Expression lambdaBody)
+            public Expression Expand(InMemoryQueryExpression queryExpression, Expression lambdaBody)
             {
                 _queryExpression = queryExpression;
 

--- a/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.CustomShaperCompilingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.CustomShaperCompilingExpressionVisitor.cs
@@ -15,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
 {
     public partial class InMemoryShapedQueryCompilingExpressionVisitor
     {
-        private class CustomShaperCompilingExpressionVisitor : ExpressionVisitor
+        private sealed class CustomShaperCompilingExpressionVisitor : ExpressionVisitor
         {
             private readonly bool _tracking;
 

--- a/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.InMemoryProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.InMemoryProjectionBindingRemovingExpressionVisitor.cs
@@ -13,7 +13,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
 {
     public partial class InMemoryShapedQueryCompilingExpressionVisitor
     {
-        private class InMemoryProjectionBindingRemovingExpressionVisitor : ExpressionVisitor
+        private sealed class InMemoryProjectionBindingRemovingExpressionVisitor : ExpressionVisitor
         {
             private readonly IDictionary<ParameterExpression, (IDictionary<IProperty, int> IndexMap, ParameterExpression valueBuffer)>
                 _materializationContextBindings

--- a/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
@@ -15,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
 {
     public partial class InMemoryShapedQueryCompilingExpressionVisitor
     {
-        private class QueryingEnumerable<T> : IAsyncEnumerable<T>, IEnumerable<T>
+        private sealed class QueryingEnumerable<T> : IAsyncEnumerable<T>, IEnumerable<T>
         {
             private readonly QueryContext _queryContext;
             private readonly IEnumerable<ValueBuffer> _innerEnumerable;

--- a/src/EFCore.Proxies/Properties/ProxiesStrings.Designer.cs
+++ b/src/EFCore.Proxies/Properties/ProxiesStrings.Designer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
     public static class ProxiesStrings
     {
         private static readonly ResourceManager _resourceManager
-            = new ResourceManager("Microsoft.EntityFrameworkCore.Properties.ProxiesStrings", typeof(ProxiesStrings).GetTypeInfo().Assembly);
+            = new ResourceManager("Microsoft.EntityFrameworkCore.Properties.ProxiesStrings", typeof(ProxiesStrings).Assembly);
 
         /// <summary>
         ///     UseLazyLoadingProxies requires AddEntityFrameworkProxies to be called on the internal service provider used.

--- a/src/EFCore.Relational/Metadata/Internal/Sequence.cs
+++ b/src/EFCore.Relational/Metadata/Internal/Sequence.cs
@@ -520,7 +520,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         void IConventionSequence.SetIsCyclic(bool? cyclic, bool fromDataAnnotation)
             => SetIsCyclic(cyclic, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
-        private class SequenceData
+        private sealed class SequenceData
         {
             public string Name { get; set; }
 

--- a/src/EFCore.Relational/Migrations/Internal/MigrationExtensions.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationExtensions.cs
@@ -21,6 +21,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public static string GetId([NotNull] this Migration migration)
-            => migration.GetType().GetTypeInfo().GetCustomAttribute<MigrationAttribute>()?.Id;
+            => migration.GetType().GetCustomAttribute<MigrationAttribute>()?.Id;
     }
 }

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsAssembly.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsAssembly.cs
@@ -56,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
 
             var assemblyName = RelationalOptionsExtension.Extract(options)?.MigrationsAssembly;
             Assembly = assemblyName == null
-                ? _contextType.GetTypeInfo().Assembly
+                ? _contextType.Assembly
                 : Assembly.Load(new AssemblyName(assemblyName));
 
             _idGenerator = idGenerator;

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -799,7 +799,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 .Concat(entityType.GetDirectlyDerivedTypes().SelectMany(GetSortedProperties));
         }
 
-        private class PropertyInfoEqualityComparer : IEqualityComparer<PropertyInfo>
+        private sealed class PropertyInfoEqualityComparer : IEqualityComparer<PropertyInfo>
         {
             private PropertyInfoEqualityComparer()
             {
@@ -2236,7 +2236,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             return result;
         }
 
-        private class EntryMapping
+        private sealed class EntryMapping
         {
             public HashSet<IUpdateEntry> SourceEntries { get; } = new HashSet<IUpdateEntry>();
             public HashSet<IUpdateEntry> TargetEntries { get; } = new HashSet<IUpdateEntry>();

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     public static class RelationalStrings
     {
         private static readonly ResourceManager _resourceManager
-            = new ResourceManager("Microsoft.EntityFrameworkCore.Properties.RelationalStrings", typeof(RelationalStrings).GetTypeInfo().Assembly);
+            = new ResourceManager("Microsoft.EntityFrameworkCore.Properties.RelationalStrings", typeof(RelationalStrings).Assembly);
 
         /// <summary>
         ///     Cannot save changes for an entity in state '{entityState}'.
@@ -610,7 +610,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
     public static class RelationalResources
     {
         private static readonly ResourceManager _resourceManager
-            = new ResourceManager("Microsoft.EntityFrameworkCore.Properties.RelationalStrings", typeof(RelationalResources).GetTypeInfo().Assembly);
+            = new ResourceManager("Microsoft.EntityFrameworkCore.Properties.RelationalStrings", typeof(RelationalResources).Assembly);
 
         /// <summary>
         ///     The 'bool' property '{property}' on entity type '{entityType}' is configured with a database-generated default. This default will always be used for inserts when the property has the value 'false', since this is the CLR default for the 'bool' type. Consider using the nullable 'bool?' type instead so that the default will only be used for inserts when the property value is 'null'.

--- a/src/EFCore.Relational/Query/Internal/BufferedDataReader.cs
+++ b/src/EFCore.Relational/Query/Internal/BufferedDataReader.cs
@@ -378,7 +378,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             return _currentResultSet.ReadAsync(cancellationToken);
         }
 
-        private class BufferedDataRecord
+        private sealed class BufferedDataRecord
         {
             private int _currentRowNumber = -1;
             private int _rowCount;

--- a/src/EFCore.Relational/Query/RelationalParameterBasedQueryTranslationPostprocessor.cs
+++ b/src/EFCore.Relational/Query/RelationalParameterBasedQueryTranslationPostprocessor.cs
@@ -63,7 +63,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return (selectExpression: (SelectExpression)fromSqlParameterOptimized, canCache);
         }
 
-        private class ParameterNullabilityBasedSqlExpressionOptimizingExpressionVisitor : SqlExpressionOptimizingExpressionVisitor
+        private sealed class ParameterNullabilityBasedSqlExpressionOptimizingExpressionVisitor : SqlExpressionOptimizingExpressionVisitor
         {
             private readonly IReadOnlyDictionary<string, object> _parametersValues;
 
@@ -125,7 +125,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        private class InExpressionValuesExpandingExpressionVisitor : ExpressionVisitor
+        private sealed class InExpressionValuesExpandingExpressionVisitor : ExpressionVisitor
         {
             private readonly ISqlExpressionFactory _sqlExpressionFactory;
             private readonly IReadOnlyDictionary<string, object> _parametersValues;
@@ -220,7 +220,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        private class FromSqlParameterApplyingExpressionVisitor : ExpressionVisitor
+        private sealed class FromSqlParameterApplyingExpressionVisitor : ExpressionVisitor
         {
             private readonly IDictionary<FromSqlExpression, Expression> _visitedFromSqlExpressions
                 = new Dictionary<FromSqlExpression, Expression>(ReferenceEqualityComparer.Instance);

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -790,7 +790,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return null;
         }
 
-        private class CorrelationFindingExpressionVisitor : ExpressionVisitor
+        private sealed class CorrelationFindingExpressionVisitor : ExpressionVisitor
         {
             private ParameterExpression _outerParameter;
             private bool _correlated;
@@ -962,7 +962,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         internal Expression ExpandWeakEntities(SelectExpression selectExpression, Expression lambdaBody)
             => _weakEntityExpandingExpressionVisitor.Expand(selectExpression, lambdaBody);
 
-        private class WeakEntityExpandingExpressionVisitor : ExpressionVisitor
+        private sealed class WeakEntityExpandingExpressionVisitor : ExpressionVisitor
         {
             private SelectExpression _selectExpression;
             private readonly RelationalSqlTranslatingExpressionVisitor _sqlTranslator;
@@ -976,7 +976,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 _sqlExpressionFactory = sqlExpressionFactory;
             }
 
-            public virtual Expression Expand(SelectExpression selectExpression, Expression lambdaBody)
+            public Expression Expand(SelectExpression selectExpression, Expression lambdaBody)
             {
                 _selectExpression = selectExpression;
 

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.CustomShaperCompilingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.CustomShaperCompilingExpressionVisitor.cs
@@ -17,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 {
     public partial class RelationalShapedQueryCompilingExpressionVisitor
     {
-        private class CustomShaperCompilingExpressionVisitor : ExpressionVisitor
+        private sealed class CustomShaperCompilingExpressionVisitor : ExpressionVisitor
         {
             private readonly ParameterExpression _dbDataReaderParameter;
             private readonly ParameterExpression _resultCoordinatorParameter;

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.RelationalProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.RelationalProjectionBindingRemovingExpressionVisitor.cs
@@ -17,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 {
     public partial class RelationalShapedQueryCompilingExpressionVisitor
     {
-        private class RelationalProjectionBindingRemovingExpressionVisitor : ExpressionVisitor
+        private sealed class RelationalProjectionBindingRemovingExpressionVisitor : ExpressionVisitor
         {
             private static readonly MethodInfo _isDbNullMethod =
                 typeof(DbDataReader).GetRuntimeMethod(nameof(DbDataReader.IsDBNull), new[] { typeof(int) });
@@ -46,7 +46,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             private ReaderColumn[] ProjectionColumns { get; }
 
-            public virtual Expression Visit(Expression node, out IReadOnlyList<ReaderColumn> projectionColumns)
+            public Expression Visit(Expression node, out IReadOnlyList<ReaderColumn> projectionColumns)
             {
                 var result = Visit(node);
                 projectionColumns = ProjectionColumns;

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperExpressionProcessingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperExpressionProcessingExpressionVisitor.cs
@@ -11,13 +11,13 @@ namespace Microsoft.EntityFrameworkCore.Query
 {
     public partial class RelationalShapedQueryCompilingExpressionVisitor
     {
-        private class ShaperExpressionProcessingExpressionVisitor : ExpressionVisitor
+        private sealed class ShaperExpressionProcessingExpressionVisitor : ExpressionVisitor
         {
             private static readonly MemberInfo _resultContextValuesMemberInfo
-                = typeof(ResultContext).GetTypeInfo().GetMember(nameof(ResultContext.Values))[0];
+                = typeof(ResultContext).GetMember(nameof(ResultContext.Values))[0];
 
             private static readonly MemberInfo _resultCoordinatorResultReadyMemberInfo
-                = typeof(ResultCoordinator).GetTypeInfo().GetMember(nameof(ResultCoordinator.ResultReady))[0];
+                = typeof(ResultCoordinator).GetMember(nameof(ResultCoordinator.ResultReady))[0];
 
             private readonly SelectExpression _selectExpression;
             private readonly ParameterExpression _dataReaderParameter;
@@ -54,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 _indexMapParameter = indexMapParameter;
             }
 
-            private class CollectionShaperFindingExpressionVisitor : ExpressionVisitor
+            private sealed class CollectionShaperFindingExpressionVisitor : ExpressionVisitor
             {
                 private bool _containsCollection;
 

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -168,7 +168,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     "SUM", new[] { sqlExpression }, inputType, sqlExpression.TypeMapping);
         }
 
-        private class SqlTypeMappingVerifyingExpressionVisitor : ExpressionVisitor
+        private sealed class SqlTypeMappingVerifyingExpressionVisitor : ExpressionVisitor
         {
             protected override Expression VisitExtension(Expression node)
             {

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -957,7 +957,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                 updatedExpressions);
         }
 
-        private class ShaperRemappingExpressionVisitor : ExpressionVisitor
+        private sealed class ShaperRemappingExpressionVisitor : ExpressionVisitor
         {
             private readonly SelectExpression _queryExpression;
             private readonly SelectExpression _innerSelectExpression;
@@ -1151,7 +1151,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         private bool ContainsTableReference(TableExpressionBase table)
             => Tables.Any(te => ReferenceEquals(te is JoinExpressionBase jeb ? jeb.Table : te, table));
 
-        private class SelectExpressionCorrelationFindingExpressionVisitor : ExpressionVisitor
+        private sealed class SelectExpressionCorrelationFindingExpressionVisitor : ExpressionVisitor
         {
             private readonly IReadOnlyList<TableExpressionBase> _tables;
             private bool _containsOuterReference;
@@ -1365,7 +1365,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         public void AddOuterApply(SelectExpression innerSelectExpression, Type transparentIdentifierType)
             => AddJoin(JoinType.OuterApply, innerSelectExpression, transparentIdentifierType);
 
-        private class SqlRemappingVisitor : ExpressionVisitor
+        private sealed class SqlRemappingVisitor : ExpressionVisitor
         {
             private readonly SelectExpression _subquery;
             private readonly IDictionary<SqlExpression, ColumnExpression> _mappings;

--- a/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
@@ -222,7 +222,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         public static readonly RelationalTypeMapping NullMapping = new NullTypeMapping("NULL");
 
-        private class NullTypeMapping : RelationalTypeMapping
+        private sealed class NullTypeMapping : RelationalTypeMapping
         {
             public NullTypeMapping(string storeType)
                 : base(storeType, typeof(object))

--- a/src/EFCore.Relational/Storage/TypedRelationalValueBufferFactoryFactory.cs
+++ b/src/EFCore.Relational/Storage/TypedRelationalValueBufferFactoryFactory.cs
@@ -250,7 +250,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 valueExpression = Expression.TryCatch(valueExpression, catchBlock);
             }
 
-            if (box && valueExpression.Type.GetTypeInfo().IsValueType)
+            if (box && valueExpression.Type.IsValueType)
             {
                 valueExpression = Expression.Convert(valueExpression, typeof(object));
             }

--- a/src/EFCore.Relational/Update/Internal/SharedTableEntryMap.cs
+++ b/src/EFCore.Relational/Update/Internal/SharedTableEntryMap.cs
@@ -249,7 +249,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
             }
         }
 
-        private class EntryComparer : IComparer<IUpdateEntry>
+        private sealed class EntryComparer : IComparer<IUpdateEntry>
         {
             private readonly IReadOnlyDictionary<IEntityType, IReadOnlyList<IEntityType>> _principals;
 

--- a/src/EFCore.Relational/Update/ModificationCommand.cs
+++ b/src/EFCore.Relational/Update/ModificationCommand.cs
@@ -353,7 +353,7 @@ namespace Microsoft.EntityFrameworkCore.Update
             }
         }
 
-        private class ColumnValuePropagator
+        private sealed class ColumnValuePropagator
         {
             private bool _write;
             private object _originalValue;

--- a/src/EFCore.SqlServer.NTS/Properties/SqlServerNTSStrings.Designer.cs
+++ b/src/EFCore.SqlServer.NTS/Properties/SqlServerNTSStrings.Designer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
     public static class SqlServerNTSStrings
     {
         private static readonly ResourceManager _resourceManager
-            = new ResourceManager("Microsoft.EntityFrameworkCore.SqlServer.Properties.SqlServerNTSStrings", typeof(SqlServerNTSStrings).GetTypeInfo().Assembly);
+            = new ResourceManager("Microsoft.EntityFrameworkCore.SqlServer.Properties.SqlServerNTSStrings", typeof(SqlServerNTSStrings).Assembly);
 
         /// <summary>
         ///     UseNetTopologySuite requires AddEntityFrameworkSqlServerNetTopologySuite to be called on the internal service provider used.

--- a/src/EFCore.SqlServer/Extensions/SqlServerDatabaseFacadeExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerDatabaseFacadeExtensions.cs
@@ -30,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns> True if SQL Server is being used; false otherwise. </returns>
         public static bool IsSqlServer([NotNull] this DatabaseFacade database)
             => database.ProviderName.Equals(
-                typeof(SqlServerOptionsExtension).GetTypeInfo().Assembly.GetName().Name,
+                typeof(SqlServerOptionsExtension).Assembly.GetName().Name,
                 StringComparison.Ordinal);
     }
 }

--- a/src/EFCore.SqlServer/Extensions/SqlServerMigrationBuilderExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerMigrationBuilderExtensions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         public static bool IsSqlServer([NotNull] this MigrationBuilder migrationBuilder)
             => string.Equals(
                 migrationBuilder.ActiveProvider,
-                typeof(SqlServerOptionsExtension).GetTypeInfo().Assembly.GetName().Name,
+                typeof(SqlServerOptionsExtension).Assembly.GetName().Name,
                 StringComparison.Ordinal);
     }
 }

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
     public static class SqlServerStrings
     {
         private static readonly ResourceManager _resourceManager
-            = new ResourceManager("Microsoft.EntityFrameworkCore.SqlServer.Properties.SqlServerStrings", typeof(SqlServerStrings).GetTypeInfo().Assembly);
+            = new ResourceManager("Microsoft.EntityFrameworkCore.SqlServer.Properties.SqlServerStrings", typeof(SqlServerStrings).Assembly);
 
         /// <summary>
         ///     Identity value generation cannot be used for the property '{property}' on entity type '{entityType}' because the property type is '{propertyType}'. Identity value generation can only be used with signed integer properties.
@@ -193,7 +193,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
     public static class SqlServerResources
     {
         private static readonly ResourceManager _resourceManager
-            = new ResourceManager("Microsoft.EntityFrameworkCore.SqlServer.Properties.SqlServerStrings", typeof(SqlServerResources).GetTypeInfo().Assembly);
+            = new ResourceManager("Microsoft.EntityFrameworkCore.SqlServer.Properties.SqlServerStrings", typeof(SqlServerResources).Assembly);
 
         /// <summary>
         ///     No type was specified for the decimal column '{property}' on entity type '{entityType}'. This will cause values to be silently truncated if they do not fit in the default precision and scale. Explicitly specify the SQL server column type that can accommodate all the values using 'HasColumnType()'.

--- a/src/EFCore.Sqlite.Core/Extensions/SqliteDatabaseFacadeExtensions.cs
+++ b/src/EFCore.Sqlite.Core/Extensions/SqliteDatabaseFacadeExtensions.cs
@@ -30,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns> True if SQLite is being used; false otherwise. </returns>
         public static bool IsSqlite([NotNull] this DatabaseFacade database)
             => database.ProviderName.Equals(
-                typeof(SqliteOptionsExtension).GetTypeInfo().Assembly.GetName().Name,
+                typeof(SqliteOptionsExtension).Assembly.GetName().Name,
                 StringComparison.Ordinal);
     }
 }

--- a/src/EFCore.Sqlite.Core/Extensions/SqliteMigrationBuilderExtensions.cs
+++ b/src/EFCore.Sqlite.Core/Extensions/SqliteMigrationBuilderExtensions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         public static bool IsSqlite([NotNull] this MigrationBuilder migrationBuilder)
             => string.Equals(
                 migrationBuilder.ActiveProvider,
-                typeof(SqliteOptionsExtension).GetTypeInfo().Assembly.GetName().Name,
+                typeof(SqliteOptionsExtension).Assembly.GetName().Name,
                 StringComparison.Ordinal);
     }
 }

--- a/src/EFCore.Sqlite.Core/Properties/SqliteStrings.Designer.cs
+++ b/src/EFCore.Sqlite.Core/Properties/SqliteStrings.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
     public static class SqliteStrings
     {
         private static readonly ResourceManager _resourceManager
-            = new ResourceManager("Microsoft.EntityFrameworkCore.Sqlite.Properties.SqliteStrings", typeof(SqliteStrings).GetTypeInfo().Assembly);
+            = new ResourceManager("Microsoft.EntityFrameworkCore.Sqlite.Properties.SqliteStrings", typeof(SqliteStrings).Assembly);
 
         /// <summary>
         ///     SQLite does not support this migration operation ('{operation}'). For more information, see http://go.microsoft.com/fwlink/?LinkId=723262.
@@ -79,7 +79,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
     public static class SqliteResources
     {
         private static readonly ResourceManager _resourceManager
-            = new ResourceManager("Microsoft.EntityFrameworkCore.Sqlite.Properties.SqliteStrings", typeof(SqliteResources).GetTypeInfo().Assembly);
+            = new ResourceManager("Microsoft.EntityFrameworkCore.Sqlite.Properties.SqliteStrings", typeof(SqliteResources).Assembly);
 
         /// <summary>
         ///     The entity type '{entityType}' is configured to use schema '{schema}'. SQLite does not support schemas. This configuration will be ignored by the SQLite provider.

--- a/src/EFCore.Sqlite.NTS/Properties/SqliteNTSStrings.Designer.cs
+++ b/src/EFCore.Sqlite.NTS/Properties/SqliteNTSStrings.Designer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
     public static class SqliteNTSStrings
     {
         private static readonly ResourceManager _resourceManager
-            = new ResourceManager("Microsoft.EntityFrameworkCore.Sqlite.Properties.SqliteNTSStrings", typeof(SqliteNTSStrings).GetTypeInfo().Assembly);
+            = new ResourceManager("Microsoft.EntityFrameworkCore.Sqlite.Properties.SqliteNTSStrings", typeof(SqliteNTSStrings).Assembly);
 
         /// <summary>
         ///     UseNetTopologySuite requires AddEntityFrameworkSqliteNetTopologySuite to be called on the internal service provider used.

--- a/src/EFCore/ChangeTracking/Internal/ArrayPropertyValues.cs
+++ b/src/EFCore/ChangeTracking/Internal/ArrayPropertyValues.cs
@@ -168,7 +168,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             if (value != null)
             {
-                if (!property.ClrType.GetTypeInfo().IsAssignableFrom(value.GetType().GetTypeInfo()))
+                if (!property.ClrType.IsAssignableFrom(value.GetType()))
                 {
                     throw new InvalidCastException(
                         CoreStrings.InvalidType(

--- a/src/EFCore/ChangeTracking/Internal/CompositeValueFactory.cs
+++ b/src/EFCore/ChangeTracking/Internal/CompositeValueFactory.cs
@@ -137,7 +137,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             return comparers.All(c => c != null)
                 ? new CompositeCustomComparer(comparers)
-                : properties.Any(p => typeof(IStructuralEquatable).GetTypeInfo().IsAssignableFrom(p.ClrType.GetTypeInfo()))
+                : properties.Any(p => typeof(IStructuralEquatable).IsAssignableFrom(p.ClrType))
                     ? (IEqualityComparer<object[]>)new StructuralCompositeComparer()
                     : new CompositeComparer();
         }

--- a/src/EFCore/ChangeTracking/Internal/SimplePrincipalKeyValueFactory.cs
+++ b/src/EFCore/ChangeTracking/Internal/SimplePrincipalKeyValueFactory.cs
@@ -40,7 +40,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             EqualityComparer
                 = comparer != null
                     ? new NoNullsCustomEqualityComparer(comparer)
-                    : typeof(IStructuralEquatable).GetTypeInfo().IsAssignableFrom(typeof(TKey).GetTypeInfo())
+                    : typeof(IStructuralEquatable).IsAssignableFrom(typeof(TKey))
                         ? (IEqualityComparer<TKey>)new NoNullsStructuralEqualityComparer()
                         : EqualityComparer<TKey>.Default;
         }

--- a/src/EFCore/ChangeTracking/Internal/Snapshot.cs
+++ b/src/EFCore/ChangeTracking/Internal/Snapshot.cs
@@ -67,7 +67,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         /// </summary>
         public static Delegate[] CreateReaders<TSnapshot>()
         {
-            var genericArguments = typeof(TSnapshot).GetTypeInfo().GenericTypeArguments;
+            var genericArguments = typeof(TSnapshot).GenericTypeArguments;
             var delegates = new Delegate[genericArguments.Length];
 
             for (var i = 0; i < genericArguments.Length; ++i)

--- a/src/EFCore/ChangeTracking/Internal/SortableBindingList.cs
+++ b/src/EFCore/ChangeTracking/Internal/SortableBindingList.cs
@@ -95,7 +95,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         /// </summary>
         protected override bool SupportsSortingCore => true;
 
-        private class PropertyComparer : Comparer<T>
+        private sealed class PropertyComparer : Comparer<T>
         {
             private readonly IComparer _comparer;
             private readonly ListSortDirection _direction;
@@ -127,7 +127,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             public static bool CanSort(Type type)
                 => type.GetInterface("IComparable") != null
-                    || (type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>));
+                    || (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>));
         }
     }
 }

--- a/src/EFCore/ChangeTracking/Internal/ValueComparerExtensions.cs
+++ b/src/EFCore/ChangeTracking/Internal/ValueComparerExtensions.cs
@@ -50,7 +50,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     newSnapshotParam));
         }
 
-        private class NonNullNullableValueComparer<T> : ValueComparer<T>
+        private sealed class NonNullNullableValueComparer<T> : ValueComparer<T>
         {
 #pragma warning disable CA1061 // Do not hide base class methods
             public NonNullNullableValueComparer(

--- a/src/EFCore/ChangeTracking/ValueComparer`.cs
+++ b/src/EFCore/ChangeTracking/ValueComparer`.cs
@@ -94,7 +94,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
             var param1 = Expression.Parameter(type, "v1");
             var param2 = Expression.Parameter(type, "v2");
 
-            if (typeof(IStructuralEquatable).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo()))
+            if (typeof(IStructuralEquatable).IsAssignableFrom(type))
             {
                 return Expression.Lambda<Func<T, T, bool>>(
                     Expression.Call(
@@ -170,7 +170,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
             var param = Expression.Parameter(type, "v");
 
             if (favorStructuralComparisons
-                && typeof(IStructuralEquatable).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo()))
+                && typeof(IStructuralEquatable).IsAssignableFrom(type))
             {
                 return Expression.Lambda<Func<T, int>>(
                     Expression.Call(

--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -93,7 +93,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             Check.NotNull(options, nameof(options));
 
-            if (!options.ContextType.GetTypeInfo().IsAssignableFrom(GetType().GetTypeInfo()))
+            if (!options.ContextType.IsAssignableFrom(GetType()))
             {
                 throw new InvalidOperationException(CoreStrings.NonGenericOptions(GetType().ShortDisplayName()));
             }

--- a/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs
+++ b/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs
@@ -2142,7 +2142,7 @@ namespace Microsoft.EntityFrameworkCore
                 .Single(
                     mi =>
                     {
-                        var typeInfo = mi.GetParameters()[0].ParameterType.GenericTypeArguments[1].GetTypeInfo();
+                        var typeInfo = mi.GetParameters()[0].ParameterType.GenericTypeArguments[1];
                         return typeInfo.IsGenericType
                             && typeInfo.GetGenericTypeDefinition() == navType;
                     });
@@ -2284,7 +2284,7 @@ namespace Microsoft.EntityFrameworkCore
                             arguments: new[] { source.Expression, Expression.Quote(navigationPropertyPath) }))
                     : source);
 
-        private class IncludableQueryable<TEntity, TProperty> : IIncludableQueryable<TEntity, TProperty>, IAsyncEnumerable<TEntity>
+        private sealed class IncludableQueryable<TEntity, TProperty> : IIncludableQueryable<TEntity, TProperty>, IAsyncEnumerable<TEntity>
         {
             private readonly IQueryable<TEntity> _queryable;
 

--- a/src/EFCore/Extensions/EntityTypeExtensions.cs
+++ b/src/EFCore/Extensions/EntityTypeExtensions.cs
@@ -32,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns> True if the type is abstract, false otherwise. </returns>
         [DebuggerStepThrough]
         public static bool IsAbstract([NotNull] this ITypeBase type)
-            => type.ClrType?.GetTypeInfo().IsAbstract ?? false;
+            => type.ClrType?.IsAbstract ?? false;
 
         /// <summary>
         ///     Gets the root base type for a given entity type.

--- a/src/EFCore/Extensions/Internal/EFPropertyExtensions.cs
+++ b/src/EFCore/Extensions/Internal/EFPropertyExtensions.cs
@@ -122,7 +122,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
             bool makeNullable)
         {
             if (propertyDeclaringType != target.Type
-                && target.Type.GetTypeInfo().IsAssignableFrom(propertyDeclaringType.GetTypeInfo()))
+                && target.Type.IsAssignableFrom(propertyDeclaringType))
             {
                 target = Expression.Convert(target, propertyDeclaringType);
             }

--- a/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
+++ b/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
@@ -139,7 +139,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public static bool IsEntityQueryable([NotNull] this ConstantExpression constantExpression)
-            => constantExpression.Type.GetTypeInfo().IsGenericType
+            => constantExpression.Type.IsGenericType
                 && constantExpression.Type.GetGenericTypeDefinition() == typeof(EntityQueryable<>);
 
         /// <summary>

--- a/src/EFCore/Extensions/Internal/TypeExtensions.cs
+++ b/src/EFCore/Extensions/Internal/TypeExtensions.cs
@@ -171,9 +171,9 @@ namespace Microsoft.EntityFrameworkCore.Internal
 
             yield return type.Namespace;
 
-            if (type.GetTypeInfo().IsGenericType)
+            if (type.IsGenericType)
             {
-                foreach (var typeArgument in type.GetTypeInfo().GenericTypeArguments)
+                foreach (var typeArgument in type.GenericTypeArguments)
                 {
                     foreach (var ns in typeArgument.GetNamespaces())
                     {

--- a/src/EFCore/Infrastructure/ExpressionExtensions.cs
+++ b/src/EFCore/Infrastructure/ExpressionExtensions.cs
@@ -48,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             var memberDeclaringClrType = member.DeclaringType;
             if (expression != null
                 && memberDeclaringClrType != expression.Type
-                && expression.Type.GetTypeInfo().IsAssignableFrom(memberDeclaringClrType.GetTypeInfo()))
+                && expression.Type.IsAssignableFrom(memberDeclaringClrType))
             {
                 expression = Expression.Convert(expression, memberDeclaringClrType);
             }
@@ -137,8 +137,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
             if (declaringType != null
                 && declaringType != parameterType
-                && declaringType.GetTypeInfo().IsInterface
-                && declaringType.GetTypeInfo().IsAssignableFrom(parameterType.GetTypeInfo()))
+                && declaringType.IsInterface
+                && declaringType.IsAssignableFrom(parameterType))
             {
                 var propertyGetter = propertyInfo.GetMethod;
                 var interfaceMapping = parameterType.GetTypeInfo().GetRuntimeInterfaceMap(declaringType);

--- a/src/EFCore/Infrastructure/ModelValidator.cs
+++ b/src/EFCore/Infrastructure/ModelValidator.cs
@@ -220,8 +220,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                         // ReSharper restore CheckForReferenceEqualityInstead.3
                         // ReSharper restore CheckForReferenceEqualityInstead.1
                     }
-                    else if (targetSequenceType == null && propertyType.GetTypeInfo().IsInterface
-                        || targetSequenceType?.GetTypeInfo().IsInterface == true)
+                    else if (targetSequenceType == null && propertyType.IsInterface
+                        || targetSequenceType?.IsInterface == true)
                     {
                         throw new InvalidOperationException(
                             CoreStrings.InterfacePropertyNotAdded(
@@ -477,7 +477,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 && entityType.FindDeclaredOwnership() == null
                 && entityType.BaseType != null)
             {
-                var baseClrType = entityType.ClrType?.GetTypeInfo().BaseType;
+                var baseClrType = entityType.ClrType?.BaseType;
                 while (baseClrType != null)
                 {
                     var baseEntityType = model.FindEntityType(baseClrType);
@@ -492,7 +492,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                         break;
                     }
 
-                    baseClrType = baseClrType.GetTypeInfo().BaseType;
+                    baseClrType = baseClrType.BaseType;
                 }
             }
 
@@ -965,7 +965,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                                 CoreStrings.SeedDatumDefaultValue(
                                     entityType.DisplayName(), property.Name, property.ClrType.GetDefaultValue()));
                         }
-                        else if (!property.ClrType.GetTypeInfo().IsAssignableFrom(value.GetType().GetTypeInfo()))
+                        else if (!property.ClrType.IsAssignableFrom(value.GetType().GetTypeInfo()))
                         {
                             if (sensitiveDataLogged)
                             {

--- a/src/EFCore/Infrastructure/ProductInfo.cs
+++ b/src/EFCore/Infrastructure/ProductInfo.cs
@@ -8,7 +8,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
     public static class ProductInfo
     {
         public static string GetVersion()
-            => typeof(ProductInfo).GetTypeInfo().Assembly
+            => typeof(ProductInfo).Assembly
                 .GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
     }
 }

--- a/src/EFCore/Infrastructure/ServiceCollectionMap.cs
+++ b/src/EFCore/Infrastructure/ServiceCollectionMap.cs
@@ -507,7 +507,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             => descriptor.ImplementationType
                 ?? descriptor.ImplementationInstance?.GetType()
                 // Generic arg on Func may be object, but this is the best we can do and matches logic in D.I. container
-                ?? descriptor.ImplementationFactory?.GetType().GetTypeInfo().GenericTypeArguments[1];
+                ?? descriptor.ImplementationFactory?.GetType().GenericTypeArguments[1];
 
         InternalServiceCollectionMap IInfrastructure<InternalServiceCollectionMap>.Instance => _map;
     }

--- a/src/EFCore/Internal/DbSetFinder.cs
+++ b/src/EFCore/Internal/DbSetFinder.cs
@@ -53,7 +53,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 .Select(
                     p => new DbSetProperty(
                         p.Name,
-                        p.PropertyType.GetTypeInfo().GenericTypeArguments.Single(),
+                        p.PropertyType.GenericTypeArguments.Single(),
                         p.SetMethod == null ? null : factory.Create(p)))
                 .ToArray();
         }

--- a/src/EFCore/Metadata/Conventions/BackingFieldConvention.cs
+++ b/src/EFCore/Metadata/Conventions/BackingFieldConvention.cs
@@ -99,7 +99,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                     return fieldInfo;
                 }
 
-                type = type.GetTypeInfo().BaseType;
+                type = type.BaseType;
             }
 
             return null;
@@ -167,7 +167,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 return existingMatch;
             }
 
-            var typeInfo = propertyBase?.ClrType.GetTypeInfo();
+            var typeInfo = propertyBase?.ClrType;
             var length = prefix.Length + middle.Length + suffix.Length;
             var currentValue = array[index];
             while (true)
@@ -240,9 +240,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             }
         }
 
-        private static bool IsConvertible(TypeInfo typeInfo, FieldInfo fieldInfo)
+        private static bool IsConvertible(Type typeInfo, FieldInfo fieldInfo)
         {
-            var fieldTypeInfo = fieldInfo.FieldType.GetTypeInfo();
+            var fieldTypeInfo = fieldInfo.FieldType;
 
             return typeInfo.IsAssignableFrom(fieldTypeInfo)
                 || fieldTypeInfo.IsAssignableFrom(typeInfo);

--- a/src/EFCore/Metadata/Conventions/DerivedTypeDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/DerivedTypeDiscoveryConvention.cs
@@ -48,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                         && !t.HasDefiningNavigation()
                         && t.FindDeclaredOwnership() == null
                         && model.FindIsOwnedConfigurationSource(t.ClrType) == null
-                        && ((t.BaseType == null && clrType.GetTypeInfo().IsAssignableFrom(t.ClrType.GetTypeInfo()))
+                        && ((t.BaseType == null && clrType.IsAssignableFrom(t.ClrType))
                             || (t.BaseType == entityType.BaseType && FindClosestBaseType(t) == entityType)))
                 .ToList();
 

--- a/src/EFCore/Metadata/Conventions/EntityTypeAttributeConventionBase.cs
+++ b/src/EFCore/Metadata/Conventions/EntityTypeAttributeConventionBase.cs
@@ -50,7 +50,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 return;
             }
 
-            var attributes = type.GetTypeInfo().GetCustomAttributes<TAttribute>(true);
+            var attributes = type.GetCustomAttributes<TAttribute>(true);
 
             foreach (var attribute in attributes)
             {

--- a/src/EFCore/Metadata/Conventions/InheritanceDiscoveryConventionBase.cs
+++ b/src/EFCore/Metadata/Conventions/InheritanceDiscoveryConventionBase.cs
@@ -39,14 +39,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             var clrType = entityType.ClrType;
             Check.NotNull(clrType, nameof(entityType.ClrType));
 
-            var baseType = clrType.GetTypeInfo().BaseType;
+            var baseType = clrType.BaseType;
             IConventionEntityType baseEntityType = null;
 
             while (baseType != null
                 && baseEntityType == null)
             {
                 baseEntityType = entityType.Model.FindEntityType(baseType);
-                baseType = baseType.GetTypeInfo().BaseType;
+                baseType = baseType.BaseType;
             }
 
             return baseEntityType;

--- a/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.cs
@@ -469,7 +469,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             return result;
         }
 
-        private class ConventionBatch : IConventionBatch
+        private sealed class ConventionBatch : IConventionBatch
         {
             private readonly ConventionDispatcher _dispatcher;
             private int? _runCount;

--- a/src/EFCore/Metadata/Conventions/Internal/ConventionNode.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ConventionNode.cs
@@ -319,7 +319,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             }
         }
 
-        private class ImmediateConventionScope : ConventionScope
+        private sealed class ImmediateConventionScope : ConventionScope
         {
             private readonly ConventionSet _conventionSet;
             private readonly ConventionDispatcher _dispatcher;
@@ -1266,7 +1266,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             }
         }
 
-        private class OnModelAnnotationChangedNode : ConventionNode
+        private sealed class OnModelAnnotationChangedNode : ConventionNode
         {
             public OnModelAnnotationChangedNode(
                 IConventionModelBuilder modelBuilder,
@@ -1288,7 +1288,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public override ConventionNode Accept(ConventionVisitor visitor) => visitor.VisitOnModelAnnotationChanged(this);
         }
 
-        private class OnEntityTypeAddedNode : ConventionNode
+        private sealed class OnEntityTypeAddedNode : ConventionNode
         {
             public OnEntityTypeAddedNode(IConventionEntityTypeBuilder entityTypeBuilder)
             {
@@ -1300,7 +1300,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public override ConventionNode Accept(ConventionVisitor visitor) => visitor.VisitOnEntityTypeAdded(this);
         }
 
-        private class OnEntityTypeIgnoredNode : ConventionNode
+        private sealed class OnEntityTypeIgnoredNode : ConventionNode
         {
             public OnEntityTypeIgnoredNode(IConventionModelBuilder modelBuilder, string name, Type type)
             {
@@ -1316,7 +1316,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public override ConventionNode Accept(ConventionVisitor visitor) => visitor.VisitOnEntityTypeIgnored(this);
         }
 
-        private class OnEntityTypeRemovedNode : ConventionNode
+        private sealed class OnEntityTypeRemovedNode : ConventionNode
         {
             public OnEntityTypeRemovedNode(IConventionModelBuilder modelBuilder, IConventionEntityType entityType)
             {
@@ -1330,7 +1330,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public override ConventionNode Accept(ConventionVisitor visitor) => visitor.VisitOnEntityTypeRemoved(this);
         }
 
-        private class OnEntityTypeMemberIgnoredNode : ConventionNode
+        private sealed class OnEntityTypeMemberIgnoredNode : ConventionNode
         {
             public OnEntityTypeMemberIgnoredNode(IConventionEntityTypeBuilder entityTypeBuilder, string name)
             {
@@ -1344,7 +1344,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public override ConventionNode Accept(ConventionVisitor visitor) => visitor.VisitOnEntityTypeMemberIgnored(this);
         }
 
-        private class OnEntityTypeBaseTypeChangedNode : ConventionNode
+        private sealed class OnEntityTypeBaseTypeChangedNode : ConventionNode
         {
             public OnEntityTypeBaseTypeChangedNode(
                 IConventionEntityTypeBuilder entityTypeBuilder,
@@ -1363,7 +1363,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public override ConventionNode Accept(ConventionVisitor visitor) => visitor.VisitOnBaseEntityTypeChanged(this);
         }
 
-        private class OnEntityTypeAnnotationChangedNode : ConventionNode
+        private sealed class OnEntityTypeAnnotationChangedNode : ConventionNode
         {
             public OnEntityTypeAnnotationChangedNode(
                 IConventionEntityTypeBuilder entityTypeBuilder,
@@ -1385,7 +1385,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public override ConventionNode Accept(ConventionVisitor visitor) => visitor.VisitOnEntityTypeAnnotationChanged(this);
         }
 
-        private class OnForeignKeyAddedNode : ConventionNode
+        private sealed class OnForeignKeyAddedNode : ConventionNode
         {
             public OnForeignKeyAddedNode(IConventionRelationshipBuilder relationshipBuilder)
             {
@@ -1397,7 +1397,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public override ConventionNode Accept(ConventionVisitor visitor) => visitor.VisitOnForeignKeyAdded(this);
         }
 
-        private class OnForeignKeyRemovedNode : ConventionNode
+        private sealed class OnForeignKeyRemovedNode : ConventionNode
         {
             public OnForeignKeyRemovedNode(IConventionEntityTypeBuilder entityTypeBuilder, IConventionForeignKey foreignKey)
             {
@@ -1411,7 +1411,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public override ConventionNode Accept(ConventionVisitor visitor) => visitor.VisitOnForeignKeyRemoved(this);
         }
 
-        private class OnForeignKeyAnnotationChangedNode : ConventionNode
+        private sealed class OnForeignKeyAnnotationChangedNode : ConventionNode
         {
             public OnForeignKeyAnnotationChangedNode(
                 IConventionRelationshipBuilder relationshipBuilder,
@@ -1433,7 +1433,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public override ConventionNode Accept(ConventionVisitor visitor) => visitor.VisitOnForeignKeyAnnotationChanged(this);
         }
 
-        private class OnForeignKeyPropertiesChangedNode : ConventionNode
+        private sealed class OnForeignKeyPropertiesChangedNode : ConventionNode
         {
             public OnForeignKeyPropertiesChangedNode(
                 IConventionRelationshipBuilder relationshipBuilder,
@@ -1452,7 +1452,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public override ConventionNode Accept(ConventionVisitor visitor) => visitor.VisitOnForeignKeyPropertiesChanged(this);
         }
 
-        private class OnForeignKeyUniquenessChangedNode : ConventionNode
+        private sealed class OnForeignKeyUniquenessChangedNode : ConventionNode
         {
             public OnForeignKeyUniquenessChangedNode(IConventionRelationshipBuilder relationshipBuilder)
             {
@@ -1464,7 +1464,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public override ConventionNode Accept(ConventionVisitor visitor) => visitor.VisitOnForeignKeyUniquenessChanged(this);
         }
 
-        private class OnForeignKeyRequirednessChangedNode : ConventionNode
+        private sealed class OnForeignKeyRequirednessChangedNode : ConventionNode
         {
             public OnForeignKeyRequirednessChangedNode(IConventionRelationshipBuilder relationshipBuilder)
             {
@@ -1476,7 +1476,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public override ConventionNode Accept(ConventionVisitor visitor) => visitor.VisitOnForeignKeyRequirednessChanged(this);
         }
 
-        private class OnForeignKeyOwnershipChangedNode : ConventionNode
+        private sealed class OnForeignKeyOwnershipChangedNode : ConventionNode
         {
             public OnForeignKeyOwnershipChangedNode(IConventionRelationshipBuilder relationshipBuilder)
             {
@@ -1488,7 +1488,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public override ConventionNode Accept(ConventionVisitor visitor) => visitor.VisitOnForeignKeyOwnershipChanged(this);
         }
 
-        private class OnForeignKeyPrincipalEndChangedNode : ConventionNode
+        private sealed class OnForeignKeyPrincipalEndChangedNode : ConventionNode
         {
             public OnForeignKeyPrincipalEndChangedNode(IConventionRelationshipBuilder relationshipBuilder)
             {
@@ -1500,7 +1500,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public override ConventionNode Accept(ConventionVisitor visitor) => visitor.VisitOnForeignKeyPrincipalEndChanged(this);
         }
 
-        private class OnNavigationAddedNode : ConventionNode
+        private sealed class OnNavigationAddedNode : ConventionNode
         {
             public OnNavigationAddedNode(IConventionRelationshipBuilder relationshipBuilder, IConventionNavigation navigation)
             {
@@ -1514,7 +1514,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public override ConventionNode Accept(ConventionVisitor visitor) => visitor.VisitOnNavigationAdded(this);
         }
 
-        private class OnNavigationRemovedNode : ConventionNode
+        private sealed class OnNavigationRemovedNode : ConventionNode
         {
             public OnNavigationRemovedNode(
                 IConventionEntityTypeBuilder sourceEntityTypeBuilder,
@@ -1536,7 +1536,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public override ConventionNode Accept(ConventionVisitor visitor) => visitor.VisitOnNavigationRemoved(this);
         }
 
-        private class OnKeyAddedNode : ConventionNode
+        private sealed class OnKeyAddedNode : ConventionNode
         {
             public OnKeyAddedNode(IConventionKeyBuilder keyBuilder)
             {
@@ -1548,7 +1548,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public override ConventionNode Accept(ConventionVisitor visitor) => visitor.VisitOnKeyAdded(this);
         }
 
-        private class OnKeyRemovedNode : ConventionNode
+        private sealed class OnKeyRemovedNode : ConventionNode
         {
             public OnKeyRemovedNode(IConventionEntityTypeBuilder entityTypeBuilder, IConventionKey key)
             {
@@ -1562,7 +1562,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public override ConventionNode Accept(ConventionVisitor visitor) => visitor.VisitOnKeyRemoved(this);
         }
 
-        private class OnKeyAnnotationChangedNode : ConventionNode
+        private sealed class OnKeyAnnotationChangedNode : ConventionNode
         {
             public OnKeyAnnotationChangedNode(
                 IConventionKeyBuilder keyBuilder,
@@ -1584,7 +1584,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public override ConventionNode Accept(ConventionVisitor visitor) => visitor.VisitOnKeyAnnotationChanged(this);
         }
 
-        private class OnEntityTypePrimaryKeyChangedNode : ConventionNode
+        private sealed class OnEntityTypePrimaryKeyChangedNode : ConventionNode
         {
             public OnEntityTypePrimaryKeyChangedNode(
                 IConventionEntityTypeBuilder entityTypeBuilder, IConventionKey newPrimaryKey, IConventionKey previousPrimaryKey)
@@ -1601,7 +1601,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public override ConventionNode Accept(ConventionVisitor visitor) => visitor.VisitOnPrimaryKeyChanged(this);
         }
 
-        private class OnIndexAddedNode : ConventionNode
+        private sealed class OnIndexAddedNode : ConventionNode
         {
             public OnIndexAddedNode(IConventionIndexBuilder indexBuilder)
             {
@@ -1613,7 +1613,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public override ConventionNode Accept(ConventionVisitor visitor) => visitor.VisitOnIndexAdded(this);
         }
 
-        private class OnIndexRemovedNode : ConventionNode
+        private sealed class OnIndexRemovedNode : ConventionNode
         {
             public OnIndexRemovedNode(IConventionEntityTypeBuilder entityTypeBuilder, IConventionIndex index)
             {
@@ -1627,7 +1627,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public override ConventionNode Accept(ConventionVisitor visitor) => visitor.VisitOnIndexRemoved(this);
         }
 
-        private class OnIndexUniquenessChangedNode : ConventionNode
+        private sealed class OnIndexUniquenessChangedNode : ConventionNode
         {
             public OnIndexUniquenessChangedNode(IConventionIndexBuilder indexBuilder)
             {
@@ -1639,7 +1639,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public override ConventionNode Accept(ConventionVisitor visitor) => visitor.VisitOnIndexUniquenessChanged(this);
         }
 
-        private class OnIndexAnnotationChangedNode : ConventionNode
+        private sealed class OnIndexAnnotationChangedNode : ConventionNode
         {
             public OnIndexAnnotationChangedNode(
                 IConventionIndexBuilder indexBuilder, string name, IConventionAnnotation annotation, IConventionAnnotation oldAnnotation)
@@ -1658,7 +1658,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public override ConventionNode Accept(ConventionVisitor visitor) => visitor.VisitOnIndexAnnotationChanged(this);
         }
 
-        private class OnPropertyAddedNode : ConventionNode
+        private sealed class OnPropertyAddedNode : ConventionNode
         {
             public OnPropertyAddedNode(IConventionPropertyBuilder propertyBuilder)
             {
@@ -1670,7 +1670,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public override ConventionNode Accept(ConventionVisitor visitor) => visitor.VisitOnPropertyAdded(this);
         }
 
-        private class OnPropertyNullableChangedNode : ConventionNode
+        private sealed class OnPropertyNullableChangedNode : ConventionNode
         {
             public OnPropertyNullableChangedNode(IConventionPropertyBuilder propertyBuilder)
             {
@@ -1682,7 +1682,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public override ConventionNode Accept(ConventionVisitor visitor) => visitor.VisitOnPropertyNullableChanged(this);
         }
 
-        private class OnPropertyFieldChangedNode : ConventionNode
+        private sealed class OnPropertyFieldChangedNode : ConventionNode
         {
             public OnPropertyFieldChangedNode(IConventionPropertyBuilder propertyBuilder, FieldInfo newFieldInfo, FieldInfo oldFieldInfo)
             {
@@ -1698,7 +1698,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public override ConventionNode Accept(ConventionVisitor visitor) => visitor.VisitOnPropertyFieldChanged(this);
         }
 
-        private class OnPropertyAnnotationChangedNode : ConventionNode
+        private sealed class OnPropertyAnnotationChangedNode : ConventionNode
         {
             public OnPropertyAnnotationChangedNode(
                 IConventionPropertyBuilder propertyBuilder,

--- a/src/EFCore/Metadata/Conventions/Internal/ConventionVisitor.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ConventionVisitor.cs
@@ -127,7 +127,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 => node;
         }
 
-        private class RunVisitor : ConventionVisitor
+        private sealed class RunVisitor : ConventionVisitor
         {
             public RunVisitor(ConventionDispatcher dispatcher)
             {

--- a/src/EFCore/Metadata/Conventions/InversePropertyAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/InversePropertyAttributeConvention.cs
@@ -82,8 +82,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 .FirstOrDefault(p => string.Equals(p.GetSimpleMemberName(), attribute.Property, StringComparison.OrdinalIgnoreCase));
 
             if (inverseNavigationPropertyInfo == null
-                || !Dependencies.MemberClassifier.FindCandidateNavigationPropertyType(inverseNavigationPropertyInfo).GetTypeInfo()
-                    .IsAssignableFrom(entityType.ClrType.GetTypeInfo()))
+                || !Dependencies.MemberClassifier.FindCandidateNavigationPropertyType(inverseNavigationPropertyInfo)
+                    .IsAssignableFrom(entityType.ClrType))
             {
                 throw new InvalidOperationException(
                     CoreStrings.InvalidNavigationWithInverseProperty(

--- a/src/EFCore/Metadata/Conventions/NonNullableConventionBase.cs
+++ b/src/EFCore/Metadata/Conventions/NonNullableConventionBase.cs
@@ -138,7 +138,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         public virtual void ProcessModelFinalized(IConventionModelBuilder modelBuilder, IConventionContext<IConventionModelBuilder> context)
             => modelBuilder.Metadata.RemoveAnnotation(StateAnnotationName);
 
-        private class NonNullabilityConventionState
+        private sealed class NonNullabilityConventionState
         {
             public Type NullableAttrType;
             public Type NullableContextAttrType;

--- a/src/EFCore/Metadata/Conventions/RelationshipDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/RelationshipDiscoveryConvention.cs
@@ -379,8 +379,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 }
 
                 var otherEntityType = existingInverse.GetTargetType();
-                if (!entityType.ClrType.GetTypeInfo()
-                    .IsAssignableFrom(otherEntityType.ClrType.GetTypeInfo()))
+                if (!entityType.ClrType
+                    .IsAssignableFrom(otherEntityType.ClrType))
                 {
                     return false;
                 }
@@ -1094,7 +1094,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             ImmutableSortedDictionary<MemberInfo, Type> ambiguousNavigations)
             => entityTypeBuilder.HasAnnotation(CoreAnnotationNames.AmbiguousNavigations, ambiguousNavigations);
 
-        private class MemberInfoNameComparer : IComparer<MemberInfo>
+        private sealed class MemberInfoNameComparer : IComparer<MemberInfo>
         {
             public static readonly MemberInfoNameComparer Instance = new MemberInfoNameComparer();
 
@@ -1105,7 +1105,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             public int Compare(MemberInfo x, MemberInfo y) => StringComparer.Ordinal.Compare(x.Name, y.Name);
         }
 
-        private class RelationshipCandidate
+        private sealed class RelationshipCandidate
         {
             public RelationshipCandidate(
                 IConventionEntityTypeBuilder targetTypeBuilder,

--- a/src/EFCore/Metadata/Internal/ClrPropertyGetterFactory.cs
+++ b/src/EFCore/Metadata/Internal/ClrPropertyGetterFactory.cs
@@ -38,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var entityParameter = Expression.Parameter(typeof(TEntity), "entity");
 
             Expression readExpression;
-            if (memberInfo.DeclaringType.GetTypeInfo().IsAssignableFrom(typeof(TEntity).GetTypeInfo()))
+            if (memberInfo.DeclaringType.IsAssignableFrom(typeof(TEntity)))
             {
                 readExpression = Expression.MakeMemberAccess(entityParameter, memberInfo);
             }

--- a/src/EFCore/Metadata/Internal/ClrPropertySetterFactory.cs
+++ b/src/EFCore/Metadata/Internal/ClrPropertySetterFactory.cs
@@ -43,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 : Expression.Convert(valueParameter, memberType);
 
             Expression writeExpression;
-            if (memberInfo.DeclaringType.GetTypeInfo().IsAssignableFrom(typeof(TEntity).GetTypeInfo()))
+            if (memberInfo.DeclaringType.IsAssignableFrom(typeof(TEntity)))
             {
                 writeExpression = Expression.MakeMemberAccess(entityParameter, memberInfo)
                     .Assign(convertedParameter);
@@ -75,7 +75,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var propertyType = propertyBase?.ClrType ?? memberInfo.GetMemberType();
 
             return propertyType.IsNullableType()
-                && propertyType.UnwrapNullableType().GetTypeInfo().IsEnum
+                && propertyType.UnwrapNullableType().IsEnum
                     ? new NullableEnumClrPropertySetter<TEntity, TValue, TNonNullableEnumValue>(setter)
                     : (IClrPropertySetter)new ClrPropertySetter<TEntity, TValue>(setter);
         }

--- a/src/EFCore/Metadata/Internal/CollectionTypeFactory.cs
+++ b/src/EFCore/Metadata/Internal/CollectionTypeFactory.cs
@@ -40,7 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return null;
             }
 
-            if (!collectionType.GetTypeInfo().IsAbstract)
+            if (!collectionType.IsAbstract)
             {
                 var constructor = collectionType.GetDeclaredConstructor(null);
                 if (constructor?.IsPublic == true)
@@ -49,23 +49,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
             }
 
-            if (typeof(INotifyPropertyChanged).GetTypeInfo().IsAssignableFrom(entityType.GetTypeInfo()))
+            if (typeof(INotifyPropertyChanged).IsAssignableFrom(entityType))
             {
                 var observableHashSetOfT = typeof(ObservableHashSet<>).MakeGenericType(elementType);
-                if (collectionType.GetTypeInfo().IsAssignableFrom(observableHashSetOfT.GetTypeInfo()))
+                if (collectionType.IsAssignableFrom(observableHashSetOfT))
                 {
                     return observableHashSetOfT;
                 }
             }
 
             var hashSetOfT = typeof(HashSet<>).MakeGenericType(elementType);
-            if (collectionType.GetTypeInfo().IsAssignableFrom(hashSetOfT.GetTypeInfo()))
+            if (collectionType.IsAssignableFrom(hashSetOfT))
             {
                 return hashSetOfT;
             }
 
             var listOfT = typeof(List<>).MakeGenericType(elementType);
-            return collectionType.GetTypeInfo().IsAssignableFrom(listOfT.GetTypeInfo()) ? listOfT : null;
+            return collectionType.IsAssignableFrom(listOfT) ? listOfT : null;
         }
     }
 }

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -278,7 +278,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         throw new InvalidOperationException(CoreStrings.NonClrBaseType(this.DisplayName(), newBaseType.DisplayName()));
                     }
 
-                    if (!newBaseType.ClrType.GetTypeInfo().IsAssignableFrom(ClrType.GetTypeInfo()))
+                    if (!newBaseType.ClrType.IsAssignableFrom(ClrType))
                     {
                         throw new InvalidOperationException(
                             CoreStrings.NotAssignableClrBaseType(
@@ -1779,7 +1779,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     throw new InvalidOperationException(CoreStrings.ClrPropertyOnShadowEntity(memberInfo.Name, this.DisplayName()));
                 }
 
-                if (memberInfo.DeclaringType?.GetTypeInfo().IsAssignableFrom(ClrType.GetTypeInfo()) != true)
+                if (memberInfo.DeclaringType?.IsAssignableFrom(ClrType) != true)
                 {
                     throw new ArgumentException(
                         CoreStrings.PropertyWrongEntityClrType(
@@ -2343,7 +2343,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             {
                 if (ClrType != null
                     && ClrType != entity.GetType()
-                    && ClrType.GetTypeInfo().IsAssignableFrom(entity.GetType().GetTypeInfo()))
+                    && ClrType.IsAssignableFrom(entity.GetType()))
                 {
                     throw new InvalidOperationException(
                         CoreStrings.SeedDatumDerivedType(
@@ -2390,14 +2390,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (ClrType != null)
             {
                 if (value != ChangeTrackingStrategy.Snapshot
-                    && !typeof(INotifyPropertyChanged).GetTypeInfo().IsAssignableFrom(ClrType.GetTypeInfo()))
+                    && !typeof(INotifyPropertyChanged).IsAssignableFrom(ClrType))
                 {
                     return CoreStrings.ChangeTrackingInterfaceMissing(this.DisplayName(), value, nameof(INotifyPropertyChanged));
                 }
 
                 if ((value == ChangeTrackingStrategy.ChangingAndChangedNotifications
                         || value == ChangeTrackingStrategy.ChangingAndChangedNotificationsWithOriginalValues)
-                    && !typeof(INotifyPropertyChanging).GetTypeInfo().IsAssignableFrom(ClrType.GetTypeInfo()))
+                    && !typeof(INotifyPropertyChanging).IsAssignableFrom(ClrType))
                 {
                     return CoreStrings.ChangeTrackingInterfaceMissing(this.DisplayName(), value, nameof(INotifyPropertyChanging));
                 }
@@ -2507,7 +2507,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             if (value != null
-                && !entityType.GetDiscriminatorProperty().ClrType.GetTypeInfo().IsAssignableFrom(value.GetType().GetTypeInfo()))
+                && !entityType.GetDiscriminatorProperty().ClrType.IsAssignableFrom(value.GetType()))
             {
                 throw new InvalidOperationException(
                     CoreStrings.DiscriminatorValueIncompatible(
@@ -3173,7 +3173,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 ? Enumerable.Empty<T>()
                 : new[] { element };
 
-        private class PropertyComparer : IComparer<string>
+        private sealed class PropertyComparer : IComparer<string>
         {
             private readonly EntityType _entityType;
 

--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -2131,8 +2131,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             var navigationProperty = navigationToTarget?.MemberInfo;
             if (inverseNavigation == null
-                && navigationProperty?.GetMemberType().GetTypeInfo().IsAssignableFrom(
-                    targetEntityType.ClrType.GetTypeInfo())
+                && navigationProperty?.GetMemberType().IsAssignableFrom(
+                    targetEntityType.ClrType)
                 == false)
             {
                 // Only one nav specified and it can't be the nav to principal

--- a/src/EFCore/Metadata/Internal/InternalPropertyBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalPropertyBuilder.cs
@@ -378,7 +378,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return HasValueGenerator((Func<IProperty, IEntityType, ValueGenerator>)null, configurationSource);
             }
 
-            if (!typeof(ValueGenerator).GetTypeInfo().IsAssignableFrom(valueGeneratorType.GetTypeInfo()))
+            if (!typeof(ValueGenerator).IsAssignableFrom(valueGeneratorType))
             {
                 throw new ArgumentException(
                     CoreStrings.BadValueGeneratorType(valueGeneratorType.ShortDisplayName(), typeof(ValueGenerator).ShortDisplayName()));

--- a/src/EFCore/Metadata/Internal/MemberClassifier.cs
+++ b/src/EFCore/Metadata/Internal/MemberClassifier.cs
@@ -66,12 +66,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             targetType = targetSequenceType ?? targetType;
             targetType = targetType.UnwrapNullableType();
 
-            return targetType.GetTypeInfo().IsInterface
-                || targetType.GetTypeInfo().IsValueType
+            return targetType.IsInterface
+                || targetType.IsValueType
                 || targetType == typeof(object)
                 || _parameterBindingFactories.FindFactory(targetType, memberInfo.GetSimpleMemberName()) != null
                 || _typeMappingSource.FindMapping(targetType) != null
-                || targetType.GetTypeInfo().IsArray
+                || targetType.IsArray
                     ? null
                     : targetType;
         }

--- a/src/EFCore/Metadata/Internal/Model.cs
+++ b/src/EFCore/Metadata/Internal/Model.cs
@@ -541,10 +541,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual IReadOnlyList<EntityType> FindLeastDerivedEntityTypes(
             [NotNull] Type type, [CanBeNull] Func<EntityType, bool> condition = null)
         {
-            var derivedLevels = new Dictionary<TypeInfo, int> { [type.GetTypeInfo()] = 0 };
+            var derivedLevels = new Dictionary<Type, int> { [type] = 0 };
 
             var leastDerivedTypesGroups = GetEntityTypes()
-                .GroupBy(t => GetDerivedLevel(t.ClrType.GetTypeInfo(), derivedLevels))
+                .GroupBy(t => GetDerivedLevel(t.ClrType, derivedLevels))
                 .Where(g => g.Key != int.MaxValue)
                 .OrderBy(g => g.Key);
 
@@ -565,7 +565,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             return new List<EntityType>();
         }
 
-        private static int GetDerivedLevel(TypeInfo derivedType, Dictionary<TypeInfo, int> derivedLevels)
+        private static int GetDerivedLevel(Type derivedType, Dictionary<Type, int> derivedLevels)
         {
             if (derivedType?.BaseType == null)
             {
@@ -577,7 +577,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return level;
             }
 
-            var baseType = derivedType.BaseType.GetTypeInfo();
+            var baseType = derivedType.BaseType;
             level = GetDerivedLevel(baseType, derivedLevels);
             level += level == int.MaxValue ? 0 : 1;
             derivedLevels.Add(derivedType, level);

--- a/src/EFCore/Metadata/Internal/Navigation.cs
+++ b/src/EFCore/Metadata/Internal/Navigation.cs
@@ -147,7 +147,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             bool? shouldBeCollection,
             bool shouldThrow)
         {
-            if (!navigationProperty.DeclaringType.GetTypeInfo().IsAssignableFrom(sourceClrType.GetTypeInfo()))
+            if (!navigationProperty.DeclaringType.IsAssignableFrom(sourceClrType))
             {
                 if (shouldThrow)
                 {
@@ -162,7 +162,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var navigationTargetClrType = navigationProperty.GetMemberType().TryGetSequenceType();
             shouldBeCollection ??= navigationTargetClrType != null && navigationProperty.GetMemberType() != targetClrType;
             if (shouldBeCollection.Value
-                && navigationTargetClrType?.GetTypeInfo().IsAssignableFrom(targetClrType.GetTypeInfo()) != true)
+                && navigationTargetClrType?.IsAssignableFrom(targetClrType) != true)
             {
                 if (shouldThrow)
                 {
@@ -178,7 +178,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             if (!shouldBeCollection.Value
-                && !navigationProperty.GetMemberType().GetTypeInfo().IsAssignableFrom(targetClrType.GetTypeInfo()))
+                && !navigationProperty.GetMemberType().IsAssignableFrom(targetClrType))
             {
                 if (shouldThrow)
                 {

--- a/src/EFCore/Metadata/Internal/PropertyBase.cs
+++ b/src/EFCore/Metadata/Internal/PropertyBase.cs
@@ -191,7 +191,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Debug.Assert(propertyName != null || !shouldThrow);
 
             if (entityClrType == null
-                || !fieldInfo.DeclaringType.GetTypeInfo().IsAssignableFrom(entityClrType.GetTypeInfo()))
+                || !fieldInfo.DeclaringType.IsAssignableFrom(entityClrType))
             {
                 if (shouldThrow)
                 {
@@ -202,9 +202,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return false;
             }
 
-            var fieldTypeInfo = fieldInfo.FieldType.GetTypeInfo();
-            if (!fieldTypeInfo.IsAssignableFrom(propertyType.GetTypeInfo())
-                && !propertyType.GetTypeInfo().IsAssignableFrom(fieldTypeInfo))
+            var fieldTypeInfo = fieldInfo.FieldType;
+            if (!fieldTypeInfo.IsAssignableFrom(propertyType)
+                && !propertyType.IsAssignableFrom(fieldTypeInfo))
             {
                 if (shouldThrow)
                 {

--- a/src/EFCore/Metadata/ObjectArrayParameterBinding.cs
+++ b/src/EFCore/Metadata/ObjectArrayParameterBinding.cs
@@ -46,7 +46,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                     {
                         var expression = b.BindToParameter(bindingInfo);
 
-                        if (expression.Type.GetTypeInfo().IsValueType)
+                        if (expression.Type.IsValueType)
                         {
                             expression = Expression.Convert(expression, typeof(object));
                         }

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     public static class CoreStrings
     {
         private static readonly ResourceManager _resourceManager
-            = new ResourceManager("Microsoft.EntityFrameworkCore.Properties.CoreStrings", typeof(CoreStrings).GetTypeInfo().Assembly);
+            = new ResourceManager("Microsoft.EntityFrameworkCore.Properties.CoreStrings", typeof(CoreStrings).Assembly);
 
         /// <summary>
         ///     Unable to save changes because a circular dependency was detected in the data to be saved: '{cycle}'.
@@ -2254,7 +2254,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
     public static class CoreResources
     {
         private static readonly ResourceManager _resourceManager
-            = new ResourceManager("Microsoft.EntityFrameworkCore.Properties.CoreStrings", typeof(CoreResources).GetTypeInfo().Assembly);
+            = new ResourceManager("Microsoft.EntityFrameworkCore.Properties.CoreStrings", typeof(CoreResources).Assembly);
 
         /// <summary>
         ///     An 'IServiceProvider' was created for internal use by Entity Framework.

--- a/src/EFCore/Query/ExpressionPrinter.cs
+++ b/src/EFCore/Query/ExpressionPrinter.cs
@@ -365,7 +365,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
             else if (constantExpression.IsEntityQueryable())
             {
-                _stringBuilder.Append($"DbSet<{constantExpression.Type.GetTypeInfo().GenericTypeArguments.First().ShortDisplayName()}>");
+                _stringBuilder.Append($"DbSet<{constantExpression.Type.GenericTypeArguments.First().ShortDisplayName()}>");
             }
             else
             {

--- a/src/EFCore/Query/Internal/CompiledQueryBase.cs
+++ b/src/EFCore/Query/Internal/CompiledQueryBase.cs
@@ -111,7 +111,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             protected override Expression VisitParameter(ParameterExpression parameterExpression)
             {
-                if (typeof(TContext).GetTypeInfo().IsAssignableFrom(parameterExpression.Type.GetTypeInfo()))
+                if (typeof(TContext).IsAssignableFrom(parameterExpression.Type))
                 {
                     return Expression.Constant(_context);
                 }

--- a/src/EFCore/Query/Internal/ExpressionEqualityComparer.cs
+++ b/src/EFCore/Query/Internal/ExpressionEqualityComparer.cs
@@ -711,7 +711,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     && Compare(a.Object, b.Object)
                     && CompareExpressionList(a.Arguments, b.Arguments);
 
-            private class ScopedDictionary<TKey, TValue>
+            private sealed class ScopedDictionary<TKey, TValue>
             {
                 private readonly ScopedDictionary<TKey, TValue> _previous;
                 private readonly Dictionary<TKey, TValue> _map;

--- a/src/EFCore/Query/Internal/GroupJoinFlatteningExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/GroupJoinFlatteningExpressionVisitor.cs
@@ -236,7 +236,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             return base.VisitMethodCall(methodCallExpression);
         }
 
-        private class SelectManyVerifyingExpressionVisitor : ExpressionVisitor
+        private sealed class SelectManyVerifyingExpressionVisitor : ExpressionVisitor
         {
             private readonly List<ParameterExpression> _allowedParameters = new List<ParameterExpression>();
             private readonly ISet<string> _allowedMethods = new HashSet<string> { nameof(Queryable.Where), nameof(Queryable.AsQueryable) };

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
@@ -254,7 +254,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                 var resultSelector = Expression.Lambda(
                     Expression.New(
-                        resultType.GetTypeInfo().GetConstructors().Single(),
+                        resultType.GetConstructors().Single(),
                         new[] { resultSelectorOuterParameter, resultSelectorInnerParameter }, transparentIdentifierOuterMemberInfo,
                         transparentIdentifierInnerMemberInfo),
                     resultSelectorOuterParameter,
@@ -294,7 +294,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
         }
 
-        private class IncludeExpandingExpressionVisitor : ExpandingExpressionVisitor
+        private sealed class IncludeExpandingExpressionVisitor : ExpandingExpressionVisitor
         {
             private readonly bool _isTracking;
 
@@ -487,7 +487,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
         }
 
-        private class PendingSelectorExpandingExpressionVisitor : ExpressionVisitor
+        private sealed class PendingSelectorExpandingExpressionVisitor : ExpressionVisitor
         {
             private readonly NavigationExpandingExpressionVisitor _visitor;
             private readonly bool _applyIncludes;
@@ -519,7 +519,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
         }
 
-        private class ReducingExpressionVisitor : ExpressionVisitor
+        private sealed class ReducingExpressionVisitor : ExpressionVisitor
         {
             public override Expression Visit(Expression expression)
             {
@@ -581,7 +581,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
         }
 
-        private class EntityReferenceOptionalMarkingExpressionVisitor : ExpressionVisitor
+        private sealed class EntityReferenceOptionalMarkingExpressionVisitor : ExpressionVisitor
         {
             public override Expression Visit(Expression expression)
             {
@@ -596,7 +596,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
         }
 
-        private class SelfReferenceEntityQueryableRewritingExpressionVisitor : ExpressionVisitor
+        private sealed class SelfReferenceEntityQueryableRewritingExpressionVisitor : ExpressionVisitor
         {
             private readonly NavigationExpandingExpressionVisitor _navigationExpandingExpressionVisitor;
             private readonly IEntityType _entityType;

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.Expressions.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.Expressions.cs
@@ -313,8 +313,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                 var parentExperssion = Parent.GetExpression();
                 return Parent.Left == this
-                    ? MakeMemberAccess(parentExperssion, parentExperssion.Type.GetTypeInfo().GetMember("Outer")[0])
-                    : MakeMemberAccess(parentExperssion, parentExperssion.Type.GetTypeInfo().GetMember("Inner")[0]);
+                    ? MakeMemberAccess(parentExperssion, parentExperssion.Type.GetMember("Outer")[0])
+                    : MakeMemberAccess(parentExperssion, parentExperssion.Type.GetMember("Inner")[0]);
             }
         }
 

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
@@ -862,7 +862,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             var newResultSelector = Expression.Lambda(
                 Expression.New(
-                    transparentIdentifierType.GetTypeInfo().GetConstructors().Single(),
+                    transparentIdentifierType.GetConstructors().Single(),
                     new[] { outerSource.CurrentParameter, innerSource.CurrentParameter }, transparentIdentifierOuterMemberInfo,
                     transparentIdentifierInnerMemberInfo),
                 outerSource.CurrentParameter,
@@ -916,7 +916,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             var newResultSelector = Expression.Lambda(
                 Expression.New(
-                    transparentIdentifierType.GetTypeInfo().GetConstructors().Single(),
+                    transparentIdentifierType.GetConstructors().Single(),
                     new[] { outerSource.CurrentParameter, innerSource.CurrentParameter }, transparentIdentifierOuterMemberInfo,
                     transparentIdentifierInnerMemberInfo),
                 outerSource.CurrentParameter,
@@ -1035,7 +1035,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                 var newResultSelector = Expression.Lambda(
                     Expression.New(
-                        transparentIdentifierType.GetTypeInfo().GetConstructors().Single(),
+                        transparentIdentifierType.GetConstructors().Single(),
                         new[] { source.CurrentParameter, collectionElementParameter }, transparentIdentifierOuterMemberInfo,
                         transparentIdentifierInnerMemberInfo),
                     source.CurrentParameter,
@@ -1522,13 +1522,13 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
         }
 
-        private class Parameters : IParameterValues
+        private sealed class Parameters : IParameterValues
         {
             private readonly IDictionary<string, object> _parameterValues = new Dictionary<string, object>();
 
             public IReadOnlyDictionary<string, object> ParameterValues => (IReadOnlyDictionary<string, object>)_parameterValues;
 
-            public virtual void AddParameter(string name, object value)
+            public void AddParameter(string name, object value)
             {
                 _parameterValues.Add(name, value);
             }

--- a/src/EFCore/Query/Internal/NullCheckRemovingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/NullCheckRemovingExpressionVisitor.cs
@@ -45,11 +45,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             return base.VisitConditional(conditionalExpression);
         }
 
-        private class NullSafeAccessVerifyingExpressionVisitor : ExpressionVisitor
+        private sealed class NullSafeAccessVerifyingExpressionVisitor : ExpressionVisitor
         {
             private readonly ISet<Expression> _nullSafeAccesses = new HashSet<Expression>(ExpressionEqualityComparer.Instance);
 
-            public virtual bool Verify(Expression caller, Expression result)
+            public bool Verify(Expression caller, Expression result)
             {
                 _nullSafeAccesses.Clear();
                 _nullSafeAccesses.Add(caller);

--- a/src/EFCore/Query/Internal/ParameterExtractingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/ParameterExtractingExpressionVisitor.cs
@@ -336,7 +336,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             return parameter;
         }
 
-        private class ContextParameterReplacingExpressionVisitor : ExpressionVisitor
+        private sealed class ContextParameterReplacingExpressionVisitor : ExpressionVisitor
         {
             private readonly Type _contextType;
 
@@ -350,7 +350,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             public override Expression Visit(Expression expression)
                 => expression?.Type != typeof(object)
-                    && expression?.Type.GetTypeInfo().IsAssignableFrom(_contextType) == true
+                    && expression?.Type.IsAssignableFrom(_contextType) == true
                     ? ContextParameterExpression
                     : base.Visit(expression);
         }
@@ -453,7 +453,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
         }
 
-        private class EvaluatableExpressionFindingExpressionVisitor : ExpressionVisitor
+        private sealed class EvaluatableExpressionFindingExpressionVisitor : ExpressionVisitor
         {
             private readonly IEvaluatableExpressionFilter _evaluatableExpressionFilter;
             private readonly ISet<ParameterExpression> _allowedParameters = new HashSet<ParameterExpression>();

--- a/src/EFCore/Query/QueryTranslationPreprocessor.cs
+++ b/src/EFCore/Query/QueryTranslationPreprocessor.cs
@@ -41,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         // TODO: For debugging
-        private class EnumerableVerifyingExpressionVisitor : ExpressionVisitor
+        private sealed class EnumerableVerifyingExpressionVisitor : ExpressionVisitor
         {
             protected override Expression VisitMethodCall(MethodCallExpression node)
             {

--- a/src/EFCore/Query/QueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore/Query/QueryableMethodTranslatingExpressionVisitor.cs
@@ -437,7 +437,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 : throw new NotImplementedException("Unhandled method: " + method.Name);
         }
 
-        private class EntityShaperNullableMarkingExpressionVisitor : ExpressionVisitor
+        private sealed class EntityShaperNullableMarkingExpressionVisitor : ExpressionVisitor
         {
             protected override Expression VisitExtension(Expression extensionExpression)
             {
@@ -493,7 +493,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new[] { outerShaper, innerShaper }, outerMemberInfo, innerMemberInfo);
         }
 
-        private class MemberAccessShiftingExpressionVisitor : ExpressionVisitor
+        private sealed class MemberAccessShiftingExpressionVisitor : ExpressionVisitor
         {
             private readonly Expression _queryExpression;
             private readonly MemberInfo _memberShift;

--- a/src/EFCore/Query/QueryableMethods.cs
+++ b/src/EFCore/Query/QueryableMethods.cs
@@ -103,7 +103,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         static QueryableMethods()
         {
-            var queryableMethods = typeof(Queryable).GetTypeInfo()
+            var queryableMethods = typeof(Queryable)
                 .GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly).ToList();
 
             AsQueryable = queryableMethods.Single(

--- a/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
@@ -155,7 +155,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return _entityMaterializerInjectingExpressionVisitor.Inject(expression);
         }
 
-        private class ConstantVerifyingExpressionVisitor : ExpressionVisitor
+        private sealed class ConstantVerifyingExpressionVisitor : ExpressionVisitor
         {
             private readonly ITypeMappingSource _typeMappingSource;
 
@@ -228,7 +228,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        private class EntityMaterializerInjectingExpressionVisitor : ExpressionVisitor
+        private sealed class EntityMaterializerInjectingExpressionVisitor : ExpressionVisitor
         {
             private static readonly ConstructorInfo _materializationContextConstructor
                 = typeof(MaterializationContext).GetConstructors().Single(ci => ci.GetParameters().Length == 2);

--- a/src/EFCore/Storage/DatabaseProvider.cs
+++ b/src/EFCore/Storage/DatabaseProvider.cs
@@ -44,7 +44,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     The unique name used to identify the database provider. This should be the same as the NuGet package name
         ///     for the providers runtime.
         /// </summary>
-        public virtual string Name => typeof(TOptionsExtension).GetTypeInfo().Assembly.GetName().Name;
+        public virtual string Name => typeof(TOptionsExtension).Assembly.GetName().Name;
 
         /// <summary>
         ///     Gets a value indicating whether this database provider has been selected for a given context.

--- a/src/EFCore/Storage/ExecutionStrategyExtensions.cs
+++ b/src/EFCore/Storage/ExecutionStrategyExtensions.cs
@@ -740,7 +740,7 @@ namespace Microsoft.EntityFrameworkCore
                     return s.Result;
                 }, async (c, s, ct) => new ExecutionResult<TResult>(s.CommitFailed && await s.VerifySucceeded(s.State, ct), s.Result));
 
-        private class ExecutionState<TState, TResult>
+        private sealed class ExecutionState<TState, TResult>
         {
             public ExecutionState(
                 Func<TState, TResult> operation,
@@ -759,7 +759,7 @@ namespace Microsoft.EntityFrameworkCore
             public bool CommitFailed { get; set; }
         }
 
-        private class ExecutionStateAsync<TState, TResult>
+        private sealed class ExecutionStateAsync<TState, TResult>
         {
             public ExecutionStateAsync(
                 Func<TState, CancellationToken, Task<TResult>> operation,

--- a/src/EFCore/ValueGeneration/HiLoValueGeneratorState.cs
+++ b/src/EFCore/ValueGeneration/HiLoValueGeneratorState.cs
@@ -137,7 +137,7 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration
             return newValue;
         }
 
-        private class HiLoValue
+        private sealed class HiLoValue
         {
             public HiLoValue(long low, long high)
             {

--- a/src/Microsoft.Data.Sqlite.Core/Extensions/TypeExtensions.cs
+++ b/src/Microsoft.Data.Sqlite.Core/Extensions/TypeExtensions.cs
@@ -13,7 +13,7 @@ namespace System
                 || (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>));
 
         public static Type UnwrapEnumType(this Type type)
-            => type.GetTypeInfo().IsEnum ? Enum.GetUnderlyingType(type) : type;
+            => type.IsEnum ? Enum.GetUnderlyingType(type) : type;
 
         public static Type UnwrapNullableType(this Type type)
             => Nullable.GetUnderlyingType(type) ?? type;

--- a/src/Microsoft.Data.Sqlite.Core/Properties/Resources.Designer.cs
+++ b/src/Microsoft.Data.Sqlite.Core/Properties/Resources.Designer.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Data.Sqlite.Properties
     internal static class Resources
     {
         private static readonly ResourceManager _resourceManager
-            = new ResourceManager("Microsoft.Data.Sqlite.Properties.Resources", typeof(Resources).GetTypeInfo().Assembly);
+            = new ResourceManager("Microsoft.Data.Sqlite.Properties.Resources", typeof(Resources).Assembly);
 
         /// <summary>
         /// {methodName} can only be called when the connection is open.

--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
@@ -771,7 +771,7 @@ namespace Microsoft.Data.Sqlite
             return values;
         }
 
-        private class AggregateContext<T>
+        private sealed class AggregateContext<T>
         {
             public AggregateContext(T seed)
                 => Accumulate = seed;
@@ -780,7 +780,7 @@ namespace Microsoft.Data.Sqlite
             public Exception Exception { get; set; }
         }
 
-        private class FunctionsKeyComparer : IEqualityComparer<(string name, int arity)>
+        private sealed class FunctionsKeyComparer : IEqualityComparer<(string name, int arity)>
         {
             public static readonly FunctionsKeyComparer Instance = new FunctionsKeyComparer();
 

--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnectionStringBuilder.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnectionStringBuilder.cs
@@ -245,7 +245,7 @@ namespace Microsoft.Data.Sqlite
             {
                 enumValue = (TEnum)value;
             }
-            else if (value.GetType().GetTypeInfo().IsEnum)
+            else if (value.GetType().IsEnum)
             {
                 throw new ArgumentException(Resources.ConvertFailed(value.GetType(), typeof(TEnum)));
             }

--- a/src/Shared/EnumerableMethods.cs
+++ b/src/Shared/EnumerableMethods.cs
@@ -126,7 +126,7 @@ namespace Microsoft.EntityFrameworkCore
 
         static EnumerableMethods()
         {
-            var enumerableMethods = typeof(Enumerable).GetTypeInfo()
+            var enumerableMethods = typeof(Enumerable)
                 .GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
                 .ToList();
 

--- a/src/Shared/MemberInfoExtensions.cs
+++ b/src/Shared/MemberInfoExtensions.cs
@@ -32,7 +32,7 @@ namespace System.Reflection
             return index >= 0 ? name.Substring(index + 1) : name;
         }
 
-        private class MemberInfoComparer : IEqualityComparer<MemberInfo>
+        private sealed class MemberInfoComparer : IEqualityComparer<MemberInfo>
         {
             public static readonly MemberInfoComparer Instance = new MemberInfoComparer();
 

--- a/src/Shared/SharedTypeExtensions.cs
+++ b/src/Shared/SharedTypeExtensions.cs
@@ -22,7 +22,7 @@ namespace System
             => !type.IsValueType || type.IsNullableValueType();
 
         public static bool IsValidEntityType(this Type type)
-            => type.GetTypeInfo().IsClass;
+            => type.IsClass;
 
         public static Type MakeNullable(this Type type, bool nullable = true)
             => type.IsNullableType() == nullable
@@ -105,9 +105,7 @@ namespace System
             return props.SingleOrDefault();
         }
 
-        public static bool IsInstantiable(this Type type) => IsInstantiable(type.GetTypeInfo());
-
-        private static bool IsInstantiable(TypeInfo type)
+        public static bool IsInstantiable(this Type type)
             => !type.IsAbstract
                 && !type.IsInterface
                 && (!type.IsGenericType || !type.IsGenericTypeDefinition);
@@ -116,7 +114,7 @@ namespace System
         {
             var isNullable = type.IsNullableType();
             var underlyingNonNullableType = isNullable ? type.UnwrapNullableType() : type;
-            if (!underlyingNonNullableType.GetTypeInfo().IsEnum)
+            if (!underlyingNonNullableType.IsEnum)
             {
                 return type;
             }
@@ -143,7 +141,7 @@ namespace System
 
         public static Type TryGetElementType(this Type type, Type interfaceOrBaseType)
         {
-            if (type.GetTypeInfo().IsGenericTypeDefinition)
+            if (type.IsGenericTypeDefinition)
             {
                 return null;
             }
@@ -164,7 +162,7 @@ namespace System
                 }
             }
 
-            return singleImplementation?.GetTypeInfo().GenericTypeArguments.FirstOrDefault();
+            return singleImplementation?.GenericTypeArguments.FirstOrDefault();
         }
 
         public static IEnumerable<Type> GetGenericTypeImplementations(this Type type, Type interfaceOrBaseType)
@@ -177,14 +175,14 @@ namespace System
                     : type.GetBaseTypes();
                 foreach (var baseType in baseTypes)
                 {
-                    if (baseType.GetTypeInfo().IsGenericType
+                    if (baseType.IsGenericType
                         && baseType.GetGenericTypeDefinition() == interfaceOrBaseType)
                     {
                         yield return baseType;
                     }
                 }
 
-                if (type.GetTypeInfo().IsGenericType
+                if (type.IsGenericType
                     && type.GetGenericTypeDefinition() == interfaceOrBaseType)
                 {
                     yield return type;
@@ -194,13 +192,13 @@ namespace System
 
         public static IEnumerable<Type> GetBaseTypes(this Type type)
         {
-            type = type.GetTypeInfo().BaseType;
+            type = type.BaseType;
 
             while (type != null)
             {
                 yield return type;
 
-                type = type.GetTypeInfo().BaseType;
+                type = type.BaseType;
             }
         }
 
@@ -210,7 +208,7 @@ namespace System
             {
                 yield return type;
 
-                type = type.GetTypeInfo().BaseType;
+                type = type.BaseType;
             }
         }
 
@@ -290,7 +288,7 @@ namespace System
 
         public static object GetDefaultValue(this Type type)
         {
-            if (!type.GetTypeInfo().IsValueType)
+            if (!type.IsValueType)
             {
                 return null;
             }

--- a/src/dotnet-ef/Project.cs
+++ b/src/dotnet-ef/Project.cs
@@ -60,7 +60,7 @@ namespace Microsoft.EntityFrameworkCore.Tools
             var efTargetsPath = Path.Combine(
                 buildExtensionsDir,
                 Path.GetFileName(file) + ".EntityFrameworkCore.targets");
-            using (var input = typeof(Resources).GetTypeInfo().Assembly.GetManifestResourceStream(
+            using (var input = typeof(Resources).Assembly.GetManifestResourceStream(
                 "Microsoft.EntityFrameworkCore.Tools.Resources.EntityFrameworkCore.targets"))
             using (var output = File.OpenWrite(efTargetsPath))
             {

--- a/src/dotnet-ef/Properties/Resources.Designer.cs
+++ b/src/dotnet-ef/Properties/Resources.Designer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
     internal static class Resources
     {
         private static readonly ResourceManager _resourceManager
-            = new ResourceManager("Microsoft.EntityFrameworkCore.Tools.Properties.Resources", typeof(Resources).GetTypeInfo().Assembly);
+            = new ResourceManager("Microsoft.EntityFrameworkCore.Tools.Properties.Resources", typeof(Resources).Assembly);
 
         /// <summary>
         ///     Build failed.

--- a/src/dotnet-ef/RootCommand.cs
+++ b/src/dotnet-ef/RootCommand.cs
@@ -88,7 +88,7 @@ namespace Microsoft.EntityFrameworkCore.Tools
             var args = new List<string>();
 
             var toolsPath = Path.Combine(
-                Path.GetDirectoryName(typeof(Program).GetTypeInfo().Assembly.Location),
+                Path.GetDirectoryName(typeof(Program).Assembly.Location),
                 "tools");
 
             var targetDir = Path.GetFullPath(Path.Combine(startupProject.ProjectDir, startupProject.OutputPath));
@@ -275,7 +275,7 @@ namespace Microsoft.EntityFrameworkCore.Tools
         }
 
         private static string GetVersion()
-            => typeof(RootCommand).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            => typeof(RootCommand).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
                 .InformationalVersion;
 
         private static bool ShouldHelp(IReadOnlyList<string> commands)

--- a/src/ef/CommandLineUtils/CommandLineApplication.cs
+++ b/src/ef/CommandLineUtils/CommandLineApplication.cs
@@ -584,7 +584,7 @@ namespace Microsoft.DotNet.Cli.CommandLine
             return File.ReadLines(fileName);
         }
 
-        private class CommandArgumentEnumerator : IEnumerator<CommandArgument>
+        private sealed class CommandArgumentEnumerator : IEnumerator<CommandArgument>
         {
             private readonly IEnumerator<CommandArgument> _enumerator;
 

--- a/src/ef/Commands/RootCommand.cs
+++ b/src/ef/Commands/RootCommand.cs
@@ -43,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
         }
 
         private static string GetVersion()
-            => typeof(RootCommand).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            => typeof(RootCommand).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
                 .InformationalVersion;
     }
 }

--- a/src/ef/Properties/Resources.Designer.cs
+++ b/src/ef/Properties/Resources.Designer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
     internal static class Resources
     {
         private static readonly ResourceManager _resourceManager
-            = new ResourceManager("Microsoft.EntityFrameworkCore.Tools.Properties.Resources", typeof(Resources).GetTypeInfo().Assembly);
+            = new ResourceManager("Microsoft.EntityFrameworkCore.Tools.Properties.Resources", typeof(Resources).Assembly);
 
         /// <summary>
         ///     The assembly to use.

--- a/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
@@ -56,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.TestUtilities
             if (dataFilePath != null)
             {
                 _dataFilePath = Path.Combine(
-                    Path.GetDirectoryName(typeof(CosmosTestStore).GetTypeInfo().Assembly.Location),
+                    Path.GetDirectoryName(typeof(CosmosTestStore).Assembly.Location),
                     dataFilePath);
             }
         }

--- a/test/EFCore.Cosmos.Tests/ApiConsistencyTest.cs
+++ b/test/EFCore.Cosmos.Tests/ApiConsistencyTest.cs
@@ -24,6 +24,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
             serviceCollection.AddEntityFrameworkCosmos();
         }
 
-        protected override Assembly TargetAssembly => typeof(CosmosDatabaseWrapper).GetTypeInfo().Assembly;
+        protected override Assembly TargetAssembly => typeof(CosmosDatabaseWrapper).Assembly;
     }
 }

--- a/test/EFCore.Design.Tests/ApiConsistencyTest.cs
+++ b/test/EFCore.Design.Tests/ApiConsistencyTest.cs
@@ -19,6 +19,6 @@ namespace Microsoft.EntityFrameworkCore
         {
         }
 
-        protected override Assembly TargetAssembly => typeof(OperationExecutor).GetTypeInfo().Assembly;
+        protected override Assembly TargetAssembly => typeof(OperationExecutor).Assembly;
     }
 }

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
@@ -485,7 +485,7 @@ namespace MyNamespace
 
             var migrationType = assembly.GetType("MyNamespace.MyMigration", throwOnError: true, ignoreCase: false);
 
-            var contextTypeAttribute = migrationType.GetTypeInfo().GetCustomAttribute<DbContextAttribute>();
+            var contextTypeAttribute = migrationType.GetCustomAttribute<DbContextAttribute>();
             Assert.NotNull(contextTypeAttribute);
             Assert.Equal(typeof(MyContext), contextTypeAttribute.ContextType);
 
@@ -772,7 +772,7 @@ namespace MyNamespace
 
             var snapshotType = assembly.GetType(modelSnapshotTypeName, throwOnError: true, ignoreCase: false);
 
-            var contextTypeAttribute = snapshotType.GetTypeInfo().GetCustomAttribute<DbContextAttribute>();
+            var contextTypeAttribute = snapshotType.GetCustomAttribute<DbContextAttribute>();
             Assert.NotNull(contextTypeAttribute);
             Assert.Equal(typeof(MyContext), contextTypeAttribute.ContextType);
 

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -3734,7 +3734,7 @@ namespace RootNamespace
             var assembly = build.BuildInMemory();
             var factoryType = assembly.GetType("RootNamespace.Snapshot");
 
-            var buildModelMethod = factoryType.GetTypeInfo().GetMethod(
+            var buildModelMethod = factoryType.GetMethod(
                 "BuildModel",
                 BindingFlags.Instance | BindingFlags.NonPublic,
                 null,

--- a/test/EFCore.InMemory.Tests/ApiConsistencyTest.cs
+++ b/test/EFCore.InMemory.Tests/ApiConsistencyTest.cs
@@ -26,6 +26,6 @@ namespace Microsoft.EntityFrameworkCore
             serviceCollection.AddEntityFrameworkInMemoryDatabase();
         }
 
-        protected override Assembly TargetAssembly => typeof(InMemoryDatabase).GetTypeInfo().Assembly;
+        protected override Assembly TargetAssembly => typeof(InMemoryDatabase).Assembly;
     }
 }

--- a/test/EFCore.InMemory.Tests/InMemoryDatabaseProviderTest.cs
+++ b/test/EFCore.InMemory.Tests/InMemoryDatabaseProviderTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore
         public void Returns_appropriate_name()
         {
             Assert.Equal(
-                typeof(InMemoryDatabase).GetTypeInfo().Assembly.GetName().Name,
+                typeof(InMemoryDatabase).Assembly.GetName().Name,
                 new DatabaseProvider<InMemoryOptionsExtension>(new DatabaseProviderDependencies()).Name);
         }
 

--- a/test/EFCore.Proxies.Tests/ApiConsistencyTest.cs
+++ b/test/EFCore.Proxies.Tests/ApiConsistencyTest.cs
@@ -13,6 +13,6 @@ namespace Microsoft.EntityFrameworkCore
             serviceCollection.AddEntityFrameworkInMemoryDatabase();
         }
 
-        protected override Assembly TargetAssembly => typeof(ProxiesExtensions).GetTypeInfo().Assembly;
+        protected override Assembly TargetAssembly => typeof(ProxiesExtensions).Assembly;
     }
 }

--- a/test/EFCore.Relational.Tests/ApiConsistencyTest.cs
+++ b/test/EFCore.Relational.Tests/ApiConsistencyTest.cs
@@ -16,15 +16,16 @@ namespace Microsoft.EntityFrameworkCore
 {
     public class ApiConsistencyTest : ApiConsistencyTestBase
     {
-        public ApiConsistencyTest()
-            : base(
+        protected override HashSet<MethodInfo> NonVirtualMethods { get; }
+            = new HashSet<MethodInfo>
+            {
                 typeof(RelationalCompiledQueryCacheKeyGenerator)
                     .GetRuntimeMethods()
                     .Single(
                         m => m.Name == "GenerateCacheKeyCore"
-                            && m.DeclaringType == typeof(RelationalCompiledQueryCacheKeyGenerator)))
-        {
-        }
+                            && m.DeclaringType == typeof(RelationalCompiledQueryCacheKeyGenerator))
+            };
+
 
         private static readonly Type[] _fluentApiTypes =
         {
@@ -48,6 +49,6 @@ namespace Microsoft.EntityFrameworkCore
             new EntityFrameworkRelationalServicesBuilder(serviceCollection).TryAddCoreServices();
         }
 
-        protected override Assembly TargetAssembly => typeof(RelationalDatabase).GetTypeInfo().Assembly;
+        protected override Assembly TargetAssembly => typeof(RelationalDatabase).Assembly;
     }
 }

--- a/test/EFCore.Relational.Tests/RelationalEventIdTest.cs
+++ b/test/EFCore.Relational.Tests/RelationalEventIdTest.cs
@@ -130,7 +130,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             public IReadOnlyDictionary<string, TypeInfo> Migrations => throw new NotImplementedException();
             public ModelSnapshot ModelSnapshot => throw new NotImplementedException();
-            public Assembly Assembly => typeof(FakeMigrationsAssembly).GetTypeInfo().Assembly;
+            public Assembly Assembly => typeof(FakeMigrationsAssembly).Assembly;
             public Migration CreateMigration(TypeInfo migrationClass, string activeProvider) => throw new NotImplementedException();
             public string FindMigrationId(string nameOrId) => throw new NotImplementedException();
         }

--- a/test/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
+++ b/test/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
@@ -1605,7 +1605,7 @@ namespace Microsoft.EntityFrameworkCore
         public static Type UnwrapNullableEnumType(Type type)
         {
             var underlyingNonNullableType = UnwrapNullableType(type);
-            if (!underlyingNonNullableType.GetTypeInfo().IsEnum)
+            if (!underlyingNonNullableType.IsEnum)
             {
                 return underlyingNonNullableType;
             }

--- a/test/EFCore.Specification.Tests/ComplianceTestBase.cs
+++ b/test/EFCore.Specification.Tests/ComplianceTestBase.cs
@@ -49,19 +49,19 @@ namespace Microsoft.EntityFrameworkCore
             var typeInfo = type.GetTypeInfo();
             if (!typeInfo.IsGenericTypeDefinition)
             {
-                var baseTypes = interfaceOrBaseType.GetTypeInfo().IsInterface
+                var baseTypes = interfaceOrBaseType.IsInterface
                     ? typeInfo.ImplementedInterfaces
                     : GetBaseTypes(type);
                 foreach (var baseType in baseTypes)
                 {
-                    if (baseType.GetTypeInfo().IsGenericType
+                    if (baseType.IsGenericType
                         && baseType.GetGenericTypeDefinition() == interfaceOrBaseType)
                     {
                         yield return baseType;
                     }
                 }
 
-                if (type.GetTypeInfo().IsGenericType
+                if (type.IsGenericType
                     && type.GetGenericTypeDefinition() == interfaceOrBaseType)
                 {
                     yield return type;
@@ -71,13 +71,13 @@ namespace Microsoft.EntityFrameworkCore
 
         private static IEnumerable<Type> GetBaseTypes(Type type)
         {
-            type = type.GetTypeInfo().BaseType;
+            type = type.BaseType;
 
             while (type != null)
             {
                 yield return type;
 
-                type = type.GetTypeInfo().BaseType;
+                type = type.BaseType;
             }
         }
     }

--- a/test/EFCore.Specification.Tests/TestUtilities/IncludeQueryResultAsserter.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/IncludeQueryResultAsserter.cs
@@ -50,7 +50,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Assert.Equal(expected == null, actual == null);
 
             var expectedType = expected.GetType();
-            if (expectedType.GetTypeInfo().IsGenericType
+            if (expectedType.IsGenericType
                 && expectedType.GetTypeInfo().ImplementedInterfaces.Any(
                     i => i.IsConstructedGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>)))
             {

--- a/test/EFCore.Specification.Tests/TestUtilities/TestServiceFactory.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/TestServiceFactory.cs
@@ -123,10 +123,10 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         }
 
         private static Type TryGetEnumerableType(Type type)
-            => !type.GetTypeInfo().IsGenericTypeDefinition
-                && type.GetTypeInfo().IsGenericType
+            => !type.IsGenericTypeDefinition
+                && type.IsGenericType
                 && type.GetGenericTypeDefinition() == typeof(IEnumerable<>)
-                    ? type.GetTypeInfo().GenericTypeArguments[0]
+                    ? type.GenericTypeArguments[0]
                     : null;
     }
 }

--- a/test/EFCore.Specification.Tests/WithConstructorsTestBase.cs
+++ b/test/EFCore.Specification.Tests/WithConstructorsTestBase.cs
@@ -1597,14 +1597,14 @@ namespace Microsoft.EntityFrameworkCore
                 var bindingFactories = context.GetService<IParameterBindingFactories>();
 
                 var blogServiceProperty = modelBuilder.Entity<LazyFieldBlog>().Metadata.AddServiceProperty(
-                    typeof(LazyFieldBlog).GetTypeInfo().GetRuntimeFields().Single(f => f.Name == "_loader"));
+                    typeof(LazyFieldBlog).GetRuntimeFields().Single(f => f.Name == "_loader"));
 
                 blogServiceProperty.ParameterBinding =
                     (ServiceParameterBinding)bindingFactories.FindFactory(typeof(ILazyLoader), "_loader")
                         .Bind(blogServiceProperty.DeclaringEntityType, typeof(ILazyLoader), "_loader");
 
                 var postServiceProperty = modelBuilder.Entity<LazyFieldPost>().Metadata.AddServiceProperty(
-                    typeof(LazyFieldPost).GetTypeInfo().GetRuntimeFields().Single(f => f.Name == "_loader"));
+                    typeof(LazyFieldPost).GetRuntimeFields().Single(f => f.Name == "_loader"));
 
                 postServiceProperty.ParameterBinding =
                     (ServiceParameterBinding)bindingFactories.FindFactory(typeof(ILazyLoader), "_loader")

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -2236,7 +2236,7 @@ WHERE [e].[Name] IS NULL");
                 {
                     var compiledQueryCache = this.GetService<ICompiledQueryCache>();
 
-                    return (MemoryCache)typeof(CompiledQueryCache).GetTypeInfo()
+                    return (MemoryCache)typeof(CompiledQueryCache)
                         .GetField("_memoryCache", BindingFlags.Instance | BindingFlags.NonPublic)
                         ?.GetValue(compiledQueryCache);
                 }
@@ -4904,7 +4904,7 @@ LEFT JOIN [Categories] AS [c] ON [p].[CategoryId] = [c].[Id]");
 
         private MemberInfo GetMemberInfo(Type type, string name)
         {
-            return type.GetTypeInfo().GetProperty(name);
+            return type.GetProperty(name);
         }
 
         [ConditionalFact]

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -1131,11 +1131,11 @@ namespace Microsoft.EntityFrameworkCore
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)
             {
-                if (typeof(INotifyPropertyChanging).GetTypeInfo().IsAssignableFrom(typeof(TBlog).GetTypeInfo()))
+                if (typeof(INotifyPropertyChanging).IsAssignableFrom(typeof(TBlog)))
                 {
                     modelBuilder.HasChangeTrackingStrategy(ChangeTrackingStrategy.ChangingAndChangedNotifications);
                 }
-                else if (typeof(INotifyPropertyChanged).GetTypeInfo().IsAssignableFrom(typeof(TBlog).GetTypeInfo()))
+                else if (typeof(INotifyPropertyChanged).IsAssignableFrom(typeof(TBlog)))
                 {
                     modelBuilder.HasChangeTrackingStrategy(ChangeTrackingStrategy.ChangedNotifications);
                 }

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerTestStore.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerTestStore.cs
@@ -60,7 +60,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
             if (scriptPath != null)
             {
-                _scriptPath = Path.Combine(Path.GetDirectoryName(typeof(SqlServerTestStore).GetTypeInfo().Assembly.Location), scriptPath);
+                _scriptPath = Path.Combine(Path.GetDirectoryName(typeof(SqlServerTestStore).Assembly.Location), scriptPath);
             }
 
             ConnectionString = CreateConnectionString(Name, _fileName, multipleActiveResultSets);

--- a/test/EFCore.SqlServer.Tests/ApiConsistencyTest.cs
+++ b/test/EFCore.SqlServer.Tests/ApiConsistencyTest.cs
@@ -31,6 +31,6 @@ namespace Microsoft.EntityFrameworkCore
             serviceCollection.AddEntityFrameworkSqlServer();
         }
 
-        protected override Assembly TargetAssembly => typeof(SqlServerConnection).GetTypeInfo().Assembly;
+        protected override Assembly TargetAssembly => typeof(SqlServerConnection).Assembly;
     }
 }

--- a/test/EFCore.SqlServer.Tests/Design/SqlServerDesignTimeProviderServicesTest.cs
+++ b/test/EFCore.SqlServer.Tests/Design/SqlServerDesignTimeProviderServicesTest.cs
@@ -11,7 +11,7 @@ namespace Microsoft.EntityFrameworkCore.Design
     public class SqlServerDesignTimeProviderServicesTest : DesignTimeProviderServicesTest
     {
         protected override Assembly GetRuntimeAssembly()
-            => typeof(SqlServerConnection).GetTypeInfo().Assembly;
+            => typeof(SqlServerConnection).Assembly;
 
         protected override Type GetDesignTimeServicesType()
             => typeof(SqlServerDesignTimeServices);

--- a/test/EFCore.SqlServer.Tests/NTSApiConsistencyTest.cs
+++ b/test/EFCore.SqlServer.Tests/NTSApiConsistencyTest.cs
@@ -24,6 +24,6 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         protected override Assembly TargetAssembly
-            => typeof(SqlServerNetTopologySuiteServiceCollectionExtensions).GetTypeInfo().Assembly;
+            => typeof(SqlServerNetTopologySuiteServiceCollectionExtensions).Assembly;
     }
 }

--- a/test/EFCore.SqlServer.Tests/SqlServerDatabaseSourceTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerDatabaseSourceTest.cs
@@ -15,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore
         public void Returns_appropriate_name()
         {
             Assert.Equal(
-                typeof(SqlServerConnection).GetTypeInfo().Assembly.GetName().Name,
+                typeof(SqlServerConnection).Assembly.GetName().Name,
                 new DatabaseProvider<SqlServerOptionsExtension>(new DatabaseProviderDependencies()).Name);
         }
 

--- a/test/EFCore.Sqlite.Tests/ApiConsistencyTest.cs
+++ b/test/EFCore.Sqlite.Tests/ApiConsistencyTest.cs
@@ -27,6 +27,6 @@ namespace Microsoft.EntityFrameworkCore
             serviceCollection.AddEntityFrameworkSqlite();
         }
 
-        protected override Assembly TargetAssembly => typeof(SqliteRelationalConnection).GetTypeInfo().Assembly;
+        protected override Assembly TargetAssembly => typeof(SqliteRelationalConnection).Assembly;
     }
 }

--- a/test/EFCore.Sqlite.Tests/Design/SqliteDesignTimeProviderServicesTest.cs
+++ b/test/EFCore.Sqlite.Tests/Design/SqliteDesignTimeProviderServicesTest.cs
@@ -11,7 +11,7 @@ namespace Microsoft.EntityFrameworkCore.Design
     public class SqliteDesignTimeProviderServicesTest : DesignTimeProviderServicesTest
     {
         protected override Assembly GetRuntimeAssembly()
-            => typeof(SqliteRelationalConnection).GetTypeInfo().Assembly;
+            => typeof(SqliteRelationalConnection).Assembly;
 
         protected override Type GetDesignTimeServicesType()
             => typeof(SqliteDesignTimeServices);

--- a/test/EFCore.Sqlite.Tests/NTSApiConsistencyTest.cs
+++ b/test/EFCore.Sqlite.Tests/NTSApiConsistencyTest.cs
@@ -25,6 +25,6 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         protected override Assembly TargetAssembly
-            => typeof(SqliteNetTopologySuiteServiceCollectionExtensions).GetTypeInfo().Assembly;
+            => typeof(SqliteNetTopologySuiteServiceCollectionExtensions).Assembly;
     }
 }

--- a/test/EFCore.Tests/ApiConsistencyTest.cs
+++ b/test/EFCore.Tests/ApiConsistencyTest.cs
@@ -19,17 +19,17 @@ namespace Microsoft.EntityFrameworkCore
 {
     public class ApiConsistencyTest : ApiConsistencyTestBase
     {
-        public ApiConsistencyTest()
-            : base(
+        protected override HashSet<MethodInfo> NonVirtualMethods { get; }
+            = new HashSet<MethodInfo>
+            {
                 typeof(CompiledQueryCacheKeyGenerator).GetRuntimeMethods().Single(m => m.Name == "GenerateCacheKeyCore"),
                 typeof(InternalEntityEntry).GetRuntimeMethods().Single(m => m.Name == "get_Item"),
                 typeof(InternalEntityEntry).GetRuntimeMethods().Single(m => m.Name == "set_Item"),
                 typeof(InternalEntityEntry).GetRuntimeMethods().Single(m => m.Name == nameof(InternalEntityEntry.HasDefaultValue)),
                 typeof(SimpleLogger).GetAnyProperty(nameof(SimpleLogger.Filter)).GetMethod,
                 typeof(SimpleLogger).GetAnyProperty(nameof(SimpleLogger.Sink)).GetMethod,
-                typeof(SimpleLogger).GetAnyProperty(nameof(SimpleLogger.FormatOptions)).GetMethod)
-        {
-        }
+                typeof(SimpleLogger).GetAnyProperty(nameof(SimpleLogger.FormatOptions)).GetMethod
+            };
 
         private static readonly Type[] _fluentApiTypes =
         {
@@ -108,6 +108,6 @@ namespace Microsoft.EntityFrameworkCore
         protected override Dictionary<Type, (Type Mutable, Type Convention)> MetadataTypes
             => _metadataTypes;
 
-        protected override Assembly TargetAssembly => typeof(EntityType).GetTypeInfo().Assembly;
+        protected override Assembly TargetAssembly => typeof(EntityType).Assembly;
     }
 }

--- a/test/EFCore.Tests/Infrastructure/EventIdTestBase.cs
+++ b/test/EFCore.Tests/Infrastructure/EventIdTestBase.cs
@@ -54,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                     var loggerParameters = loggerMethod.GetParameters();
                     var category = loggerParameters[0].ParameterType.GenericTypeArguments[0];
 
-                    if (category.GetTypeInfo().ContainsGenericParameters)
+                    if (category.ContainsGenericParameters)
                     {
                         category = typeof(DbLoggerCategory.Infrastructure);
                         loggerMethod = loggerMethod.MakeGenericMethod(category);

--- a/test/EFCore.Tests/Metadata/Conventions/RelationshipDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/RelationshipDiscoveryConventionTest.cs
@@ -945,7 +945,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             var fk = entityType.GetForeignKeys().Single();
             Assert.False(fk.IsUnique);
-            Assert.True(fk.PrincipalEntityType.ClrType.GetTypeInfo().IsAbstract);
+            Assert.True(fk.PrincipalEntityType.ClrType.IsAbstract);
             Assert.Single(entityType.GetNavigations());
         }
 

--- a/test/dotnet-ef.Tests/ExeTest.cs
+++ b/test/dotnet-ef.Tests/ExeTest.cs
@@ -38,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore.Tools
         }
 
         private static string ToArguments(IReadOnlyList<string> args)
-            => (string)typeof(Exe).GetTypeInfo().GetMethod("ToArguments", BindingFlags.Static | BindingFlags.NonPublic)
+            => (string)typeof(Exe).GetMethod("ToArguments", BindingFlags.Static | BindingFlags.NonPublic)
                 .Invoke(null, new object[] { args });
     }
 }

--- a/tools/Resources.tt
+++ b/tools/Resources.tt
@@ -69,7 +69,7 @@ namespace <#= model.Namespace #>
     <#= model.AccessModifier #> static class <#= model.Class #>
     {
         private static readonly ResourceManager _resourceManager
-            = new ResourceManager("<#= model.ResourceName #>", typeof(<#= model.Class #>).GetTypeInfo().Assembly);
+            = new ResourceManager("<#= model.ResourceName #>", typeof(<#= model.Class #>).Assembly);
 <#
     foreach (var resource in model.Resources)
     {
@@ -136,7 +136,7 @@ namespace <#= model.Namespace.EndsWith(".Internal") ? model.Namespace : (model.N
     <#= model.AccessModifier #> static class <#= model.DiagnosticsClass #>
     {
         private static readonly ResourceManager _resourceManager
-            = new ResourceManager("<#= model.ResourceName #>", typeof(<#= model.DiagnosticsClass #>).GetTypeInfo().Assembly);
+            = new ResourceManager("<#= model.ResourceName #>", typeof(<#= model.DiagnosticsClass #>).Assembly);
 <#
         foreach (var resource in model.Resources)
         {

--- a/tools/SqliteResources.tt
+++ b/tools/SqliteResources.tt
@@ -22,7 +22,7 @@ namespace <#= model.Namespace #>
     internal static class <#= model.Class #>
     {
         private static readonly ResourceManager _resourceManager
-            = new ResourceManager("<#= model.ResourceName #>", typeof(<#= model.Class #>).GetTypeInfo().Assembly);
+            = new ResourceManager("<#= model.ResourceName #>", typeof(<#= model.Class #>).Assembly);
 <#
     foreach (var resource in model.Resources)
     {


### PR DESCRIPTION
Fixes #19066

Also removed `GetTypeInfo` when it is not needed
