### PR TITLE
Query: Sql translation is null if type mapping cannot be assigned to …

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
@@ -60,11 +60,9 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
             {
                 translation = _sqlExpressionFactory.ApplyDefaultTypeMapping(translation);
 
-                if ((translation is SqlConstantExpression
-                     || translation is SqlParameterExpression)
-                    && translation.TypeMapping == null)
+                if (translation.TypeMapping == null)
                 {
-                    // Non-mappable constant/parameter
+                    // The return type is not-mappable hence return null
                     return null;
                 }
 

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -60,11 +60,9 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 translation = SqlExpressionFactory.ApplyDefaultTypeMapping(translation);
 
-                if ((translation is SqlConstantExpression
-                        || translation is SqlParameterExpression)
-                    && translation.TypeMapping == null)
+                if (translation.TypeMapping == null)
                 {
-                    // Non-mappable constant/parameter
+                    // The return type is not-mappable hence return null
                     return null;
                 }
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
@@ -1088,6 +1088,17 @@ ORDER BY c[""EmployeeID""]");
             return base.Projection_AsEnumerable_projection(async);
         }
 
+        public override async Task Projection_custom_type_in_both_sides_of_ternary(bool async)
+        {
+            await base.Projection_custom_type_in_both_sides_of_ternary(async);
+
+            AssertSql(
+                @"SELECT (c[""City""] = ""Seattle"") AS c
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY c[""CustomerID""]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
@@ -1697,5 +1697,26 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true,
                 entryCount: 18);
         }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Projection_custom_type_in_both_sides_of_ternary(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Customer>()
+                    .OrderBy(c => c.CustomerID)
+                    .Select(c => c.City == "Seattle"
+                        ? new IdName<string> { Id = "PAY", Name = "Pay" }
+                        : new IdName<string> { Id = "REC", Name = "Receive" }),
+                assertOrder: true,
+                elementAsserter: (e, a) => { Assert.Equal(e.Id, a.Id); Assert.Equal(e.Name, a.Name); });
+        }
+
+        private class IdName<T>
+        {
+            public T Id { get; set; }
+            public string Name { get; set; }
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
@@ -1381,6 +1381,19 @@ WHERE ([c].[CustomerID] LIKE N'A%') AND ((
 ORDER BY [c].[CustomerID], [t].[OrderID]");
         }
 
+        public override async Task Projection_custom_type_in_both_sides_of_ternary(bool async)
+        {
+            await base.Projection_custom_type_in_both_sides_of_ternary(async);
+
+            AssertSql(
+                @"SELECT CASE
+    WHEN ([c].[City] = N'Seattle') AND [c].[City] IS NOT NULL THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
…expression

Resolves #19435

We had logic in place for Constant/Parameter but they appeared in SqlCaseExpression.
Overall, if the top level type cannot be mapped then it cannot be put in SQL tree so translation should return null
