### PR TITLE
Query: Convert Enumerable methods to queryable specified after ToList…

### DIFF
--- a/src/EFCore/Query/Internal/EnumerableToQueryableMethodConvertingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/EnumerableToQueryableMethodConvertingExpressionVisitor.cs
@@ -178,7 +178,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             => expression is ConstantExpression
                 || expression is MemberInitExpression
                 || expression is NewExpression
-                || expression is ParameterExpression;
+                || (expression is ParameterExpression parameter
+                    && parameter.Name.StartsWith(CompiledQueryCache.CompiledQueryParameterPrefix, StringComparison.Ordinal));
 
         private static bool CanConvertEnumerableToQueryable(Type enumerableType, Type queryableType)
         {
@@ -198,19 +199,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             enumerableType = enumerableType.GetGenericTypeDefinition();
             queryableType = queryableType.GetGenericTypeDefinition();
 
-            if (enumerableType == typeof(IEnumerable<>)
-                && queryableType == typeof(IQueryable<>))
-            {
-                return true;
-            }
-
-            if (enumerableType == typeof(IOrderedEnumerable<>)
-                && queryableType == typeof(IOrderedQueryable<>))
-            {
-                return true;
-            }
-
-            return false;
+            return enumerableType == typeof(IEnumerable<>) && queryableType == typeof(IQueryable<>)
+                || enumerableType == typeof(IOrderedEnumerable<>) && queryableType == typeof(IOrderedQueryable<>);
         }
     }
 }

--- a/src/EFCore/Query/QueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore/Query/QueryableMethodTranslatingExpressionVisitor.cs
@@ -526,15 +526,12 @@ namespace Microsoft.EntityFrameworkCore.Query
             {
                 Check.NotNull(node, nameof(node));
 
-                if (node is ProjectionBindingExpression projectionBindingExpression)
-                {
-                    return new ProjectionBindingExpression(
+                return node is ProjectionBindingExpression projectionBindingExpression
+                    ? new ProjectionBindingExpression(
                         _queryExpression,
                         projectionBindingExpression.ProjectionMember.Prepend(_memberShift),
-                        projectionBindingExpression.Type);
-                }
-
-                return base.VisitExtension(node);
+                        projectionBindingExpression.Type)
+                    : base.VisitExtension(node);
             }
         }
 

--- a/src/Shared/EnumerableMethods.cs
+++ b/src/Shared/EnumerableMethods.cs
@@ -20,6 +20,7 @@ namespace Microsoft.EntityFrameworkCore
         public static MethodInfo Contains { get; }
 
         public static MethodInfo ToList { get; }
+        public static MethodInfo ToArray { get; }
 
         public static MethodInfo Concat { get; }
         public static MethodInfo Except { get; }
@@ -153,6 +154,8 @@ namespace Microsoft.EntityFrameworkCore
 
             ToList = enumerableMethods.Single(
                 mi => mi.Name == nameof(Enumerable.ToList) && mi.GetParameters().Length == 1);
+            ToArray = enumerableMethods.Single(
+                mi => mi.Name == nameof(Enumerable.ToArray) && mi.GetParameters().Length == 1);
 
             Concat = enumerableMethods.Single(
                 mi => mi.Name == nameof(Enumerable.Concat) && mi.GetParameters().Length == 2);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
@@ -1082,6 +1082,12 @@ WHERE (c[""Discriminator""] = ""Employee"")
 ORDER BY c[""EmployeeID""]");
         }
 
+        [ConditionalTheory(Skip = "Issue#17246")]
+        public override Task Projection_AsEnumerable_projection(bool async)
+        {
+            return base.Projection_AsEnumerable_projection(async);
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindWhereQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindWhereQueryCosmosTest.cs
@@ -1947,6 +1947,102 @@ WHERE ((c[""Discriminator""] = ""Order"") AND @__p_0)");
             AssertSql(" ");
         }
 
