### PR TITLE
Fix to #26344 - SqlNullabilityProcessor and COALESCE with more than two arguments

### DIFF
--- a/src/EFCore.Relational/Query/ISqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/ISqlExpressionFactory.cs
@@ -238,12 +238,12 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         // Other
         /// <summary>
-        ///     Creates a <see cref="SqlBinaryExpression" /> which represents a bitwise OR operation.
+        ///     Creates a <see cref="SqlFunctionExpression" /> which represents a COALESCE operation.
         /// </summary>
         /// <param name="left">The left operand.</param>
         /// <param name="right">The right operand.</param>
         /// <param name="typeMapping">A type mapping to be assigned to the created expression.</param>
-        /// <returns>An expression representing a SQL bitwise OR operation.</returns>
+        /// <returns>An expression representing a SQL COALESCE operation.</returns>
         SqlFunctionExpression Coalesce(
             SqlExpression left,
             SqlExpression right,

--- a/src/EFCore.Relational/Query/SqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/SqlExpressionFactory.cs
@@ -447,7 +447,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 "COALESCE",
                 typeMappedArguments,
                 nullable: true,
-                // COALESCE is handled separately since it's only nullable if *both* arguments are null
+                // COALESCE is handled separately since it's only nullable if *all* arguments are null
                 argumentsPropagateNullability: new[] { false, false },
                 resultType,
                 inferredTypeMapping);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -5151,11 +5151,11 @@ FROM [Gears] AS [g]");
             await base.Select_subquery_int_with_outside_cast_and_coalesce(async);
 
             AssertSql(
-                @"SELECT COALESCE(COALESCE((
+                @"SELECT COALESCE((
     SELECT TOP(1) [w].[Id]
     FROM [Weapons] AS [w]
     WHERE [g].[FullName] = [w].[OwnerFullName]
-    ORDER BY [w].[Id]), 0), 42)
+    ORDER BY [w].[Id]), 0, 42)
 FROM [Gears] AS [g]");
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -5641,14 +5641,14 @@ ORDER BY [a].[Id], [a0].[Id], [t].[Id]");
                     @"SELECT [a].[Id], [a].[ActivityTypeId], [a].[DateTime], [a].[Points], (
     SELECT TOP(1) [c].[Id]
     FROM [CompetitionSeasons] AS [c]
-    WHERE ([c].[StartDate] <= [a].[DateTime]) AND ([a].[DateTime] < [c].[EndDate])) AS [CompetitionSeasonId], COALESCE([a].[Points], COALESCE((
+    WHERE ([c].[StartDate] <= [a].[DateTime]) AND ([a].[DateTime] < [c].[EndDate])) AS [CompetitionSeasonId], COALESCE([a].[Points], (
     SELECT TOP(1) [a1].[Points]
     FROM [ActivityTypePoints12456] AS [a1]
     INNER JOIN [CompetitionSeasons] AS [c0] ON [a1].[CompetitionSeasonId] = [c0].[Id]
     WHERE ([a0].[Id] = [a1].[ActivityTypeId]) AND ([c0].[Id] = (
         SELECT TOP(1) [c1].[Id]
         FROM [CompetitionSeasons] AS [c1]
-        WHERE ([c1].[StartDate] <= [a].[DateTime]) AND ([a].[DateTime] < [c1].[EndDate])))), 0)) AS [Points]
+        WHERE ([c1].[StartDate] <= [a].[DateTime]) AND ([a].[DateTime] < [c1].[EndDate])))), 0) AS [Points]
 FROM [Activities] AS [a]
 INNER JOIN [ActivityType12456] AS [a0] ON [a].[ActivityTypeId] = [a0].[Id]");
             }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
@@ -6093,11 +6093,11 @@ FROM [Gears] AS [g]");
             await base.Select_subquery_int_with_outside_cast_and_coalesce(async);
 
             AssertSql(
-                @"SELECT COALESCE(COALESCE((
+                @"SELECT COALESCE((
     SELECT TOP(1) [w].[Id]
     FROM [Weapons] AS [w]
     WHERE [g].[FullName] = [w].[OwnerFullName]
-    ORDER BY [w].[Id]), 0), 42)
+    ORDER BY [w].[Id]), 0, 42)
 FROM [Gears] AS [g]");
         }
 


### PR DESCRIPTION
Nested coalesce ops are converted to coalesce with multiple arguments. Fixing null semantics logic that only assumed coalesce function would have two arguments

Fixes #26344