### PR TITLE
Don't use MERGE for single row insert with non-identity store-generated key

### DIFF
--- a/src/EFCore.Relational/Update/UpdateSqlGenerator.cs
+++ b/src/EFCore.Relational/Update/UpdateSqlGenerator.cs
@@ -253,7 +253,6 @@ namespace Microsoft.EntityFrameworkCore.Update
 
             AppendSelectCommandHeader(commandStringBuilder, readOperations);
             AppendFromClause(commandStringBuilder, name, schema);
-            // TODO: there is no notion of operator - currently all the where conditions check equality
             AppendWhereAffectedClause(commandStringBuilder, conditionOperations);
             commandStringBuilder.AppendLine(SqlGenerationHelper.StatementTerminator)
                 .AppendLine();

--- a/test/EFCore.SqlServer.FunctionalTests/BatchingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BatchingTest.cs
@@ -20,6 +20,7 @@ namespace Microsoft.EntityFrameworkCore
         public BatchingTest(BatchingTestFixture fixture)
         {
             Fixture = fixture;
+            Fixture.TestSqlLoggerFactory.Clear();
         }
 
         protected BatchingTestFixture Fixture { get; }
@@ -210,6 +211,9 @@ namespace Microsoft.EntityFrameworkCore
 
         protected void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
             => facade.UseTransaction(transaction.GetDbTransaction());
+
+        private void AssertSql(params string[] expected)
+            => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 
         private class BloggingContext : PoolableDbContext
         {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -9275,8 +9275,7 @@ VALUES (i.[Value])
 OUTPUT INSERTED.[Id], i._Position
 INTO @inserted0;
 
-SELECT [t].[Id] FROM [BaseEntities] t
-INNER JOIN @inserted0 i ON ([t].[Id] = [i].[Id])
+SELECT [i].[Id] FROM @inserted0 i
 ORDER BY [i].[_Position];");
             }
         }

--- a/test/EFCore.SqlServer.FunctionalTests/UpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/UpdatesSqlServerTest.cs
@@ -57,18 +57,12 @@ VALUES (@p0, @p1, @p2);",
 @p2=NULL (Size = 4000)
 
 SET NOCOUNT ON;
-DECLARE @inserted0 TABLE ([Id] uniqueidentifier, [_Position] [int]);
-MERGE [ProductBase] USING (
-VALUES (@p0, @p1, @p2, 0)) AS i ([Bytes], [Discriminator], [ProductWithBytes_Name], _Position) ON 1=0
-WHEN NOT MATCHED THEN
-INSERT ([Bytes], [Discriminator], [ProductWithBytes_Name])
-VALUES (i.[Bytes], i.[Discriminator], i.[ProductWithBytes_Name])
-OUTPUT INSERTED.[Id], i._Position
-INTO @inserted0;
-
-SELECT [t].[Id] FROM [ProductBase] t
-INNER JOIN @inserted0 i ON ([t].[Id] = [i].[Id])
-ORDER BY [i].[_Position];");
+DECLARE @inserted0 TABLE ([Id] uniqueidentifier);
+INSERT INTO [ProductBase] ([Bytes], [Discriminator], [ProductWithBytes_Name])
+OUTPUT INSERTED.[Id]
+INTO @inserted0
+VALUES (@p0, @p1, @p2);
+SELECT [i].[Id] FROM @inserted0 i;");
         }
 
         public override void Save_replaced_principal()


### PR DESCRIPTION
Don't use MERGE for single row insert with non-identity store-generated key
Don't join the temporary table with the target table if only key values are store-generated

Fixes #25712
Fixes #25345