### PR TITLE
Query Fix for #13487 Translate byte[].Length for SqlServer & Sqlite

### DIFF
--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -20,8 +20,9 @@ namespace Microsoft.EntityFrameworkCore.Query
     {
         private readonly IModel _model;
         private readonly QueryableMethodTranslatingExpressionVisitor _queryableMethodTranslatingExpressionVisitor;
-        private readonly ISqlExpressionFactory _sqlExpressionFactory;
         private readonly SqlTypeMappingVerifyingExpressionVisitor _sqlTypeMappingVerifyingExpressionVisitor;
+
+        protected readonly ISqlExpressionFactory SqlExpressionFactory;
 
         public RelationalSqlTranslatingExpressionVisitor(
             [NotNull] RelationalSqlTranslatingExpressionVisitorDependencies dependencies,
@@ -33,10 +34,10 @@ namespace Microsoft.EntityFrameworkCore.Query
             Check.NotNull(queryableMethodTranslatingExpressionVisitor, nameof(queryableMethodTranslatingExpressionVisitor));
 
             Dependencies = dependencies;
+            SqlExpressionFactory = dependencies.SqlExpressionFactory;
 
             _model = model;
             _queryableMethodTranslatingExpressionVisitor = queryableMethodTranslatingExpressionVisitor;
-            _sqlExpressionFactory = dependencies.SqlExpressionFactory;
             _sqlTypeMappingVerifyingExpressionVisitor = new SqlTypeMappingVerifyingExpressionVisitor();
         }
 
@@ -57,7 +58,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     translation = sqlUnaryExpression.Operand;
                 }
 
-                translation = _sqlExpressionFactory.ApplyDefaultTypeMapping(translation);
+                translation = SqlExpressionFactory.ApplyDefaultTypeMapping(translation);
 
                 if ((translation is SqlConstantExpression
                         || translation is SqlParameterExpression)
@@ -93,17 +94,17 @@ namespace Microsoft.EntityFrameworkCore.Query
             if (inputType == typeof(int)
                 || inputType == typeof(long))
             {
-                sqlExpression = _sqlExpressionFactory.ApplyDefaultTypeMapping(
-                    _sqlExpressionFactory.Convert(sqlExpression, typeof(double)));
+                sqlExpression = SqlExpressionFactory.ApplyDefaultTypeMapping(
+                    SqlExpressionFactory.Convert(sqlExpression, typeof(double)));
             }
 
             return inputType == typeof(float)
-                ? _sqlExpressionFactory.Convert(
-                    _sqlExpressionFactory.Function(
+                ? SqlExpressionFactory.Convert(
+                    SqlExpressionFactory.Function(
                         "AVG", new[] { sqlExpression }, typeof(double)),
                     sqlExpression.Type,
                     sqlExpression.TypeMapping)
-                : (SqlExpression)_sqlExpressionFactory.Function(
+                : (SqlExpression)SqlExpressionFactory.Function(
                     "AVG", new[] { sqlExpression }, sqlExpression.Type, sqlExpression.TypeMapping);
         }
 
@@ -115,8 +116,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 return null;
             }
 
-            return _sqlExpressionFactory.ApplyDefaultTypeMapping(
-                _sqlExpressionFactory.Function("COUNT", new[] { _sqlExpressionFactory.Fragment("*") }, typeof(int)));
+            return SqlExpressionFactory.ApplyDefaultTypeMapping(
+                SqlExpressionFactory.Function("COUNT", new[] { SqlExpressionFactory.Fragment("*") }, typeof(int)));
         }
 
         public virtual SqlExpression TranslateLongCount([CanBeNull] Expression expression = null)
@@ -127,8 +128,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 return null;
             }
 
-            return _sqlExpressionFactory.ApplyDefaultTypeMapping(
-                _sqlExpressionFactory.Function("COUNT", new[] { _sqlExpressionFactory.Fragment("*") }, typeof(long)));
+            return SqlExpressionFactory.ApplyDefaultTypeMapping(
+                SqlExpressionFactory.Function("COUNT", new[] { SqlExpressionFactory.Fragment("*") }, typeof(long)));
         }
 
         public virtual SqlExpression TranslateMax([NotNull] Expression expression)
@@ -141,7 +142,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
 
             return sqlExpression != null
-                ? _sqlExpressionFactory.Function("MAX", new[] { sqlExpression }, sqlExpression.Type, sqlExpression.TypeMapping)
+                ? SqlExpressionFactory.Function("MAX", new[] { sqlExpression }, sqlExpression.Type, sqlExpression.TypeMapping)
                 : null;
         }
 
@@ -155,7 +156,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
 
             return sqlExpression != null
-                ? _sqlExpressionFactory.Function("MIN", new[] { sqlExpression }, sqlExpression.Type, sqlExpression.TypeMapping)
+                ? SqlExpressionFactory.Function("MIN", new[] { sqlExpression }, sqlExpression.Type, sqlExpression.TypeMapping)
                 : null;
         }
 
@@ -176,11 +177,11 @@ namespace Microsoft.EntityFrameworkCore.Query
             var inputType = sqlExpression.Type.UnwrapNullableType();
 
             return inputType == typeof(float)
