### PR TITLE
Updates to simple logging based on design meeting feedback

### DIFF
--- a/src/EFCore.Design/Design/DesignTimeServiceCollectionExtensions.cs
+++ b/src/EFCore.Design/Design/DesignTimeServiceCollectionExtensions.cs
@@ -81,7 +81,7 @@ namespace Microsoft.EntityFrameworkCore.Design
                 .AddSingleton<IScaffoldingModelFactory, RelationalScaffoldingModelFactory>()
                 .AddSingleton<IScaffoldingTypeMapper, ScaffoldingTypeMapper>()
                 .AddSingleton<IValueConverterSelector, ValueConverterSelector>()
-                .AddSingleton<ISimpleLogger, NullSimpleLogger>()
+                .AddSingleton<IDbContextLogger, NullDbContextLogger>()
                 .AddTransient<MigrationsScaffolderDependencies>()
                 .AddTransient<IMigrationsScaffolder, MigrationsScaffolder>()
                 .AddTransient<ISnapshotModelProcessor, SnapshotModelProcessor>()

--- a/src/EFCore.Relational/Diagnostics/RelationalLoggerExtensions.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalLoggerExtensions.cs
@@ -2217,7 +2217,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             if (simpleLogEnabled)
             {
-                diagnostics.SimpleLogger.Log(eventData);
+                diagnostics.DbContextLogger.Log(eventData);
             }
 
             return eventData;

--- a/src/EFCore/DbContextOptionsBuilder.cs
+++ b/src/EFCore/DbContextOptionsBuilder.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -113,26 +114,26 @@ namespace Microsoft.EntityFrameworkCore
         ///     </para>
         ///     <para>
         ///         This overload allows the minimum level of logging and the log formatting to be controlled.
-        ///         Use the <see cref="LogTo(Action{string},IEnumerable{EventId},LogLevel,SimpleLoggerFormatOptions?)" />
+        ///         Use the <see cref="LogTo(Action{string},IEnumerable{EventId},LogLevel,DbContextLoggerOptions?)" />
         ///         overload to log only specific events.
-        ///         Use the <see cref="LogTo(Action{string},IEnumerable{string},LogLevel,SimpleLoggerFormatOptions?)" />
+        ///         Use the <see cref="LogTo(Action{string},IEnumerable{string},LogLevel,DbContextLoggerOptions?)" />
         ///         overload to log only events in specific categories.
-        ///         Use the <see cref="LogTo(Action{string},Func{EventId,LogLevel,bool},SimpleLoggerFormatOptions?)" />
+        ///         Use the <see cref="LogTo(Action{string},Func{EventId,LogLevel,bool},DbContextLoggerOptions?)" />
         ///         overload to use a custom filter for events.
-        ///         Use the <see cref="LogTo(ISimpleLogger)" /> overload to log to a fully custom logger.
+        ///         Use the <see cref="LogTo(Func{EventId,LogLevel,bool},Action{EventData})" /> overload to log to a fully custom logger.
         ///     </para>
         /// </summary>
         /// <param name="sink"> The sink to which log messages will be written. </param>
         /// <param name="minimumLevel"> The minimum level of logging event to log. Defaults to <see cref="LogLevel.Debug" /> </param>
-        /// <param name="formatOptions">
-        ///     Formatting options for log messages. Passing null (the default) means use <see cref="SimpleLoggerFormatOptions.DefaultWithLocalTime" />
+        /// <param name="options">
+        ///     Formatting options for log messages. Passing null (the default) means use <see cref="DbContextLoggerOptions.DefaultWithLocalTime" />
         /// </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
         public virtual DbContextOptionsBuilder LogTo(
             [NotNull] Action<string> sink,
             LogLevel minimumLevel = LogLevel.Debug,
-            SimpleLoggerFormatOptions? formatOptions = null)
-            => LogTo(sink, (i, l) => l >= minimumLevel, formatOptions);
+            DbContextLoggerOptions? options = null)
+            => LogTo(sink, (i, l) => l >= minimumLevel, options);
 
         /// <summary>
         ///     <para>
@@ -141,27 +142,27 @@ namespace Microsoft.EntityFrameworkCore
         ///         <see cref="CoreEventId.ContextInitialized" /> event to the console.
         ///     </para>
         ///     <para>
-        ///         Use the <see cref="LogTo(Action{string},LogLevel,SimpleLoggerFormatOptions?)" /> overload for default logging of
+        ///         Use the <see cref="LogTo(Action{string},LogLevel,DbContextLoggerOptions?)" /> overload for default logging of
         ///         all events.
-        ///         Use the <see cref="LogTo(Action{string},IEnumerable{string},LogLevel,SimpleLoggerFormatOptions?)" />
+        ///         Use the <see cref="LogTo(Action{string},IEnumerable{string},LogLevel,DbContextLoggerOptions?)" />
         ///         overload to log only events in specific categories.
-        ///         Use the <see cref="LogTo(Action{string},Func{EventId,LogLevel,bool},SimpleLoggerFormatOptions?)" />
+        ///         Use the <see cref="LogTo(Action{string},Func{EventId,LogLevel,bool},DbContextLoggerOptions?)" />
         ///         overload to use a custom filter for events.
-        ///         Use the <see cref="LogTo(ISimpleLogger)" /> overload to log to a fully custom logger.
+        ///         Use the <see cref="LogTo(Func{EventId,LogLevel,bool},Action{EventData})" /> overload to log to a fully custom logger.
         ///     </para>
         /// </summary>
         /// <param name="sink"> The sink to which log messages will be written. </param>
         /// <param name="events"> The <see cref="EventId" /> of each event to log. </param>
         /// <param name="minimumLevel"> The minimum level of logging event to log. Defaults to <see cref="LogLevel.Debug" /> </param>
-        /// <param name="formatOptions">
-        ///     Formatting options for log messages. Passing null (the default) means use <see cref="SimpleLoggerFormatOptions.DefaultWithLocalTime" />
+        /// <param name="options">
+        ///     Formatting options for log messages. Passing null (the default) means use <see cref="DbContextLoggerOptions.DefaultWithLocalTime" />
         /// </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
         public virtual DbContextOptionsBuilder LogTo(
             [NotNull] Action<string> sink,
             [NotNull] IEnumerable<EventId> events,
             LogLevel minimumLevel = LogLevel.Debug,
-            SimpleLoggerFormatOptions? formatOptions = null)
+            DbContextLoggerOptions? options = null)
         {
             Check.NotNull(events, nameof(events));
 
@@ -179,7 +180,7 @@ namespace Microsoft.EntityFrameworkCore
                     sink,
                     (eventId, level) => level >= minimumLevel
                         && eventId == firstEvent,
-                    formatOptions);
+                    options);
             }
 
             if (eventsArray.Length < 6)
@@ -188,7 +189,7 @@ namespace Microsoft.EntityFrameworkCore
                     sink,
                     (eventId, level) => level >= minimumLevel
                         && eventsArray.Contains(eventId),
-                    formatOptions);
+                    options);
             }
 
             var eventsHash = eventsArray.ToHashSet();
@@ -196,7 +197,7 @@ namespace Microsoft.EntityFrameworkCore
                 sink,
                 (eventId, level) => level >= minimumLevel
                     && eventsHash.Contains(eventId),
-                formatOptions);
+                options);
         }
 
         /// <summary>
@@ -206,27 +207,27 @@ namespace Microsoft.EntityFrameworkCore
         ///         events in the <see cref="DbLoggerCategory.Infrastructure" /> category.
         ///     </para>
         ///     <para>
