### PR TITLE
[SMALL] Fix to #26357 - [Q] SqlNullabilityProcessor.VisitSqlFunction, Nullability of SUM function

### DIFF
--- a/src/EFCore.Relational/Query/SqlNullabilityProcessor.cs
+++ b/src/EFCore.Relational/Query/SqlNullabilityProcessor.cs
@@ -1058,13 +1058,18 @@ namespace Microsoft.EntityFrameworkCore.Query
                 arguments[i] = Visit(sqlFunctionExpression.Arguments[i], out _);
             }
 
-            return sqlFunctionExpression.IsBuiltIn
-                && string.Equals(sqlFunctionExpression.Name, "SUM", StringComparison.OrdinalIgnoreCase)
-                    ? _sqlExpressionFactory.Coalesce(
-                        sqlFunctionExpression.Update(instance, arguments),
-                        _sqlExpressionFactory.Constant(0, sqlFunctionExpression.TypeMapping),
-                        sqlFunctionExpression.TypeMapping)
-                    : sqlFunctionExpression.Update(instance, arguments);
+            if (sqlFunctionExpression.IsBuiltIn
+                && string.Equals(sqlFunctionExpression.Name, "SUM", StringComparison.OrdinalIgnoreCase))
+            {
+                nullable = false;
+
+                return _sqlExpressionFactory.Coalesce(
+                    sqlFunctionExpression.Update(instance, arguments),
+                    _sqlExpressionFactory.Constant(0, sqlFunctionExpression.TypeMapping),
+                    sqlFunctionExpression.TypeMapping);
+            }
+
+            return sqlFunctionExpression.Update(instance, arguments);
         }
 
         /// <summary>

--- a/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
@@ -1854,6 +1854,15 @@ namespace Microsoft.EntityFrameworkCore.Query
                         : x.NullableBoolC != x.NullableBoolA)));
         }
 
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Sum_function_is_always_considered_non_nullable(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<NullSemanticsEntity1>().GroupBy(e => e.NullableIntA).Select(g => new { g.Key, Sum = g.Sum(x => x.IntA) != g.Key }));
+        }
+
         private string NormalizeDelimitersInRawString(string sql)
             => Fixture.TestStore.NormalizeDelimitersInRawString(sql);
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -2102,7 +2102,7 @@ END");
         SELECT 1
         FROM [Orders] AS [o]
         GROUP BY [o].[CustomerID]
-        HAVING NOT (COALESCE(SUM([o].[OrderID]), 0) >= 0)) THEN CAST(1 AS bit)
+        HAVING COALESCE(SUM([o].[OrderID]), 0) < 0) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END");
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -2263,6 +2263,19 @@ WHERE CASE
 END = CAST(1 AS bit)");
         }
 
+        public override async Task Sum_function_is_always_considered_non_nullable(bool async)
+        {
+            await base.Sum_function_is_always_considered_non_nullable(async);
+
+            AssertSql(
+                @"SELECT [e].[NullableIntA] AS [Key], CASE
+    WHEN (COALESCE(SUM([e].[IntA]), 0) <> [e].[NullableIntA]) OR [e].[NullableIntA] IS NULL THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END AS [Sum]
+FROM [Entities1] AS [e]
+GROUP BY [e].[NullableIntA]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Small optimization, Nullability processor was already doing the right thing during expand null semantics step (since it was evaluating nullability of the COALESCE(sum, 0) which is never null), but now we are bit more efficient. We mark the SUM function as non nullable earlier so we never need to compute its nullability during the later step.

Fixes #26357