### PR TITLE
Query: Lift pending collections property when applying single result …

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -871,6 +871,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
 
             innerSelectExpression.ApplyProjection();
             var projectionCount = innerSelectExpression.Projection.Count;
+            var pendingCollectionOffset = _pendingCollections.Count;
             AddOuterApply(innerSelectExpression, null);
 
             // Joined SelectExpression may different based on left join or outer apply
@@ -885,7 +886,8 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                 AddToProjection(MakeNullable(addedSelectExperssion.GenerateOuterColumn(projection.Expression)));
             }
 
-            return new ShaperRemappingExpressionVisitor(this, innerSelectExpression, indexOffset)
+            // We move pendingCollectionOffset if one was lifted from inner.
+            return new ShaperRemappingExpressionVisitor(this, innerSelectExpression, indexOffset, pendingCollectionOffset)
                 .Visit(shaperExpression);
 
             static Expression RemoveConvert(Expression expression)
@@ -980,7 +982,9 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                 AppendOrdering(new OrderingExpression(updatedColumn, ascending: true));
             }
 
-            var shaperRemapper = new ShaperRemappingExpressionVisitor(this, innerSelectExpression, indexOffset);
+            // Inner should not have pendingCollection since we apply them first.
+            // Shaper should not have CollectionShaperExpression as any collection would get converted to RelationalCollectionShaperExpression.
+            var shaperRemapper = new ShaperRemappingExpressionVisitor(this, innerSelectExpression, indexOffset, pendingCollectionOffset: 0);
             innerShaper = shaperRemapper.Visit(innerShaper);
             selfIdentifier = shaperRemapper.Visit(selfIdentifier);
 
@@ -1014,43 +1018,54 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         {
             private readonly SelectExpression _queryExpression;
             private readonly SelectExpression _innerSelectExpression;
-            private readonly int _offset;
+            private readonly int _projectionOffset;
+            private readonly int _pendingCollectionOffset;
 
-            public ShaperRemappingExpressionVisitor(SelectExpression queryExpression, SelectExpression innerSelectExpression, int offset)
+            public ShaperRemappingExpressionVisitor(
+                SelectExpression queryExpression, SelectExpression innerSelectExpression, int projectionOffset, int pendingCollectionOffset)
             {
                 _queryExpression = queryExpression;
                 _innerSelectExpression = innerSelectExpression;
-                _offset = offset;
+                _projectionOffset = projectionOffset;
+                _pendingCollectionOffset = pendingCollectionOffset;
             }
 
             protected override Expression VisitExtension(Expression extensionExpression)
             {
                 Check.NotNull(extensionExpression, nameof(extensionExpression));
 
-                if (extensionExpression is ProjectionBindingExpression projectionBindingExpression)
+                switch (extensionExpression)
                 {
-                    var oldIndex = (int)GetProjectionIndex(projectionBindingExpression);
+                    case ProjectionBindingExpression projectionBindingExpression:
+                        var oldIndex = (int)GetProjectionIndex(projectionBindingExpression);
 
-                    return new ProjectionBindingExpression(_queryExpression, oldIndex + _offset, projectionBindingExpression.Type);
+                        return new ProjectionBindingExpression(
+                            _queryExpression, oldIndex + _projectionOffset, projectionBindingExpression.Type);
+
+                    case EntityShaperExpression entityShaperExpression:
+                        var oldIndexMap = (IDictionary<IProperty, int>)GetProjectionIndex(
+                            (ProjectionBindingExpression)entityShaperExpression.ValueBufferExpression);
+                        var indexMap = new Dictionary<IProperty, int>();
+                        foreach (var keyValuePair in oldIndexMap)
+                        {
+                            indexMap[keyValuePair.Key] = keyValuePair.Value + _projectionOffset;
+                        }
+
+                        return new EntityShaperExpression(
+                            entityShaperExpression.EntityType,
+                            new ProjectionBindingExpression(_queryExpression, indexMap),
+                            nullable: true);
+
+                    case CollectionShaperExpression collectionShaperExpression:
+                        var collectionIndex = (int)GetProjectionIndex((ProjectionBindingExpression)collectionShaperExpression.Projection);
+
+                        return collectionShaperExpression.Update(
+                            new ProjectionBindingExpression(_queryExpression, collectionIndex + _pendingCollectionOffset, typeof(object)),
+                            collectionShaperExpression.InnerShaper);
+
+                    default:
+                        return base.VisitExtension(extensionExpression);
                 }
-
-                if (extensionExpression is EntityShaperExpression entityShaper)
-                {
-                    var oldIndexMap = (IDictionary<IProperty, int>)GetProjectionIndex(
-                        (ProjectionBindingExpression)entityShaper.ValueBufferExpression);
-                    var indexMap = new Dictionary<IProperty, int>();
-                    foreach (var keyValuePair in oldIndexMap)
-                    {
-                        indexMap[keyValuePair.Key] = keyValuePair.Value + _offset;
-                    }
-
-                    return new EntityShaperExpression(
-                        entityShaper.EntityType,
-                        new ProjectionBindingExpression(_queryExpression, indexMap),
-                        nullable: true);
-                }
-
-                return base.VisitExtension(extensionExpression);
             }
 
             private object GetProjectionIndex(ProjectionBindingExpression projectionBindingExpression)
@@ -1363,6 +1378,9 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             }
 
             var innerTable = innerSelectExpression.Tables.Single();
