### PR TITLE
[6.0] Fix to #26271 - Temporal history table name always based on entity type name, not table name

### DIFF
--- a/src/EFCore.SqlServer/Extensions/SqlServerEntityTypeExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerEntityTypeExtensions.cs
@@ -206,7 +206,9 @@ namespace Microsoft.EntityFrameworkCore
                 : entityType[SqlServerAnnotationNames.TemporalHistoryTableName] is string historyTableName
                     ? historyTableName
                     : entityType[SqlServerAnnotationNames.IsTemporal] as bool? == true
-                        ? entityType.ShortName() + DefaultHistoryTableNameSuffix
+                        ? entityType.GetTableName() is string tableName
+                            ? tableName + DefaultHistoryTableNameSuffix
+                            : null
                         : null;
 
         /// <summary>

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsSqlServerTest.cs
@@ -2086,7 +2086,7 @@ EXEC(N'CREATE TABLE [Customer] (
                     Assert.Equal("Customers", table.Name);
                     Assert.Equal("mySchema", table.Schema);
                     Assert.Equal(true, table[SqlServerAnnotationNames.IsTemporal]);
-                    Assert.Equal("CustomerHistory", table[SqlServerAnnotationNames.TemporalHistoryTableName]);
+                    Assert.Equal("CustomersHistory", table[SqlServerAnnotationNames.TemporalHistoryTableName]);
                     Assert.Equal("SystemTimeStart", table[SqlServerAnnotationNames.TemporalPeriodStartPropertyName]);
                     Assert.Equal("SystemTimeEnd", table[SqlServerAnnotationNames.TemporalPeriodEndPropertyName]);
 
@@ -2109,7 +2109,7 @@ EXEC(N'CREATE TABLE [Customer] (
     [SystemTimeStart] datetime2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
     CONSTRAINT [PK_Customers] PRIMARY KEY ([Id]),
     PERIOD FOR SYSTEM_TIME([SystemTimeStart], [SystemTimeEnd])
-) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [mySchema].[CustomerHistory]));");
+) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [mySchema].[CustomersHistory]));");
         }
 
         [ConditionalFact]
@@ -2142,7 +2142,7 @@ EXEC(N'CREATE TABLE [Customer] (
                     Assert.Equal("Customers", table.Name);
                     Assert.Equal("myDefaultSchema", table.Schema);
                     Assert.Equal(true, table[SqlServerAnnotationNames.IsTemporal]);
-                    Assert.Equal("CustomerHistory", table[SqlServerAnnotationNames.TemporalHistoryTableName]);
+                    Assert.Equal("CustomersHistory", table[SqlServerAnnotationNames.TemporalHistoryTableName]);
                     Assert.Equal("SystemTimeStart", table[SqlServerAnnotationNames.TemporalPeriodStartPropertyName]);
                     Assert.Equal("SystemTimeEnd", table[SqlServerAnnotationNames.TemporalPeriodEndPropertyName]);
 
@@ -2165,7 +2165,7 @@ EXEC(N'CREATE TABLE [Customer] (
     [SystemTimeStart] datetime2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
     CONSTRAINT [PK_Customers] PRIMARY KEY ([Id]),
     PERIOD FOR SYSTEM_TIME([SystemTimeStart], [SystemTimeEnd])
-) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [myDefaultSchema].[CustomerHistory]));");
+) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [myDefaultSchema].[CustomersHistory]));");
         }
 
         [ConditionalFact]
