### PR TITLE
No test left behind

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
@@ -1,589 +1,775 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Linq;
+using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
+using Microsoft.EntityFrameworkCore.Cosmos.Internal;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 using Xunit.Abstractions;
+using Xunit.Sdk;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
-    public class NorthwindAggregateOperatorsQueryCosmosTest : NorthwindAggregateOperatorsQueryTestBase<
-        NorthwindQueryCosmosFixture<NoopModelCustomizer>>
+    public class NorthwindAggregateOperatorsQueryCosmosTest
+        : NorthwindAggregateOperatorsQueryTestBase<NorthwindQueryCosmosFixture<NoopModelCustomizer>>
     {
         public NorthwindAggregateOperatorsQueryCosmosTest(
             NorthwindQueryCosmosFixture<NoopModelCustomizer> fixture,
-#pragma warning disable IDE0060 // Remove unused parameter
             ITestOutputHelper testOutputHelper)
-#pragma warning restore IDE0060 // Remove unused parameter
             : base(fixture)
         {
             ClearLog();
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
-        [ConditionalFact(Skip = "Issue#17246")]
-        public override void Select_All()
+        [ConditionalFact]
+        public virtual void Check_all_tests_overridden()
+            => TestHelpers.AssertAllMethodsOverridden(GetType());
+
+        public override async Task Average_over_default_returns_default(bool async)
         {
-            base.Select_All();
+            await base.Average_over_default_returns_default(async);
+
+            AssertSql(
+                @"SELECT AVG((c[""OrderID""] - 10248)) AS c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = 10248))");
+        }
+
+        public override void Contains_over_keyless_entity_throws()
+        {
+            // Aggregates. Issue #16146.
+            AssertTranslationFailed(() =>
+            {
+                base.Contains_over_keyless_entity_throws();
+                return Task.CompletedTask;
+            });
 
             AssertSql(
                 @"SELECT c
 FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")
+OFFSET 0 LIMIT 1");
+        }
+
+        public override async Task Contains_with_local_non_primitive_list_closure_mix(bool async)
+        {
+            await base.Contains_with_local_non_primitive_list_closure_mix(async);
+
+            AssertSql(
+                @"SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND c[""CustomerID""] IN (""ABCDE"", ""ALFKI""))");
+        }
+
+        public override async Task Contains_with_local_non_primitive_list_inline_closure_mix(bool async)
+        {
+            await base.Contains_with_local_non_primitive_list_inline_closure_mix(async);
+
+            AssertSql(
+                @"SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND c[""CustomerID""] IN (""ABCDE"", ""ALFKI""))",
+                //
+                @"SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND c[""CustomerID""] IN (""ABCDE"", ""ANATR""))");
+        }
+
+        public override async Task Count_on_projection_with_client_eval(bool async)
+        {
+            await base.Count_on_projection_with_client_eval(async);
+
+            AssertSql(
+                @"SELECT COUNT(1) AS c
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")",
+                //
+                @"SELECT COUNT(1) AS c
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")",
+                //
+                @"SELECT COUNT(1) AS c
+FROM root c
 WHERE (c[""Discriminator""] = ""Order"")");
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
+        public override async Task First(bool async)
+        {
+            await base.First(async);
+
+            AssertSql(
+                @"SELECT c
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY c[""ContactName""]
+OFFSET 0 LIMIT 1");
+        }
+
+        public override async Task Max_over_default_returns_default(bool async)
+        {
+            await base.Max_over_default_returns_default(async);
+
+            AssertSql(
+                @"SELECT MAX((c[""OrderID""] - 10248)) AS c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = 10248))");
+        }
+
+        public override async Task Min_over_default_returns_default(bool async)
+
+        {
+            await base.Min_over_default_returns_default(async);
+
+            AssertSql(
+                @"SELECT MIN((c[""OrderID""] - 10248)) AS c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = 10248))");
+        }
+
+        public override async Task Sum_over_empty_returns_zero(bool async)
+        {
+            await base.Sum_over_empty_returns_zero(async);
+
+            AssertSql(
+                @"SELECT SUM(c[""OrderID""]) AS c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = 42))");
+        }
+
+        public override async Task First_Predicate(bool async)
+        {
+            await base.First_Predicate(async);
+
+            AssertSql(
+                @"SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))
+ORDER BY c[""ContactName""]
+OFFSET 0 LIMIT 1");
+        }
+
+        public override async Task Single_Throws(bool async)
+        {
+            await base.Single_Throws(async);
+
+            AssertSql(
+                @"SELECT c
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")
+OFFSET 0 LIMIT 2");
+        }
+
+        public override async Task Where_First(bool async)
+        {
+            await base.Where_First(async);
+
+            AssertSql(
+                @"SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))
+ORDER BY c[""ContactName""]
+OFFSET 0 LIMIT 1");
+        }
+
+        public override async Task Where_Single(bool async)
+        {
+            await base.Where_Single(async);
+
+            AssertSql(
+                @"SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))
+OFFSET 0 LIMIT 2");
+        }
+
+        public override async Task FirstOrDefault(bool async)
+        {
+            await base.FirstOrDefault(async);
+
+            AssertSql(
+                @"SELECT c
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY c[""ContactName""]
+OFFSET 0 LIMIT 1");
+        }
+
+        public override async Task Array_cast_to_IEnumerable_Contains_with_constant(bool async)
+        {
+            await base.Array_cast_to_IEnumerable_Contains_with_constant(async);
+
+            AssertSql(
+                @"SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND c[""CustomerID""] IN (""ALFKI"", ""WRONG""))");
+        }
+
+        public override async Task FirstOrDefault_Predicate(bool async)
+        {
+            await base.FirstOrDefault_Predicate(async);
+
+            AssertSql(
+                @"SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))
+ORDER BY c[""ContactName""]
+OFFSET 0 LIMIT 1");
+        }
+
+        public override async Task SingleOrDefault_Predicate(bool async)
+        {
+            await base.SingleOrDefault_Predicate(async);
+
+            AssertSql(
+                @"SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))
+OFFSET 0 LIMIT 2");
+        }
+
+        public override async Task SingleOrDefault_Throws(bool async)
+        {
+            await base.SingleOrDefault_Throws(async);
+
+            AssertSql(
+                @"SELECT c
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")
+OFFSET 0 LIMIT 2");
+        }
+
+        public override async Task Where_FirstOrDefault(bool async)
+        {
+            await base.Where_FirstOrDefault(async);
+
+            AssertSql(
+                @"SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))
+ORDER BY c[""ContactName""]
+OFFSET 0 LIMIT 1");
+        }
+
+        public override async Task Where_SingleOrDefault(bool async)
+        {
+            await base.Where_SingleOrDefault(async);
+
+            AssertSql(
+                @"SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))
+OFFSET 0 LIMIT 2");
+        }
+
+        public override void Select_All()
+        {
+            // Contains over subquery. Issue #17246.
+            AssertTranslationFailed(() =>
+            {
+                base.Select_All();
+                return Task.CompletedTask;
+            });
+
+            AssertSql();
+        }
+
         public override async Task Sum_with_no_arg(bool async)
         {
             await base.Sum_with_no_arg(async);
 
             AssertSql(
-                @"SELECT c
+                @"SELECT SUM(c[""OrderID""]) AS c
 FROM root c
 WHERE (c[""Discriminator""] = ""Order"")");
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
-        public override Task Sum_with_no_data_cast_to_nullable(bool async)
+        public override async Task Sum_with_no_data_cast_to_nullable(bool async)
         {
-            return base.Sum_with_no_data_cast_to_nullable(async);
+            await base.Sum_with_no_data_cast_to_nullable(async);
+
+            AssertSql(
+                @"SELECT SUM(c[""OrderID""]) AS c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 0))");
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Sum_with_binary_expression(bool async)
         {
             await base.Sum_with_binary_expression(async);
 
             AssertSql(
-                @"SELECT c
+                @"SELECT SUM((c[""OrderID""] * 2)) AS c
 FROM root c
 WHERE (c[""Discriminator""] = ""Order"")");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
-        public override Task Sum_with_no_arg_empty(bool async)
+        public override async Task Sum_with_no_arg_empty(bool async)
         {
-            return base.Sum_with_no_arg_empty(async);
+            await base.Sum_with_no_arg_empty(async);
+
+            AssertSql(
+                @"SELECT SUM(c[""OrderID""]) AS c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = 42))");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
-        public override Task Sum_with_no_data_nullable(bool async)
+        public override async Task Sum_with_no_data_nullable(bool async)
         {
-            return base.Sum_with_no_data_nullable(async);
+            await base.Sum_with_no_data_nullable(async);
+
+            AssertSql(
+                @"SELECT SUM(c[""SupplierID""]) AS c
+FROM root c
+WHERE (c[""Discriminator""] = ""Product"")");
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Sum_with_arg(bool async)
         {
             await base.Sum_with_arg(async);
 
             AssertSql(
-                @"SELECT c
+                @"SELECT SUM(c[""OrderID""]) AS c
 FROM root c
 WHERE (c[""Discriminator""] = ""Order"")");
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Sum_with_arg_expression(bool async)
         {
             await base.Sum_with_arg_expression(async);
 
             AssertSql(
-                @"SELECT c
+                @"SELECT SUM((c[""OrderID""] + c[""OrderID""])) AS c
 FROM root c
 WHERE (c[""Discriminator""] = ""Order"")");
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Sum_with_division_on_decimal(bool async)
         {
-            await base.Sum_with_division_on_decimal(async);
+            // Aggregate selecting non-mapped type. Issue #20677.
+            await Assert.ThrowsAsync<KeyNotFoundException>(async () => await base.Sum_with_division_on_decimal(async));
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""OrderDetail"")");
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Sum_with_division_on_decimal_no_significant_digits(bool async)
         {
-            await base.Sum_with_division_on_decimal_no_significant_digits(async);
+            // Aggregate selecting non-mapped type. Issue #20677.
+            await Assert.ThrowsAsync<KeyNotFoundException>(
+                async () => await base.Sum_with_division_on_decimal_no_significant_digits(async));
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""OrderDetail"")");
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Sum_with_coalesce(bool async)
         {
             await base.Sum_with_coalesce(async);
 
             AssertSql(
-                @"SELECT c
+                @"SELECT SUM(((c[""UnitPrice""] != null) ? c[""UnitPrice""] : 0.0)) AS c
 FROM root c
 WHERE ((c[""Discriminator""] = ""Product"") AND (c[""ProductID""] < 40))");
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Sum_over_subquery_is_client_eval(bool async)
         {
-            await AssertSum(
-                async,
-                ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI"),
-                selector: c => c.Orders.Sum(o => o.OrderID));
+            // Aggregates. Issue #16146.
+            await AssertTranslationFailed(() => base.Sum_over_subquery_is_client_eval(async));
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Sum_over_nested_subquery_is_client_eval(bool async)
         {
-            await AssertSum(
-                async,
-                ss => ss.Set<Customer>().Where(c => c.CustomerID == "CENTC"),
-                selector: c => c.Orders.Sum(
-                    o => 5 + o.OrderDetails.Where(od => od.OrderID >= 10250 && od.OrderID <= 10300).Sum(od => od.ProductID)));
+            // Aggregates. Issue #16146.
+            await AssertTranslationFailed(() => base.Sum_over_nested_subquery_is_client_eval(async));
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""CENTC""))");
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Sum_over_min_subquery_is_client_eval(bool async)
         {
-            await AssertSum(
-                async,
-                ss => ss.Set<Customer>().Where(c => c.CustomerID == "CENTC"),
-                selector: c => c.Orders.Sum(
-                    o => 5 + o.OrderDetails.Where(od => od.OrderID >= 10250 && od.OrderID <= 10300).Min(od => od.ProductID)));
+            // Aggregates. Issue #16146.
+            await AssertTranslationFailed(() => base.Sum_over_min_subquery_is_client_eval(async));
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""CENTC""))");
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Sum_on_float_column(bool async)
         {
             await base.Sum_on_float_column(async);
 
             AssertSql(
-                @"SELECT c
+                @"SELECT SUM(c[""Discount""]) AS c
 FROM root c
 WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""ProductID""] = 1))");
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Sum_on_float_column_in_subquery(bool async)
         {
-            await AssertQuery(
-                async,
-                ss => ss.Set<Order>().Where(o => o.OrderID < 10250)
-                    .Select(o => new { o.OrderID, Sum = o.OrderDetails.Sum(od => od.Discount) }),
-                e => e.OrderID);
+            // Aggregates. Issue #16146.
+            await AssertTranslationFailed(() => base.Sum_on_float_column_in_subquery(async));
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10250))");
+            AssertSql();
         }
 
-        [ConditionalFact(Skip = "Issue#16146")]
         public override void Average_no_data()
         {
             base.Average_no_data();
+
+            AssertSql(
+                @"SELECT AVG(c[""OrderID""]) AS c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = -1))");
         }
 
-        [ConditionalFact(Skip = "Issue#16146")]
         public override void Average_no_data_nullable()
         {
+            base.Average_no_data_nullable();
+
+            AssertSql(
+                @"SELECT AVG(c[""SupplierID""]) AS c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Product"") AND (c[""SupplierID""] = -1))");
         }
 
-        [ConditionalFact(Skip = "Issue#16146")]
         public override void Average_no_data_cast_to_nullable()
         {
+            base.Average_no_data_cast_to_nullable();
+
+            AssertSql(
+                @"SELECT AVG(c[""OrderID""]) AS c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = -1))");
         }
 
-        [ConditionalFact(Skip = "Issue#16146")]
         public override void Min_no_data()
         {
             base.Min_no_data();
+
+            AssertSql(
+                @"SELECT MIN(c[""OrderID""]) AS c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = -1))");
         }
 
-        [ConditionalFact(Skip = "Issue#16146")]
         public override void Max_no_data()
         {
             base.Max_no_data();
-        }
-
-        [ConditionalFact(Skip = "Issue#16146")]
-        public override void Average_no_data_subquery()
-        {
-            base.Average_no_data_subquery();
-        }
-
-        [ConditionalFact(Skip = "Issue#16146")]
-        public override void Max_no_data_subquery()
-        {
-            base.Max_no_data_subquery();
-        }
-
-        [ConditionalFact(Skip = "Issue#16146")]
-        public override void Max_no_data_nullable()
-        {
-        }
-
-        [ConditionalFact(Skip = "Issue#16146")]
-        public override void Max_no_data_cast_to_nullable()
-        {
-        }
-
-        [ConditionalFact(Skip = "Issue#16146")]
-        public override void Min_no_data_subquery()
-        {
-            base.Min_no_data_subquery();
-        }
-
-        [ConditionalTheory(Skip = "Issue#16146")]
-        public override async Task Average_with_no_arg(bool async)
-        {
-            await base.Average_with_no_arg(async);
 
             AssertSql(
-                @"SELECT c
+                @"SELECT MAX(c[""OrderID""]) AS c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = -1))");
+        }
+
+        public override void Average_no_data_subquery()
+        {
+            // Aggregates. Issue #16146.
+            AssertTranslationFailed(() =>
+            {
+                base.Average_no_data_subquery();
+                return Task.CompletedTask;
+            });
+
+            AssertSql();
+        }
+
+        public override void Max_no_data_subquery()
+        {
+            // Aggregates. Issue #16146.
+            AssertTranslationFailed(() =>
+            {
+                base.Max_no_data_subquery();
+                return Task.CompletedTask;
+            });
+
+            AssertSql();
+        }
+
+        public override void Max_no_data_nullable()
+        {
+            base.Max_no_data_nullable();
+
+            AssertSql(
+                @"SELECT MAX(c[""SupplierID""]) AS c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Product"") AND (c[""SupplierID""] = -1))");
+        }
+
+        public override void Max_no_data_cast_to_nullable()
+        {
+            base.Max_no_data_cast_to_nullable();
+
+            AssertSql(
+                @"SELECT MAX(c[""OrderID""]) AS c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = -1))");
+        }
+
+        public override void Min_no_data_subquery()
+        {
+            // Aggregates. Issue #16146.
+            AssertTranslationFailed(() =>
+            {
+                base.Min_no_data_subquery();
+                return Task.CompletedTask;
+            });
+
+            AssertSql();
+        }
+
+        public override async Task Average_with_no_arg(bool async)
+        {
+            // Average truncates. Issue #26378.
+            await Assert.ThrowsAsync<EqualException>(async () => await base.Average_with_no_arg(async));
+
+            AssertSql(
+                @"SELECT AVG(c[""OrderID""]) AS c
 FROM root c
 WHERE (c[""Discriminator""] = ""Order"")");
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Average_with_binary_expression(bool async)
         {
             await base.Average_with_binary_expression(async);
 
             AssertSql(
-                @"SELECT c
+                @"SELECT AVG((c[""OrderID""] * 2)) AS c
 FROM root c
 WHERE (c[""Discriminator""] = ""Order"")");
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Average_with_arg(bool async)
         {
-            await base.Average_with_arg(async);
+            // Average truncates. Issue #26378.
+            await Assert.ThrowsAsync<EqualException>(async () => await base.Average_with_arg(async));
 
             AssertSql(
-                @"SELECT c
+                @"SELECT AVG(c[""OrderID""]) AS c
 FROM root c
 WHERE (c[""Discriminator""] = ""Order"")");
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Average_with_arg_expression(bool async)
         {
             await base.Average_with_arg_expression(async);
 
             AssertSql(
-                @"SELECT c
+                @"SELECT AVG((c[""OrderID""] + c[""OrderID""])) AS c
 FROM root c
 WHERE (c[""Discriminator""] = ""Order"")");
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Average_with_division_on_decimal(bool async)
         {
-            await base.Average_with_division_on_decimal(async);
+            // Aggregate selecting non-mapped type. Issue #20677.
+            await Assert.ThrowsAsync<KeyNotFoundException>(async () => await base.Average_with_division_on_decimal(async));
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""OrderDetail"")");
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Average_with_division_on_decimal_no_significant_digits(bool async)
         {
-            await base.Average_with_division_on_decimal_no_significant_digits(async);
+            // Aggregate selecting non-mapped type. Issue #20677.
+            await Assert.ThrowsAsync<KeyNotFoundException>(
+                async () => await base.Average_with_division_on_decimal_no_significant_digits(async));
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""OrderDetail"")");
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Average_with_coalesce(bool async)
         {
             await base.Average_with_coalesce(async);
 
             AssertSql(
-                @"SELECT c
+                @"SELECT AVG(((c[""UnitPrice""] != null) ? c[""UnitPrice""] : 0.0)) AS c
 FROM root c
 WHERE ((c[""Discriminator""] = ""Product"") AND (c[""ProductID""] < 40))");
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Average_over_subquery_is_client_eval(bool async)
         {
-            await AssertAverage(
-                async,
-                ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI"),
-                selector: c => c.Orders.Where(o => o.OrderID < 10250).Sum(o => o.OrderID));
+            // Aggregates. Issue #16146.
+            await AssertTranslationFailed(() => base.Average_over_subquery_is_client_eval(async));
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Average_over_nested_subquery_is_client_eval(bool async)
         {
-            await AssertAverage(
-                async,
-                ss => ss.Set<Customer>().Where(c => c.CustomerID == "CENTC"),
-                selector: c => (decimal)c.Orders
-                    .Average(o => 5 + o.OrderDetails.Where(od => od.OrderID > 10250 && od.OrderID < 10300).Average(od => od.ProductID)));
+            // Aggregates. Issue #16146.
+            await AssertTranslationFailed(() => base.Average_over_nested_subquery_is_client_eval(async));
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""CENTC""))");
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Average_over_max_subquery_is_client_eval(bool async)
         {
-            await AssertAverage(
-                async,
-                ss => ss.Set<Customer>().Where(c => c.CustomerID == "CENTC"),
-                selector: c => (decimal)c.Orders
-                    .Average(o => 5 + o.OrderDetails.Where(od => od.OrderID > 10250 && od.OrderID < 10300).Max(od => od.ProductID)));
+            // Aggregates. Issue #16146.
+            await AssertTranslationFailed(() => base.Average_over_max_subquery_is_client_eval(async));
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""CENTC""))");
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Average_on_float_column(bool async)
         {
             await base.Average_on_float_column(async);
 
             AssertSql(
-                @"SELECT c
+                @"SELECT AVG(c[""Discount""]) AS c
 FROM root c
 WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""ProductID""] = 1))");
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Average_on_float_column_in_subquery(bool async)
         {
-            await AssertQuery(
-                async,
-                ss => ss.Set<Order>().Where(o => o.OrderID < 10250).Select(
-                    o => new { o.OrderID, Sum = o.OrderDetails.Average(od => od.Discount) }),
-                e => e.OrderID);
+            // Aggregates. Issue #16146.
+            await AssertTranslationFailed(() => base.Average_on_float_column_in_subquery(async));
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10250))");
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Average_on_float_column_in_subquery_with_cast(bool async)
         {
-            await AssertQuery(
-                async,
-                ss => ss.Set<Order>().Where(o => o.OrderID < 10250)
-                    .Select(
-                        o => new { o.OrderID, Sum = o.OrderDetails.Average(od => (float?)od.Discount) }),
-                e => e.OrderID);
+            // Aggregates. Issue #16146.
+            await AssertTranslationFailed(() => base.Average_on_float_column_in_subquery_with_cast(async));
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10250))");
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Min_with_no_arg(bool async)
         {
             await base.Min_with_no_arg(async);
 
             AssertSql(
-                @"SELECT c
+                @"SELECT MIN(c[""OrderID""]) AS c
 FROM root c
 WHERE (c[""Discriminator""] = ""Order"")");
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Min_with_arg(bool async)
         {
             await base.Min_with_arg(async);
 
             AssertSql(
-                @"SELECT c
+                @"SELECT MIN(c[""OrderID""]) AS c
 FROM root c
 WHERE (c[""Discriminator""] = ""Order"")");
         }
 
-        [ConditionalFact(Skip = "Issue#16146")]
         public override void Min_no_data_nullable()
         {
+            base.Min_no_data_nullable();
+
+            AssertSql(
+                @"SELECT MIN(c[""SupplierID""]) AS c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Product"") AND (c[""SupplierID""] = -1))");
         }
 
-        [ConditionalFact(Skip = "Issue#16146")]
         public override void Min_no_data_cast_to_nullable()
         {
+            base.Min_no_data_cast_to_nullable();
+
+            AssertSql(
+                @"SELECT MIN(c[""OrderID""]) AS c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = -1))");
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Min_with_coalesce(bool async)
         {
             await base.Min_with_coalesce(async);
 
             AssertSql(
-                @"SELECT c
+                @"SELECT MIN(((c[""UnitPrice""] != null) ? c[""UnitPrice""] : 0.0)) AS c
 FROM root c
 WHERE ((c[""Discriminator""] = ""Product"") AND (c[""ProductID""] < 40))");
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Min_over_subquery_is_client_eval(bool async)
         {
-            await AssertMin(
-                async,
-                ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI"),
-                selector: c => c.Orders.Sum(o => o.OrderID));
+            // Aggregates. Issue #16146.
+            await AssertTranslationFailed(() => base.Min_over_subquery_is_client_eval(async));
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Min_over_nested_subquery_is_client_eval(bool async)
         {
-            await AssertMin(
-                async,
-                ss => ss.Set<Customer>().Where(c => c.CustomerID == "CENTC"),
-                selector: c =>
-                    c.Orders.Min(o => 5 + o.OrderDetails.Where(od => od.OrderID > 10250 && od.OrderID < 10300).Min(od => od.ProductID)));
+            // Aggregates. Issue #16146.
+            await AssertTranslationFailed(() => base.Min_over_nested_subquery_is_client_eval(async));
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""CENTC""))");
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Min_over_max_subquery_is_client_eval(bool async)
         {
-            await AssertMin(
-                async,
-                ss => ss.Set<Customer>().Where(c => c.CustomerID == "CENTC"),
-                selector: c =>
-                    c.Orders.Min(o => 5 + o.OrderDetails.Where(od => od.OrderID > 10250 && od.OrderID < 10300).Max(od => od.ProductID)));
+            // Aggregates. Issue #16146.
+            await AssertTranslationFailed(() => base.Min_over_max_subquery_is_client_eval(async));
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""CENTC""))");
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Max_with_no_arg(bool async)
         {
             await base.Max_with_no_arg(async);
 
             AssertSql(
-                @"SELECT c
+                @"SELECT MAX(c[""OrderID""]) AS c
 FROM root c
 WHERE (c[""Discriminator""] = ""Order"")");
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Max_with_arg(bool async)
         {
             await base.Max_with_arg(async);
 
             AssertSql(
-                @"SELECT c
+                @"SELECT MAX(c[""OrderID""]) AS c
 FROM root c
 WHERE (c[""Discriminator""] = ""Order"")");
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Max_with_coalesce(bool async)
         {
             await base.Max_with_coalesce(async);
 
             AssertSql(
-                @"SELECT c
+                @"SELECT MAX(((c[""UnitPrice""] != null) ? c[""UnitPrice""] : 0.0)) AS c
 FROM root c
 WHERE ((c[""Discriminator""] = ""Product"") AND (c[""ProductID""] < 40))");
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Max_over_subquery_is_client_eval(bool async)
         {
-            await AssertMax(
-                async,
-                ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI"),
-                selector: c => c.Orders.Sum(o => o.OrderID));
+            // Aggregates. Issue #16146.
+            await AssertTranslationFailed(() => base.Max_over_subquery_is_client_eval(async));
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Max_over_nested_subquery_is_client_eval(bool async)
         {
-            await AssertMax(
-                async,
-                ss => ss.Set<Customer>().Where(c => c.CustomerID == "CENTC"),
-                selector: c =>
-                    c.Orders.Max(o => 5 + o.OrderDetails.Where(od => od.OrderID > 10250 && od.OrderID < 10300).Max(od => od.ProductID)));
+            // Aggregates. Issue #16146.
+            await AssertTranslationFailed(() => base.Max_over_nested_subquery_is_client_eval(async));
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""CENTC""))");
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Max_over_sum_subquery_is_client_eval(bool async)
         {
-            await AssertMax(
-                async,
-                ss => ss.Set<Customer>().Where(c => c.CustomerID == "CENTC"),
-                selector: c =>
-                    c.Orders.Max(o => 5 + o.OrderDetails.Where(od => od.OrderID > 10250 && od.OrderID < 10300).Sum(od => od.ProductID)));
+            // Aggregates. Issue #16146.
+            await AssertTranslationFailed(() => base.Max_over_sum_subquery_is_client_eval(async));
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""CENTC""))");
+            AssertSql();
         }
 
-        [ConditionalTheory]
         public override async Task Count_with_no_predicate(bool async)
         {
             await base.Count_with_no_predicate(async);
@@ -594,184 +780,147 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Order"")");
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Count_with_predicate(bool async)
         {
             await base.Count_with_predicate(async);
 
             AssertSql(
-                @"SELECT c
+                @"SELECT COUNT(1) AS c
 FROM root c
 WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
-        public override Task Count_with_order_by(bool async)
+        public async override Task Count_with_order_by(bool async)
         {
-            return base.Count_with_order_by(async);
+            await base.Count_with_order_by(async);
+
+            AssertSql(
+                @"SELECT COUNT(1) AS c
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Where_OrderBy_Count(bool async)
         {
             await base.Where_OrderBy_Count(async);
 
             AssertSql(
-                @"SELECT c
+                @"SELECT COUNT(1) AS c
 FROM root c
 WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task OrderBy_Where_Count(bool async)
         {
             await base.OrderBy_Where_Count(async);
 
             AssertSql(
-                @"SELECT c
+                @"SELECT COUNT(1) AS c
 FROM root c
 WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
+
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task OrderBy_Count_with_predicate(bool async)
         {
             await base.OrderBy_Count_with_predicate(async);
 
             AssertSql(
-                @"SELECT c
+                @"SELECT COUNT(1) AS c
 FROM root c
 WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task OrderBy_Where_Count_with_predicate(bool async)
         {
             await base.OrderBy_Where_Count_with_predicate(async);
 
             AssertSql(
-                @"SELECT c
+                @"SELECT COUNT(1) AS c
 FROM root c
 WHERE (((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] > 10)) AND (c[""CustomerID""] != ""ALFKI""))");
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task Where_OrderBy_Count_client_eval(bool async)
         {
             await base.Where_OrderBy_Count_client_eval(async);
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+            AssertSql();
         }
 
-        //        public override async Task Where_OrderBy_Count_client_eval_mixed(bool async)
-        //        {
-        //            await base.Where_OrderBy_Count_client_eval_mixed(async);
-
-        //            AssertSql(
-        //                @"SELECT c
-        //FROM root c
-        //WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] > 10))");
-        //        }
-
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task OrderBy_Where_Count_client_eval(bool async)
         {
             await base.OrderBy_Where_Count_client_eval(async);
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task OrderBy_Where_Count_client_eval_mixed(bool async)
         {
             await base.OrderBy_Where_Count_client_eval_mixed(async);
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task OrderBy_Count_with_predicate_client_eval(bool async)
         {
             await base.OrderBy_Count_with_predicate_client_eval(async);
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task OrderBy_Count_with_predicate_client_eval_mixed(bool async)
         {
             await base.OrderBy_Count_with_predicate_client_eval_mixed(async);
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task OrderBy_Where_Count_with_predicate_client_eval(bool async)
         {
             await base.OrderBy_Where_Count_with_predicate_client_eval(async);
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
         public override async Task OrderBy_Where_Count_with_predicate_client_eval_mixed(bool async)
         {
             await base.OrderBy_Where_Count_with_predicate_client_eval_mixed(async);
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
-        public override async Task Average_on_nav_subquery_in_projection(bool isAsync)
+        public override async Task Average_on_nav_subquery_in_projection(bool async)
         {
-            await base.Average_on_nav_subquery_in_projection(isAsync);
+            // Aggregates. Issue #16146.
+            await AssertTranslationFailed(() => base.Average_on_nav_subquery_in_projection(async));
 
-            AssertSql(
-                @"");
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
-        public override async Task Count_after_client_projection(bool isAsync)
+        public override async Task Count_after_client_projection(bool async)
         {
-            await base.Count_after_client_projection(isAsync);
+            // Aggregates. Issue #16146.
+            await AssertTranslationFailed(() => base.Count_after_client_projection(async));
 
-            AssertSql(
-                @"");
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#17246")]
         public override async Task OrderBy_client_Take(bool async)
         {
-            await base.OrderBy_client_Take(async);
+            await Assert.ThrowsAsync<CosmosException>(
+                async () => await base.OrderBy_client_Take(async));
 
             AssertSql(
-                @"SELECT c
+                @"@__p_0='10'
+
+SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+WHERE (c[""Discriminator""] = ""Employee"")
+ORDER BY 42
+OFFSET 0 LIMIT @__p_0");
         }
 
-        [ConditionalTheory]
         public override async Task Distinct(bool async)
         {
             await base.Distinct(async);
@@ -782,7 +931,6 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
-        [ConditionalTheory]
         public override async Task Distinct_Scalar(bool async)
         {
             await base.Distinct_Scalar(async);
@@ -793,7 +941,6 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
-        [ConditionalTheory]
         public override async Task OrderBy_Distinct(bool async)
         {
             await base.OrderBy_Distinct(async);
@@ -805,59 +952,46 @@ WHERE (c[""Discriminator""] = ""Customer"")
 ORDER BY c[""CustomerID""]");
         }
 
-        [ConditionalTheory(Skip = "Issue#16156")]
         public override async Task Distinct_OrderBy(bool async)
         {
-            await base.Distinct_OrderBy(async);
-
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+            // Subquery pushdown. Issue #16156.
+            Assert.Equal(
+                "See issue#16156",
+                (await Assert.ThrowsAsync<InvalidOperationException>(async () => await base.Distinct_OrderBy(async))).Message);
         }
 
-        [ConditionalTheory(Skip = "Issue#16156")]
         public override async Task Distinct_OrderBy2(bool async)
         {
-            await base.Distinct_OrderBy2(async);
-
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+            // Subquery pushdown. Issue #16156.
+            Assert.Equal(
+                "See issue#16156",
+                (await Assert.ThrowsAsync<InvalidOperationException>(async () => await base.Distinct_OrderBy2(async))).Message);
         }
 
-        [ConditionalTheory(Skip = "Issue#16156")]
         public override async Task Distinct_OrderBy3(bool async)
         {
-            await base.Distinct_OrderBy3(async);
+            // Subquery pushdown. Issue #16156.
+            Assert.Equal(
+                "See issue#16156",
+                (await Assert.ThrowsAsync<InvalidOperationException>(async () => await base.Distinct_OrderBy3(async))).Message);
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#16156")]
         public override async Task Distinct_Count(bool async)
         {
-            await base.Distinct_Count(async);
+            // Aggregates. Issue #16146.
+            await AssertTranslationFailed(() => base.Distinct_Count(async));
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#16156")]
         public override async Task Select_Select_Distinct_Count(bool async)
         {
-            await base.Select_Select_Distinct_Count(async);
+            // Aggregates. Issue #16146.
+            await AssertTranslationFailed(() => base.Select_Select_Distinct_Count(async));
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+            AssertSql();
         }
 
         public override async Task Single_Predicate(bool async)
@@ -871,32 +1005,28 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")
 OFFSET 0 LIMIT 2");
         }
 
-        [ConditionalTheory(Skip = "Issue#17246")]
         public override async Task FirstOrDefault_inside_subquery_gets_server_evaluated(bool async)
         {
-            await base.FirstOrDefault_inside_subquery_gets_server_evaluated(async);
+            // Contains over subquery. Issue #17246.
+            await AssertTranslationFailed(() => base.FirstOrDefault_inside_subquery_gets_server_evaluated(async));
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
-        public override Task Multiple_collection_navigation_with_FirstOrDefault_chained_projecting_scalar(bool async)
+        public override async Task Multiple_collection_navigation_with_FirstOrDefault_chained_projecting_scalar(bool async)
         {
-            return base.Multiple_collection_navigation_with_FirstOrDefault_chained_projecting_scalar(async);
+            // Contains over subquery. Issue #17246.
+            await AssertTranslationFailed(() => base.Multiple_collection_navigation_with_FirstOrDefault_chained_projecting_scalar(async));
+
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#17246")]
         public override async Task First_inside_subquery_gets_client_evaluated(bool async)
         {
-            await base.First_inside_subquery_gets_client_evaluated(async);
+            // Contains over subquery. Issue #17246.
+            await AssertTranslationFailed(() => base.First_inside_subquery_gets_client_evaluated(async));
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+            AssertSql();
         }
 
         public override async Task Last(bool async)
@@ -911,7 +1041,6 @@ ORDER BY c[""ContactName""] DESC
 OFFSET 0 LIMIT 1");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Last_when_no_order_by(bool async)
         {
             await base.Last_when_no_order_by(async);
@@ -919,10 +1048,10 @@ OFFSET 0 LIMIT 1");
             AssertSql(
                 @"SELECT c
 FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))
+OFFSET 0 LIMIT 1");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task LastOrDefault_when_no_order_by(bool async)
         {
             await base.LastOrDefault_when_no_order_by(async);
@@ -930,7 +1059,8 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")
             AssertSql(
                 @"SELECT c
 FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))
+OFFSET 0 LIMIT 1");
         }
 
         public override async Task Last_Predicate(bool async)
@@ -993,15 +1123,12 @@ ORDER BY c[""ContactName""] DESC
 OFFSET 0 LIMIT 1");
         }
 
-        [ConditionalTheory(Skip = "Issue#17246")]
         public override async Task Contains_with_subquery(bool async)
         {
-            await base.Contains_with_subquery(async);
+            // Contains over subquery. Issue #17246.
+            await AssertTranslationFailed(() => base.Contains_with_subquery(async));
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+            AssertSql();
         }
 
         public override async Task Contains_with_local_array_closure(bool async)
@@ -1018,15 +1145,12 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND c[""CustomerID""] IN (""ABCDE""))");
         }
 
-        [ConditionalTheory(Skip = "Issue#17246")]
         public override async Task Contains_with_subquery_and_local_array_closure(bool async)
         {
-            await base.Contains_with_subquery_and_local_array_closure(async);
+            // Contains over subquery. Issue #17246.
+            await AssertTranslationFailed(() => base.Contains_with_subquery_and_local_array_closure(async));
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+            AssertSql();
         }
 
         public override async Task Contains_with_local_uint_array_closure(bool async)
@@ -1201,135 +1325,123 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND NOT((true = false)))");
         }
 
-        [ConditionalTheory(Skip = "Issue#17246")]
         public override async Task Contains_top_level(bool async)
         {
-            await base.Contains_top_level(async);
+            // Contains over subquery. Issue #17246.
+            await AssertTranslationFailed(() => base.Contains_top_level(async));
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Contains_with_local_tuple_array_closure(bool async)
         {
-            await base.Contains_with_local_tuple_array_closure(async);
+            // Contains over subquery. Issue #17246.
+            await AssertTranslationFailed(() => base.Contains_with_local_tuple_array_closure(async));
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""OrderDetail"")");
+            AssertSql();
         }
 
         public override async Task Contains_with_local_anonymous_type_array_closure(bool async)
         {
-            await base.Contains_with_local_anonymous_type_array_closure(async);
+            // Contains over subquery. Issue #17246.
+            await AssertTranslationFailed(() => base.Contains_with_local_anonymous_type_array_closure(async));
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""OrderDetail"")");
+            AssertSql();
         }
 
-        [ConditionalFact(Skip = "Issue #17246")]
         public override void OfType_Select()
         {
-            base.OfType_Select();
+            // Contains over subquery. Issue #15937.
+            AssertTranslationFailed(() =>
+            {
+                base.OfType_Select();
+                return Task.CompletedTask;
+            });
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+            AssertSql();
         }
 
-        [ConditionalFact(Skip = "Issue #17246")]
         public override void OfType_Select_OfType_Select()
         {
-            base.OfType_Select_OfType_Select();
+            // Contains over subquery. Issue #17246.
+            AssertTranslationFailed(() =>
+            {
+                base.OfType_Select_OfType_Select();
+                return Task.CompletedTask;
+            });
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#17246")]
         public override async Task Average_with_non_matching_types_in_projection_doesnt_produce_second_explicit_cast(bool async)
         {
-            await base.Average_with_non_matching_types_in_projection_doesnt_produce_second_explicit_cast(async);
+            // Aggregate selecting non-mapped type. Issue #20677.
+            await Assert.ThrowsAsync<KeyNotFoundException>(
+                async () => await base.Average_with_non_matching_types_in_projection_doesnt_produce_second_explicit_cast(async));
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#17246")]
         public override async Task Max_with_non_matching_types_in_projection_introduces_explicit_cast(bool async)
         {
-            await base.Max_with_non_matching_types_in_projection_introduces_explicit_cast(async);
+            // Aggregate selecting non-mapped type. Issue #20677.
+            await Assert.ThrowsAsync<KeyNotFoundException>(
+                async () => await base.Max_with_non_matching_types_in_projection_introduces_explicit_cast(async));
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#17246")]
         public override async Task Min_with_non_matching_types_in_projection_introduces_explicit_cast(bool async)
         {
-            await base.Min_with_non_matching_types_in_projection_introduces_explicit_cast(async);
+            // Aggregate selecting non-mapped type. Issue #20677.
+            await Assert.ThrowsAsync<KeyNotFoundException>(
+                async () => await base.Min_with_non_matching_types_in_projection_introduces_explicit_cast(async));
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#17246")]
         public override async Task OrderBy_Take_Last_gives_correct_result(bool async)
         {
-            await base.OrderBy_Take_Last_gives_correct_result(async);
+            Assert.Equal(
+                CosmosStrings.ReverseAfterSkipTakeNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    async () => await base.OrderBy_Take_Last_gives_correct_result(async))).Message);
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#17246")]
         public override async Task OrderBy_Skip_Last_gives_correct_result(bool async)
         {
-            await base.OrderBy_Skip_Last_gives_correct_result(async);
+            Assert.Equal(
+                CosmosStrings.ReverseAfterSkipTakeNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    async () => await base.OrderBy_Skip_Last_gives_correct_result(async))).Message);
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+            AssertSql();
         }
 
-        [ConditionalFact(Skip = "Issue#17246 (Contains over subquery is not supported)")]
         public override void Contains_over_entityType_should_rewrite_to_identity_equality()
         {
-            base.Contains_over_entityType_should_rewrite_to_identity_equality();
+            // Contains over subquery. Issue #17246.
+            AssertTranslationFailed(() =>
+            {
+                base.Contains_over_entityType_should_rewrite_to_identity_equality();
+                return Task.CompletedTask;
+            });
 
             AssertSql(
                 @"SELECT c
 FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = 10248))");
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = 10248))
+OFFSET 0 LIMIT 2");
         }
 
-        [ConditionalTheory(Skip = "Issue#17246 (Contains over subquery is not supported)")]
         public override async Task List_Contains_over_entityType_should_rewrite_to_identity_equality(bool async)
         {
-            await base.List_Contains_over_entityType_should_rewrite_to_identity_equality(async);
+            // Contains over subquery. Issue #17246.
+            await AssertTranslationFailed(() => base.List_Contains_over_entityType_should_rewrite_to_identity_equality(async));
 
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = 10248))");
+            AssertSql();
         }
 
         public override async Task List_Contains_with_constant_list(bool async)
@@ -1392,16 +1504,20 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND c[""CustomerID""] IN (""ALFKI""))");
         }
 
-        [ConditionalTheory(Skip = "Issue#17246 (Contains over subquery is not supported)")]
-        public override Task Contains_over_entityType_with_null_should_rewrite_to_false(bool async)
+        public override async Task Contains_over_entityType_with_null_should_rewrite_to_false(bool async)
         {
-            return base.Contains_over_entityType_with_null_should_rewrite_to_false(async);
+            // Contains over subquery. Issue #17246.
+            await AssertTranslationFailed(() => base.Contains_over_entityType_with_null_should_rewrite_to_false(async));
+
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#17246 (Contains over subquery is not supported)")]
-        public override Task Contains_over_entityType_with_null_in_projection(bool async)
+        public override async Task Contains_over_entityType_with_null_in_projection(bool async)
         {
-            return base.Contains_over_entityType_with_null_in_projection(async);
+            // Contains over subquery. Issue #17246.
+            await AssertTranslationFailed(() => base.Contains_over_entityType_with_null_in_projection(async));
+
+            AssertSql();
         }
 
         public override async Task String_FirstOrDefault_in_projection_does_not_do_client_eval(bool async)
@@ -1414,13 +1530,12 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Project_constant_Sum(bool async)
         {
             await base.Project_constant_Sum(async);
 
             AssertSql(
-                @"SELECT c
+                @"SELECT SUM(1) AS c
 FROM root c
 WHERE (c[""Discriminator""] = ""Employee"")");
         }
@@ -1513,147 +1628,198 @@ FROM root c
 WHERE (((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""México D.F."")) AND NOT(c[""CustomerID""] IN (""ABCDE"", ""ALFKI"", ""ANATR"")))");
         }
 
-        [ConditionalTheory(Skip = "Issue#17246")]
         public override async Task Cast_to_same_Type_Count_works(bool async)
         {
             await base.Cast_to_same_Type_Count_works(async);
 
             AssertSql(
-                @"SELECT c
+                @"SELECT COUNT(1) AS c
 FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
-        public override Task Cast_before_aggregate_is_preserved(bool async)
+        public override async Task Cast_before_aggregate_is_preserved(bool async)
         {
-            return base.Cast_before_aggregate_is_preserved(async);
+            // Contains over subquery. Issue #17246.
+            await AssertTranslationFailed(() => base.Cast_before_aggregate_is_preserved(async));
+
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
-        public override Task Enumerable_min_is_mapped_to_Queryable_1(bool async)
+        public override async Task Enumerable_min_is_mapped_to_Queryable_1(bool async)
         {
-            return base.Enumerable_min_is_mapped_to_Queryable_1(async);
+            // Contains over subquery. Issue #17246.
+            await AssertTranslationFailed(() => base.Enumerable_min_is_mapped_to_Queryable_1(async));
+
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
-        public override Task Enumerable_min_is_mapped_to_Queryable_2(bool async)
+        public override async Task Enumerable_min_is_mapped_to_Queryable_2(bool async)
         {
-            return base.Enumerable_min_is_mapped_to_Queryable_2(async);
+            // Contains over subquery. Issue #17246.
+            await AssertTranslationFailed(() => base.Enumerable_min_is_mapped_to_Queryable_2(async));
+
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#17246")]
-        public override Task DefaultIfEmpty_selects_only_required_columns(bool async)
+        public override async Task DefaultIfEmpty_selects_only_required_columns(bool async)
         {
-            return base.DefaultIfEmpty_selects_only_required_columns(async);
+            // Contains over subquery. Issue #17246.
+            await AssertTranslationFailed(() => base.DefaultIfEmpty_selects_only_required_columns(async));
+
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#17246")]
-        public override Task Collection_Last_member_access_in_projection_translated(bool async)
+        public override async Task Collection_Last_member_access_in_projection_translated(bool async)
         {
-            return base.Collection_Last_member_access_in_projection_translated(async);
+            // Contains over subquery. Issue #17246.
+            await AssertTranslationFailed(() => base.Collection_Last_member_access_in_projection_translated(async));
+
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#17246")]
-        public override Task Collection_LastOrDefault_member_access_in_projection_translated(bool async)
+        public override async Task Collection_LastOrDefault_member_access_in_projection_translated(bool async)
         {
-            return base.Collection_LastOrDefault_member_access_in_projection_translated(async);
+            // Contains over subquery. Issue #17246.
+            await AssertTranslationFailed(() => base.Collection_LastOrDefault_member_access_in_projection_translated(async));
+
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#16146")]
-        public override Task Sum_over_explicit_cast_over_column(bool async)
+        public override async Task Sum_over_explicit_cast_over_column(bool async)
         {
-            return base.Sum_over_explicit_cast_over_column(async);
+            // Aggregate selecting non-mapped type. Issue #20677.
+            await Assert.ThrowsAsync<KeyNotFoundException>(async () => await base.Sum_over_explicit_cast_over_column(async));
+
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#17246 (Contains over subquery is not supported)")]
-        public override Task Contains_over_scalar_with_null_should_rewrite_to_identity_equality_subquery(bool async)
+        public override async Task Contains_over_scalar_with_null_should_rewrite_to_identity_equality_subquery(bool async)
         {
-            return base.Contains_over_scalar_with_null_should_rewrite_to_identity_equality_subquery(async);
+            // Contains over subquery. Issue #17246.
+            await AssertTranslationFailed(
+                () => base.Contains_over_scalar_with_null_should_rewrite_to_identity_equality_subquery(async));
+
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#17246 (Contains over subquery is not supported)")]
-        public override Task Contains_over_nullable_scalar_with_null_in_subquery_translated_correctly(bool async)
+        public override async Task Contains_over_nullable_scalar_with_null_in_subquery_translated_correctly(bool async)
         {
-            return base.Contains_over_nullable_scalar_with_null_in_subquery_translated_correctly(async);
+            // Contains over subquery. Issue #17246.
+            await AssertTranslationFailed(
+                () => base.Contains_over_nullable_scalar_with_null_in_subquery_translated_correctly(async));
+
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#17246 (Contains over subquery is not supported)")]
-        public override Task Contains_over_non_nullable_scalar_with_null_in_subquery_simplifies_to_false(bool async)
+        public override async Task Contains_over_non_nullable_scalar_with_null_in_subquery_simplifies_to_false(bool async)
         {
-            return base.Contains_over_non_nullable_scalar_with_null_in_subquery_simplifies_to_false(async);
+            // Contains over subquery. Issue #17246.
+            await AssertTranslationFailed(
+                () => base.Contains_over_non_nullable_scalar_with_null_in_subquery_simplifies_to_false(async));
+
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#17246 (Contains over subquery is not supported)")]
-        public override Task Contains_over_entityType_with_null_should_rewrite_to_identity_equality_subquery(bool async)
+        public override async Task Contains_over_entityType_with_null_should_rewrite_to_identity_equality_subquery(bool async)
         {
-            return base.Contains_over_entityType_with_null_should_rewrite_to_identity_equality_subquery(async);
+            // Contains over subquery. Issue #17246.
+            await AssertTranslationFailed(
+                () => base.Contains_over_entityType_with_null_should_rewrite_to_identity_equality_subquery(async));
+
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#17246 (Contains over subquery is not supported)")]
-        public override Task Contains_over_entityType_with_null_should_rewrite_to_identity_equality_subquery_complex(bool async)
+        public override async Task Contains_over_entityType_with_null_should_rewrite_to_identity_equality_subquery_complex(bool async)
         {
-            return base.Contains_over_entityType_with_null_should_rewrite_to_identity_equality_subquery_complex(async);
+            // Contains over subquery. Issue #17246.
+            await AssertTranslationFailed(
+                () => base.Contains_over_entityType_with_null_should_rewrite_to_identity_equality_subquery_complex(async));
+
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#17246 (Contains over subquery is not supported)")]
-        public override Task Contains_over_entityType_with_null_should_rewrite_to_identity_equality_subquery_negated(bool async)
+        public override async Task Contains_over_entityType_with_null_should_rewrite_to_identity_equality_subquery_negated(bool async)
         {
-            return base.Contains_over_entityType_with_null_should_rewrite_to_identity_equality_subquery_negated(async);
+            // Contains over subquery. Issue #17246.
+            await AssertTranslationFailed(
+                () => base.Contains_over_entityType_with_null_should_rewrite_to_identity_equality_subquery_negated(async));
+
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#17246 (Contains over subquery is not supported)")]
-        public override Task Contains_over_entityType_should_materialize_when_composite(bool async)
+        public override async Task Contains_over_entityType_should_materialize_when_composite(bool async)
         {
-            return base.Contains_over_entityType_should_materialize_when_composite(async);
+            // Contains over subquery. Issue #17246.
+            await AssertTranslationFailed(() => base.Contains_over_entityType_should_materialize_when_composite(async));
+
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#17246 (Contains over subquery is not supported)")]
-        public override Task Contains_over_entityType_should_materialize_when_composite2(bool async)
+        public override async Task Contains_over_entityType_should_materialize_when_composite2(bool async)
         {
-            return base.Contains_over_entityType_should_materialize_when_composite2(async);
+            // Contains over subquery. Issue #17246.
+            await AssertTranslationFailed(() => base.Contains_over_entityType_should_materialize_when_composite2(async));
+
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#17246 (DefaultIfEmpty is not translated)")]
-        public override Task Average_after_default_if_empty_does_not_throw(bool isAsync)
+        public override async Task Average_after_default_if_empty_does_not_throw(bool async)
         {
-            return base.Average_after_default_if_empty_does_not_throw(isAsync);
+            // Contains over subquery. Issue #17246.
+            await AssertTranslationFailed(() => base.Average_after_default_if_empty_does_not_throw(async));
+
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#17246 (DefaultIfEmpty is not translated)")]
-        public override Task Max_after_default_if_empty_does_not_throw(bool isAsync)
+        public override async Task Max_after_default_if_empty_does_not_throw(bool async)
         {
-            return base.Max_after_default_if_empty_does_not_throw(isAsync);
+            // Contains over subquery. Issue #17246.
+            await AssertTranslationFailed(() => base.Max_after_default_if_empty_does_not_throw(async));
+
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#17246 (DefaultIfEmpty is not translated)")]
-        public override Task Min_after_default_if_empty_does_not_throw(bool isAsync)
+        public override async Task Min_after_default_if_empty_does_not_throw(bool async)
         {
-            return base.Min_after_default_if_empty_does_not_throw(isAsync);
+            // Contains over subquery. Issue #17246.
+            await AssertTranslationFailed(() => base.Min_after_default_if_empty_does_not_throw(async));
+
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#20677")]
-        public override Task Average_with_unmapped_property_access_throws_meaningful_exception(bool async)
+        public override async Task Average_with_unmapped_property_access_throws_meaningful_exception(bool async)
         {
-            return base.Average_with_unmapped_property_access_throws_meaningful_exception(async);
+            // Aggregate selecting non-mapped type. Issue #20677.
+            await Assert.ThrowsAsync<KeyNotFoundException>(
+                () => AssertAverage(
+                    async,
+                    ss => ss.Set<Order>(),
+                    selector: c => c.ShipVia));
+
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
-        public override Task Multiple_collection_navigation_with_FirstOrDefault_chained(bool async)
+        public override async Task Multiple_collection_navigation_with_FirstOrDefault_chained(bool async)
         {
-            return base.Multiple_collection_navigation_with_FirstOrDefault_chained(async);
+            // Contains over subquery. Issue #17246.
+            await AssertTranslationFailed(() => base.Multiple_collection_navigation_with_FirstOrDefault_chained(async));
+
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#20441")]
-        public override Task All_true(bool async)
+        public override async Task All_true(bool async)
         {
-            return base.All_true(async);
+            await base.All_true(async);
+
+            AssertSql();
         }
 
-        [ConditionalTheory(Skip = "Issue#20441")]
-        public override Task Not_Any_false(bool async)
+        public override async Task Not_Any_false(bool async)
         {
-            return base.Not_Any_false(async);
+            await base.Not_Any_false(async);
+
+            AssertSql();
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.InMemory.FunctionalTests/Query/NorthwindAggregateOperatorsQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/NorthwindAggregateOperatorsQueryInMemoryTest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 using Xunit.Abstractions;
@@ -55,24 +54,18 @@ namespace Microsoft.EntityFrameworkCore.Query
                     () => context.Customers.Select(c => c.Orders.Where(o => o.OrderID == -1).Min(o => o.OrderID)).ToList()).Message);
         }
 
-        public override async Task Average_on_nav_subquery_in_projection(bool isAsync)
+        public override async Task Average_on_nav_subquery_in_projection(bool async)
         {
             Assert.Equal(
                 "Sequence contains no elements",
                 (await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => base.Average_on_nav_subquery_in_projection(isAsync))).Message);
+                    () => base.Average_on_nav_subquery_in_projection(async))).Message);
         }
 
         public override Task Collection_Last_member_access_in_projection_translated(bool async)
         {
             return Assert.ThrowsAsync<InvalidOperationException>(
                 () => base.Collection_Last_member_access_in_projection_translated(async));
-        }
-
-        [ConditionalFact(Skip = "Issue#20023")]
-        public override void Contains_over_keyless_entity_throws()
-        {
-            base.Contains_over_keyless_entity_throws();
         }
     }
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindAggregateOperatorsQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindAggregateOperatorsQueryRelationalTestBase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
@@ -34,9 +35,12 @@ namespace Microsoft.EntityFrameworkCore.Query
                     () => base.LastOrDefault_when_no_order_by(async))).Message);
         }
 
-        public override Task Contains_with_local_tuple_array_closure(bool async)
+        public override void Contains_over_keyless_entity_throws()
         {
-            return AssertTranslationFailed(() => base.Contains_with_local_tuple_array_closure(async));
+            Assert.Equal(
+                CoreStrings.EntityEqualityOnKeylessEntityNotSupported("==", nameof(CustomerQuery)),
+                (Assert.Throws<InvalidOperationException>(
+                    () => base.Contains_over_keyless_entity_throws())).Message);
         }
 
         protected virtual bool CanExecuteQueryString

--- a/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
@@ -167,7 +167,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 selector: p => p.UnitPrice ?? 0);
         }
 
-        [ConditionalTheory(Skip = "Issue #15937")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Sum_over_subquery_is_client_eval(bool async)
         {
@@ -177,7 +177,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 selector: c => c.Orders.Sum(o => o.OrderID));
         }
 
-        [ConditionalTheory(Skip = "Issue #15937")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Sum_over_nested_subquery_is_client_eval(bool async)
         {
@@ -187,7 +187,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 selector: c => c.Orders.Sum(o => 5 + o.OrderDetails.Sum(od => od.ProductID)));
         }
 
-        [ConditionalTheory(Skip = "Issue #15937")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Sum_over_min_subquery_is_client_eval(bool async)
         {
@@ -289,7 +289,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 asserter: (e, a) => Assert.InRange(e - a, -0.1m, 0.1m));
         }
 
-        [ConditionalTheory(Skip = "Issue #15937")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Average_over_subquery_is_client_eval(bool async)
         {
@@ -299,7 +299,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 selector: c => c.Orders.Sum(o => o.OrderID));
         }
 
-        [ConditionalTheory(Skip = "Issue #15937")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Average_over_nested_subquery_is_client_eval(bool async)
         {
@@ -309,7 +309,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 selector: c => (decimal)c.Orders.Average(o => 5 + o.OrderDetails.Average(od => od.ProductID)));
         }
 
-        [ConditionalTheory(Skip = "Issue #15937")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Average_over_max_subquery_is_client_eval(bool async)
         {
@@ -476,7 +476,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 selector: p => p.UnitPrice ?? 0);
         }
 
-        [ConditionalTheory(Skip = "Issue #15937")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Min_over_subquery_is_client_eval(bool async)
         {
@@ -486,7 +486,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 selector: c => c.Orders.Sum(o => o.OrderID));
         }
 
-        [ConditionalTheory(Skip = "Issue #15937")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Min_over_nested_subquery_is_client_eval(bool async)
         {
@@ -496,7 +496,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 selector: c => c.Orders.Min(o => 5 + o.OrderDetails.Min(od => od.ProductID)));
         }
 
-        [ConditionalTheory(Skip = "Issue #15937")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Min_over_max_subquery_is_client_eval(bool async)
         {
@@ -535,7 +535,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 selector: p => p.UnitPrice ?? 0);
         }
 
-        [ConditionalTheory(Skip = "Issue #15937")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Max_over_subquery_is_client_eval(bool async)
         {
@@ -545,7 +545,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 selector: c => c.Orders.Sum(o => o.OrderID));
         }
 
-        [ConditionalTheory(Skip = "Issue #15937")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Max_over_nested_subquery_is_client_eval(bool async)
         {
@@ -555,7 +555,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 selector: c => c.Orders.Max(o => 5 + o.OrderDetails.Max(od => od.ProductID)));
         }
 
-        [ConditionalTheory(Skip = "Issue #15937")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Max_over_sum_subquery_is_client_eval(bool async)
         {
@@ -1349,21 +1349,17 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 1);
         }
 
-        [ConditionalTheory(Skip = "Issue #15937")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Contains_with_local_anonymous_type_array_closure(bool async)
         {
             var ids = new[] { new { Id1 = 1, Id2 = 2 }, new { Id1 = 10248, Id2 = 11 } };
 
-            return AssertTranslationFailed(
-                () => AssertQuery(
-                    async,
-                    ss => ss.Set<OrderDetail>().Where(o => ids.Contains(new { Id1 = o.OrderID, Id2 = o.ProductID })),
-                    entryCount: 1));
+            return AssertQuery(
+                async,
+                ss => ss.Set<OrderDetail>().Where(o => ids.Contains(new { Id1 = o.OrderID, Id2 = o.ProductID })),
+                entryCount: 1);
         }
-
-        //protected string RemoveNewLines(string message)
-        //    => message.Replace("\n", "").Replace("\r", "");
 
         [ConditionalFact]
         public virtual void OfType_Select()
@@ -1543,7 +1539,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         private static readonly IEnumerable<string> _customers = new[] { "ALFKI", "WRONG" };
 
-        [ConditionalTheory(Skip = "Issue#18658")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Array_cast_to_IEnumerable_Contains_with_constant(bool async)
         {
@@ -1557,7 +1553,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual void Contains_over_keyless_entity_throws()
         {
             using var context = CreateContext();
-            Assert.Throws<InvalidOperationException>(() => context.CustomerQueries.Contains(new CustomerQuery()));
+            var customerQuery = context.CustomerQueries.First();
+
+            Assert.True(context.CustomerQueries.Contains(customerQuery));
         }
 
         [ConditionalTheory]
@@ -1932,77 +1930,77 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual Task Sum_over_empty_returns_zero(bool isAsync)
+        public virtual Task Sum_over_empty_returns_zero(bool async)
         {
             return AssertSum(
-                isAsync,
+                async,
                 ss => ss.Set<Order>().Where(o => o.OrderID == 42),
                 o => o.OrderID);
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual Task Average_over_default_returns_default(bool isAsync)
+        public virtual Task Average_over_default_returns_default(bool async)
         {
             return AssertAverage(
-                isAsync,
+                async,
                 ss => ss.Set<Order>().Where(o => o.OrderID == 10248),
                 o => o.OrderID - 10248);
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual Task Max_over_default_returns_default(bool isAsync)
+        public virtual Task Max_over_default_returns_default(bool async)
         {
             return AssertMax(
-                isAsync,
+                async,
                 ss => ss.Set<Order>().Where(o => o.OrderID == 10248),
                 o => o.OrderID - 10248);
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual Task Min_over_default_returns_default(bool isAsync)
+        public virtual Task Min_over_default_returns_default(bool async)
         {
             return AssertMin(
-                isAsync,
+                async,
                 ss => ss.Set<Order>().Where(o => o.OrderID == 10248),
                 o => o.OrderID - 10248);
         }
 
-        [ConditionalTheory(Skip = "Issue#20637")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual Task Average_after_default_if_empty_does_not_throw(bool isAsync)
+        public virtual Task Average_after_default_if_empty_does_not_throw(bool async)
         {
             return AssertAverage(
-                isAsync,
+                async,
                 ss => ss.Set<Order>().Where(o => o.OrderID == 10243).Select(o => o.OrderID).DefaultIfEmpty());
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual Task Max_after_default_if_empty_does_not_throw(bool isAsync)
+        public virtual Task Max_after_default_if_empty_does_not_throw(bool async)
         {
             return AssertMax(
-                isAsync,
+                async,
                 ss => ss.Set<Order>().Where(o => o.OrderID == 10243).Select(o => o.OrderID).DefaultIfEmpty());
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual Task Min_after_default_if_empty_does_not_throw(bool isAsync)
+        public virtual Task Min_after_default_if_empty_does_not_throw(bool async)
         {
             return AssertMin(
-                isAsync,
+                async,
                 ss => ss.Set<Order>().Where(o => o.OrderID == 10243).Select(o => o.OrderID).DefaultIfEmpty());
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual Task Average_on_nav_subquery_in_projection(bool isAsync)
+        public virtual Task Average_on_nav_subquery_in_projection(bool async)
         {
             return AssertQuery(
-                isAsync,
+                async,
                 ss => ss.Set<Customer>()
                     .OrderBy(c => c.CustomerID)
                     .Select(c => new { Ave = (double?)c.Orders.Average(o => o.OrderID) }),
@@ -2030,10 +2028,10 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual Task Count_after_client_projection(bool isAsync)
+        public virtual Task Count_after_client_projection(bool async)
         {
             return AssertCount(
-                isAsync,
+                async,
                 ss => ss.Set<Order>()
                     .Select(o => new
                     {

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqliteTest.cs
@@ -22,17 +22,59 @@ namespace Microsoft.EntityFrameworkCore.Query
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
-        public override Task Sum_with_division_on_decimal(bool async)
-            => Assert.ThrowsAsync<NotSupportedException>(() => base.Sum_with_division_on_decimal(async));
+        public override async Task Sum_with_division_on_decimal(bool async)
+        {
+            Assert.Equal(
+                SqliteStrings.AggregateOperationNotSupported("Sum", "decimal"),
+                (await Assert.ThrowsAsync<NotSupportedException>(
+                    async () => await base.Sum_with_division_on_decimal(async)))
+                .Message);
+        }
 
-        public override Task Sum_with_division_on_decimal_no_significant_digits(bool async)
-            => Assert.ThrowsAsync<NotSupportedException>(() => base.Sum_with_division_on_decimal_no_significant_digits(async));
+        public override async Task Sum_with_division_on_decimal_no_significant_digits(bool async)
+        {
+            Assert.Equal(
+                SqliteStrings.AggregateOperationNotSupported("Sum", "decimal"),
+                (await Assert.ThrowsAsync<NotSupportedException>(
+                    async () => await base.Sum_with_division_on_decimal_no_significant_digits(async)))
+                .Message);
+        }
 
-        public override Task Average_with_division_on_decimal(bool async)
-            => Assert.ThrowsAsync<NotSupportedException>(() => base.Average_with_division_on_decimal(async));
+        public override async Task Average_with_division_on_decimal(bool async)
+        {
+            Assert.Equal(
+                SqliteStrings.AggregateOperationNotSupported("Average", "decimal"),
+                (await Assert.ThrowsAsync<NotSupportedException>(
+                    async () => await base.Average_with_division_on_decimal(async)))
+                .Message);
+        }
 
-        public override Task Average_with_division_on_decimal_no_significant_digits(bool async)
-            => Assert.ThrowsAsync<NotSupportedException>(() => base.Average_with_division_on_decimal_no_significant_digits(async));
+        public override async Task Average_with_division_on_decimal_no_significant_digits(bool async)
+        {
+            Assert.Equal(
+                SqliteStrings.AggregateOperationNotSupported("Average", "decimal"),
+                (await Assert.ThrowsAsync<NotSupportedException>(
+                    async () => await base.Average_with_division_on_decimal_no_significant_digits(async)))
+                .Message);
+        }
+
+        public override async Task Average_over_max_subquery_is_client_eval(bool async)
+        {
+            Assert.Equal(
+                SqliteStrings.AggregateOperationNotSupported("Average", "decimal"),
+                (await Assert.ThrowsAsync<NotSupportedException>(
+                    async () => await base.Average_over_max_subquery_is_client_eval(async)))
+                .Message);
+        }
+
+        public override async Task Average_over_nested_subquery_is_client_eval(bool async)
+        {
+            Assert.Equal(
+                SqliteStrings.AggregateOperationNotSupported("Average", "decimal"),
+                (await Assert.ThrowsAsync<NotSupportedException>(
+                    async () => await base.Average_over_nested_subquery_is_client_eval(async)))
+                .Message);
+        }
 
         public override async Task Multiple_collection_navigation_with_FirstOrDefault_chained(bool async)
         {
@@ -40,6 +82,17 @@ namespace Microsoft.EntityFrameworkCore.Query
                 SqliteStrings.ApplyNotSupported,
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => base.Multiple_collection_navigation_with_FirstOrDefault_chained(async))).Message);
+        }
+
+        public override async Task Contains_with_local_anonymous_type_array_closure(bool async)
+        {
+            // Aggregates. Issue #15937.
+            await AssertTranslationFailed(() => base.Contains_with_local_anonymous_type_array_closure(async));
+        }
+
+        public override async Task Contains_with_local_tuple_array_closure(bool async)
+        {
+            await AssertTranslationFailed(() => base.Contains_with_local_tuple_array_closure(async));
         }
     }
 }


### PR DESCRIPTION
Part of #26088 and #17235

Ideas for better catching behavior changes in the product code. Specifically:
- Detect when a negative case stops failing
- Detect when a negative case starts failing in a different way

Fundamental approach: don't skip tests.

In NorthwindAggregateOperatorsQueryTests, we had:
- Negative cases that were no longer failing
- Negative cases that were skipped for all providers, but worked on some. For example:
  - Failed on relational, but passed on in-memory
  - Failed on relational, but passed on Cosmos
  - Failed on SQL Server, but passed on SQLite
- Negative cases that failed in different ways on different providers

Specifics:
- If a test throws, catch the exception
  - Where feasible, also validate the exception message or error number
- Always call base where possible, rather than repeating the query in an overriden test
- Add a standard comment where we have a bug or enhancement tracking the issue. For example:
  - `// Contains over subquery. Issue #17246.`
- Always have an `AssertSql` call in Cosmos and SQL Server tests
  - Where we expect a provider-specific class to verify SQL, then add a test that checks all test methods are overriden.