-        ///         Use the <see cref="LogTo(Action{string},LogLevel,SimpleLoggerFormatOptions?)" /> overload for default logging of
+        ///         Use the <see cref="LogTo(Action{string},LogLevel,DbContextLoggerOptions?)" /> overload for default logging of
         ///         all events.
-        ///         Use the <see cref="LogTo(Action{string},IEnumerable{EventId},LogLevel,SimpleLoggerFormatOptions?)" />
+        ///         Use the <see cref="LogTo(Action{string},IEnumerable{EventId},LogLevel,DbContextLoggerOptions?)" />
         ///         overload to log only specific events.
-        ///         Use the <see cref="LogTo(Action{string},Func{EventId,LogLevel,bool},SimpleLoggerFormatOptions?)" />
+        ///         Use the <see cref="LogTo(Action{string},Func{EventId,LogLevel,bool},DbContextLoggerOptions?)" />
         ///         overload to use a custom filter for events.
-        ///         Use the <see cref="LogTo(ISimpleLogger)" /> overload to log to a fully custom logger.
+        ///         Use the <see cref="LogTo(Func{EventId,LogLevel,bool},Action{EventData})" /> overload to log to a fully custom logger.
         ///     </para>
         /// </summary>
         /// <param name="sink"> The sink to which log messages will be written. </param>
         /// <param name="categories"> The <see cref="DbLoggerCategory" /> of each event to log. </param>
         /// <param name="minimumLevel"> The minimum level of logging event to log. Defaults to <see cref="LogLevel.Debug" /> </param>
-        /// <param name="formatOptions">
-        ///     Formatting options for log messages. Passing null (the default) means use <see cref="SimpleLoggerFormatOptions.DefaultWithLocalTime" />
+        /// <param name="options">
+        ///     Formatting options for log messages. Passing null (the default) means use <see cref="DbContextLoggerOptions.DefaultWithLocalTime" />
         /// </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
         public virtual DbContextOptionsBuilder LogTo(
             [NotNull] Action<string> sink,
             [NotNull] IEnumerable<string> categories,
             LogLevel minimumLevel = LogLevel.Debug,
-            SimpleLoggerFormatOptions? formatOptions = null)
+            DbContextLoggerOptions? options = null)
         {
             Check.NotNull(categories, nameof(categories));
 
@@ -258,7 +259,7 @@ namespace Microsoft.EntityFrameworkCore
 
                         return false;
                     },
-                    formatOptions);
+                    options);
             }
 
             var singleCategory = categoriesArray[0];
@@ -266,7 +267,7 @@ namespace Microsoft.EntityFrameworkCore
                 sink,
                 (eventId, level) => level >= minimumLevel
                     && eventId.Name.StartsWith(singleCategory, StringComparison.OrdinalIgnoreCase),
-                formatOptions);
+                options);
         }
 
         /// <summary>
@@ -275,54 +276,62 @@ namespace Microsoft.EntityFrameworkCore
         ///         log a message, or false to filter it out of the log.
         ///     </para>
         ///     <para>
-        ///         Use the <see cref="LogTo(Action{string},LogLevel,SimpleLoggerFormatOptions?)" /> overload for default logging of
+        ///         Use the <see cref="LogTo(Action{string},LogLevel,DbContextLoggerOptions?)" /> overload for default logging of
         ///         all events.
-        ///         Use the <see cref="LogTo(Action{string},IEnumerable{EventId},LogLevel,SimpleLoggerFormatOptions?)" />
-        ///         Use the <see cref="LogTo(Action{string},IEnumerable{string},LogLevel,SimpleLoggerFormatOptions?)" />
+        ///         Use the <see cref="LogTo(Action{string},IEnumerable{EventId},LogLevel,DbContextLoggerOptions?)" />
+        ///         Use the <see cref="LogTo(Action{string},IEnumerable{string},LogLevel,DbContextLoggerOptions?)" />
         ///         overload to log only events in specific categories.
-        ///         Use the <see cref="LogTo(ISimpleLogger)" /> overload to log to a fully custom logger.
+        ///         Use the <see cref="LogTo(Func{EventId,LogLevel,bool},Action{EventData})" /> overload to log to a fully custom logger.
         ///     </para>
         /// </summary>
         /// <param name="sink"> The sink to which log messages will be written. </param>
         /// <param name="filter"> Delegate that returns true to log the message or false to ignore it. </param>
-        /// <param name="formatOptions">
-        ///     Formatting options for log messages. Passing null (the default) means use <see cref="SimpleLoggerFormatOptions.DefaultWithLocalTime" />
+        /// <param name="options">
+        ///     Formatting options for log messages. Passing null (the default) means use <see cref="DbContextLoggerOptions.DefaultWithLocalTime" />
         /// </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
         public virtual DbContextOptionsBuilder LogTo(
             [NotNull] Action<string> sink,
             [NotNull] Func<EventId, LogLevel, bool> filter,
-            SimpleLoggerFormatOptions? formatOptions = null)
+            DbContextLoggerOptions? options = null)
         {
             Check.NotNull(sink, nameof(sink));
             Check.NotNull(filter, nameof(filter));
 
-            return LogTo(new SimpleLogger(sink, filter, formatOptions ?? SimpleLoggerFormatOptions.DefaultWithLocalTime));
+            return LogTo(new FormattingDbContextLogger(sink, filter, options ?? DbContextLoggerOptions.DefaultWithLocalTime));
         }
 
         /// <summary>
         ///     <para>
-        ///         Logs to the supplied <see cref="ISimpleLogger" /> implementation.
+        ///         Logs events to a custom logger delegate filtered by a custom filter delegate. The filter should return true to
+        ///         log a message, or false to filter it out of the log.
         ///     </para>
         ///     <para>
-        ///         Use this method when the other overloads do not provide enough control over filtering and formatting of the output.
-        ///         Use the <see cref="LogTo(Action{string},LogLevel,SimpleLoggerFormatOptions?)" /> overload for default logging of
+        ///         Use the <see cref="LogTo(Action{string},LogLevel,DbContextLoggerOptions?)" /> overload for default logging of
         ///         all events.
-        ///         Use the <see cref="LogTo(Action{string},IEnumerable{EventId},LogLevel,SimpleLoggerFormatOptions?)" />
-        ///         Use the <see cref="LogTo(Action{string},IEnumerable{string},LogLevel,SimpleLoggerFormatOptions?)" />
+        ///         Use the <see cref="LogTo(Action{string},IEnumerable{EventId},LogLevel,DbContextLoggerOptions?)" />
+        ///         Use the <see cref="LogTo(Action{string},IEnumerable{string},LogLevel,DbContextLoggerOptions?)" />
         ///         overload to log only events in specific categories.
-        ///         Use the <see cref="LogTo(Action{string},Func{EventId,LogLevel,bool},SimpleLoggerFormatOptions?)" />
+        ///         Use the <see cref="LogTo(Action{string},Func{EventId,LogLevel,bool},DbContextLoggerOptions?)" />
         ///         overload to use a custom filter for events.
         ///     </para>
         /// </summary>