@@ -2198,7 +2198,7 @@ EXEC(N'CREATE TABLE [Customer] (
                     Assert.Equal("Customers", table.Name);
                     Assert.Equal("mySchema", table.Schema);
                     Assert.Equal(true, table[SqlServerAnnotationNames.IsTemporal]);
-                    Assert.Equal("CustomerHistory", table[SqlServerAnnotationNames.TemporalHistoryTableName]);
+                    Assert.Equal("CustomersHistory", table[SqlServerAnnotationNames.TemporalHistoryTableName]);
                     Assert.Equal("SystemTimeStart", table[SqlServerAnnotationNames.TemporalPeriodStartPropertyName]);
                     Assert.Equal("SystemTimeEnd", table[SqlServerAnnotationNames.TemporalPeriodEndPropertyName]);
 
@@ -2221,7 +2221,7 @@ EXEC(N'CREATE TABLE [Customer] (
     [SystemTimeStart] datetime2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
     CONSTRAINT [PK_Customers] PRIMARY KEY ([Id]),
     PERIOD FOR SYSTEM_TIME([SystemTimeStart], [SystemTimeEnd])
-) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [mySchema].[CustomerHistory]));");
+) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [mySchema].[CustomersHistory]));");
         }
 
         [ConditionalFact]
@@ -3849,7 +3849,7 @@ ALTER TABLE [Customers] ALTER COLUMN [Name] nvarchar(450) NULL;",
     [SystemTimeStart] datetime2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
     CONSTRAINT [PK_Customers] PRIMARY KEY ([Id]),
     PERIOD FOR SYSTEM_TIME([SystemTimeStart], [SystemTimeEnd])
-) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [mySchema].[CustomerHistory]));",
+) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [mySchema].[CustomersHistory]));",
                 //
                 @"CREATE TABLE [mySchema].[Orders] (
     [Id] int NOT NULL,
@@ -3858,7 +3858,7 @@ ALTER TABLE [Customers] ALTER COLUMN [Name] nvarchar(450) NULL;",
     [SystemTimeStart] datetime2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
     CONSTRAINT [PK_Orders] PRIMARY KEY ([Id]),
     PERIOD FOR SYSTEM_TIME([SystemTimeStart], [SystemTimeEnd])
-) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [mySchema].[OrderHistory]));");
+) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [mySchema].[OrdersHistory]));");
         }
 
         [ConditionalFact]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalComplexNavigationsQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalComplexNavigationsQuerySqlServerFixture.cs
@@ -31,20 +31,20 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             ChangesDate = new DateTime(2010, 1, 1);
 
-            var historyTableInfos = new List<(string table, string historyTable)>()
+            var tableNames = new List<string>
             {
-                ("LevelOne", "Level1History"),
-                ("LevelTwo", "Level2History"),
-                ("LevelThree", "Level3History"),
-                ("LevelFour", "Level4History"),
+                "LevelOne",
+                "LevelTwo",
+                "LevelThree",
+                "LevelFour"
             };
 
             // clean up intermittent history since in the Seed method we do fixup in multiple stages 
-            foreach (var historyTableInfo in historyTableInfos)
+            foreach (var tableName in tableNames)
             {
-                context.Database.ExecuteSqlRaw($"ALTER TABLE [{historyTableInfo.table}] SET (SYSTEM_VERSIONING = OFF)");
-                context.Database.ExecuteSqlRaw($"DELETE FROM [{historyTableInfo.historyTable}]");
-                context.Database.ExecuteSqlRaw($"ALTER TABLE [{historyTableInfo.table}] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[{historyTableInfo.historyTable}]))");
+                context.Database.ExecuteSqlRaw($"ALTER TABLE [{tableName}] SET (SYSTEM_VERSIONING = OFF)");
+                context.Database.ExecuteSqlRaw($"DELETE FROM [{tableName + "History"}]");
+                context.Database.ExecuteSqlRaw($"ALTER TABLE [{tableName}] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[{tableName + "History"}]))");
             }
 
             foreach (var entityOne in context.ChangeTracker.Entries().Where(e => e.Entity is Level1).Select(e => e.Entity))
@@ -69,16 +69,16 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             context.SaveChanges();
 
