### PR TITLE
[SMALL] Fix to #25954 - [EFCore 6.0] [Firebird] Problem with test NorthwindMiscellaneousQueryTestBase.Entity_equality_on_subquery_with_null_check

### DIFF
--- a/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
@@ -6301,7 +6301,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         c.CustomerID,
                         Order = (c.Orders.Any() ? c.Orders.FirstOrDefault() : null) == null
                             ? null
-                            : new { c.Orders.FirstOrDefault().OrderDate }
+                            : new { c.Orders.OrderBy(o => o.OrderID).FirstOrDefault().OrderDate }
                     }),
                 elementSorter: c => c.CustomerID,
                 elementAsserter: (e, a) => AssertEqual(e.Order, a.Order));

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -5205,7 +5205,8 @@ FROM [Customers] AS [c]");
 END, (
     SELECT TOP(1) [o1].[OrderDate]
     FROM [Orders] AS [o1]
-    WHERE [c].[CustomerID] = [o1].[CustomerID])
+    WHERE [c].[CustomerID] = [o1].[CustomerID]
+    ORDER BY [o1].[OrderID])
 FROM [Customers] AS [c]");
         }
 


### PR DESCRIPTION
Adding the missing ordering so now the results should be always deterministic

Fixes #25954