### PR TITLE
Replace Debug.Assert with less complex alternative

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitor.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -629,7 +628,9 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                             Expression ownerJObjectExpression = null;
                             if (_ownerMappings.TryGetValue(jObjectExpression, out var ownerInfo))
                             {
-                                Debug.Assert(principalProperty.DeclaringEntityType.IsAssignableFrom(ownerInfo.EntityType));
+                                Check.DebugAssert(
+                                    principalProperty.DeclaringEntityType.IsAssignableFrom(ownerInfo.EntityType),
+                                    $"{principalProperty.DeclaringEntityType} is not assignable from {ownerInfo.EntityType}");
 
                                 ownerJObjectExpression = ownerInfo.JObjectExpression;
                             }

--- a/src/EFCore.Cosmos/Storage/Internal/CosmosDatabaseWrapper.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosDatabaseWrapper.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -15,6 +14,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Update;
+using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json.Linq;
 
@@ -80,7 +80,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
                 var entry = entries[i];
                 var entityType = entry.EntityType;
 
-                Debug.Assert(!entityType.IsAbstract());
+                Check.DebugAssert(!entityType.IsAbstract(), $"{entityType} is abstract");
 
                 if (!entityType.IsDocumentRoot())
                 {
@@ -133,7 +133,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
                 var entry = entries[i];
                 var entityType = entry.EntityType;
 
-                Debug.Assert(!entityType.IsAbstract());
+                Check.DebugAssert(!entityType.IsAbstract(), $"{entityType} is abstract");
+
                 if (!entityType.IsDocumentRoot())
                 {
                     var root = GetRootDocument((InternalEntityEntry)entry);

--- a/src/EFCore.Cosmos/Storage/Internal/CosmosTypeMappingSource.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosTypeMappingSource.cs
@@ -3,10 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
 {
@@ -45,7 +45,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         protected override CoreTypeMapping FindMapping(in TypeMappingInfo mappingInfo)
         {
             var clrType = mappingInfo.ClrType;
-            Debug.Assert(clrType != null);
+            Check.DebugAssert(clrType != null, "ClrType is null");
 
             if (_clrTypeMappings.TryGetValue(clrType, out var mapping))
             {

--- a/src/EFCore.Design/Design/Internal/CSharpHelper.cs
+++ b/src/EFCore.Design/Design/Internal/CSharpHelper.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
@@ -245,7 +244,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
 
             if (type.IsNested)
             {
-                Debug.Assert(type.DeclaringType != null);
+                Check.DebugAssert(type.DeclaringType != null, "DeclaringType is null");
                 builder
                     .Append(Reference(type.DeclaringType))
                     .Append(".");

--- a/src/EFCore.Design/Design/Internal/DbContextOperations.cs
+++ b/src/EFCore.Design/Design/Internal/DbContextOperations.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
@@ -305,7 +304,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
                 throw new OperationException(DesignStrings.MultipleContextsWithQualifiedName(name));
             }
 
-            Debug.Assert(candidates.Count == 1, "candidates.Count is not 1.");
+            Check.DebugAssert(candidates.Count == 1, $"candidates.Count is {candidates.Count}");
 
             return candidates.First();
         }

--- a/src/EFCore.Design/Design/Internal/DesignTimeServicesBuilder.cs
+++ b/src/EFCore.Design/Design/Internal/DesignTimeServicesBuilder.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
@@ -194,7 +193,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             Type designTimeServicesType,
             IServiceCollection services)
         {
-            Debug.Assert(designTimeServicesType != null, "designTimeServicesType is null.");
+            Check.DebugAssert(designTimeServicesType != null, "designTimeServicesType is null.");
 
             var designTimeServices = (IDesignTimeServices)Activator.CreateInstance(designTimeServicesType);
             designTimeServices.ConfigureDesignTimeServices(services);

--- a/src/EFCore.Design/Migrations/Design/CSharpMigrationOperationGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpMigrationOperationGenerator.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Design;
@@ -2098,7 +2097,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
 
         private static object[] ToOnedimensionalArray(object[,] values, bool firstDimension = false)
         {
-            Debug.Assert(
+            Check.DebugAssert(
                 values.GetLength(firstDimension ? 1 : 0) == 1,
                 $"Length of dimension {(firstDimension ? 1 : 0)} is not 1.");
 

--- a/src/EFCore.Design/Migrations/Design/MigrationsScaffolder.cs
+++ b/src/EFCore.Design/Migrations/Design/MigrationsScaffolder.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -335,7 +334,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             else
             {
                 var modelSnapshotNamespace = modelSnapshot.GetType().Namespace;
-                Debug.Assert(!string.IsNullOrEmpty(modelSnapshotNamespace));
+                Check.DebugAssert(!string.IsNullOrEmpty(modelSnapshotNamespace), "modelSnapshotNamespace is null or empty");
                 var modelSnapshotCode = codeGenerator.GenerateSnapshot(
                     modelSnapshotNamespace,
                     _contextType,

--- a/src/EFCore.InMemory/Storage/Internal/InMemoryStore.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryStore.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -10,6 +9,7 @@ using Microsoft.EntityFrameworkCore.InMemory.Internal;
 using Microsoft.EntityFrameworkCore.InMemory.ValueGeneration.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Update;
+using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
 {
@@ -179,7 +179,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
                     var entry = entries[i];
                     var entityType = entry.EntityType;
 
-                    Debug.Assert(!entityType.IsAbstract());
+                    Check.DebugAssert(!entityType.IsAbstract(), "entityType is abstract");
 
                     var key = _useNameMatching ? (object)entityType.Name : entityType;
                     var table = EnsureTable(key, entityType);

--- a/src/EFCore.InMemory/Storage/Internal/InMemoryTypeMappingSource.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryTypeMappingSource.cs
@@ -2,11 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
@@ -46,7 +46,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
         protected override CoreTypeMapping FindMapping(in TypeMappingInfo mappingInfo)
         {
             var clrType = mappingInfo.ClrType;
-            Debug.Assert(clrType != null);
+            Check.DebugAssert(clrType != null, "ClrType is null");
 
             if (clrType.IsValueType
                 || clrType == typeof(string))

--- a/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -289,7 +288,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
             foreach (var invalidEntityType in unvalidatedTypes)
             {
-                Debug.Assert(root != null);
+                Check.DebugAssert(root != null, "root is null");
                 throw new InvalidOperationException(
                     RelationalStrings.IncompatibleTableNoRelationship(
                         tableName,

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
@@ -272,7 +271,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 else
                 {
                     leftovers.Add(operation);
-                    Debug.Assert(false, "Unexpected operation type: " + operation.GetType());
+                    Check.DebugAssert(false, "Unexpected operation type: " + operation.GetType());
                 }
             }
 
@@ -722,7 +721,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 var index = clrType.GetTypeInfo().DeclaredProperties
                     .IndexOf(clrProperty, PropertyInfoEqualityComparer.Instance);
 
-                Debug.Assert(clrType != null);
+                Check.DebugAssert(clrType != null, "clrType is null");
                 types.GetOrAddNew(clrType)[index] = clrProperty;
             }
 
@@ -758,7 +757,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 var index = clrType.GetTypeInfo().DeclaredProperties
                     .IndexOf(clrProperty, PropertyInfoEqualityComparer.Instance);
 
-                Debug.Assert(clrType != null);
+                Check.DebugAssert(clrType != null, "clrType is null");
                 types.GetOrAddNew(clrType)[index] = clrProperty;
             }
 
@@ -2220,7 +2219,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             var width = array.GetLength(0);
             var height = array.GetLength(1);
 
-            Debug.Assert(height == values.Count);
+            Check.DebugAssert(height == values.Count, $"height of {height} != values.Count of {values.Count}");
 
             var result = new object[width + 1, height];
             for (var i = 0; i < width; i++)

--- a/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
+++ b/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
@@ -1565,7 +1564,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     builder.Append("SET DEFAULT");
                     break;
                 default:
-                    Debug.Assert(
+                    Check.DebugAssert(
                         referentialAction == ReferentialAction.NoAction,
                         "Unexpected value: " + referentialAction);
                     break;

--- a/src/EFCore.Relational/Migrations/Operations/DeleteDataOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/DeleteDataOperation.cs
@@ -45,7 +45,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
         /// <returns> The commands that correspond to this operation. </returns>
         public virtual IEnumerable<ModificationCommand> GenerateModificationCommands([CanBeNull] IModel model)
         {
-            Debug.Assert(
+            Check.DebugAssert(
                 KeyColumns.Length == KeyValues.GetLength(1),
                 $"The number of key values doesn't match the number of keys (${KeyColumns.Length})");
 

--- a/src/EFCore.Relational/Migrations/Operations/InsertDataOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/InsertDataOperation.cs
@@ -44,7 +44,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
         /// <returns> The commands that correspond to this operation. </returns>
         public virtual IEnumerable<ModificationCommand> GenerateModificationCommands([CanBeNull] IModel model)
         {
-            Debug.Assert(
+            Check.DebugAssert(
                 Columns.Length == Values.GetLength(1),
                 $"The number of values doesn't match the number of keys (${Columns.Length})");
 

--- a/src/EFCore.Relational/Migrations/Operations/UpdateDataOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/UpdateDataOperation.cs
@@ -57,13 +57,13 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
         /// <returns> The commands that correspond to this operation. </returns>
         public virtual IEnumerable<ModificationCommand> GenerateModificationCommands([CanBeNull] IModel model)
         {
-            Debug.Assert(
+            Check.DebugAssert(
                 KeyColumns.Length == KeyValues.GetLength(1),
                 $"The number of key values doesn't match the number of keys (${KeyColumns.Length})");
-            Debug.Assert(
+            Check.DebugAssert(
                 Columns.Length == Values.GetLength(1),
                 $"The number of values doesn't match the number of keys (${Columns.Length})");
-            Debug.Assert(
+            Check.DebugAssert(
                 KeyValues.GetLength(0) == Values.GetLength(0),
                 $"The number of key values doesn't match the number of values (${KeyValues.GetLength(0)})");
 

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
@@ -703,7 +702,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                     var projectionMember = projectionBindingExpression.ProjectionMember;
 
-                    Debug.Assert(
+                    Check.DebugAssert(
                         new ProjectionMember().Equals(projectionMember),
                         "Invalid ProjectionMember when processing OfType");
 
@@ -850,7 +849,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             public (LambdaExpression, bool, bool) IsCorrelated(LambdaExpression lambdaExpression)
             {
-                Debug.Assert(lambdaExpression.Parameters.Count == 1, "Multiparameter lambda passed to CorrelationFindingExpressionVisitor");
+                Check.DebugAssert(lambdaExpression.Parameters.Count == 1, "Multiparameter lambda passed to CorrelationFindingExpressionVisitor");
 
                 _correlated = false;
                 _defaultIfEmpty = false;

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.CustomShaperCompilingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.CustomShaperCompilingExpressionVisitor.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Data.Common;
-using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -382,7 +381,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 if (extensionExpression is IncludeExpression includeExpression)
                 {
-                    Debug.Assert(
+                    Check.DebugAssert(
                         !includeExpression.Navigation.IsCollection(),
                         "Only reference include should be present in tree");
                     var entityClrType = includeExpression.EntityExpression.Type;

--- a/src/EFCore.Relational/Storage/Internal/TypeMappedPropertyRelationalParameter.cs
+++ b/src/EFCore.Relational/Storage/Internal/TypeMappedPropertyRelationalParameter.cs
@@ -2,9 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Data.Common;
-using System.Diagnostics;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Internal
 {
@@ -42,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         /// </summary>
         public override void AddDbParameter(DbCommand command, object value)
         {
-            Debug.Assert(value != null);
+            Check.DebugAssert(value != null, "value is null");
 
             base.AddDbParameter(command, _clrPropertyGetter.GetClrValue(value));
         }

--- a/src/EFCore.Relational/Storage/Internal/TypedRelationalValueBufferFactory.cs
+++ b/src/EFCore.Relational/Storage/Internal/TypedRelationalValueBufferFactory.cs
@@ -3,9 +3,9 @@
 
 using System;
 using System.Data.Common;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Internal
 {
@@ -41,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ValueBuffer Create(DbDataReader dataReader)
         {
-            Debug.Assert(dataReader != null); // hot path
+            Check.DebugAssert(dataReader != null, "dataReader != null"); // hot path
 
             var values = _valueFactory(dataReader);
 

--- a/src/EFCore.Relational/Storage/RelationalTransaction.cs
+++ b/src/EFCore.Relational/Storage/RelationalTransaction.cs
@@ -323,7 +323,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         protected virtual void ClearTransaction()
         {
-            Debug.Assert(Connection.CurrentTransaction == null || Connection.CurrentTransaction == this);
+            Check.DebugAssert(
+                Connection.CurrentTransaction == null || Connection.CurrentTransaction == this,
+                "Connection.CurrentTransaction is unexpected instance");
 
             Connection.UseTransaction(null);
 
@@ -340,7 +342,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         protected virtual async Task ClearTransactionAsync(CancellationToken cancellationToken = default)
         {
-            Debug.Assert(Connection.CurrentTransaction == null || Connection.CurrentTransaction == this);
+            Check.DebugAssert(
+                Connection.CurrentTransaction == null || Connection.CurrentTransaction == this,
+                "Connection.CurrentTransaction is unexpected instance");
 
             await Connection.UseTransactionAsync(null, cancellationToken);
 

--- a/src/EFCore.Relational/Update/AffectedCountModificationCommandBatch.cs
+++ b/src/EFCore.Relational/Update/AffectedCountModificationCommandBatch.cs
@@ -3,13 +3,13 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Update
 {
@@ -39,7 +39,10 @@ namespace Microsoft.EntityFrameworkCore.Update
         /// <param name="reader"> The data reader. </param>
         protected override void Consume(RelationalDataReader reader)
         {
-            Debug.Assert(CommandResultSet.Count == ModificationCommands.Count);
+            Check.DebugAssert(
+                CommandResultSet.Count == ModificationCommands.Count,
+                $"CommandResultSet.Count of {CommandResultSet.Count} != ModificationCommands.Count of {ModificationCommands.Count}");
+
             var commandIndex = 0;
 
             try
@@ -71,13 +74,13 @@ namespace Microsoft.EntityFrameworkCore.Update
                     commandIndex++;
                 }
 
-                Debug.Assert(
+                Check.DebugAssert(
                     commandIndex == ModificationCommands.Count,
                     "Expected " + ModificationCommands.Count + " results, got " + commandIndex);
 
                 var expectedResultSetCount = CommandResultSet.Count(e => e == ResultSetMapping.LastInResultSet);
 
-                Debug.Assert(
+                Check.DebugAssert(
                     actualResultSetCount == expectedResultSetCount,
                     "Expected " + expectedResultSetCount + " result sets, got " + actualResultSetCount);
 #endif
@@ -101,7 +104,10 @@ namespace Microsoft.EntityFrameworkCore.Update
             RelationalDataReader reader,
             CancellationToken cancellationToken = default)
         {
-            Debug.Assert(CommandResultSet.Count == ModificationCommands.Count);
+            Check.DebugAssert(
+                CommandResultSet.Count == ModificationCommands.Count,
+                $"CommandResultSet.Count of {CommandResultSet.Count} != ModificationCommands.Count of {ModificationCommands.Count}");
+
             var commandIndex = 0;
 
             try
@@ -133,13 +139,13 @@ namespace Microsoft.EntityFrameworkCore.Update
                     commandIndex++;
                 }
 
-                Debug.Assert(
+                Check.DebugAssert(
                     commandIndex == ModificationCommands.Count,
                     "Expected " + ModificationCommands.Count + " results, got " + commandIndex);
 
                 var expectedResultSetCount = CommandResultSet.Count(e => e == ResultSetMapping.LastInResultSet);
 
-                Debug.Assert(
+                Check.DebugAssert(
                     actualResultSetCount == expectedResultSetCount,
                     "Expected " + expectedResultSetCount + " result sets, got " + actualResultSetCount);
 #endif
@@ -166,7 +172,7 @@ namespace Microsoft.EntityFrameworkCore.Update
             do
             {
                 var tableModification = ModificationCommands[commandIndex];
-                Debug.Assert(tableModification.RequiresResultPropagation);
+                Check.DebugAssert(tableModification.RequiresResultPropagation, "RequiresResultPropagation is false");
 
                 if (!reader.Read())
                 {
@@ -209,7 +215,7 @@ namespace Microsoft.EntityFrameworkCore.Update
             do
             {
                 var tableModification = ModificationCommands[commandIndex];
-                Debug.Assert(tableModification.RequiresResultPropagation);
+                Check.DebugAssert(tableModification.RequiresResultPropagation, "RequiresResultPropagation is false");
 
                 if (!await reader.ReadAsync(cancellationToken))
                 {
@@ -247,7 +253,7 @@ namespace Microsoft.EntityFrameworkCore.Update
             while (++commandIndex < CommandResultSet.Count
                 && CommandResultSet[commandIndex - 1] == ResultSetMapping.NotLastInResultSet)
             {
-                Debug.Assert(!ModificationCommands[commandIndex].RequiresResultPropagation);
+                Check.DebugAssert(!ModificationCommands[commandIndex].RequiresResultPropagation, "RequiresResultPropagation is true");
 
                 expectedRowsAffected++;
             }
@@ -286,7 +292,7 @@ namespace Microsoft.EntityFrameworkCore.Update
             while (++commandIndex < CommandResultSet.Count
                 && CommandResultSet[commandIndex - 1] == ResultSetMapping.NotLastInResultSet)
             {
-                Debug.Assert(!ModificationCommands[commandIndex].RequiresResultPropagation);
+                Check.DebugAssert(!ModificationCommands[commandIndex].RequiresResultPropagation, "RequiresResultPropagation is true");
 
                 expectedRowsAffected++;
             }

--- a/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerGeometryMemberTranslator.cs
+++ b/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerGeometryMemberTranslator.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query;
@@ -59,7 +58,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
 
             if (typeof(Geometry).IsAssignableFrom(member.DeclaringType))
             {
-                Debug.Assert(instance.TypeMapping != null, "Instance must have typeMapping assigned.");
+                Check.DebugAssert(instance.TypeMapping != null, "Instance must have typeMapping assigned.");
                 var storeType = instance.TypeMapping.StoreType;
                 var isGeography = string.Equals(storeType, "geography", StringComparison.OrdinalIgnoreCase);
 

--- a/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerGeometryMethodTranslator.cs
+++ b/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerGeometryMethodTranslator.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
@@ -73,7 +72,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                     arguments.Where(e => typeof(Geometry).IsAssignableFrom(e.Type)));
                 var typeMapping = ExpressionExtensions.InferTypeMapping(geometryExpressions.ToArray());
 
-                Debug.Assert(typeMapping != null, "At least one argument must have typeMapping.");
+                Check.DebugAssert(typeMapping != null, "At least one argument must have typeMapping.");
                 var storeType = typeMapping.StoreType;
                 var isGeography = string.Equals(storeType, "geography", StringComparison.OrdinalIgnoreCase);
 

--- a/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerLineStringMemberTranslator.cs
+++ b/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerLineStringMemberTranslator.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
@@ -44,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
 
             if (_memberToFunctionName.TryGetValue(member, out var functionName))
             {
-                Debug.Assert(instance.TypeMapping != null, "Instance must have typeMapping assigned.");
+                Check.DebugAssert(instance.TypeMapping != null, "Instance must have typeMapping assigned.");
                 var storeType = instance.TypeMapping.StoreType;
                 var isGeography = string.Equals(storeType, "geography", StringComparison.OrdinalIgnoreCase);
 

--- a/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerPointMemberTranslator.cs
+++ b/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerPointMemberTranslator.cs
@@ -3,10 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Microsoft.EntityFrameworkCore.Utilities;
 using NetTopologySuite.Geometries;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
@@ -39,7 +39,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
         {
             if (typeof(Point).IsAssignableFrom(member.DeclaringType))
             {
-                Debug.Assert(instance.TypeMapping != null, "Instance must have typeMapping assigned.");
+                Check.DebugAssert(instance.TypeMapping != null, "Instance must have typeMapping assigned.");
                 var storeType = instance.TypeMapping.StoreType;
                 var isGeography = string.Equals(storeType, "geography", StringComparison.OrdinalIgnoreCase);
 

--- a/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerPolygonMemberTranslator.cs
+++ b/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerPolygonMemberTranslator.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query;
@@ -42,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
 
             if (typeof(Polygon).IsAssignableFrom(member.DeclaringType))
             {
-                Debug.Assert(instance.TypeMapping != null, "Instance must have typeMapping assigned.");
+                Check.DebugAssert(instance.TypeMapping != null, "Instance must have typeMapping assigned.");
                 var storeType = instance.TypeMapping.StoreType;
                 var isGeography = string.Equals(storeType, "geography", StringComparison.OrdinalIgnoreCase);
 

--- a/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
+++ b/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
-using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -873,7 +872,7 @@ ORDER BY [table_schema], [table_name], [index_name], [ic].[key_ordinal]";
                         var column = table.Columns.FirstOrDefault(c => c.Name == columnName)
                             ?? table.Columns.FirstOrDefault(
                                 c => c.Name.Equals(columnName, StringComparison.OrdinalIgnoreCase));
-                        Debug.Assert(column != null, "column is null.");
+                        Check.DebugAssert(column != null, "column is null.");
 
                         primaryKey.Columns.Add(column);
                     }
@@ -906,7 +905,7 @@ ORDER BY [table_schema], [table_name], [index_name], [ic].[key_ordinal]";
                         var column = table.Columns.FirstOrDefault(c => c.Name == columnName)
                             ?? table.Columns.FirstOrDefault(
                                 c => c.Name.Equals(columnName, StringComparison.OrdinalIgnoreCase));
-                        Debug.Assert(column != null, "column is null.");
+                        Check.DebugAssert(column != null, "column is null.");
 
                         uniqueConstraint.Columns.Add(column);
                     }
@@ -950,7 +949,7 @@ ORDER BY [table_schema], [table_name], [index_name], [ic].[key_ordinal]";
                         var column = table.Columns.FirstOrDefault(c => c.Name == columnName)
                             ?? table.Columns.FirstOrDefault(
                                 c => c.Name.Equals(columnName, StringComparison.OrdinalIgnoreCase));
-                        Debug.Assert(column != null, "column is null.");
+                        Check.DebugAssert(column != null, "column is null.");
 
                         index.Columns.Add(column);
                     }
@@ -1047,7 +1046,7 @@ ORDER BY [table_schema], [table_name], [f].[name], [fc].[constraint_column_id]";
                         var column = table.Columns.FirstOrDefault(c => c.Name == columnName)
                             ?? table.Columns.FirstOrDefault(
                                 c => c.Name.Equals(columnName, StringComparison.OrdinalIgnoreCase));
-                        Debug.Assert(column != null, "column is null.");
+                        Check.DebugAssert(column != null, "column is null.");
 
                         var principalColumnName = dataRecord.GetValueOrDefault<string>("referenced_column_name");
                         var principalColumn = foreignKey.PrincipalTable.Columns.FirstOrDefault(c => c.Name == principalColumnName)

--- a/src/EFCore.SqlServer/Update/Internal/SqlServerUpdateSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Update/Internal/SqlServerUpdateSqlGenerator.cs
@@ -3,13 +3,13 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Update;
+using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Update.Internal
@@ -134,7 +134,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Update.Internal
             IReadOnlyList<ModificationCommand> modificationCommands,
             List<ColumnModification> writeOperations)
         {
-            Debug.Assert(writeOperations.Count > 0);
+            Check.DebugAssert(writeOperations.Count > 0, $"writeOperations.Count is {writeOperations.Count}");
 
             var name = modificationCommands[0].TableName;
             var schema = modificationCommands[0].Schema;

--- a/src/EFCore.SqlServer/ValueGeneration/Internal/SqlServerValueGeneratorCache.cs
+++ b/src/EFCore.SqlServer/ValueGeneration/Internal/SqlServerValueGeneratorCache.cs
@@ -2,10 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Concurrent;
-using System.Diagnostics;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -50,7 +50,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.ValueGeneration.Internal
         {
             var sequence = property.FindHiLoSequence();
 
-            Debug.Assert(sequence != null);
+            Check.DebugAssert(sequence != null, "sequence is null");
 
             return _sequenceGeneratorCache.GetOrAdd(
                 GetSequenceName(sequence, connection),

--- a/src/EFCore.Sqlite.Core/Infrastructure/SpatialiteLoader.cs
+++ b/src/EFCore.Sqlite.Core/Infrastructure/SpatialiteLoader.cs
@@ -173,7 +173,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                         }
                     }
 
-                    Debug.Assert(assetFullPath != null);
+                    Check.DebugAssert(assetFullPath != null, "assetFullPath is null");
 
                     var assetDirectory = Path.GetDirectoryName(assetFullPath);
 

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteDateTimeMemberTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteDateTimeMemberTranslator.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query;
@@ -118,7 +117,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
                         return null;
                 }
 
-                Debug.Assert(timestring != null);
+                Check.DebugAssert(timestring != null, "timestring is null");
 
                 return _sqlExpressionFactory.Function(
                     "rtrim",

--- a/src/EFCore.Sqlite.Core/Scaffolding/Internal/SqliteDatabaseModelFactory.cs
+++ b/src/EFCore.Sqlite.Core/Scaffolding/Internal/SqliteDatabaseModelFactory.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -336,7 +335,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Scaffolding.Internal
                     var columnName = reader.GetString(0);
                     var column = columns.FirstOrDefault(c => c.Name == columnName)
                         ?? columns.FirstOrDefault(c => c.Name.Equals(columnName, StringComparison.OrdinalIgnoreCase));
-                    Debug.Assert(column != null, "column is null.");
+                    Check.DebugAssert(column != null, "column is null.");
 
                     primaryKey.Columns.Add(column);
                 }
@@ -371,9 +370,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Scaffolding.Internal
             var columnName = reader.GetString(0);
             var column = columns.FirstOrDefault(c => c.Name == columnName)
                 ?? columns.FirstOrDefault(c => c.Name.Equals(columnName, StringComparison.OrdinalIgnoreCase));
-            Debug.Assert(column != null, "column is null.");
+            Check.DebugAssert(column != null, "column is null.");
 
-            Debug.Assert(!reader.Read(), "Unexpected composite primary key.");
+            Check.DebugAssert(!reader.Read(), "Unexpected composite primary key.");
 
             return new DatabasePrimaryKey { Columns = { column } };
         }
@@ -428,7 +427,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Scaffolding.Internal
                         var column = columns.FirstOrDefault(c => c.Name == columnName)
                             ?? columns.FirstOrDefault(
                                 c => c.Name.Equals(columnName, StringComparison.OrdinalIgnoreCase));
-                        Debug.Assert(column != null, "column is null.");
+                        Check.DebugAssert(column != null, "column is null.");
 
                         uniqueConstraint.Columns.Add(column);
                     }
@@ -482,7 +481,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Scaffolding.Internal
                         var name = reader2.GetString(0);
                         var column = columns.FirstOrDefault(c => c.Name == name)
                             ?? columns.FirstOrDefault(c => c.Name.Equals(name, StringComparison.Ordinal));
-                        Debug.Assert(column != null, "column is null.");
+                        Check.DebugAssert(column != null, "column is null.");
 
                         index.Columns.Add(column);
                     }
@@ -556,7 +555,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Scaffolding.Internal
                         var column = table.Columns.FirstOrDefault(c => c.Name == columnName)
                             ?? table.Columns.FirstOrDefault(
                                 c => c.Name.Equals(columnName, StringComparison.OrdinalIgnoreCase));
-                        Debug.Assert(column != null, "column is null.");
+                        Check.DebugAssert(column != null, "column is null.");
 
                         var principalColumnName = reader2.GetString(1);
                         var principalColumn =
@@ -603,7 +602,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Scaffolding.Internal
                     return ReferentialAction.NoAction;
 
                 default:
-                    Debug.Assert(value == "NONE", "Unexpected value: " + value);
+                    Check.DebugAssert(value == "NONE", "Unexpected value: " + value);
                     return null;
             }
         }

--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -18,6 +18,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Update;
+using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 {
@@ -709,7 +710,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         /// </summary>
         protected virtual object ReadPropertyValue([NotNull] IPropertyBase propertyBase)
         {
-            Debug.Assert(!propertyBase.IsShadowProperty());
+            Check.DebugAssert(!propertyBase.IsShadowProperty(), "propertyBase is shadow property");
 
             return ((PropertyBase)propertyBase).Getter.GetClrValue(Entity);
         }
@@ -722,7 +723,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         /// </summary>
         protected virtual bool PropertyHasDefaultValue([NotNull] IPropertyBase propertyBase)
         {
-            Debug.Assert(!propertyBase.IsShadowProperty());
+            Check.DebugAssert(!propertyBase.IsShadowProperty(), "propertyBase is shadow property");
 
             return ((PropertyBase)propertyBase).Getter.HasDefaultValue(Entity);
         }
@@ -738,7 +739,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             [CanBeNull] object value,
             bool forMaterialization)
         {
-            Debug.Assert(!propertyBase.IsShadowProperty());
+            Check.DebugAssert(!propertyBase.IsShadowProperty(), "propertyBase is shadow property");
 
             var concretePropertyBase = (PropertyBase)propertyBase;
 
@@ -757,7 +758,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         /// </summary>
         public virtual object GetOrCreateCollection([NotNull] INavigation navigation, bool forMaterialization)
         {
-            Debug.Assert(!navigation.IsShadowProperty());
+            Check.DebugAssert(!navigation.IsShadowProperty(), "navigation is shadow property");
 
             return ((Navigation)navigation).CollectionAccessor.GetOrCreate(Entity, forMaterialization);
         }
@@ -770,7 +771,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         /// </summary>
         public virtual bool CollectionContains([NotNull] INavigation navigation, [NotNull] InternalEntityEntry value)
         {
-            Debug.Assert(!navigation.IsShadowProperty());
+            Check.DebugAssert(!navigation.IsShadowProperty(), "navigation is shadow property");
 
             return ((Navigation)navigation).CollectionAccessor.Contains(Entity, value.Entity);
         }
@@ -786,7 +787,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             [NotNull] InternalEntityEntry value,
             bool forMaterialization)
         {
-            Debug.Assert(!navigation.IsShadowProperty());
+            Check.DebugAssert(!navigation.IsShadowProperty(), "navigation is shadow property");
 
             return ((Navigation)navigation).CollectionAccessor.Add(Entity, value.Entity, forMaterialization);
         }
@@ -799,7 +800,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         /// </summary>
         public virtual bool RemoveFromCollection([NotNull] INavigation navigation, [NotNull] InternalEntityEntry value)
         {
-            Debug.Assert(!navigation.IsShadowProperty());
+            Check.DebugAssert(!navigation.IsShadowProperty(), "navigation is shadow property");
 
             return ((Navigation)navigation).CollectionAccessor.Remove(Entity, value.Entity);
         }
@@ -1153,7 +1154,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     else
                     {
                         var storeGeneratedIndex = asProperty.GetStoreGeneratedIndex();
-                        Debug.Assert(storeGeneratedIndex >= 0);
+                        Check.DebugAssert(storeGeneratedIndex >= 0, $"storeGeneratedIndex is {storeGeneratedIndex}");
 
                         if (valueType == CurrentValueType.StoreGenerated)
                         {

--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntryFactory.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntryFactory.cs
@@ -1,10 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
@@ -50,7 +50,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 return new InternalShadowEntityEntry(stateManager, entityType);
             }
 
-            Debug.Assert(entity != null);
+            Check.DebugAssert(entity != null, "entity is null");
 
             return entityType.ShadowPropertyCount() > 0
                 ? (InternalEntityEntry)new InternalMixedEntityEntry(stateManager, entityType, entity)

--- a/src/EFCore/ChangeTracking/Internal/KeyPropagator.cs
+++ b/src/EFCore/ChangeTracking/Internal/KeyPropagator.cs
@@ -1,13 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -51,7 +51,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         /// </summary>
         public virtual InternalEntityEntry PropagateValue(InternalEntityEntry entry, IProperty property)
         {
-            Debug.Assert(property.IsForeignKey());
+            Check.DebugAssert(property.IsForeignKey(), $"property {property} is not part of an FK");
 
             var principalEntry = TryPropagateValue(entry, property);
             if (principalEntry == null
@@ -88,7 +88,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             IProperty property,
             CancellationToken cancellationToken = default)
         {
-            Debug.Assert(property.IsForeignKey());
+            Check.DebugAssert(property.IsForeignKey(), $"property {property} is not part of an FK");
 
             var principalEntry = TryPropagateValue(entry, property);
             if (principalEntry == null

--- a/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
@@ -3,10 +3,10 @@
 
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
@@ -137,7 +137,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 }
                 else
                 {
-                    Debug.Assert(foreignKey.IsUnique);
+                    Check.DebugAssert(foreignKey.IsUnique, $"foreignKey {foreignKey} is not unique");
 
                     if (oldTargetEntry != null)
                     {

--- a/src/EFCore/ChangeTracking/Internal/ObservableBackedBindingList.cs
+++ b/src/EFCore/ChangeTracking/Internal/ObservableBackedBindingList.cs
@@ -3,9 +3,9 @@
 
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 {
@@ -36,7 +36,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             _observableCollection = observableCollection;
 
-            Debug.Assert(_observableCollection is INotifyCollectionChanged);
+            Check.DebugAssert(_observableCollection is INotifyCollectionChanged, "_observableCollection is not INotifyCollectionChanged");
 
             ((INotifyCollectionChanged)observableCollection).CollectionChanged += ObservableCollectionChanged;
         }

--- a/src/EFCore/ChangeTracking/Internal/OriginalValues.cs
+++ b/src/EFCore/ChangeTracking/Internal/OriginalValues.cs
@@ -2,11 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 {
@@ -47,7 +47,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             public void SetValue(IProperty property, object value, int index)
             {
-                Debug.Assert(!IsEmpty);
+                Check.DebugAssert(!IsEmpty, "Original values are empty");
 
                 if (index == -1)
                 {

--- a/src/EFCore/ChangeTracking/Internal/RelationshipsSnapshot.cs
+++ b/src/EFCore/ChangeTracking/Internal/RelationshipsSnapshot.cs
@@ -2,10 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 {
@@ -39,8 +39,10 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     }
                 }
 
-                Debug.Assert(!IsEmpty);
-                Debug.Assert(!(propertyBase is INavigation) || !((INavigation)propertyBase).IsCollection());
+                Check.DebugAssert(!IsEmpty, "relationship snapshot is empty");
+                Check.DebugAssert(
+                    !(propertyBase is INavigation) || !((INavigation)propertyBase).IsCollection(),
+                    $"property {propertyBase} is is not reference navigation");
 
                 _values[propertyBase.GetRelationshipIndex()] = SnapshotValue(propertyBase, value);
             }

--- a/src/EFCore/ChangeTracking/Internal/SidecarValues.cs
+++ b/src/EFCore/ChangeTracking/Internal/SidecarValues.cs
@@ -2,10 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 {
@@ -37,7 +37,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             public void SetValue(IProperty property, object value, int index)
             {
-                Debug.Assert(!IsEmpty);
+                Check.DebugAssert(!IsEmpty, "sidecar is empty");
 
                 if (value == null
                     && !property.ClrType.IsNullableType())

--- a/src/EFCore/ChangeTracking/LocalView.cs
+++ b/src/EFCore/ChangeTracking/LocalView.cs
@@ -7,13 +7,13 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.ChangeTracking
 {
@@ -98,7 +98,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
         private void LocalViewCollectionChanged(object _, NotifyCollectionChangedEventArgs args)
         {
-            Debug.Assert(args.Action == NotifyCollectionChangedAction.Add || args.Action == NotifyCollectionChangedAction.Remove);
+            Check.DebugAssert(
+                args.Action == NotifyCollectionChangedAction.Add || args.Action == NotifyCollectionChangedAction.Remove,
+                "action is not Add or Remove");
 
             if (_triggeringLocalViewChange)
             {
@@ -111,12 +113,12 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
                 if (args.Action == NotifyCollectionChangedAction.Remove)
                 {
-                    Debug.Assert(args.OldItems.Count == 1);
+                    Check.DebugAssert(args.OldItems.Count == 1, $"OldItems.Count is {args.OldItems.Count}");
                     _observable.Remove((TEntity)args.OldItems[0]);
                 }
                 else
                 {
-                    Debug.Assert(args.NewItems.Count == 1);
+                    Check.DebugAssert(args.NewItems.Count == 1, $"NewItems.Count is {args.NewItems.Count}");
                     _observable.Add((TEntity)args.NewItems[0]);
                 }
             }

--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -621,10 +620,10 @@ namespace Microsoft.EntityFrameworkCore
 
             if (configurationSnapshot.AutoDetectChangesEnabled != null)
             {
-                Debug.Assert(configurationSnapshot.QueryTrackingBehavior.HasValue);
-                Debug.Assert(configurationSnapshot.LazyLoadingEnabled.HasValue);
-                Debug.Assert(configurationSnapshot.CascadeDeleteTiming.HasValue);
-                Debug.Assert(configurationSnapshot.DeleteOrphansTiming.HasValue);
+                Check.DebugAssert(configurationSnapshot.QueryTrackingBehavior.HasValue, "!configurationSnapshot.QueryTrackingBehavior.HasValue");
+                Check.DebugAssert(configurationSnapshot.LazyLoadingEnabled.HasValue, "!configurationSnapshot.LazyLoadingEnabled.HasValue");
+                Check.DebugAssert(configurationSnapshot.CascadeDeleteTiming.HasValue, "!configurationSnapshot.CascadeDeleteTiming.HasValue");
+                Check.DebugAssert(configurationSnapshot.DeleteOrphansTiming.HasValue, "!configurationSnapshot.DeleteOrphansTiming.HasValue");
 
                 ChangeTracker.AutoDetectChangesEnabled = configurationSnapshot.AutoDetectChangesEnabled.Value;
                 ChangeTracker.QueryTrackingBehavior = configurationSnapshot.QueryTrackingBehavior.Value;

--- a/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
+++ b/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
@@ -42,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         public static IReadOnlyList<PropertyInfo> MatchPropertyAccessList(
             [NotNull] this LambdaExpression lambdaExpression, [NotNull] Func<Expression, Expression, PropertyInfo> propertyMatcher)
         {
-            Debug.Assert(lambdaExpression.Body != null);
+            Check.DebugAssert(lambdaExpression.Body != null, "lambdaExpression.Body is null");
 
             var parameterExpression = lambdaExpression.Parameters.Single();
 

--- a/src/EFCore/Infrastructure/ExpressionExtensions.cs
+++ b/src/EFCore/Infrastructure/ExpressionExtensions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -120,7 +119,9 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <returns> The <see cref="PropertyInfo" />. </returns>
         public static PropertyInfo GetPropertyAccess([NotNull] this LambdaExpression propertyAccessExpression)
         {
-            Debug.Assert(propertyAccessExpression.Parameters.Count == 1);
+            Check.DebugAssert(
+                propertyAccessExpression.Parameters.Count == 1,
+                $"Parameters.Count is {propertyAccessExpression.Parameters.Count}");
 
             var parameterExpression = propertyAccessExpression.Parameters.Single();
             var propertyInfo = parameterExpression.MatchSimplePropertyAccess(propertyAccessExpression.Body);

--- a/src/EFCore/Infrastructure/ModelValidator.cs
+++ b/src/EFCore/Infrastructure/ModelValidator.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
@@ -274,7 +273,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                                     ignoredMember, entityType.DisplayName(), property.DeclaringEntityType.DisplayName()));
                         }
 
-                        Debug.Assert(false);
+                        Check.DebugAssert(false, "Should never get here...");
                     }
 
                     var navigation = entityType.FindNavigation(ignoredMember);
@@ -287,7 +286,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                                     ignoredMember, entityType.DisplayName(), navigation.DeclaringEntityType.DisplayName()));
                         }
 
-                        Debug.Assert(false);
+                        Check.DebugAssert(false, "Should never get here...");
                     }
                 }
             }

--- a/src/EFCore/Internal/ConcurrencyDetector.cs
+++ b/src/EFCore/Internal/ConcurrencyDetector.cs
@@ -2,10 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.Threading;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.Internal
@@ -65,7 +65,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
 
         private void ExitCriticalSection()
         {
-            Debug.Assert(_inCriticalSection == 1, "Expected to be in a critical section");
+            Check.DebugAssert(_inCriticalSection == 1, "Expected to be in a critical section");
 
             if (--_refCount == 0)
             {

--- a/src/EFCore/Internal/CoreOptions.cs
+++ b/src/EFCore/Internal/CoreOptions.cs
@@ -2,9 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.Internal
@@ -49,7 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
 
             if (AreDetailedErrorsEnabled != coreOptions.DetailedErrorsEnabled)
             {
-                Debug.Assert(coreOptions.InternalServiceProvider != null);
+                Check.DebugAssert(coreOptions.InternalServiceProvider != null, "InternalServiceProvider is null");
 
                 throw new InvalidOperationException(
                     CoreStrings.SingletonOptionChanged(

--- a/src/EFCore/Internal/DbContextPool.cs
+++ b/src/EFCore/Internal/DbContextPool.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -12,6 +11,7 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Internal
 {
@@ -155,7 +155,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
             {
                 Interlocked.Decrement(ref _count);
 
-                Debug.Assert(_count >= 0);
+                Check.DebugAssert(_count >= 0, $"_count is {_count}");
 
                 ((IDbContextPoolable)context).Resurrect(_configurationSnapshot);
 
@@ -194,7 +194,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
 
             Interlocked.Decrement(ref _count);
 
-            Debug.Assert(_maxSize == 0 || _pool.Count <= _maxSize);
+            Check.DebugAssert(_maxSize == 0 || _pool.Count <= _maxSize, $"_maxSize is {_maxSize}");
 
             return false;
         }

--- a/src/EFCore/Internal/LoggingOptions.cs
+++ b/src/EFCore/Internal/LoggingOptions.cs
@@ -2,9 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.Internal
@@ -50,7 +50,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
 
             if (IsSensitiveDataLoggingEnabled != coreOptions.IsSensitiveDataLoggingEnabled)
             {
-                Debug.Assert(coreOptions.InternalServiceProvider != null);
+                Check.DebugAssert(coreOptions.InternalServiceProvider != null, "InternalServiceProvider is null");
 
                 throw new InvalidOperationException(
                     CoreStrings.SingletonOptionChanged(
@@ -60,7 +60,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
 
             if (WarningsConfiguration?.GetServiceProviderHashCode() != coreOptions.WarningsConfiguration?.GetServiceProviderHashCode())
             {
-                Debug.Assert(coreOptions.InternalServiceProvider != null);
+                Check.DebugAssert(coreOptions.InternalServiceProvider != null, "InternalServiceProvider is null");
 
                 throw new InvalidOperationException(
                     CoreStrings.SingletonOptionChanged(

--- a/src/EFCore/Metadata/Conventions/Internal/ConventionNode.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ConventionNode.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 {
@@ -74,7 +75,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             private void Add(ConventionNode node)
             {
 #if DEBUG
-                Debug.Assert(!_readonly);
+                Check.DebugAssert(!_readonly, "_readonly is true");
 #endif
 
                 if (_children == null)

--- a/src/EFCore/Metadata/Conventions/Internal/MetadataTracker.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/MetadataTracker.cs
@@ -2,9 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 {
@@ -27,7 +27,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         /// </summary>
         public virtual void Update([NotNull] ForeignKey oldForeignKey, [NotNull] ForeignKey newForeignKey)
         {
-            Debug.Assert(oldForeignKey.Builder == null && newForeignKey.Builder != null);
+            Check.DebugAssert(
+                oldForeignKey.Builder == null && newForeignKey.Builder != null,
+                "oldForeignKey.Builder is not null or newForeignKey.Builder is null");
 
             if (_trackedForeignKeys.TryGetValue(oldForeignKey, out var reference))
             {

--- a/src/EFCore/Metadata/Conventions/InversePropertyAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/InversePropertyAttributeConvention.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
@@ -13,6 +12,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 {
@@ -241,7 +241,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             IConventionContext<string> context)
         {
             var declaringType = navigationMemberInfo.DeclaringType;
-            Debug.Assert(declaringType != null);
+            Check.DebugAssert(declaringType != null, "declaringType is null");
             if (modelBuilder.Metadata.FindEntityType(declaringType) != null)
             {
                 return;

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -250,7 +250,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             [CanBeNull] EntityType newBaseType,
             ConfigurationSource configurationSource)
         {
-            Debug.Assert(Builder != null);
+            Check.DebugAssert(Builder != null, "Builder is null");
 
             if (_baseType == newBaseType)
             {
@@ -511,7 +511,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             [CanBeNull] IReadOnlyList<Property> properties,
             ConfigurationSource configurationSource)
         {
-            Debug.Assert(Builder != null);
+            Check.DebugAssert(Builder != null, "Builder is null");
 
             if (_baseType != null)
             {
@@ -804,7 +804,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual Key RemoveKey([NotNull] Key key)
         {
-            Debug.Assert(Builder != null);
+            Check.DebugAssert(Builder != null, "Builder is null");
+
             if (key.DeclaringEntityType != this)
             {
                 throw new InvalidOperationException(
@@ -820,7 +821,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             var removed = _keys.Remove(key.Properties);
-            Debug.Assert(removed);
+            Check.DebugAssert(removed, "removed is false");
             key.Builder = null;
 
             foreach (var property in key.Properties)
@@ -918,7 +919,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual void OnForeignKeyUpdating([NotNull] ForeignKey foreignKey)
         {
             var removed = _foreignKeys.Remove(foreignKey);
-            Debug.Assert(removed);
+            Check.DebugAssert(removed, "removed is false");
 
             foreach (var property in foreignKey.Properties)
             {
@@ -933,9 +934,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             removed = foreignKey.PrincipalKey.ReferencingForeignKeys.Remove(foreignKey);
-            Debug.Assert(removed);
+            Check.DebugAssert(removed, "removed is false");
             removed = foreignKey.PrincipalEntityType.DeclaredReferencingForeignKeys.Remove(foreignKey);
-            Debug.Assert(removed);
+            Check.DebugAssert(removed, "removed is false");
         }
 
         /// <summary>
@@ -947,7 +948,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual void OnForeignKeyUpdated([NotNull] ForeignKey foreignKey)
         {
             var added = _foreignKeys.Add(foreignKey);
-            Debug.Assert(added);
+            Check.DebugAssert(added, "added is false");
 
             foreach (var property in foreignKey.Properties)
             {
@@ -969,7 +970,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             else
             {
                 added = principalKey.ReferencingForeignKeys.Add(foreignKey);
-                Debug.Assert(added);
+                Check.DebugAssert(added, "added is false");
             }
 
             var principalEntityType = foreignKey.PrincipalEntityType;
@@ -980,7 +981,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             else
             {
                 added = principalEntityType.DeclaredReferencingForeignKeys.Add(foreignKey);
-                Debug.Assert(added);
+                Check.DebugAssert(added, "added is false");
             }
         }
 
@@ -1346,11 +1347,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         duplicateProperty.DeclaringType.DisplayName()));
             }
 
-            Debug.Assert(
+            Check.DebugAssert(
                 !GetNavigations().Any(n => n.ForeignKey == foreignKey && n.IsDependentToPrincipal() == pointsToPrincipal),
                 "There is another navigation corresponding to the same foreign key and pointing in the same direction.");
 
-            Debug.Assert(
+            Check.DebugAssert(
                 (pointsToPrincipal ? foreignKey.DeclaringEntityType : foreignKey.PrincipalEntityType) == this,
                 "EntityType mismatch");
 
@@ -1761,7 +1762,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             Check.NotNull(name, nameof(name));
             Check.NotNull(propertyType, nameof(propertyType));
-            Debug.Assert(Builder != null);
+            Check.DebugAssert(Builder != null, "Builder is null");
 
             var conflictingMember = FindMembersInHierarchy(name).FirstOrDefault();
             if (conflictingMember != null)
@@ -1963,7 +1964,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             CheckPropertyNotInUse(property);
 
             var removed = _properties.Remove(property.Name);
-            Debug.Assert(removed);
+            Check.DebugAssert(removed, "removed is false");
             property.Builder = null;
 
             return property;

--- a/src/EFCore/Metadata/Internal/ForeignKey.cs
+++ b/src/EFCore/Metadata/Internal/ForeignKey.cs
@@ -394,7 +394,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             if (oldNavigation != null)
             {
-                Debug.Assert(oldNavigation.Name != null);
+                Check.DebugAssert(oldNavigation.Name != null, "oldNavigation.Name is null");
                 if (pointsToPrincipal)
                 {
                     DeclaringEntityType.RemoveNavigation(oldNavigation.Name);
@@ -433,7 +433,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             if (oldNavigation != null)
             {
-                Debug.Assert(oldNavigation.Name != null);
+                Check.DebugAssert(oldNavigation.Name != null, "oldNavigation.Name is null");
 
                 if (pointsToPrincipal)
                 {

--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -649,7 +649,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             [NotNull] Property property, ConfigurationSource configurationSource, bool canOverrideSameSource = true)
         {
             Check.NotNull(property, nameof(property));
-            Debug.Assert(property.DeclaringEntityType == Metadata);
+            Check.DebugAssert(property.DeclaringEntityType == Metadata, "property.DeclaringEntityType != Metadata");
 
             var currentConfigurationSource = property.GetConfigurationSource();
             return configurationSource.Overrides(currentConfigurationSource)
@@ -837,7 +837,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual bool CanRemoveForeignKey([NotNull] ForeignKey foreignKey, ConfigurationSource configurationSource)
         {
-            Debug.Assert(foreignKey.DeclaringEntityType == Metadata);
+            Check.DebugAssert(foreignKey.DeclaringEntityType == Metadata, "foreignKey.DeclaringEntityType != Metadata");
 
             var currentConfigurationSource = foreignKey.GetConfigurationSource();
             return configurationSource.Overrides(currentConfigurationSource);
@@ -872,7 +872,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 if (navigation != null)
                 {
                     var foreignKey = navigation.ForeignKey;
-                    Debug.Assert(navigation.DeclaringEntityType == Metadata);
+                    Check.DebugAssert(navigation.DeclaringEntityType == Metadata, "navigation.DeclaringEntityType != Metadata");
 
                     var isDependent = navigation.IsDependentToPrincipal();
                     var navigationConfigurationSource = isDependent
@@ -882,13 +882,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     {
                         var navigationRemoved = foreignKey.Builder.HasNavigation(
                             (MemberInfo)null, isDependent, configurationSource);
-                        Debug.Assert(navigationRemoved != null);
+                        Check.DebugAssert(navigationRemoved != null, "navigationRemoved is null");
                     }
                     else
                     {
                         var removed = foreignKey.DeclaringEntityType.Builder.HasNoRelationship(
                             foreignKey, configurationSource);
-                        Debug.Assert(removed != null);
+                        Check.DebugAssert(removed != null, "removed is null");
                     }
                 }
                 else
@@ -896,19 +896,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     var property = Metadata.FindProperty(name);
                     if (property != null)
                     {
-                        Debug.Assert(property.DeclaringEntityType == Metadata);
+                        Check.DebugAssert(property.DeclaringEntityType == Metadata, "property.DeclaringEntityType != Metadata");
 
                         var removed = property.DeclaringEntityType.Builder.RemoveProperty(
                             property, configurationSource);
 
-                        Debug.Assert(removed != null);
+                        Check.DebugAssert(removed != null, "removed is null");
                     }
                     else
                     {
                         var serviceProperty = Metadata.FindServiceProperty(name);
                         if (serviceProperty != null)
                         {
-                            Debug.Assert(serviceProperty.DeclaringEntityType == Metadata);
+                            Check.DebugAssert(serviceProperty.DeclaringEntityType == Metadata, "serviceProperty.DeclaringEntityType != Metadata");
 
                             serviceProperty.DeclaringEntityType.RemoveServiceProperty(name);
                         }
@@ -1499,7 +1499,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         property.DeclaringEntityType.RemoveProperty(property.Name);
                     }
 
-                    Debug.Assert(removedConfigurationSource.HasValue);
+                    Check.DebugAssert(removedConfigurationSource.HasValue, "removedConfigurationSource.HasValue is false");
                     detachedProperties.Add(propertyBuilder);
                 }
             }
@@ -1568,19 +1568,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         key.GetReferencingForeignKeys().ToList()
                             .Select(DetachRelationship));
                     var removed = key.DeclaringEntityType.Builder.HasNoKey(key, configurationSource);
-                    Debug.Assert(removed != null);
+                    Check.DebugAssert(removed != null, "removed is null");
                 }
 
                 foreach (var index in property.GetContainingIndexes().ToList())
                 {
                     var removed = index.DeclaringEntityType.Builder.HasNoIndex(index, configurationSource);
-                    Debug.Assert(removed != null);
+                    Check.DebugAssert(removed != null, "removed is null");
                 }
 
                 if (property.Builder != null)
                 {
                     var removedProperty = Metadata.RemoveProperty(property.Name);
-                    Debug.Assert(removedProperty == property);
+                    Check.DebugAssert(removedProperty == property, "removedProperty != property");
                 }
 
                 foreach (var relationshipSnapshot in detachedRelationships)
@@ -1612,7 +1612,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var detachedBuilder = foreignKey.Builder;
             var relationshipConfigurationSource = foreignKey.DeclaringEntityType.Builder
                 .HasNoRelationship(foreignKey, foreignKey.GetConfigurationSource());
-            Debug.Assert(relationshipConfigurationSource != null);
+            Check.DebugAssert(relationshipConfigurationSource != null, "relationshipConfigurationSource is null");
 
             EntityType.Snapshot definedSnapshot = null;
             if (includeDefinedType)
@@ -1791,7 +1791,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             var removedProperty = property.DeclaringEntityType.RemoveProperty(property.Name);
-            Debug.Assert(removedProperty == property);
+            Check.DebugAssert(removedProperty == property, "removedProperty != property");
         }
 
         /// <summary>
@@ -1881,7 +1881,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             var removedIndex = Metadata.RemoveIndex(index.Properties);
-            Debug.Assert(removedIndex == index);
+            Check.DebugAssert(removedIndex == index, "removedIndex != index");
 
             RemoveUnusedShadowProperties(index.Properties);
 
@@ -1917,7 +1917,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var entityTypeBuilder = indexToDetach.DeclaringEntityType.Builder;
             var indexBuilder = indexToDetach.Builder;
             var removedConfigurationSource = entityTypeBuilder.HasNoIndex(indexToDetach, indexToDetach.GetConfigurationSource());
-            Debug.Assert(removedConfigurationSource != null);
+            Check.DebugAssert(removedConfigurationSource != null, "removedConfigurationSource is null");
             return indexBuilder;
         }
 
@@ -2125,9 +2125,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             ConfigurationSource configurationSource,
             bool? required = null)
         {
-            Debug.Assert(
-                navigationToTarget != null
-                || inverseNavigation != null);
+            Check.DebugAssert(
+                navigationToTarget != null || inverseNavigation != null,
+                "navigationToTarget == null and inverseNavigation == null");
 
             var navigationProperty = navigationToTarget?.MemberInfo;
             if (inverseNavigation == null
@@ -2949,9 +2949,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
                 else
                 {
-                    Debug.Assert(
+                    Check.DebugAssert(
                         foreignKey != null
-                        || Metadata.FindForeignKey(dependentProperties, principalKey, principalType) == null);
+                        || Metadata.FindForeignKey(dependentProperties, principalKey, principalType) == null,
+                        "FK not found");
                 }
             }
             else

--- a/src/EFCore/Metadata/Internal/InternalModelBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalModelBuilder.cs
@@ -2,13 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
@@ -422,20 +422,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 foreach (var foreignKey in entityType.GetDeclaredForeignKeys().ToList())
                 {
                     var removed = entityTypeBuilder.HasNoRelationship(foreignKey, configurationSource);
-                    Debug.Assert(removed != null);
+                    Check.DebugAssert(removed != null, "removed is null");
                 }
 
                 foreach (var foreignKey in entityType.GetDeclaredReferencingForeignKeys().ToList())
                 {
                     var removed = foreignKey.DeclaringEntityType.Builder.HasNoRelationship(foreignKey, configurationSource);
-                    Debug.Assert(removed != null);
+                    Check.DebugAssert(removed != null, "removed is null");
                 }
 
                 foreach (var directlyDerivedType in entityType.GetDirectlyDerivedTypes().ToList())
                 {
                     var derivedEntityTypeBuilder = directlyDerivedType.Builder
                         .HasBaseType(entityType.BaseType, configurationSource);
-                    Debug.Assert(derivedEntityTypeBuilder != null);
+                    Check.DebugAssert(derivedEntityTypeBuilder != null, "derivedEntityTypeBuilder is null");
                 }
 
                 foreach (var definedType in Metadata.GetEntityTypes().Where(e => e.DefiningEntityType == entityType).ToList())

--- a/src/EFCore/Metadata/Internal/InternalPropertyBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalPropertyBuilder.cs
@@ -11,6 +11,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
@@ -63,7 +64,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         }
 
                         var removed = key.DeclaringEntityType.Builder.HasNoKey(key, configurationSource);
-                        Debug.Assert(removed != null);
+                        Check.DebugAssert(removed != null, "removed is null");
                     }
 
                     Metadata.SetIsNullable(true, configurationSource);

--- a/src/EFCore/Metadata/Internal/InternalRelationshipBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalRelationshipBuilder.cs
@@ -257,8 +257,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             IReadOnlyList<Property> principalProperties = null;
             if (shouldInvert == true)
             {
-                Debug.Assert(configurationSource.Overrides(Metadata.GetPropertiesConfigurationSource()));
-                Debug.Assert(configurationSource.Overrides(Metadata.GetPrincipalKeyConfigurationSource()));
+                Check.DebugAssert(
+                    configurationSource.Overrides(Metadata.GetPropertiesConfigurationSource()),
+                    "configurationSource does not override Metadata.GetPropertiesConfigurationSource");
+
+                Check.DebugAssert(
+                    configurationSource.Overrides(Metadata.GetPrincipalKeyConfigurationSource()),
+                    "configurationSource does not override Metadata.GetPrincipalKeyConfigurationSource");
 
                 var entityType = principalEntityType;
                 principalEntityType = dependentEntityType;
@@ -302,7 +307,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     return null;
                 }
 
-                Debug.Assert(builder.Metadata.Builder != null);
+                Check.DebugAssert(builder.Metadata.Builder != null, "builder.Metadata.Builder is null");
             }
             else
             {
@@ -1033,9 +1038,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
                 if (declaringType.HasDefiningNavigation())
                 {
-                    Debug.Assert(
+                    Check.DebugAssert(
                         Metadata.PrincipalToDependent == null
-                        || declaringType.DefiningNavigationName == Metadata.PrincipalToDependent.Name);
+                        || declaringType.DefiningNavigationName == Metadata.PrincipalToDependent.Name,
+                        $"Unexpected navigation");
 
                     if (otherOwnership != null
                         && !configurationSource.Overrides(otherOwnership.GetConfigurationSource()))
@@ -1198,11 +1204,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var newOwnership = newEntityType.GetForeignKeys().SingleOrDefault(fk => fk.IsOwnership);
             if (newOwnership == null)
             {
-                Debug.Assert(Metadata.Builder != null);
+                Check.DebugAssert(Metadata.Builder != null, "Metadata.Builder is null");
                 return Metadata.Builder;
             }
 
-            Debug.Assert(Metadata.Builder == null);
+            Check.DebugAssert(Metadata.Builder == null, "Metadata.Builder is not null");
             ModelBuilder.Metadata.ConventionDispatcher.Tracker.Update(Metadata, newOwnership);
             return newOwnership.Builder;
         }
@@ -1257,7 +1263,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             builder = builder.Metadata.SetIsUnique(unique, configurationSource)?.Builder;
-            Debug.Assert(builder != null);
+            Check.DebugAssert(builder != null, "builder is null");
 
             return batch.Run(builder);
         }
@@ -1492,10 +1498,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var builder = this;
             if (shouldInvert)
             {
-                Debug.Assert(
-                    configurationSource.Overrides(Metadata.GetPropertiesConfigurationSource()));
-                Debug.Assert(
-                    configurationSource.Overrides(Metadata.GetPrincipalKeyConfigurationSource()));
+                Check.DebugAssert(
+                    configurationSource.Overrides(Metadata.GetPropertiesConfigurationSource()),
+                    "configurationSource does not override Metadata.GetPropertiesConfigurationSource");
+
+                Check.DebugAssert(
+                    configurationSource.Overrides(Metadata.GetPrincipalKeyConfigurationSource()),
+                    "configurationSource does not override Metadata.GetPrincipalKeyConfigurationSource");
 
                 principalEntityType = principalEntityType.LeastDerivedType(Metadata.DeclaringEntityType);
                 dependentEntityType = dependentEntityType.LeastDerivedType(Metadata.PrincipalEntityType);
@@ -2183,15 +2192,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             Check.NotNull(principalEntityTypeBuilder, nameof(principalEntityTypeBuilder));
             Check.NotNull(dependentEntityTypeBuilder, nameof(dependentEntityTypeBuilder));
-            Debug.Assert(
+
+            Check.DebugAssert(
                 navigationToPrincipal?.Name == null
                 || navigationToPrincipal.Value.MemberInfo != null
-                || !dependentEntityTypeBuilder.Metadata.HasClrType());
-            Debug.Assert(
+                || !dependentEntityTypeBuilder.Metadata.HasClrType(),
+                "Principal navigation check failed");
+
+            Check.DebugAssert(
                 navigationToDependent?.Name == null
                 || navigationToDependent.Value.MemberInfo != null
-                || !principalEntityTypeBuilder.Metadata.HasClrType());
-            Debug.Assert(
+                || !principalEntityTypeBuilder.Metadata.HasClrType(),
+                "Dependent navigation check failed");
+
+            Check.DebugAssert(
                 AreCompatible(
                     principalEntityTypeBuilder.Metadata,
                     dependentEntityTypeBuilder.Metadata,
@@ -2200,13 +2214,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     dependentProperties?.Count > 0 ? dependentProperties : null,
                     principalProperties?.Count > 0 ? principalProperties : null,
                     isUnique,
-                    configurationSource));
-            Debug.Assert(oldNameDependentProperties == null || (dependentProperties?.Count ?? 0) == 0);
-            Debug.Assert(
+                    configurationSource),
+                "Compatibility check failed");
+
+            Check.DebugAssert(
+                oldNameDependentProperties == null || (dependentProperties?.Count ?? 0) == 0,
+                "Dependent properties check failed");
+
+            Check.DebugAssert(
                 removeCurrent
                 || Metadata.Builder == null
                 || (Metadata.PrincipalEntityType.IsAssignableFrom(principalEntityTypeBuilder.Metadata)
-                    && Metadata.DeclaringEntityType.IsAssignableFrom(dependentEntityTypeBuilder.Metadata)));
+                    && Metadata.DeclaringEntityType.IsAssignableFrom(dependentEntityTypeBuilder.Metadata)),
+                "Entity type check failed");
 
             InternalRelationshipBuilder newRelationshipBuilder;
             using (var batch = Metadata.DeclaringEntityType.Model.ConventionDispatcher.DelayConventions())
@@ -2336,7 +2356,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                             {
                                 var updated = newRelationshipBuilder.HasForeignKey(
                                     dependentProperties, foreignKeyPropertiesConfigurationSource.Value);
-                                Debug.Assert(updated == newRelationshipBuilder);
+
+                                Check.DebugAssert(updated == newRelationshipBuilder, "updated != newRelationshipBuilder");
                             }
                             else if (dependentProperties.Count > 0
                                 || (!removeCurrent
@@ -2367,7 +2388,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                             {
                                 var updated = newRelationshipBuilder.HasPrincipalKey(
                                     principalProperties, principalKeyConfigurationSource.Value);
-                                Debug.Assert(updated == newRelationshipBuilder);
+
+                                Check.DebugAssert(updated == newRelationshipBuilder, "updated != newRelationshipBuilder");
                             }
                             else if (principalProperties.Count > 0
                                 || (!removeCurrent
@@ -3286,7 +3308,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             if (dependentEntityType.GetForeignKeys().Contains(Metadata, ReferenceEqualityComparer.Instance))
             {
-                Debug.Assert(Metadata.Builder != null);
+                Check.DebugAssert(Metadata.Builder != null, "Metadata.Builder is null");
+
                 return Metadata.Builder;
             }
 

--- a/src/EFCore/Metadata/Internal/Model.cs
+++ b/src/EFCore/Metadata/Internal/Model.cs
@@ -6,7 +6,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
@@ -174,7 +173,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
 
                 var added = entityTypesWithSameType.Add(entityType);
-                Debug.Assert(added);
+                Check.DebugAssert(added, "added is false");
             }
             else
             {
@@ -290,7 +289,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
 
                 var removed = entityTypesWithSameType.Remove(entityType);
-                Debug.Assert(removed);
+                Check.DebugAssert(removed, "removed is false");
 
                 if (entityTypesWithSameType.Count == 0)
                 {
@@ -300,7 +299,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             else
             {
                 var removed = _entityTypes.Remove(entityTypeName);
-                Debug.Assert(removed);
+                Check.DebugAssert(removed, "removed is false");
             }
 
             entityType.OnTypeRemoved();

--- a/src/EFCore/Metadata/Internal/PropertyBase.cs
+++ b/src/EFCore/Metadata/Internal/PropertyBase.cs
@@ -120,7 +120,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public static FieldInfo GetFieldInfo(
             [NotNull] string fieldName, [NotNull] TypeBase type, [CanBeNull] string propertyName, bool shouldThrow)
         {
-            Debug.Assert(propertyName != null || !shouldThrow);
+            Check.DebugAssert(propertyName != null || !shouldThrow, "propertyName is null");
 
             if (!type.GetRuntimeFields().TryGetValue(fieldName, out var fieldInfo)
                 && shouldThrow)
@@ -188,7 +188,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             [CanBeNull] string propertyName,
             bool shouldThrow)
         {
-            Debug.Assert(propertyName != null || !shouldThrow);
+            Check.DebugAssert(propertyName != null || !shouldThrow, "propertyName is null");
 
             if (entityClrType == null
                 || !fieldInfo.DeclaringType.IsAssignableFrom(entityClrType))

--- a/src/EFCore/Storage/MaterializationContext.cs
+++ b/src/EFCore/Storage/MaterializationContext.cs
@@ -1,10 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Storage
 {
@@ -37,7 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             in ValueBuffer valueBuffer,
             [NotNull] DbContext context)
         {
-            Debug.Assert(context != null); // Hot path
+            Check.DebugAssert(context != null, "context is null"); // Hot path
 
             ValueBuffer = valueBuffer;
             Context = context;

--- a/src/EFCore/Storage/ValueBuffer.cs
+++ b/src/EFCore/Storage/ValueBuffer.cs
@@ -2,11 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Storage
 {
@@ -34,7 +34,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="values"> The list of values for this buffer. </param>
         public ValueBuffer([NotNull] object[] values)
         {
-            Debug.Assert(values != null);
+            Check.DebugAssert(values != null, "values is null");
 
             _values = values;
         }

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTestBase.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTestBase.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
@@ -12,6 +11,7 @@ using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.EntityFrameworkCore.Update;
 using Microsoft.EntityFrameworkCore.Update.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Migrations.Internal
@@ -95,7 +95,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
 
         protected static T[] ToOnedimensionalArray<T>(T[,] values, bool firstDimension = false)
         {
-            Debug.Assert(
+            Check.DebugAssert(
                 values.GetLength(firstDimension ? 1 : 0) == 1,
                 $"Length of dimension {(firstDimension ? 1 : 0)} is not 1.");
 

--- a/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeDbCommand.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeDbCommand.cs
@@ -4,9 +4,9 @@
 using System;
 using System.Data;
 using System.Data.Common;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider
 {
@@ -124,14 +124,16 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider
         {
             if (Transaction == null)
             {
-                Debug.Assert(((FakeDbConnection)DbConnection).ActiveTransaction == null);
+                Check.DebugAssert(
+                    ((FakeDbConnection)DbConnection).ActiveTransaction == null,
+                    "((FakeDbConnection)DbConnection).ActiveTransaction is null");
             }
             else
             {
                 var transaction = (FakeDbTransaction)Transaction;
 
-                Debug.Assert(transaction.Connection == Connection);
-                Debug.Assert(transaction.DisposeCount == 0);
+                Check.DebugAssert(transaction.Connection == Connection, "transaction.Connection != Connection");
+                Check.DebugAssert(transaction.DisposeCount == 0, $"transaction.DisposeCount is {transaction.DisposeCount}");
             }
         }
     }


### PR DESCRIPTION
Fixes #17204

Simple, compiled-out check that will not cause silent failures no matter how the environment is configured.