+        [ConditionalTheory(Skip = "Issue #17246")]
+        public override Task Where_Queryable_ToList_Count(bool async)
+        {
+            return base.Where_Queryable_ToList_Count(async);
+        }
+
+        [ConditionalTheory(Skip = "Issue #17246")]
+        public override Task Where_Queryable_ToList_Contains(bool async)
+        {
+            return base.Where_Queryable_ToList_Contains(async);
+        }
+
+        [ConditionalTheory(Skip = "Issue #17246")]
+        public override Task Where_Queryable_ToArray_Count(bool async)
+        {
+            return base.Where_Queryable_ToArray_Count(async);
+        }
+
+        [ConditionalTheory(Skip = "Issue #17246")]
+        public override Task Where_Queryable_ToArray_Contains(bool async)
+        {
+            return base.Where_Queryable_ToArray_Contains(async);
+        }
+
+        [ConditionalTheory(Skip = "Issue #17246")]
+        public override Task Where_Queryable_AsEnumerable_Count(bool async)
+        {
+            return base.Where_Queryable_AsEnumerable_Count(async);
+        }
+
+        [ConditionalTheory(Skip = "Issue #17246")]
+        public override Task Where_Queryable_AsEnumerable_Contains(bool async)
+        {
+            return base.Where_Queryable_AsEnumerable_Contains(async);
+        }
+
+        [ConditionalTheory(Skip = "Issue #17246")]
+        public override Task Where_Queryable_ToList_Count_member(bool async)
+        {
+            return base.Where_Queryable_ToList_Count_member(async);
+        }
+
+        [ConditionalTheory(Skip = "Issue #17246")]
+        public override Task Where_Queryable_ToArray_Length_member(bool async)
+        {
+            return base.Where_Queryable_ToArray_Length_member(async);
+        }
+
+        [ConditionalTheory(Skip = "Issue #17246")]
+        public override Task Where_collection_navigation_ToList_Count(bool async)
+        {
+            return base.Where_collection_navigation_ToList_Count(async);
+        }
+
+        [ConditionalTheory(Skip = "Issue #17246")]
+        public override Task Where_collection_navigation_ToList_Contains(bool async)
+        {
+            return base.Where_collection_navigation_ToList_Contains(async);
+        }
+
+        [ConditionalTheory(Skip = "Issue #17246")]
+        public override Task Where_collection_navigation_ToArray_Count(bool async)
+        {
+            return base.Where_collection_navigation_ToArray_Count(async);
+        }
+
+        [ConditionalTheory(Skip = "Issue #17246")]
+        public override Task Where_collection_navigation_ToArray_Contains(bool async)
+        {
+            return base.Where_collection_navigation_ToArray_Contains(async);
+        }
+
+        [ConditionalTheory(Skip = "Issue #17246")]
+        public override Task Where_collection_navigation_AsEnumerable_Count(bool async)
+        {
+            return base.Where_collection_navigation_AsEnumerable_Count(async);
+        }
+
+        [ConditionalTheory(Skip = "Issue #17246")]
+        public override Task Where_collection_navigation_AsEnumerable_Contains(bool async)
+        {
+            return base.Where_collection_navigation_AsEnumerable_Contains(async);
+        }
+
+        [ConditionalTheory(Skip = "Issue #17246")]
+        public override Task Where_collection_navigation_ToList_Count_member(bool async)
+        {
+            return base.Where_collection_navigation_ToList_Count_member(async);
+        }
+
+        [ConditionalTheory(Skip = "Issue #17246")]
+        public override Task Where_collection_navigation_ToArray_Length_member(bool async)
+        {
+            return base.Where_collection_navigation_ToArray_Length_member(async);
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
@@ -248,6 +248,36 @@ WHERE (c[""Discriminator""] = ""LeafA"")");
             return base.Client_method_skip_loads_owned_navigations_variation_2(async);
         }
 
+        [ConditionalTheory(Skip = "Composition over embedded collection #16926")]
+        public override Task Where_owned_collection_navigation_ToList_Count(bool async)
+        {
+            return base.Where_owned_collection_navigation_ToList_Count(async);
+        }
+
+        [ConditionalTheory(Skip = "Composition over embedded collection #16926")]
+        public override Task Where_collection_navigation_ToArray_Count(bool async)
+        {
+            return base.Where_collection_navigation_ToArray_Count(async);
+        }
+
+        [ConditionalTheory(Skip = "Composition over embedded collection #16926")]
+        public override Task Where_collection_navigation_AsEnumerable_Count(bool async)
+        {
+            return base.Where_collection_navigation_AsEnumerable_Count(async);
+        }
+
+        [ConditionalTheory(Skip = "Composition over embedded collection #16926")]
+        public override Task Where_collection_navigation_ToList_Count_member(bool async)
+        {
+            return base.Where_collection_navigation_ToList_Count_member(async);
+        }
+
+        [ConditionalTheory(Skip = "Composition over embedded collection #16926")]
+        public override Task Where_collection_navigation_ToArray_Length_member(bool async)
+        {
+            return base.Where_collection_navigation_ToArray_Length_member(async);
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
@@ -5279,7 +5279,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                           group o by o.CustomerID
                           into g
                           orderby g.Key
-                          select g.OrderByDescending(x => x.OrderID),
+                          select g.OrderByDescending(x => x.OrderID).ToList(),
                     assertOrder: true,
                     elementAsserter: (e, a) => AssertCollection(e, a, ordered: true)));
         }