-            foreach (var historyTableInfo in historyTableInfos)
+            foreach (var tableName in tableNames)
             {
-                context.Database.ExecuteSqlRaw($"ALTER TABLE [{historyTableInfo.table}] SET (SYSTEM_VERSIONING = OFF)");
-                context.Database.ExecuteSqlRaw($"ALTER TABLE [{historyTableInfo.table}] DROP PERIOD FOR SYSTEM_TIME");
+                context.Database.ExecuteSqlRaw($"ALTER TABLE [{tableName}] SET (SYSTEM_VERSIONING = OFF)");
+                context.Database.ExecuteSqlRaw($"ALTER TABLE [{tableName}] DROP PERIOD FOR SYSTEM_TIME");
 
-                context.Database.ExecuteSqlRaw($"UPDATE [{historyTableInfo.historyTable}] SET PeriodStart = '2000-01-01T01:00:00.0000000Z'");
-                context.Database.ExecuteSqlRaw($"UPDATE [{historyTableInfo.historyTable}] SET PeriodEnd = '2020-07-01T07:00:00.0000000Z'");
+                context.Database.ExecuteSqlRaw($"UPDATE [{tableName + "History"}] SET PeriodStart = '2000-01-01T01:00:00.0000000Z'");
+                context.Database.ExecuteSqlRaw($"UPDATE [{tableName + "History"}] SET PeriodEnd = '2020-07-01T07:00:00.0000000Z'");
 
-                context.Database.ExecuteSqlRaw($"ALTER TABLE [{historyTableInfo.table}] ADD PERIOD FOR SYSTEM_TIME ([PeriodStart], [PeriodEnd])");
-                context.Database.ExecuteSqlRaw($"ALTER TABLE [{historyTableInfo.table}] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[{historyTableInfo.historyTable}]))");
+                context.Database.ExecuteSqlRaw($"ALTER TABLE [{tableName}] ADD PERIOD FOR SYSTEM_TIME ([PeriodStart], [PeriodEnd])");
+                context.Database.ExecuteSqlRaw($"ALTER TABLE [{tableName}] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[{tableName + "History"}]))");
             }
         }
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalFiltersInheritanceQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalFiltersInheritanceQuerySqlServerFixture.cs
@@ -36,24 +36,24 @@ namespace Microsoft.EntityFrameworkCore.Query
             context.RemoveRange(context.ChangeTracker.Entries().Where(e => e.Entity is Drink).Select(e => e.Entity));
             context.SaveChanges();
 
-            var historyTableInfos = new List<(string table, string historyTable)>()
+            var tableNames = new List<string>
             {
-                ("Animals", "AnimalHistory"),
-                ("Plants", "PlantHistory"),
-                ("Countries", "CountryHistory"),
-                ("Drinks", "DrinkHistory"),
+                "Animals",
+                "Plants",
+                "Countries",
+                "Drinks"
             };
 
