### PR TITLE
Metadata: Disallow backing field on indexer property

### DIFF
--- a/src/EFCore/Metadata/Conventions/BackingFieldConvention.cs
+++ b/src/EFCore/Metadata/Conventions/BackingFieldConvention.cs
@@ -84,7 +84,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         private FieldInfo GetFieldToSet(IConventionPropertyBase propertyBase)
         {
             if (propertyBase == null
-                || !ConfigurationSource.Convention.Overrides(propertyBase.GetFieldInfoConfigurationSource()))
+                || !ConfigurationSource.Convention.Overrides(propertyBase.GetFieldInfoConfigurationSource())
+                || propertyBase.IsIndexerProperty())
             {
                 return null;
             }

--- a/src/EFCore/Metadata/Internal/PropertyBase.cs
+++ b/src/EFCore/Metadata/Internal/PropertyBase.cs
@@ -151,6 +151,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (fieldInfo != null)
             {
                 IsCompatible(fieldInfo, ClrType, DeclaringType.ClrType, Name, shouldThrow: true);
+
+                if (PropertyInfo != null
+                    && PropertyInfo.IsIndexerProperty())
+                {
+                    throw new InvalidOperationException(
+                        CoreStrings.BackingFieldOnIndexer(fieldInfo.GetSimpleMemberName(), DeclaringType.DisplayName(), Name));
+                }
             }
 
             if (PropertyInfo == null

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2316,6 +2316,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 GetString("NonIndexerEntityType", nameof(property), nameof(entity), nameof(type)),
                 property, entity, type);
 
+        /// <summary>
+        ///     Cannot set backing field '{field}' for the indexer property '{entityType}.{property}'. Indexer properties are not allowed to use a backing field.
+        /// </summary>
+        public static string BackingFieldOnIndexer([CanBeNull] object field, [CanBeNull] object entityType, [CanBeNull] object property)
+            => string.Format(
+                GetString("BackingFieldOnIndexer", nameof(field), nameof(entityType), nameof(property)),
+                field, entityType, property);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1248,4 +1248,7 @@
   <data name="NonIndexerEntityType" xml:space="preserve">
     <value>Cannot add property '{property}' on entity type '{entity}' since there is no indexer on '{entity}' taking a single argument of type '{type}'.</value>
   </data>
+  <data name="BackingFieldOnIndexer" xml:space="preserve">
+    <value>Cannot set backing field '{field}' for the indexer property '{entityType}.{property}'. Indexer properties are not allowed to use a backing field.</value>
+  </data>
 </root>

--- a/test/EFCore.Tests/Metadata/Conventions/BackingFieldConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/BackingFieldConventionTest.cs
@@ -241,6 +241,29 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             Assert.Equal("m_onTheRun", property.GetFieldName());
         }
 
+        [ConditionalFact]
+        public void Backing_field_is_not_discovered_for_indexer_property()
+        {
+            var entityType = CreateModel().AddEntityType(typeof(IndexedClass));
+            var property = entityType.AddIndexedProperty("Nation", typeof(string));
+
+            RunConvention(property);
+            Validate(property);
+
+            Assert.Null(property.GetFieldName());
+        }
+
+        [ConditionalFact]
+        public void Setting_field_on_indexer_property_throws()
+        {
+            var entityType = CreateModel().AddEntityType(typeof(IndexedClass));
+            var property = entityType.AddIndexedProperty("Nation", typeof(string));
+
+            Assert.Equal(
+                CoreStrings.BackingFieldOnIndexer("nation", entityType.DisplayName(), "Nation"),
+                Assert.Throws<InvalidOperationException>(() => property.SetField("nation")).Message);
+        }
+
         private void RunConvention(IMutableProperty property)
             => new BackingFieldConvention(CreateDependencies())
                 .ProcessPropertyAdded(
@@ -457,6 +480,17 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 get { return m_onTheRun; }
                 set { m_onTheRun = (int)value; }
             }
+        }
+
+        private class IndexedClass
+        {
+            private string nation;
+            private string _nation;
+            private string _Nation;
+            private string m_nation;
+            private string m_Nation;
+
+            public object this[string name] => null;
         }
 
 #pragma warning disable RCS1222 // Merge preprocessor directives.


### PR DESCRIPTION
- Don't discover backing field for indexer property by convention
- Throw if trying to set a backing field for indexer property

Resolves #19448