--- a/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
@@ -1681,5 +1681,21 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => ss.Set<Customer>().Select(c => ss.Set<CustomerView>().FirstOrDefault(cv => cv.CompanyName == c.CompanyName)));
         }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Projection_AsEnumerable_projection(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Customer>()
+                .Where(c => c.CustomerID.StartsWith("A"))
+                .OrderBy(c => c.CustomerID)
+                .Select(c => ss.Set<Order>().Where(o => o.CustomerID == c.CustomerID).AsEnumerable())
+                .Where(e => e.Where(o => o.OrderID < 11000).Count() > 0)
+                .Select(e => e.Where(o => o.OrderID < 10750)),
+                assertOrder: true,
+                entryCount: 18);
+        }
     }
 }

--- a/test/EFCore.Specification.Tests/Query/NorthwindWhereQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindWhereQueryTestBase.cs
@@ -1997,95 +1997,219 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Select(c => c.CustomerID));
         }
 
-        //[ConditionalTheory]
-        //[MemberData(nameof(IsAsyncData))]
-        //public virtual Task Where_ToList_Count(bool async)
-        //{
-        //    return AssertQuery(
-        //        async,
-        //        ss => ss.Set<Customer>().Select(c => ss.Set<Order>().Where(o => o.CustomerID == c.CustomerID).ToList())
-        //            .Where(e => e.Count() == 0),
-        //        entryCount: 6);
-        //}
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_Queryable_ToList_Count(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Customer>().OrderBy(c => c.CustomerID)
+                    .Select(c => ss.Set<Order>().Where(o => o.CustomerID == c.CustomerID).ToList())
+                    .Where(e => e.Count() == 0),
+                assertOrder: true,
+                elementAsserter: (e, a) => AssertCollection(e, a));
+        }
 
-        //[ConditionalTheory]
-        //[MemberData(nameof(IsAsyncData))]
-        //public virtual Task Where_ToList_Contains(bool async)
-        //{
-        //    return AssertQuery(
-        //        async,
-        //        ss => ss.Set<Customer>()
-        //            .Select(c => ss.Set<Order>().Where(o => o.CustomerID == c.CustomerID).Select(o => o.CustomerID).ToList())
-        //            .Where(e => e.Contains("ALFKI")),
-        //        entryCount: 6);
-        //}
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_Queryable_ToList_Contains(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Customer>()
+                    .Select(c => ss.Set<Order>().Where(o => o.CustomerID == c.CustomerID).Select(o => o.CustomerID).ToList())
+                    .Where(e => e.Contains("ALFKI")));
+        }
 
-        //[ConditionalTheory]
-        //[MemberData(nameof(IsAsyncData))]
-        //public virtual Task Where_ToArray_Count(bool async)
-        //{
-        //    return AssertQuery(
-        //        async,
-        //        ss => ss.Set<Customer>().Select(c => ss.Set<Order>().Where(o => o.CustomerID == c.CustomerID).ToArray())
-        //            .Where(e => e.Count() == 0),
-        //        entryCount: 6);
-        //}
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_Queryable_ToArray_Count(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Customer>().OrderBy(c => c.CustomerID)
+                    .Select(c => ss.Set<Order>().Where(o => o.CustomerID == c.CustomerID).ToArray())
+                    .Where(e => e.Count() == 0),
+                assertOrder: true,
+                elementAsserter: (e, a) => AssertCollection(e, a));
+        }
 
-        //[ConditionalTheory]
-        //[MemberData(nameof(IsAsyncData))]
-        //public virtual Task Where_ToArray_Contains(bool async)
-        //{
-        //    return AssertQuery(
-        //        async,
-        //        ss => ss.Set<Customer>()
-        //            .Select(c => ss.Set<Order>().Where(o => o.CustomerID == c.CustomerID).Select(o => o.CustomerID).ToArray())
-        //            .Where(e => e.Contains("ALFKI")),
-        //        entryCount: 6);
-        //}
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_Queryable_ToArray_Contains(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Customer>()
+                    .Select(c => ss.Set<Order>().Where(o => o.CustomerID == c.CustomerID).Select(o => o.CustomerID).ToArray())
+                    .Where(e => e.Contains("ALFKI")));
+        }
 