-            foreach (var historyTableInfo in historyTableInfos)
+            foreach (var tableName in tableNames)
             {
-                context.Database.ExecuteSqlRaw($"ALTER TABLE [{historyTableInfo.table}] SET (SYSTEM_VERSIONING = OFF)");
-                context.Database.ExecuteSqlRaw($"ALTER TABLE [{historyTableInfo.table}] DROP PERIOD FOR SYSTEM_TIME");
+                context.Database.ExecuteSqlRaw($"ALTER TABLE [{tableName}] SET (SYSTEM_VERSIONING = OFF)");
+                context.Database.ExecuteSqlRaw($"ALTER TABLE [{tableName}] DROP PERIOD FOR SYSTEM_TIME");
 
-                context.Database.ExecuteSqlRaw($"UPDATE [{historyTableInfo.historyTable}] SET PeriodStart = '2000-01-01T01:00:00.0000000Z'");
-                context.Database.ExecuteSqlRaw($"UPDATE [{historyTableInfo.historyTable}] SET PeriodEnd = '2020-07-01T07:00:00.0000000Z'");
+                context.Database.ExecuteSqlRaw($"UPDATE [{tableName + "History"}] SET PeriodStart = '2000-01-01T01:00:00.0000000Z'");
+                context.Database.ExecuteSqlRaw($"UPDATE [{tableName + "History"}] SET PeriodEnd = '2020-07-01T07:00:00.0000000Z'");
 
-                context.Database.ExecuteSqlRaw($"ALTER TABLE [{historyTableInfo.table}] ADD PERIOD FOR SYSTEM_TIME ([PeriodStart], [PeriodEnd])");
-                context.Database.ExecuteSqlRaw($"ALTER TABLE [{historyTableInfo.table}] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[{historyTableInfo.historyTable}]))");
+                context.Database.ExecuteSqlRaw($"ALTER TABLE [{tableName}] ADD PERIOD FOR SYSTEM_TIME ([PeriodStart], [PeriodEnd])");
+                context.Database.ExecuteSqlRaw($"ALTER TABLE [{tableName}] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[{tableName + "History"}]))");
             }
         }
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerFixture.cs
@@ -39,12 +39,12 @@ namespace Microsoft.EntityFrameworkCore.Query
             //// clean up intermittent history - we do the data fixup in 2 steps (due to cycle)
             //// so we want to remove the temporary states, so that further manipulation is easier
             context.Database.ExecuteSqlRaw("ALTER TABLE [LocustLeaders] SET (SYSTEM_VERSIONING = OFF)");
-            context.Database.ExecuteSqlRaw("DELETE FROM [LocustLeaderHistory]");
-            context.Database.ExecuteSqlRaw("ALTER TABLE [LocustLeaders] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[LocustLeaderHistory]))");
+            context.Database.ExecuteSqlRaw("DELETE FROM [LocustLeadersHistory]");
+            context.Database.ExecuteSqlRaw("ALTER TABLE [LocustLeaders] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[LocustLeadersHistory]))");
 
             context.Database.ExecuteSqlRaw("ALTER TABLE [Missions] SET (SYSTEM_VERSIONING = OFF)");
-            context.Database.ExecuteSqlRaw("DELETE FROM [MissionHistory]");
-            context.Database.ExecuteSqlRaw("ALTER TABLE [Missions] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[MissionHistory]))");
+            context.Database.ExecuteSqlRaw("DELETE FROM [MissionsHistory]");
+            context.Database.ExecuteSqlRaw("ALTER TABLE [Missions] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[MissionsHistory]))");
 
             context.RemoveRange(context.ChangeTracker.Entries().Where(e => e.Entity is City).Select(e => e.Entity));
             context.RemoveRange(context.ChangeTracker.Entries().Where(e => e.Entity is CogTag).Select(e => e.Entity));
@@ -62,34 +62,34 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             // clean up Faction history
             context.Database.ExecuteSqlRaw("ALTER TABLE [Factions] SET (SYSTEM_VERSIONING = OFF)");
-            context.Database.ExecuteSqlRaw("DELETE FROM [FactionHistory] WHERE CommanderName IS NULL");
-            context.Database.ExecuteSqlRaw("ALTER TABLE [Factions] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[FactionHistory]))");
+            context.Database.ExecuteSqlRaw("DELETE FROM [FactionsHistory] WHERE CommanderName IS NULL");
+            context.Database.ExecuteSqlRaw("ALTER TABLE [Factions] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[FactionsHistory]))");
 
-            var historyTableInfos = new List<(string table, string historyTable)>()
+            var tableNames = new List<string>
             {
-                ("Cities", "CityHistory"),
-                ("Tags", "CogTagHistory"),
-                ("Gears", "GearHistory"),
-                ("LocustHighCommands", "LocustHighCommandHistory"),
-                ("Missions", "MissionHistory"),
-                ("Squads", "SquadHistory"),
-                ("SquadMissions", "SquadMissionHistory"),
-                ("Weapons", "WeaponHistory"),
+                "Cities",
+                "Tags",
+                "Gears",
+                "LocustHighCommands",
+                "Missions",
+                "Squads",
+                "SquadMissions",
+                "Weapons",
 
-                ("LocustLeaders", "LocustLeaderHistory"),
-                ("Factions", "FactionHistory"),
+                "LocustLeaders",
+                "Factions",
             };
 
