### PR TITLE
WIP on new migration tests

### DIFF
--- a/src/EFCore.Relational/Scaffolding/Metadata/DatabaseColumn.cs
+++ b/src/EFCore.Relational/Scaffolding/Metadata/DatabaseColumn.cs
@@ -52,5 +52,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Metadata
         ///     the database will not generate values.
         /// </summary>
         public virtual ValueGenerated? ValueGenerated { get; set; }
+
+        public override string ToString() => Name;
     }
 }

--- a/src/EFCore.Relational/Scaffolding/Metadata/DatabaseForeignKey.cs
+++ b/src/EFCore.Relational/Scaffolding/Metadata/DatabaseForeignKey.cs
@@ -44,5 +44,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Metadata
         ///     is deleted, or <c>null</c> if there is no action defined.
         /// </summary>
         public virtual ReferentialAction? OnDelete { get; set; }
+
+        public override string ToString() => Name;
     }
 }

--- a/src/EFCore.Relational/Scaffolding/Metadata/DatabaseIndex.cs
+++ b/src/EFCore.Relational/Scaffolding/Metadata/DatabaseIndex.cs
@@ -36,5 +36,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Metadata
         ///     The filter expression, or <c>null</c> if the index has no filter.
         /// </summary>
         public virtual string Filter { get; [param: CanBeNull] set; }
+
+        public override string ToString() => Name;
     }
 }

--- a/src/EFCore.Relational/Scaffolding/Metadata/DatabaseModel.cs
+++ b/src/EFCore.Relational/Scaffolding/Metadata/DatabaseModel.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -10,7 +11,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Metadata
     /// <summary>
     ///     A simple model for a database used when reverse engineering an existing database.
     /// </summary>
-    public class DatabaseModel : Annotatable
+    public class DatabaseModel : Annotatable, IEquatable<DatabaseModel>
     {
         /// <summary>
         ///     The database name, or <c>null</c> if none is set.
@@ -31,5 +32,54 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Metadata
         ///     The list of sequences in the database.
         /// </summary>
         public virtual IList<DatabaseSequence> Sequences { get; } = new List<DatabaseSequence>();
+
+        /// <summary>Indicates whether the current object is equal to another object of the same type.</summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns>
+        /// <see langword="true" /> if the current object is equal to the <paramref name="other" /> parameter; otherwise, <see langword="false" />.</returns>
+        public bool Equals(DatabaseModel other)
+        {
+            if (other == null
+                || !base.Equals(other)
+                || DatabaseName != other.DatabaseName
+                || DefaultSchema != other.DefaultSchema
+                || Tables.Count != other.Tables.Count
+                || Sequences.Count != other.Sequences.Count)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < Tables.Count; i++)
+            {
+                if (!Tables[i].Equals(other.Tables[i]))
+                {
+                    return false;
+                }
+            }
+
+            for (var i = 0; i < Sequences.Count; i++)
+            {
+                if (!Sequences[i].Equals(other.Sequences[i]))
+                {
+                    return false;
+                }
+            }
+
+            // TODO: Compare annotations too.
+            // Can't implement Equals on Annotatable because that takes over equality for everything that derives
+            // from it (e.g. EntityType).
+
+            return true;
+        }
+
+        /// <summary>Determines whether the specified object is equal to the current object.</summary>
+        /// <param name="obj">The object to compare with the current object.</param>
+        /// <returns>
+        /// <see langword="true" /> if the specified object  is equal to the current object; otherwise, <see langword="false" />.</returns>
+        public override bool Equals(object obj) => obj is DatabaseModel other && Equals(other);
+
+        /// <summary>Serves as the default hash function.</summary>
+        /// <returns>A hash code for the current object.</returns>
+        public override int GetHashCode() => 0;   // TODO
     }
 }

--- a/src/EFCore.Relational/Scaffolding/Metadata/DatabasePrimaryKey.cs
+++ b/src/EFCore.Relational/Scaffolding/Metadata/DatabasePrimaryKey.cs
@@ -26,5 +26,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Metadata
         ///     The ordered list of columns that make up the primary key.
         /// </summary>
         public virtual IList<DatabaseColumn> Columns { get; } = new List<DatabaseColumn>();
+
+        public override string ToString() => Name;
     }
 }

--- a/src/EFCore.Relational/Scaffolding/Metadata/DatabaseSequence.cs
+++ b/src/EFCore.Relational/Scaffolding/Metadata/DatabaseSequence.cs
@@ -55,5 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Metadata
         ///     Indicates whether or not the sequence will start over when the max value is reached, or <c>null</c> if not set.
         /// </summary>
         public virtual bool? IsCyclic { get; set; }
+
+        public override string ToString() => Schema == null ? Name : $"{Schema}.{Name}";
     }
 }

--- a/src/EFCore.Relational/Scaffolding/Metadata/DatabaseTable.cs
+++ b/src/EFCore.Relational/Scaffolding/Metadata/DatabaseTable.cs
@@ -56,5 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Metadata
         ///     The list of foreign key constraints defined on the table.
         /// </summary>
         public virtual IList<DatabaseForeignKey> ForeignKeys { get; } = new List<DatabaseForeignKey>();
+
+        public override string ToString() => Schema == null ? Name : $"{Schema}.{Name}";
     }
 }

--- a/src/EFCore.Relational/Scaffolding/Metadata/DatabaseUniqueConstraint.cs
+++ b/src/EFCore.Relational/Scaffolding/Metadata/DatabaseUniqueConstraint.cs
@@ -26,5 +26,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Metadata
         ///     The ordered list of columns that make up the constraint.
         /// </summary>
         public virtual IList<DatabaseColumn> Columns { get; } = new List<DatabaseColumn>();
+
+        public override string ToString() => Name;
     }
 }

--- a/test/EFCore.Relational.Specification.Tests/MigrationsTestBase2.cs
+++ b/test/EFCore.Relational.Specification.Tests/MigrationsTestBase2.cs
@@ -1,0 +1,145 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Scaffolding;
+using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public class MigrationsTestBase2<TFixture> : IClassFixture<TFixture>
+        where TFixture : MigrationsTestBase2<TFixture>.MigrationsFixtureBase2, new()
+    {
+        protected TFixture Fixture { get; }
+
+        protected MigrationsTestBase2(TFixture fixture)
+        {
+            Fixture = fixture;
+        }
+
+        [ConditionalFact]
+        public virtual void CreateIndexOperation_unique()
+            => ExecuteIncremental(
+                modelBuilder =>
+                {
+                    modelBuilder.Entity(
+                        "People", entityBuilder =>
+                        {
+                            entityBuilder.Property<int>("Id");
+                            entityBuilder.Property<string>("FirstName");
+                            entityBuilder.Property<string>("LastName");
+                        });
+                },
+                modelBuilder => modelBuilder.Entity("People").HasIndex("FirstName", "LastName").IsUnique(),
+                model => Assert.True(model.Tables.Single().Indexes.Single().IsUnique));
+
+        protected virtual void ExecuteIncremental(
+            Action<ModelBuilder> buildSourceAction,
+            Action<ModelBuilder> buildTargetIncrementalAction,
+            Action<DatabaseModel> modelAsserter)
+            => Execute(
+                buildSourceAction,
+                modelBuilder =>
+                {
+                    buildSourceAction(modelBuilder);
+                    buildTargetIncrementalAction(modelBuilder);
+                },
+                modelAsserter);
+
+        protected virtual void Execute(
+            Action<ModelBuilder> buildSourceAction,
+            Action<ModelBuilder> buildTargetAction,
+            Action<DatabaseModel> modelAsserter)
+        {
+            var context = Fixture.CreateContext();
+            var serviceProvider = ((IInfrastructure<IServiceProvider>)context).Instance;
+            var migrationsSqlGenerator = serviceProvider.GetRequiredService<IMigrationsSqlGenerator>();
+            var modelDiffer = serviceProvider.GetRequiredService<IMigrationsModelDiffer>();
+            var migrationsCommandExecutor = serviceProvider.GetRequiredService<IMigrationCommandExecutor>();
+            var connection = serviceProvider.GetRequiredService<IRelationalConnection>();
+            var databaseModelFactory = serviceProvider.GetRequiredService<IDatabaseModelFactory>();
+
+            // Build the source and target models
+            var sourceModelBuilder = Fixture.TestHelpers.CreateConventionBuilder(skipValidation: true);
+            buildSourceAction(sourceModelBuilder);
+            var sourceModel = sourceModelBuilder.FinalizeModel();
+
+            var targetModelBuilder = Fixture.TestHelpers.CreateConventionBuilder(skipValidation: true);
+            buildTargetAction(targetModelBuilder);
+            var targetModel = targetModelBuilder.FinalizeModel();
+
+            // Apply migrations to get to the source state, and do a scaffolding snapshot for later comparison
+            migrationsCommandExecutor.ExecuteNonQuery(
+                migrationsSqlGenerator.Generate(modelDiffer.GetDifferences(null, sourceModel), sourceModel),
+                connection);
+            var sourceScaffoldedModel = databaseModelFactory.Create(
+                context.Database.GetDbConnection(),
+                new DatabaseModelFactoryOptions());
+
+            try
+            {
+                // Apply migrations to get from source to target
+                migrationsCommandExecutor.ExecuteNonQuery(
+                    migrationsSqlGenerator.Generate(modelDiffer.GetDifferences(sourceModel, targetModel), targetModel),
+                    connection);
+
+                // Reverse-engineer and execute the test-provided assertions on the resulting database model
+                var targetScaffoldedModel = databaseModelFactory.Create(
+                    context.Database.GetDbConnection(),
+                    new DatabaseModelFactoryOptions());
+
+                modelAsserter(targetScaffoldedModel);
+
+                // Apply reverse migrations to go back to the source state
+                migrationsCommandExecutor.ExecuteNonQuery(
+                    migrationsSqlGenerator.Generate(modelDiffer.GetDifferences(targetModel, sourceModel), sourceModel),
+                    connection);
+
+                var sourceScaffoldedModel2 = databaseModelFactory.Create(
+                    context.Database.GetDbConnection(),
+                    new DatabaseModelFactoryOptions());
+
+                // TODO: Complete all equality implementations in DatabaseModel and related types
+                //Assert.Equal(sourceScaffoldedModel, sourceScaffoldedModel2);
+
+                // Apply reverse migrations to go back to the initial empty state
+                migrationsCommandExecutor.ExecuteNonQuery(
+                    migrationsSqlGenerator.Generate(modelDiffer.GetDifferences(sourceModel, null)),
+                    connection);
+
+                var emptyModel = databaseModelFactory.Create(
+                    context.Database.GetDbConnection(),
+                    new DatabaseModelFactoryOptions());
+
+                Assert.Empty(emptyModel.Tables);
+                Assert.Empty(emptyModel.Sequences);
+            }
+            catch
+            {
+                try
+                {
+                    Fixture.TestStore.Clean(context);
+                }
+                catch
+                {
+                    // ignored, throw the original exception
+                }
+
+                throw;
+            }
+        }
+
+        public abstract class MigrationsFixtureBase2 : SharedStoreFixtureBase<PoolableDbContext>
+        {
+            public abstract TestHelpers TestHelpers { get; }
+            public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ListLoggerFactory;
+        }
+    }
+}

