### PR TITLE
Query: Remove public setters from custom expression properties

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitor.cs
@@ -184,14 +184,9 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
             Check.NotNull(source, nameof(source));
             Check.NotNull(resultType, nameof(resultType));
 
-            if (source.ShaperExpression.Type == resultType)
-            {
-                return source;
-            }
-
-            source.ShaperExpression = Expression.Convert(source.ShaperExpression, resultType);
-
-            return source;
+            return source.ShaperExpression.Type != resultType
+                ? source.UpdateShaperExpression(Expression.Convert(source.ShaperExpression, resultType))
+                : source;
         }
 
         /// <summary>
@@ -256,9 +251,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
 
             selectExpression.ClearOrdering();
             selectExpression.ReplaceProjectionMapping(projectionMapping);
-            source.ShaperExpression = new ProjectionBindingExpression(source.QueryExpression, new ProjectionMember(), typeof(int));
-
-            return source;
+            return source.UpdateShaperExpression(new ProjectionBindingExpression(source.QueryExpression, new ProjectionMember(), typeof(int)));
         }
 
         /// <summary>
@@ -342,12 +335,9 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
             var selectExpression = (SelectExpression)source.QueryExpression;
             selectExpression.ApplyLimit(TranslateExpression(Expression.Constant(1)));
 
-            if (source.ShaperExpression.Type != returnType)
-            {
-                source.ShaperExpression = Expression.Convert(source.ShaperExpression, returnType);
-            }
-
-            return source;
+            return source.ShaperExpression.Type != returnType
+                ? source.UpdateShaperExpression(Expression.Convert(source.ShaperExpression, returnType))
+                : source;
         }
 
         /// <summary>
@@ -449,12 +439,9 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
             selectExpression.ReverseOrderings();
             selectExpression.ApplyLimit(TranslateExpression(Expression.Constant(1)));
 
-            if (source.ShaperExpression.Type != returnType)
-            {
-                source.ShaperExpression = Expression.Convert(source.ShaperExpression, returnType);
-            }
-
-            return source;
+            return source.ShaperExpression.Type != returnType
+                ? source.UpdateShaperExpression(Expression.Convert(source.ShaperExpression, returnType))
+                : source;
         }
 
         /// <summary>
@@ -510,9 +497,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
 
             selectExpression.ClearOrdering();
             selectExpression.ReplaceProjectionMapping(projectionMapping);
-            source.ShaperExpression = new ProjectionBindingExpression(source.QueryExpression, new ProjectionMember(), typeof(long));
-
-            return source;
+            return source.UpdateShaperExpression(new ProjectionBindingExpression(source.QueryExpression, new ProjectionMember(), typeof(long)));
         }
 
         /// <summary>
@@ -657,10 +642,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
 
             var newSelectorBody = ReplacingExpressionVisitor.Replace(selector.Parameters.Single(), source.ShaperExpression, selector.Body);
 
-            source.ShaperExpression = _projectionBindingExpressionVisitor
-                .Translate(selectExpression, newSelectorBody);
-
-            return source;
+            return source.UpdateShaperExpression(_projectionBindingExpressionVisitor.Translate(selectExpression, newSelectorBody));
         }
 
         /// <summary>
@@ -717,12 +699,9 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
             var selectExpression = (SelectExpression)source.QueryExpression;
             selectExpression.ApplyLimit(TranslateExpression(Expression.Constant(2)));
 
-            if (source.ShaperExpression.Type != returnType)
-            {
-                source.ShaperExpression = Expression.Convert(source.ShaperExpression, returnType);
-            }
-
-            return source;
+            return source.ShaperExpression.Type != returnType
+                ? source.UpdateShaperExpression(Expression.Convert(source.ShaperExpression, returnType))
+                : source;
         }
 
         /// <summary>
@@ -948,9 +927,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 shaper = Expression.Convert(shaper, resultType);
             }
 