-            foreach (var historyTableInfo in historyTableInfos)
+            foreach (var tableName in tableNames)
             {
-                context.Database.ExecuteSqlRaw($"ALTER TABLE [{historyTableInfo.table}] SET (SYSTEM_VERSIONING = OFF)");
-                context.Database.ExecuteSqlRaw($"ALTER TABLE [{historyTableInfo.table}] DROP PERIOD FOR SYSTEM_TIME");
+                context.Database.ExecuteSqlRaw($"ALTER TABLE [{tableName}] SET (SYSTEM_VERSIONING = OFF)");
+                context.Database.ExecuteSqlRaw($"ALTER TABLE [{tableName}] DROP PERIOD FOR SYSTEM_TIME");
 
-                context.Database.ExecuteSqlRaw($"UPDATE [{historyTableInfo.historyTable}] SET PeriodStart = '2000-01-01T01:00:00.0000000Z'");
-                context.Database.ExecuteSqlRaw($"UPDATE [{historyTableInfo.historyTable}] SET PeriodEnd = '2020-07-01T07:00:00.0000000Z'");
+                context.Database.ExecuteSqlRaw($"UPDATE [{tableName + "History"}] SET PeriodStart = '2000-01-01T01:00:00.0000000Z'");
+                context.Database.ExecuteSqlRaw($"UPDATE [{tableName + "History"}] SET PeriodEnd = '2020-07-01T07:00:00.0000000Z'");
 
-                context.Database.ExecuteSqlRaw($"ALTER TABLE [{historyTableInfo.table}] ADD PERIOD FOR SYSTEM_TIME ([PeriodStart], [PeriodEnd])");
-                context.Database.ExecuteSqlRaw($"ALTER TABLE [{historyTableInfo.table}] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[{historyTableInfo.historyTable}]))");
+                context.Database.ExecuteSqlRaw($"ALTER TABLE [{tableName}] ADD PERIOD FOR SYSTEM_TIME ([PeriodStart], [PeriodEnd])");
+                context.Database.ExecuteSqlRaw($"ALTER TABLE [{tableName}] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[{tableName + "History"}]))");
             }
         }
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalManyToManyQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalManyToManyQuerySqlServerFixture.cs
@@ -193,39 +193,39 @@ namespace Microsoft.EntityFrameworkCore.Query
             context.RemoveRange(context.ChangeTracker.Entries().Where(e => e.Entity is EntityRoot).Select(e => e.Entity));
             context.SaveChanges();
 
-            var historyTableInfos = new List<(string table, string historyTable)>()
+            var tableNames = new List<string>
             {
-                ("EntityCompositeKeys", "EntityCompositeKeyHistory"),
-                ("EntityOneEntityTwo", "EntityOneEntityTwoHistory"),
-                ("EntityOnes", "EntityOneHistory"),
-                ("EntityTwos", "EntityTwoHistory"),
-                ("EntityThrees", "EntityThreeHistory"),
-                ("EntityRoots", "EntityRootHistory"),
-                ("EntityRootEntityThree", "EntityRootEntityThreeHistory"),
+                "EntityCompositeKeys",
+                "EntityOneEntityTwo",
+                "EntityOnes",
+                "EntityTwos",
+                "EntityThrees",
+                "EntityRoots",
+                "EntityRootEntityThree",
 
-                ("JoinCompositeKeyToLeaf", "JoinCompositeKeyToLeafHistory"),
-                ("EntityCompositeKeyEntityRoot", "EntityCompositeKeyEntityRootHistory"),
-                ("JoinOneSelfPayload", "JoinOneSelfPayloadHistory"),
-                ("JoinOneToBranch", "JoinOneToBranchHistory"),
-                ("JoinOneToThreePayloadFull", "JoinOneToThreePayloadFullHistory"),
-                ("JoinOneToThreePayloadFullShared", "JoinOneToThreePayloadFullSharedHistory"),
-                ("JoinOneToTwo", "JoinOneToTwoHistory"),
-                ("JoinThreeToCompositeKeyFull", "JoinThreeToCompositeKeyFullHistory"),
-                ("EntityTwoEntityTwo", "EntityTwoEntityTwoHistory"),
-                ("EntityCompositeKeyEntityTwo", "EntityCompositeKeyEntityTwoHistory"),
-                ("JoinTwoToThree", "JoinTwoToThreeHistory"),
+                "JoinCompositeKeyToLeaf",
+                "EntityCompositeKeyEntityRoot",
+                "JoinOneSelfPayload",
+                "JoinOneToBranch",
+                "JoinOneToThreePayloadFull",
+                "JoinOneToThreePayloadFullShared",
+                "JoinOneToTwo",
+                "JoinThreeToCompositeKeyFull",
+                "EntityTwoEntityTwo",
+                "EntityCompositeKeyEntityTwo",
+                "JoinTwoToThree",
             };
 
