### PR TITLE
[release/3.0] Use Microsoft.NETCore.App.Internal for runtime version

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -45,6 +45,10 @@
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>547ae1f5f072d130b32ec3089876711070b2dc4f</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.NETCore.App.Internal" Version="3.0.2-servicing-19576-08" CoherentParentDependency="Microsoft.Extensions.Logging">
+      <Uri>https://github.com/dotnet/core-setup</Uri>
+      <Sha>547ae1f5f072d130b32ec3089876711070b2dc4f</Sha>
+    </Dependency>
     <Dependency Name="NETStandard.Library.Ref" Version="2.1.0" Pinned="true">
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>7d57652f33493fa022125b7f63aad0d70c52d810</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -51,6 +51,7 @@
     <MicrosoftExtensionsDependencyModelPackageVersion>3.0.2-servicing-19576-08</MicrosoftExtensionsDependencyModelPackageVersion>
     <MicrosoftNETCoreAppRefPackageVersion>3.0.0</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftNETCoreAppRuntimewinx64PackageVersion>3.0.2-servicing-19576-08</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftNETCoreAppInternalPackageVersion>3.0.2-servicing-19576-08</MicrosoftNETCoreAppInternalPackageVersion>
     <NETStandardLibraryRefPackageVersion>2.1.0</NETStandardLibraryRefPackageVersion>
   </PropertyGroup>
   <PropertyGroup Label="Dependencies from dotnet/roslyn">

--- a/global.json
+++ b/global.json
@@ -4,7 +4,7 @@
     "runtimes": {
       "dotnet": [
         "2.0.9",
-        "$(MicrosoftNETCoreAppRuntimeVersion)"
+        "$(MicrosoftNETCoreAppInternalPackageVersion)"
       ]
     }
   },


### PR DESCRIPTION
* Use Microsoft.NETCore.App.Internal for runtime version
For stable builds, core-setup is now publishing its artifacts to a suffixed directory (e.g. 3.0.1-servicing-19510-13) instead of 3.0.1. This ensures we don't have to overwrite outputs when we rebuild stable versions. Within that directory, it publishes the same set of files with the final file names as well as suffixed file names:
- https://dotnetcli.blob.core.windows.net/dotnet/Runtime/3.0.1-servicing-19510-13/dotnet-apphost-pack-3.0.1-win-x64.msi
- https://dotnetcli.blob.core.windows.net/dotnet/Runtime/3.0.1-servicing-19510-13/dotnet-apphost-pack-3.0.1-servicing-19510-13-win-x64.msi

Downstream repos should install the runtime using the full suffixed version.