### PR TITLE
Query: Make partitions optional in RowNumberExpression

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressions/RowNumberExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/RowNumberExpression.cs
@@ -14,15 +14,14 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
     public class RowNumberExpression : SqlExpression
     {
         public RowNumberExpression(
-            [NotNull] IReadOnlyList<SqlExpression> partitions,
+            [CanBeNull] IReadOnlyList<SqlExpression> partitions,
             [NotNull] IReadOnlyList<OrderingExpression> orderings,
             [CanBeNull] RelationalTypeMapping typeMapping)
             : base(typeof(long), typeMapping)
         {
-            Check.NotNull(partitions, nameof(partitions));
             Check.NotEmpty(orderings, nameof(orderings));
 
-            Partitions = partitions;
+            Partitions = partitions ?? Array.Empty<SqlExpression>();
             Orderings = orderings;
         }
 


### PR DESCRIPTION
Resolves #19331