-                ? _sqlExpressionFactory.Convert(
-                    _sqlExpressionFactory.Function("SUM", new[] { sqlExpression }, typeof(double)),
+                ? SqlExpressionFactory.Convert(
+                    SqlExpressionFactory.Function("SUM", new[] { sqlExpression }, typeof(double)),
                     inputType,
                     sqlExpression.TypeMapping)
-                : (SqlExpression)_sqlExpressionFactory.Function(
+                : (SqlExpression)SqlExpressionFactory.Function(
                     "SUM", new[] { sqlExpression }, inputType, sqlExpression.TypeMapping);
         }
 
@@ -257,7 +258,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 var entityType = entityProjectionExpression.EntityType;
                 if (entityType.GetAllBaseTypesInclusive().Any(et => et.ClrType == typeBinaryExpression.TypeOperand))
                 {
-                    return _sqlExpressionFactory.Constant(true);
+                    return SqlExpressionFactory.Constant(true);
                 }
 
                 var derivedType = entityType.GetDerivedTypes().SingleOrDefault(et => et.ClrType == typeBinaryExpression.TypeOperand);
@@ -267,16 +268,16 @@ namespace Microsoft.EntityFrameworkCore.Query
                     var discriminatorColumn = entityProjectionExpression.BindProperty(entityType.GetDiscriminatorProperty());
 
                     return concreteEntityTypes.Count == 1
-                        ? _sqlExpressionFactory.Equal(
+                        ? SqlExpressionFactory.Equal(
                             discriminatorColumn,
-                            _sqlExpressionFactory.Constant(concreteEntityTypes[0].GetDiscriminatorValue()))
-                        : (Expression)_sqlExpressionFactory.In(
+                            SqlExpressionFactory.Constant(concreteEntityTypes[0].GetDiscriminatorValue()))
+                        : (Expression)SqlExpressionFactory.In(
                             discriminatorColumn,
-                            _sqlExpressionFactory.Constant(concreteEntityTypes.Select(et => et.GetDiscriminatorValue()).ToList()),
+                            SqlExpressionFactory.Constant(concreteEntityTypes.Select(et => et.GetDiscriminatorValue()).ToList()),
                             negated: false);
                 }
 
-                return _sqlExpressionFactory.Constant(false);
+                return SqlExpressionFactory.Constant(false);
             }
 
             return null;
@@ -511,7 +512,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return TranslationFailed(binaryExpression.Left, Visit(left), out var sqlLeft)
                 || TranslationFailed(binaryExpression.Right, Visit(right), out var sqlRight)
                 ? null
