### PR TITLE
Query: Translate Contains only when it is a server-side list

### DIFF
--- a/src/EFCore.Relational/Query/Internal/ContainsTranslator.cs
+++ b/src/EFCore.Relational/Query/Internal/ContainsTranslator.cs
@@ -26,7 +26,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             Check.NotNull(arguments, nameof(arguments));
 
             if (method.IsGenericMethod
-                && method.GetGenericMethodDefinition().Equals(EnumerableMethods.Contains))
+                && method.GetGenericMethodDefinition().Equals(EnumerableMethods.Contains)
+                && ValidateValues(arguments[0]))
             {
                 return _sqlExpressionFactory.In(arguments[1], arguments[0], negated: false);
             }
@@ -36,12 +37,16 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 && method.DeclaringType.GetInterfaces().Append(method.DeclaringType).Any(
                     t => t == typeof(IList)
                         || (t.IsGenericType
-                            && t.GetGenericTypeDefinition() == typeof(ICollection<>))))
+                            && t.GetGenericTypeDefinition() == typeof(ICollection<>)))
+                && ValidateValues(instance))
             {
                 return _sqlExpressionFactory.In(arguments[0], instance, negated: false);
             }
 
             return null;
         }
+
+        private bool ValidateValues(SqlExpression values)
+            => values is SqlConstantExpression || values is SqlParameterExpression;
     }
 }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
@@ -1273,7 +1273,7 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
-        [ConditionalFact(Skip = "Issue#17246 (Contains not implemented)")]
+        [ConditionalFact(Skip = "Issue#17246 (Contains over subquery is not supported)")]
         public override void Contains_over_entityType_should_rewrite_to_identity_equality()
         {
             base.Contains_over_entityType_should_rewrite_to_identity_equality();
@@ -1284,7 +1284,7 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = 10248))");
         }
 
-        [ConditionalTheory(Skip = "Issue#17246 (Contains not implemented)")]
+        [ConditionalTheory(Skip = "Issue#17246 (Contains over subquery is not supported)")]
         public override async Task List_Contains_over_entityType_should_rewrite_to_identity_equality(bool async)
         {
             await base.List_Contains_over_entityType_should_rewrite_to_identity_equality(async);
@@ -1295,7 +1295,6 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = 10248))");
         }
 
-        [ConditionalTheory(Skip = "Issue#17246 (Contains not implemented)")]
         public override async Task List_Contains_with_constant_list(bool async)
         {
             await base.List_Contains_with_constant_list(async);
@@ -1303,10 +1302,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = 10248))");
             AssertSql(
                 @"SELECT c
 FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = 10248))");
+WHERE ((c[""Discriminator""] = ""Customer"") AND c[""CustomerID""] IN (""ALFKI"", ""ANATR""))");
         }
 
-        [ConditionalTheory(Skip = "Issue#17246 (Contains not implemented)")]
         public override async Task List_Contains_with_parameter_list(bool async)
         {
             await base.List_Contains_with_parameter_list(async);
@@ -1314,10 +1312,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = 10248))");
             AssertSql(
                 @"SELECT c
 FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = 10248))");
+WHERE ((c[""Discriminator""] = ""Customer"") AND c[""CustomerID""] IN (""ALFKI"", ""ANATR""))");
         }
 
-        [ConditionalTheory(Skip = "Issue#17246 (Contains not implemented)")]
         public override async Task Contains_with_parameter_list_value_type_id(bool async)
         {
             await base.Contains_with_parameter_list_value_type_id(async);
@@ -1325,10 +1322,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = 10248))");
             AssertSql(
                 @"SELECT c
 FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = 10248))");
+WHERE ((c[""Discriminator""] = ""Order"") AND c[""OrderID""] IN (10248, 10249))");
         }
 
-        [ConditionalTheory(Skip = "Issue#17246 (Contains not implemented)")]
         public override async Task Contains_with_constant_list_value_type_id(bool async)
         {
             await base.Contains_with_constant_list_value_type_id(async);
@@ -1336,10 +1332,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = 10248))");
             AssertSql(
                 @"SELECT c
 FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = 10248))");
