### PR TITLE
Mitigation for race condition in SpatialiteLoader.FindExtension()

### DIFF
--- a/src/EFCore.Sqlite.Core/Infrastructure/SpatialiteLoader.cs
+++ b/src/EFCore.Sqlite.Core/Infrastructure/SpatialiteLoader.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 using JetBrains.Annotations;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -176,8 +177,20 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
                     var assetDirectory = Path.GetDirectoryName(assetFullPath);
 
+                    // GetEnvironmentVariable can sometimes return null when there is a race condition
+                    // with another thread setting it. Therefore we do a bit of back off and retry here.
+                    // Note that the result can be null if no path is set on the system.
+                    var delay = 1;
                     var currentPath = Environment.GetEnvironmentVariable(_pathVariableName);
-                    if (!currentPath.Split(Path.PathSeparator).Any(
+                    while (currentPath == null && delay < 1000)
+                    {
+                        Thread.Sleep(delay);
+                        delay *= 2;
+                        currentPath = Environment.GetEnvironmentVariable(_pathVariableName);
+                    }
+
+                    if (currentPath == null
+                        || !currentPath.Split(Path.PathSeparator).Any(
                         p => string.Equals(
                             p.TrimEnd(Path.DirectorySeparatorChar),
                             assetDirectory,


### PR DESCRIPTION
Fixes #18724 (Hopefully)

Retrying if we get a null for up to one second and then assuming null is correct. We'll see how it goes...