-        //[ConditionalTheory]
-        //[MemberData(nameof(IsAsyncData))]
-        //public virtual Task Where_AsEnumerable_Count(bool async)
-        //{
-        //    return AssertQuery(
-        //        async,
-        //        ss => ss.Set<Customer>().Select(c => ss.Set<Order>().Where(o => o.CustomerID == c.CustomerID).AsEnumerable())
-        //            .Where(e => e.Count() == 0),
-        //        entryCount: 6);
-        //}
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_Queryable_AsEnumerable_Count(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Customer>().OrderBy(c => c.CustomerID)
+                    .Select(c => ss.Set<Order>().Where(o => o.CustomerID == c.CustomerID).AsEnumerable())
+                    .Where(e => e.Count() == 0),
+                assertOrder: true,
+                elementAsserter: (e, a) => AssertCollection(e, a));
+        }
 
-        //[ConditionalTheory]
-        //[MemberData(nameof(IsAsyncData))]
-        //public virtual Task Where_AsEnumerable_Contains(bool async)
-        //{
-        //    return AssertQuery(
-        //        async,
-        //        ss => ss.Set<Customer>()
-        //            .Select(c => ss.Set<Order>().Where(o => o.CustomerID == c.CustomerID).Select(o => o.CustomerID).AsEnumerable())
-        //            .Where(e => e.Contains("ALFKI")),
-        //        entryCount: 6);
-        //}
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_Queryable_AsEnumerable_Contains(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Customer>()
+                    .Select(c => ss.Set<Order>().Where(o => o.CustomerID == c.CustomerID).Select(o => o.CustomerID).AsEnumerable())
+                    .Where(e => e.Contains("ALFKI")));
+        }
 
-        //[ConditionalTheory]
-        //[MemberData(nameof(IsAsyncData))]
-        //public virtual Task Where_ToList_Count_member(bool async)
-        //{
-        //    return AssertQuery(
-        //        async,
-        //        ss => ss.Set<Customer>().Select(c => ss.Set<Order>().Where(o => o.CustomerID == c.CustomerID).ToList())
-        //            .Where(e => e.Count == 0),
-        //        entryCount: 6);
-        //}
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_Queryable_ToList_Count_member(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Customer>().OrderBy(c => c.CustomerID)
+                    .Select(c => ss.Set<Order>().Where(o => o.CustomerID == c.CustomerID).ToList())
+                    .Where(e => e.Count == 0),
+                assertOrder: true,
+                elementAsserter: (e, a) => AssertCollection(e, a));
+        }
 