+            // Copy over pending collection if in join else that info would be lost.
+            _pendingCollections.AddRange(innerSelectExpression._pendingCollections);
+
             var joinTable = joinType switch
             {
                 JoinType.InnerJoin => new InnerJoinExpression(innerTable, joinPredicate),

--- a/test/EFCore.InMemory.FunctionalTests/Query/ComplexNavigationsQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/ComplexNavigationsQueryInMemoryTest.cs
@@ -32,5 +32,17 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return base.Lift_projection_mapping_when_pushing_down_subquery(async);
         }
+
+        [ConditionalTheory(Skip = "issue #19344")]
+        public override Task Select_subquery_single_nested_subquery(bool async)
+        {
+            return base.Select_subquery_single_nested_subquery(async);
+        }
+
+        [ConditionalTheory(Skip = "issue #19344")]
+        public override Task Select_subquery_single_nested_subquery2(bool async)
+        {
+            return base.Select_subquery_single_nested_subquery2(async);
+        }
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/Query/ComplexNavigationsWeakQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/ComplexNavigationsWeakQueryInMemoryTest.cs
@@ -59,5 +59,17 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return base.OrderBy_collection_count_ThenBy_reference_navigation(async);
         }
+
+        [ConditionalTheory(Skip = "issue #19344")]
+        public override Task Select_subquery_single_nested_subquery(bool async)
+        {
+            return base.Select_subquery_single_nested_subquery(async);
+        }
+
+        [ConditionalTheory(Skip = "issue #19344")]
+        public override Task Select_subquery_single_nested_subquery2(bool async)
+        {
+            return base.Select_subquery_single_nested_subquery2(async);
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -4363,6 +4363,48 @@ LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
 WHERE [l].[Id] = [l0].[Id]");
         }
 
+        public override async Task Select_subquery_single_nested_subquery(bool async)
+        {
+            await base.Select_subquery_single_nested_subquery(async);
+
+            AssertSql(
+                @"SELECT [t0].[c], [l].[Id], [l1].[Id]
+FROM [LevelOne] AS [l]
+LEFT JOIN (
+    SELECT [t].[c], [t].[Id], [t].[OneToMany_Optional_Inverse2Id]
+    FROM (
+        SELECT 1 AS [c], [l0].[Id], [l0].[OneToMany_Optional_Inverse2Id], ROW_NUMBER() OVER(PARTITION BY [l0].[OneToMany_Optional_Inverse2Id] ORDER BY [l0].[Id]) AS [row]
+        FROM [LevelTwo] AS [l0]
+    ) AS [t]
+    WHERE [t].[row] <= 1
+) AS [t0] ON [l].[Id] = [t0].[OneToMany_Optional_Inverse2Id]
+LEFT JOIN [LevelThree] AS [l1] ON [t0].[Id] = [l1].[OneToMany_Optional_Inverse3Id]
+ORDER BY [l].[Id], [l1].[Id]");
+        }
+
+        public override async Task Select_subquery_single_nested_subquery2(bool async)
+        {
+            await base.Select_subquery_single_nested_subquery2(async);
+
+            AssertSql(
+                @"SELECT [l].[Id], [t1].[c], [t1].[Id], [t1].[Id0]
+FROM [LevelOne] AS [l]
+LEFT JOIN (
+    SELECT [t0].[c], [l0].[Id], [l2].[Id] AS [Id0], [l0].[OneToMany_Optional_Inverse2Id]
+    FROM [LevelTwo] AS [l0]
+    LEFT JOIN (
+        SELECT [t].[c], [t].[Id], [t].[OneToMany_Optional_Inverse3Id]
+        FROM (
+            SELECT 1 AS [c], [l1].[Id], [l1].[OneToMany_Optional_Inverse3Id], ROW_NUMBER() OVER(PARTITION BY [l1].[OneToMany_Optional_Inverse3Id] ORDER BY [l1].[Id]) AS [row]
+            FROM [LevelThree] AS [l1]
+        ) AS [t]
+        WHERE [t].[row] <= 1
+    ) AS [t0] ON [l0].[Id] = [t0].[OneToMany_Optional_Inverse3Id]
+    LEFT JOIN [LevelFour] AS [l2] ON [t0].[Id] = [l2].[OneToMany_Optional_Inverse4Id]
+) AS [t1] ON [l].[Id] = [t1].[OneToMany_Optional_Inverse2Id]
+ORDER BY [l].[Id], [t1].[Id], [t1].[Id0]");
+        }
+
         private void AssertSql(params string[] expected) => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }
 }


### PR DESCRIPTION
…projection

Resolves #18812
Issue: When generating left join for single result using RowNumber, pending collection from inner was bubbling up but we lost it when generating join.
Later when we encountered CollectionShaperExpression, we threw exception since projectionBindingExpression there references collectionId rather than actual projection

Fix: Copy over pending collection for join. Remap collection shapers if any.
