### PR TITLE
[3.1.1] Set ordinal key values for embedded owned collection entities

### DIFF
--- a/src/EFCore.Cosmos/Metadata/Internal/CosmosPropertyExtensions.cs
+++ b/src/EFCore.Cosmos/Metadata/Internal/CosmosPropertyExtensions.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Diagnostics;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static class CosmosPropertyExtensions
+    {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public static bool IsOrdinalKeyProperty(this IProperty property)
+        {
+            Debug.Assert(property.DeclaringEntityType.IsOwned());
+            Debug.Assert(property.GetPropertyName().Length == 0);
+
+            return property.IsPrimaryKey()
+                && !property.IsForeignKey()
+                && property.ClrType == typeof(int)
+                && property.ValueGenerated == ValueGenerated.OnAdd
+                && property.DeclaringEntityType.FindPrimaryKey().Properties.Count > 1;
+        }
+    }
+}

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitor.cs
@@ -604,9 +604,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                     {
                         var ownership = entityType.FindOwnership();
                         if (!ownership.IsUnique
-                            && property.IsPrimaryKey()
-                            && !property.IsForeignKey()
-                            && property.ClrType == typeof(int))
+                            && property.IsOrdinalKeyProperty())
                         {
                             Expression readExpression = _ordinalParameterBindings[jObjectExpression];
                             if (readExpression.Type != clrType)

--- a/src/EFCore/ChangeTracking/Internal/IStateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/IStateManager.cs
@@ -63,6 +63,14 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        bool SavingChanges { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         InternalEntityEntry GetOrCreateEntry([NotNull] object entity);
 
         /// <summary>

--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -449,7 +449,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             if (changeState
                 && !isConceptualNull
                 && isModified
-                && property.IsKey())
+                && !StateManager.SavingChanges
+                && property.IsKey()
+                && property.GetAfterSaveBehavior() == PropertySaveBehavior.Throw)
             {
                 throw new InvalidOperationException(CoreStrings.KeyReadOnly(property.Name, EntityType.DisplayName()));
             }
@@ -608,7 +610,12 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             }
 
             SetProperty(
-                property, value, isMaterialization: false, setModified: true, isCascadeDelete: false, CurrentValueType.StoreGenerated);
+                property,
+                value,
+                isMaterialization: false,
+                setModified: true,
+                isCascadeDelete: false,
+                CurrentValueType.StoreGenerated);
         }
 
         /// <summary>

--- a/src/EFCore/ChangeTracking/Internal/StateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/StateManager.cs
@@ -129,6 +129,14 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public virtual bool SavingChanges { get; set; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public virtual IInternalEntityEntryNotifier InternalEntityEntryNotifier { get; }
 
         /// <summary>
@@ -651,6 +659,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             Tracked = null;
             StateChanged = null;
+
+            SavingChanges = false;
         }
 
         /// <summary>
@@ -1062,7 +1072,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             }
         }
 
-
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -1089,6 +1098,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             try
             {
+                SavingChanges = true;
                 var result = SaveChanges(entriesToSave);
 
                 if (acceptAllChangesOnSuccess)
@@ -1106,6 +1116,10 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 }
 
                 throw;
+            }
+            finally
+            {
+                SavingChanges = false;
             }
         }
 
@@ -1137,6 +1151,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             try
             {
+                SavingChanges = true;
                 var result = await SaveChangesAsync(entriesToSave, cancellationToken);
 
                 if (acceptAllChangesOnSuccess)
@@ -1154,6 +1169,10 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 }
 
                 throw;
+            }
+            finally
+            {
+                SavingChanges = false;
             }
         }
 

--- a/test/EFCore.Tests/TestUtilities/FakeStateManager.cs
+++ b/test/EFCore.Tests/TestUtilities/FakeStateManager.cs
@@ -62,13 +62,17 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             bool unchanged = false)
             => throw new NotImplementedException();
 
+        public int ChangedCount { get; set; }
+
         public int Count => throw new NotImplementedException();
+
+        public IDiagnosticsLogger<DbLoggerCategory.Update> UpdateLogger { get; }
+
+        public bool SavingChanges => throw new NotImplementedException();
 
         public IEnumerable<TEntity> GetNonDeletedEntities<TEntity>()
             where TEntity : class
             => throw new NotImplementedException();
-
-        public int ChangedCount { get; set; }
 
         public IEntityFinder CreateEntityFinder(IEntityType entityType) => throw new NotImplementedException();
         public void UpdateIdentityMap(InternalEntityEntry entry, IKey principalKey) => throw new NotImplementedException();
@@ -153,7 +157,5 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         {
             throw new NotImplementedException();
         }
-
-        public IDiagnosticsLogger<DbLoggerCategory.Update> UpdateLogger { get; }
     }
 }


### PR DESCRIPTION
Fixes #18948

## Description
Cosmos provider allows to save collections of owned entities as embedded documents in a JSON array property in the owner document without storing the key values explicitly. They are synthesized from the owner key and the ordinal in the collection. However we didn't synthesize the values when saving the entities, only when querying.

The fix is to synthesize the key values when saving the entities. And also consistently allow readonly properties to be set the current store values during SaveChanges to allow propagation of the new values.

## Customer Impact
The bug leads to the newly saved entities having a different identity and causes duplication in the owned collections if queried after saving a new entity using the same context.

## How found
Customer-reported

## Test coverage
We did not have tests querying back the entities that were just saved using the same context.

## Regression?
No

## Risk
Low, only affects the Cosmos provider