-        //[ConditionalTheory]
-        //[MemberData(nameof(IsAsyncData))]
-        //public virtual Task Where_ToArray_Length_member(bool async)
-        //{
-        //    return AssertQuery(
-        //        async,
-        //        ss => ss.Set<Customer>().Select(c => ss.Set<Order>().Where(o => o.CustomerID == c.CustomerID).ToArray())
-        //            .Where(e => e.Length == 0),
-        //        entryCount: 6);
-        //}
+        [ConditionalTheory(Skip = "Issue#19431")]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_Queryable_ToArray_Length_member(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Customer>().OrderBy(c => c.CustomerID)
+                    .Select(c => ss.Set<Order>().Where(o => o.CustomerID == c.CustomerID).ToArray())
+                    .Where(e => e.Length == 0),
+                assertOrder: true,
+                elementAsserter: (e, a) => AssertCollection(e, a));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_collection_navigation_ToList_Count(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Order>()
+                    .Where(o => o.OrderID < 10300)
+                    .OrderBy(o => o.OrderID)
+                    .Select(o => o.OrderDetails.ToList())
+                    .Where(e => e.Count() == 0),
+                assertOrder: true,
+                elementAsserter: (e, a) => AssertCollection(e, a));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_collection_navigation_ToList_Contains(bool async)
+        {
+            var order = new Order { OrderID = 10248 };
+
+            return AssertQuery(
+                async,
+                ss => ss.Set<Customer>()
+                    .Select(c => c.Orders.ToList())
+                    .Where(e => e.Contains(order)),
+                entryCount: 5);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_collection_navigation_ToArray_Count(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Order>()
+                    .Where(o => o.OrderID < 10300)
+                    .OrderBy(o => o.OrderID)
+                    .Select(o => o.OrderDetails.ToArray())
+                    .Where(e => e.Count() == 0),
+                assertOrder: true,
+                elementAsserter: (e, a) => AssertCollection(e, a));
+        }
+
+        [ConditionalTheory(Skip = "Issue#19433")]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_collection_navigation_ToArray_Contains(bool async)
+        {
+            var order = new Order { OrderID = 10248 };
+
+            return AssertQuery(
+                async,
+                ss => ss.Set<Customer>()
+                    .Select(c => c.Orders.ToArray())
+                    .Where(e => e.Contains(order)),
+                entryCount: 5);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_collection_navigation_AsEnumerable_Count(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Order>()
+                    .Where(o => o.OrderID < 10300)
+                    .OrderBy(o => o.OrderID)
+                    .Select(o => o.OrderDetails.AsEnumerable())
+                    .Where(e => e.Count() == 0),
+                assertOrder: true,
+                elementAsserter: (e, a) => AssertCollection(e, a));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_collection_navigation_AsEnumerable_Contains(bool async)
+        {
+            var order = new Order { OrderID = 10248 };
+
+            return AssertQuery(
+                async,
+                ss => ss.Set<Customer>()
+                    .Select(c => c.Orders.AsEnumerable())
+                    .Where(e => e.Contains(order)),
+                entryCount: 5);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_collection_navigation_ToList_Count_member(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Order>()
+                    .Where(o => o.OrderID < 10300)
+                    .OrderBy(o => o.OrderID)
+                    .Select(o => o.OrderDetails.ToList())
+                    .Where(e => e.Count == 0),
+                assertOrder: true,
+                elementAsserter: (e, a) => AssertCollection(e, a));
+        }
+
+        [ConditionalTheory(Skip = "Issue#19431")]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_collection_navigation_ToArray_Length_member(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Order>()
+                    .Where(o => o.OrderID < 10300)
+                    .OrderBy(o => o.OrderID)
+                    .Select(o => o.OrderDetails.ToArray())
+                    .Where(e => e.Length == 0),
+                assertOrder: true,
+                elementAsserter: (e, a) => AssertCollection(e, a));
+        }
     }
 }

--- a/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
@@ -476,9 +476,77 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<OwnedPerson>().OrderBy(e => e.Id).Select(e => Identity(e)).Skip(1).Take(2));
         }
 
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_owned_collection_navigation_ToList_Count(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<OwnedPerson>()
+                    .OrderBy(p => p.Id)
+                    .Select(p => p.Orders.ToList())
+                    .Where(e => e.Count() == 0),
+                assertOrder: true,
+                elementAsserter: (e, a) => AssertCollection(e, a));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_collection_navigation_ToArray_Count(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<OwnedPerson>()
+                    .OrderBy(p => p.Id)
+                    .Select(p => p.Orders.ToArray())
+                    .Where(e => e.Count() == 0),
+                assertOrder: true,
+                elementAsserter: (e, a) => AssertCollection(e, a));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_collection_navigation_AsEnumerable_Count(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<OwnedPerson>()
+                    .OrderBy(p => p.Id)
+                    .Select(p => p.Orders.AsEnumerable())
+                    .Where(e => e.Count() == 0),
+                assertOrder: true,
+                elementAsserter: (e, a) => AssertCollection(e, a));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_collection_navigation_ToList_Count_member(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<OwnedPerson>()
+                    .OrderBy(p => p.Id)
+                    .Select(p => p.Orders.ToList())
+                    .Where(e => e.Count == 0),
+                assertOrder: true,
+                elementAsserter: (e, a) => AssertCollection(e, a));
+        }
+
+        [ConditionalTheory(Skip = "Issue#19431")]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_collection_navigation_ToArray_Length_member(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<OwnedPerson>()
+                    .OrderBy(p => p.Id)
+                    .Select(p => p.Orders.ToArray())
+                    .Where(e => e.Length == 0),
+                assertOrder: true,
+                elementAsserter: (e, a) => AssertCollection(e, a));
+        }
+
         private static OwnedPerson Identity(OwnedPerson person) => person;