--- a/test/EFCore.Relational.Specification.Tests/MigrationsTestBase2.cs
+++ b/test/EFCore.Relational.Specification.Tests/MigrationsTestBase2.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Scaffolding;
 using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
@@ -25,25 +27,502 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
-        public virtual void CreateIndexOperation_unique()
+        public virtual Task CreateIndexOperation_with_filter_where_clause()
             => ExecuteIncremental(
-                modelBuilder =>
-                {
-                    modelBuilder.Entity(
-                        "People", entityBuilder =>
-                        {
-                            entityBuilder.Property<int>("Id");
-                            entityBuilder.Property<string>("FirstName");
-                            entityBuilder.Property<string>("LastName");
-                        });
-                },
-                modelBuilder => modelBuilder.Entity("People").HasIndex("FirstName", "LastName").IsUnique(),
-                model => Assert.True(model.Tables.Single().Indexes.Single().IsUnique));
+                builder => builder.Entity(
+                    "People", e =>
+                    {
+                        e.Property<int>("Id");
+                        e.Property<string>("Name");
+                    }),
+                builder => builder.Entity("People").HasIndex("Name").HasFilter("[Name] IS NOT NULL"), // TODO: Quotes for other databases
+                model => Assert.Equal("([Name] IS NOT NULL)", model.Tables.Single().Indexes.Single().Filter));  // TODO: Why parentheses?
 
         [ConditionalFact]
