### PR TITLE
[6.0] Flag all properties as not unknown when saving changes

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -1436,6 +1436,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             }
 
             _stateData.FlagAllProperties(EntityType.PropertyCount(), PropertyFlag.IsTemporary, false);
+            _stateData.FlagAllProperties(EntityType.PropertyCount(), PropertyFlag.Unknown, false);
 
             var currentState = EntityState;
             if ((currentState == EntityState.Unchanged)

--- a/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBase.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBase.cs
@@ -434,6 +434,10 @@ namespace Microsoft.EntityFrameworkCore
                             b => b.HasKey("OwnerWithKeyedCollectionId", "PrivateKey"));
                     });
 
+                modelBuilder
+                    .Entity<OwnerWithNonCompositeOwnedCollection>()
+                    .OwnsMany(e => e.Owned, owned => owned.HasKey("Id"));
+
                 modelBuilder.Entity<OwnerNoKeyGeneration>(
                     b =>
                     {
@@ -3284,6 +3288,35 @@ namespace Microsoft.EntityFrameworkCore
             {
                 get => _bar;
                 set => SetWithNotify(value, ref _bar);
+            }
+        }
+
+        protected class OwnerWithNonCompositeOwnedCollection : NotifyingEntity
+        {
+            private int _id;
+            private ICollection<NonCompositeOwnedCollection> _owned = new ObservableHashSet<NonCompositeOwnedCollection>();
+
+            public int Id
+            {
+                get => _id;
+                set => SetWithNotify(value, ref _id);
+            }
+
+            public ICollection<NonCompositeOwnedCollection> Owned
+            {
+                get => _owned;
+                set => SetWithNotify(value, ref _owned);
+            }
+        }
+
+        protected class NonCompositeOwnedCollection : NotifyingEntity
+        {
+            private string _foo;
+
+            public string Foo
+            {
+                get => _foo;
+                set => SetWithNotify(value, ref _foo);
             }
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerOwnedTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerOwnedTest.cs
@@ -454,6 +454,10 @@ namespace Microsoft.EntityFrameworkCore
                             b => b.HasKey("OwnerWithKeyedCollectionId", "PrivateKey"));
                     });
 
+                modelBuilder
+                    .Entity<OwnerWithNonCompositeOwnedCollection>()
+                    .OwnsMany(e => e.Owned, owned => owned.HasKey("Id"));
+
                 modelBuilder.Entity<OwnerNoKeyGeneration>(
                     b =>
                     {


### PR DESCRIPTION
Fixes #26330

### Description

When saving changes to the database for an entity with a potentially unknown key value, that key value remained marked as unknown after saving if the property uses a value generator that does not generate temporary values.

### Customer impact

Exception thrown when saving changes with the in-memory provider using owned collections, but also fails with other providers when using value generators that do not generate temporary values.

### How found

Multiple customer reports on RC2.

### Regression

Yes, from 5.0.

### Testing

Test for this scenario added in the PR which runs for multiple providers and value generators.

### Risk

Low; the fix is to clear the unknown flag when accepting saved changes into the state manager.