-        /// <param name="simpleLogger"> The <see cref="ISimpleLogger" /> to use. </param>
+        /// <param name="filter"> Delegate that returns true to log the message or false to ignore it. </param>
+        /// <param name="logger"> Delegate called when there is a message to log. </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
-        public virtual DbContextOptionsBuilder LogTo([NotNull] ISimpleLogger simpleLogger)
+        // Filter comes first, logger second, otherwise it's hard to get the correct overload to resolve
+        public virtual DbContextOptionsBuilder LogTo(
+            [NotNull] Func<EventId, LogLevel, bool> filter,
+            [NotNull] Action<EventData> logger)
         {
-            Check.NotNull(simpleLogger, nameof(simpleLogger));
+            Check.NotNull(logger, nameof(logger));
+            Check.NotNull(filter, nameof(filter));
 
-            return WithOption(e => e.WithSimpleLogger(simpleLogger));
+            return LogTo(new DelegatingDbContextLogger(logger, filter));
         }
+
+        private DbContextOptionsBuilder LogTo([NotNull] IDbContextLogger logger)
+            => WithOption(e => e.WithDbContextLogger(logger));
 
         /// <summary>
         ///     <para>

--- a/src/EFCore/DbContextOptionsBuilder`.cs
+++ b/src/EFCore/DbContextOptionsBuilder`.cs
@@ -91,26 +91,26 @@ namespace Microsoft.EntityFrameworkCore
         ///     </para>
         ///     <para>
         ///         This overload allows the minimum level of logging and the log formatting to be controlled.
-        ///         Use the <see cref="LogTo(Action{string},IEnumerable{EventId},LogLevel,SimpleLoggerFormatOptions?)" />
+        ///         Use the <see cref="LogTo(Action{string},IEnumerable{EventId},LogLevel,DbContextLoggerOptions?)" />
         ///         overload to log only specific events.
-        ///         Use the <see cref="LogTo(Action{string},IEnumerable{string},LogLevel,SimpleLoggerFormatOptions?)" />
+        ///         Use the <see cref="LogTo(Action{string},IEnumerable{string},LogLevel,DbContextLoggerOptions?)" />
         ///         overload to log only events in specific categories.
-        ///         Use the <see cref="LogTo(Action{string},Func{EventId,LogLevel,bool},SimpleLoggerFormatOptions?)" />
+        ///         Use the <see cref="LogTo(Action{string},Func{EventId,LogLevel,bool},DbContextLoggerOptions?)" />
         ///         overload to use a custom filter for events.
-        ///         Use the <see cref="LogTo(ISimpleLogger)" /> overload to log to a fully custom logger.
+        ///         Use the <see cref="LogTo(Func{EventId,LogLevel,bool},Action{EventData})" /> overload to log to a fully custom logger.
         ///     </para>
         /// </summary>
         /// <param name="sink"> The sink to which log messages will be written. </param>
         /// <param name="minimumLevel"> The minimum level of logging event to log. Defaults to <see cref="LogLevel.Debug" /> </param>
-        /// <param name="formatOptions">
-        ///     Formatting options for log messages. Passing null (the default) means use <see cref="SimpleLoggerFormatOptions.DefaultWithLocalTime" />
+        /// <param name="options">
+        ///     Formatting options for log messages. Passing null (the default) means use <see cref="DbContextLoggerOptions.DefaultWithLocalTime" />
         /// </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
         public new virtual DbContextOptionsBuilder<TContext> LogTo(
             [NotNull] Action<string> sink,
             LogLevel minimumLevel = LogLevel.Debug,
-            SimpleLoggerFormatOptions? formatOptions = null)
-            => (DbContextOptionsBuilder<TContext>)base.LogTo(sink, minimumLevel, formatOptions);
+            DbContextLoggerOptions? options = null)
+            => (DbContextOptionsBuilder<TContext>)base.LogTo(sink, minimumLevel, options);
 
         /// <summary>
         ///     <para>
@@ -119,28 +119,28 @@ namespace Microsoft.EntityFrameworkCore
         ///         <see cref="CoreEventId.ContextInitialized" /> event to the console.
         ///     </para>
         ///     <para>
-        ///         Use the <see cref="LogTo(Action{string},LogLevel,SimpleLoggerFormatOptions?)" /> overload for default logging of
+        ///         Use the <see cref="LogTo(Action{string},LogLevel,DbContextLoggerOptions?)" /> overload for default logging of
         ///         all events.
-        ///         Use the <see cref="LogTo(Action{string},IEnumerable{string},LogLevel,SimpleLoggerFormatOptions?)" />
+        ///         Use the <see cref="LogTo(Action{string},IEnumerable{string},LogLevel,DbContextLoggerOptions?)" />
         ///         overload to log only events in specific categories.
-        ///         Use the <see cref="LogTo(Action{string},Func{EventId,LogLevel,bool},SimpleLoggerFormatOptions?)" />
+        ///         Use the <see cref="LogTo(Action{string},Func{EventId,LogLevel,bool},DbContextLoggerOptions?)" />
         ///         overload to use a custom filter for events.
-        ///         Use the <see cref="LogTo(ISimpleLogger)" /> overload to log to a fully custom logger.
+        ///         Use the <see cref="LogTo(Func{EventId,LogLevel,bool},Action{EventData})" /> overload to log to a fully custom logger.
         ///     </para>
         /// </summary>
         /// <param name="sink"> The sink to which log messages will be written. </param>
         /// <param name="events"> The <see cref="EventId" /> of each event to log. </param>
         /// <param name="minimumLevel"> The minimum level of logging event to log. Defaults to <see cref="LogLevel.Debug" /> </param>
-        /// <param name="formatOptions">
-        ///     Formatting options for log messages. Passing null (the default) means use <see cref="SimpleLoggerFormatOptions.DefaultWithLocalTime" />
+        /// <param name="options">
+        ///     Formatting options for log messages. Passing null (the default) means use <see cref="DbContextLoggerOptions.DefaultWithLocalTime" />
         /// </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
         public new virtual DbContextOptionsBuilder<TContext> LogTo(
             [NotNull] Action<string> sink,
             [NotNull] IEnumerable<EventId> events,
             LogLevel minimumLevel = LogLevel.Debug,
-            SimpleLoggerFormatOptions? formatOptions = null)
-            => (DbContextOptionsBuilder<TContext>)base.LogTo(sink, events, minimumLevel, formatOptions);
+            DbContextLoggerOptions? options = null)
+            => (DbContextOptionsBuilder<TContext>)base.LogTo(sink, events, minimumLevel, options);
 
         /// <summary>
         ///     <para>
@@ -149,28 +149,28 @@ namespace Microsoft.EntityFrameworkCore
         ///         events in the <see cref="DbLoggerCategory.Infrastructure" /> category.
         ///     </para>
         ///     <para>
-        ///         Use the <see cref="LogTo(Action{string},LogLevel,SimpleLoggerFormatOptions?)" /> overload for default logging of
+        ///         Use the <see cref="LogTo(Action{string},LogLevel,DbContextLoggerOptions?)" /> overload for default logging of
         ///         all events.
-        ///         Use the <see cref="LogTo(Action{string},IEnumerable{EventId},LogLevel,SimpleLoggerFormatOptions?)" />
+        ///         Use the <see cref="LogTo(Action{string},IEnumerable{EventId},LogLevel,DbContextLoggerOptions?)" />
         ///         overload to log only specific events.
-        ///         Use the <see cref="LogTo(Action{string},Func{EventId,LogLevel,bool},SimpleLoggerFormatOptions?)" />
+        ///         Use the <see cref="LogTo(Action{string},Func{EventId,LogLevel,bool},DbContextLoggerOptions?)" />
         ///         overload to use a custom filter for events.
