### PR TITLE
Expose an annotation-free DebugView of the model

### DIFF
--- a/src/EFCore/Metadata/Internal/DebugView.cs
+++ b/src/EFCore/Metadata/Internal/DebugView.cs
@@ -19,10 +19,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         private readonly TMetadata _metadata;
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private readonly Func<TMetadata, string> _toDebugString;
+        private readonly Func<TMetadata, string> _toShortDebugString;
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private string _view;
+        private readonly Func<TMetadata, string> _toLongDebugString;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -30,10 +30,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public DebugView([NotNull] TMetadata metadata, [NotNull] Func<TMetadata, string> toDebugString)
+        public DebugView(
+            [NotNull] TMetadata metadata,
+            [NotNull] Func<TMetadata, string> toShortDebugString,
+            [NotNull] Func<TMetadata, string> toLongDebugString)
         {
             _metadata = metadata;
-            _toDebugString = toDebugString;
+            _toShortDebugString = toShortDebugString;
+            _toLongDebugString = toLongDebugString;
         }
 
         /// <summary>
@@ -42,6 +46,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual string View => _view ?? (_view = _toDebugString(_metadata));
+        public virtual string LongView => _toLongDebugString(_metadata);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual string ShortView => _toShortDebugString(_metadata);
     }
 }

--- a/src/EFCore/Metadata/Internal/DebugViewOptions.cs
+++ b/src/EFCore/Metadata/Internal/DebugViewOptions.cs
@@ -1,11 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Runtime.CompilerServices;
-using System.Text;
-using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
+using System;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
@@ -15,7 +11,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public static class ServicePropertyExtensions
+    [Flags]
+    public enum DebugViewOptions
     {
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -23,8 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static ServiceParameterBinding GetParameterBinding([NotNull] this IServiceProperty serviceProperty)
-            => serviceProperty.AsServiceProperty().ParameterBinding;
+        IncludeAnnotations = 1,
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -32,42 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static string ToDebugString(
-            [NotNull] this IServiceProperty serviceProperty,
-            DebugViewOptions options,
-            [NotNull] string indent = "")
-        {
-            var builder = new StringBuilder();
-
-            builder.Append(indent);
-
-            var singleLine = (options & DebugViewOptions.SingleLine) != 0;
-            if (singleLine)
-            {
-                builder.Append("Service property: ").Append(serviceProperty.DeclaringType.DisplayName()).Append(".");
-            }
-
-            builder.Append(serviceProperty.Name);
-
-            if (serviceProperty.GetFieldName() == null)
-            {
-                builder.Append(" (no field, ");
-            }
-            else
-            {
-                builder.Append(" (").Append(serviceProperty.GetFieldName()).Append(", ");
-            }
-
-            builder.Append(serviceProperty.ClrType?.ShortDisplayName()).Append(")");
-
-            if (!singleLine &&
-                (options & DebugViewOptions.IncludeAnnotations) != 0)
-            {
-                builder.Append(serviceProperty.AnnotationsToDebugString(indent + "  "));
-            }
-
-            return builder.ToString();
-        }
+        IncludePropertyIndexes = 2,
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -75,8 +36,30 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static ServiceProperty AsServiceProperty(
-            [NotNull] this IServiceProperty serviceProperty, [NotNull] [CallerMemberName] string methodName = "")
-            => MetadataExtensions.AsConcreteMetadataType<IServiceProperty, ServiceProperty>(serviceProperty, methodName);
+        SingleLine = 4,
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        ShortDefault = 0,
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        LongDefault = IncludeAnnotations,
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        SingleLineDefault = SingleLine
     }
 }

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -463,7 +463,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public override string ToString() => this.ToDebugString();
+        public override string ToString() => this.ToDebugString(DebugViewOptions.SingleLineDefault);
 
         /// <summary>
         ///     Runs the conventions when an annotation was set or removed.