-        public virtual void CreateSequenceOperation_with_minValue_and_maxValue()
+        public virtual Task CreateIndexOperation_with_filter_where_clause_and_is_unique()
+            => ExecuteIncremental(
+                builder => builder.Entity(
+                    "People", e =>
+                    {
+                        e.Property<int>("Id");
+                        e.Property<string>("Name");
+                    }),
+                builder => builder.Entity("People").HasIndex("Name").IsUnique()
+                    .HasFilter("[Name] IS NOT NULL AND [Name] <> ''"), // TODO: Quotes
+                model => Assert.Equal("([Name] IS NOT NULL AND [Name]<>'')", model.Tables.Single().Indexes.Single().Filter));  // TODO: Whitespace is gonna be difficult, provider-specific...
+
+        [ConditionalFact]
+        public virtual Task AddColumnOperation_with_defaultValue()
+            => ExecuteIncremental(
+                builder => builder.Entity("People").Property<int>("Id"),
+                builder => builder.Entity("People").Property<string>("Name")
+                    //                  .HasColumnType("varchar(30)")
+                    .IsRequired()
+                    .HasDefaultValue("John Doe"),
+                model =>
+                {
+                    var table = Assert.Single(model.Tables);
+                    Assert.Equal(2, table.Columns.Count);
+                    var nameColumn = Assert.Single(table.Columns, c => c.Name == "Name");
+//                    Assert.Equal("varchar(30)", nameColumn.StoreType);
+                    Assert.False(nameColumn.IsNullable);
+                    Assert.Equal("(N'John Doe')", nameColumn.DefaultValueSql); // TODO: No
+                });
+
+        [ConditionalFact]
+        public virtual Task AddColumnOperation_with_defaultValueSql()
+            => ExecuteIncremental(
+                builder => builder.Entity("People").Property<int>("Id"),
+                builder => builder.Entity("People").Property<DateTime?>("Birthday")
+                    .HasColumnType("date")
+                    .HasDefaultValueSql("CURRENT_TIMESTAMP"),
+                model =>
+                {
+                    var table = Assert.Single(model.Tables);
+                    Assert.Equal(2, table.Columns.Count);
+                    var nameColumn = Assert.Single(table.Columns, c => c.Name == "Birthday");
+                    Assert.Equal("date", nameColumn.StoreType);
+                    Assert.True(nameColumn.IsNullable);
+                    Assert.Equal("(getdate())", nameColumn.DefaultValueSql);
+                });
+
+        [ConditionalFact]
+        public virtual Task AddColumnOperation_without_column_type()
+            => ExecuteIncremental(
+                builder => builder.Entity("People").Property<int>("Id"),
+                builder => builder.Entity("People").Property<string>("Name").IsRequired(),
+                model =>
+                {
+                    var table = Assert.Single(model.Tables);
+                    var column = Assert.Single(table.Columns, c => c.Name == "Name");
+                    Assert.Equal("nvarchar(max)", column.StoreType);
+                    Assert.False(column.IsNullable);
+                });
+
+        [ConditionalFact]
+        public virtual Task AddColumnOperation_with_ansi()
+            => ExecuteIncremental(
+                builder => builder.Entity("People").Property<int>("Id"),
+                builder => builder.Entity("People").Property<string>("Name").IsUnicode(false),
+                model =>
+                {
+                    var table = Assert.Single(model.Tables);
+                    var column = Assert.Single(table.Columns, c => c.Name == "Name");
+                    Assert.Equal("varchar(max)", column.StoreType);
+                    Assert.True(column.IsNullable);
+                });
+
+        // TODO: AddColumnOperation_with_unicode_overridden. In which scenarios do we need to do this?
+
+        // TODO: AddColumnOperation_with_unicode_no_model. In which scenarios do we need to do this?
+
+        [ConditionalFact]
+        public virtual Task AddColumnOperation_with_fixed_length()
+            => ExecuteIncremental(
+                builder => builder.Entity("People").Property<int>("Id"),
+                builder => builder.Entity("People").Property<string>("Name").IsFixedLength(),
+                model =>
+                {
+                    var table = Assert.Single(model.Tables);
+                    var column = Assert.Single(table.Columns, c => c.Name == "Name");
+                    Assert.Equal("nvarchar(max)", column.StoreType);
+                });
+
+        // TODO: AddColumnOperation_with_fixed_length_no_model
+
+        [ConditionalFact]
+        public virtual Task AddColumnOperation_with_maxLength()
+            => ExecuteIncremental(
+                builder => builder.Entity("People").Property<int>("Id"),
+                builder => builder.Entity("People").Property<string>("Name").HasMaxLength(30),
+                model =>
+                {
+                    var table = Assert.Single(model.Tables);
+                    var column = Assert.Single(table.Columns, c => c.Name == "Name");
+                    Assert.Equal("nvarchar(30)", column.StoreType);
+                });
+
+        // TODO: AddColumnOperation_with_maxLength_overridden
+
+        // TODO: AddColumnOperation_with_maxLength_no_model
+
+        [ConditionalFact]
+        public virtual Task AddColumnOperation_with_maxLength_on_derived()
+            => ExecuteIncremental(
+                builder =>
+                {
+                    builder.Entity("Person");
+                    builder.Entity(
+                        "SpecialPerson", e =>
+                        {
+                            e.HasBaseType("Person");
+                            e.Property<string>("Name").HasMaxLength(30);
+                        });
+
+                    builder.Entity("MoreSpecialPerson").HasBaseType("SpecialPerson");
+                },
+                builder => builder.Entity("Person").Property<string>("Name").HasMaxLength(30),
+                model =>
+                {
+                    var table = Assert.Single(model.Tables, t => t.Name == "Person");
+                    var column = Assert.Single(table.Columns, c => c.Name == "Name");
+                    Assert.Equal("nvarchar(30)", column.StoreType);
+                });
+
+        [ConditionalFact]
+        public virtual Task AddColumnOperation_with_shared_column()
+            => ExecuteIncremental(
+                builder =>
+                {
+                    builder.Entity("Base").Property<int>("Id");
+                    builder.Entity("Derived1").Property<string>("Foo");
+                    builder.Entity("Derived2").Property<string>("Foo");
+                },
+                builder => builder.Entity("Base").Property<string>("Foo"),
+                model =>
+                {
+                    // var table = Assert.Single(model.Tables);
+                    // var column = Assert.Single(table.Columns, c => c.Name == "Name");
+                    // Assert.Equal("nvarchar(30)", column.StoreType);
+                });
+
+        [ConditionalFact]
+        public virtual Task AddForeignKeyOperation()
+            => ExecuteIncremental(
+                builder =>
+                {
+                    builder.Entity("Customers").Property<int>("Id");
+                    builder.Entity(
+                        "Orders", e =>
+                        {
+                            e.Property<int>("Id");
+                            e.Property<int>("CustomerId");
+                        });
+                },
+                builder => builder.Entity("Orders").HasOne("Customers").WithMany().HasForeignKey("CustomerId"),
+                model =>
+                {
+                    var customersTable = Assert.Single(model.Tables, t => t.Name == "Customers");
+                    var ordersTable = Assert.Single(model.Tables, t => t.Name == "Orders");
+                    var foreignKey = ordersTable.ForeignKeys.Single();
+                    Assert.Equal("FK_Orders_Customers_CustomerId", foreignKey.Name);
+                    Assert.Equal(ReferentialAction.Cascade, foreignKey.OnDelete);
+                    Assert.Same(customersTable, foreignKey.PrincipalTable);
+                    Assert.Same(customersTable.Columns.Single(), Assert.Single(foreignKey.PrincipalColumns));
+                    Assert.Equal("CustomerId", Assert.Single(foreignKey.Columns).Name);
+                });
+
+        [ConditionalFact]
+        public virtual Task AddForeignKeyOperation_with_name()
+            => ExecuteIncremental(
+                builder =>
+                {
+                    builder.Entity("Customers").Property<int>("Id");
+                    builder.Entity(
+                        "Orders", e =>
+                        {
+                            e.Property<int>("Id");
+                            e.Property<int>("CustomerId");
+                        });
+                },
+                builder => builder.Entity("Orders").HasOne("Customers").WithMany().HasForeignKey("CustomerId").HasConstraintName("FK_Foo"),
+                model =>
+                {
+                    var table = Assert.Single(model.Tables, t => t.Name == "Orders");
+                    var foreignKey = table.ForeignKeys.Single();
+                    Assert.Equal("FK_Foo", foreignKey.Name);
+                });
+
+        // TODO: AddForeignKeyOperation_without_principal_columns, how to generate the scenario via model diffing
+
+        [ConditionalFact]
+        public virtual Task AddPrimaryKeyOperation()
+            => ExecuteIncremental(
+                builder => builder.Entity("People").Property<string>("SomeField"),
+                builder => builder.Entity("People").HasKey("SomeField"),
+                model =>
+                {
+                    var table = Assert.Single(model.Tables);
+                    var primaryKey = table.PrimaryKey;
+                    Assert.Same(table, primaryKey.Table);
+                    Assert.Same(table.Columns.Single(), Assert.Single(primaryKey.Columns));
+                    Assert.Equal("PK_People", primaryKey.Name);
+                });
+
+        [ConditionalFact]
+        public virtual Task AddPrimaryKeyOperation_composite_with_name()
+            => ExecuteIncremental(
+                builder => builder.Entity(
+                    "People", e =>
+                    {
+                        e.Property<string>("SomeField1");
+                        e.Property<string>("SomeField2");
+                    }),
+                builder => builder.Entity("People").HasKey("SomeField1", "SomeField2").HasName("PK_Foo"),
+                model =>
+                {
+                    var table = Assert.Single(model.Tables);
+                    var primaryKey = table.PrimaryKey;
+                    Assert.Same(table, primaryKey.Table);
+                    Assert.Collection(
+                        primaryKey.Columns,
+                        c => Assert.Same(table.Columns[0], c),
+                        c => Assert.Same(table.Columns[1], c));
+                    Assert.Equal("PK_Foo", primaryKey.Name);
+                });
+
+        [ConditionalFact]
+        public virtual Task AddUniqueConstraintOperation()
+            => ExecuteIncremental(
+                builder => builder.Entity(
+                    "People", e =>
+                    {
+                        e.Property<int>("Id");
+                        e.Property<int>("AlternateKeyColumn");
+                    }),
+                builder => builder.Entity("People").HasAlternateKey("AlternateKeyColumn"),
+                model =>
+                {
+                    var table = Assert.Single(model.Tables);
+                    var uniqueConstraint = table.UniqueConstraints.Single();
+                    Assert.Same(table, uniqueConstraint.Table);
+                    Assert.Same(table.Columns.Single(c => c.Name == "AlternateKeyColumn"), Assert.Single(uniqueConstraint.Columns));
+                    Assert.Equal("AK_People_AlternateKeyColumn", uniqueConstraint.Name);
+                });
+
+        [ConditionalFact]
+        public virtual Task AddUniqueConstraintOperation_composite_with_name()
+            => ExecuteIncremental(
+                builder => builder.Entity(
+                    "People", e =>
+                    {
+                        e.Property<int>("Id");
+                        e.Property<int>("AlternateKeyColumn1");
+                        e.Property<int>("AlternateKeyColumn2");
+                    }),
+                builder => builder.Entity("People").HasAlternateKey("AlternateKeyColumn1", "AlternateKeyColumn2").HasName("AK_Foo"),
+                model =>
+                {
+                    var table = Assert.Single(model.Tables);
+                    var uniqueConstraint = table.UniqueConstraints.Single();
+                    Assert.Same(table, uniqueConstraint.Table);
+                    Assert.Collection(
+                        uniqueConstraint.Columns,
+                        c => Assert.Same(table.Columns.Single(c => c.Name == "AlternateKeyColumn1"), c),
+                        c => Assert.Same(table.Columns.Single(c => c.Name == "AlternateKeyColumn2"), c));
+                    Assert.Equal("AK_Foo", uniqueConstraint.Name);
+                });
+
+        [ConditionalFact]
+        public virtual Task CreateCheckConstraintOperation_with_name()
+            => ExecuteIncremental(
+                builder => builder.Entity(
+                    "People", e =>
+                    {
+                        e.Property<int>("Id");
+                        e.Property<int>("DriverLicense");
+                    }),
+                builder => builder.Entity("People").HasCheckConstraint("CK_Foo", "[DriverLicense] > 0"), // TODO: Quote
+                model =>
+                {
+                    // TODO: no scaffolding support for check constraints, https://github.com/aspnet/EntityFrameworkCore/issues/15408
+                });
+
+        [ConditionalFact]
+        public virtual Task AlterColumnOperation_name()
             => Execute(
-                modelBuilder => modelBuilder.HasSequence<long>("TestSequence", "dbo")
+                builder => builder.Entity(
+                    "People", e =>
+                    {
+                        e.Property<int>("Id");
+                        e.Property<int>("SomeColumn");
+                    }),
+                builder => builder.Entity(
+                    "People", e =>
+                    {
+                        e.Property<int>("Id");
+                        e.Property<int>("somecolumn");
+                    }),
+                model =>
+                {
+                    var table = Assert.Single(model.Tables);
+                    var column = Assert.Single(table.Columns, c => c.Name != "Id");
+                    Assert.Equal("somecolumn", column.Name);
+                });
+
+        [ConditionalFact]
+        public virtual Task AlterColumnOperation_type()
+            => Execute(
+                builder => builder.Entity(
+                    "People", e =>
+                    {
+                        e.Property<int>("Id");
+                        e.Property<int>("SomeColumn");
+                    }),
+                builder => builder.Entity(
+                    "People", e =>
+                    {
+                        e.Property<int>("Id");
+                        e.Property<long>("SomeColumn");
+                    }),
+                model =>
+                {
+                    var table = Assert.Single(model.Tables);
+                    var column = Assert.Single(table.Columns, c => c.Name != "Id");
+                    Assert.Equal("bigint", column.StoreType); // TODO: store type name
+                });
+
+        [ConditionalFact]
+        public virtual Task AlterColumnOperation_required()
+            => Execute(
+                builder => builder.Entity(
+                    "People", e =>
+                    {
+                        e.Property<int>("Id");
+                        e.Property<string>("SomeColumn").IsRequired(false);
+                    }),
+                builder => builder.Entity(
+                    "People", e =>
+                    {
+                        e.Property<int>("Id");
+                        e.Property<string>("SomeColumn").IsRequired(true);
+                    }),
+                model =>
+                {
+                    var table = Assert.Single(model.Tables);
+                    var column = Assert.Single(table.Columns, c => c.Name != "Id");
+                    Assert.False(column.IsNullable);
+                });
+
+        // TODO: More AlterColumn scenarios
+
+        [ConditionalFact]
+        public virtual Task AlterSequenceOperation_all_settings()
+            => Execute(
+                builder => builder.HasSequence<int>("foo"),
+                builder => builder.HasSequence<int>("foo")
+                    .StartsAt(-3)
+                    .IncrementsBy(2)
+                    .HasMin(-5)
+                    .HasMax(10)
+                    .IsCyclic(),
+                model =>
+                {
+                    var sequence = Assert.Single(model.Sequences);
+                    Assert.Equal(-3, sequence.StartValue);
+                    Assert.Equal(2, sequence.IncrementBy);
+                    Assert.Equal(-5, sequence.MinValue);
+                    Assert.Equal(10, sequence.MaxValue);
+                    Assert.True(sequence.IsCyclic);
+                });
+
+        [ConditionalFact]
+        public virtual Task AlterSequenceOperation_increment_by()
+            => Execute(
+                builder => builder.HasSequence<int>("foo"),
+                builder => builder.HasSequence<int>("foo").IncrementsBy(2),
+                model =>
+                {
+                    var sequence = Assert.Single(model.Sequences);
+                    Assert.Equal(2, sequence.IncrementBy);
+                });
+
+        [ConditionalFact]
+        public virtual Task RenameTableOperation()
+            => Execute(
+                builder => builder.Entity("People").Property<int>("Id"),
+                builder => builder.Entity("people").Property<int>("Id"),
+                model =>
+                {
+                    var table = Assert.Single(model.Tables);
+                    Assert.Equal("people", table.Name);
+                });
+
+        [ConditionalFact]
+        public virtual Task RenameTableOperation_schema()
+            => Execute(
+                builder => builder.Entity("People").ToTable("People", "dbo").Property<int>("Id"),
+                builder => builder.Entity("People").ToTable("People", "dbo2").Property<int>("Id"),
+                model =>
+                {
+                    var table = Assert.Single(model.Tables);
+                    Assert.Equal("dbo2", table.Schema);
+                    Assert.Equal("People", table.Name);
+                });
+
+        [ConditionalFact]
+        public virtual Task CreateIndexOperation()
+            => ExecuteIncremental(
+                builder => builder.Entity(
+                    "People", entityBuilder =>
+                    {
+                        entityBuilder.Property<int>("Id");
+                        entityBuilder.Property<string>("FirstName");
+                    }),
+                builder => builder.Entity("People").HasIndex("FirstName"),
+                model =>
+                {
+                    var table = Assert.Single(model.Tables);
+                    var index = Assert.Single(table.Indexes);
+                    Assert.Same(table, index.Table);
+                    Assert.Same(table.Columns.Single(c => c.Name == "FirstName"), Assert.Single(index.Columns));
+                    Assert.Equal("IX_People_FirstName", index.Name);
+                    Assert.False(index.IsUnique);
+                    Assert.Null(index.Filter);
+                });
+
+        [ConditionalFact]
+        public virtual Task CreateIndexOperation_unique()
+            => ExecuteIncremental(
+                builder => builder.Entity(
+                    "People", entityBuilder =>
+                    {
+                        entityBuilder.Property<int>("Id");
+                        entityBuilder.Property<string>("FirstName");
+                        entityBuilder.Property<string>("LastName");
+                    }),
+                builder => builder.Entity("People").HasIndex("FirstName", "LastName").IsUnique(),
+                model =>
+                {
+                    var table = Assert.Single(model.Tables);
+                    var index = Assert.Single(table.Indexes);
+                    Assert.True(index.IsUnique);
+                });
+
+        [ConditionalFact]
+        public virtual Task CreateIndexOperation_with_where_clauses()
+            => ExecuteIncremental(
+                builder => builder.Entity(
+                    "People", entityBuilder =>
+                    {
+                        entityBuilder.Property<int>("Id");
+                        entityBuilder.Property<int>("Age");
+                    }),
+                builder => builder.Entity("People").HasIndex("Age").HasFilter("[Age] > 18"), // TODO: Quote
+                model =>
+                {
+                    var table = Assert.Single(model.Tables);
+                    var index = Assert.Single(table.Indexes);
+                    Assert.Same(table.Columns.Single(c => c.Name == "Age"), Assert.Single(index.Columns));
+                    Assert.Equal("([Age]>(18))", index.Filter); // TODO: Assert non-null?
+                });
+
+        [ConditionalFact]
+        public virtual Task CreateSequenceOperation()
+            => Execute(
+                builder => { },
+                builder => builder.HasSequence<int>("TestSequence"),
+                model =>
+                {
+                    var sequence = Assert.Single(model.Sequences);
+                    Assert.Equal("TestSequence", sequence.Name);
+                });
+
+        [ConditionalFact]
+        public virtual Task CreateSequenceOperation_all_settings()
+            => Execute(
+                builder => { },
+                builder => builder.HasSequence<long>("TestSequence", "dbo2")
                     .StartsAt(3)
                     .IncrementsBy(2)
                     .HasMin(2)
@@ -52,6 +531,8 @@ namespace Microsoft.EntityFrameworkCore
                 model =>
                 {
                     var sequence = Assert.Single(model.Sequences);
+                    Assert.Equal("TestSequence", sequence.Name);
+                    Assert.Equal("dbo2", sequence.Schema);
                     Assert.Equal(3, sequence.StartValue);
                     Assert.Equal(2, sequence.IncrementBy);
                     Assert.Equal(2, sequence.MinValue);
@@ -60,28 +541,231 @@ namespace Microsoft.EntityFrameworkCore
                 });
 
         [ConditionalFact]