-            source.ShaperExpression = shaper;
-
-            return source;
+            return source.UpdateShaperExpression(shaper);
         }
     }
 }

--- a/src/EFCore.Cosmos/Query/Internal/EntityProjectionExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/EntityProjectionExpression.cs
@@ -90,12 +90,19 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         {
             Check.NotNull(visitor, nameof(visitor));
 
-            var accessExpression = visitor.Visit(AccessExpression);
+            return Update(visitor.Visit(AccessExpression));
+        }
 
-            return accessExpression != AccessExpression
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual Expression Update([NotNull] Expression accessExpression)
+            => accessExpression != AccessExpression
                 ? new EntityProjectionExpression(EntityType, accessExpression)
                 : this;
-        }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Cosmos/Query/Internal/KeyAccessExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/KeyAccessExpression.cs
@@ -68,9 +68,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         {
             Check.NotNull(visitor, nameof(visitor));
 
-            var outerExpression = visitor.Visit(AccessExpression);
-
-            return Update(outerExpression);
+            return Update(visitor.Visit(AccessExpression));
         }
 
         /// <summary>

--- a/src/EFCore.Cosmos/Query/Internal/ObjectAccessExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/ObjectAccessExpression.cs
@@ -87,9 +87,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         {
             Check.NotNull(visitor, nameof(visitor));
 
-            var outerExpression = visitor.Visit(AccessExpression);
-
-            return Update(outerExpression);
+            return Update(visitor.Visit(AccessExpression));
         }
 
         /// <summary>

--- a/src/EFCore.Cosmos/Query/Internal/OrderingExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/OrderingExpression.cs
@@ -81,11 +81,9 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual OrderingExpression Update([NotNull] SqlExpression expression)
-        {
-            return expression != Expression
+            => expression != Expression
                 ? new OrderingExpression(expression, IsAscending)
                 : this;
-        }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Query/Internal/CollectionJoinApplyingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/CollectionJoinApplyingExpressionVisitor.cs
@@ -39,14 +39,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     collectionShaperExpression.ElementType);
             }
 
-            if (extensionExpression is ShapedQueryExpression shapedQueryExpression)
-            {
-                shapedQueryExpression.ShaperExpression = Visit(shapedQueryExpression.ShaperExpression);
-
-                return shapedQueryExpression;
-            }
-
-            return base.VisitExtension(extensionExpression);
+            return extensionExpression is ShapedQueryExpression shapedQueryExpression
+                ? shapedQueryExpression.UpdateShaperExpression(Visit(shapedQueryExpression.ShaperExpression))
+                : base.VisitExtension(extensionExpression);
         }
     }
 }

--- a/src/EFCore.Relational/Query/Internal/SelectExpressionProjectionApplyingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/SelectExpressionProjectionApplyingExpressionVisitor.cs
@@ -9,16 +9,22 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 {
     public class SelectExpressionProjectionApplyingExpressionVisitor : ExpressionVisitor
     {
-        protected override Expression VisitExtension(Expression node)
+        protected override Expression VisitExtension(Expression extensionExpression)
         {
-            Check.NotNull(node, nameof(node));
+            Check.NotNull(extensionExpression, nameof(extensionExpression));
 
-            if (node is SelectExpression selectExpression)
+            if (extensionExpression is ShapedQueryExpression shapedQueryExpression)
             {
-                selectExpression.ApplyProjection();
+                return shapedQueryExpression.Update(Visit(shapedQueryExpression.QueryExpression), shapedQueryExpression.ShaperExpression);
             }
 
-            return base.VisitExtension(node);
+            if (extensionExpression is SelectExpression selectExpression)
+            {
+                selectExpression.ApplyProjection();
+                // We visit base to apply projection to inner SelectExpressions
+            }
+
+            return base.VisitExtension(extensionExpression);
         }
     }
 }

