### PR TITLE
Always store original values for index properties

### DIFF
--- a/src/EFCore/Extensions/PropertyExtensions.cs
+++ b/src/EFCore/Extensions/PropertyExtensions.cs
@@ -98,6 +98,16 @@ namespace Microsoft.EntityFrameworkCore
             => Check.NotNull(property, nameof(property)).AsProperty().Indexes != null;
 
         /// <summary>
+        ///     Gets a value indicating whether this property is used as a unique index (or part of a unique composite index).
+        /// </summary>
+        /// <param name="property"> The property to check. </param>
+        /// <returns>
+        ///     <c>true</c> if the property is used as an uniqueindex, otherwise <c>false</c>.
+        /// </returns>
+        public static bool IsUniqueIndex([NotNull] this IProperty property)
+            => Check.NotNull(property, nameof(property)).AsProperty().Indexes?.Any(e => e.IsUnique) == true;
+
+        /// <summary>
         ///     Gets a value indicating whether this property is used as the primary key (or part of a composite primary key).
         /// </summary>
         /// <param name="property"> The property to check. </param>

--- a/src/EFCore/Metadata/Internal/PropertyExtensions.cs
+++ b/src/EFCore/Metadata/Internal/PropertyExtensions.cs
@@ -141,7 +141,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             => property.DeclaringEntityType.GetChangeTrackingStrategy() != ChangeTrackingStrategy.ChangingAndChangedNotifications
                 || property.IsConcurrencyToken
                 || property.IsKey()
-                || property.IsForeignKey();
+                || property.IsForeignKey()
+                || property.IsUniqueIndex();
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/test/EFCore.Specification.Tests/GraphUpdatesFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdatesFixtureBase.cs
@@ -365,6 +365,10 @@ namespace Microsoft.EntityFrameworkCore
 
                 modelBuilder.Entity<Poost>();
                 modelBuilder.Entity<Bloog>();
+
+                modelBuilder.Entity<Produce>()
+                    .HasIndex(e => e.BarCode)
+                    .IsUnique();
             }
 
             protected virtual object CreateFullGraph()
@@ -2703,6 +2707,31 @@ namespace Microsoft.EntityFrameworkCore
             {
                 get => _choices;
                 set => SetWithNotify(value, ref _choices);
+            }
+        }
+
+        protected class Produce : NotifyingEntity
+        {
+            private Guid _produceId;
+            private string _name;
+            private int _barCode;
+
+            public Guid ProduceId
+            {
+                get => _produceId;
+                set => SetWithNotify(value, ref _produceId);
+            }
+
+            public string Name
+            {
+                get => _name;
+                set => SetWithNotify(value, ref _name);
+            }
+
+            public int BarCode
+            {
+                get => _barCode;
+                set => SetWithNotify(value, ref _barCode);
             }
         }
 

--- a/test/EFCore.Specification.Tests/GraphUpdatesTestBase.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdatesTestBase.cs
@@ -727,6 +727,34 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
+        public virtual void Notification_entities_can_have_indexes()
+        {
+            ExecuteWithStrategyInTransaction(
+                context =>
+                {
+                    var produce = new Produce { Name = "Apple", BarCode = 77 };
+                    context.Add(produce);
+
+                    Assert.Equal(EntityState.Added, context.Entry(produce).State);
+
+                    context.SaveChanges();
+
+                    Assert.Equal(EntityState.Unchanged, context.Entry(produce).State);
+                    Assert.NotEqual(Guid.Empty, context.Entry(produce).Property(e => e.ProduceId).OriginalValue);
+                    Assert.Equal(77, context.Entry(produce).Property(e => e.BarCode).OriginalValue);
+
+                    context.Remove(produce);
+                    Assert.Equal(EntityState.Deleted, context.Entry(produce).State);
+                    Assert.NotEqual(Guid.Empty, context.Entry(produce).Property(e => e.ProduceId).OriginalValue);
+                    Assert.Equal(77, context.Entry(produce).Property(e => e.BarCode).OriginalValue);
+
+                    context.SaveChanges();
+
+                    Assert.Equal(EntityState.Detached, context.Entry(produce).State);
+                });
+        }
+
+        [ConditionalFact]
         public virtual void Resetting_a_deleted_reference_fixes_up_again()
         {
             ExecuteWithStrategyInTransaction(

--- a/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
@@ -2580,10 +2580,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             Assert.Equal(0, entityType.FindProperty("Id").GetOriginalValueIndex());
             Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetOriginalValueIndex());
-            Assert.Equal(2, entityType.FindProperty("Name").GetOriginalValueIndex());
-            Assert.Equal(3, entityType.FindProperty("Token").GetOriginalValueIndex());
+            Assert.Equal(2, entityType.FindProperty("Index").GetOriginalValueIndex());
+            Assert.Equal(3, entityType.FindProperty("Name").GetOriginalValueIndex());
+            Assert.Equal(4, entityType.FindProperty("Token").GetOriginalValueIndex());
+            Assert.Equal(5, entityType.FindProperty("UniqueIndex").GetOriginalValueIndex());
 
-            Assert.Equal(4, entityType.OriginalValueCount());
+            Assert.Equal(6, entityType.OriginalValueCount());
         }
 
         [ConditionalFact]