@@ -3306,6 +3306,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual DebugView<EntityType> DebugView
-            => new DebugView<EntityType>(this, m => m.ToDebugString(false));
+            => new DebugView<EntityType>(
+                this,
+                m => m.ToDebugString(DebugViewOptions.ShortDefault),
+                m => m.ToDebugString(DebugViewOptions.LongDefault));
     }
 }

--- a/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
+++ b/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
@@ -481,7 +481,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static string ToDebugString([NotNull] this IEntityType entityType, bool singleLine = true, [NotNull] string indent = "")
+        public static string ToDebugString(
+            [NotNull] this IEntityType entityType,
+            DebugViewOptions options,
+            [NotNull] string indent = "")
         {
             var builder = new StringBuilder();
 
@@ -510,7 +513,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 builder.Append(" ChangeTrackingStrategy.").Append(entityType.GetChangeTrackingStrategy());
             }
 
-            if (!singleLine)
+            if ((options & DebugViewOptions.SingleLine) == 0)
             {
                 var properties = entityType.GetDeclaredProperties().ToList();
                 if (properties.Count != 0)
@@ -518,7 +521,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     builder.AppendLine().Append(indent).Append("  Properties: ");
                     foreach (var property in properties)
                     {
-                        builder.AppendLine().Append(property.ToDebugString(singleLine: false, indent: indent + "    "));
+                        builder.AppendLine().Append(property.ToDebugString(options, indent + "    "));
                     }
                 }
 
@@ -528,7 +531,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     builder.AppendLine().Append(indent).Append("  Navigations: ");
                     foreach (var navigation in navigations)
                     {
-                        builder.AppendLine().Append(navigation.ToDebugString(singleLine: false, indent: indent + "    "));
+                        builder.AppendLine().Append(navigation.ToDebugString(options, indent + "    "));
                     }
                 }
 
@@ -538,7 +541,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     builder.AppendLine().Append(indent).Append("  Service properties: ");
                     foreach (var serviceProperty in serviceProperties)
                     {
-                        builder.AppendLine().Append(serviceProperty.ToDebugString(singleLine: false, indent: indent + "    "));
+                        builder.AppendLine().Append(serviceProperty.ToDebugString(options, indent + "    "));
                     }
                 }
 
@@ -548,7 +551,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     builder.AppendLine().Append(indent).Append("  Keys: ");
                     foreach (var key in keys)
                     {
-                        builder.AppendLine().Append(key.ToDebugString(singleLine: false, indent: indent + "    "));
+                        builder.AppendLine().Append(key.ToDebugString(options, indent + "    "));
                     }
                 }
 
@@ -558,11 +561,24 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     builder.AppendLine().Append(indent).Append("  Foreign keys: ");
                     foreach (var fk in fks)
                     {
-                        builder.AppendLine().Append(fk.ToDebugString(singleLine: false, indent: indent + "    "));
+                        builder.AppendLine().Append(fk.ToDebugString(options, indent + "    "));
                     }
                 }
 
-                builder.Append(entityType.AnnotationsToDebugString(indent: indent + "  "));
+                var indexes = entityType.GetDeclaredIndexes().ToList();
+                if (indexes.Count != 0)
+                {
+                    builder.AppendLine().Append(indent).Append("  Indexes: ");
+                    foreach (var index in indexes)
+                    {
+                        builder.AppendLine().Append(index.ToDebugString(options, indent + "    "));
+                    }
+                }
+
+                if ((options & DebugViewOptions.IncludeAnnotations) != 0)
+                {
+                    builder.Append(entityType.AnnotationsToDebugString(indent: indent + "  "));
+                }
             }
 
             return builder.ToString();

