### PR TITLE
Controversial: Allow parameter values to be obtained along with query string

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
@@ -64,13 +64,15 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                         .Visit(_selectExpression),
                     _cosmosQueryContext.ParameterValues);
 
-            public string ToQueryString()
+            public string ToQueryString(IDictionary<string, object> parameterValues = null)
             {
                 var sqlQuery = GenerateQuery();
                 if (sqlQuery.Parameters.Count == 0)
                 {
                     return sqlQuery.Query;
                 }
+
+                parameterValues?.Clear();
 
                 var builder = new StringBuilder();
                 foreach (var parameter in sqlQuery.Parameters)
@@ -81,6 +83,11 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                         .Append("='")
                         .Append(parameter.Value)
                         .AppendLine("'");
+
+                    if (parameterValues != null)
+                    {
+                        parameterValues[parameter.Name] = parameter.Value;
+                    }
                 }
 
                 return builder.Append(sqlQuery.Query).ToString();

--- a/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
@@ -51,7 +51,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
 
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-            public string ToQueryString() => InMemoryStrings.NoQueryStrings;
+            public string ToQueryString(IDictionary<string, object> parameterValues = null) => InMemoryStrings.NoQueryStrings;
 
             private sealed class Enumerator : IEnumerator<T>
             {

--- a/src/EFCore.Relational/Storage/Internal/DbParameterCollectionExtensions.cs
+++ b/src/EFCore.Relational/Storage/Internal/DbParameterCollectionExtensions.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.Globalization;
@@ -31,7 +30,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public static string FormatParameters(
             [NotNull] this DbParameterCollection parameters,
             bool logParameterValues)
-            => FormatParameterList(parameters, logParameterValues).Join();
+            => parameters
+                .Cast<DbParameter>()
+                .Select(p => FormatParameter(p, logParameterValues)).Join();
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -39,24 +40,17 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static IEnumerable<string> FormatParameterList(
-            [NotNull] this DbParameterCollection parameters,
-            bool logParameterValues)
-        {
-            return parameters
-                .Cast<DbParameter>()
-                .Select(
-                    p => FormatParameter(
-                        p.ParameterName,
-                        logParameterValues ? p.Value : "?",
-                        logParameterValues,
-                        p.Direction,
-                        p.DbType,
-                        p.IsNullable,
-                        p.Size,
-                        p.Precision,
-                        p.Scale));
-        }
+        public static string FormatParameter([NotNull] this DbParameter parameter, bool logParameterValues)
+            => FormatParameter(
+                parameter.ParameterName,
+                logParameterValues ? parameter.Value : "?",
+                logParameterValues,
+                parameter.Direction,
+                parameter.DbType,
+                parameter.IsNullable,
+                parameter.Size,
+                parameter.Precision,
+                parameter.Scale);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs
+++ b/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs
@@ -34,13 +34,14 @@ namespace Microsoft.EntityFrameworkCore
         ///     </para>
         /// </summary>
         /// <param name="source"> The query source. </param>
+        /// <param name="parameterValues"> If not null, then EF will populate the given dictionary with parameter name/value pairs. </param>
         /// <returns> The query string for debugging. </returns>
-        public static string ToQueryString([NotNull] this IQueryable source)
+        public static string ToQueryString([NotNull] this IQueryable source, [CanBeNull] IDictionary<string, object> parameterValues = null)
         {
             Check.NotNull(source, nameof(source));
 
             return source.Provider.Execute<IEnumerable>(source.Expression) is IQueryingEnumerable queryingEnumerable
-                ? queryingEnumerable.ToQueryString()
+                ? queryingEnumerable.ToQueryString(parameterValues)
                 : CoreStrings.NotQueryingEnumerable;
         }
 

--- a/src/EFCore/Query/IQueryingEnumerable.cs
+++ b/src/EFCore/Query/IQueryingEnumerable.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections;
+using System.Collections.Generic;
+using JetBrains.Annotations;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
@@ -21,7 +23,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         ///     A string representation of the query used. This string may not be suitable for direct execution is intended only
         ///     for use in debugging.
         /// </summary>
+        /// <param name="parameterValues"> If not null, then EF will populate the given dictionary with parameter name/value pairs. </param>
         /// <returns> The query string. </returns>
-        string ToQueryString();
+        string ToQueryString([CanBeNull] IDictionary<string, object> parameterValues = null);
     }
 }

--- a/src/EFCore/Query/Internal/EntityQueryable`.cs
+++ b/src/EFCore/Query/Internal/EntityQueryable`.cs
@@ -145,6 +145,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual QueryDebugView DebugView => new QueryDebugView(() => Expression.Print(), this.ToQueryString);
+        public virtual QueryDebugView DebugView
+            => new QueryDebugView(
+                () => Expression.Print(),
+                () => this.ToQueryString(null));
     }
 }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindWhereQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindWhereQueryCosmosTest.cs
@@ -2,11 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -391,9 +393,12 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
         }
 
-        public override async Task<string> Where_simple_closure(bool async)
+        public override async Task<(string, IDictionary<string, object>)> Where_simple_closure(bool async)
         {
-            var queryString = await base.Where_simple_closure(async);
+            var (queryString, parameters) = await base.Where_simple_closure(async);
+
+            Assert.Single(parameters);
+            Assert.Equal(new JValue("London"), parameters["@__city_0"]);
 
             AssertSql(
                 @"@__city_0='London'
@@ -408,7 +413,7 @@ SELECT c
 FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = @__city_0))", queryString, ignoreLineEndingDifferences: true, ignoreWhiteSpaceDifferences: true);
 
-            return null;
+            return (null, null);
         }
 
         public override async Task Where_indexer_closure(bool async)