-        ///         Use the <see cref="LogTo(ISimpleLogger)" /> overload to log to a fully custom logger.
+        ///         Use the <see cref="LogTo(Func{EventId,LogLevel,bool},Action{EventData})" /> overload to log to a fully custom logger.
         ///     </para>
         /// </summary>
         /// <param name="sink"> The sink to which log messages will be written. </param>
         /// <param name="categories"> The <see cref="DbLoggerCategory" /> of each event to log. </param>
         /// <param name="minimumLevel"> The minimum level of logging event to log. Defaults to <see cref="LogLevel.Debug" /> </param>
-        /// <param name="formatOptions">
-        ///     Formatting options for log messages. Passing null (the default) means use <see cref="SimpleLoggerFormatOptions.DefaultWithLocalTime" />
+        /// <param name="options">
+        ///     Formatting options for log messages. Passing null (the default) means use <see cref="DbContextLoggerOptions.DefaultWithLocalTime" />
         /// </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
         public new virtual DbContextOptionsBuilder<TContext> LogTo(
             [NotNull] Action<string> sink,
             [NotNull] IEnumerable<string> categories,
             LogLevel minimumLevel = LogLevel.Debug,
-            SimpleLoggerFormatOptions? formatOptions = null)
-            => (DbContextOptionsBuilder<TContext>)base.LogTo(sink, categories, minimumLevel, formatOptions);
+            DbContextLoggerOptions? options = null)
+            => (DbContextOptionsBuilder<TContext>)base.LogTo(sink, categories, minimumLevel, options);
 
         /// <summary>
         ///     <para>
@@ -178,45 +178,49 @@ namespace Microsoft.EntityFrameworkCore
         ///         log a message, or false to filter it out of the log.
         ///     </para>
         ///     <para>
-        ///         Use the <see cref="LogTo(Action{string},LogLevel,SimpleLoggerFormatOptions?)" /> overload for default logging of
+        ///         Use the <see cref="LogTo(Action{string},LogLevel,DbContextLoggerOptions?)" /> overload for default logging of
         ///         all events.
-        ///         Use the <see cref="LogTo(Action{string},IEnumerable{EventId},LogLevel,SimpleLoggerFormatOptions?)" />
-        ///         Use the <see cref="LogTo(Action{string},IEnumerable{string},LogLevel,SimpleLoggerFormatOptions?)" />
+        ///         Use the <see cref="LogTo(Action{string},IEnumerable{EventId},LogLevel,DbContextLoggerOptions?)" />
+        ///         Use the <see cref="LogTo(Action{string},IEnumerable{string},LogLevel,DbContextLoggerOptions?)" />
         ///         overload to log only events in specific categories.
-        ///         Use the <see cref="LogTo(ISimpleLogger)" /> overload to log to a fully custom logger.
+        ///         Use the <see cref="LogTo(Func{EventId,LogLevel,bool},Action{EventData})" /> overload to log to a fully custom logger.
         ///     </para>
         /// </summary>
         /// <param name="sink"> The sink to which log messages will be written. </param>
         /// <param name="filter"> Delegate that returns true to log the message or false to ignore it. </param>
-        /// <param name="formatOptions">
-        ///     Formatting options for log messages. Passing null (the default) means use <see cref="SimpleLoggerFormatOptions.DefaultWithLocalTime" />
+        /// <param name="options">
+        ///     Formatting options for log messages. Passing null (the default) means use <see cref="DbContextLoggerOptions.DefaultWithLocalTime" />
         /// </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
         public new virtual DbContextOptionsBuilder<TContext> LogTo(
             [NotNull] Action<string> sink,
             [NotNull] Func<EventId, LogLevel, bool> filter,
-            SimpleLoggerFormatOptions? formatOptions = null)
-            => (DbContextOptionsBuilder<TContext>)base.LogTo(sink, filter, formatOptions);
+            DbContextLoggerOptions? options = null)
+            => (DbContextOptionsBuilder<TContext>)base.LogTo(sink, filter, options);
 
         /// <summary>
         ///     <para>
-        ///         Logs to the supplied <see cref="ISimpleLogger" /> implementation.
+        ///         Logs events to a custom logger delegate filtered by a custom filter delegate. The filter should return true to
+        ///         log a message, or false to filter it out of the log.
         ///     </para>
         ///     <para>
-        ///         Use this method when the other overloads do not provide enough control over filtering and formatting of the output.
-        ///         Use the <see cref="LogTo(Action{string},LogLevel,SimpleLoggerFormatOptions?)" /> overload for default logging of
+        ///         Use the <see cref="LogTo(Action{string},LogLevel,DbContextLoggerOptions?)" /> overload for default logging of
         ///         all events.
-        ///         Use the <see cref="LogTo(Action{string},IEnumerable{EventId},LogLevel,SimpleLoggerFormatOptions?)" />
-        ///         Use the <see cref="LogTo(Action{string},IEnumerable{string},LogLevel,SimpleLoggerFormatOptions?)" />
+        ///         Use the <see cref="LogTo(Action{string},IEnumerable{EventId},LogLevel,DbContextLoggerOptions?)" />
+        ///         Use the <see cref="LogTo(Action{string},IEnumerable{string},LogLevel,DbContextLoggerOptions?)" />
         ///         overload to log only events in specific categories.
-        ///         Use the <see cref="LogTo(Action{string},Func{EventId,LogLevel,bool},SimpleLoggerFormatOptions?)" />
+        ///         Use the <see cref="LogTo(Action{string},Func{EventId,LogLevel,bool},DbContextLoggerOptions?)" />
         ///         overload to use a custom filter for events.
         ///     </para>
         /// </summary>
-        /// <param name="simpleLogger"> The <see cref="ISimpleLogger" /> to use. </param>
+        /// <param name="filter"> Delegate that returns true to log the message or false to ignore it. </param>
+        /// <param name="logger"> Delegate called when there is a message to log. </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
-        public new virtual DbContextOptionsBuilder<TContext> LogTo([NotNull] ISimpleLogger simpleLogger)
-            => (DbContextOptionsBuilder<TContext>)base.LogTo(simpleLogger);
+        // Filter comes first, logger second, otherwise it's hard to get the correct overload to resolve
+        public new virtual DbContextOptionsBuilder<TContext> LogTo(
+            [NotNull] Func<EventId, LogLevel, bool> filter,
+            [NotNull] Action<EventData> logger)
+            => (DbContextOptionsBuilder<TContext>)base.LogTo(filter, logger);
 
         /// <summary>
         ///     <para>