--- a/src/EFCore/Metadata/Internal/ForeignKey.cs
+++ b/src/EFCore/Metadata/Internal/ForeignKey.cs
@@ -1068,7 +1068,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public override string ToString() => this.ToDebugString();
+        public override string ToString() => this.ToDebugString(DebugViewOptions.SingleLineDefault);
 
         private void Validate(
             IReadOnlyList<Property> properties,
@@ -1258,7 +1258,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual DebugView<ForeignKey> DebugView
-            => new DebugView<ForeignKey>(this, m => m.ToDebugString(false));
+            => new DebugView<ForeignKey>(
+                this,
+                m => m.ToDebugString(DebugViewOptions.ShortDefault),
+                m => m.ToDebugString(DebugViewOptions.LongDefault));
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/ForeignKeyExtensions.cs
+++ b/src/EFCore/Metadata/Internal/ForeignKeyExtensions.cs
@@ -270,12 +270,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static string ToDebugString([NotNull] this IForeignKey foreignKey, bool singleLine = true, [NotNull] string indent = "")
+        public static string ToDebugString(
+            [NotNull] this IForeignKey foreignKey,
+            DebugViewOptions options,
+            [NotNull] string indent = "")
         {
             var builder = new StringBuilder();
 
             builder.Append(indent);
 
+            var singleLine = (options & DebugViewOptions.SingleLine) != 0;
             if (singleLine)
             {
                 builder.Append("ForeignKey: ");
@@ -310,7 +314,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 builder.Append(" ToPrincipal: ").Append(foreignKey.DependentToPrincipal.Name);
             }
 
-            if (!singleLine)
+            if (!singleLine &&
+                (options & DebugViewOptions.IncludeAnnotations) != 0)
             {
                 builder.Append(foreignKey.AnnotationsToDebugString(indent + "  "));
             }

--- a/src/EFCore/Metadata/Internal/Index.cs
+++ b/src/EFCore/Metadata/Internal/Index.cs
@@ -173,7 +173,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public override string ToString() => this.ToDebugString();
+        public override string ToString() => this.ToDebugString(DebugViewOptions.SingleLineDefault);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -182,7 +182,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual DebugView<Index> DebugView
-            => new DebugView<Index>(this, m => m.ToDebugString(false));
+            => new DebugView<Index>(
+                this,
+                m => m.ToDebugString(DebugViewOptions.ShortDefault),
+                m => m.ToDebugString(DebugViewOptions.LongDefault));
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/IndexExtensions.cs
+++ b/src/EFCore/Metadata/Internal/IndexExtensions.cs
@@ -42,12 +42,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static string ToDebugString([NotNull] this IIndex index, bool singleLine = true, [NotNull] string indent = "")
+        public static string ToDebugString(
+            [NotNull] this IIndex index,
+            DebugViewOptions options,
+            [NotNull] string indent = "")
         {
             var builder = new StringBuilder();
 
             builder.Append(indent);
 
+            var singleLine = (options & DebugViewOptions.SingleLine) != 0;
             if (singleLine)
             {
                 builder.Append("Index: ");
@@ -66,7 +70,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 builder.Append(" Unique");
             }
 
-            if (!singleLine)
+            if (!singleLine &&
+                (options & DebugViewOptions.IncludeAnnotations) != 0)
             {
                 builder.Append(index.AnnotationsToDebugString(indent + "  "));
             }

--- a/src/EFCore/Metadata/Internal/Key.cs
+++ b/src/EFCore/Metadata/Internal/Key.cs
@@ -157,7 +157,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public override string ToString() => this.ToDebugString();
+        public override string ToString() => this.ToDebugString(DebugViewOptions.SingleLineDefault);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -166,7 +166,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual DebugView<Key> DebugView
-            => new DebugView<Key>(this, m => m.ToDebugString(false));
+            => new DebugView<Key>(
+                this,
+                m => m.ToDebugString(DebugViewOptions.ShortDefault),
+                m => m.ToDebugString(DebugViewOptions.LongDefault));
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/KeyExtensions.cs
+++ b/src/EFCore/Metadata/Internal/KeyExtensions.cs
@@ -59,12 +59,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static string ToDebugString([NotNull] this IKey key, bool singleLine = true, [NotNull] string indent = "")
+        public static string ToDebugString(
+            [NotNull] this IKey key,
+            DebugViewOptions options,
+            [NotNull] string indent = "")
         {
             var builder = new StringBuilder();
 
             builder.Append(indent);
 
+            var singleLine = (options & DebugViewOptions.SingleLine) != 0;
             if (singleLine)
             {
                 builder.Append("Key: ");
@@ -81,7 +85,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 builder.Append(" PK");
             }
 
-            if (!singleLine)
+            if (!singleLine &&
+                (options & DebugViewOptions.IncludeAnnotations) != 0)
             {
                 builder.Append(key.AnnotationsToDebugString(indent + "  "));
             }

--- a/src/EFCore/Metadata/Internal/Model.cs
+++ b/src/EFCore/Metadata/Internal/Model.cs
@@ -849,7 +849,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual DebugView<Model> DebugView
-            => new DebugView<Model>(this, m => m.ToDebugString());
+            => new DebugView<Model>(
+                this,
+                m => m.ToDebugString(DebugViewOptions.ShortDefault),
+                m => m.ToDebugString(DebugViewOptions.LongDefault));
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/ModelExtensions.cs
+++ b/src/EFCore/Metadata/Internal/ModelExtensions.cs
@@ -42,7 +42,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static string ToDebugString([NotNull] this IModel model, [NotNull] string indent = "")
+        public static string ToDebugString(
+            [NotNull] this IModel model,
+            DebugViewOptions options,
+            [NotNull] string indent = "")
         {
             var builder = new StringBuilder();
 
@@ -60,10 +63,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             foreach (var entityType in model.GetEntityTypes())
             {
-                builder.AppendLine().Append(entityType.ToDebugString(false, indent + "  "));
+                builder.AppendLine().Append(entityType.ToDebugString(options, indent + "  "));
             }
 
-            builder.Append(model.AnnotationsToDebugString(indent));
+            if ((options & DebugViewOptions.IncludeAnnotations) != 0)
+            {
+                builder.Append(model.AnnotationsToDebugString(indent));
+            }
 
             return builder.ToString();
         }

--- a/src/EFCore/Metadata/Internal/Navigation.cs
+++ b/src/EFCore/Metadata/Internal/Navigation.cs
@@ -235,7 +235,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public override string ToString() => this.ToDebugString();
+        public override string ToString() => this.ToDebugString(DebugViewOptions.SingleLineDefault);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -244,7 +244,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual DebugView<Navigation> DebugView
-            => new DebugView<Navigation>(this, m => m.ToDebugString(false));
+            => new DebugView<Navigation>(
+                this,
+                m => m.ToDebugString(DebugViewOptions.ShortDefault),
+                m => m.ToDebugString(DebugViewOptions.LongDefault));
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/NavigationExtensions.cs
+++ b/src/EFCore/Metadata/Internal/NavigationExtensions.cs
@@ -26,26 +26,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public static string ToDebugString(
             [NotNull] this INavigation navigation,
-            bool singleLine = true,
-            bool includeIndexes = false,
-            [NotNull] string indent = "",
-            bool detailed = true)
+            DebugViewOptions options,
+            [NotNull] string indent = "")
         {
             var builder = new StringBuilder();
 
             builder.Append(indent);
 
+            var singleLine = (options & DebugViewOptions.SingleLine) != 0;
             if (singleLine)
             {
                 builder.Append($"Navigation: {navigation.DeclaringEntityType.DisplayName()}.");
             }
 
             builder.Append(navigation.Name);
-
-            if (!detailed)
-            {
-                return builder.ToString();
-            }
 
             var field = navigation.GetFieldName();
             if (field == null)
@@ -82,7 +76,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 builder.Append(" PropertyAccessMode.").Append(navigation.GetPropertyAccessMode());
             }
 
-            if (includeIndexes)
+            if ((options & DebugViewOptions.IncludePropertyIndexes) != 0)
             {
                 var indexes = navigation.GetPropertyIndexes();
                 builder.Append(" ").Append(indexes.Index);
@@ -92,7 +86,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 builder.Append(" ").Append(indexes.StoreGenerationIndex);
             }
 
-            if (!singleLine)
+            if (!singleLine &&
+                (options & DebugViewOptions.IncludeAnnotations) != 0)
             {
                 builder.Append(navigation.AnnotationsToDebugString(indent + "  "));
             }

--- a/src/EFCore/Metadata/Internal/Property.cs
+++ b/src/EFCore/Metadata/Internal/Property.cs
@@ -635,7 +635,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public override string ToString() => this.ToDebugString();
+        public override string ToString() => this.ToDebugString(DebugViewOptions.SingleLineDefault);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -644,7 +644,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual DebugView<Property> DebugView
-            => new DebugView<Property>(this, m => m.ToDebugString(false));
+            => new DebugView<Property>(
+                this,
+                m => m.ToDebugString(DebugViewOptions.ShortDefault),
+                m => m.ToDebugString(DebugViewOptions.LongDefault));
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/PropertyExtensions.cs
+++ b/src/EFCore/Metadata/Internal/PropertyExtensions.cs
@@ -199,14 +199,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public static string ToDebugString(
             [NotNull] this IProperty property,
-            bool singleLine = true,
-            bool includeIndexes = false,
+            DebugViewOptions options,
             [NotNull] string indent = "")
         {
             var builder = new StringBuilder();
 
             builder.Append(indent);
 
+            var singleLine = (options & DebugViewOptions.SingleLine) != 0;
             if (singleLine)
             {
                 builder.Append($"Property: {property.DeclaringEntityType.DisplayName()}.");
@@ -292,7 +292,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 builder.Append(" PropertyAccessMode.").Append(property.GetPropertyAccessMode());
             }
 
-            if (includeIndexes)
+            if ((options & DebugViewOptions.IncludePropertyIndexes) != 0)
             {
                 var indexes = property.GetPropertyIndexes();
                 if (indexes != null)
@@ -305,7 +305,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
             }
 
-            if (!singleLine)
+            if (!singleLine &&
+                (options & DebugViewOptions.IncludeAnnotations) != 0)
             {
                 builder.Append(property.AnnotationsToDebugString(indent + "  "));
             }

--- a/src/EFCore/Metadata/Internal/ServiceProperty.cs
+++ b/src/EFCore/Metadata/Internal/ServiceProperty.cs
@@ -188,7 +188,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public override string ToString() => this.ToDebugString();
+        public override string ToString() => this.ToDebugString(DebugViewOptions.SingleLineDefault);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -197,6 +197,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual DebugView<ServiceProperty> DebugView
-            => new DebugView<ServiceProperty>(this, m => m.ToDebugString(false));
+            => new DebugView<ServiceProperty>(
+                this,
+                m => m.ToDebugString(DebugViewOptions.ShortDefault),
+                m => m.ToDebugString(DebugViewOptions.LongDefault));
     }
 }

--- a/src/EFCore/Query/MaterializeCollectionNavigationExpression.cs
+++ b/src/EFCore/Query/MaterializeCollectionNavigationExpression.cs
@@ -35,7 +35,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             expressionPrinter.AppendLine("MaterializeCollectionNavigation(");
             using (expressionPrinter.Indent())
             {
-                expressionPrinter.AppendLine($"navigation: {Navigation.ToDebugString(detailed: false)},");
+                expressionPrinter.AppendLine($"navigation: Navigation: {Navigation.DeclaringEntityType.DisplayName()}.{Navigation.Name},");
                 expressionPrinter.Append("subquery: ");
                 expressionPrinter.Visit(Subquery);
             }

--- a/test/EFCore.CrossStore.FunctionalTests/EFCore.CrossStore.FunctionalTests.csproj
+++ b/test/EFCore.CrossStore.FunctionalTests/EFCore.CrossStore.FunctionalTests.csproj
@@ -8,10 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Update="..\EFCore.SqlServer.FunctionalTests\Northwind.sql">
-      <Link>Northwind.sql</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
     <None Update="..\xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
This is mostly for me when debugging issues, since I frequently manually remove annotations to make the model easier to read.
