### PR TITLE
Query: Match memberInfo in hierarchy for reducing MemberInitExpression

### DIFF
--- a/src/EFCore/Query/ReplacingExpressionVisitor.cs
+++ b/src/EFCore/Query/ReplacingExpressionVisitor.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 
@@ -60,7 +61,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             if (innerExpression is MemberInitExpression memberInitExpression
                 && memberInitExpression.Bindings.SingleOrDefault(
-                    mb => mb.Member == memberExpression.Member) is MemberAssignment memberAssignment)
+                    mb => mb.Member.IsSameAs(memberExpression.Member)) is MemberAssignment memberAssignment)
             {
                 return memberAssignment.Expression;
             }

--- a/src/Shared/MemberInfoExtensions.cs
+++ b/src/Shared/MemberInfoExtensions.cs
@@ -31,16 +31,5 @@ namespace System.Reflection
             var index = name.LastIndexOf('.');
             return index >= 0 ? name.Substring(index + 1) : name;
         }
-
-        private sealed class MemberInfoComparer : IEqualityComparer<MemberInfo>
-        {
-            public static readonly MemberInfoComparer Instance = new MemberInfoComparer();
-
-            public bool Equals(MemberInfo x, MemberInfo y)
-                => x.IsSameAs(y);
-
-            public int GetHashCode(MemberInfo obj)
-                => obj.GetHashCode();
-        }
     }
 }

--- a/test/EFCore.Specification.Tests/Query/InheritanceTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/InheritanceTestBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
+using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestModels.Inheritance;
@@ -523,8 +524,6 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        protected virtual bool EnforcesFkConstraints => true;
-
         [ConditionalFact]
         public virtual void Byte_enum_value_constant_used_in_projection()
         {
@@ -536,7 +535,31 @@ namespace Microsoft.EntityFrameworkCore.Query
             Assert.Equal(Island.North, result[0]);
         }
 
+        [ConditionalFact]
+        public virtual void Member_access_on_intermediate_type_works()
+        {
+            using var context = CreateContext();
+            var query = context.Set<Kiwi>().Select(k => new Kiwi { Name = k.Name });
+
+            var parameter = Expression.Parameter(query.ElementType, "p");
+            var property = Expression.Property(parameter, "Name");
+            var getProperty = Expression.Lambda(property, new[] { parameter });
+
+            var expression = Expression.Call(typeof(Queryable), nameof(Queryable.OrderBy),
+                new[] { query.ElementType, typeof(string) },
+                new[] { query.Expression, Expression.Quote(getProperty) });
+
+            query = query.Provider.CreateQuery<Kiwi>(expression);
+
+            var result = query.ToList();
+
+            var kiwi = Assert.Single(result);
+            Assert.Equal("Great spotted kiwi", kiwi.Name);
+        }
+
         protected InheritanceContext CreateContext() => Fixture.CreateContext();
+
+        protected virtual bool EnforcesFkConstraints => true;
 
         protected virtual void ClearLog()
         {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceSqlServerTest.cs
@@ -500,6 +500,17 @@ FROM (
 WHERE CAST(0 AS bit) = CAST(1 AS bit)");
         }
 
+        public override void Member_access_on_intermediate_type_works()
+        {
+            base.Member_access_on_intermediate_type_works();
+
+            AssertSql(
+                @"SELECT [a].[Name]
+FROM [Animal] AS [a]
+WHERE [a].[Discriminator] = N'Kiwi'
+ORDER BY [a].[Name]");
+        }
+
         protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
             => facade.UseTransaction(transaction.GetDbTransaction());
 


### PR DESCRIPTION
Issue: For compiler generated trees the MemberInfos always in sync. But for manually generated trees, if derived type parameter is used then the MemberInfo.ReflectedType is different. Which throws off ReplacingExpressionVisitor when comparing MemberInfo.
Fix: Use helper method IsSameAs which compare memberInfos which refer to same member access in given hierarchy

Resolves #19087
