### PR TITLE
RevEng: Do not generate redundant ColumnName/Type in fluent API

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
@@ -572,6 +572,10 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             {
                 // Strip out any annotations handled as attributes - these are already handled when generating
                 // the entity's properties
+                // Only relational ones need to be removed here. Core ones are already removed by FilterIgnoredAnnotations
+                annotations.Remove(RelationalAnnotationNames.ColumnName);
+                annotations.Remove(RelationalAnnotationNames.ColumnType);
+
                 _ = _annotationCodeGenerator.GenerateDataAnnotationAttributes(property, annotations);
             }
             else
@@ -640,7 +644,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
             var valueGenerated = property.ValueGenerated;
             var isRowVersion = false;
-            if (((IConventionProperty)property).GetValueGeneratedConfigurationSource().HasValue
+            if (((IConventionProperty)property).GetValueGeneratedConfigurationSource() is ConfigurationSource valueGeneratedConfigurationSource
+                && valueGeneratedConfigurationSource != ConfigurationSource.Convention
                 && RelationalValueGenerationConvention.GetValueGenerated(property) != valueGenerated)
             {
                 var methodName = valueGenerated switch

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 new ModelCodeGenerationOptions(),
                 code =>
                 {
-                    Assert.Equal(
+                    AssertFileContents(
                         @"using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -63,8 +63,7 @@ namespace TestNamespace
     }
 }
 ",
-                        code.ContextFile.Code,
-                        ignoreLineEndingDifferences: true);
+                        code.ContextFile);
 
                     Assert.Empty(code.AdditionalFiles);
                 },
@@ -79,7 +78,7 @@ namespace TestNamespace
                 new ModelCodeGenerationOptions { SuppressConnectionStringWarning = true },
                 code =>
                 {
-                    Assert.Equal(
+                    AssertFileContents(
                         @"using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -116,8 +115,7 @@ namespace TestNamespace
     }
 }
 ",
-                        code.ContextFile.Code,
-                        ignoreLineEndingDifferences: true);
+                        code.ContextFile);
 
                     Assert.Empty(code.AdditionalFiles);
                 },
@@ -132,7 +130,7 @@ namespace TestNamespace
                 new ModelCodeGenerationOptions { SuppressOnConfiguring = true },
                 code =>
                 {
-                    Assert.Equal(
+                    AssertFileContents(
                         @"using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -161,11 +159,11 @@ namespace TestNamespace
     }
 }
 ",
-                        code.ContextFile.Code,
-                        ignoreLineEndingDifferences: true);
+                        code.ContextFile);
 
                     Assert.Empty(code.AdditionalFiles);
-                });
+                },
+                null);
         }
 
         [ConditionalFact]
@@ -448,7 +446,7 @@ namespace TestNamespace
                 new ModelCodeGenerationOptions { UseDataAnnotations = false },
                 code =>
                 {
-                    Assert.Equal(
+                    AssertFileContents(
                         @"using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -502,8 +500,7 @@ namespace TestNamespace
     }
 }
 ",
-                        code.ContextFile.Code,
-                        ignoreLineEndingDifferences: true);
+                        code.ContextFile);
                 },
                 model =>
                     Assert.Equal(2, model.FindEntityType("TestNamespace.EntityWithIndexes").GetIndexes().Count()));
@@ -532,7 +529,7 @@ namespace TestNamespace
                 new ModelCodeGenerationOptions { UseDataAnnotations = true },
                 code =>
                 {
-                    Assert.Equal(
+                    AssertFileContents(
                         @"using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -583,8 +580,7 @@ namespace TestNamespace
     }
 }
 ",
-                        code.ContextFile.Code,
-                        ignoreLineEndingDifferences: true);
+                        code.ContextFile);
                 },
                 model =>
                     Assert.Equal(2, model.FindEntityType("TestNamespace.EntityWithIndexes").GetIndexes().Count()));
@@ -616,7 +612,7 @@ namespace TestNamespace
                 new ModelCodeGenerationOptions { UseDataAnnotations = false },
                 code =>
                 {
-                    Assert.Equal(
+                    AssertFileContents(
                         @"using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -659,8 +655,6 @@ namespace TestNamespace
 
                 entity.Property(e => e.Id).UseIdentityColumn();
 
-                entity.Property(e => e.DependentId).ValueGeneratedNever();
-
                 entity.HasOne(d => d.NavigationToPrincipal)
                     .WithOne(p => p.NavigationToDependent)
                     .HasPrincipalKey<PrincipalEntity>(p => p.PrincipalId)
@@ -672,8 +666,6 @@ namespace TestNamespace
                 entity.HasKey(e => e.AlternateId);
 
                 entity.Property(e => e.AlternateId).UseIdentityColumn();
-
-                entity.Property(e => e.Id).ValueGeneratedNever();
             });
 
             OnModelCreatingPartial(modelBuilder);
@@ -683,8 +675,7 @@ namespace TestNamespace
     }
 }
 ",
