### PR TITLE
Use Cosmos emulator instead of Azure instance

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,6 +57,22 @@ stages:
                 - _DotNetPublishToBlobFeed: true
                 - _InternalBuildArgs: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName) /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1) /p:DotNetPublishBlobFeedUrl=$(_PublishBlobFeedUrl) /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed) /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines) /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory) /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
             steps:
+              - task: Cache@2
+                inputs:
+                  key: 'ConstantCosmosMsiKey'
+                  path: cosmosdb-emulator-cache-dir
+                  cacheHitVar: CACHE_RESTORED
+                displayName: Cache Cosmos Emulator MSI
+              - powershell: mkdir cosmosdb-emulator-cache-dir; Invoke-WebRequest https://aka.ms/cosmosdb-emulator -outfile cosmosdb-emulator-cache-dir\cosmosdb-emulator.msi
+                condition: ne(variables.CACHE_RESTORED, 'true')
+                displayName: Download CosmosDB Emulator
+              - powershell: msiexec /i cosmosdb-emulator-cache-dir\cosmosdb-emulator.msi /qn /quiet /norestart /log install.log
+                displayName: Install CosmosDB Emulator
+              - powershell: |
+                  Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
+                  Start-CosmosDbEmulator
+                displayName: Start CosmosDB Emulator
+
               - task: NuGetCommand@2
                 displayName: 'Clear NuGet caches'
                 condition: succeeded()
@@ -125,20 +141,9 @@ stages:
               - bash: sudo apt-get install -y libsqlite3-mod-spatialite
                 displayName: Install SpatiaLite
                 continueOnError: true
-              - bash: |
-                    echo "##vso[task.setvariable variable=_CosmosConnectionUrl]https://ef-nightly-test.documents.azure.com:443/"
-                    echo "##vso[task.setvariable variable=_CosmosToken]$(ef-nightly-cosmos-key)"
-                displayName: Prepare to run Cosmos tests on ef-nightly-test
-                condition: and(eq(variables['_CosmosConnectionUrl'], 'true'), or(endsWith(variables['_runCounter'], '0'), endsWith(variables['_runCounter'], '2'), endsWith(variables['_runCounter'], '4'), endsWith(variables['_runCounter'], '6'), endsWith(variables['_runCounter'], '8')))
-              - bash: |
-                    echo "##vso[task.setvariable variable=_CosmosConnectionUrl]https://ef-pr-test.documents.azure.com:443/"
-                    echo "##vso[task.setvariable variable=_CosmosToken]$(ef-pr-cosmos-test)"
-                displayName: Prepare to run Cosmos tests on ef-pr-test
-                condition: and(eq(variables['_CosmosConnectionUrl'], 'true'), or(endsWith(variables['_runCounter'], '1'), endsWith(variables['_runCounter'], '3'), endsWith(variables['_runCounter'], '5'), endsWith(variables['_runCounter'], '7'), endsWith(variables['_runCounter'], '9')))
               - script: eng/common/cibuild.sh --configuration $(_BuildConfig) --prepareMachine
                 env:
                   Test__Cosmos__DefaultConnection: $(_CosmosConnectionUrl)
-                  Test__Cosmos__AuthToken: $(_CosmosToken)
                 name: Build
               - task: PublishBuildArtifacts@1
                 displayName: Upload TestResults


### PR DESCRIPTION
* Windows job downloads and sets up a local Cosmos emulator, and tests against it.
* Linux job no longer runs tests against our Azure instance.