--- a/test/EFCore.InMemory.FunctionalTests/Query/NorthwindWhereQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/NorthwindWhereQueryInMemoryTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.InMemory.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -38,13 +39,14 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return base.Where_equals_on_null_nullable_int_types(async);
         }
-        public override async Task<string> Where_simple_closure(bool async)
+        public override async Task<(string, IDictionary<string, object>)> Where_simple_closure(bool async)
         {
-            var queryString = await base.Where_simple_closure(async);
+            var (queryString, parameters) = await base.Where_simple_closure(async);
 
+            Assert.Empty(parameters);
             Assert.Equal(InMemoryStrings.NoQueryStrings, queryString );
 
-            return null;
+            return (null, null);
         }
 
         // Casting int to object to string is invalid for InMemory

--- a/test/EFCore.Specification.Tests/Query/NorthwindWhereQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindWhereQueryTestBase.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
@@ -53,7 +52,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task<string> Where_simple_closure(bool async)
+        public virtual async Task<(string, IDictionary<string, object>)> Where_simple_closure(bool async)
         {
             var city = "London";
 
@@ -63,7 +62,14 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 6);
 
             using var context = CreateContext();
-            return context.Set<Customer>().Where(c => c.City == city).ToQueryString();
+
+            var queryable = context.Set<Customer>().Where(c => c.City == city);
+            var parameters = new Dictionary<string, object>();
+            var queryString = queryable.ToQueryString(parameters);
+
+            Assert.Equal(queryString, queryable.ToQueryString());
+
+            return (queryString, parameters);
         }
 
         [ConditionalTheory]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlQuerySqlServerTest.cs
@@ -2,8 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
@@ -332,9 +334,13 @@ WHERE [c].[CustomerID] = [o].[CustomerID]");
 SELECT * FROM ""Employees"" WHERE ""ReportsTo"" = @p0 OR (""ReportsTo"" IS NULL AND @p0 IS NULL)");
         }
 
-        public override string FromSqlRaw_queryable_with_parameters_and_closure()
+        public override async Task<(string, IDictionary<string, object>)> FromSqlRaw_queryable_with_parameters_and_closure()
         {
-            var queryString = base.FromSqlRaw_queryable_with_parameters_and_closure();
+            var (queryString, parameters) = await base.FromSqlRaw_queryable_with_parameters_and_closure();
+
+            Assert.Equal(2, parameters.Count);
+            Assert.Equal("London", parameters["p0"]);
+            Assert.Equal("Sales Representative", parameters["@__contactTitle_1"]);
 
             AssertSql(
                 @"p0='London' (Size = 4000)
@@ -354,7 +360,7 @@ FROM (
 ) AS [c]
 WHERE [c].[ContactTitle] = @__contactTitle_1", queryString);
 
-            return null;
+            return (null, null);
         }
 
         public override void FromSqlRaw_queryable_simple_cache_key_includes_query_string()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
@@ -40,9 +41,12 @@ WHERE EXISTS (
     WHERE ([c].[CustomerID] = [o].[CustomerID]) AND ([o].[CustomerID] = N'ALFKI'))");
         }
 
-        public override async Task<string> Where_simple_closure(bool async)
+        public override async Task<(string, IDictionary<string, object>)> Where_simple_closure(bool async)
         {
-            var queryString = await base.Where_simple_closure(async);
+            var (queryString, parameters) = await base.Where_simple_closure(async);
+
+            Assert.Single(parameters);
+            Assert.Equal("London", parameters["@__city_0"]);
 
             AssertSql(
                 @"@__city_0='London' (Size = 4000)
@@ -57,7 +61,7 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM [Customers] AS [c]
 WHERE [c].[City] = @__city_0", queryString, ignoreLineEndingDifferences: true, ignoreWhiteSpaceDifferences: true);
 
-            return null;
+            return (null, null);
         }
 
         public override async Task Where_indexer_closure(bool async)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindWhereQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindWhereQuerySqliteTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
@@ -24,9 +25,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         public override Task Where_datetimeoffset_utcnow_component(bool async)
             => AssertTranslationFailed(() => base.Where_datetimeoffset_utcnow_component(async));
 
-        public override async Task<string> Where_simple_closure(bool async)
+        public override async Task<(string, IDictionary<string, object>)> Where_simple_closure(bool async)
         {
-            var queryString = await base.Where_simple_closure(async);
+            var (queryString, parameters) = await base.Where_simple_closure(async);
+
+            Assert.Single(parameters);
+            Assert.Equal("London", parameters["@__city_0"]);
 
             AssertSql(
                 @"@__city_0='London' (Size = 6)
@@ -41,7 +45,7 @@ SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyN
 FROM ""Customers"" AS ""c""
 WHERE ""c"".""City"" = @__city_0", queryString, ignoreLineEndingDifferences: true, ignoreWhiteSpaceDifferences: true);
 
-            return null;
+            return (null, null);
         }
 
         public override async Task Where_datetime_now(bool async)


### PR DESCRIPTION
Issue #6482

```C#
var parameters = new Dictionary<string, object>();
var queryString = queryable.ToQueryString(parameters);
```

Not 100% convinced we should do this. Here's my thinking:
* This can be useful for diagnostics/testing by providing the parameter values in a machine-readable, non string converted form. For example, imagine a profiling tool that can read the dictionary and make the parameter values available to run perf testing, get query plan, etc.
* On the other hand, this could be used by people who want to use EF only to generate queries which are then executing somewhere else. This is not a goal of EF and the queries may not run in some other context, so it could give a false impression of what EF is designed to do.
* But if we don't do this publicly, then I think the discussion on #6482 indicates that people are going to continue to hack EF into doing it. This could end up being more painful than just supporting the feature.
