### PR TITLE
#5783 - Casting with as causing exceptions

### DIFF
--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -666,6 +666,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     return _sqlExpressionFactory.Negate(sqlOperand);
 
                 case ExpressionType.Convert:
+                case ExpressionType.TypeAs:
                     // Object convert needs to be converted to explicit cast when mismatching types
                     if (operand.Type.IsInterface
                         && unaryExpression.Type.GetInterfaces().Any(e => e == operand.Type)

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -5587,5 +5587,34 @@ namespace Microsoft.EntityFrameworkCore.Query
                           OneToMany_Required2 = l2 == null ? null : l2.OneToMany_Required2
                       });
         }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Sum_with_selector_cast_using_as(bool async)
+        {
+            return AssertSum(
+                async,
+                ss => ss.Set<Level1>().Select(s => s.Id as int?));
+        }
+
+        [ConditionalTheory(Skip = "Issue#12657")]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Sum_with_filter_with_include_selector_cast_using_as(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Level1>().Where(l1 => l1.Id > l1.OneToMany_Optional1.Select(l2 => l2.Id as int?).Sum()));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Select_with_joined_where_clause_cast_using_as(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Level1>().Where(w => w.Id == w.OneToOne_Optional_FK1.Id as int?),
+                ss => ss.Set<Level1>()
+                    .Where(w => w.Id == (MaybeScalar<int>(w.OneToOne_Optional_FK1, () => w.OneToOne_Optional_FK1.Id) as int?)));
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -4328,6 +4328,41 @@ WHERE [l].[Name] IN (N'L1 01', N'L1 02')
 ORDER BY [l].[Id], [l1].[Id]");
         }
 
+        public override async Task Sum_with_selector_cast_using_as(bool async)
+        {
+            await base.Sum_with_selector_cast_using_as(async);
+
+            AssertSql(
+                @"SELECT SUM([l].[Id])
+FROM [LevelOne] AS [l]");
+        }
+
+        public override async Task Sum_with_filter_with_include_selector_cast_using_as(bool async)
+        {
+            await base.Sum_with_filter_with_include_selector_cast_using_as(async);
+
+            AssertSql(
+                @"SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id]
+FROM [LevelOne] AS [l]
+LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]
+WHERE [l].[Id] > (
+    SELECT SUM([l1].[Id])
+    FROM [LevelTwo] AS [l1]
+    WHERE [l].[Id] = [l1].[OneToMany_Optional_Inverse2Id])
+ORDER BY [l].[Id], [l0].[Id]");
+        }
+
+        public override async Task Select_with_joined_where_clause_cast_using_as(bool async)
+        {
+            await base.Select_with_joined_where_clause_cast_using_as(async);
+
+            AssertSql(
+                @"SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
+FROM [LevelOne] AS [l]
+LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
+WHERE [l].[Id] = [l0].[Id]");
+        }
+
         private void AssertSql(params string[] expected) => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }
 }


### PR DESCRIPTION
Minor code change to fix translation of `x.Foo as Bar`. 

There were 2 different exceptions here - either KeyNotFound when the **as** was inside an aggregate like **Sum**, or a ClientEvaluation when the **as** as inside a a **Where** clause. With tests covering both of these, the 3'rd test covers the exact repro that was reported in issue #5783