-
-
 
         protected virtual DbContext CreateContext() => Fixture.CreateContext();
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -4016,11 +4016,13 @@ ORDER BY [g].[Nickname], [g].[SquadId], [w].[Id]");
             await base.Correlated_collections_naked_navigation_with_ToList_followed_by_projecting_count(async);
 
             AssertSql(
-                @"SELECT [g].[Nickname], [g].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+                @"SELECT (
+    SELECT COUNT(*)
+    FROM [Weapons] AS [w]
+    WHERE [g].[FullName] = [w].[OwnerFullName])
 FROM [Gears] AS [g]
-LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
 WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND ([g].[Nickname] <> N'Marcus')
-ORDER BY [g].[Nickname], [g].[SquadId], [w].[Id]");
+ORDER BY [g].[Nickname]");
         }
 
         public override async Task Correlated_collections_naked_navigation_with_ToArray(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
@@ -1362,6 +1362,25 @@ FROM [Employees] AS [e]
 ORDER BY [e].[EmployeeID]");
         }
 
+        public override async Task Projection_AsEnumerable_projection(bool async)
+        {
+            await base.Projection_AsEnumerable_projection(async);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN (
+    SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    FROM [Orders] AS [o]
+    WHERE [o].[OrderID] < 10750
+) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
+WHERE ([c].[CustomerID] LIKE N'A%') AND ((
+    SELECT COUNT(*)
+    FROM [Orders] AS [o0]
+    WHERE ([o0].[CustomerID] = [c].[CustomerID]) AND ([o0].[OrderID] < 11000)) > 0)
+ORDER BY [c].[CustomerID], [t].[OrderID]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
@@ -1765,6 +1765,236 @@ FROM [Customers] AS [c]
 WHERE ((CAST(@__i_0 AS nchar(5)) + [c].[CustomerID]) + CAST(@__i_0 AS nchar(5))) = [c].[CompanyName]");
         }
 