-                : _sqlExpressionFactory.MakeBinary(
+                : SqlExpressionFactory.MakeBinary(
                     binaryExpression.NodeType,
                     sqlLeft,
                     sqlRight,
@@ -643,7 +644,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 || TranslationFailed(conditionalExpression.IfTrue, ifTrue, out var sqlIfTrue)
                 || TranslationFailed(conditionalExpression.IfFalse, ifFalse, out var sqlIfFalse)
                 ? null
-                : _sqlExpressionFactory.Case(new[] { new CaseWhenClause(sqlTest, sqlIfTrue) }, sqlIfFalse);
+                : SqlExpressionFactory.Case(new[] { new CaseWhenClause(sqlTest, sqlIfTrue) }, sqlIfFalse);
         }
 
         protected override Expression VisitUnary(UnaryExpression unaryExpression)
@@ -660,10 +661,10 @@ namespace Microsoft.EntityFrameworkCore.Query
             switch (unaryExpression.NodeType)
             {
                 case ExpressionType.Not:
-                    return _sqlExpressionFactory.Not(sqlOperand);
+                    return SqlExpressionFactory.Not(sqlOperand);
 
                 case ExpressionType.Negate:
-                    return _sqlExpressionFactory.Negate(sqlOperand);
+                    return SqlExpressionFactory.Negate(sqlOperand);
 
                 case ExpressionType.Convert:
                 case ExpressionType.TypeAs:
@@ -678,11 +679,11 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                     // Introduce explicit cast only if the target type is mapped else we need to client eval
                     if (unaryExpression.Type == typeof(object)
-                        || _sqlExpressionFactory.FindMapping(unaryExpression.Type) != null)
+                        || SqlExpressionFactory.FindMapping(unaryExpression.Type) != null)
                     {
-                        sqlOperand = _sqlExpressionFactory.ApplyDefaultTypeMapping(sqlOperand);
+                        sqlOperand = SqlExpressionFactory.ApplyDefaultTypeMapping(sqlOperand);
 
-                        return _sqlExpressionFactory.Convert(sqlOperand, unaryExpression.Type);
+                        return SqlExpressionFactory.Convert(sqlOperand, unaryExpression.Type);
                     }
 
                     break;

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         private readonly QueryableMethodTranslatingExpressionVisitor _queryableMethodTranslatingExpressionVisitor;
         private readonly SqlTypeMappingVerifyingExpressionVisitor _sqlTypeMappingVerifyingExpressionVisitor;
 
-        protected readonly ISqlExpressionFactory SqlExpressionFactory;
+        protected virtual ISqlExpressionFactory SqlExpressionFactory { get; }
 
         public RelationalSqlTranslatingExpressionVisitor(
             [NotNull] RelationalSqlTranslatingExpressionVisitorDependencies dependencies,

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitor.cs
@@ -74,7 +74,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
 
                 var isBinaryMaxDataType = GetProviderType(sqlExpression) == "varbinary(max)" || sqlExpression is SqlParameterExpression;
                 var dataLengthSqlFunction = SqlExpressionFactory.Function(
-                    "DATALENGTH", new[] { sqlExpression }, isBinaryMaxDataType ? typeof(int) : typeof(long));
+                    "DATALENGTH", new[] { sqlExpression }, isBinaryMaxDataType ? typeof(long) : typeof(int));
 
                 return isBinaryMaxDataType
                     ? (Expression)SqlExpressionFactory.Convert(dataLengthSqlFunction, typeof(int))

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitor.cs
@@ -67,14 +67,12 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
         protected override Expression VisitUnary(UnaryExpression unaryExpression)
         {
             if (unaryExpression.NodeType == ExpressionType.ArrayLength
-             && unaryExpression.Operand.Type == typeof(byte[])
-             && Visit(unaryExpression.Operand) is ColumnExpression columnExpression)
+                && unaryExpression.Operand.Type == typeof(byte[])
+                && Visit(unaryExpression.Operand) is ColumnExpression columnExpression)
             {
-                var intMapping = _sqlExpressionFactory.FindMapping(typeof(int));
-
                 return _sqlExpressionFactory.Convert(
-                    _sqlExpressionFactory.Function("DATALENGTH", new[] { columnExpression }, typeof(int?), intMapping),
-                    typeof(int?), intMapping);
+                    _sqlExpressionFactory.Function("DATALENGTH", new[] { columnExpression }, typeof(int?)),
+                    typeof(int?));
             }
 
             return base.VisitUnary(unaryExpression);

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitor.cs
@@ -67,9 +67,15 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
             {
                 var visitedExpression = (SqlExpression)base.Visit(unaryExpression.Operand);
 
+                if (visitedExpression == null)
+                {
+                    return null;
+                }
+
                 var dataLengthSqlFunction = SqlExpressionFactory.Function("DATALENGTH", new[] { visitedExpression }, typeof(int));
 
-                return visitedExpression is ColumnExpression && GetProviderType(visitedExpression) == "varbinary(max)"
+                return (visitedExpression is ColumnExpression && GetProviderType(visitedExpression) == "varbinary(max)"
+                 || visitedExpression is SqlParameterExpression)
                     ? (Expression)SqlExpressionFactory.Convert(dataLengthSqlFunction, typeof(int))
                     : dataLengthSqlFunction;
             }

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlTranslatingExpressionVisitor.cs
@@ -88,10 +88,13 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
             Check.NotNull(unaryExpression, nameof(unaryExpression));
 
             if (unaryExpression.NodeType == ExpressionType.ArrayLength
-                 && unaryExpression.Operand.Type == typeof(byte[])
-                 && base.Visit(unaryExpression.Operand) is SqlExpression sqlExpression)
+                 && unaryExpression.Operand.Type == typeof(byte[]))
             {
-                return SqlExpressionFactory.Function("length", new[] { sqlExpression }, typeof(int));
+                var sqlExpression = base.Visit(unaryExpression.Operand) as SqlExpression;
+
+                return sqlExpression == null
+                    ? null
+                    : SqlExpressionFactory.Function("length", new[] { sqlExpression }, typeof(int));
             }
 
             var visitedExpression = base.VisitUnary(unaryExpression);

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlTranslatingExpressionVisitor.cs
@@ -91,11 +91,6 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
              && unaryExpression.Operand.Type == typeof(byte[])
              && base.Visit(unaryExpression.Operand) is SqlExpression sqlExpression)
             {
-                if (sqlExpression == null)
-                {
-                    return null;
-                }
-
                 return SqlExpressionFactory.Function("length", new[] { sqlExpression }, typeof(int));
             }
 

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlTranslatingExpressionVisitor.cs
@@ -87,6 +87,13 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
         {
             Check.NotNull(unaryExpression, nameof(unaryExpression));
 
+            if (unaryExpression.NodeType == ExpressionType.ArrayLength
+             && unaryExpression.Operand.Type == typeof(byte[])
+             && base.Visit(unaryExpression.Operand) is ColumnExpression columnExpression)
+            {
+                return SqlExpressionFactory.Function("length", new[] { columnExpression }, typeof(int?));
+            }
+
             var visitedExpression = base.VisitUnary(unaryExpression);
             if (visitedExpression == null)
             {

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlTranslatingExpressionVisitor.cs
@@ -90,7 +90,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
             if (unaryExpression.NodeType == ExpressionType.ArrayLength
                  && unaryExpression.Operand.Type == typeof(byte[]))
             {
-                var sqlExpression = base.Visit(unaryExpression.Operand) as SqlExpression;
+return base.Visit(unaryExpression.Operand) is SqlExpression operandExpression
+    ? SqlExpressionFactory.Function("length", new[] { sqlExpression }, typeof(int))
+    : null;
 
                 return sqlExpression == null
                     ? null

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlTranslatingExpressionVisitor.cs
@@ -89,9 +89,14 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
 
             if (unaryExpression.NodeType == ExpressionType.ArrayLength
              && unaryExpression.Operand.Type == typeof(byte[])
-             && base.Visit(unaryExpression.Operand) is ColumnExpression columnExpression)
+             && base.Visit(unaryExpression.Operand) is SqlExpression sqlExpression)
             {
-                return SqlExpressionFactory.Function("length", new[] { columnExpression }, typeof(int?));
+                if (sqlExpression == null)
+                {
+                    return null;
+                }
+
+                return SqlExpressionFactory.Function("length", new[] { sqlExpression }, typeof(int));
             }
 
             var visitedExpression = base.VisitUnary(unaryExpression);

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlTranslatingExpressionVisitor.cs
@@ -88,8 +88,8 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
             Check.NotNull(unaryExpression, nameof(unaryExpression));
 
             if (unaryExpression.NodeType == ExpressionType.ArrayLength
-             && unaryExpression.Operand.Type == typeof(byte[])
-             && base.Visit(unaryExpression.Operand) is SqlExpression sqlExpression)
+                 && unaryExpression.Operand.Type == typeof(byte[])
+                 && base.Visit(unaryExpression.Operand) is SqlExpression sqlExpression)
             {
                 return SqlExpressionFactory.Function("length", new[] { sqlExpression }, typeof(int));
             }

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlTranslatingExpressionVisitor.cs
@@ -90,13 +90,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
             if (unaryExpression.NodeType == ExpressionType.ArrayLength
                  && unaryExpression.Operand.Type == typeof(byte[]))
             {
-return base.Visit(unaryExpression.Operand) is SqlExpression operandExpression
-    ? SqlExpressionFactory.Function("length", new[] { sqlExpression }, typeof(int))
-    : null;
-
-                return sqlExpression == null
-                    ? null
-                    : SqlExpressionFactory.Function("length", new[] { sqlExpression }, typeof(int));
+                return base.Visit(unaryExpression.Operand) is SqlExpression sqlExpression
+                    ? SqlExpressionFactory.Function("length", new[] { sqlExpression }, typeof(int))
+                    : null;
             }
 
             var visitedExpression = base.VisitUnary(unaryExpression);

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryFixtureBase.cs
@@ -190,6 +190,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                             {
                                 Assert.True(Enumerable.SequenceEqual(e.Banner, a.Banner));
                             }
+                            Assert.Equal(e.Banner5 == null, a.Banner5 == null);
+                            if (e.Banner5 != null)
+                            {
+                                Assert.True(Enumerable.SequenceEqual(e.Banner5, a.Banner5));
+                            }
                         }
                     }
                 },
