### PR TITLE
Query: Translate Queryable.Reverse()

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitor.cs
@@ -622,7 +622,15 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         {
             Check.NotNull(source, nameof(source));
 
-            return null;
+            var selectExpression = (SelectExpression)source.QueryExpression;
+            if (selectExpression.Orderings.Count == 0)
+            {
+                return null;
+            }
+
+            selectExpression.ReverseOrderings();
+
+            return source;
         }
 
         /// <summary>

--- a/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
@@ -673,7 +673,15 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
         {
             Check.NotNull(source, nameof(source));
 
-            return null;
+            var inMemoryQueryExpression = (InMemoryQueryExpression)source.QueryExpression;
+
+            inMemoryQueryExpression.ServerQueryExpression
+                = Expression.Call(
+                    EnumerableMethods.Reverse
+                    .MakeGenericMethod(inMemoryQueryExpression.CurrentParameter.Type),
+                    inMemoryQueryExpression.ServerQueryExpression);
+
+            return source;
         }
 
         protected override ShapedQueryExpression TranslateSelect(ShapedQueryExpression source, LambdaExpression selector)

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -746,7 +746,15 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             Check.NotNull(source, nameof(source));
 
-            return null;
+            var selectExpression = (SelectExpression)source.QueryExpression;
+            if (selectExpression.Orderings.Count == 0)
+            {
+                return null;
+            }
+
+            selectExpression.ReverseOrderings();
+
+            return source;
         }
 
         protected override ShapedQueryExpression TranslateSelect(ShapedQueryExpression source, LambdaExpression selector)

--- a/src/EFCore/Query/Internal/EntityEqualityRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/EntityEqualityRewritingExpressionVisitor.cs
@@ -301,7 +301,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     when genericMethod == QueryableMethods.OrderByDescending:
                 case nameof(Queryable.ThenBy)
                     when genericMethod == QueryableMethods.ThenBy:
-                case nameof(Queryable.ThenByDescending) when genericMethod == QueryableMethods.ThenByDescending:
+                case nameof(Queryable.ThenByDescending)
+                    when genericMethod == QueryableMethods.ThenByDescending:
                     return VisitOrderingMethodCall(methodCallExpression);
 
                 // The following are projecting methods, which flow the entity type from *within* the lambda outside.

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
@@ -458,6 +458,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                                 methodCallExpression.Arguments[1].UnwrapLambdaFromQuote(),
                                 thenBy: true);
 
+                        case nameof(Queryable.Reverse)
+                            when genericMethod == QueryableMethods.Reverse:
+                            return ProcessReverse(source);
+
                         case nameof(Queryable.Select)
                             when genericMethod == QueryableMethods.Select:
                             return ProcessSelect(
@@ -979,6 +983,16 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             {
                 source.AddPendingOrdering(genericMethod, lambdaBody);
             }
+
+            return source;
+        }
+
+        private Expression ProcessReverse(NavigationExpansionExpression source)
+        {
+            source.UpdateSource(
+                Expression.Call(
+                    QueryableMethods.Reverse.MakeGenericMethod(source.SourceElementType),
+                    source.Source));
 
             return source;
         }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
@@ -1062,6 +1062,26 @@ WHERE (c[""Discriminator""] = ""Order"")");
             return base.Project_keyless_entity_FirstOrDefault_without_orderby(async);
         }
 
+        public override async Task Reverse_changes_asc_order_to_desc(bool async)
+        {
+            await base.Reverse_changes_asc_order_to_desc(async);
+
+            AssertSql(@"SELECT c[""EmployeeID""]
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")
+ORDER BY c[""EmployeeID""] DESC");
+        }
+
+        public override async Task Reverse_changes_desc_order_to_asc(bool async)
+        {
+            await base.Reverse_changes_desc_order_to_asc(async);
+
+            AssertSql(@"SELECT c[""EmployeeID""]
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")
+ORDER BY c[""EmployeeID""]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.InMemory.FunctionalTests/Query/NorthwindSelectQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/NorthwindSelectQueryInMemoryTest.cs
@@ -38,5 +38,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return base.SelectMany_correlated_with_outer_3(async);
         }
+
+        [ConditionalTheory(Skip = "Issue#17386")]
+        public override Task Reverse_without_explicit_ordering_throws(bool async)
+        {
+            return base.Reverse_without_explicit_ordering_throws(async);
+        }
     }
 }

--- a/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
@@ -865,6 +865,43 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
+        public virtual Task Reverse_changes_asc_order_to_desc(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Employee>().OrderBy(e => e.EmployeeID)
+                    .Reverse()
+                    .Select(e => $"{e.EmployeeID}"),
+                assertOrder: true);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Reverse_changes_desc_order_to_asc(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Employee>().OrderByDescending(e => e.EmployeeID)
+                    .Select(e => $"{e.EmployeeID}")
+                    .Reverse(),
+                assertOrder: true);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Reverse_without_explicit_ordering_throws(bool async)
+        {
+            return AssertTranslationFailed(
+                () => AssertQuery(
+                    async,
+                    ss => ss.Set<Employee>()
+                        .Reverse()
+                        .Select(e => $"{e.EmployeeID}")
+                ));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual Task Projection_containing_DateTime_subtraction(bool async)
         {
             return AssertQueryScalar(

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
@@ -1344,6 +1344,24 @@ LEFT JOIN (
 ) AS [t0] ON [c].[CompanyName] = [t0].[CompanyName]");
         }
 
+        public override async Task Reverse_changes_asc_order_to_desc(bool async)
+        {
+            await base.Reverse_changes_asc_order_to_desc(async);
+
+            AssertSql(@"SELECT [e].[EmployeeID]
+FROM [Employees] AS [e]
+ORDER BY [e].[EmployeeID] DESC");
+        }
+
+        public override async Task Reverse_changes_desc_order_to_asc(bool async)
+        {
+            await base.Reverse_changes_desc_order_to_asc(async);
+
+            AssertSql(@"SELECT [e].[EmployeeID]
+FROM [Employees] AS [e]
+ORDER BY [e].[EmployeeID]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Resolves #17388

In order to translate Reverse, we reverse the existing ordering. If there is no existing ordering then we throw translation failure.