--- a/src/EFCore.Relational/Query/Internal/SqlExpressionOptimizingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/SqlExpressionOptimizingExpressionVisitor.cs
@@ -47,12 +47,25 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         {
             Check.NotNull(extensionExpression, nameof(extensionExpression));
 
-            return extensionExpression switch
+#pragma warning disable IDE0066 // Convert switch statement to expression
+            switch (extensionExpression)
+#pragma warning restore IDE0066 // Convert switch statement to expression
             {
-                SqlUnaryExpression sqlUnaryExpression => VisitSqlUnaryExpression(sqlUnaryExpression),
-                SqlBinaryExpression sqlBinaryExpression => VisitSqlBinaryExpression(sqlBinaryExpression),
-                SelectExpression selectExpression => VisitSelectExpression(selectExpression),
-                _ => base.VisitExtension(extensionExpression),
+                case ShapedQueryExpression shapedQueryExpression:
+                    return shapedQueryExpression.Update(
+                        Visit(shapedQueryExpression.QueryExpression), shapedQueryExpression.ShaperExpression);
+
+                case SqlUnaryExpression sqlUnaryExpression:
+                    return VisitSqlUnaryExpression(sqlUnaryExpression);
+
+                case SqlBinaryExpression sqlBinaryExpression:
+                    return VisitSqlBinaryExpression(sqlBinaryExpression);
+
+                case SelectExpression selectExpression:
+                    return VisitSelectExpression(selectExpression);
+
+                default:
+                    return base.VisitExtension(extensionExpression);
             };
         }
 