@@ -255,6 +260,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 {
                     b.HasKey(s => s.Id);
                     b.Property(s => s.Id).ValueGeneratedNever();
+                    b.Property(s => s.Banner5).HasMaxLength(5);
                     b.HasMany(s => s.Members).WithOne(g => g.Squad).HasForeignKey(g => g.SquadId);
                 });
 

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
-using Castle.Core.Logging;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -7355,6 +7354,15 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => ss.Set<Squad>().Where(s => s.Banner.Contains(someByte)),
                 ss => ss.Set<Squad>().Where(s => s.Banner != null && s.Banner.Contains(someByte)));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Byte_array_filter_by_length_literal_does_not_cast_on_varbinary_n(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Squad>().Where(w => w.Banner5.Length == 5));
         }
 
         [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -7362,7 +7362,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss => ss.Set<Squad>().Where(w => w.Banner5.Length == 5));
+                ss => ss.Set<Squad>().Where(w => w.Banner5.Length == 5),
+                ss => ss.Set<Squad>().Where(w => w.Banner5 != null && w.Banner5.Length == 5));
         }
 
         [ConditionalTheory]
@@ -7371,7 +7372,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss => ss.Set<Squad>().Where(w => w.Banner.Length == 1));
+                ss => ss.Set<Squad>().Where(w => w.Banner.Length == 1),
+                ss => ss.Set<Squad>().Where(w => w.Banner != null && w.Banner.Length == 1));
         }
 
         [ConditionalTheory]
@@ -7381,7 +7383,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             var someByteArr = new[] { (byte)42 };
             return AssertQuery(
                 async,
-                ss => ss.Set<Squad>().Where(w => w.Banner.Length == someByteArr.Length));
+                ss => ss.Set<Squad>().Where(w => w.Banner.Length == someByteArr.Length),
+                ss => ss.Set<Squad>().Where(w => w.Banner != null && w.Banner.Length == someByteArr.Length));
         }
 
         [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
+using Castle.Core.Logging;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -7384,6 +7385,19 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<Weapon>().Select(w => w.SynergyWith).OrderBy(g => g.IsAutomatic),
                 ss => ss.Set<Weapon>().Select(w => w.SynergyWith).OrderBy(g => MaybeScalar<bool>(g, () => g.IsAutomatic)),
                 assertOrder: true);