-        public virtual void DropSequenceOperation()
+        public virtual Task CreateTableOperation_all_settings()
+            => ExecuteIncremental(
+                builder => builder.Entity("Employers").Property<int>("Id"),
+                builder => builder.Entity(
+                    "People", e =>
+                    {
+                        e.ToTable("People", "dbo2");
+
+                        e.Property<int>("CustomId");
+                        e.Property<int>("EmployerId")
+                            .HasComment("Employer ID comment");
+                        e.Property<string>("SSN")
+                            .HasColumnType("char(11)") // TODO: Provider-specific type
+                            .IsRequired(false);
+
+                        e.HasKey("CustomId");
+                        e.HasAlternateKey("SSN");
+                        e.HasCheckConstraint("CK_SSN", "[SSN] > 0"); // TODO: Quote
+                        e.HasOne("Employers").WithMany("People").HasForeignKey("EmployerId");
+                    }),
+                model =>
+                {
+                    var employersTable = Assert.Single(model.Tables, t => t.Name == "Employers");
+                    var peopleTable = Assert.Single(model.Tables, t => t.Name == "People");
+
+                    Assert.Equal("People", peopleTable.Name);
+                    Assert.Equal("dbo2", peopleTable.Schema);
+
+                    Assert.Collection(
+                        peopleTable.Columns,
+                        c =>
+                        {
+                            Assert.Equal("CustomId", c.Name);
+                            Assert.False(c.IsNullable);
+                            Assert.Equal("int", c.StoreType); // TODO: Provider-specific type
+                            Assert.Null(c.Comment);
+                        },
+                        c =>
+                        {
+                            Assert.Equal("EmployerId", c.Name);
+                            Assert.False(c.IsNullable);
+                            Assert.Equal("int", c.StoreType); // TODO: Provider-specific type
+                            Assert.Equal("Employer ID comment", c.Comment);
+                        },
+                        c =>
+                        {
+                            Assert.Equal("SSN", c.Name);
+                            //Assert.True(c.IsNullable); // TODO: This fails!
+                            Assert.Equal("char(11)", c.StoreType); // TODO: Provider-specific type
+                            Assert.Null(c.Comment);
+                        });
+
+                    Assert.Same(
+                        peopleTable.Columns.Single(c => c.Name == "CustomId"),
+                        Assert.Single(peopleTable.PrimaryKey.Columns));
+                    Assert.Same(
+                        peopleTable.Columns.Single(c => c.Name == "SSN"),
+                        Assert.Single(Assert.Single(peopleTable.UniqueConstraints).Columns));
+                    // TODO: Need to scaffold check constraints, https://github.com/aspnet/EntityFrameworkCore/issues/15408
+
+                    var foreignKey = Assert.Single(peopleTable.ForeignKeys);
+                    Assert.Same(peopleTable, foreignKey.Table);
+                    Assert.Same(peopleTable.Columns.Single(c => c.Name == "EmployerId"), Assert.Single(foreignKey.Columns));
+                    Assert.Same(employersTable, foreignKey.PrincipalTable);
+                    Assert.Same(employersTable.Columns.Single(), Assert.Single(foreignKey.PrincipalColumns));
+                });
+
+        [ConditionalFact]
+        public virtual Task CreateTableOperation_no_key()
             => Execute(
-                modelBuilder => modelBuilder.HasSequence("TestSequence"),
-                modelBuilder => { },
+                builder => { },
+                builder => builder.Entity("Anonymous").Property<int>("SomeColumn"),
+                model =>
+                {
+                    var table = Assert.Single(model.Tables);
+                    Assert.Null(table.PrimaryKey);
+                });
+
+        [ConditionalFact]
+        public virtual Task DropColumnOperation()
+            => Execute(
+                builder => builder.Entity(
+                    "People", e =>
+                    {
+                        e.Property<int>("Id");
+                        e.Property<int>("SomeColumn");
+                    }),
+                builder => builder.Entity("People").Property<int>("Id"),
+                model =>
+                {
+                    var table = Assert.Single(model.Tables);
+                    Assert.Equal("Id", Assert.Single(table.Columns).Name);
+                });
+
+        [ConditionalFact]
+        public virtual Task DropForeignKeyOperation()
+            => Execute(
+                builder =>
+                {
+                    builder.Entity("Customers").Property<int>("Id");
+                    builder.Entity(
+                        "Orders", e =>
+                        {
+                            e.Property<int>("Id");
+                            e.Property<int>("CustomerId");
+                            e.HasOne("Customers").WithMany().HasForeignKey("CustomerId");
+                        });
+                },
+                builder =>
+                {
+                    builder.Entity("Customers").Property<int>("Id");
+                    builder.Entity(
+                        "Orders", e =>
+                        {
+                            e.Property<int>("Id");
+                            e.Property<int>("CustomerId");
+                        });
+                },
+                model =>
+                {
+                    var customersTable = Assert.Single(model.Tables, t => t.Name == "Customers");
+                    Assert.Empty(customersTable.ForeignKeys);
+                });
+
+        [ConditionalFact]
+        public virtual Task DropIndexOperation()
+            => Execute(
+                builder => builder.Entity(
+                    "People", e =>
+                    {
+                        e.Property<int>("Id");
+                        e.Property<int>("SomeField");
+                        e.HasIndex("SomeField");
+                    }),
+                builder => builder.Entity(
+                    "People", e =>
+                    {
+                        e.Property<int>("Id");
+                        e.Property<int>("SomeField");
+                    }),
+                model => Assert.Empty(Assert.Single(model.Tables).Indexes));
+
+        [ConditionalFact]
+        public virtual Task DropPrimaryKeyOperation()
+            => Execute(
+                builder => builder.Entity(
+                    "People", e =>
+                    {
+                        e.Property<int>("Id");
+                        e.Property<int>("SomeField");
+                    }),
+                builder => builder.Entity(
+                    "People", e =>
+                    {
+                        e.Property<int>("SomeField");
+                    }),
+                model => Assert.Null(Assert.Single(model.Tables).PrimaryKey));
+
+        [ConditionalFact]
+        public virtual Task DropSequenceOperation()
+            => Execute(
+                builder => builder.HasSequence("TestSequence"),
+                builder => { },
                 model => Assert.Empty(model.Sequences));
 
         [ConditionalFact]