--- a/src/EFCore.Relational/Query/Internal/TableAliasUniquifyingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/TableAliasUniquifyingExpressionVisitor.cs
@@ -21,6 +21,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         {
             Check.NotNull(extensionExpression, nameof(extensionExpression));
 
+            if (extensionExpression is ShapedQueryExpression shapedQueryExpression)
+            {
+                return shapedQueryExpression.Update(Visit(shapedQueryExpression.QueryExpression), shapedQueryExpression.ShaperExpression);
+            }
+
             var visitedExpression = base.VisitExtension(extensionExpression);
             if (visitedExpression is TableExpressionBase tableExpressionBase
                 && !_visitedTableExpressionBases.Contains(tableExpressionBase)

--- a/src/EFCore.Relational/Query/SqlExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/SqlExpressionVisitor.cs
@@ -16,6 +16,10 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             switch (extensionExpression)
             {
+                case ShapedQueryExpression shapedQueryExpression:
+                    return shapedQueryExpression.Update(
+                        Visit(shapedQueryExpression.QueryExpression), shapedQueryExpression.ShaperExpression);
+
                 case CaseExpression caseExpression:
                     return VisitCase(caseExpression);
 

--- a/src/EFCore/Query/IncludeExpression.cs
+++ b/src/EFCore/Query/IncludeExpression.cs
@@ -11,10 +11,6 @@ namespace Microsoft.EntityFrameworkCore.Query
 {
     public class IncludeExpression : Expression, IPrintableExpression
     {
-        private Expression _entityExpression;
-        private Expression _navigationExpression;
-        private INavigation _navigation;
-
         public IncludeExpression(
             [NotNull] Expression entityExpression,
             [NotNull] Expression navigationExpression,
@@ -30,23 +26,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             Type = EntityExpression.Type;
         }
 
-        public virtual Expression EntityExpression
-        {
-            get => _entityExpression;
-            [param: NotNull] set => _entityExpression = Check.NotNull(value, nameof(value));
-        }
-
-        public virtual Expression NavigationExpression
-        {
-            get => _navigationExpression;
-            [param: NotNull] set => _navigationExpression = Check.NotNull(value, nameof(value));
-        }
-
-        public virtual INavigation Navigation
-        {
-            get => _navigation;
-            [param: NotNull] set => _navigation = Check.NotNull(value, nameof(value));
-        }
+        public virtual Expression EntityExpression { get; }
+        public virtual Expression NavigationExpression { get; }
+        public virtual INavigation Navigation { get; }
 
         public sealed override ExpressionType NodeType => ExpressionType.Extension;
         public override Type Type { get; }

--- a/src/EFCore/Query/QueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore/Query/QueryableMethodTranslatingExpressionVisitor.cs
@@ -71,17 +71,17 @@ namespace Microsoft.EntityFrameworkCore.Query
                     {
                         case nameof(Queryable.All)
                             when genericMethod == QueryableMethods.All:
-                            shapedQueryExpression.ResultCardinality = ResultCardinality.Single;
+                            shapedQueryExpression = shapedQueryExpression.UpdateResultCardinality(ResultCardinality.Single);
                             return CheckTranslated(TranslateAll(shapedQueryExpression, GetLambdaExpressionFromArgument(1)));
 
                         case nameof(Queryable.Any)
                             when genericMethod == QueryableMethods.AnyWithoutPredicate:
-                            shapedQueryExpression.ResultCardinality = ResultCardinality.Single;
+                            shapedQueryExpression = shapedQueryExpression.UpdateResultCardinality(ResultCardinality.Single);
                             return CheckTranslated(TranslateAny(shapedQueryExpression, null));
 
                         case nameof(Queryable.Any)
                             when genericMethod == QueryableMethods.AnyWithPredicate:
-                            shapedQueryExpression.ResultCardinality = ResultCardinality.Single;
+                            shapedQueryExpression = shapedQueryExpression.UpdateResultCardinality(ResultCardinality.Single);
                             return CheckTranslated(TranslateAny(shapedQueryExpression, GetLambdaExpressionFromArgument(1)));
 
                         case nameof(Queryable.AsQueryable)
@@ -90,12 +90,12 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                         case nameof(Queryable.Average)
                             when QueryableMethods.IsAverageWithoutSelector(method):
-                            shapedQueryExpression.ResultCardinality = ResultCardinality.Single;
+                            shapedQueryExpression = shapedQueryExpression.UpdateResultCardinality(ResultCardinality.Single);
                             return CheckTranslated(TranslateAverage(shapedQueryExpression, null, methodCallExpression.Type));
 
                         case nameof(Queryable.Average)
                             when QueryableMethods.IsAverageWithSelector(method):
-                            shapedQueryExpression.ResultCardinality = ResultCardinality.Single;
+                            shapedQueryExpression = shapedQueryExpression.UpdateResultCardinality(ResultCardinality.Single);
                             return CheckTranslated(
                                 TranslateAverage(shapedQueryExpression, GetLambdaExpressionFromArgument(1), methodCallExpression.Type));
 
@@ -119,17 +119,17 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                         case nameof(Queryable.Contains)
                             when genericMethod == QueryableMethods.Contains:
-                            shapedQueryExpression.ResultCardinality = ResultCardinality.Single;
+                            shapedQueryExpression = shapedQueryExpression.UpdateResultCardinality(ResultCardinality.Single);
                             return CheckTranslated(TranslateContains(shapedQueryExpression, methodCallExpression.Arguments[1]));
 
                         case nameof(Queryable.Count)
                             when genericMethod == QueryableMethods.CountWithoutPredicate:
-                            shapedQueryExpression.ResultCardinality = ResultCardinality.Single;
+                            shapedQueryExpression = shapedQueryExpression.UpdateResultCardinality(ResultCardinality.Single);
                             return CheckTranslated(TranslateCount(shapedQueryExpression, null));
 
                         case nameof(Queryable.Count)
                             when genericMethod == QueryableMethods.CountWithPredicate:
-                            shapedQueryExpression.ResultCardinality = ResultCardinality.Single;
+                            shapedQueryExpression = shapedQueryExpression.UpdateResultCardinality(ResultCardinality.Single);
                             return CheckTranslated(TranslateCount(shapedQueryExpression, GetLambdaExpressionFromArgument(1)));
 
                         case nameof(Queryable.DefaultIfEmpty)
@@ -146,13 +146,13 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                         case nameof(Queryable.ElementAt)
                             when genericMethod == QueryableMethods.ElementAt:
-                            shapedQueryExpression.ResultCardinality = ResultCardinality.Single;
+                            shapedQueryExpression = shapedQueryExpression.UpdateResultCardinality(ResultCardinality.Single);
                             return CheckTranslated(
                                 TranslateElementAtOrDefault(shapedQueryExpression, methodCallExpression.Arguments[1], false));
 
                         case nameof(Queryable.ElementAtOrDefault)
                             when genericMethod == QueryableMethods.ElementAtOrDefault:
-                            shapedQueryExpression.ResultCardinality = ResultCardinality.SingleOrDefault;
+                            shapedQueryExpression = shapedQueryExpression.UpdateResultCardinality(ResultCardinality.SingleOrDefault);
                             return CheckTranslated(
                                 TranslateElementAtOrDefault(shapedQueryExpression, methodCallExpression.Arguments[1], true));
 
@@ -173,24 +173,24 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                         case nameof(Queryable.First)
                             when genericMethod == QueryableMethods.FirstWithoutPredicate:
-                            shapedQueryExpression.ResultCardinality = ResultCardinality.Single;
+                            shapedQueryExpression = shapedQueryExpression.UpdateResultCardinality(ResultCardinality.Single);
                             return CheckTranslated(TranslateFirstOrDefault(shapedQueryExpression, null, methodCallExpression.Type, false));
 
                         case nameof(Queryable.First)
                             when genericMethod == QueryableMethods.FirstWithPredicate:
-                            shapedQueryExpression.ResultCardinality = ResultCardinality.Single;
+                            shapedQueryExpression = shapedQueryExpression.UpdateResultCardinality(ResultCardinality.Single);
                             return CheckTranslated(
                                 TranslateFirstOrDefault(
                                     shapedQueryExpression, GetLambdaExpressionFromArgument(1), methodCallExpression.Type, false));
 
                         case nameof(Queryable.FirstOrDefault)
                             when genericMethod == QueryableMethods.FirstOrDefaultWithoutPredicate:
-                            shapedQueryExpression.ResultCardinality = ResultCardinality.SingleOrDefault;
+                            shapedQueryExpression = shapedQueryExpression.UpdateResultCardinality(ResultCardinality.SingleOrDefault);
                             return CheckTranslated(TranslateFirstOrDefault(shapedQueryExpression, null, methodCallExpression.Type, true));
 
                         case nameof(Queryable.FirstOrDefault)
                             when genericMethod == QueryableMethods.FirstOrDefaultWithPredicate:
-                            shapedQueryExpression.ResultCardinality = ResultCardinality.SingleOrDefault;
+                            shapedQueryExpression = shapedQueryExpression.UpdateResultCardinality(ResultCardinality.SingleOrDefault);
                             return CheckTranslated(
                                 TranslateFirstOrDefault(
                                     shapedQueryExpression, GetLambdaExpressionFromArgument(1), methodCallExpression.Type, true));
@@ -276,57 +276,57 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                         case nameof(Queryable.Last)
                             when genericMethod == QueryableMethods.LastWithoutPredicate:
-                            shapedQueryExpression.ResultCardinality = ResultCardinality.Single;
+                            shapedQueryExpression = shapedQueryExpression.UpdateResultCardinality(ResultCardinality.Single);
                             return CheckTranslated(TranslateLastOrDefault(shapedQueryExpression, null, methodCallExpression.Type, false));
 
                         case nameof(Queryable.Last)
                             when genericMethod == QueryableMethods.LastWithPredicate:
-                            shapedQueryExpression.ResultCardinality = ResultCardinality.Single;
+                            shapedQueryExpression = shapedQueryExpression.UpdateResultCardinality(ResultCardinality.Single);
                             return CheckTranslated(
                                 TranslateLastOrDefault(
                                     shapedQueryExpression, GetLambdaExpressionFromArgument(1), methodCallExpression.Type, false));
 
                         case nameof(Queryable.LastOrDefault)
                             when genericMethod == QueryableMethods.LastOrDefaultWithoutPredicate:
-                            shapedQueryExpression.ResultCardinality = ResultCardinality.SingleOrDefault;
+                            shapedQueryExpression = shapedQueryExpression.UpdateResultCardinality(ResultCardinality.SingleOrDefault);
                             return CheckTranslated(TranslateLastOrDefault(shapedQueryExpression, null, methodCallExpression.Type, true));
 
                         case nameof(Queryable.LastOrDefault)
                             when genericMethod == QueryableMethods.LastOrDefaultWithPredicate:
-                            shapedQueryExpression.ResultCardinality = ResultCardinality.SingleOrDefault;
+                            shapedQueryExpression = shapedQueryExpression.UpdateResultCardinality(ResultCardinality.SingleOrDefault);
                             return CheckTranslated(
                                 TranslateLastOrDefault(
                                     shapedQueryExpression, GetLambdaExpressionFromArgument(1), methodCallExpression.Type, true));
 
                         case nameof(Queryable.LongCount)
                             when genericMethod == QueryableMethods.LongCountWithoutPredicate:
-                            shapedQueryExpression.ResultCardinality = ResultCardinality.Single;
+                            shapedQueryExpression = shapedQueryExpression.UpdateResultCardinality(ResultCardinality.Single);
                             return CheckTranslated(TranslateLongCount(shapedQueryExpression, null));
 
                         case nameof(Queryable.LongCount)
                             when genericMethod == QueryableMethods.LongCountWithPredicate:
-                            shapedQueryExpression.ResultCardinality = ResultCardinality.Single;
+                            shapedQueryExpression = shapedQueryExpression.UpdateResultCardinality(ResultCardinality.Single);
                             return CheckTranslated(TranslateLongCount(shapedQueryExpression, GetLambdaExpressionFromArgument(1)));
 
                         case nameof(Queryable.Max)
                             when genericMethod == QueryableMethods.MaxWithoutSelector:
-                            shapedQueryExpression.ResultCardinality = ResultCardinality.Single;
+                            shapedQueryExpression = shapedQueryExpression.UpdateResultCardinality(ResultCardinality.Single);
                             return CheckTranslated(TranslateMax(shapedQueryExpression, null, methodCallExpression.Type));
 
                         case nameof(Queryable.Max)
                             when genericMethod == QueryableMethods.MaxWithSelector:
-                            shapedQueryExpression.ResultCardinality = ResultCardinality.Single;
+                            shapedQueryExpression = shapedQueryExpression.UpdateResultCardinality(ResultCardinality.Single);
                             return CheckTranslated(
                                 TranslateMax(shapedQueryExpression, GetLambdaExpressionFromArgument(1), methodCallExpression.Type));
 
                         case nameof(Queryable.Min)
                             when genericMethod == QueryableMethods.MinWithoutSelector:
-                            shapedQueryExpression.ResultCardinality = ResultCardinality.Single;
+                            shapedQueryExpression = shapedQueryExpression.UpdateResultCardinality(ResultCardinality.Single);
                             return CheckTranslated(TranslateMin(shapedQueryExpression, null, methodCallExpression.Type));
 
                         case nameof(Queryable.Min)
                             when genericMethod == QueryableMethods.MinWithSelector:
-                            shapedQueryExpression.ResultCardinality = ResultCardinality.Single;
+                            shapedQueryExpression = shapedQueryExpression.UpdateResultCardinality(ResultCardinality.Single);
                             return CheckTranslated(
                                 TranslateMin(shapedQueryExpression, GetLambdaExpressionFromArgument(1), methodCallExpression.Type));
 
@@ -362,24 +362,24 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                         case nameof(Queryable.Single)
                             when genericMethod == QueryableMethods.SingleWithoutPredicate:
-                            shapedQueryExpression.ResultCardinality = ResultCardinality.Single;
+                            shapedQueryExpression = shapedQueryExpression.UpdateResultCardinality(ResultCardinality.Single);
                             return CheckTranslated(TranslateSingleOrDefault(shapedQueryExpression, null, methodCallExpression.Type, false));
 
                         case nameof(Queryable.Single)
                             when genericMethod == QueryableMethods.SingleWithPredicate:
-                            shapedQueryExpression.ResultCardinality = ResultCardinality.Single;
+                            shapedQueryExpression = shapedQueryExpression.UpdateResultCardinality(ResultCardinality.Single);
                             return CheckTranslated(
                                 TranslateSingleOrDefault(
                                     shapedQueryExpression, GetLambdaExpressionFromArgument(1), methodCallExpression.Type, false));
 
                         case nameof(Queryable.SingleOrDefault)
                             when genericMethod == QueryableMethods.SingleOrDefaultWithoutPredicate:
-                            shapedQueryExpression.ResultCardinality = ResultCardinality.SingleOrDefault;
+                            shapedQueryExpression = shapedQueryExpression.UpdateResultCardinality(ResultCardinality.SingleOrDefault);
                             return CheckTranslated(TranslateSingleOrDefault(shapedQueryExpression, null, methodCallExpression.Type, true));
 
                         case nameof(Queryable.SingleOrDefault)
                             when genericMethod == QueryableMethods.SingleOrDefaultWithPredicate:
-                            shapedQueryExpression.ResultCardinality = ResultCardinality.SingleOrDefault;
+                            shapedQueryExpression = shapedQueryExpression.UpdateResultCardinality(ResultCardinality.SingleOrDefault);
                             return CheckTranslated(
                                 TranslateSingleOrDefault(
                                     shapedQueryExpression, GetLambdaExpressionFromArgument(1), methodCallExpression.Type, true));
@@ -394,12 +394,12 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                         case nameof(Queryable.Sum)
                             when QueryableMethods.IsSumWithoutSelector(method):
-                            shapedQueryExpression.ResultCardinality = ResultCardinality.Single;
+                            shapedQueryExpression = shapedQueryExpression.UpdateResultCardinality(ResultCardinality.Single);
                             return CheckTranslated(TranslateSum(shapedQueryExpression, null, methodCallExpression.Type));
 
                         case nameof(Queryable.Sum)
                             when QueryableMethods.IsSumWithSelector(method):
-                            shapedQueryExpression.ResultCardinality = ResultCardinality.Single;
+                            shapedQueryExpression = shapedQueryExpression.UpdateResultCardinality(ResultCardinality.Single);
                             return CheckTranslated(
                                 TranslateSum(shapedQueryExpression, GetLambdaExpressionFromArgument(1), methodCallExpression.Type));
 
@@ -474,11 +474,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             Check.NotNull(resultSelector, nameof(resultSelector));
             Check.NotNull(innerShaper, nameof(innerShaper));
 
-            outer.ShaperExpression = CombineShapers(
-                outer.QueryExpression,
-                outer.ShaperExpression,
-                innerShaper,
-                transparentIdentifierType);
+            outer = outer.UpdateShaperExpression(
+                CombineShapers(outer.QueryExpression, outer.ShaperExpression, innerShaper, transparentIdentifierType));
 
             var transparentIdentifierParameter = Expression.Parameter(transparentIdentifierType);
 

--- a/src/EFCore/Query/ShapedQueryExpression.cs
+++ b/src/EFCore/Query/ShapedQueryExpression.cs
@@ -11,31 +11,26 @@ namespace Microsoft.EntityFrameworkCore.Query
 {
     public class ShapedQueryExpression : Expression, IPrintableExpression
     {
-        private Expression _queryExpression;
-        private Expression _shaperExpression;
-
         public ShapedQueryExpression([NotNull] Expression queryExpression, [NotNull] Expression shaperExpression)
+            : this(Check.NotNull(queryExpression, nameof(queryExpression)),
+                  Check.NotNull(shaperExpression, nameof(shaperExpression)),
+                  ResultCardinality.Enumerable)
         {
-            Check.NotNull(queryExpression, nameof(queryExpression));
-            Check.NotNull(shaperExpression, nameof(shaperExpression));
+        }
 
+        private ShapedQueryExpression(
+            [NotNull] Expression queryExpression, [NotNull] Expression shaperExpression, ResultCardinality resultCardinality)
+        {
             QueryExpression = queryExpression;
             ShaperExpression = shaperExpression;
+            ResultCardinality = resultCardinality;
         }
 
-        public virtual Expression QueryExpression
-        {
-            get => _queryExpression;
-            [param: NotNull] set => _queryExpression = Check.NotNull(value, nameof(value));
-        }
+        public virtual Expression QueryExpression { get; }
 
-        public virtual ResultCardinality ResultCardinality { get; set; }
+        public virtual ResultCardinality ResultCardinality { get; }
 
-        public virtual Expression ShaperExpression
-        {
-            get => _shaperExpression;
-            [param: NotNull] set => _shaperExpression = Check.NotNull(value, nameof(value));
-        }
+        public virtual Expression ShaperExpression { get; }
 
         public override Type Type => ResultCardinality == ResultCardinality.Enumerable
             ? typeof(IQueryable<>).MakeGenericType(ShaperExpression.Type)
@@ -44,13 +39,30 @@ namespace Microsoft.EntityFrameworkCore.Query
         public sealed override ExpressionType NodeType => ExpressionType.Extension;
 
         protected override Expression VisitChildren(ExpressionVisitor visitor)
+            => throw new InvalidOperationException("Calling ShapedQueryExpression.VisitChildren is not allowed. " +
+                "Visit expression manually for relevant part.");
+
+        public virtual ShapedQueryExpression Update([NotNull] Expression queryExpression, [NotNull] Expression shaperExpression)
         {
-            Check.NotNull(visitor, nameof(visitor));
+            Check.NotNull(queryExpression, nameof(queryExpression));
+            Check.NotNull(shaperExpression, nameof(shaperExpression));
 
-            QueryExpression = visitor.Visit(QueryExpression);
-
-            return this;
+            return queryExpression != QueryExpression || shaperExpression != ShaperExpression
+                ? new ShapedQueryExpression(queryExpression, shaperExpression, ResultCardinality)
+                : this;
         }
+
+        public virtual ShapedQueryExpression UpdateShaperExpression([NotNull] Expression shaperExpression)
+        {
+            Check.NotNull(shaperExpression, nameof(shaperExpression));
+
+            return shaperExpression != ShaperExpression
+                ? new ShapedQueryExpression(QueryExpression, shaperExpression, ResultCardinality)
+                : this;
+        }
+
+        public virtual ShapedQueryExpression UpdateResultCardinality(ResultCardinality resultCardinality)
+            => new ShapedQueryExpression(QueryExpression, ShaperExpression, resultCardinality);
 
         public virtual void Print(ExpressionPrinter expressionPrinter)
         {


### PR DESCRIPTION
Resolves #19192

Changes
- Only server side query expression are in place updated using private setters, public methods
- Moved to Update method pattern in certain cases
- TableExpressionBase still has internal set which will be fixed in #17337
- ShapedQueryExpression.VisitChildren throws now. Since ShapedQuery contains query expression (server side) and shaper expression (client side), it is unlikely that a visitor needs to visit both components. Hence we force visitor to decide which component to visit. This improves perf as we wouldn't go into client side shaper when updating something in sql tree