--- a/src/EFCore/Diagnostics/DbContextLoggerOptions.cs
+++ b/src/EFCore/Diagnostics/DbContextLoggerOptions.cs
@@ -2,16 +2,17 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.EntityFrameworkCore.Diagnostics
 {
     /// <summary>
-    ///     Formatting options for use with <see cref="SimpleLogger" />
-    ///     and <see cref="DbContextOptionsBuilder.LogTo(Action{string},LogLevel,SimpleLoggerFormatOptions?)" />.
+    ///     Formatting options for use with <see cref="FormattingDbContextLogger" />
+    ///     and <see cref="DbContextOptionsBuilder.LogTo(Action{string},LogLevel,DbContextLoggerOptions?)" />.
     /// </summary>
     [Flags]
-    public enum SimpleLoggerFormatOptions
+    public enum DbContextLoggerOptions
     {
         /// <summary>
         ///     The raw log message with no additional metadata or formatting.
@@ -51,7 +52,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
         /// <summary>
         ///     <para>
-        ///         The default used by <see cref="DbContextOptionsBuilder.LogTo(Action{string},LogLevel,SimpleLoggerFormatOptions?)" />.
+        ///         The default used by <see cref="DbContextOptionsBuilder.LogTo(Action{string},LogLevel,DbContextLoggerOptions?)" />.
         ///     </para>
         ///     <para>
         ///         Includes <see cref="Level" />, <see cref="Category" />, <see cref="Id" />, <see cref="LocalTime" />.
@@ -61,7 +62,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
         /// <summary>
         ///     <para>
-        ///         The same defaults as used by <see cref="DbContextOptionsBuilder.LogTo(Action{string},LogLevel,SimpleLoggerFormatOptions?)" />,
+        ///         The same defaults as used by <see cref="DbContextOptionsBuilder.LogTo(Action{string},LogLevel,DbContextLoggerOptions?)" />,
         ///         but with UTC timestamps.
         ///     </para>
         ///     <para>

--- a/src/EFCore/Diagnostics/DiagnosticsLoggerExtensions.cs
+++ b/src/EFCore/Diagnostics/DiagnosticsLoggerExtensions.cs
@@ -35,13 +35,13 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
         /// <summary>
         ///     Dispatches the given <see cref="EventData" /> to a <see cref="DiagnosticSource" />, if enabled, and
-        ///     a <see cref="ISimpleLogger" />, if enabled.
+        ///     a <see cref="IDbContextLogger" />, if enabled.
         /// </summary>
         /// <param name="diagnostics"> The <see cref="IDiagnosticsLogger" /> being used. </param>
         /// <param name="definition"> The definition of the event to log. </param>
         /// <param name="eventData"> The event data. </param>
         /// <param name="diagnosticSourceEnabled"> True to dispatch to a <see cref="DiagnosticSource" />; false otherwise. </param>
-        /// <param name="simpleLogEnabled"> True to dispatch to a <see cref="ISimpleLogger" />; false otherwise. </param>
+        /// <param name="simpleLogEnabled"> True to dispatch to a <see cref="IDbContextLogger" />; false otherwise. </param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)] // Because hot path for logging
         public static void DispatchEventData(
             [NotNull] this IDiagnosticsLogger diagnostics,
@@ -59,20 +59,20 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             if (simpleLogEnabled)
             {
-                diagnostics.SimpleLogger.Log(eventData);
+                diagnostics.DbContextLogger.Log(eventData);
             }
         }
 
         /// <summary>
         ///     Determines whether or not an <see cref="EventData" /> instance is needed based on whether or
-        ///     not there is a <see cref="DiagnosticSource" /> or an <see cref="ISimpleLogger" /> enabled for
+        ///     not there is a <see cref="DiagnosticSource" /> or an <see cref="IDbContextLogger" /> enabled for
         ///     the given event.
         /// </summary>
         /// <param name="diagnostics"> The <see cref="IDiagnosticsLogger" /> being used. </param>
         /// <param name="definition"> The definition of the event. </param>
         /// <param name="diagnosticSourceEnabled"> Set to true if a <see cref="DiagnosticSource" /> is enabled; false otherwise. </param>
-        /// <param name="simpleLogEnabled"> True to true if a <see cref="ISimpleLogger" /> is enabled; false otherwise. </param>
-        /// <returns> True if either a diagnostic source or a simple logger is enabled; false otherwise. </returns>
+        /// <param name="simpleLogEnabled"> True to true if a <see cref="IDbContextLogger" /> is enabled; false otherwise. </param>
+        /// <returns> True if either a diagnostic source or a LogTo logger is enabled; false otherwise. </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)] // Because hot path for logging
         public static bool NeedsEventData(
             [NotNull] this IDiagnosticsLogger diagnostics,
@@ -85,7 +85,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             diagnosticSourceEnabled = diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name);
 
             simpleLogEnabled = definition.WarningBehavior == WarningBehavior.Log
-                && diagnostics.SimpleLogger.ShouldLog(definition.EventId, definition.Level);
+                && diagnostics.DbContextLogger.ShouldLog(definition.EventId, definition.Level);
 
             return diagnosticSourceEnabled
                 || simpleLogEnabled;
@@ -93,15 +93,15 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
         /// <summary>
         ///     Determines whether or not an <see cref="EventData" /> instance is needed based on whether or
-        ///     not there is a <see cref="DiagnosticSource" />, an <see cref="ISimpleLogger" />, or an <see cref="IInterceptor" /> enabled for
+        ///     not there is a <see cref="DiagnosticSource" />, an <see cref="IDbContextLogger" />, or an <see cref="IInterceptor" /> enabled for
         ///     the given event.
         /// </summary>
         /// <param name="diagnostics"> The <see cref="IDiagnosticsLogger" /> being used. </param>
         /// <param name="definition"> The definition of the event. </param>
         /// <param name="interceptor"> The <see cref="IInterceptor" /> to use if enabled; otherwise null. </param>
         /// <param name="diagnosticSourceEnabled"> Set to true if a <see cref="DiagnosticSource" /> is enabled; false otherwise. </param>
-        /// <param name="simpleLogEnabled"> True to true if a <see cref="ISimpleLogger" /> is enabled; false otherwise. </param>
-        /// <returns> True if either a diagnostic source, a simple logger, or an interceptor is enabled; false otherwise. </returns>
+        /// <param name="simpleLogEnabled"> True to true if a <see cref="IDbContextLogger" /> is enabled; false otherwise. </param>
+        /// <returns> True if either a diagnostic source, a LogTo logger, or an interceptor is enabled; false otherwise. </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)] // Because hot path for logging
         public static bool NeedsEventData<TInterceptor>(
             [NotNull] this IDiagnosticsLogger diagnostics,
@@ -118,7 +118,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             interceptor = diagnostics.Interceptors?.Aggregate<TInterceptor>();
 
             simpleLogEnabled = definition.WarningBehavior == WarningBehavior.Log
-                && diagnostics.SimpleLogger.ShouldLog(definition.EventId, definition.Level);
+                && diagnostics.DbContextLogger.ShouldLog(definition.EventId, definition.Level);
 
             return diagnosticSourceEnabled
                 || simpleLogEnabled

--- a/src/EFCore/Diagnostics/IDbContextLogger.cs
+++ b/src/EFCore/Diagnostics/IDbContextLogger.cs
@@ -9,9 +9,9 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 {
     /// <summary>
     ///     A simple logging interface for Entity Framework events.
-    ///     Used by <see cref="DbContextOptionsBuilder.LogTo(Action{string},LogLevel,SimpleLoggerFormatOptions?)" />
+    ///     Used by <see cref="DbContextOptionsBuilder.LogTo(Action{string},LogLevel,DbContextLoggerOptions?)" />
     /// </summary>
-    public interface ISimpleLogger
+    public interface IDbContextLogger
     {
         /// <summary>
         ///     <para>

--- a/src/EFCore/Diagnostics/IDiagnosticsLogger.cs
+++ b/src/EFCore/Diagnostics/IDiagnosticsLogger.cs
@@ -49,9 +49,9 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         DiagnosticSource DiagnosticSource { get; }
 
         /// <summary>
-        ///     The <see cref="ISimpleLogger" />.
+        ///     The <see cref="IDbContextLogger" />.
         /// </summary>
-        ISimpleLogger SimpleLogger { get; }
+        IDbContextLogger DbContextLogger { get; }
 
         /// <summary>
         ///     Holds registered interceptors, if any.

--- a/src/EFCore/Diagnostics/Internal/DelegatingDbContextLogger.cs
+++ b/src/EFCore/Diagnostics/Internal/DelegatingDbContextLogger.cs
@@ -1,0 +1,56 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public class DelegatingDbContextLogger : IDbContextLogger
+    {
+        [NotNull]
+        private readonly Action<EventData> _logger;
+
+        [NotNull]
+        private readonly Func<EventId, LogLevel, bool> _filter;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public DelegatingDbContextLogger(
+            [NotNull] Action<EventData> logger,
+            [NotNull] Func<EventId, LogLevel, bool> filter)
+        {
+            _logger = logger;
+            _filter = filter;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual void Log(EventData eventData)
+            => _logger(eventData);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool ShouldLog(EventId eventId, LogLevel logLevel)
+            => _filter(eventId, logLevel);
+    }
+}

--- a/src/EFCore/Diagnostics/Internal/NullDbContextLogger.cs
+++ b/src/EFCore/Diagnostics/Internal/NullDbContextLogger.cs
@@ -11,7 +11,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public class NullSimpleLogger : ISimpleLogger
+    public class NullDbContextLogger : IDbContextLogger
     {
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Infrastructure/CoreOptionsExtension.cs
+++ b/src/EFCore/Infrastructure/CoreOptionsExtension.cs
@@ -33,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         private IServiceProvider _applicationServiceProvider;
         private IModel _model;
         private ILoggerFactory _loggerFactory;
-        private ISimpleLogger _simpleLogger;
+        private IDbContextLogger _contextLogger;
         private IMemoryCache _memoryCache;
         private bool _sensitiveDataLoggingEnabled;
         private bool _detailedErrorsEnabled;
@@ -67,7 +67,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             _applicationServiceProvider = copyFrom.ApplicationServiceProvider;
             _model = copyFrom.Model;
             _loggerFactory = copyFrom.LoggerFactory;
-            _simpleLogger = copyFrom.SimpleLogger;
+            _contextLogger = copyFrom.DbContextLogger;
             _memoryCache = copyFrom.MemoryCache;
             _sensitiveDataLoggingEnabled = copyFrom.IsSensitiveDataLoggingEnabled;
             _detailedErrorsEnabled = copyFrom.DetailedErrorsEnabled;
@@ -174,13 +174,13 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     Creates a new instance with all options the same as for this instance, but with the given option changed.
         ///     It is unusual to call this method directly. Instead use <see cref="DbContextOptionsBuilder" />.
         /// </summary>
-        /// <param name="simpleLogger"> The option to change. </param>
+        /// <param name="contextLogger"> The option to change. </param>
         /// <returns> A new instance with the option changed. </returns>
-        public virtual CoreOptionsExtension WithSimpleLogger([CanBeNull] ISimpleLogger simpleLogger)
+        public virtual CoreOptionsExtension WithDbContextLogger([CanBeNull] IDbContextLogger contextLogger)
         {
             var clone = Clone();
 
-            clone._simpleLogger = simpleLogger;
+            clone._contextLogger = contextLogger;
 
             return clone;
         }
@@ -336,9 +336,9 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         public virtual ILoggerFactory LoggerFactory => _loggerFactory;
 
         /// <summary>
-        ///     The option set from the <see cref="DbContextOptionsBuilder.LogTo(Action{string},LogLevel,SimpleLoggerFormatOptions?)" /> method.
+        ///     The option set from the <see cref="DbContextOptionsBuilder.LogTo(Action{string},LogLevel,DbContextLoggerOptions?)" /> method.
         /// </summary>
-        public virtual ISimpleLogger SimpleLogger => _simpleLogger;
+        public virtual IDbContextLogger DbContextLogger => _contextLogger;
 
         /// <summary>
         ///     The option set from the <see cref="DbContextOptionsBuilder.UseMemoryCache" /> method.

--- a/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
+++ b/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
@@ -130,7 +130,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 { typeof(IDbContextTransactionManager), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IQueryContextFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IQueryCompilationContextFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
-                { typeof(ISimpleLogger), new ServiceCharacteristics(ServiceLifetime.Scoped) },
+                { typeof(IDbContextLogger), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(ILazyLoader), new ServiceCharacteristics(ServiceLifetime.Transient) },
                 {
                     typeof(IParameterBindingFactory), new ServiceCharacteristics(ServiceLifetime.Singleton, multipleRegistrations: true)
@@ -266,7 +266,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             TryAdd<IQueryTranslationPreprocessorFactory, QueryTranslationPreprocessorFactory>();
             TryAdd<IQueryTranslationPostprocessorFactory, QueryTranslationPostprocessorFactory>();
 
-            TryAdd(p => p.GetService<IDbContextOptions>()?.FindExtension<CoreOptionsExtension>()?.SimpleLogger ?? new NullSimpleLogger());
+            TryAdd(p => p.GetService<IDbContextOptions>()?.FindExtension<CoreOptionsExtension>()?.DbContextLogger ?? new NullDbContextLogger());
 
             // This has to be lazy to avoid creating instances that are not disposed
             ServiceCollectionMap

--- a/src/EFCore/Internal/DiagnosticsLogger.cs
+++ b/src/EFCore/Internal/DiagnosticsLogger.cs
@@ -37,12 +37,12 @@ namespace Microsoft.EntityFrameworkCore.Internal
             [NotNull] ILoggingOptions loggingOptions,
             [NotNull] DiagnosticSource diagnosticSource,
             [NotNull] LoggingDefinitions loggingDefinitions,
-            [NotNull] ISimpleLogger simpleLogger,
+            [NotNull] IDbContextLogger contextLogger,
             [CanBeNull] IInterceptors interceptors = null)
         {
             DiagnosticSource = diagnosticSource;
             Definitions = loggingDefinitions;
-            SimpleLogger = simpleLogger;
+            DbContextLogger = contextLogger;
             Logger = loggerFactory.CreateLogger(new TLoggerCategory());
             Options = loggingOptions;
             Interceptors = interceptors;
@@ -94,7 +94,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual ISimpleLogger SimpleLogger { get; }
+        public virtual IDbContextLogger DbContextLogger { get; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Internal/ServiceProviderCache.cs
+++ b/src/EFCore/Internal/ServiceProviderCache.cs
@@ -133,7 +133,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                             scopedProvider.GetService<ILoggingOptions>(),
                             scopedProvider.GetService<DiagnosticSource>(),
                             loggingDefinitions,
-                            new NullSimpleLogger());
+                            new NullDbContextLogger());
 
                         if (_configurations.Count == 0)
                         {

--- a/test/EFCore.InMemory.Tests/InMemoryTransactionManagerTest.cs
+++ b/test/EFCore.InMemory.Tests/InMemoryTransactionManagerTest.cs
@@ -68,7 +68,7 @@ namespace Microsoft.EntityFrameworkCore
                 options,
                 new DiagnosticListener("Fake"),
                 new InMemoryLoggingDefinitions(),
-                new NullSimpleLogger());
+                new NullDbContextLogger());
             return logger;
         }
     }

--- a/test/EFCore.Relational.Tests/Storage/RelationalCommandTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalCommandTest.cs
@@ -940,7 +940,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 new FakeLoggingOptions(false),
                 new DiagnosticListener("Fake"),
                 new TestRelationalLoggingDefinitions(),
-                new NullSimpleLogger());
+                new NullDbContextLogger());
 
             var relationalCommand = CreateRelationalCommand(
                 commandText: "Logged Command",
@@ -998,7 +998,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 new FakeLoggingOptions(true),
                 new DiagnosticListener("Fake"),
                 new TestRelationalLoggingDefinitions(),
-                new NullSimpleLogger());
+                new NullDbContextLogger());
 
             var relationalCommand = CreateRelationalCommand(
                 commandText: "Logged Command",
@@ -1056,7 +1056,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 new FakeLoggingOptions(false),
                 new ListDiagnosticSource(diagnostic),
                 new TestRelationalLoggingDefinitions(),
-                new NullSimpleLogger());
+                new NullDbContextLogger());
 
             var relationalCommand = CreateRelationalCommand(
                 parameters: new[]
@@ -1127,7 +1127,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 new FakeLoggingOptions(false),
                 new ListDiagnosticSource(diagnostic),
                 new TestRelationalLoggingDefinitions(),
-                new NullSimpleLogger());
+                new NullDbContextLogger());
 
             var relationalCommand = CreateRelationalCommand(
                 parameters: new[]

--- a/test/EFCore.Relational.Tests/Storage/RelationalTransactionExtensionsTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalTransactionExtensionsTest.cs
@@ -38,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                     new LoggingOptions(),
                     new DiagnosticListener("Fake"),
                     new TestRelationalLoggingDefinitions(),
-                    new NullSimpleLogger()),
+                    new NullDbContextLogger()),
                 false);
 
             Assert.Equal(dbTransaction, transaction.GetDbTransaction());