-        public virtual void DropTableOperation()
+        public virtual Task DropTableOperation()
             => Execute(
-                modelBuilder => modelBuilder.Entity("People", entityBuilder => entityBuilder.Property<int>("Id")),
-                modelBuilder => { },
+                builder => builder.Entity("People", e => e.Property<int>("Id")),
+                builder => { },
                 model => Assert.Empty(model.Tables));
 
-        protected virtual void Execute(
-            Action<ModelBuilder> buildTargetAction,
-            Action<DatabaseModel> modelAsserter)
+        [ConditionalFact]
+        public virtual Task DropUniqueConstraintOperation()
             => Execute(
-                builder => { },
-                buildTargetAction,
-                modelAsserter);
+                builder => builder.Entity(
+                    "People", e =>
+                    {
+                        e.Property<int>("Id");
+                        e.Property<int>("AlternateKeyColumn");
+                        e.HasAlternateKey("AlternateKeyColumn");
+                    }),
+                builder => builder.Entity(
+                    "People", e =>
+                    {
+                        e.Property<int>("Id");
+                        e.Property<int>("AlternateKeyColumn");
+                    }),
+                model =>
+                {
+                    Assert.Empty(Assert.Single(model.Tables).UniqueConstraints);
+                });
 
-        protected virtual void ExecuteIncremental(
+        [ConditionalFact]
+        public virtual Task DropCheckConstraintOperation()
+            => Execute(
+                builder => builder.Entity(
+                    "People", e =>
+                    {
+                        e.Property<int>("Id");
+                        e.Property<int>("DriverLicense");
+                        e.HasCheckConstraint("CK_Foo", "[DriverLicense] > 0"); // TODO: Quote
+                    }),
+                builder => builder.Entity(
+                    "People", e =>
+                    {
+                        e.Property<int>("Id");
+                        e.Property<int>("DriverLicense");
+                    }),
+                model =>
+                {
+                    // TODO: no scaffolding support for check constraints, https://github.com/aspnet/EntityFrameworkCore/issues/15408
+                });
+
+        // TODO: SqlOperation
+
+        // TODO: Data tests
+
+        private class Person
+        {
+            public int Id { get; set; }
+            public string FullName { get; set; }
+        }
+
+        protected virtual Task ExecuteIncremental(
             Action<ModelBuilder> buildSourceAction,
             Action<ModelBuilder> buildTargetIncrementalAction,
             Action<DatabaseModel> modelAsserter)
@@ -94,7 +778,7 @@ namespace Microsoft.EntityFrameworkCore
                 },
                 modelAsserter);
 
