### PR TITLE
#3836 - Coalescing string concatenation on nullable Expressions

### DIFF
--- a/src/EFCore.Relational/Query/Internal/NullSemanticsRewritingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/NullSemanticsRewritingExpressionVisitor.cs
@@ -367,6 +367,30 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 return sqlBinaryExpression.Update(newLeft, newRight);
             }
 
+            if (sqlBinaryExpression.OperatorType == ExpressionType.Add
+                && sqlBinaryExpression.Type == typeof(string))
+            {
+                if (leftNullable)
+                {
+                    newLeft = newLeft is SqlConstantExpression
+                        ? _sqlExpressionFactory.Constant(string.Empty)
+                        : newLeft is ColumnExpression || newLeft is SqlParameterExpression
+                            ? _sqlExpressionFactory.Coalesce(newLeft, _sqlExpressionFactory.Constant(string.Empty))
+                            : newLeft;
+                }
+
+                if (rightNullable)
+                {
+                    newRight = newRight is SqlConstantExpression
+                        ? _sqlExpressionFactory.Constant(string.Empty)
+                        : newRight is ColumnExpression || newRight is SqlParameterExpression
+                            ? _sqlExpressionFactory.Coalesce(newRight, _sqlExpressionFactory.Constant(string.Empty))
+                            : newRight;
+                }
+
+                return sqlBinaryExpression.Update(newLeft, newRight);
+            }
+
             if (sqlBinaryExpression.OperatorType == ExpressionType.Equal
                 || sqlBinaryExpression.OperatorType == ExpressionType.NotEqual)
             {

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -5886,6 +5886,18 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true);
         }
 
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task String_concat_nullable_expressions_are_coalesced(bool async)
+        {
+            object nullableParam = null;
+
+            return AssertQuery(
+                async,
+                ss => ss.Set<Gear>().Select(w => w.FullName + null + w.LeaderNickname + nullableParam),
+                ss => ss.Set<Gear>().Select(w => w.FullName + string.Empty + w.LeaderNickname ?? string.Empty + nullableParam ?? string.Empty));
+        }
+
         [ConditionalTheory(Skip = "issue #14205")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task String_concat_on_various_types(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -3097,7 +3097,7 @@ ORDER BY [l].[Id], [t].[Id], [t].[Id0]");
             await base.Select_optional_navigation_property_string_concat(async);
 
             AssertSql(
-                @"SELECT ([l].[Name] + N' ') + CASE
+                @"SELECT (COALESCE([l].[Name], N'') + N' ') + CASE
     WHEN [t].[Id] IS NOT NULL THEN [t].[Name]
     ELSE N'NULL'
 END

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -1871,7 +1871,7 @@ WHERE CHARINDEX('Jacinto', [c].[Location]) > 0");
             AssertSql(
                 @"SELECT [c].[Name], [c].[Location], [c].[Nation]
 FROM [Cities] AS [c]
-WHERE CHARINDEX('Add', [c].[Location] + 'Added') > 0");
+WHERE CHARINDEX('Add', COALESCE([c].[Location], '') + 'Added') > 0");
         }
 
         public override void Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result1()
@@ -6014,7 +6014,7 @@ ORDER BY [w].[Id] + 2");
                 @"SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
 FROM [Weapons] AS [w]
 LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
-ORDER BY [w0].[Name] + CAST(5 AS nvarchar(max))");
+ORDER BY COALESCE([w0].[Name], N'') + CAST(5 AS nvarchar(max))");
         }
 
         public override async Task String_concat_with_null_conditional_argument2(bool async)
@@ -6025,7 +6025,7 @@ ORDER BY [w0].[Name] + CAST(5 AS nvarchar(max))");
                 @"SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
 FROM [Weapons] AS [w]
 LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
-ORDER BY [w0].[Name] + N'Marcus'' Lancer'");
+ORDER BY COALESCE([w0].[Name], N'') + N'Marcus'' Lancer'");
         }
 
         public override async Task String_concat_on_various_types(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindDbFunctionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindDbFunctionsQuerySqlServerTest.cs
@@ -667,7 +667,7 @@ WHERE CAST(ISDATE(CONVERT(VARCHAR(100), [o].[OrderDate])) AS bit) = CAST(1 AS bi
             AssertSql(
                 @"SELECT COUNT(*)
 FROM [Orders] AS [o]
-WHERE CAST(ISDATE([o].[CustomerID] + CAST([o].[OrderID] AS nchar(5))) AS bit) = CAST(1 AS bit)");
+WHERE CAST(ISDATE(COALESCE([o].[CustomerID], N'') + CAST([o].[OrderID] AS nchar(5))) AS bit) = CAST(1 AS bit)");
         }
 
         [ConditionalFact]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -1034,7 +1034,7 @@ OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY");
                 @"@__p_0='10'
 @__p_1='5'
 
-SELECT ([c].[ContactName] + N' ') + [c].[ContactTitle] AS [Contact], [o].[OrderID]
+SELECT (COALESCE([c].[ContactName], N'') + N' ') + COALESCE([c].[ContactTitle], N'') AS [Contact], [o].[OrderID]
 FROM [Customers] AS [c]
 INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 ORDER BY [o].[OrderID]
@@ -2756,7 +2756,7 @@ WHERE (@__NewLine_0 = N'') OR (CHARINDEX(@__NewLine_0, [c].[CustomerID]) > 0)");
             await base.String_concat_with_navigation1(async);
 
             AssertSql(
-                @"SELECT ([o].[CustomerID] + N' ') + [c].[City]
+                @"SELECT (COALESCE([o].[CustomerID], N'') + N' ') + COALESCE([c].[City], N'')
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]");
         }
@@ -2766,7 +2766,7 @@ LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]");
             await base.String_concat_with_navigation2(async);
 
             AssertSql(
-                @"SELECT ([c].[City] + N' ') + [c].[City]
+                @"SELECT (COALESCE([c].[City], N'') + N' ') + COALESCE([c].[City], N'')
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]");
         }
