### PR TITLE
Cosmos: remove automatic composition of discriminator filter in raw SQL queries

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/QuerySqlGenerator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/QuerySqlGenerator.cs
@@ -247,11 +247,10 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
             }
 
             Visit(selectExpression.FromExpression);
-            _sqlBuilder.AppendLine();
 
             if (selectExpression.Predicate != null)
             {
-                _sqlBuilder.Append("WHERE ");
+                _sqlBuilder.AppendLine().Append("WHERE ");
                 Visit(selectExpression.Predicate);
             }
 

--- a/src/EFCore.Cosmos/Query/Internal/SqlExpressionFactory.cs
+++ b/src/EFCore.Cosmos/Query/Internal/SqlExpressionFactory.cs
@@ -525,12 +525,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual SelectExpression Select(IEntityType entityType, string sql, Expression argument)
-        {
-            var selectExpression = new SelectExpression(entityType, sql, argument);
-            AddDiscriminator(selectExpression, entityType);
-
-            return selectExpression;
-        }
+            => new(entityType, sql, argument);
 
         private void AddDiscriminator(SelectExpression selectExpression, IEntityType entityType)
         {


### PR DESCRIPTION
Closes #26124

### Description

When executing a Cosmos raw SQL query, EF Core automatically appends the discriminator filter corresponding to the DbSet queried. If the discriminator projected by the user doesn't correspond to it, no rows are return. This PR removes the automatic discriminator filter, causing an exception to be thrown instead by the materializer.

### Customer impact

If the user forgets to project out a discriminator in a Cosmos raw SQL, currently no rows at all are returned by the query (rather than throwing an exception). This is a case of incorrect results which is somewhat hard to diagnose.

### How found

Flagged by @JeremyLikness in #26124

### Regression

No, Cosmos FromSql is a new feature introduced in 6.0.

### Testing

Yes, introduced in this PR.

### Risk

Low, the fix is trivial and affects a new feature (FromSql)