-                        code.ContextFile.Code,
-                        ignoreLineEndingDifferences: true);
+                        code.ContextFile);
                 },
                 model => { });
                 }

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityTypeGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityTypeGeneratorTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
+using Microsoft.EntityFrameworkCore.Internal;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
@@ -9,7 +10,882 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
     public class CSharpEntityTypeGeneratorTest : ModelCodeGeneratorTestBase
     {
         [ConditionalFact]
-        public void Navigation_properties()
+        public void KeylessAttribute_is_generated_for_key_less_entity()
+        {
+            Test(
+                modelBuilder => modelBuilder.Entity("Vista").HasNoKey(),
+                new ModelCodeGenerationOptions { UseDataAnnotations = true },
+                code =>
+                {
+                    AssertFileContents(
+                        @"using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+#nullable disable
+
+namespace TestNamespace
+{
+    [Keyless]
+    public partial class Vista
+    {
+    }
+}
+",
+                        code.AdditionalFiles.Single(f => f.Path == "Vista.cs"));
+
+                    AssertFileContents(
+                        @"using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+#nullable disable
+
+namespace TestNamespace
+{
+    public partial class TestDbContext : DbContext
+    {
+        public TestDbContext()
+        {
+        }
+
+        public TestDbContext(DbContextOptions<TestDbContext> options)
+            : base(options)
+        {
+        }
+
+        public virtual DbSet<Vista> Vista { get; set; }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            if (!optionsBuilder.IsConfigured)
+            {
+#warning "
+                        + DesignStrings.SensitiveInformationWarning
+                        + @"
+                optionsBuilder.UseSqlServer(""Initial Catalog=TestDatabase"");
+            }
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            OnModelCreatingPartial(modelBuilder);
+        }
+
+        partial void OnModelCreatingPartial(ModelBuilder modelBuilder);
+    }
+}
+",
+                        code.ContextFile);
+                },
+                model =>
+                {
+                    var entityType = model.FindEntityType("TestNamespace.Vista");
+                    Assert.Null(entityType.FindPrimaryKey());
+                });
+        }
+
+        [ConditionalFact]
+        public void TableAttribute_is_generated_for_custom_name()
+        {
+            Test(
+                modelBuilder =>
+                {
+                    modelBuilder.Entity("Vista",
+                    b =>
+                    {
+                        b.ToTable("Vistas"); // Default name is "Vista" in the absence of pluralizer
+                        b.Property<int>("Id");
+                        b.HasKey("Id");
+                    });
+                },
+                new ModelCodeGenerationOptions { UseDataAnnotations = true },
+                code =>
+                {
+                    AssertFileContents(
+                        @"using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+#nullable disable
+
+namespace TestNamespace
+{
+    [Table(""Vistas"")]
+    public partial class Vista
+    {
+        [Key]
+        public int Id { get; set; }
+    }
+}
+",
+                        code.AdditionalFiles.Single(f => f.Path == "Vista.cs"));
+                },
+                model =>
+                {
+                    var entityType = model.FindEntityType("TestNamespace.Vista");
+                    Assert.Equal("Vistas", entityType.GetTableName());
+                    Assert.Null(entityType.GetSchema());
+                });
+        }
+
+        [ConditionalFact]
+        public void TableAttribute_is_not_generated_for_default_schema()
+        {
+            Test(
+                modelBuilder =>
+                {
+                    modelBuilder.HasDefaultSchema("dbo");
+                    modelBuilder.Entity("Vista",
+                    b =>
+                    {
+                        b.ToTable("Vista", "dbo"); // Default name is "Vista" in the absence of pluralizer
+                        b.Property<int>("Id");
+                        b.HasKey("Id");
+                    });
+                },
+                new ModelCodeGenerationOptions { UseDataAnnotations = true },
+                code =>
+                {
+                    AssertFileContents(
+                        @"using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+#nullable disable
+
+namespace TestNamespace
+{
+    public partial class Vista
+    {
+        [Key]
+        public int Id { get; set; }
+    }
+}
+",
+                        code.AdditionalFiles.Single(f => f.Path == "Vista.cs"));
+                },
+                model =>
+                {
+                    var entityType = model.FindEntityType("TestNamespace.Vista");
+                    Assert.Equal("Vista", entityType.GetTableName());
+                    Assert.Null(entityType.GetSchema()); // Takes through model default schema
+                });
+        }
+
+        [ConditionalFact]
+        public void TableAttribute_is_generated_for_non_default_schema()
+        {
+            Test(
+                modelBuilder =>
+                {
+                    modelBuilder.HasDefaultSchema("dbo");
+                    modelBuilder.Entity("Vista",
+                    b =>
+                    {
+                        b.ToTable("Vista", "custom");
+                        b.Property<int>("Id");
+                        b.HasKey("Id");
+                    });
+                },
+                new ModelCodeGenerationOptions { UseDataAnnotations = true },
+                code =>
+                {
+                    AssertFileContents(
+                        @"using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+#nullable disable
+
+namespace TestNamespace
+{
+    [Table(""Vista"", Schema = ""custom"")]
+    public partial class Vista
+    {
+        [Key]
+        public int Id { get; set; }
+    }
+}
+",
+                        code.AdditionalFiles.Single(f => f.Path == "Vista.cs"));
+                },
+                model =>
+                {
+                    var entityType = model.FindEntityType("TestNamespace.Vista");
+                    Assert.Equal("Vista", entityType.GetTableName());
+                    Assert.Equal("custom", entityType.GetSchema());
+                });
+        }
+
+        [ConditionalFact]
+        public void TableAttribute_is_not_generated_for_views()
+        {
+            Test(
+                modelBuilder => modelBuilder.Entity("Vista").ToView("Vistas", "dbo"),
+                new ModelCodeGenerationOptions { UseDataAnnotations = true },
+                code =>
+                {
+                    AssertFileContents(
+                        @"using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+#nullable disable
+
+namespace TestNamespace
+{
+    [Keyless]
+    public partial class Vista
+    {
+    }
+}
+",
+                        code.AdditionalFiles.Single(f => f.Path == "Vista.cs"));
+                },
+                model =>
+                {
+                    var entityType = model.FindEntityType("TestNamespace.Vista");
+                    Assert.Equal("Vistas", entityType.GetViewName());
+                    Assert.Null(entityType.GetTableName());
+                    Assert.Equal("dbo", entityType.GetViewSchema());
+                    Assert.Null(entityType.GetSchema());
+                });
+        }
+
+        [ConditionalFact]
+        public void IndexAttribute_is_generated_for_multiple_indexes_with_name_unique()
+        {
+            Test(
+                modelBuilder => modelBuilder
+                    .Entity(
+                        "EntityWithIndexes",
+                        x =>
+                        {
+                            x.Property<int>("Id");
+                            x.Property<int>("A");
+                            x.Property<int>("B");
+                            x.Property<int>("C");
+                            x.HasKey("Id");
+                            x.HasIndex(new[] { "A", "B" }, "IndexOnAAndB")
+                                .IsUnique();
+                            x.HasIndex(new[] { "B", "C" }, "IndexOnBAndC");
+                            x.HasIndex("C");
+                        }),
+                new ModelCodeGenerationOptions { UseDataAnnotations = true },
+                code =>
+                {
+                    AssertFileContents(
+                        @"using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+#nullable disable
+
+namespace TestNamespace
+{
+    [Index(nameof(C))]
+    [Index(nameof(A), nameof(B), Name = ""IndexOnAAndB"", IsUnique = true)]
+    [Index(nameof(B), nameof(C), Name = ""IndexOnBAndC"")]
+    public partial class EntityWithIndexes
+    {
+        [Key]
+        public int Id { get; set; }
+        public int A { get; set; }
+        public int B { get; set; }
+        public int C { get; set; }
+    }
+}
+",
+                        code.AdditionalFiles.Single(f => f.Path == "EntityWithIndexes.cs"));
+                },
+                model =>
+                {
+                    var entityType = model.FindEntityType("TestNamespace.EntityWithIndexes");
+                    var indexes = entityType.GetIndexes();
+                    Assert.Collection(indexes,
+                        t => Assert.Null(t.Name),
+                        t => Assert.Equal("IndexOnAAndB", t.Name),
+                        t => Assert.Equal("IndexOnBAndC", t.Name));
+                });
+        }
+
+        [ConditionalFact]
+        public void Entity_with_indexes_generates_IndexAttribute_only_for_indexes_without_annotations()
+        {
+            Test(
+                modelBuilder => modelBuilder
+                    .Entity(
+                        "EntityWithIndexes",
+                        x =>
+                        {
+                            x.Property<int>("Id");
+                            x.Property<int>("A");
+                            x.Property<int>("B");
+                            x.Property<int>("C");
+                            x.HasKey("Id");
+                            x.HasIndex(new[] { "A", "B" }, "IndexOnAAndB")
+                                .IsUnique();
+                            x.HasIndex(new[] { "B", "C" }, "IndexOnBAndC")
+                                .HasFilter("Filter SQL");
+                        }),
+                new ModelCodeGenerationOptions { UseDataAnnotations = true },
+                code =>
+                {
+                    AssertFileContents(
+                        @"using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+#nullable disable
+
+namespace TestNamespace
+{
+    [Index(nameof(A), nameof(B), Name = ""IndexOnAAndB"", IsUnique = true)]
+    public partial class EntityWithIndexes
+    {
+        [Key]
+        public int Id { get; set; }
+        public int A { get; set; }
+        public int B { get; set; }
+        public int C { get; set; }
+    }
+}
+",
+                        code.AdditionalFiles.Single(f => f.Path == "EntityWithIndexes.cs"));
+
+                    AssertFileContents(
+                        @"using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+#nullable disable
+
+namespace TestNamespace
+{
+    public partial class TestDbContext : DbContext
+    {
+        public TestDbContext()
+        {
+        }
+
+        public TestDbContext(DbContextOptions<TestDbContext> options)
+            : base(options)
+        {
+        }
+
+        public virtual DbSet<EntityWithIndexes> EntityWithIndexes { get; set; }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            if (!optionsBuilder.IsConfigured)
+            {
+#warning "
+                        + DesignStrings.SensitiveInformationWarning
+                        + @"
+                optionsBuilder.UseSqlServer(""Initial Catalog=TestDatabase"");
+            }
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<EntityWithIndexes>(entity =>
+            {
+                entity.HasIndex(e => new { e.B, e.C }, ""IndexOnBAndC"")
+                    .HasFilter(""Filter SQL"");
+
+                entity.Property(e => e.Id).UseIdentityColumn();
+            });
+
+            OnModelCreatingPartial(modelBuilder);
+        }
+
+        partial void OnModelCreatingPartial(ModelBuilder modelBuilder);
+    }
+}
+",
+                        code.ContextFile);
+                },
+                model =>
+                    Assert.Equal(2, model.FindEntityType("TestNamespace.EntityWithIndexes").GetIndexes().Count()));
+        }
+
+        [ConditionalFact]
+        public void KeyAttribute_is_generated_for_single_property_and_no_fluent_api()
+        {
+            Test(
+                modelBuilder => modelBuilder
+                    .Entity(
+                        "Entity",
+                        x =>
+                        {
+                            x.Property<int>("PrimaryKey");
+                            x.HasKey("PrimaryKey");
+                        }),
+                new ModelCodeGenerationOptions { UseDataAnnotations = true },
+                code =>
+                {
+                    AssertFileContents(
+                        @"using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+#nullable disable
+
+namespace TestNamespace
+{
+    public partial class Entity
+    {
+        [Key]
+        public int PrimaryKey { get; set; }
+    }
+}
+",
+                        code.AdditionalFiles.Single(f => f.Path == "Entity.cs"));
+
+                    AssertFileContents(
+                        @"using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+#nullable disable
+
+namespace TestNamespace
+{
+    public partial class TestDbContext : DbContext
+    {
+        public TestDbContext()
+        {
+        }
+
+        public TestDbContext(DbContextOptions<TestDbContext> options)
+            : base(options)
+        {
+        }
+
+        public virtual DbSet<Entity> Entity { get; set; }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            if (!optionsBuilder.IsConfigured)
+            {
+#warning "
+                        + DesignStrings.SensitiveInformationWarning
+                        + @"
+                optionsBuilder.UseSqlServer(""Initial Catalog=TestDatabase"");
+            }
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Entity>(entity =>
+            {
+                entity.Property(e => e.PrimaryKey).UseIdentityColumn();
+            });
+
+            OnModelCreatingPartial(modelBuilder);
+        }
+
+        partial void OnModelCreatingPartial(ModelBuilder modelBuilder);
+    }
+}
+",
+                        code.ContextFile);
+                },
+                model =>
+                    Assert.Equal("PrimaryKey", model.FindEntityType("TestNamespace.Entity").FindPrimaryKey().Properties[0].Name));
+        }
+
+        [ConditionalFact]
+        public void KeyAttribute_is_generated_on_multiple_properties_but_configuring_using_fluent_api_for_composite_key()
+        {
+            Test(
+                modelBuilder => modelBuilder
+                    .Entity(
+                        "Post",
+                        x =>
+                        {
+                            x.Property<int>("Key");
+                            x.Property<int>("Serial");
+                            x.HasKey("Key", "Serial");
+                        }),
+                new ModelCodeGenerationOptions { UseDataAnnotations = true },
+                code =>
+                {
+                    AssertFileContents(
+                        @"using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+#nullable disable
+
+namespace TestNamespace
+{
+    public partial class Post
+    {
+        [Key]
+        public int Key { get; set; }
+        [Key]
+        public int Serial { get; set; }
+    }
+}
+",
+                        code.AdditionalFiles.Single(f => f.Path == "Post.cs"));
+
+                    AssertFileContents(
+                        @"using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+#nullable disable
+
+namespace TestNamespace
+{
+    public partial class TestDbContext : DbContext
+    {
+        public TestDbContext()
+        {
+        }
+
+        public TestDbContext(DbContextOptions<TestDbContext> options)
+            : base(options)
+        {
+        }
+
+        public virtual DbSet<Post> Post { get; set; }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            if (!optionsBuilder.IsConfigured)
+            {
+#warning "
+                        + DesignStrings.SensitiveInformationWarning
+                        + @"
+                optionsBuilder.UseSqlServer(""Initial Catalog=TestDatabase"");
+            }
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Post>(entity =>
+            {
+                entity.HasKey(e => new { e.Key, e.Serial });
+            });
+
+            OnModelCreatingPartial(modelBuilder);
+        }
+
+        partial void OnModelCreatingPartial(ModelBuilder modelBuilder);
+    }
+}
+",
+                        code.ContextFile);
+                },
+                model =>
+                {
+                    var postType = model.FindEntityType("TestNamespace.Post");
+                    Assert.Equal(new[] { "Key", "Serial" }, postType.FindPrimaryKey().Properties.Select(p => p.Name));
+                });
+        }
+
+        [ConditionalFact]
+        public void RequiredAttribute_is_generated_for_property()
+        {
+            Test(
+                modelBuilder => modelBuilder
+                    .Entity(
+                        "Entity",
+                        x =>
+                        {
+                            x.Property<int>("Id");
+                            x.Property<string>("RequiredString").IsRequired();
+                        }),
+                new ModelCodeGenerationOptions { UseDataAnnotations = true },
+                code =>
+                {
+                    AssertFileContents(
+                        @"using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+#nullable disable
+
+namespace TestNamespace
+{
+    public partial class Entity
+    {
+        [Key]
+        public int Id { get; set; }
+        [Required]
+        public string RequiredString { get; set; }
+    }
+}
+",
+                        code.AdditionalFiles.Single(f => f.Path == "Entity.cs"));
+                },
+                model =>
+                    Assert.False(model.FindEntityType("TestNamespace.Entity").GetProperty("RequiredString").IsNullable));
+        }
+
+        [ConditionalFact]
+        public void RequiredAttribute_is_not_generated_for_key_property()
+        {
+            Test(
+                modelBuilder => modelBuilder
+                    .Entity(
+                        "Entity",
+                        x =>
+                        {
+                            x.Property<string>("RequiredString");
+                            x.HasKey("RequiredString");
+                        }),
+                new ModelCodeGenerationOptions { UseDataAnnotations = true },
+                code =>
+                {
+                    AssertFileContents(
+                        @"using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+#nullable disable
+
+namespace TestNamespace
+{
+    public partial class Entity
+    {
+        [Key]
+        public string RequiredString { get; set; }
+    }
+}
+",
+                        code.AdditionalFiles.Single(f => f.Path == "Entity.cs"));
+                },
+                model =>
+                    Assert.False(model.FindEntityType("TestNamespace.Entity").GetProperty("RequiredString").IsNullable));
+        }
+
+        [ConditionalFact]
+        public void ColumnAttribute_is_generated_for_property()
+        {
+            Test(
+                modelBuilder => modelBuilder
+                    .Entity(
+                        "Entity",
+                        x =>
+                        {
+                            x.Property<int>("Id");
+                            x.Property<string>("A").HasColumnName("propertyA");
+                            x.Property<string>("B").HasColumnType("nchar(10)");
+                            x.Property<string>("C").HasColumnName("random").HasColumnType("varchar(200)");
+                            x.Property<decimal>("D").HasColumnType("numeric(18, 2)");
+                            x.Property<string>("E").HasMaxLength(100);
+                        }),
+                new ModelCodeGenerationOptions { UseDataAnnotations = true },
+                code =>
+                {
+                    AssertFileContents(
+                        @"using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+#nullable disable
+
+namespace TestNamespace
+{
+    public partial class Entity
+    {
+        [Key]
+        public int Id { get; set; }
+        [Column(""propertyA"")]
+        public string A { get; set; }
+        [Column(TypeName = ""nchar(10)"")]
+        public string B { get; set; }
+        [Column(""random"", TypeName = ""varchar(200)"")]
+        public string C { get; set; }
+        [Column(TypeName = ""numeric(18, 2)"")]
+        public decimal D { get; set; }
+        [StringLength(100)]
+        public string E { get; set; }
+    }
+}
+",
+                        code.AdditionalFiles.Single(f => f.Path == "Entity.cs"));
+
+                    AssertFileContents(
+                        @"using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+#nullable disable
+
+namespace TestNamespace
+{
+    public partial class TestDbContext : DbContext
+    {
+        public TestDbContext()
+        {
+        }
+
+        public TestDbContext(DbContextOptions<TestDbContext> options)
+            : base(options)
+        {
+        }
+
+        public virtual DbSet<Entity> Entity { get; set; }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            if (!optionsBuilder.IsConfigured)
+            {
+#warning "
+                        + DesignStrings.SensitiveInformationWarning
+                        + @"
+                optionsBuilder.UseSqlServer(""Initial Catalog=TestDatabase"");
+            }
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Entity>(entity =>
+            {
+                entity.Property(e => e.Id).UseIdentityColumn();
+            });
+
+            OnModelCreatingPartial(modelBuilder);
+        }
+
+        partial void OnModelCreatingPartial(ModelBuilder modelBuilder);
+    }
+}
+",
+                        code.ContextFile);
+                },
+                model =>
+                {
+                    var entitType = model.FindEntityType("TestNamespace.Entity");
+                    Assert.Equal("propertyA", entitType.GetProperty("A").GetColumnName());
+                    Assert.Equal("nchar(10)", entitType.GetProperty("B").GetColumnType());
+                    Assert.Equal("random", entitType.GetProperty("C").GetColumnName());
+                    Assert.Equal("varchar(200)", entitType.GetProperty("C").GetColumnType());
+                });
+        }
+
+        [ConditionalFact]
+        public void MaxLengthAttribute_is_generated_for_property()
+        {
+            Test(
+                modelBuilder => modelBuilder
+                    .Entity(
+                        "Entity",
+                        x =>
+                        {
+                            x.Property<int>("Id");
+                            x.Property<string>("A").HasMaxLength(34);
+                            x.Property<byte[]>("B").HasMaxLength(10);
+                        }),
+                new ModelCodeGenerationOptions { UseDataAnnotations = true },
+                code =>
+                {
+                    AssertFileContents(
+                        @"using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+#nullable disable
+
+namespace TestNamespace
+{
+    public partial class Entity
+    {
+        [Key]
+        public int Id { get; set; }
+        [StringLength(34)]
+        public string A { get; set; }
+        [MaxLength(10)]
+        public byte[] B { get; set; }
+    }
+}
+",
+                        code.AdditionalFiles.Single(f => f.Path == "Entity.cs"));
+                },
+                model =>
+                {
+                    var entitType = model.FindEntityType("TestNamespace.Entity");
+                    Assert.Equal(34, entitType.GetProperty("A").GetMaxLength());
+                    Assert.Equal(10, entitType.GetProperty("B").GetMaxLength());
+                });
+        }
+
+        [ConditionalFact]
+        public void Properties_are_sorted_in_order_of_definition_in_table()
+        {
+            Test(
+                modelBuilder => modelBuilder
+                    .Entity(
+                        "Entity",
+                        x =>
+                        {
+                            // Order would be PK first and then rest alphabetically since they are all shadow
+                            x.Property<int>("Id");
+                            x.Property<string>("LastProperty");
+                            x.Property<string>("FirstProperty");
+                        }),
+                new ModelCodeGenerationOptions { UseDataAnnotations = true },
+                code =>
+                {
+                    AssertFileContents(
+                        @"using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+#nullable disable
+
+namespace TestNamespace
+{
+    public partial class Entity
+    {
+        [Key]
+        public int Id { get; set; }
+        public string FirstProperty { get; set; }
+        public string LastProperty { get; set; }
+    }
+}
+",
+                        code.AdditionalFiles.Single(f => f.Path == "Entity.cs"));
+                },
+                model => { });
+        }
+
+        [ConditionalFact]
+        public void Navigation_properties_are_sorted_after_properties_and_collection_are_initialized_in_ctor()
         {
             Test(
                 modelBuilder => modelBuilder
@@ -31,8 +907,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 new ModelCodeGenerationOptions { UseDataAnnotations = true },
                 code =>
                 {
-                    var postFile = code.AdditionalFiles.First(f => f.Path == "Post.cs");
-                    Assert.Equal(
+                    AssertFileContents(
                         @"using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -61,7 +936,35 @@ namespace TestNamespace
     }
 }
 ",
-                        postFile.Code, ignoreLineEndingDifferences: true);
+                        code.AdditionalFiles.Single(f => f.Path == "Post.cs"));
+
+                    AssertFileContents(
+                        @"using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+#nullable disable
+
+namespace TestNamespace
+{
+    public partial class Person
+    {
+        public Person()
+        {
+            Posts = new HashSet<Post>();
+        }
+
+        [Key]
+        public int Id { get; set; }
+
+        [InverseProperty(nameof(Post.Author))]
+        public virtual ICollection<Post> Posts { get; set; }
+    }
+}
+",
+                        code.AdditionalFiles.Single(f => f.Path == "Person.cs"));
                 },
                 model =>
                 {
@@ -77,7 +980,241 @@ namespace TestNamespace
         }
 
         [ConditionalFact]
