### PR TITLE
Configure the correct end as principal for self-ref collection with [ForeignKey]

### DIFF
--- a/src/EFCore/Metadata/Conventions/ForeignKeyAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/ForeignKeyAttributeConvention.cs
@@ -116,7 +116,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             foreach (var navigation in foreignKeyNavigations)
             {
                 entityTypeBuilder.HasRelationship(
-                    entityType, foreignKeyNavigations[0], setTargetAsPrincipal: true, fromDataAnnotation: true);
+                    entityType,
+                    navigation,
+                    setTargetAsPrincipal: navigation.GetMemberType().IsAssignableFrom(entityType.ClrType),
+                    fromDataAnnotation: true);
             }
         }
 

--- a/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
@@ -73,6 +73,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         [ConditionalFact]
+        public void Collection_navigation_to_principal_throws()
+        {
+            var modelBuilder = CreateModelBuilder();
+            var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
+            var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+
+            Assert.Equal(CoreStrings.PrincipalEndIncompatibleNavigations(
+                nameof(Customer) + "." + nameof(Customer.Orders), nameof(Order), nameof(Order)),
+                Assert.Throws<InvalidOperationException>(() =>
+                    principalEntityBuilder.HasRelationship(
+                        dependentEntityBuilder.Metadata,
+                        Customer.OrdersProperty,
+                        ConfigurationSource.DataAnnotation,
+                        targetIsPrincipal: true)).Message);
+        }
+
+        [ConditionalFact]
         public void Can_add_relationship_if_principal_entity_PK_name_contains_principal_entity_name()
         {
             var modelBuilder = CreateModelBuilder();


### PR DESCRIPTION
Fixes #26364

### Description

Using `[ForeignKey]` on a self-ref collection navigation results in an exception during model building.

### Customer impact

The exception is thrown from a convention that runs before Fluent API configuration. The only reasonable workaround is to remove the `[ForeignKey]`.

### How found

Multiple customer reports on RC2.

### Regression

Yes, from 6.0 RC1, introduced in https://github.com/dotnet/efcore/pull/25806

### Testing

Test for this scenario added in the PR.

### Risk

Low, the changed code only affects self-ref navigations with `[ForeignKey]`.
