### PR TITLE
Add Github Actions Cosmos testing

### DIFF
--- a/.github/workflows/TestCosmos.yaml
+++ b/.github/workflows/TestCosmos.yaml
@@ -1,0 +1,26 @@
+name: Test Cosmos
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Start Cosmos Emulator
+        run: |
+          Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
+          Start-CosmosDbEmulator
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Restore
+        run: restore.cmd
+        shell: cmd
+
+      - name: Test on Cosmos
+        run: .dotnet\dotnet test test\EFCore.Cosmos.FunctionalTests


### PR DESCRIPTION
Leaving the existing testing against a real Azure Cosmos instance for now, although we're happy with GA we could disable that and save some money.