-        public void Navigation_property_with_same_type_and_navigation_name()
+        public void ForeignKeyAttribute_is_generated_for_composite_fk()
+        {
+            Test(
+                modelBuilder => modelBuilder
+                    .Entity(
+                        "Blog",
+                        x =>
+                        {
+                            x.Property<int>("Id1");
+                            x.Property<int>("Id2");
+                            x.HasKey("Id1", "Id2");
+                        })
+                    .Entity(
+                        "Post",
+                        x =>
+                        {
+                            x.Property<int>("Id");
+
+                            x.HasOne("Blog", "BlogNavigation").WithMany("Posts").HasForeignKey("BlogId1", "BlogId2");
+                        }),
+                new ModelCodeGenerationOptions { UseDataAnnotations = true },
+                code =>
+                {
+                    AssertFileContents(
+                        @"using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+#nullable disable
+
+namespace TestNamespace
+{
+    public partial class Post
+    {
+        [Key]
+        public int Id { get; set; }
+        public int? BlogId1 { get; set; }
+        public int? BlogId2 { get; set; }
+
+        [ForeignKey(""BlogId1,BlogId2"")]
+        [InverseProperty(nameof(Blog.Posts))]
+        public virtual Blog BlogNavigation { get; set; }
+    }
+}
+",
+                        code.AdditionalFiles.Single(f => f.Path == "Post.cs"));
+
+                    AssertFileContents(
+                        @"using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+#nullable disable
+
+namespace TestNamespace
+{
+    public partial class TestDbContext : DbContext
+    {
+        public TestDbContext()
+        {
+        }
+
+        public TestDbContext(DbContextOptions<TestDbContext> options)
+            : base(options)
+        {
+        }
+
+        public virtual DbSet<Blog> Blog { get; set; }
+        public virtual DbSet<Post> Post { get; set; }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            if (!optionsBuilder.IsConfigured)
+            {
+#warning "
+                        + DesignStrings.SensitiveInformationWarning
+                        + @"
+                optionsBuilder.UseSqlServer(""Initial Catalog=TestDatabase"");
+            }
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Blog>(entity =>
+            {
+                entity.HasKey(e => new { e.Id1, e.Id2 });
+            });
+
+            modelBuilder.Entity<Post>(entity =>
+            {
+                entity.Property(e => e.Id).UseIdentityColumn();
+            });
+
+            OnModelCreatingPartial(modelBuilder);
+        }
+
+        partial void OnModelCreatingPartial(ModelBuilder modelBuilder);
+    }
+}
+",
+                        code.ContextFile);
+                },
+                model =>
+                {
+                    var postType = model.FindEntityType("TestNamespace.Post");
+                    var blogNavigation = postType.FindNavigation("BlogNavigation");
+                    Assert.Equal("TestNamespace.Blog", blogNavigation.ForeignKey.PrincipalEntityType.Name);
+                    Assert.Equal(new[] { "BlogId1", "BlogId2" }, blogNavigation.ForeignKey.Properties.Select(p => p.Name));
+                });
+        }
+
+        [ConditionalFact]
+        public void ForeignKeyAttribute_InversePropertyAttribute_is_not_generated_for_alternate_key()
+        {
+            Test(
+                modelBuilder => modelBuilder
+                    .Entity(
+                        "Blog",
+                        x =>
+                        {
+                            x.Property<int>("Id");
+                            x.Property<int>("Id1");
+                            x.Property<int>("Id2");
+                        })
+                    .Entity(
+                        "Post",
+                        x =>
+                        {
+                            x.Property<int>("Id");
+
+                            x.HasOne("Blog", "BlogNavigation").WithMany("Posts")
+                                .HasPrincipalKey("Id1", "Id2")
+                                .HasForeignKey("BlogId1", "BlogId2");
+                        }),
+                new ModelCodeGenerationOptions { UseDataAnnotations = true },
+                code =>
+                {
+                    AssertFileContents(
+                        @"using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+#nullable disable
+
+namespace TestNamespace
+{
+    public partial class Post
+    {
+        [Key]
+        public int Id { get; set; }
+        public int? BlogId1 { get; set; }
+        public int? BlogId2 { get; set; }
+
+        public virtual Blog BlogNavigation { get; set; }
+    }
+}
+",
+                        code.AdditionalFiles.Single(f => f.Path == "Post.cs"));
+
+                    AssertFileContents(
+                        @"using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+#nullable disable
+
+namespace TestNamespace
+{
+    public partial class TestDbContext : DbContext
+    {
+        public TestDbContext()
+        {
+        }
+
+        public TestDbContext(DbContextOptions<TestDbContext> options)
+            : base(options)
+        {
+        }
+
+        public virtual DbSet<Blog> Blog { get; set; }
+        public virtual DbSet<Post> Post { get; set; }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            if (!optionsBuilder.IsConfigured)
+            {
+#warning "
+                        + DesignStrings.SensitiveInformationWarning
+                        + @"
+                optionsBuilder.UseSqlServer(""Initial Catalog=TestDatabase"");
+            }
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Blog>(entity =>
+            {
+                entity.Property(e => e.Id).UseIdentityColumn();
+            });
+
+            modelBuilder.Entity<Post>(entity =>
+            {
+                entity.Property(e => e.Id).UseIdentityColumn();
+
+                entity.HasOne(d => d.BlogNavigation)
+                    .WithMany(p => p.Posts)
+                    .HasPrincipalKey(p => new { p.Id1, p.Id2 })
+                    .HasForeignKey(d => new { d.BlogId1, d.BlogId2 });
+            });
+
+            OnModelCreatingPartial(modelBuilder);
+        }
+
+        partial void OnModelCreatingPartial(ModelBuilder modelBuilder);
+    }
+}
+",
+                        code.ContextFile);
+                },
+                model =>
+                {
+                    var postType = model.FindEntityType("TestNamespace.Post");
+                    var blogNavigation = postType.FindNavigation("BlogNavigation");
+                    Assert.Equal("TestNamespace.Blog", blogNavigation.ForeignKey.PrincipalEntityType.Name);
+                    Assert.Equal(new[] { "BlogId1", "BlogId2" }, blogNavigation.ForeignKey.Properties.Select(p => p.Name));
+                    Assert.Equal(new[] { "Id1", "Id2" }, blogNavigation.ForeignKey.PrincipalKey.Properties.Select(p => p.Name));
+                });
+        }
+
+        [ConditionalFact]
+        public void InverseProperty_when_navigation_property_with_same_type_and_navigation_name()
         {
             Test(
                 modelBuilder => modelBuilder
@@ -94,8 +1231,7 @@ namespace TestNamespace
                 new ModelCodeGenerationOptions { UseDataAnnotations = true },
                 code =>
                 {
-                    var postFile = code.AdditionalFiles.First(f => f.Path == "Post.cs");
-                    Assert.Equal(
+                    AssertFileContents(
                         @"using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -118,7 +1254,7 @@ namespace TestNamespace
     }
 }
 ",
-                        postFile.Code, ignoreLineEndingDifferences: true);
+                        code.AdditionalFiles.Single(f => f.Path == "Post.cs"));
                 },
                 model =>
                 {
@@ -135,7 +1271,7 @@ namespace TestNamespace
         }
 
         [ConditionalFact]
