### PR TITLE
Cosmos: Remove Guid type mapping

### DIFF
--- a/src/EFCore.Cosmos/Storage/Internal/CosmosTypeMappingSource.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosTypeMappingSource.cs
@@ -59,6 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         {
             var clrType = mappingInfo.ClrType!;
             if ((clrType.IsValueType
+                    && clrType != typeof(Guid)
                     && !clrType.IsEnum)
                 || clrType == typeof(string))
             {

--- a/src/EFCore/Storage/ValueConversion/ValueConverterSelector.cs
+++ b/src/EFCore/Storage/ValueConversion/ValueConverterSelector.cs
@@ -141,19 +141,19 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
             else if (modelClrType == typeof(Guid))
             {
                 if (providerClrType == null
-                    || providerClrType == typeof(byte[]))
-                {
-                    yield return _converters.GetOrAdd(
-                        (modelClrType, typeof(byte[])),
-                        k => GuidToBytesConverter.DefaultInfo);
-                }
-
-                if (providerClrType == null
                     || providerClrType == typeof(string))
                 {
                     yield return _converters.GetOrAdd(
                         (modelClrType, typeof(string)),
                         k => GuidToStringConverter.DefaultInfo);
+                }
+
+                if (providerClrType == null
+                    || providerClrType == typeof(byte[]))
+                {
+                    yield return _converters.GetOrAdd(
+                        (modelClrType, typeof(byte[])),
+                        k => GuidToBytesConverter.DefaultInfo);
                 }
             }
             else if (modelClrType == typeof(byte[]))

--- a/test/EFCore.Cosmos.FunctionalTests/EndToEndCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/EndToEndCosmosTest.cs
@@ -569,7 +569,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
                 modelBuilder.Entity<CustomerGuid>(
                     cb =>
                     {
-                        cb.Property(c => c.Id).HasConversion<string>().ToJsonProperty("id");
+                        cb.Property(c => c.Id).ToJsonProperty("id");
                         cb.Property(c => c.PartitionKey).HasConversion<string>().ToJsonProperty("pk");
                         cb.HasPartitionKey(c => c.PartitionKey);
                     });

--- a/test/EFCore.Tests/Storage/ValueConverterSelectorTest.cs
+++ b/test/EFCore.Tests/Storage/ValueConverterSelectorTest.cs
@@ -384,8 +384,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
         {
             AssertConverters(
                 _selector.Select(typeof(Guid)).ToList(),
-                (typeof(GuidToBytesConverter), new ConverterMappingHints(size: 16)),
-                (typeof(GuidToStringConverter), new ConverterMappingHints(size: 36)));
+                (typeof(GuidToStringConverter), new ConverterMappingHints(size: 36)),
+                (typeof(GuidToBytesConverter), new ConverterMappingHints(size: 16)));
         }
 
         [ConditionalFact]


### PR DESCRIPTION
Try to convert `Guid` to `string` before `byte[]`

Fixes #25753