@@ -2595,8 +2597,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             Assert.Equal(0, entityType.FindProperty("Id").GetRelationshipIndex());
             Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetRelationshipIndex());
+            Assert.Equal(-1, entityType.FindProperty("Index").GetRelationshipIndex());
             Assert.Equal(-1, entityType.FindProperty("Name").GetRelationshipIndex());
             Assert.Equal(-1, entityType.FindProperty("Token").GetRelationshipIndex());
+            Assert.Equal(-1, entityType.FindProperty("UniqueIndex").GetRelationshipIndex());
             Assert.Equal(2, entityType.FindNavigation("CollectionNav").GetRelationshipIndex());
             Assert.Equal(3, entityType.FindNavigation("ReferenceNav").GetRelationshipIndex());
 
@@ -2612,10 +2616,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             Assert.Equal(0, entityType.FindProperty("Id").GetOriginalValueIndex());
             Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetOriginalValueIndex());
-            Assert.Equal(2, entityType.FindProperty("Name").GetOriginalValueIndex());
-            Assert.Equal(3, entityType.FindProperty("Token").GetOriginalValueIndex());
+            Assert.Equal(2, entityType.FindProperty("Index").GetOriginalValueIndex());
+            Assert.Equal(3, entityType.FindProperty("Name").GetOriginalValueIndex());
+            Assert.Equal(4, entityType.FindProperty("Token").GetOriginalValueIndex());
+            Assert.Equal(5, entityType.FindProperty("UniqueIndex").GetOriginalValueIndex());
 
-            Assert.Equal(4, entityType.OriginalValueCount());
+            Assert.Equal(6, entityType.OriginalValueCount());
         }
 
         [ConditionalFact]
@@ -2627,8 +2633,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             Assert.Equal(0, entityType.FindProperty("Id").GetRelationshipIndex());
             Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetRelationshipIndex());
+            Assert.Equal(-1, entityType.FindProperty("Index").GetRelationshipIndex());
             Assert.Equal(-1, entityType.FindProperty("Name").GetRelationshipIndex());
             Assert.Equal(-1, entityType.FindProperty("Token").GetRelationshipIndex());
+            Assert.Equal(-1, entityType.FindProperty("UniqueIndex").GetRelationshipIndex());
             Assert.Equal(-1, entityType.FindNavigation("CollectionNav").GetRelationshipIndex());
             Assert.Equal(2, entityType.FindNavigation("ReferenceNav").GetRelationshipIndex());
 
