### PR TITLE
Throw if identifying foreign key is still unknown when saving changes

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -639,6 +639,15 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             }
         }
 
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual void MarkUnknown([NotNull] IProperty property)
+            => _stateData.FlagProperty(property.GetIndex(), PropertyFlag.Unknown, true);
+
         internal static readonly MethodInfo ReadShadowValueMethod
             = typeof(InternalEntityEntry).GetTypeInfo().GetDeclaredMethod(nameof(ReadShadowValue));
 
@@ -1285,6 +1294,13 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                             CoreStrings.PropertyReadOnlyBeforeSave(
                                 property.Name,
                                 EntityType.DisplayName()));
+                    }
+
+                    if (property.IsKey()
+                        && property.IsForeignKey()
+                        && _stateData.IsPropertyFlagged(property.GetIndex(), PropertyFlag.Unknown))
+                    {
+                        throw new InvalidOperationException(CoreStrings.UnknownKeyValue(entityType.DisplayName(), property.Name));
                     }
                 }
             }

--- a/src/EFCore/ChangeTracking/Internal/KeyPropagator.cs
+++ b/src/EFCore/ChangeTracking/Internal/KeyPropagator.cs
@@ -71,6 +71,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     {
                         entry[property] = value;
                     }
+
+                    entry.MarkUnknown(property);
                 }
             }
 
@@ -108,6 +110,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     {
                         entry[property] = value;
                     }
+
+                    entry.MarkUnknown(property);
                 }
             }
 

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -515,6 +515,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 property, entityType, state);
 
         /// <summary>
+        ///     The value of '{entityType}.{property}' is unknown when attempting to save changes. This is because the property is also part of a foreign key for which the principal entity in the relationship is not known.
+        /// </summary>
+        public static string UnknownKeyValue([CanBeNull] object entityType, [CanBeNull] object property)
+            => string.Format(
+                GetString("UnknownKeyValue", nameof(entityType), nameof(property)),
+                entityType, property);
+
+        /// <summary>
         ///     The EF.Property&lt;T&gt; method may only be used within LINQ queries.
         /// </summary>
         public static string PropertyMethodInvoked

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -322,6 +322,9 @@
   <data name="TempValuePersists" xml:space="preserve">
     <value>The property '{property}' on entity type '{entityType}' has a temporary value while attempting to change the entity's state to '{state}'. Either set a permanent value explicitly or ensure that the database is configured to generate values for this property.</value>
   </data>
+  <data name="UnknownKeyValue" xml:space="preserve">
+    <value>The value of '{entityType}.{property}' is unknown when attempting to save changes. This is because the property is also part of a foreign key for which the principal entity in the relationship is not known.</value>
+  </data>
   <data name="LogExceptionDuringQueryIteration" xml:space="preserve">
     <value>An exception occurred while iterating over the results of a query for context type '{contextType}'.{newline}{error}</value>
     <comment>Error CoreEventId.QueryIterationFailed Type string Exception</comment>


### PR DESCRIPTION
Fixes #13666

Investigated this in more detail. Two `Object` (this is a custom `Object` class, not the normal `System.Object` type) entities are created. The first one is directly associated with a Container. The second one has no Container reference or FK set. However, because the FK is also part of the PK, and the PK uses generated values, it means that the FK gets a value set.

We do this to handle dependents encountered before principals when attaching the graph. But the intention here is that the dummy key value generated will be replaced once the principal is attached. If this doesn't happen, then SaveChanges will throw due to the FK constraint violation. This change provides clarity by failing in SaveChanges so we avoid ever sending the dummy value to the database.
