### PR TITLE
PropertyBuilder can have custom ValueComparer

### DIFF
--- a/src/EFCore/Metadata/Builders/PropertyBuilder.cs
+++ b/src/EFCore/Metadata/Builders/PropertyBuilder.cs
@@ -4,6 +4,7 @@
 using System;
 using System.ComponentModel;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
@@ -365,6 +366,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         public virtual PropertyBuilder HasConversion([CanBeNull] ValueConverter converter)
         {
             Builder.HasConversion(converter, ConfigurationSource.Explicit);
+
+            return this;
+        }
+
+        /// <summary>
+        ///     Configures the property so that the property value can be compared to other instances
+        ///     using the given <see cref="ValueComparer" />.
+        /// </summary>
+        /// <param name="comparer"> The comparer to use. </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public virtual PropertyBuilder HasValueComparer([CanBeNull] ValueComparer comparer)
+        {
+            Builder.HasValueComparer(comparer, ConfigurationSource.Explicit);
 
             return this;
         }

--- a/src/EFCore/Metadata/Builders/PropertyBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/PropertyBuilder`.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -286,6 +287,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
         public new virtual PropertyBuilder<TProperty> HasConversion([CanBeNull] ValueConverter converter)
             => (PropertyBuilder<TProperty>)base.HasConversion(converter);
+
+
+        /// <summary>
+        ///     Configures the property so that the property value can be compared to other instances
+        ///     using the given <see cref="ValueComparer" />.
+        /// </summary>
+        /// <param name="comparer"> The comparer to use. </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public virtual PropertyBuilder<TProperty> HasValueComparer<TProvider>([CanBeNull] ValueComparer<TProvider> comparer)
+            => (PropertyBuilder<TProperty>)base.HasValueComparer(comparer);
 
         /// <summary>
         ///     <para>


### PR DESCRIPTION
I have a DbContext with a conversion like this: 

```
public void Configure(EntityTypeBuilder<CachedGroup> builder)
{
	builder.Property(e => e.Roles).HasConversion(
		x => JsonConvert.SerializeObject(x, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }),
		x => JsonConvert.DeserializeObject<IList<string>>(x, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }));
}
```

When the DbContext gets created, it logs the following warning:

> The property '"Roles"' on entity type '"CachedUser"' is a collection or enumeration type with a value converter but with no value comparer. Set a value comparer to ensure the collection/enumeration elements are compared correctly.

Apparently there is no ValueComparer associated with this property. Only InternalPropertyBuilder allowed setting custom ValueCompareres. I though it was a good idea to allow custom ValueComparers to get rid of the mentioned warning. What do you think?