@@ -2636,7 +2644,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         [ConditionalFact]
-        public void Only_concurrency_and_key_properties_have_original_value_indexes_when_using_full_notifications()
+        public void Only_concurrency_index_and_key_properties_have_original_value_indexes_when_using_full_notifications()
         {
             var entityType = BuildFullNotificationEntityModel().FindEntityType(typeof(FullNotificationEntity));
             entityType.SetChangeTrackingStrategy(ChangeTrackingStrategy.ChangingAndChangedNotifications);
@@ -2645,9 +2653,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Assert.Equal(0, entityType.FindProperty("Id").GetOriginalValueIndex());
             Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetOriginalValueIndex());
             Assert.Equal(-1, entityType.FindProperty("Name").GetOriginalValueIndex());
+            Assert.Equal(-1, entityType.FindProperty("Index").GetOriginalValueIndex());
             Assert.Equal(2, entityType.FindProperty("Token").GetOriginalValueIndex());
+            Assert.Equal(3, entityType.FindProperty("UniqueIndex").GetOriginalValueIndex());
 
-            Assert.Equal(3, entityType.OriginalValueCount());
+            Assert.Equal(4, entityType.OriginalValueCount());
         }
 
         [ConditionalFact]
@@ -2659,8 +2669,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             Assert.Equal(0, entityType.FindProperty("Id").GetRelationshipIndex());
             Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetRelationshipIndex());
+            Assert.Equal(-1, entityType.FindProperty("Index").GetRelationshipIndex());
             Assert.Equal(-1, entityType.FindProperty("Name").GetRelationshipIndex());
             Assert.Equal(-1, entityType.FindProperty("Token").GetRelationshipIndex());
+            Assert.Equal(-1, entityType.FindProperty("UniqueIndex").GetRelationshipIndex());
             Assert.Equal(-1, entityType.FindNavigation("CollectionNav").GetRelationshipIndex());
             Assert.Equal(2, entityType.FindNavigation("ReferenceNav").GetRelationshipIndex());
 
@@ -2676,10 +2688,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             Assert.Equal(0, entityType.FindProperty("Id").GetOriginalValueIndex());
             Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetOriginalValueIndex());
-            Assert.Equal(2, entityType.FindProperty("Name").GetOriginalValueIndex());
-            Assert.Equal(3, entityType.FindProperty("Token").GetOriginalValueIndex());
+            Assert.Equal(2, entityType.FindProperty("Index").GetOriginalValueIndex());
+            Assert.Equal(3, entityType.FindProperty("Name").GetOriginalValueIndex());
+            Assert.Equal(4, entityType.FindProperty("Token").GetOriginalValueIndex());
+            Assert.Equal(5, entityType.FindProperty("UniqueIndex").GetOriginalValueIndex());
 
-            Assert.Equal(4, entityType.OriginalValueCount());
+            Assert.Equal(6, entityType.OriginalValueCount());
         }
 
         [ConditionalFact]
@@ -2691,8 +2705,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             Assert.Equal(0, entityType.FindProperty("Id").GetRelationshipIndex());
             Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetRelationshipIndex());
+            Assert.Equal(-1, entityType.FindProperty("Index").GetRelationshipIndex());
             Assert.Equal(-1, entityType.FindProperty("Name").GetRelationshipIndex());
             Assert.Equal(-1, entityType.FindProperty("Token").GetRelationshipIndex());
+            Assert.Equal(-1, entityType.FindProperty("UniqueIndex").GetRelationshipIndex());
             Assert.Equal(-1, entityType.FindNavigation("CollectionNav").GetRelationshipIndex());
             Assert.Equal(2, entityType.FindNavigation("ReferenceNav").GetRelationshipIndex());
 
@@ -2869,6 +2885,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         .WithOne();
 
                     b.Property(e => e.Token).IsConcurrencyToken();
+
+                    b.HasIndex(e => e.Index);
+
+                    b.HasIndex(e => e.UniqueIndex).IsUnique();
                 });
 
             return (Model)builder.Model;
@@ -2880,6 +2900,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             public int Id { get; set; }
             public string Name { get; set; }
             public int Token { get; set; }
+            public int Index { get; set; }
+            public int UniqueIndex { get; set; }
 
             public AnotherEntity ReferenceNav { get; set; }
             public int AnotherEntityId { get; set; }


### PR DESCRIPTION
Since these are used by the update pipeline.

Fixes #18859