+WHERE ((c[""Discriminator""] = ""Order"") AND c[""OrderID""] IN (10248, 10249))");
         }
 
-        [ConditionalTheory(Skip = "Issue#17246 (Contains not implemented)")]
         public override async Task HashSet_Contains_with_parameter(bool async)
         {
             await base.HashSet_Contains_with_parameter(async);
@@ -1347,10 +1342,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = 10248))");
             AssertSql(
                 @"SELECT c
 FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = 10248))");
+WHERE ((c[""Discriminator""] = ""Customer"") AND c[""CustomerID""] IN (""ALFKI""))");
         }
 
-        [ConditionalTheory(Skip = "Issue#17246 (Contains not implemented)")]
         public override async Task ImmutableHashSet_Contains_with_parameter(bool async)
         {
             await base.ImmutableHashSet_Contains_with_parameter(async);
@@ -1358,10 +1352,10 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = 10248))");
             AssertSql(
                 @"SELECT c
 FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = 10248))");
+WHERE ((c[""Discriminator""] = ""Customer"") AND c[""CustomerID""] IN (""ALFKI""))");
         }
 
-        [ConditionalFact(Skip = "Issue#17246 (Contains not implemented)")]
+        [ConditionalFact(Skip = "Issue#17246 (Contains over subquery is not supported)")]
         public override void Contains_over_entityType_with_null_should_rewrite_to_identity_equality()
         {
             base.Contains_over_entityType_with_null_should_rewrite_to_identity_equality();
@@ -1370,17 +1364,6 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = 10248))");
                 @"SELECT c
 FROM root c
 WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = 10248))");
-        }
-
-        [ConditionalFact(Skip = "Issue #17246")]
-        public override void Contains_over_entityType_should_materialize_when_composite()
-        {
-            base.Contains_over_entityType_should_materialize_when_composite();
-
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""OrderDetail"") AND ((c[""OrderID""] = 10248) AND (c[""ProductID""] = 42)))");
         }
 
         public override async Task String_FirstOrDefault_in_projection_does_client_eval(bool async)

--- a/test/EFCore.InMemory.FunctionalTests/CustomConvertersInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/CustomConvertersInMemoryTest.cs
@@ -32,9 +32,15 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact(Skip = "Issue#17050")]
-        public override void Collection_property_as_scalar()
+        public override void Collection_property_as_scalar_Any()
         {
-            base.Collection_property_as_scalar();
+            base.Collection_property_as_scalar_Any();
+        }
+
+        [ConditionalFact(Skip = "Issue#17050")]
+        public override void Collection_enum_as_string_Contains()
+        {
+            base.Collection_enum_as_string_Contains();
         }
 
         public class CustomConvertersInMemoryFixture : CustomConvertersFixtureBase

--- a/test/EFCore.SqlServer.FunctionalTests/CustomConvertersSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/CustomConvertersSqlServerTest.cs
@@ -148,6 +148,8 @@ BuiltInNullableDataTypesShadow.TestNullableUnsignedInt16 ---> [nullable int] [Pr
 BuiltInNullableDataTypesShadow.TestNullableUnsignedInt32 ---> [nullable bigint] [Precision = 19 Scale = 0]
 BuiltInNullableDataTypesShadow.TestNullableUnsignedInt64 ---> [nullable decimal] [Precision = 20 Scale = 0]
 BuiltInNullableDataTypesShadow.TestString ---> [nullable nvarchar] [MaxLength = -1]
+CollectionEnum.Id ---> [int] [Precision = 10 Scale = 0]
+CollectionEnum.Roles ---> [nullable nvarchar] [MaxLength = -1]
 CollectionScalar.Id ---> [int] [Precision = 10 Scale = 0]
 CollectionScalar.Tags ---> [nullable nvarchar] [MaxLength = -1]
 EmailTemplate.Id ---> [uniqueidentifier]


### PR DESCRIPTION
Based on how values are expanded into InExpression values cannot be anything other than SqlConstant/SqlParameter

Resolves #18970

Apply fix for #17342 for cosmos
Also enable Contains tests in Cosmos which were already working