-        public void Navigation_property_with_same_type_and_property_name()
+        public void InverseProperty_when_navigation_property_with_same_type_and_property_name()
         {
             Test(
                 modelBuilder => modelBuilder
@@ -152,8 +1288,7 @@ namespace TestNamespace
                 new ModelCodeGenerationOptions { UseDataAnnotations = true },
                 code =>
                 {
-                    var postFile = code.AdditionalFiles.First(f => f.Path == "Post.cs");
-                    Assert.Equal(
+                    AssertFileContents(
                         @"using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -176,7 +1311,7 @@ namespace TestNamespace
     }
 }
 ",
-                        postFile.Code, ignoreLineEndingDifferences: true);
+                        code.AdditionalFiles.Single(f => f.Path == "Post.cs"));
                 },
                 model =>
                 {
@@ -193,7 +1328,7 @@ namespace TestNamespace
         }
 
         [ConditionalFact]
-        public void Navigation_property_with_same_type_and_other_navigation_name()
+        public void InverseProperty_when_navigation_property_with_same_type_and_other_navigation_name()
         {
             Test(
                 modelBuilder => modelBuilder
@@ -211,8 +1346,7 @@ namespace TestNamespace
                 new ModelCodeGenerationOptions { UseDataAnnotations = true },
                 code =>
                 {
-                    var postFile = code.AdditionalFiles.First(f => f.Path == "Post.cs");
-                    Assert.Equal(
+                    AssertFileContents(
                         @"using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -239,7 +1373,7 @@ namespace TestNamespace
     }
 }
 ",
-                        postFile.Code, ignoreLineEndingDifferences: true);
+                        code.AdditionalFiles.Single(f => f.Path == "Post.cs"));
                 },
                 model =>
                 {
@@ -265,458 +1399,6 @@ namespace TestNamespace
                 });
         }
 