+        }
+        
+        [ConditionalFact]
+        public virtual void Byte_array_filter_by_length_parameter_compiled()
+        {
+            var query = EF.CompileQuery(
+                (GearsOfWarContext context, byte[] byteArrayParam)
+                    => context.Squads.Where(w => w.Banner.Length == byteArrayParam.Length).Count());
+
+            using var context = CreateContext();
+            var byteQueryParam = new[] { (byte)42, (byte)128 };
+
+            Assert.Equal(2, query(context, byteQueryParam));
         }
 
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext();

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -7358,6 +7358,31 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
+        public virtual Task Byte_array_filter_by_length(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Squad>().Where(w => w.Banner.Length == 1));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Byte_array_filter_by_length_with_join(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Gear>().Where(w => w.Squad.Banner.Length == 1));
+        }
+
+        protected async Task AssertTranslationFailed(Func<Task> testCode)
+        {
+            Assert.Contains(
+                CoreStrings.TranslationFailed("").Substring(21),
+                (await Assert.ThrowsAsync<InvalidOperationException>(testCode)).Message);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual Task OrderBy_bool_coming_from_optional_navigation(bool async)
         {
             return AssertQuery(

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -7367,11 +7367,12 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual Task Byte_array_filter_by_length_with_join(bool async)
+        public virtual Task Byte_array_filter_by_length_parameter(bool async)
         {
+            var someByteArr = new[] { (byte)42 };
             return AssertQuery(
                 async,
-                ss => ss.Set<Gear>().Where(w => w.Squad.Banner.Length == 1));
+                ss => ss.Set<Squad>().Where(w => w.Banner.Length == someByteArr.Length));
         }
 
         [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -7358,7 +7358,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual Task Byte_array_filter_by_length(bool async)
+        public virtual Task Byte_array_filter_by_length_literal(bool async)
         {
             return AssertQuery(
                 async,

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -7374,13 +7374,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<Gear>().Where(w => w.Squad.Banner.Length == 1));
         }
 
-        protected async Task AssertTranslationFailed(Func<Task> testCode)
-        {
-            Assert.Contains(
-                CoreStrings.TranslationFailed("").Substring(21),
-                (await Assert.ThrowsAsync<InvalidOperationException>(testCode)).Message);
-        }
-
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task OrderBy_bool_coming_from_optional_navigation(bool async)

--- a/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/GearsOfWarData.cs
+++ b/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/GearsOfWarData.cs
@@ -107,8 +107,8 @@ namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel
         public static IReadOnlyList<Squad> CreateSquads()
             => new List<Squad>
             {
-                new Squad { Id = 1, Name = "Delta", Banner = new byte[] { 0x00, 0x01 } },
-                new Squad { Id = 2, Name = "Kilo", Banner = new byte[] { 0x02, 0x03 } }
+                new Squad { Id = 1, Name = "Delta", Banner = new byte[] { 0x00, 0x01 }, Banner5 = new byte[] { 0x04, 0x05, 0x06, 0x07, 0x08 } },
+                new Squad { Id = 2, Name = "Kilo", Banner = new byte[] { 0x02, 0x03 }, Banner5 = new byte[] { 0x04, 0x05, 0x06, 0x07, 0x08 } }
             };
 
         public static IReadOnlyList<Mission> CreateMissions()

--- a/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/Squad.cs
+++ b/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/Squad.cs
@@ -22,6 +22,8 @@ namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel
 
         public virtual byte[] Banner { get; set; }
 
+        public virtual byte[] Banner5 { get; set; }
+
         public virtual ICollection<Gear> Members { get; set; }
         public virtual ICollection<SquadMission> Missions { get; set; }
     }

--- a/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
@@ -51,19 +51,20 @@ FROM [MappedNullableDataTypes] AS [m]
 WHERE [m].[TimeSpanAsTime] = '00:01:02'");
         }
 
-        [ConditionalFact(Skip = "Issue#13487")]
+        [ConditionalFact]
         public void Translate_array_length()
         {
-            using var db = CreateContext();
-            db.Set<MappedDataTypesWithIdentity>()
-                .Where(p => p.BytesAsImage.Length == 0)
-                .Select(p => p.BytesAsImage.Length)
-                .FirstOrDefault();
+            using var context = CreateContext();
+            var results
+                = context.Set<MappedDataTypesWithIdentity>()
+                    .Where(p => p.BytesAsImage.Length == 0)
+                    .Select(p => p.BytesAsImage.Length)
+                    .FirstOrDefault();
 
             AssertSql(
-                @"SELECT TOP(1) CAST(DATALENGTH([p].[BytesAsImage]) AS int)
-FROM [MappedDataTypesWithIdentity] AS [p]
-WHERE CAST(DATALENGTH([p].[BytesAsImage]) AS int) = 0");
+                @"SELECT TOP(1) CAST(DATALENGTH([m].[BytesAsImage]) AS int)
+FROM [MappedDataTypesWithIdentity] AS [m]
+WHERE CAST(DATALENGTH([m].[BytesAsImage]) AS int) = 0");
         }
 
         [ConditionalFact]

--- a/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
@@ -52,22 +52,6 @@ WHERE [m].[TimeSpanAsTime] = '00:01:02'");
         }
 
         [ConditionalFact]
-        public void Translate_array_length()
-        {
-            using var context = CreateContext();
-            var results
-                = context.Set<MappedDataTypesWithIdentity>()
-                    .Where(p => p.BytesAsImage.Length == 0)
-                    .Select(p => p.BytesAsImage.Length)
-                    .FirstOrDefault();
-
-            AssertSql(
-                @"SELECT TOP(1) CAST(DATALENGTH([m].[BytesAsImage]) AS int)
-FROM [MappedDataTypesWithIdentity] AS [m]
-WHERE CAST(DATALENGTH([m].[BytesAsImage]) AS int) = 0");
-        }
-
-        [ConditionalFact]
         public void Sql_translation_uses_type_mapper_when_parameter()
         {
             using var context = CreateContext();

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -7313,6 +7313,18 @@ FROM [Squads] AS [s]
 WHERE CAST(DATALENGTH([s].[Banner]) AS int) = @__p_0");
         }
 
+        public override void Byte_array_filter_by_length_parameter_compiled()
+        {
+            base.Byte_array_filter_by_length_parameter_compiled();
+
+            AssertSql(
+                @"@__byteArrayParam='0x2A80' (Size = 8000)
+
+SELECT COUNT(*)
+FROM [Squads] AS [s]
+WHERE (CAST(DATALENGTH([s].[Banner]) AS int) = CAST(DATALENGTH(@__byteArrayParam) AS int)) OR (DATALENGTH([s].[Banner]) IS NULL AND DATALENGTH(@__byteArrayParam) IS NULL)");
+        }
+
         public override async Task Byte_array_contains_parameter(bool async)
         {
             await base.Byte_array_contains_parameter(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -7343,7 +7343,7 @@ WHERE CHARINDEX(CAST(@__someByte_0 AS varbinary(max)), [s].[Banner]) > 0");
 
             AssertSql(@"SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
 FROM [Squads] AS [s]
-WHERE DATALENGTH([s].[Banner5]) = CAST(5 AS bigint)");
+WHERE DATALENGTH([s].[Banner5]) = 5");
         }
 
         public override async Task Conditional_expression_with_test_being_simplified_to_constant_simple(bool isAsync)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -52,7 +52,7 @@ ORDER BY [t].[Id], [w].[Id]");
             await base.Include_multiple_one_to_one_optional_and_one_to_one_required(async);
 
             AssertSql(
-                @"SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[Note], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[Discriminator], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [s].[Id], [s].[Banner], [s].[InternalNumber], [s].[Name]
+                @"SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[Note], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[Discriminator], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
 FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
@@ -2877,7 +2877,7 @@ WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND (([t].[Note] <> N'Foo') O
             await base.FirstOrDefault_with_manually_created_groupjoin_is_translated_to_sql(async);
 
             AssertSql(
-                @"SELECT TOP(1) [s].[Id], [s].[Banner], [s].[InternalNumber], [s].[Name]
+                @"SELECT TOP(1) [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
 FROM [Squads] AS [s]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
@@ -3704,7 +3704,7 @@ WHERE [l].[Discriminator] IN (N'LocustLeader', N'LocustCommander')");
             await base.Include_reference_on_derived_type_using_string_nested1(async);
 
             AssertSql(
-                @"SELECT [l].[Name], [l].[Discriminator], [l].[LocustHordeId], [l].[ThreatLevel], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [l].[HighCommandId], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [s].[Id], [s].[Banner], [s].[InternalNumber], [s].[Name]
+                @"SELECT [l].[Name], [l].[Discriminator], [l].[LocustHordeId], [l].[ThreatLevel], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [l].[HighCommandId], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
 FROM [LocustLeaders] AS [l]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
@@ -3958,10 +3958,10 @@ ORDER BY [f].[Id], [t1].[Nickname], [t1].[SquadId]");
             await base.Include_on_derived_multi_level(async);
 
             AssertSql(
-                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Id], [t].[Banner], [t].[InternalNumber], [t].[Name], [t].[SquadId0], [t].[MissionId]
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Id], [t].[Banner], [t].[Banner5], [t].[InternalNumber], [t].[Name], [t].[SquadId0], [t].[MissionId]
 FROM [Gears] AS [g]
 LEFT JOIN (
-    SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], [s].[Id], [s].[Banner], [s].[InternalNumber], [s].[Name], [s0].[SquadId] AS [SquadId0], [s0].[MissionId]
+    SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name], [s0].[SquadId] AS [SquadId0], [s0].[MissionId]
     FROM [Gears] AS [g0]
     INNER JOIN [Squads] AS [s] ON [g0].[SquadId] = [s].[Id]
     LEFT JOIN [SquadMissions] AS [s0] ON [s].[Id] = [s0].[SquadId]
@@ -5274,7 +5274,7 @@ WHERE [g].[Discriminator] IN (N'Gear', N'Officer')");
                 @"SELECT [s].[Name] AS [SquadName], [t0].[Name] AS [WeaponName]
 FROM [Squads] AS [s]
 INNER JOIN (
-    SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [s0].[Id] AS [Id0], [s0].[Banner], [s0].[InternalNumber], [s0].[Name] AS [Name0]
+    SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [s0].[Id] AS [Id0], [s0].[Banner], [s0].[Banner5], [s0].[InternalNumber], [s0].[Name] AS [Name0]
     FROM [Weapons] AS [w]
     LEFT JOIN (
         SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
@@ -5294,7 +5294,7 @@ INNER JOIN (
                 @"SELECT [s].[Name] AS [SquadName], [t0].[Name] AS [WeaponName]
 FROM [Squads] AS [s]
 LEFT JOIN (
-    SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [s0].[Id] AS [Id0], [s0].[Banner], [s0].[InternalNumber], [s0].[Name] AS [Name0]
+    SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [s0].[Id] AS [Id0], [s0].[Banner], [s0].[Banner5], [s0].[InternalNumber], [s0].[Name] AS [Name0]
     FROM [Weapons] AS [w]
     LEFT JOIN (
         SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
@@ -5459,7 +5459,7 @@ LEFT JOIN (
             await base.Include_with_order_by_constant(async);
 
             AssertSql(
-                @"SELECT [s].[Id], [s].[Banner], [s].[InternalNumber], [s].[Name], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
+                @"SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
 FROM [Squads] AS [s]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
@@ -6220,7 +6220,7 @@ ORDER BY [g].[Nickname], [g].[SquadId], [w].[Id]");
             await base.Multiple_includes_with_client_method_around_entity_and_also_projecting_included_collection();
 
             AssertSql(
-                @"SELECT [s].[Name], [s].[Id], [s].[Banner], [s].[InternalNumber], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Id], [t].[AmmunitionType], [t].[IsAutomatic], [t].[Name], [t].[OwnerFullName], [t].[SynergyWithId]
+                @"SELECT [s].[Name], [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Id], [t].[AmmunitionType], [t].[IsAutomatic], [t].[Name], [t].[OwnerFullName], [t].[SynergyWithId]
 FROM [Squads] AS [s]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
@@ -6856,7 +6856,7 @@ ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id]");
             await base.Reference_include_chain_loads_correctly_when_middle_is_null(async);
 
             AssertSql(
-                @"SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[Note], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[Discriminator], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [s].[Id], [s].[Banner], [s].[InternalNumber], [s].[Name]
+                @"SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[Note], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOfBirthName], [t0].[Discriminator], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
 FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
@@ -7286,7 +7286,7 @@ END IS NULL)");
             await base.Byte_array_contains_literal(async);
 
             AssertSql(
-                @"SELECT [s].[Id], [s].[Banner], [s].[InternalNumber], [s].[Name]
+                @"SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
 FROM [Squads] AS [s]
 WHERE CHARINDEX(0x01, [s].[Banner]) > 0");
         }
@@ -7296,7 +7296,7 @@ WHERE CHARINDEX(0x01, [s].[Banner]) > 0");
             await base.Byte_array_filter_by_length_literal(async);
 
             AssertSql(
-                @"SELECT [s].[Id], [s].[Banner], [s].[InternalNumber], [s].[Name]
+                @"SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
 FROM [Squads] AS [s]
 WHERE CAST(DATALENGTH([s].[Banner]) AS int) = 1");
         }
@@ -7308,7 +7308,7 @@ WHERE CAST(DATALENGTH([s].[Banner]) AS int) = 1");
             AssertSql(
                 @"@__p_0='1'
 
-SELECT [s].[Id], [s].[Banner], [s].[InternalNumber], [s].[Name]
+SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
 FROM [Squads] AS [s]
 WHERE CAST(DATALENGTH([s].[Banner]) AS int) = @__p_0");
         }
@@ -7320,9 +7320,18 @@ WHERE CAST(DATALENGTH([s].[Banner]) AS int) = @__p_0");
             AssertSql(
                 @"@__someByte_0='1' (Size = 1)
 
-SELECT [s].[Id], [s].[Banner], [s].[InternalNumber], [s].[Name]
+SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
 FROM [Squads] AS [s]
 WHERE CHARINDEX(CAST(@__someByte_0 AS varbinary(max)), [s].[Banner]) > 0");
+        }
+
+        public override async Task Byte_array_filter_by_length_literal_does_not_cast_on_varbinary_n(bool async)
+        {
+            await base.Byte_array_filter_by_length_literal_does_not_cast_on_varbinary_n(async);
+
+            AssertSql(@"SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
+FROM [Squads] AS [s]
+WHERE DATALENGTH([s].[Banner5]) = CAST(5 AS bigint)");
         }
 
         public override async Task Conditional_expression_with_test_being_simplified_to_constant_simple(bool isAsync)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -7291,9 +7291,9 @@ FROM [Squads] AS [s]
 WHERE CHARINDEX(0x01, [s].[Banner]) > 0");
         }
 
-        public override async Task Byte_array_filter_by_length(bool async)
+        public override async Task Byte_array_filter_by_length_literal(bool async)
         {
-            await base.Byte_array_filter_by_length(async);
+            await base.Byte_array_filter_by_length_literal(async);
 
             AssertSql(
                 @"SELECT [s].[Id], [s].[Banner], [s].[InternalNumber], [s].[Name]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -7291,6 +7291,27 @@ FROM [Squads] AS [s]
 WHERE CHARINDEX(0x01, [s].[Banner]) > 0");
         }
 
+        public override async Task Byte_array_filter_by_length(bool async)
+        {
+            await base.Byte_array_filter_by_length(async);
+
+            AssertSql(
+                @"SELECT [s].[Id], [s].[Banner], [s].[InternalNumber], [s].[Name]
+FROM [Squads] AS [s]
+WHERE CAST(DATALENGTH([s].[Banner]) AS int) = 1");
+        }
+
+        public override async Task Byte_array_filter_by_length_with_join(bool async)
+        {
+            await base.Byte_array_filter_by_length_with_join(async);
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+FROM [Gears] AS [g]
+INNER JOIN [Squads] AS [s] ON [g].[SquadId] = [s].[Id]
+WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND (CAST(DATALENGTH([s].[Banner]) AS int) = 1)");
+        }
+
         public override async Task Byte_array_contains_parameter(bool async)
         {
             await base.Byte_array_contains_parameter(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -7301,15 +7301,16 @@ FROM [Squads] AS [s]
 WHERE CAST(DATALENGTH([s].[Banner]) AS int) = 1");
         }
 
-        public override async Task Byte_array_filter_by_length_with_join(bool async)
+        public override async Task Byte_array_filter_by_length_parameter(bool async)
         {
-            await base.Byte_array_filter_by_length_with_join(async);
+            await base.Byte_array_filter_by_length_parameter(async);
 
             AssertSql(
-                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
-FROM [Gears] AS [g]
-INNER JOIN [Squads] AS [s] ON [g].[SquadId] = [s].[Id]
-WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND (CAST(DATALENGTH([s].[Banner]) AS int) = 1)");
+                @"@__p_0='1'
+
+SELECT [s].[Id], [s].[Banner], [s].[InternalNumber], [s].[Name]
+FROM [Squads] AS [s]
+WHERE CAST(DATALENGTH([s].[Banner]) AS int) = @__p_0");
         }
 
         public override async Task Byte_array_contains_parameter(bool async)

--- a/test/EFCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
@@ -25,22 +25,6 @@ namespace Microsoft.EntityFrameworkCore
             //fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
-        [ConditionalFact(Skip = "Issue#13487")]
-        public void Translate_array_length()
-        {
-            using var db = CreateContext();
-            db.Set<MappedDataTypesWithIdentity>()
-                .Where(p => p.Blob.Length == 0)
-                .Select(p => p.Blob.Length)
-                .FirstOrDefault();
-
-            AssertSql(
-                @"SELECT length(""p"".""Blob"")
-FROM ""MappedDataTypesWithIdentity"" AS ""p""
-WHERE length(""p"".""Blob"") = 0
-LIMIT 1");
-        }
-
         [ConditionalFact]
         public virtual void Can_insert_and_query_decimal()
         {

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -102,6 +102,10 @@ FROM ""Squads"" AS ""s""
 WHERE instr(""s"".""Banner"", char(@__someByte_0)) > 0");
         }
 
+        public override Task Byte_array_filter_by_length(bool async) => null; // Work in Progress
+
+        public override Task Byte_array_filter_by_length_with_join(bool async) => null; // Work in progress
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -102,9 +102,9 @@ FROM ""Squads"" AS ""s""
 WHERE instr(""s"".""Banner"", char(@__someByte_0)) > 0");
         }
 
-        public override async Task Byte_array_filter_by_length(bool async)
+        public override async Task Byte_array_filter_by_length_literal(bool async)
         {
-            await base.Byte_array_filter_by_length(async);
+            await base.Byte_array_filter_by_length_literal(async);
 
             AssertSql(@"SELECT ""s"".""Id"", ""s"".""Banner"", ""s"".""InternalNumber"", ""s"".""Name""
 FROM ""Squads"" AS ""s""

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -102,9 +102,25 @@ FROM ""Squads"" AS ""s""
 WHERE instr(""s"".""Banner"", char(@__someByte_0)) > 0");
         }
 
-        public override Task Byte_array_filter_by_length(bool async) => null; // Work in Progress
+        public override async Task Byte_array_filter_by_length(bool async)
+        {
+            await base.Byte_array_filter_by_length(async);
 
-        public override Task Byte_array_filter_by_length_parameter(bool async) => null; // Work in progress
+            AssertSql(@"SELECT ""s"".""Id"", ""s"".""Banner"", ""s"".""InternalNumber"", ""s"".""Name""
+FROM ""Squads"" AS ""s""
+WHERE length(""s"".""Banner"") = 1");
+        }
+
+        public override async Task Byte_array_filter_by_length_parameter(bool async)
+        {
+            await base.Byte_array_filter_by_length_parameter(async);
+
+            AssertSql(@"@__p_0='1' (DbType = String)
+
+SELECT ""s"".""Id"", ""s"".""Banner"", ""s"".""InternalNumber"", ""s"".""Name""
+FROM ""Squads"" AS ""s""
+WHERE length(""s"".""Banner"") = @__p_0");
+        }
 
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -104,7 +104,7 @@ WHERE instr(""s"".""Banner"", char(@__someByte_0)) > 0");
 
         public override Task Byte_array_filter_by_length(bool async) => null; // Work in Progress
 
-        public override Task Byte_array_filter_by_length_with_join(bool async) => null; // Work in progress
+        public override Task Byte_array_filter_by_length_parameter(bool async) => null; // Work in progress
 
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -122,6 +122,18 @@ FROM ""Squads"" AS ""s""
 WHERE length(""s"".""Banner"") = @__p_0");
         }
 
+        public override void Byte_array_filter_by_length_parameter_compiled()
+        {
+            base.Byte_array_filter_by_length_parameter_compiled();
+
+            AssertSql(
+                @"@__byteArrayParam='0x2A80' (Size = 2) (DbType = String)
+
+SELECT COUNT(*)
+FROM ""Squads"" AS ""s""
+WHERE (length(""s"".""Banner"") = length(@__byteArrayParam)) OR (length(""s"".""Banner"") IS NULL AND length(@__byteArrayParam) IS NULL)");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -85,7 +85,7 @@ FROM ""Missions"" AS ""m""");
             await base.Byte_array_contains_literal(async);
 
             AssertSql(
-                @"SELECT ""s"".""Id"", ""s"".""Banner"", ""s"".""InternalNumber"", ""s"".""Name""
+                @"SELECT ""s"".""Id"", ""s"".""Banner"", ""s"".""Banner5"", ""s"".""InternalNumber"", ""s"".""Name""
 FROM ""Squads"" AS ""s""
 WHERE instr(""s"".""Banner"", X'01') > 0");
         }
@@ -97,7 +97,7 @@ WHERE instr(""s"".""Banner"", X'01') > 0");
             AssertSql(
                 @"@__someByte_0='1' (DbType = String)
 
-SELECT ""s"".""Id"", ""s"".""Banner"", ""s"".""InternalNumber"", ""s"".""Name""
+SELECT ""s"".""Id"", ""s"".""Banner"", ""s"".""Banner5"", ""s"".""InternalNumber"", ""s"".""Name""
 FROM ""Squads"" AS ""s""
 WHERE instr(""s"".""Banner"", char(@__someByte_0)) > 0");
         }
@@ -106,7 +106,7 @@ WHERE instr(""s"".""Banner"", char(@__someByte_0)) > 0");
         {
             await base.Byte_array_filter_by_length_literal(async);
 
-            AssertSql(@"SELECT ""s"".""Id"", ""s"".""Banner"", ""s"".""InternalNumber"", ""s"".""Name""
+            AssertSql(@"SELECT ""s"".""Id"", ""s"".""Banner"", ""s"".""Banner5"", ""s"".""InternalNumber"", ""s"".""Name""
 FROM ""Squads"" AS ""s""
 WHERE length(""s"".""Banner"") = 1");
         }
@@ -117,7 +117,7 @@ WHERE length(""s"".""Banner"") = 1");
 
             AssertSql(@"@__p_0='1' (DbType = String)
 
-SELECT ""s"".""Id"", ""s"".""Banner"", ""s"".""InternalNumber"", ""s"".""Name""
+SELECT ""s"".""Id"", ""s"".""Banner"", ""s"".""Banner5"", ""s"".""InternalNumber"", ""s"".""Name""
 FROM ""Squads"" AS ""s""
 WHERE length(""s"".""Banner"") = @__p_0");
         }


### PR DESCRIPTION
I am creating this PR with the implementation working for SQL Server, with all tests passing. Porting this to Sqlite will be simple, but I wanted to verify my implementation is acceptable.

Rationale here is that, given this is a provider-specific implementation of a unary expression, it becomes necessary to override SqlServer's ExpressionVisitor's `VisitUnary` method to catch `ArrayLength` expressions on `byte[]` columns, and then translate it as a `SqlFunctionExpression` which maps to an int.

Concerns - 
* Rationale is correct, yes? We want to capture and visit the unary expression before passing it to the base class because this is sql-specific
* May not need to check the CLR type of byte[], since, I think, binary columns are the only way to get an array (and therefore arraylength) type in SQL Server?
* Converting to a SQL INT here will cause arithmetic overflows on binary columns larger than int's max_size. Should this be long/BIGINT instead?

Thank you @roji for the warm welcome on the issue! ❤️ 