+        public override async Task Where_Queryable_ToList_Count(bool async)
+        {
+            await base.Where_Queryable_ToList_Count(async);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE (
+    SELECT COUNT(*)
+    FROM [Orders] AS [o0]
+    WHERE [o0].[CustomerID] = [c].[CustomerID]) = 0
+ORDER BY [c].[CustomerID], [o].[OrderID]");
+        }
+
+        public override async Task Where_Queryable_ToList_Contains(bool async)
+        {
+            await base.Where_Queryable_ToList_Contains(async);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [o].[CustomerID], [o].[OrderID]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE N'ALFKI' IN (
+    SELECT [o0].[CustomerID]
+    FROM [Orders] AS [o0]
+    WHERE [o0].[CustomerID] = [c].[CustomerID]
+)
+
+ORDER BY [c].[CustomerID], [o].[OrderID]");
+        }
+
+        public override async Task Where_Queryable_ToArray_Count(bool async)
+        {
+            await base.Where_Queryable_ToArray_Count(async);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE (
+    SELECT COUNT(*)
+    FROM [Orders] AS [o0]
+    WHERE [o0].[CustomerID] = [c].[CustomerID]) = 0
+ORDER BY [c].[CustomerID], [o].[OrderID]");
+        }
+
+        public override async Task Where_Queryable_ToArray_Contains(bool async)
+        {
+            await base.Where_Queryable_ToArray_Contains(async);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [o].[CustomerID], [o].[OrderID]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE N'ALFKI' IN (
+    SELECT [o0].[CustomerID]
+    FROM [Orders] AS [o0]
+    WHERE [o0].[CustomerID] = [c].[CustomerID]
+)
+
+ORDER BY [c].[CustomerID], [o].[OrderID]");
+        }
+
+        public override async Task Where_Queryable_AsEnumerable_Count(bool async)
+        {
+            await base.Where_Queryable_AsEnumerable_Count(async);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE (
+    SELECT COUNT(*)
+    FROM [Orders] AS [o0]
+    WHERE [o0].[CustomerID] = [c].[CustomerID]) = 0
+ORDER BY [c].[CustomerID], [o].[OrderID]");
+        }
+
+        public override async Task Where_Queryable_AsEnumerable_Contains(bool async)
+        {
+            await base.Where_Queryable_AsEnumerable_Contains(async);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [o].[CustomerID], [o].[OrderID]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE N'ALFKI' IN (
+    SELECT [o0].[CustomerID]
+    FROM [Orders] AS [o0]
+    WHERE [o0].[CustomerID] = [c].[CustomerID]
+)
+
+ORDER BY [c].[CustomerID], [o].[OrderID]");
+        }
+
+        public override async Task Where_Queryable_ToList_Count_member(bool async)
+        {
+            await base.Where_Queryable_ToList_Count_member(async);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE (
+    SELECT COUNT(*)
+    FROM [Orders] AS [o0]
+    WHERE [o0].[CustomerID] = [c].[CustomerID]) = 0
+ORDER BY [c].[CustomerID], [o].[OrderID]");
+        }
+
+        public override async Task Where_Queryable_ToArray_Length_member(bool async)
+        {
+            await base.Where_Queryable_ToArray_Length_member(async);
+
+            AssertSql(" ");
+        }
+
+        public override async Task Where_collection_navigation_ToList_Count(bool async)
+        {
+            await base.Where_collection_navigation_ToList_Count(async);
+
+            AssertSql(
+                @"SELECT [o].[OrderID], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Orders] AS [o]
+LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+WHERE ([o].[OrderID] < 10300) AND ((
+    SELECT COUNT(*)
+    FROM [Order Details] AS [o1]
+    WHERE [o].[OrderID] = [o1].[OrderID]) = 0)
+ORDER BY [o].[OrderID], [o0].[OrderID], [o0].[ProductID]");
+        }
+
+        public override async Task Where_collection_navigation_ToList_Contains(bool async)
+        {
+            await base.Where_collection_navigation_ToList_Contains(async);
+
+            AssertSql(
+                @"@__entity_equality_order_0_OrderID='10248' (Nullable = true)
+
+SELECT [c].[CustomerID], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE @__entity_equality_order_0_OrderID IN (
+    SELECT [o0].[OrderID]
+    FROM [Orders] AS [o0]
+    WHERE [c].[CustomerID] = [o0].[CustomerID]
+)
+
+ORDER BY [c].[CustomerID], [o].[OrderID]");
+        }
+
+        public override async Task Where_collection_navigation_ToArray_Count(bool async)
+        {
+            await base.Where_collection_navigation_ToArray_Count(async);
+
+            AssertSql(
+                @"SELECT [o].[OrderID], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Orders] AS [o]
+LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+WHERE ([o].[OrderID] < 10300) AND ((
+    SELECT COUNT(*)
+    FROM [Order Details] AS [o1]
+    WHERE [o].[OrderID] = [o1].[OrderID]) = 0)
+ORDER BY [o].[OrderID], [o0].[OrderID], [o0].[ProductID]");
+        }
+
+        public override async Task Where_collection_navigation_ToArray_Contains(bool async)
+        {
+            await base.Where_collection_navigation_ToArray_Contains(async);
+
+            AssertSql(" ");
+        }
+
+        public override async Task Where_collection_navigation_AsEnumerable_Count(bool async)
+        {
+            await base.Where_collection_navigation_AsEnumerable_Count(async);
+
+            AssertSql(
+                @"SELECT [o].[OrderID], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Orders] AS [o]
+LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+WHERE ([o].[OrderID] < 10300) AND ((
+    SELECT COUNT(*)
+    FROM [Order Details] AS [o1]
+    WHERE [o].[OrderID] = [o1].[OrderID]) = 0)
+ORDER BY [o].[OrderID], [o0].[OrderID], [o0].[ProductID]");
+        }
+
+        public override async Task Where_collection_navigation_AsEnumerable_Contains(bool async)
+        {
+            await base.Where_collection_navigation_AsEnumerable_Contains(async);
+
+            AssertSql(
+                @"@__entity_equality_order_0_OrderID='10248' (Nullable = true)
+
+SELECT [c].[CustomerID], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE @__entity_equality_order_0_OrderID IN (
+    SELECT [o0].[OrderID]
+    FROM [Orders] AS [o0]
+    WHERE [c].[CustomerID] = [o0].[CustomerID]
+)
+
+ORDER BY [c].[CustomerID], [o].[OrderID]");
+        }
+
+        public override async Task Where_collection_navigation_ToList_Count_member(bool async)
+        {
+            await base.Where_collection_navigation_ToList_Count_member(async);
+
+            AssertSql(
+                @"SELECT [o].[OrderID], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Orders] AS [o]
+LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+WHERE ([o].[OrderID] < 10300) AND ((
+    SELECT COUNT(*)
+    FROM [Order Details] AS [o1]
+    WHERE [o].[OrderID] = [o1].[OrderID]) = 0)
+ORDER BY [o].[OrderID], [o0].[OrderID], [o0].[ProductID]");
+        }
+
+        public override async Task Where_collection_navigation_ToArray_Length_member(bool async)
+        {
+            await base.Where_collection_navigation_ToArray_Length_member(async);
+
+            AssertSql(" ");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
@@ -2366,6 +2366,73 @@ LEFT JOIN [Order] AS [o22] ON [t].[Id] = [o22].[ClientId]
 ORDER BY [t].[Id], [o22].[ClientId], [o22].[Id]");
         }
 
+        public override async Task Where_owned_collection_navigation_ToList_Count(bool async)
+        {
+            await base.Where_owned_collection_navigation_ToList_Count(async);
+
+            AssertSql(
+                @"SELECT [o].[Id], [o0].[ClientId], [o0].[Id]
+FROM [OwnedPerson] AS [o]
+LEFT JOIN [Order] AS [o0] ON [o].[Id] = [o0].[ClientId]
+WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA') AND ((
+    SELECT COUNT(*)
+    FROM [Order] AS [o1]
+    WHERE [o].[Id] = [o1].[ClientId]) = 0)
+ORDER BY [o].[Id], [o0].[ClientId], [o0].[Id]");
+        }
+
+        public override async Task Where_collection_navigation_ToArray_Count(bool async)
+        {
+            await base.Where_collection_navigation_ToArray_Count(async);
+
+            AssertSql(
+                @"SELECT [o].[Id], [o0].[ClientId], [o0].[Id]
+FROM [OwnedPerson] AS [o]
+LEFT JOIN [Order] AS [o0] ON ([o].[Id] = [o0].[ClientId]) AND ([o].[Id] = [o0].[ClientId])
+WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA') AND ((
+    SELECT COUNT(*)
+    FROM [Order] AS [o1]
+    WHERE [o].[Id] = [o1].[ClientId]) = 0)
+ORDER BY [o].[Id], [o0].[ClientId], [o0].[Id]");
+        }
+
+        public override async Task Where_collection_navigation_AsEnumerable_Count(bool async)
+        {
+            await base.Where_collection_navigation_AsEnumerable_Count(async);
+
+            AssertSql(
+                @"SELECT [o].[Id], [o0].[ClientId], [o0].[Id]
+FROM [OwnedPerson] AS [o]
+LEFT JOIN [Order] AS [o0] ON [o].[Id] = [o0].[ClientId]
+WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA') AND ((
+    SELECT COUNT(*)
+    FROM [Order] AS [o1]
+    WHERE [o].[Id] = [o1].[ClientId]) = 0)
+ORDER BY [o].[Id], [o0].[ClientId], [o0].[Id]");
+        }
+
+        public override async Task Where_collection_navigation_ToList_Count_member(bool async)
+        {
+            await base.Where_collection_navigation_ToList_Count_member(async);
+
+            AssertSql(
+                @"SELECT [o].[Id], [o0].[ClientId], [o0].[Id]
+FROM [OwnedPerson] AS [o]
+LEFT JOIN [Order] AS [o0] ON [o].[Id] = [o0].[ClientId]
+WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA') AND ((
+    SELECT COUNT(*)
+    FROM [Order] AS [o1]
+    WHERE [o].[Id] = [o1].[ClientId]) = 0)
+ORDER BY [o].[Id], [o0].[ClientId], [o0].[Id]");
+        }
+
+        public override async Task Where_collection_navigation_ToArray_Length_member(bool async)
+        {
+            await base.Where_collection_navigation_ToArray_Length_member(async);
+
+            AssertSql(" ");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
…/ToArray/AsEnumerable

- Convert all enumerable methods to queryable unless specified on query parameter (coming from closure)
- Convert ICollection<T>.Count to Queryable.Count<T>()
- Simplify (Queryable/CollectionNav/OwnedCollectionNav).(ToList/ToArray/AsEnumerable).AsQueryable to underlying queryable
- Remove MaterializeCollectionNavigation when ToList/ToArray is called on collection navigation.
- Convert Array.Length to Queryable.Count<T>()

Resolves #19059
Resolves #19060

<!--
Please check if the PR fulfills these requirements

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines.
      https://github.com/aspnet/AspNetCore/wiki/Engineering-guidelines

Review the guidelines for CONTRIBUTING.md for more details.
-->


