### PR TITLE
Fix to #26353 - Test Subquery_with_Distinct_Skip_FirstOrDefault_without_OrderBy is non-deterministic

### DIFF
--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -2772,9 +2772,15 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => from l1 in ss.Set<Level1>()
                       where l1.Id < 3
-                      select (from l3 in ss.Set<Level3>()
-                              orderby l3.Id
-                              select l3).Distinct().Skip(1).FirstOrDefault().Name);
+                      select new
+                      {
+                          Key = l1.Id,
+                          Subquery = (from l3 in ss.Set<Level3>()
+                                      orderby l3.Id
+                                      select l3).Distinct().Skip(1).FirstOrDefault().Name
+                      },
+                elementSorter: e => e.Key,
+                elementAsserter: (e, a) => Assert.Equal(e.Key, a.Key));
         }
 
         [ConditionalTheory]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -2526,14 +2526,14 @@ WHERE [l].[Id] < 3");
             await base.Subquery_with_Distinct_Skip_FirstOrDefault_without_OrderBy(async);
 
             AssertSql(
-                @"SELECT (
+                @"SELECT [l].[Id] AS [Key], (
     SELECT [t].[Name]
     FROM (
         SELECT DISTINCT [l0].[Id], [l0].[Level2_Optional_Id], [l0].[Level2_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse3Id], [l0].[OneToMany_Optional_Self_Inverse3Id], [l0].[OneToMany_Required_Inverse3Id], [l0].[OneToMany_Required_Self_Inverse3Id], [l0].[OneToOne_Optional_PK_Inverse3Id], [l0].[OneToOne_Optional_Self3Id]
         FROM [LevelThree] AS [l0]
     ) AS [t]
     ORDER BY (SELECT 1)
-    OFFSET 1 ROWS FETCH NEXT 1 ROWS ONLY)
+    OFFSET 1 ROWS FETCH NEXT 1 ROWS ONLY) AS [Subquery]
 FROM [LevelOne] AS [l]
 WHERE [l].[Id] < 3");
         }


### PR DESCRIPTION
added way to order on the client on the top level but don't actually verify the subquery result, because its not deterministic.

Fixes #26353