--- a/test/EFCore.Relational.Tests/TestUtilities/FakeDiagnosticsLogger.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/FakeDiagnosticsLogger.cs
@@ -21,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
         public DiagnosticSource DiagnosticSource { get; } = new DiagnosticListener("Fake");
 
-        public ISimpleLogger SimpleLogger { get; } = new NullSimpleLogger();
+        public IDbContextLogger DbContextLogger { get; } = new NullDbContextLogger();
 
         public void Log<TState>(
             LogLevel logLevel,

--- a/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalConnection.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalConnection.cs
@@ -28,13 +28,13 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider
                         new LoggingOptions(),
                         new DiagnosticListener("FakeDiagnosticListener"),
                         new TestRelationalLoggingDefinitions(),
-                        new NullSimpleLogger()),
+                        new NullDbContextLogger()),
                     new DiagnosticsLogger<DbLoggerCategory.Database.Connection>(
                         new LoggerFactory(),
                         new LoggingOptions(),
                         new DiagnosticListener("FakeDiagnosticListener"),
                         new TestRelationalLoggingDefinitions(),
-                        new NullSimpleLogger()),
+                        new NullDbContextLogger()),
                     new NamedConnectionStringResolver(options ?? CreateOptions()),
                     new RelationalTransactionFactory(new RelationalTransactionFactoryDependencies()),
                     new CurrentDbContext(new FakeDbContext())))