-            foreach (var historyTableInfo in historyTableInfos)
+            foreach (var tableName in tableNames)
             {
-                context.Database.ExecuteSqlRaw($"ALTER TABLE [{historyTableInfo.table}] SET (SYSTEM_VERSIONING = OFF)");
-                context.Database.ExecuteSqlRaw($"ALTER TABLE [{historyTableInfo.table}] DROP PERIOD FOR SYSTEM_TIME");
+                context.Database.ExecuteSqlRaw($"ALTER TABLE [{tableName}] SET (SYSTEM_VERSIONING = OFF)");
+                context.Database.ExecuteSqlRaw($"ALTER TABLE [{tableName}] DROP PERIOD FOR SYSTEM_TIME");
 
-                context.Database.ExecuteSqlRaw($"UPDATE [{historyTableInfo.historyTable}] SET PeriodStart = '2000-01-01T01:00:00.0000000Z'");
-                context.Database.ExecuteSqlRaw($"UPDATE [{historyTableInfo.historyTable}] SET PeriodEnd = '2020-07-01T07:00:00.0000000Z'");
+                context.Database.ExecuteSqlRaw($"UPDATE [{tableName + "History"}] SET PeriodStart = '2000-01-01T01:00:00.0000000Z'");
+                context.Database.ExecuteSqlRaw($"UPDATE [{tableName + "History"}] SET PeriodEnd = '2020-07-01T07:00:00.0000000Z'");
 
-                context.Database.ExecuteSqlRaw($"ALTER TABLE [{historyTableInfo.table}] ADD PERIOD FOR SYSTEM_TIME ([PeriodStart], [PeriodEnd])");
-                context.Database.ExecuteSqlRaw($"ALTER TABLE [{historyTableInfo.table}] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[{historyTableInfo.historyTable}]))");
+                context.Database.ExecuteSqlRaw($"ALTER TABLE [{tableName}] ADD PERIOD FOR SYSTEM_TIME ([PeriodStart], [PeriodEnd])");
+                context.Database.ExecuteSqlRaw($"ALTER TABLE [{tableName}] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[{tableName + "History"}]))");
             }
         }
     }


### PR DESCRIPTION
When deciding on history table name use entityType.GetTableName() function instead of entity type name directly.

Fixes #26271



### Customer impact

No impact for customers starting with RTM. For customers who were using pre-release versions of EFCore and were using the feature and were using default name for history table, we will generate a migration (history table rename) that they will have to execute to fix the model.

### How found

Validating and documenting new features in EF Core 6.0.

### Regression

No.

### Testing

Several functional tests execute the code path, as well as testing the migration path from pre-release to RTM (assuming it contains this fix)

### Risk

Low. We are changing temporal table naming pattern.