-        protected virtual void Execute(
+        protected virtual async Task Execute(
             Action<ModelBuilder> buildSourceAction,
             Action<ModelBuilder> buildTargetAction,
             Action<DatabaseModel> modelAsserter)
@@ -107,29 +791,43 @@ namespace Microsoft.EntityFrameworkCore
             var connection = serviceProvider.GetRequiredService<IRelationalConnection>();
             var databaseModelFactory = serviceProvider.GetRequiredService<IDatabaseModelFactory>();
 
-            // Build the source and target models
+            // Build the source and target models. Add current/latest product version if one wasn't set.
             var sourceModelBuilder = Fixture.TestHelpers.CreateConventionBuilder(skipValidation: true);
             buildSourceAction(sourceModelBuilder);
+            if (sourceModelBuilder.Model.GetProductVersion() is null)
+            {
+                sourceModelBuilder.Model.SetProductVersion(ProductInfo.GetVersion());
+            }
             var sourceModel = sourceModelBuilder.FinalizeModel();
 
             var targetModelBuilder = Fixture.TestHelpers.CreateConventionBuilder(skipValidation: true);
             buildTargetAction(targetModelBuilder);
+            if (targetModelBuilder.Model.GetProductVersion() is null)
+            {
+                targetModelBuilder.Model.SetProductVersion(ProductInfo.GetVersion());
+            }
             var targetModel = targetModelBuilder.FinalizeModel();
-
-            // Apply migrations to get to the source state, and do a scaffolding snapshot for later comparison
-            migrationsCommandExecutor.ExecuteNonQuery(
-                migrationsSqlGenerator.Generate(modelDiffer.GetDifferences(null, sourceModel), sourceModel),
-                connection);
-            var sourceScaffoldedModel = databaseModelFactory.Create(
-                context.Database.GetDbConnection(),
-                new DatabaseModelFactoryOptions());
 
             try
             {
+                using (Fixture.TestSqlLoggerFactory.SuspendRecordingEvents())
+                {
+                    // Apply migrations to get to the source state, and do a scaffolding snapshot for later comparison
+                    await migrationsCommandExecutor.ExecuteNonQueryAsync(
+                        migrationsSqlGenerator.Generate(modelDiffer.GetDifferences(null, sourceModel), sourceModel),
+                        connection);
+                }
+
+                var sourceScaffoldedModel = databaseModelFactory.Create(
+                    context.Database.GetDbConnection(),
+                    new DatabaseModelFactoryOptions());
+
                 // Apply migrations to get from source to target
-                migrationsCommandExecutor.ExecuteNonQuery(
+                await migrationsCommandExecutor.ExecuteNonQueryAsync(
                     migrationsSqlGenerator.Generate(modelDiffer.GetDifferences(sourceModel, targetModel), targetModel),
                     connection);
+
+                using var _ = Fixture.TestSqlLoggerFactory.SuspendRecordingEvents();
 
                 // Reverse-engineer and execute the test-provided assertions on the resulting database model
                 var targetScaffoldedModel = databaseModelFactory.Create(
@@ -139,7 +837,8 @@ namespace Microsoft.EntityFrameworkCore
                 modelAsserter(targetScaffoldedModel);
 
                 // Apply reverse migrations to go back to the source state
-                migrationsCommandExecutor.ExecuteNonQuery(
+
+                await migrationsCommandExecutor.ExecuteNonQueryAsync(
                     migrationsSqlGenerator.Generate(modelDiffer.GetDifferences(targetModel, sourceModel), sourceModel),
                     connection);
 
@@ -151,7 +850,7 @@ namespace Microsoft.EntityFrameworkCore
                 //Assert.Equal(sourceScaffoldedModel, sourceScaffoldedModel2);
 
                 // Apply reverse migrations to go back to the initial empty state
-                migrationsCommandExecutor.ExecuteNonQuery(
+                await migrationsCommandExecutor.ExecuteNonQueryAsync(
                     migrationsSqlGenerator.Generate(modelDiffer.GetDifferences(sourceModel, null)),
                     connection);
 
@@ -176,6 +875,9 @@ namespace Microsoft.EntityFrameworkCore
                 throw;
             }
         }
+
+        protected virtual void AssertSql(params string[] expected)
+            => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 
         public abstract class MigrationsFixtureBase2 : SharedStoreFixtureBase<PoolableDbContext>
         {

--- a/test/EFCore.Relational.Specification.Tests/TestUtilities/TestSqlLoggerFactory.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestUtilities/TestSqlLoggerFactory.cs
@@ -119,7 +119,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                         base.UnsafeLog(logLevel, eventId, message, state, exception);
                     }
 
-                    if (message != null
+                    if (!IsRecordingSuspended
+                        && message != null
                         && eventId.Id != RelationalEventId.CommandExecuting.Id)
                     {
                         var structure = (IReadOnlyList<KeyValuePair<string, object>>)state;

--- a/test/EFCore.SqlServer.FunctionalTests/MigrationsSqlServerTest2.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/MigrationsSqlServerTest2.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Scaffolding;
+using Microsoft.EntityFrameworkCore.SqlServer.Scaffolding.Internal;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public class MigrationsSqlServerTest2 : MigrationsTestBase2<MigrationsSqlServerTest2.MigrationsSqlServerFixture2>
+    {
+        public MigrationsSqlServerTest2(MigrationsSqlServerFixture2 fixture, ITestOutputHelper testOutputHelper)
+            : base(fixture)
+        {
+            Fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+        }
+
+        public class MigrationsSqlServerFixture2 : MigrationsFixtureBase2
+        {
+            protected override string StoreName { get; } = nameof(MigrationsSqlServerTest2);
+            protected override ITestStoreFactory TestStoreFactory => SqlServerTestStoreFactory.Instance;
+            public override TestHelpers TestHelpers => SqlServerTestHelpers.Instance;
+
+            protected override IServiceCollection AddServices(IServiceCollection serviceCollection)
+                => base.AddServices(serviceCollection)
+                    .AddScoped<IDatabaseModelFactory, SqlServerDatabaseModelFactory>();
+        }
+    }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/MigrationsSqlServerTest2.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/MigrationsSqlServerTest2.cs
@@ -1,10 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Scaffolding;
 using Microsoft.EntityFrameworkCore.SqlServer.Scaffolding.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore
@@ -17,6 +20,444 @@ namespace Microsoft.EntityFrameworkCore
             Fixture.TestSqlLoggerFactory.Clear();
             Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
+
+        public override async Task CreateIndexOperation_with_filter_where_clause()
+        {
+            await base.CreateIndexOperation_with_filter_where_clause();
+
+            AssertSql(
+                @"DECLARE @var0 sysname;
+SELECT @var0 = [d].[name]
+FROM [sys].[default_constraints] [d]
+INNER JOIN [sys].[columns] [c] ON [d].[parent_column_id] = [c].[column_id] AND [d].[parent_object_id] = [c].[object_id]
+WHERE ([d].[parent_object_id] = OBJECT_ID(N'[People]') AND [c].[name] = N'Name');
+IF @var0 IS NOT NULL EXEC(N'ALTER TABLE [People] DROP CONSTRAINT [' + @var0 + '];');
+ALTER TABLE [People] ALTER COLUMN [Name] nvarchar(450) NULL;",
+                //
+                @"CREATE INDEX [IX_People_Name] ON [People] ([Name]) WHERE [Name] IS NOT NULL;");
+        }
+
+        public override async Task CreateIndexOperation_with_filter_where_clause_and_is_unique()
+        {
+            await base.CreateIndexOperation_with_filter_where_clause_and_is_unique();
+
+            AssertSql(
+                @"DECLARE @var0 sysname;
+SELECT @var0 = [d].[name]
+FROM [sys].[default_constraints] [d]
+INNER JOIN [sys].[columns] [c] ON [d].[parent_column_id] = [c].[column_id] AND [d].[parent_object_id] = [c].[object_id]
+WHERE ([d].[parent_object_id] = OBJECT_ID(N'[People]') AND [c].[name] = N'Name');
+IF @var0 IS NOT NULL EXEC(N'ALTER TABLE [People] DROP CONSTRAINT [' + @var0 + '];');
+ALTER TABLE [People] ALTER COLUMN [Name] nvarchar(450) NULL;",
+                //
+                @"CREATE UNIQUE INDEX [IX_People_Name] ON [People] ([Name]) WHERE [Name] IS NOT NULL AND [Name] <> '';");
+        }
+
+        public override async Task AddColumnOperation_with_defaultValue()
+        {
+            await base.AddColumnOperation_with_defaultValue();
+
+            AssertSql(
+                @"ALTER TABLE [People] ADD [Name] nvarchar(max) NOT NULL DEFAULT N'John Doe';");
+        }
+
+        public override async Task AddColumnOperation_with_defaultValueSql()
+        {
+            await base.AddColumnOperation_with_defaultValueSql();
+
+            AssertSql(
+                @"ALTER TABLE [People] ADD [Birthday] date NULL DEFAULT (CURRENT_TIMESTAMP);");
+        }
+
+        public override async Task AddColumnOperation_without_column_type()
+        {
+            await base.AddColumnOperation_without_column_type();
+
+            AssertSql(
+                @"ALTER TABLE [People] ADD [Name] nvarchar(max) NOT NULL DEFAULT N'';");
+        }
+
+        public override async Task AddColumnOperation_with_ansi()
+        {
+            await base.AddColumnOperation_with_ansi();
+
+            AssertSql(
+                @"ALTER TABLE [People] ADD [Name] varchar(max) NULL;");
+        }
+
+        // TODO: AddColumnOperation_with_unicode_overridden. In which scenarios do we need to do this?
+
+        // TODO: AddColumnOperation_with_unicode_no_model. In which scenarios do we need to do this?
+
+        public override async Task AddColumnOperation_with_fixed_length()
+        {
+            await base.AddColumnOperation_with_fixed_length();
+
+            AssertSql(
+                @"ALTER TABLE [People] ADD [Name] nvarchar(max) NULL;");
+        }
+
+        // TODO: AddColumnOperation_with_fixed_length_no_model
+
+        public override async Task AddColumnOperation_with_maxLength()
+        {
+            await base.AddColumnOperation_with_maxLength();
+
+            AssertSql(
+                @"ALTER TABLE [People] ADD [Name] nvarchar(30) NULL;");
+        }
+
+        public override async Task AddColumnOperation_with_maxLength_on_derived()
+        {
+            await base.AddColumnOperation_with_maxLength_on_derived();
+
+            Assert.Empty(Fixture.TestSqlLoggerFactory.SqlStatements);
+        }
+
+        public override async Task AddColumnOperation_with_shared_column()
+        {
+            await base.AddColumnOperation_with_shared_column();
+
+            AssertSql(
+                @"ALTER TABLE [Base] ADD [Foo] nvarchar(max) NULL;");
+        }
+
+        public override async Task AddForeignKeyOperation()
+        {
+            await base.AddForeignKeyOperation();
+
+            AssertSql(
+                @"CREATE INDEX [IX_Orders_CustomerId] ON [Orders] ([CustomerId]);",
+                //
+                @"ALTER TABLE [Orders] ADD CONSTRAINT [FK_Orders_Customers_CustomerId] FOREIGN KEY ([CustomerId]) REFERENCES [Customers] ([Id]) ON DELETE CASCADE;");
+        }
+
+        public override async Task AddForeignKeyOperation_with_name()
+        {
+            await base.AddForeignKeyOperation_with_name();
+
+            AssertSql(
+                @"CREATE INDEX [IX_Orders_CustomerId] ON [Orders] ([CustomerId]);",
+                //
+                @"ALTER TABLE [Orders] ADD CONSTRAINT [FK_Foo] FOREIGN KEY ([CustomerId]) REFERENCES [Customers] ([Id]) ON DELETE CASCADE;");
+        }
+
+        // TODO: AddForeignKeyOperation_without_principal_columns, how to generate the scenario via model diffing
+
+        public override async Task AddPrimaryKeyOperation()
+        {
+            await base.AddPrimaryKeyOperation();
+
+            AssertSql(
+                @"DECLARE @var0 sysname;
+SELECT @var0 = [d].[name]
+FROM [sys].[default_constraints] [d]
+INNER JOIN [sys].[columns] [c] ON [d].[parent_column_id] = [c].[column_id] AND [d].[parent_object_id] = [c].[object_id]
+WHERE ([d].[parent_object_id] = OBJECT_ID(N'[People]') AND [c].[name] = N'SomeField');
+IF @var0 IS NOT NULL EXEC(N'ALTER TABLE [People] DROP CONSTRAINT [' + @var0 + '];');
+ALTER TABLE [People] ALTER COLUMN [SomeField] nvarchar(450) NOT NULL;",
+                //
+                @"ALTER TABLE [People] ADD CONSTRAINT [PK_People] PRIMARY KEY ([SomeField]);");
+        }
+
+        public override async Task AddPrimaryKeyOperation_composite_with_name()
+        {
+            await base.AddPrimaryKeyOperation_composite_with_name();
+
+            AssertSql(
+                @"DECLARE @var0 sysname;
+SELECT @var0 = [d].[name]
+FROM [sys].[default_constraints] [d]
+INNER JOIN [sys].[columns] [c] ON [d].[parent_column_id] = [c].[column_id] AND [d].[parent_object_id] = [c].[object_id]
+WHERE ([d].[parent_object_id] = OBJECT_ID(N'[People]') AND [c].[name] = N'SomeField2');
+IF @var0 IS NOT NULL EXEC(N'ALTER TABLE [People] DROP CONSTRAINT [' + @var0 + '];');
+ALTER TABLE [People] ALTER COLUMN [SomeField2] nvarchar(450) NOT NULL;",
+                //
+                @"DECLARE @var1 sysname;
+SELECT @var1 = [d].[name]
+FROM [sys].[default_constraints] [d]
+INNER JOIN [sys].[columns] [c] ON [d].[parent_column_id] = [c].[column_id] AND [d].[parent_object_id] = [c].[object_id]
+WHERE ([d].[parent_object_id] = OBJECT_ID(N'[People]') AND [c].[name] = N'SomeField1');
+IF @var1 IS NOT NULL EXEC(N'ALTER TABLE [People] DROP CONSTRAINT [' + @var1 + '];');
+ALTER TABLE [People] ALTER COLUMN [SomeField1] nvarchar(450) NOT NULL;",
+                //
+                @"ALTER TABLE [People] ADD CONSTRAINT [PK_Foo] PRIMARY KEY ([SomeField1], [SomeField2]);");
+        }
+
+        public override async Task AddUniqueConstraintOperation()
+        {
+            await base.AddUniqueConstraintOperation();
+
+            AssertSql(
+                @"ALTER TABLE [People] ADD CONSTRAINT [AK_People_AlternateKeyColumn] UNIQUE ([AlternateKeyColumn]);");
+        }
+
+        public override async Task AddUniqueConstraintOperation_composite_with_name()
+        {
+            await base.AddUniqueConstraintOperation_composite_with_name();
+
+            AssertSql(
+                @"ALTER TABLE [People] ADD CONSTRAINT [AK_Foo] UNIQUE ([AlternateKeyColumn1], [AlternateKeyColumn2]);");
+        }
+
+        public override async Task CreateCheckConstraintOperation_with_name()
+        {
+            await base.CreateCheckConstraintOperation_with_name();
+
+            AssertSql(
+                @"ALTER TABLE [People] ADD CONSTRAINT [CK_Foo] CHECK ([DriverLicense] > 0);");
+        }
+
+        public override async Task AlterColumnOperation_name()
+        {
+            await base.AlterColumnOperation_name();
+
+            AssertSql(
+                @"EXEC sp_rename N'[People].[SomeColumn]', N'somecolumn', N'COLUMN';");
+        }
+
+        public override async Task AlterColumnOperation_type()
+        {
+            await base.AlterColumnOperation_type();
+
+            AssertSql(
+                @"DECLARE @var0 sysname;
+SELECT @var0 = [d].[name]
+FROM [sys].[default_constraints] [d]
+INNER JOIN [sys].[columns] [c] ON [d].[parent_column_id] = [c].[column_id] AND [d].[parent_object_id] = [c].[object_id]
+WHERE ([d].[parent_object_id] = OBJECT_ID(N'[People]') AND [c].[name] = N'SomeColumn');
+IF @var0 IS NOT NULL EXEC(N'ALTER TABLE [People] DROP CONSTRAINT [' + @var0 + '];');
+ALTER TABLE [People] ALTER COLUMN [SomeColumn] bigint NOT NULL;");
+        }
+
+        public override async Task AlterColumnOperation_required()
+        {
+            await base.AlterColumnOperation_required();
+
+            AssertSql(
+                @"DECLARE @var0 sysname;
+SELECT @var0 = [d].[name]
+FROM [sys].[default_constraints] [d]
+INNER JOIN [sys].[columns] [c] ON [d].[parent_column_id] = [c].[column_id] AND [d].[parent_object_id] = [c].[object_id]
+WHERE ([d].[parent_object_id] = OBJECT_ID(N'[People]') AND [c].[name] = N'SomeColumn');
+IF @var0 IS NOT NULL EXEC(N'ALTER TABLE [People] DROP CONSTRAINT [' + @var0 + '];');
+ALTER TABLE [People] ALTER COLUMN [SomeColumn] nvarchar(max) NOT NULL;");
+        }
+
+        public override async Task AlterSequenceOperation_all_settings()
+        {
+            await base.AlterSequenceOperation_all_settings();
+
+            AssertSql(
+                @"ALTER SEQUENCE [foo] INCREMENT BY 2 MINVALUE -5 MAXVALUE 10 CYCLE;",
+                //
+                @"ALTER SEQUENCE [foo] RESTART WITH -3;");
+        }
+
+        public override async Task AlterSequenceOperation_increment_by()
+        {
+            await base.AlterSequenceOperation_increment_by();
+
+            AssertSql(
+                @"ALTER SEQUENCE [foo] INCREMENT BY 2 NO MINVALUE NO MAXVALUE NO CYCLE;");
+        }
+
+        public override async Task RenameTableOperation()
+        {
+            await base.RenameTableOperation();
+
+            AssertSql(
+                @"ALTER TABLE [People] DROP CONSTRAINT [PK_People];",
+                //
+                @"EXEC sp_rename N'[People]', N'people';",
+                //
+                @"ALTER TABLE [people] ADD CONSTRAINT [PK_people] PRIMARY KEY ([Id]);");
+        }
+
+        public override async Task RenameTableOperation_schema()
+        {
+            await base.RenameTableOperation_schema();
+
+            AssertSql(
+                @"IF SCHEMA_ID(N'dbo2') IS NULL EXEC(N'CREATE SCHEMA [dbo2];');",
+                //
+                @"ALTER SCHEMA [dbo2] TRANSFER [dbo].[People];");
+        }
+
+        // TODO: RenameTableOperation_legacy
+
+        public override async Task CreateIndexOperation()
+        {
+            await base.CreateIndexOperation();
+
+            AssertSql(
+                @"DECLARE @var0 sysname;
+SELECT @var0 = [d].[name]
+FROM [sys].[default_constraints] [d]
+INNER JOIN [sys].[columns] [c] ON [d].[parent_column_id] = [c].[column_id] AND [d].[parent_object_id] = [c].[object_id]
+WHERE ([d].[parent_object_id] = OBJECT_ID(N'[People]') AND [c].[name] = N'FirstName');
+IF @var0 IS NOT NULL EXEC(N'ALTER TABLE [People] DROP CONSTRAINT [' + @var0 + '];');
+ALTER TABLE [People] ALTER COLUMN [FirstName] nvarchar(450) NULL;",
+                //
+                @"CREATE INDEX [IX_People_FirstName] ON [People] ([FirstName]);");
+        }
+
+        public override async Task CreateIndexOperation_unique()
+        {
+            await base.CreateIndexOperation_unique();
+
+            AssertSql(
+                @"DECLARE @var0 sysname;
+SELECT @var0 = [d].[name]
+FROM [sys].[default_constraints] [d]
+INNER JOIN [sys].[columns] [c] ON [d].[parent_column_id] = [c].[column_id] AND [d].[parent_object_id] = [c].[object_id]
+WHERE ([d].[parent_object_id] = OBJECT_ID(N'[People]') AND [c].[name] = N'LastName');
+IF @var0 IS NOT NULL EXEC(N'ALTER TABLE [People] DROP CONSTRAINT [' + @var0 + '];');
+ALTER TABLE [People] ALTER COLUMN [LastName] nvarchar(450) NULL;",
+                //
+                @"DECLARE @var1 sysname;
+SELECT @var1 = [d].[name]
+FROM [sys].[default_constraints] [d]
+INNER JOIN [sys].[columns] [c] ON [d].[parent_column_id] = [c].[column_id] AND [d].[parent_object_id] = [c].[object_id]
+WHERE ([d].[parent_object_id] = OBJECT_ID(N'[People]') AND [c].[name] = N'FirstName');
+IF @var1 IS NOT NULL EXEC(N'ALTER TABLE [People] DROP CONSTRAINT [' + @var1 + '];');
+ALTER TABLE [People] ALTER COLUMN [FirstName] nvarchar(450) NULL;",
+                //
+                @"CREATE UNIQUE INDEX [IX_People_FirstName_LastName] ON [People] ([FirstName], [LastName]) WHERE [FirstName] IS NOT NULL AND [LastName] IS NOT NULL;");
+        }
+
+        public override async Task CreateIndexOperation_with_where_clauses()
+        {
+            await base.CreateIndexOperation_with_where_clauses();
+
+            AssertSql(
+                @"CREATE INDEX [IX_People_Age] ON [People] ([Age]) WHERE [Age] > 18;");
+        }
+
+        public override async Task CreateSequenceOperation_all_settings()
+        {
+            await base.CreateSequenceOperation_all_settings();
+
+            AssertSql(
+                @"IF SCHEMA_ID(N'dbo2') IS NULL EXEC(N'CREATE SCHEMA [dbo2];');",
+                //
+                @"CREATE SEQUENCE [dbo2].[TestSequence] START WITH 3 INCREMENT BY 2 MINVALUE 2 MAXVALUE 916 CYCLE;");
+        }
+
+        public override async Task CreateTableOperation_all_settings()
+        {
+            await base.CreateTableOperation_all_settings();
+
+            AssertSql(
+                @"IF SCHEMA_ID(N'dbo2') IS NULL EXEC(N'CREATE SCHEMA [dbo2];');",
+                //
+                @"CREATE TABLE [dbo2].[People] (
+    [CustomId] int NOT NULL IDENTITY,
+    [EmployerId] int NOT NULL,
+    [SSN] char(11) NOT NULL,
+    CONSTRAINT [PK_People] PRIMARY KEY ([CustomId]),
+    CONSTRAINT [AK_People_SSN] UNIQUE ([SSN]),
+    CONSTRAINT [CK_SSN] CHECK ([SSN] > 0),
+    CONSTRAINT [FK_People_Employers_EmployerId] FOREIGN KEY ([EmployerId]) REFERENCES [Employers] ([Id]) ON DELETE CASCADE
+);
+EXEC sp_addextendedproperty 'MS_Description', N'Employer ID comment', 'SCHEMA', N'dbo2', 'TABLE', N'People', 'COLUMN', N'EmployerId';",
+                //
+                @"CREATE INDEX [IX_People_EmployerId] ON [dbo2].[People] ([EmployerId]);");
+        }
+
+        public override async Task CreateTableOperation_no_key()
+        {
+            await base.CreateTableOperation_no_key();
+
+            AssertSql(
+                @"CREATE TABLE [Anonymous] (
+    [SomeColumn] int NOT NULL
+);");
+        }
+
+        public override async Task DropColumnOperation()
+        {
+            await base.DropColumnOperation();
+
+            AssertSql(
+                @"DECLARE @var0 sysname;
+SELECT @var0 = [d].[name]
+FROM [sys].[default_constraints] [d]
+INNER JOIN [sys].[columns] [c] ON [d].[parent_column_id] = [c].[column_id] AND [d].[parent_object_id] = [c].[object_id]
+WHERE ([d].[parent_object_id] = OBJECT_ID(N'[People]') AND [c].[name] = N'SomeColumn');
+IF @var0 IS NOT NULL EXEC(N'ALTER TABLE [People] DROP CONSTRAINT [' + @var0 + '];');
+ALTER TABLE [People] DROP COLUMN [SomeColumn];");
+        }
+
+        public override async Task DropForeignKeyOperation()
+        {
+            await base.DropForeignKeyOperation();
+
+            AssertSql(
+                @"ALTER TABLE [Orders] DROP CONSTRAINT [FK_Orders_Customers_CustomerId];",
+                //
+                @"DROP INDEX [IX_Orders_CustomerId] ON [Orders];");
+        }
+
+        public override async Task DropIndexOperation()
+        {
+            await base.DropIndexOperation();
+
+            AssertSql(
+                @"DROP INDEX [IX_People_SomeField] ON [People];");
+        }
+
+        public override async Task DropPrimaryKeyOperation()
+        {
+            await base.DropPrimaryKeyOperation();
+
+            AssertSql(
+                @"ALTER TABLE [People] DROP CONSTRAINT [PK_People];",
+                //
+                @"DECLARE @var0 sysname;
+SELECT @var0 = [d].[name]
+FROM [sys].[default_constraints] [d]
+INNER JOIN [sys].[columns] [c] ON [d].[parent_column_id] = [c].[column_id] AND [d].[parent_object_id] = [c].[object_id]
+WHERE ([d].[parent_object_id] = OBJECT_ID(N'[People]') AND [c].[name] = N'Id');
+IF @var0 IS NOT NULL EXEC(N'ALTER TABLE [People] DROP CONSTRAINT [' + @var0 + '];');
+ALTER TABLE [People] DROP COLUMN [Id];");
+        }
+
+        public override async Task DropSequenceOperation()
+        {
+            await base.DropSequenceOperation();
+
+            AssertSql(
+                @"DROP SEQUENCE [TestSequence];");
+        }
+
+        public override async Task DropTableOperation()
+        {
+            await base.DropTableOperation();
+
+            AssertSql(
+                @"DROP TABLE [People];");
+        }
+
+        public override async Task DropUniqueConstraintOperation()
+        {
+            await base.DropUniqueConstraintOperation();
+
+            AssertSql(
+                @"ALTER TABLE [People] DROP CONSTRAINT [AK_People_AlternateKeyColumn];");
+        }
+
+        public override async Task DropCheckConstraintOperation()
+        {
+            await base.DropCheckConstraintOperation();
+
+            AssertSql(
+                @"ALTER TABLE [People] DROP CONSTRAINT [CK_Foo];");
+        }
+
+        // TODO: SqlOperation
+
+        // TODO: Data tests
 
         public class MigrationsSqlServerFixture2 : MigrationsFixtureBase2
         {


### PR DESCRIPTION
This is a total draft on #19039 (migration tests which work on the database) to get feedback on the general approach before investing more time. It works as follows:

1. The test provides a source and target model (much like the model differ tests)
2. We migrate to the source, and scaffold a "snapshot"
3. We then migrate to the target, and scaffold another snapshot - and execute the test-provided asserter against it
4. We then migrate back down to the source, snapshot again and compare with the initial snapshot. If they aren't equal, that means that the up and down migrations aren't symmetrical
5. We finally migrate back down to an empty database, scaffold and make sure it's empty
6. If any exception was thrown, we clean the database.

The target model can also be specified as an incremental addition over the source model, to avoid repetition in case we're just adding stuff on top.

Notes:

* All these operations are always executed against the same database, which is shared between all tests. This should hopefully mean the tests run quickly (it's very similar to the existing SqlServerDatabaseModelFactoryTest in that sense).
* Do we think it's interesting enough to do SQL assertions? Assuming the scaffolded model corresponds exactly to what we're looking, I'm not sure asserting on DDL has much additional value...

If people like this, I'll convert all the existing migration tests to this new framework.