### PR TITLE
Query: Insert Select 1 ordering for rownumber paging when there is no…

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -1299,9 +1299,12 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                         {
                             var partitions = new List<SqlExpression>();
                             GetPartitions(joinPredicate, partitions);
-                            var orderings = innerSelectExpression.Orderings.Any()
+                            var orderings = innerSelectExpression.Orderings.Count > 0
                                 ? innerSelectExpression.Orderings
-                                : innerSelectExpression._identifier.Select(e => new OrderingExpression(e, true));
+                                : innerSelectExpression._identifier.Count > 0
+                                    ? innerSelectExpression._identifier.Select(e => new OrderingExpression(e, true))
+                                    : new[] { new OrderingExpression(new SqlFragmentExpression("(SELECT 1)"), true) };
+
                             var rowNumberExpression = new RowNumberExpression(partitions, orderings.ToList(), limit.TypeMapping);
                             innerSelectExpression.ClearOrdering();
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
@@ -1056,6 +1056,12 @@ WHERE (c[""Discriminator""] = ""Order"")");
             return base.Project_uint_through_collection_FirstOrDefault(async);
         }
 
+        [ConditionalTheory(Skip = "Issue#17246")]
+        public override Task Project_keyless_entity_FirstOrDefault_without_orderby(bool async)
+        {
+            return base.Project_keyless_entity_FirstOrDefault_without_orderby(async);
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
@@ -1635,5 +1635,14 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<Customer>().Select(c => c.Orders.OrderBy(o => o.OrderID).FirstOrDefault())
                     .Select(e => MaybeScalar(e, () => e.EmployeeID)));
         }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Project_keyless_entity_FirstOrDefault_without_orderby(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Select(c => ss.Set<CustomerView>().FirstOrDefault(cv => cv.CompanyName == c.CompanyName)));
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
@@ -1325,6 +1325,25 @@ FROM [Orders] AS [o]");
 FROM [Customers] AS [c]");
         }
 
+        public override async Task Project_keyless_entity_FirstOrDefault_without_orderby(bool async)
+        {
+            await base.Project_keyless_entity_FirstOrDefault_without_orderby(async);
+
+            AssertSql(
+                @"SELECT [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle]
+FROM [Customers] AS [c]
+LEFT JOIN (
+    SELECT [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle]
+    FROM (
+        SELECT [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], ROW_NUMBER() OVER(PARTITION BY [c0].[CompanyName] ORDER BY (SELECT 1)) AS [row]
+        FROM (
+            SELECT [c].[CustomerID] + N'' as [CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region] FROM [Customers] AS [c]
+        ) AS [c0]
+    ) AS [t]
+    WHERE [t].[row] <= 1
+) AS [t0] ON [c].[CompanyName] = [t0].[CompanyName]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
… other ordering

Case when there is no explicit order by and no implicit key ordering for keyless entities

Resolves #18925