--- a/test/EFCore.Specification.Tests/TestUtilities/TestDbContextLogger.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/TestDbContextLogger.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities
 {
-    public class TestSimpleLogger : ISimpleLogger
+    public class TestDbContextLogger : IDbContextLogger
     {
         public LogLevel? LoggedAt { get; set; }
         public EventId LoggedEvent { get; set; }

--- a/test/EFCore.Specification.Tests/TestUtilities/TestLoggerBase.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/TestLoggerBase.cs
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         public EventId LoggedEvent { get; set; }
         public string Message { get; set; }
 
-        public ISimpleLogger SimpleLogger { get; } = new TestSimpleLogger();
+        public IDbContextLogger DbContextLogger { get; } = new TestDbContextLogger();
 
         public DiagnosticSource DiagnosticSource { get; } = new TestDiagnosticSource();
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Scaffolding/SqlServerDatabaseModelFactoryTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Scaffolding/SqlServerDatabaseModelFactoryTest.cs
@@ -2203,7 +2203,7 @@ DROP TABLE PrincipalTable;");
                         new LoggingOptions(),
                         new DiagnosticListener("Fake"),
                         new SqlServerLoggingDefinitions(),
-                        new NullSimpleLogger()));
+                        new NullDbContextLogger()));
 
                 var databaseModel = databaseModelFactory.Create(
                     Fixture.TestStore.ConnectionString,

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerDatabaseCleaner.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerDatabaseCleaner.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                     new LoggingOptions(),
                     new DiagnosticListener("Fake"),
                     new SqlServerLoggingDefinitions(),
-                    new NullSimpleLogger()));
+                    new NullDbContextLogger()));
 
         protected override bool AcceptTable(DatabaseTable table) => !(table is DatabaseView);
 

--- a/test/EFCore.SqlServer.Tests/SqlServerConnectionTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerConnectionTest.cs
@@ -73,13 +73,13 @@ namespace Microsoft.EntityFrameworkCore
                     new LoggingOptions(),
                     new DiagnosticListener("FakeDiagnosticListener"),
                     new SqlServerLoggingDefinitions(),
-                    new NullSimpleLogger()),
+                    new NullDbContextLogger()),
                 new DiagnosticsLogger<DbLoggerCategory.Database.Connection>(
                     new LoggerFactory(),
                     new LoggingOptions(),
                     new DiagnosticListener("FakeDiagnosticListener"),
                     new SqlServerLoggingDefinitions(),
-                    new NullSimpleLogger()),
+                    new NullDbContextLogger()),
                 new NamedConnectionStringResolver(options),
                 new RelationalTransactionFactory(new RelationalTransactionFactoryDependencies()),
                 new CurrentDbContext(new FakeDbContext()));

--- a/test/EFCore.Sqlite.FunctionalTests/Scaffolding/SqliteDatabaseModelFactoryTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Scaffolding/SqliteDatabaseModelFactoryTest.cs
@@ -51,7 +51,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
                     .AddSingleton(typeof(IDiagnosticsLogger<>), typeof(DiagnosticsLogger<>))
                     .AddSingleton<IValueConverterSelector, ValueConverterSelector>()
                     .AddSingleton<ILoggerFactory>(Fixture.ListLoggerFactory)
-                    .AddSingleton<ISimpleLogger, NullSimpleLogger>();
+                    .AddSingleton<IDbContextLogger, NullDbContextLogger>();
 
                 new SqliteDesignTimeServices().ConfigureDesignTimeServices(services);
 

--- a/test/EFCore.Sqlite.FunctionalTests/TestUtilities/SqliteDatabaseCleaner.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/TestUtilities/SqliteDatabaseCleaner.cs
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 .AddSingleton<ValueConverterSelectorDependencies>()
                 .AddSingleton<DiagnosticSource>(new DiagnosticListener(DbLoggerCategory.Name))
                 .AddSingleton<ILoggingOptions, LoggingOptions>()
-                .AddSingleton<ISimpleLogger, NullSimpleLogger>()
+                .AddSingleton<IDbContextLogger, NullDbContextLogger>()
                 .AddSingleton<LoggingDefinitions, SqliteLoggingDefinitions>()
                 .AddSingleton(typeof(IDiagnosticsLogger<>), typeof(DiagnosticsLogger<>))
                 .AddSingleton<IValueConverterSelector, ValueConverterSelector>()