-        [ConditionalFact]
-        public void Composite_key()
-        {
-            Test(
-                modelBuilder => modelBuilder
-                    .Entity(
-                        "Post",
-                        x =>
-                        {
-                            x.Property<int>("Key");
-                            x.Property<int>("Serial");
-                            x.HasKey("Key", "Serial");
-                        }),
-                new ModelCodeGenerationOptions { UseDataAnnotations = true },
-                code =>
-                {
-                    var postFile = code.AdditionalFiles.First(f => f.Path == "Post.cs");
-                    Assert.Equal(
-                        @"using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
-namespace TestNamespace
-{
-    public partial class Post
-    {
-        [Key]
-        public int Key { get; set; }
-        [Key]
-        public int Serial { get; set; }
-    }
-}
-",
-                        postFile.Code, ignoreLineEndingDifferences: true);
-                },
-                model =>
-                {
-                    var postType = model.FindEntityType("TestNamespace.Post");
-                    Assert.NotNull(postType.FindPrimaryKey());
-                });
-        }
-
-        [ConditionalFact]
-        public void Views_dont_generate_TableAttribute()
-        {
-            Test(
-                modelBuilder => modelBuilder.Entity("Vista").ToView("Vistas", "dbo"),
-                new ModelCodeGenerationOptions { UseDataAnnotations = true },
-                code =>
-                {
-                    var vistaFile = code.AdditionalFiles.First(f => f.Path == "Vista.cs");
-                    Assert.Equal(
-                        @"using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
-
-#nullable disable
-
-namespace TestNamespace
-{
-    [Keyless]
-    public partial class Vista
-    {
-    }
-}
-",
-                        vistaFile.Code, ignoreLineEndingDifferences: true);
-                },
-                model =>
-                {
-                    var entityType = model.FindEntityType("TestNamespace.Vista");
-                    Assert.Equal("Vistas", entityType.GetViewName());
-                    Assert.Null(entityType.GetTableName());
-                    Assert.Equal("dbo", entityType.GetViewSchema());
-                    Assert.Null(entityType.GetSchema());
-                });
-        }
-
-        [ConditionalFact]
-        public void Keyless_entity_generates_KeylesssAttribute()
-        {
-            Test(
-                modelBuilder => modelBuilder.Entity("Vista").HasNoKey(),
-                new ModelCodeGenerationOptions { UseDataAnnotations = true },
-                code =>
-                {
-                    var vistaFile = code.AdditionalFiles.First(f => f.Path == "Vista.cs");
-                    Assert.Equal(
-                        @"using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
-
-#nullable disable
-
-namespace TestNamespace
-{
-    [Keyless]
-    public partial class Vista
-    {
-    }
-}
-",
-                        vistaFile.Code, ignoreLineEndingDifferences: true);
-
-                    Assert.Equal(
-                        @"using System;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata;
-
-#nullable disable
-
-namespace TestNamespace
-{
-    public partial class TestDbContext : DbContext
-    {
-        public TestDbContext()
-        {
-        }
-
-        public TestDbContext(DbContextOptions<TestDbContext> options)
-            : base(options)
-        {
-        }
-
-        public virtual DbSet<Vista> Vista { get; set; }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            if (!optionsBuilder.IsConfigured)
-            {
-#warning To protect potentially sensitive information in your connection string, you should move it out of source code. You can avoid scaffolding the connection string by using the Name= syntax to read it from configuration - see https://go.microsoft.com/fwlink/?linkid=2131148. For more guidance on storing connection strings, see http://go.microsoft.com/fwlink/?LinkId=723263.
-                optionsBuilder.UseSqlServer(""Initial Catalog=TestDatabase"");
-            }
-        }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            OnModelCreatingPartial(modelBuilder);
-        }
-
-        partial void OnModelCreatingPartial(ModelBuilder modelBuilder);
-    }
-}
-",
-                        code.ContextFile.Code, ignoreLineEndingDifferences: true);
-                },
-                model =>
-                {
-                    var entityType = model.FindEntityType("TestNamespace.Vista");
-                    Assert.Null(entityType.FindPrimaryKey());
-                });
-        }
-
-        [ConditionalFact]
-        public void Entity_with_multiple_indexes_generates_multiple_IndexAttributes()
-        {
-            Test(
-                modelBuilder => modelBuilder
-                    .Entity(
-                        "EntityWithIndexes",
-                        x =>
-                        {
-                            x.Property<int>("Id");
-                            x.Property<int>("A");
-                            x.Property<int>("B");
-                            x.Property<int>("C");
-                            x.HasKey("Id");
-                            x.HasIndex(new[] { "A", "B" }, "IndexOnAAndB")
-                                .IsUnique();
-                            x.HasIndex(new[] { "B", "C" }, "IndexOnBAndC");
-                        }),
-                new ModelCodeGenerationOptions { UseDataAnnotations = true },
-                code =>
-                {
-                    var entityFile = code.AdditionalFiles.First(f => f.Path == "EntityWithIndexes.cs");
-                    Assert.Equal(
-                        @"using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
-
-#nullable disable
-
-namespace TestNamespace
-{
-    [Index(nameof(A), nameof(B), Name = ""IndexOnAAndB"", IsUnique = true)]
-    [Index(nameof(B), nameof(C), Name = ""IndexOnBAndC"")]
-    public partial class EntityWithIndexes
-    {
-        [Key]
-        public int Id { get; set; }
-        public int A { get; set; }
-        public int B { get; set; }
-        public int C { get; set; }
-    }
-}
-",
-                        entityFile.Code, ignoreLineEndingDifferences: true);
-                },
-                model =>
-                {
-                    var entityType = model.FindEntityType("TestNamespace.EntityWithIndexes");
-                    var indexes = entityType.GetIndexes();
-                    Assert.Equal(2, indexes.Count());
-                    Assert.Equal("IndexOnAAndB", indexes.First().Name);
-                    Assert.Equal("IndexOnBAndC", indexes.Skip(1).First().Name);
-                });
-        }
-
-        [ConditionalFact]
-        public void Entity_with_indexes_generates_IndexAttribute_only_for_indexes_without_annotations()
-        {
-            Test(
-                modelBuilder => modelBuilder
-                    .Entity(
-                        "EntityWithIndexes",
-                        x =>
-                        {
-                            x.Property<int>("Id");
-                            x.Property<int>("A");
-                            x.Property<int>("B");
-                            x.Property<int>("C");
-                            x.HasKey("Id");
-                            x.HasIndex(new[] { "A", "B" }, "IndexOnAAndB")
-                                .IsUnique();
-                            x.HasIndex(new[] { "B", "C" }, "IndexOnBAndC")
-                                .HasFilter("Filter SQL");
-                        }),
-                new ModelCodeGenerationOptions { UseDataAnnotations = true },
-                code =>
-                {
-                    var entityFile = code.AdditionalFiles.First(f => f.Path == "EntityWithIndexes.cs");
-                    Assert.Equal(
-                        @"using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
-
-#nullable disable
-
-namespace TestNamespace
-{
-    [Index(nameof(A), nameof(B), Name = ""IndexOnAAndB"", IsUnique = true)]
-    public partial class EntityWithIndexes
-    {
-        [Key]
-        public int Id { get; set; }
-        public int A { get; set; }
-        public int B { get; set; }
-        public int C { get; set; }
-    }
-}
-",
-                        entityFile.Code, ignoreLineEndingDifferences: true);
-                },
-                model =>
-                    Assert.Equal(2, model.FindEntityType("TestNamespace.EntityWithIndexes").GetIndexes().Count()));
-        }
-
-        [ConditionalFact]
-        public void KeyAttribute_is_generated_for_property()
-        {
-            Test(
-                modelBuilder => modelBuilder
-                    .Entity(
-                        "Entity",
-                        x =>
-                        {
-                            x.Property<int>("PrimaryKey");
-                            x.HasKey("PrimaryKey");
-                        }),
-                new ModelCodeGenerationOptions { UseDataAnnotations = true },
-                code =>
-                {
-                    var entityFile = code.AdditionalFiles.First(f => f.Path == "Entity.cs");
-                    Assert.Equal(
-                        @"using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
-
-#nullable disable
-
-namespace TestNamespace
-{
-    public partial class Entity
-    {
-        [Key]
-        public int PrimaryKey { get; set; }
-    }
-}
-",
-                        entityFile.Code, ignoreLineEndingDifferences: true);
-                },
-                model =>
-                    Assert.Equal("PrimaryKey", model.FindEntityType("TestNamespace.Entity").FindPrimaryKey().Properties[0].Name));
-        }
-
-        [ConditionalFact]
-        public void RequiredAttribute_is_generated_for_property()
-        {
-            Test(
-                modelBuilder => modelBuilder
-                    .Entity(
-                        "Entity",
-                        x =>
-                        {
-                            x.Property<int>("Id");
-                            x.Property<string>("RequiredString").IsRequired();
-                        }),
-                new ModelCodeGenerationOptions { UseDataAnnotations = true },
-                code =>
-                {
-                    var entityFile = code.AdditionalFiles.First(f => f.Path == "Entity.cs");
-                    Assert.Equal(
-                        @"using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
-
-#nullable disable
-
-namespace TestNamespace
-{
-    public partial class Entity
-    {
-        [Key]
-        public int Id { get; set; }
-        [Required]
-        public string RequiredString { get; set; }
-    }
-}
-",
-                        entityFile.Code, ignoreLineEndingDifferences: true);
-                },
-                model =>
-                    Assert.False(model.FindEntityType("TestNamespace.Entity").GetProperty("RequiredString").IsNullable));
-        }
-
-        [ConditionalFact]
-        public void ColumnAttribute_is_generated_for_property()
-        {
-            Test(
-                modelBuilder => modelBuilder
-                    .Entity(
-                        "Entity",
-                        x =>
-                        {
-                            x.Property<int>("Id");
-                            x.Property<string>("A").HasColumnName("propertyA");
-                            x.Property<string>("B").HasColumnType("nchar(10)");
-                            x.Property<string>("C").HasColumnName("random").HasColumnType("varchar(200)");
-                        }),
-                new ModelCodeGenerationOptions { UseDataAnnotations = true },
-                code =>
-                {
-                    var entityFile = code.AdditionalFiles.First(f => f.Path == "Entity.cs");
-                    Assert.Equal(
-                        @"using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
-
-#nullable disable
-
-namespace TestNamespace
-{
-    public partial class Entity
-    {
-        [Key]
-        public int Id { get; set; }
-        [Column(""propertyA"")]
-        public string A { get; set; }
-        [Column(TypeName = ""nchar(10)"")]
-        public string B { get; set; }
-        [Column(""random"", TypeName = ""varchar(200)"")]
-        public string C { get; set; }
-    }
-}
-",
-                        entityFile.Code, ignoreLineEndingDifferences: true);
-                },
-                model =>
-                {
-                    var entitType = model.FindEntityType("TestNamespace.Entity");
-                    Assert.Equal("propertyA", entitType.GetProperty("A").GetColumnName());
-                    Assert.Equal("nchar(10)", entitType.GetProperty("B").GetColumnType());
-                    Assert.Equal("random", entitType.GetProperty("C").GetColumnName());
-                    Assert.Equal("varchar(200)", entitType.GetProperty("C").GetColumnType());
-                });
-        }
-
-        [ConditionalFact]
-        public void MaxLengthAttribute_is_generated_for_property()
-        {
-            Test(
-                modelBuilder => modelBuilder
-                    .Entity(
-                        "Entity",
-                        x =>
-                        {
-                            x.Property<int>("Id");
-                            x.Property<string>("A").HasMaxLength(34);
-                            x.Property<byte[]>("B").HasMaxLength(10);
-                        }),
-                new ModelCodeGenerationOptions { UseDataAnnotations = true },
-                code =>
-                {
-                    var entityFile = code.AdditionalFiles.First(f => f.Path == "Entity.cs");
-                    Assert.Equal(
-                        @"using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
-
-#nullable disable
-
-namespace TestNamespace
-{
-    public partial class Entity
-    {
-        [Key]
-        public int Id { get; set; }
-        [StringLength(34)]
-        public string A { get; set; }
-        [MaxLength(10)]
-        public byte[] B { get; set; }
-    }
-}
-",
-                        entityFile.Code, ignoreLineEndingDifferences: true);
-                },
-                model =>
-                {
-                    var entitType = model.FindEntityType("TestNamespace.Entity");
-                    Assert.Equal(34, entitType.GetProperty("A").GetMaxLength());
-                    Assert.Equal(10, entitType.GetProperty("B").GetMaxLength());
-                });
-        }
     }
 }

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/ModelCodeGeneratorTestBase.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/ModelCodeGeneratorTestBase.cs
@@ -10,19 +10,12 @@ using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Design.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
+using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 {
     public abstract class ModelCodeGeneratorTestBase
     {
-        protected void Test(
-            Action<ModelBuilder> buildModel,
-            ModelCodeGenerationOptions options,
-            Action<ScaffoldedModel> assertScaffold)
-        {
-            Test(buildModel, options, assertScaffold, null);
-        }
-
         protected void Test(
             Action<ModelBuilder> buildModel,
             ModelCodeGenerationOptions options,
@@ -76,5 +69,10 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 assertModel(compiledModel);
             }
         }
+
+        protected static void AssertFileContents(
+            string expectedCode,
+            ScaffoldedFile file)
+            => Assert.Equal(expectedCode, file.Code, ignoreLineEndingDifferences: true);
     }
 }


### PR DESCRIPTION
Resolves #22122

Added full code coverage on CSharpEntityTypeGenerator. (Yes, it is soooo boring, so I will do DbContext one some other day)

Filed #22170 For ValueGenerated part.