@@ -3665,9 +3665,9 @@ WHERE [t].[CustomerID] LIKE N'A%'");
             await base.Anonymous_complex_distinct_where(async);
 
             AssertSql(
-                @"SELECT DISTINCT [c].[CustomerID] + [c].[City] AS [A]
+                @"SELECT DISTINCT [c].[CustomerID] + COALESCE([c].[City], N'') AS [A]
 FROM [Customers] AS [c]
-WHERE ([c].[CustomerID] + [c].[City]) = N'ALFKIBerlin'");
+WHERE ([c].[CustomerID] + COALESCE([c].[City], N'')) = N'ALFKIBerlin'");
         }
 
         public override async Task Anonymous_complex_distinct_orderby(bool async)
@@ -3677,7 +3677,7 @@ WHERE ([c].[CustomerID] + [c].[City]) = N'ALFKIBerlin'");
             AssertSql(
                 @"SELECT [t].[c] AS [A]
 FROM (
-    SELECT DISTINCT [c].[CustomerID] + [c].[City] AS [c]
+    SELECT DISTINCT [c].[CustomerID] + COALESCE([c].[City], N'') AS [c]
     FROM [Customers] AS [c]
 ) AS [t]
 ORDER BY [t].[c]");
@@ -3690,7 +3690,7 @@ ORDER BY [t].[c]");
             AssertSql(
                 @"SELECT COUNT(*)
 FROM (
-    SELECT DISTINCT [c].[CustomerID] + [c].[City] AS [c]
+    SELECT DISTINCT [c].[CustomerID] + COALESCE([c].[City], N'') AS [c]
     FROM [Customers] AS [c]
 ) AS [t]
 WHERE [t].[c] IS NOT NULL AND ([t].[c] LIKE N'A%')");
@@ -3701,9 +3701,9 @@ WHERE [t].[c] IS NOT NULL AND ([t].[c] LIKE N'A%')");
             await base.Anonymous_complex_orderby(async);
 
             AssertSql(
-                @"SELECT [c].[CustomerID] + [c].[City] AS [A]
+                @"SELECT [c].[CustomerID] + COALESCE([c].[City], N'') AS [A]
 FROM [Customers] AS [c]
-ORDER BY [c].[CustomerID] + [c].[City]");
+ORDER BY [c].[CustomerID] + COALESCE([c].[City], N'')");
         }
 
         public override async Task Anonymous_subquery_orderby(bool async)
@@ -3769,9 +3769,9 @@ WHERE [t].[CustomerID] LIKE N'A%'");
             await base.DTO_complex_distinct_where(async);
 
             AssertSql(
-                @"SELECT DISTINCT [c].[CustomerID] + [c].[City] AS [Property]
+                @"SELECT DISTINCT [c].[CustomerID] + COALESCE([c].[City], N'') AS [Property]
 FROM [Customers] AS [c]
-WHERE ([c].[CustomerID] + [c].[City]) = N'ALFKIBerlin'");
+WHERE ([c].[CustomerID] + COALESCE([c].[City], N'')) = N'ALFKIBerlin'");
         }
 
         public override async Task DTO_complex_distinct_orderby(bool async)
@@ -3781,7 +3781,7 @@ WHERE ([c].[CustomerID] + [c].[City]) = N'ALFKIBerlin'");
             AssertSql(
                 @"SELECT [t].[c] AS [Property]
 FROM (
-    SELECT DISTINCT [c].[CustomerID] + [c].[City] AS [c]
+    SELECT DISTINCT [c].[CustomerID] + COALESCE([c].[City], N'') AS [c]
     FROM [Customers] AS [c]
 ) AS [t]
 ORDER BY [t].[c]");
@@ -3794,7 +3794,7 @@ ORDER BY [t].[c]");
             AssertSql(
                 @"SELECT COUNT(*)
 FROM (
-    SELECT DISTINCT [c].[CustomerID] + [c].[City] AS [c]
+    SELECT DISTINCT [c].[CustomerID] + COALESCE([c].[City], N'') AS [c]
     FROM [Customers] AS [c]
 ) AS [t]
 WHERE [t].[c] IS NOT NULL AND ([t].[c] LIKE N'A%')");

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
@@ -1333,7 +1333,7 @@ WHERE ((CAST([o].[OrderID] AS nchar(5)) + [o].[CustomerID]) = [o].[CustomerID]) 
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE (@__i_0 + [c].[CustomerID]) = [c].[CompanyName]");
+WHERE (COALESCE(@__i_0, N'') + [c].[CustomerID]) = [c].[CompanyName]");
         }
 
         public override async Task Where_string_concat_method_comparison(bool async)
@@ -1345,7 +1345,7 @@ WHERE (@__i_0 + [c].[CustomerID]) = [c].[CompanyName]");
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE (@__i_0 + [c].[CustomerID]) = [c].[CompanyName]");
+WHERE (COALESCE(@__i_0, N'') + [c].[CustomerID]) = [c].[CompanyName]");
         }
 
         public override async Task Where_ternary_boolean_condition_true(bool async)


### PR DESCRIPTION
Fixes https://github.com/aspnet/EntityFrameworkCore/issues/3836

I was hoping to get a review of the auto-coalescing implementation before I fixed the broken tests (if there's a better way than creating a PR with knowingly broken tests let me know (or if I should have fixed the tests first)). This feature is a slight breaking change if anyone was dependent on return nullability, and it also breaks around 30 or so existing tests due to the difference in output SQL.

Based on comments from @smitpatel on the issue we should be able to handle 3 expressions (column/const/param) in the NullSemanticsVisitor and appropriately coalesce these so we can better emulate expected C# functionality 