--- a/test/EFCore.Tests/ApiConsistencyTest.cs
+++ b/test/EFCore.Tests/ApiConsistencyTest.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -25,10 +26,7 @@ namespace Microsoft.EntityFrameworkCore
                 typeof(CompiledQueryCacheKeyGenerator).GetRuntimeMethods().Single(m => m.Name == "GenerateCacheKeyCore"),
                 typeof(InternalEntityEntry).GetRuntimeMethods().Single(m => m.Name == "get_Item"),
                 typeof(InternalEntityEntry).GetRuntimeMethods().Single(m => m.Name == "set_Item"),
-                typeof(InternalEntityEntry).GetRuntimeMethods().Single(m => m.Name == nameof(InternalEntityEntry.HasDefaultValue)),
-                typeof(SimpleLogger).GetAnyProperty(nameof(SimpleLogger.Filter)).GetMethod,
-                typeof(SimpleLogger).GetAnyProperty(nameof(SimpleLogger.Sink)).GetMethod,
-                typeof(SimpleLogger).GetAnyProperty(nameof(SimpleLogger.FormatOptions)).GetMethod
+                typeof(InternalEntityEntry).GetRuntimeMethods().Single(m => m.Name == nameof(InternalEntityEntry.HasDefaultValue))
             };
 
         private static readonly Type[] _fluentApiTypes =

--- a/test/EFCore.Tests/Infrastructure/DiagnosticsLoggerTest.cs
+++ b/test/EFCore.Tests/Infrastructure/DiagnosticsLoggerTest.cs
@@ -46,11 +46,11 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             var loggerFactory = new ListLoggerFactory(filter);
 
             var dbLogger = new DiagnosticsLogger<DbLoggerCategory.Database>(
-                loggerFactory, new LoggingOptions(), new DiagnosticListener("Fake"), new TestLoggingDefinitions(), new NullSimpleLogger());
+                loggerFactory, new LoggingOptions(), new DiagnosticListener("Fake"), new TestLoggingDefinitions(), new NullDbContextLogger());
             var sqlLogger = new DiagnosticsLogger<DbLoggerCategory.Database.Command>(
-                loggerFactory, new LoggingOptions(), new DiagnosticListener("Fake"), new TestLoggingDefinitions(), new NullSimpleLogger());
+                loggerFactory, new LoggingOptions(), new DiagnosticListener("Fake"), new TestLoggingDefinitions(), new NullDbContextLogger());
             var queryLogger = new DiagnosticsLogger<DbLoggerCategory.Query>(
-                loggerFactory, new LoggingOptions(), new DiagnosticListener("Fake"), new TestLoggingDefinitions(), new NullSimpleLogger());
+                loggerFactory, new LoggingOptions(), new DiagnosticListener("Fake"), new TestLoggingDefinitions(), new NullDbContextLogger());
             var randomLogger = loggerFactory.CreateLogger("Random");
 
             dbLogger.Logger.LogInformation(1, "DB1");

--- a/test/EFCore.Tests/Infrastructure/EventIdTestBase.cs
+++ b/test/EFCore.Tests/Infrastructure/EventIdTestBase.cs
@@ -70,7 +70,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                     var testLogger =
                         (TestLoggerBase)Activator.CreateInstance(typeof(TestLogger<,>).MakeGenericType(category, loggerDefinitionsType));
                     var testDiagnostics = (TestDiagnosticSource)testLogger.DiagnosticSource;
-                    var simpleLogger = (TestSimpleLogger)testLogger.SimpleLogger;
+                    var contextLogger = (TestDbContextLogger)testLogger.DbContextLogger;
 
                     var args = new object[loggerParameters.Length];
                     args[0] = testLogger;
@@ -116,8 +116,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
                                 if (categoryName != DbLoggerCategory.Scaffolding.Name)
                                 {
-                                    Assert.Equal(logLevel, simpleLogger.LoggedAt);
-                                    Assert.Equal(eventId, simpleLogger.LoggedEvent);
+                                    Assert.Equal(logLevel, contextLogger.LoggedAt);
+                                    Assert.Equal(eventId, contextLogger.LoggedEvent);
                                 }
                             }
 

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTestBase.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTestBase.cs
@@ -222,7 +222,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 options,
                 new DiagnosticListener("Fake"),
                 TestHelpers.LoggingDefinitions,
-                new NullSimpleLogger());
+                new NullDbContextLogger());
         }
 
         protected DiagnosticsLogger<DbLoggerCategory.Model> CreateModelLogger(bool sensitiveDataLoggingEnabled = false)
@@ -234,7 +234,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 options,
                 new DiagnosticListener("Fake"),
                 TestHelpers.LoggingDefinitions,
-                new NullSimpleLogger());
+                new NullDbContextLogger());
         }
 
         protected virtual ModelBuilder CreateConventionalModelBuilder(bool sensitiveDataLoggingEnabled = false)

--- a/test/EFCore.Tests/Metadata/Conventions/ForeignKeyPropertyDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/ForeignKeyPropertyDiscoveryConventionTest.cs
@@ -1155,7 +1155,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 options,
                 new DiagnosticListener("Fake"),
                 new TestLoggingDefinitions(),
-                new NullSimpleLogger());
+                new NullDbContextLogger());
             return modelLogger;
         }
 

--- a/test/EFCore.Tests/Metadata/Conventions/KeyDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/KeyDiscoveryConventionTest.cs
@@ -170,7 +170,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 options,
                 new DiagnosticListener("Fake"),
                 new TestLoggingDefinitions(),
-                new NullSimpleLogger());
+                new NullDbContextLogger());
             return modelLogger;
         }
 

--- a/test/EFCore.Tests/Metadata/Conventions/NavigationAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/NavigationAttributeConventionTest.cs
@@ -897,7 +897,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 options,
                 new DiagnosticListener("Fake"),
                 new TestLoggingDefinitions(),
-                new NullSimpleLogger());
+                new NullDbContextLogger());
             return modelLogger;
         }
 

--- a/test/EFCore.Tests/Metadata/Conventions/NonNullableNavigationConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/NonNullableNavigationConventionTest.cs
@@ -227,7 +227,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 options,
                 new DiagnosticListener("Fake"),
                 new TestLoggingDefinitions(),
-                new NullSimpleLogger());
+                new NullDbContextLogger());
             return modelLogger;
         }
 

--- a/test/EFCore.Tests/Metadata/Conventions/RelationshipDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/RelationshipDiscoveryConventionTest.cs
@@ -992,7 +992,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 options,
                 new DiagnosticListener("Fake"),
                 new TestLoggingDefinitions(),
-                new NullSimpleLogger());
+                new NullDbContextLogger());
             return modelLogger;
         }
 

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderTestBase.cs
@@ -124,7 +124,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                     options,
                     new DiagnosticListener("Fake"),
                     testHelpers.LoggingDefinitions,
-                    new NullSimpleLogger());
+                    new NullDbContextLogger());
 
                 ModelLoggerFactory = new ListLoggerFactory(l => l == DbLoggerCategory.Model.Name);
                 var modelLogger = new DiagnosticsLogger<DbLoggerCategory.Model>(
@@ -132,7 +132,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                     options,
                     new DiagnosticListener("Fake"),
                     testHelpers.LoggingDefinitions,
-                    new NullSimpleLogger());
+                    new NullDbContextLogger());
 
                 ModelBuilder = testHelpers.CreateConventionBuilder(modelLogger, validationLogger);
             }


### PR DESCRIPTION
#1199

* Stop exposing the interface in LogTo and replace with delegates overload.
* Rename SimpleLoggerFormatOptions to LogToOptions
  * Similar renaming across the internal implementation
