### PR TITLE
Fix to #26397 - Query/Test: convert the "no_data" tests in NorthwindAggregateOperatorsQueryTestBase to use AssertQuery

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
@@ -40,14 +40,10 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = 10248))");
         }
 
-        public override void Contains_over_keyless_entity_throws()
+        public override async Task Contains_over_keyless_entity_throws(bool async)
         {
             // Aggregates. Issue #16146.
-            AssertTranslationFailed(() =>
-            {
-                base.Contains_over_keyless_entity_throws();
-                return Task.CompletedTask;
-            });
+            await AssertTranslationFailed(() => base.Contains_over_keyless_entity_throws(async));
 
             AssertSql(
                 @"SELECT c
@@ -266,14 +262,10 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")
 OFFSET 0 LIMIT 2");
         }
 
-        public override void Select_All()
+        public override async Task Select_All(bool async)
         {
             // Contains over subquery. Issue #17246.
-            AssertTranslationFailed(() =>
-            {
-                base.Select_All();
-                return Task.CompletedTask;
-            });
+            await AssertTranslationFailed(() => base.Select_All(async));
 
             AssertSql();
         }
@@ -417,9 +409,9 @@ WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""ProductID""] = 1))");
             AssertSql();
         }
 
-        public override void Average_no_data()
+        public override async Task Average_no_data(bool async)
         {
-            base.Average_no_data();
+            await base.Average_no_data(async);
 
             AssertSql(
                 @"SELECT AVG(c[""OrderID""]) AS c
@@ -427,9 +419,9 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = -1))");
         }
 
-        public override void Average_no_data_nullable()
+        public override async Task Average_no_data_nullable(bool async)
         {
-            base.Average_no_data_nullable();
+            await base.Average_no_data_nullable(async);
 
             AssertSql(
                 @"SELECT AVG(c[""SupplierID""]) AS c
@@ -437,9 +429,9 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Product"") AND (c[""SupplierID""] = -1))");
         }
 
-        public override void Average_no_data_cast_to_nullable()
+        public override async Task Average_no_data_cast_to_nullable(bool async)
         {
-            base.Average_no_data_cast_to_nullable();
+            await base.Average_no_data_cast_to_nullable(async);
 
             AssertSql(
                 @"SELECT AVG(c[""OrderID""]) AS c
@@ -447,9 +439,9 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = -1))");
         }
 
-        public override void Min_no_data()
+        public override async Task Min_no_data(bool async)
         {
-            base.Min_no_data();
+            await base.Min_no_data(async);
 
             AssertSql(
                 @"SELECT MIN(c[""OrderID""]) AS c
@@ -457,9 +449,9 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = -1))");
         }
 
-        public override void Max_no_data()
+        public override async Task Max_no_data(bool async)
         {
-            base.Max_no_data();
+            await base.Max_no_data(async);
 
             AssertSql(
                 @"SELECT MAX(c[""OrderID""]) AS c
@@ -467,33 +459,25 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = -1))");
         }
 
-        public override void Average_no_data_subquery()
+        public override async Task Average_no_data_subquery(bool async)
         {
             // Aggregates. Issue #16146.
-            AssertTranslationFailed(() =>
-            {
-                base.Average_no_data_subquery();
-                return Task.CompletedTask;
-            });
+            await AssertTranslationFailed(() => base.Average_no_data_subquery(async));
 
             AssertSql();
         }
 
-        public override void Max_no_data_subquery()
+        public override async Task Max_no_data_subquery(bool async)
         {
             // Aggregates. Issue #16146.
-            AssertTranslationFailed(() =>
-            {
-                base.Max_no_data_subquery();
-                return Task.CompletedTask;
-            });
+            await AssertTranslationFailed(() => base.Max_no_data_subquery(async));
 
             AssertSql();
         }
 
-        public override void Max_no_data_nullable()
+        public override async Task Max_no_data_nullable(bool async)
         {
-            base.Max_no_data_nullable();
+            await base.Max_no_data_nullable(async);
 
             AssertSql(
                 @"SELECT MAX(c[""SupplierID""]) AS c
@@ -501,9 +485,9 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Product"") AND (c[""SupplierID""] = -1))");
         }
 
-        public override void Max_no_data_cast_to_nullable()
+        public override async Task Max_no_data_cast_to_nullable(bool async)
         {
-            base.Max_no_data_cast_to_nullable();
+            await base.Max_no_data_cast_to_nullable(async);
 
             AssertSql(
                 @"SELECT MAX(c[""OrderID""]) AS c
@@ -511,14 +495,10 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = -1))");
         }
 
-        public override void Min_no_data_subquery()
+        public override async Task Min_no_data_subquery(bool async)
         {
             // Aggregates. Issue #16146.
-            AssertTranslationFailed(() =>
-            {
-                base.Min_no_data_subquery();
-                return Task.CompletedTask;
-            });
+            await AssertTranslationFailed(() => base.Min_no_data_subquery(async));
 
             AssertSql();
         }
@@ -662,9 +642,9 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Order"")");
         }
 
-        public override void Min_no_data_nullable()
+        public override async Task Min_no_data_nullable(bool async)
         {
-            base.Min_no_data_nullable();
+            await base.Min_no_data_nullable(async);
 
             AssertSql(
                 @"SELECT MIN(c[""SupplierID""]) AS c
@@ -672,9 +652,9 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Product"") AND (c[""SupplierID""] = -1))");
         }
 
-        public override void Min_no_data_cast_to_nullable()
+        public override async Task Min_no_data_cast_to_nullable(bool async)
         {
-            base.Min_no_data_cast_to_nullable();
+            await base.Min_no_data_cast_to_nullable(async);
 
             AssertSql(
                 @"SELECT MIN(c[""OrderID""]) AS c
@@ -1349,26 +1329,18 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND NOT((true = false)))");
             AssertSql();
         }
 
-        public override void OfType_Select()
+        public override async Task OfType_Select(bool async)
         {
             // Contains over subquery. Issue #15937.
-            AssertTranslationFailed(() =>
-            {
-                base.OfType_Select();
-                return Task.CompletedTask;
-            });
+            await AssertTranslationFailed(() => base.OfType_Select(async));
 
             AssertSql();
         }
 
-        public override void OfType_Select_OfType_Select()
+        public override async Task OfType_Select_OfType_Select(bool async)
         {
             // Contains over subquery. Issue #17246.
-            AssertTranslationFailed(() =>
-            {
-                base.OfType_Select_OfType_Select();
-                return Task.CompletedTask;
-            });
+            await AssertTranslationFailed(() => base.OfType_Select_OfType_Select(async));
 
             AssertSql();
         }
@@ -1420,14 +1392,10 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND NOT((true = false)))");
             AssertSql();
         }
 
-        public override void Contains_over_entityType_should_rewrite_to_identity_equality()
+        public override async Task Contains_over_entityType_should_rewrite_to_identity_equality(bool async)
         {
             // Contains over subquery. Issue #17246.
-            AssertTranslationFailed(() =>
-            {
-                base.Contains_over_entityType_should_rewrite_to_identity_equality();
-                return Task.CompletedTask;
-            });
+            await AssertTranslationFailed(() => base.Contains_over_entityType_should_rewrite_to_identity_equality(async));
 
             AssertSql(
                 @"SELECT c

--- a/test/EFCore.InMemory.FunctionalTests/Query/NorthwindAggregateOperatorsQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/NorthwindAggregateOperatorsQueryInMemoryTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 using Xunit.Abstractions;
@@ -24,34 +25,28 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         // InMemory can throw server side exception
-        public override void Average_no_data_subquery()
+        public override async Task Average_no_data_subquery(bool async)
         {
-            using var context = CreateContext();
-
             Assert.Equal(
                 "Sequence contains no elements",
-                Assert.Throws<InvalidOperationException>(
-                    () => context.Customers.Select(c => c.Orders.Where(o => o.OrderID == -1).Average(o => o.OrderID)).ToList()).Message);
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Average_no_data_subquery(async))).Message);
         }
 
-        public override void Max_no_data_subquery()
+        public override async Task Max_no_data_subquery(bool async)
         {
-            using var context = CreateContext();
-
             Assert.Equal(
                 "Sequence contains no elements",
-                Assert.Throws<InvalidOperationException>(
-                    () => context.Customers.Select(c => c.Orders.Where(o => o.OrderID == -1).Max(o => o.OrderID)).ToList()).Message);
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Max_no_data_subquery(async))).Message);
         }
 
-        public override void Min_no_data_subquery()
+        public override async Task Min_no_data_subquery(bool async)
         {
-            using var context = CreateContext();
-
             Assert.Equal(
                 "Sequence contains no elements",
-                Assert.Throws<InvalidOperationException>(
-                    () => context.Customers.Select(c => c.Orders.Where(o => o.OrderID == -1).Min(o => o.OrderID)).ToList()).Message);
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Min_no_data_subquery(async))).Message);
         }
 
         public override async Task Average_on_nav_subquery_in_projection(bool async)

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindAggregateOperatorsQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindAggregateOperatorsQueryRelationalTestBase.cs
@@ -35,12 +35,36 @@ namespace Microsoft.EntityFrameworkCore.Query
                     () => base.LastOrDefault_when_no_order_by(async))).Message);
         }
 
-        public override void Contains_over_keyless_entity_throws()
+        public override async Task Contains_over_keyless_entity_throws(bool async)
         {
             Assert.Equal(
                 CoreStrings.EntityEqualityOnKeylessEntityNotSupported("==", nameof(CustomerQuery)),
-                (Assert.Throws<InvalidOperationException>(
-                    () => base.Contains_over_keyless_entity_throws())).Message);
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Contains_over_keyless_entity_throws(async))).Message);
+        }
+
+        public override async Task Min_no_data_subquery(bool async)
+        {
+            Assert.Equal(
+                "Nullable object must have a value.",
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Min_no_data_subquery(async))).Message);
+        }
+
+        public override async Task Max_no_data_subquery(bool async)
+        {
+            Assert.Equal(
+                "Nullable object must have a value.",
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Max_no_data_subquery(async))).Message);
+        }
+
+        public override async Task Average_no_data_subquery(bool async)
+        {
+            Assert.Equal(
+                "Nullable object must have a value.",
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Average_no_data_subquery(async))).Message);
         }
 
         protected virtual bool CanExecuteQueryString

--- a/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
@@ -31,17 +31,15 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
         }
 
-        [ConditionalFact]
-        public virtual void Select_All()
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Select_All(bool async)
         {
-            using var context = CreateContext();
-            Assert.False(
-                context
-                    .Set<Order>()
-                    .Select(
-                        o => new ProjectedType { Order = o.OrderID, Customer = o.CustomerID })
-                    .All(p => p.Customer == "ALFKI")
-            );
+            return AssertAll(
+                async,
+                ss => ss.Set<Order>()
+                    .Select(o => new ProjectedType { Order = o.OrderID, Customer = o.CustomerID }),
+                predicate: p => p.Customer == "ALFKI");
         }
 
         private class ProjectedType
@@ -370,100 +368,124 @@ namespace Microsoft.EntityFrameworkCore.Query
                 selector: o => o.OrderID);
         }
 
-        [ConditionalFact]
-        public virtual void Min_no_data()
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Min_no_data(bool async)
         {
-            using var context = CreateContext();
-            Assert.Throws<InvalidOperationException>(() => context.Orders.Where(o => o.OrderID == -1).Min(o => o.OrderID));
+            return Assert.ThrowsAsync<InvalidOperationException>(
+                () => AssertMin(
+                async,
+                ss => ss.Set<Order>().Where(o => o.OrderID == -1),
+                selector: o => o.OrderID));
         }
 
-        [ConditionalFact]
-        public virtual void Min_no_data_nullable()
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Min_no_data_nullable(bool async)
         {
-            using var context = CreateContext();
-            Assert.Null(context.Products.Where(o => o.SupplierID == -1).Min(o => o.SupplierID));
+            return AssertMin(
+                async,
+                ss => ss.Set<Product>().Where(o => o.SupplierID == -1),
+                selector: o => o.SupplierID);
         }
 
-        [ConditionalFact]
-        public virtual void Min_no_data_cast_to_nullable()
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Min_no_data_cast_to_nullable(bool async)
         {
-            using var context = CreateContext();
-            Assert.Null(context.Orders.Where(o => o.OrderID == -1).Min(o => (int?)o.OrderID));
+            return AssertMin(
+                async,
+                ss => ss.Set<Order>().Where(o => o.OrderID == -1),
+                selector: o => (int?)o.OrderID);
         }
 
-        [ConditionalFact]
-        public virtual void Min_no_data_subquery()
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Min_no_data_subquery(bool async)
         {
-            using var context = CreateContext();
-
-            Assert.Equal(
-                "Nullable object must have a value.",
-                Assert.Throws<InvalidOperationException>(
-                    () => context.Customers.Select(c => c.Orders.Where(o => o.OrderID == -1).Min(o => o.OrderID)).ToList()).Message);
+            return AssertQueryScalar(
+                async,
+                ss => ss.Set<Customer>().Select(c => c.Orders.Where(o => o.OrderID == -1).Min(o => o.OrderID)));
         }
 
-        [ConditionalFact]
-        public virtual void Max_no_data()
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Max_no_data(bool async)
         {
-            using var context = CreateContext();
-            Assert.Throws<InvalidOperationException>(() => context.Orders.Where(o => o.OrderID == -1).Max(o => o.OrderID));
+            return Assert.ThrowsAsync<InvalidOperationException>(
+                () => AssertMax(
+                async,
+                ss => ss.Set<Order>().Where(o => o.OrderID == -1),
+                selector: o => o.OrderID));
         }
 
-        [ConditionalFact]
-        public virtual void Max_no_data_nullable()
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Max_no_data_nullable(bool async)
         {
-            using var context = CreateContext();
-            Assert.Null(context.Products.Where(o => o.SupplierID == -1).Max(o => o.SupplierID));
+            return AssertMax(
+                async,
+                ss => ss.Set<Product>().Where(o => o.SupplierID == -1),
+                selector: o => o.SupplierID);
         }
 
-        [ConditionalFact]
-        public virtual void Max_no_data_cast_to_nullable()
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Max_no_data_cast_to_nullable(bool async)
         {
-            using var context = CreateContext();
-            Assert.Null(context.Orders.Where(o => o.OrderID == -1).Max(o => (int?)o.OrderID));
+            return AssertMax(
+                async,
+                ss => ss.Set<Order>().Where(o => o.OrderID == -1),
+                selector: o => (int?)o.OrderID);
         }
 
-        [ConditionalFact]
-        public virtual void Max_no_data_subquery()
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Max_no_data_subquery(bool async)
         {
-            using var context = CreateContext();
-
-            Assert.Equal(
-                "Nullable object must have a value.",
-                Assert.Throws<InvalidOperationException>(
-                    () => context.Customers.Select(c => c.Orders.Where(o => o.OrderID == -1).Max(o => o.OrderID)).ToList()).Message);
+            return AssertQueryScalar(
+                async,
+                ss => ss.Set<Customer>().Select(c => c.Orders.Where(o => o.OrderID == -1).Max(o => o.OrderID)));
         }
 
-        [ConditionalFact]
-        public virtual void Average_no_data()
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Average_no_data(bool async)
         {
-            using var context = CreateContext();
-            Assert.Throws<InvalidOperationException>(() => context.Orders.Where(o => o.OrderID == -1).Average(o => o.OrderID));
+            return Assert.ThrowsAsync<InvalidOperationException>(
+                () => AssertAverage(
+                async,
+                ss => ss.Set<Order>().Where(o => o.OrderID == -1),
+                selector: o => o.OrderID));
         }
 
-        [ConditionalFact]
-        public virtual void Average_no_data_nullable()
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Average_no_data_nullable(bool async)
         {
-            using var context = CreateContext();
-            Assert.Null(context.Products.Where(o => o.SupplierID == -1).Average(o => o.SupplierID));
+            return AssertAverage(
+                async,
+                ss => ss.Set<Product>().Where(o => o.SupplierID == -1),
+                selector: o => o.SupplierID);
         }
 
-        [ConditionalFact]
-        public virtual void Average_no_data_cast_to_nullable()
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Average_no_data_cast_to_nullable(bool async)
         {
-            using var context = CreateContext();
-            Assert.Null(context.Orders.Where(o => o.OrderID == -1).Average(o => (int?)o.OrderID));
+            return AssertAverage(
+                async,
+                ss => ss.Set<Order>().Where(o => o.OrderID == -1),
+                selector: o => (int?)o.OrderID);
         }
 
-        [ConditionalFact]
-        public virtual void Average_no_data_subquery()
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Average_no_data_subquery(bool async)
         {
-            using var context = CreateContext();
-
-            Assert.Equal(
-                "Nullable object must have a value.",
-                Assert.Throws<InvalidOperationException>(
-                    () => context.Customers.Select(c => c.Orders.Where(o => o.OrderID == -1).Average(o => o.OrderID)).ToList()).Message);
+            return AssertQueryScalar(
+                async,
+                ss => ss.Set<Customer>().Select(c => c.Orders.Where(o => o.OrderID == -1).Average(o => o.OrderID)));
         }
 
         [ConditionalTheory]
@@ -1361,32 +1383,30 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 1);
         }
 
-        [ConditionalFact]
-        public virtual void OfType_Select()
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task OfType_Select(bool async)
         {
-            using var context = CreateContext();
-            Assert.Equal(
-                "Reims",
-                context.Set<Order>()
+            return AssertFirst(
+                async,
+                ss => ss.Set<Order>()
                     .OfType<Order>()
                     .OrderBy(o => o.OrderID)
-                    .Select(o => o.Customer.City)
-                    .First());
+                    .Select(o => o.Customer.City));
         }
 
-        [ConditionalFact]
-        public virtual void OfType_Select_OfType_Select()
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task OfType_Select_OfType_Select(bool async)
         {
-            using var context = CreateContext();
-            Assert.Equal(
-                "Reims",
-                context.Set<Order>()
+            return AssertFirst(
+                async,
+                ss => ss.Set<Order>()
                     .OfType<Order>()
                     .Select(o => o)
                     .OfType<Order>()
                     .OrderBy(o => o.OrderID)
-                    .Select(o => o.Customer.City)
-                    .First());
+                    .Select(o => o.Customer.City));
         }
 
         [ConditionalTheory]
@@ -1444,15 +1464,19 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 1);
         }
 
-        [ConditionalFact]
-        public virtual void Contains_over_entityType_should_rewrite_to_identity_equality()
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Contains_over_entityType_should_rewrite_to_identity_equality(bool async)
         {
-            using var context = CreateContext();
-            var query
-                = context.Orders.Where(o => o.CustomerID == "VINET")
-                    .Contains(context.Orders.Single(o => o.OrderID == 10248));
-
-            Assert.True(query);
+            return AssertSingleResult(
+                async,
+                ss => ss.Set<Order>()
+                    .Where(o => o.CustomerID == "VINET")
+                    .Contains(ss.Set<Order>().Single(o => o.OrderID == 10248)),
+                ss => ss.Set<Order>()
+                    .Where(o => o.CustomerID == "VINET")
+                    .ContainsAsync(ss.Set<Order>().Single(o => o.OrderID == 10248), default),
+                entryCount: 1);
         }
 
         [ConditionalTheory]
@@ -1549,13 +1573,14 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 1);
         }
 
-        [ConditionalFact]
-        public virtual void Contains_over_keyless_entity_throws()
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Contains_over_keyless_entity_throws(bool async)
         {
-            using var context = CreateContext();
-            var customerQuery = context.CustomerQueries.First();
-
-            Assert.True(context.CustomerQueries.Contains(customerQuery));
+            return AssertSingleResult(
+                async,
+                ss => ss.Set<CustomerQuery>().Contains(ss.Set<CustomerQuery>().First()),
+                ss => ss.Set<CustomerQuery>().ContainsAsync(ss.Set<CustomerQuery>().First(), default));
         }
 
         [ConditionalTheory]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
@@ -57,9 +57,9 @@ FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (N'ALFKI', N'WRONG')");
         }
 
-        public override void Contains_over_keyless_entity_throws()
+        public override async Task Contains_over_keyless_entity_throws(bool async)
         {
-            base.Contains_over_keyless_entity_throws();
+            await base.Contains_over_keyless_entity_throws(async);
 
             AssertSql(
                 @"SELECT TOP(1) [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle]
@@ -216,9 +216,9 @@ FROM [Orders] AS [o]
 WHERE [o].[OrderID] = 42");
         }
 
-        public override void Min_no_data()
+        public override async Task Min_no_data(bool async)
         {
-            base.Min_no_data();
+            await base.Min_no_data(async);
 
             AssertSql(
                 @"SELECT MIN([o].[OrderID])
@@ -226,9 +226,9 @@ FROM [Orders] AS [o]
 WHERE [o].[OrderID] = -1");
         }
 
-        public override void Min_no_data_nullable()
+        public override async Task Min_no_data_nullable(bool async)
         {
-            base.Min_no_data_nullable();
+            await base.Min_no_data_nullable(async);
 
             AssertSql(
                 @"SELECT MIN([p].[SupplierID])
@@ -236,9 +236,9 @@ FROM [Products] AS [p]
 WHERE [p].[SupplierID] = -1");
         }
 
-        public override void Min_no_data_cast_to_nullable()
+        public override async Task Min_no_data_cast_to_nullable(bool async)
         {
-            base.Min_no_data_cast_to_nullable();
+            await base.Min_no_data_cast_to_nullable(async);
 
             AssertSql(
                 @"SELECT MIN([o].[OrderID])
@@ -246,9 +246,9 @@ FROM [Orders] AS [o]
 WHERE [o].[OrderID] = -1");
         }
 
-        public override void Min_no_data_subquery()
+        public override async Task Min_no_data_subquery(bool async)
         {
-            base.Min_no_data_subquery();
+            await base.Min_no_data_subquery(async);
 
             AssertSql(
                 @"SELECT (
@@ -258,9 +258,9 @@ WHERE [o].[OrderID] = -1");
 FROM [Customers] AS [c]");
         }
 
-        public override void Max_no_data()
+        public override async Task Max_no_data(bool async)
         {
-            base.Max_no_data();
+            await base.Max_no_data(async);
 
             AssertSql(
                 @"SELECT MAX([o].[OrderID])
@@ -268,9 +268,9 @@ FROM [Orders] AS [o]
 WHERE [o].[OrderID] = -1");
         }
 
-        public override void Max_no_data_nullable()
+        public override async Task Max_no_data_nullable(bool async)
         {
-            base.Max_no_data_nullable();
+            await base.Max_no_data_nullable(async);
 
             AssertSql(
                 @"SELECT MAX([p].[SupplierID])
@@ -278,9 +278,9 @@ FROM [Products] AS [p]
 WHERE [p].[SupplierID] = -1");
         }
 
-        public override void Max_no_data_cast_to_nullable()
+        public override async Task Max_no_data_cast_to_nullable(bool async)
         {
-            base.Max_no_data_cast_to_nullable();
+            await base.Max_no_data_cast_to_nullable(async);
 
             AssertSql(
                 @"SELECT MAX([o].[OrderID])
@@ -288,9 +288,9 @@ FROM [Orders] AS [o]
 WHERE [o].[OrderID] = -1");
         }
 
-        public override void Max_no_data_subquery()
+        public override async Task Max_no_data_subquery(bool async)
         {
-            base.Max_no_data_subquery();
+            await base.Max_no_data_subquery(async);
 
             AssertSql(
                 @"SELECT (
@@ -300,9 +300,9 @@ WHERE [o].[OrderID] = -1");
 FROM [Customers] AS [c]");
         }
 
-        public override void Average_no_data()
+        public override async Task Average_no_data(bool async)
         {
-            base.Average_no_data();
+            await base.Average_no_data(async);
 
             AssertSql(
                 @"SELECT AVG(CAST([o].[OrderID] AS float))
@@ -310,9 +310,9 @@ FROM [Orders] AS [o]
 WHERE [o].[OrderID] = -1");
         }
 
-        public override void Average_no_data_nullable()
+        public override async Task Average_no_data_nullable(bool async)
         {
-            base.Average_no_data_nullable();
+            await base.Average_no_data_nullable(async);
 
             AssertSql(
                 @"SELECT AVG(CAST([p].[SupplierID] AS float))
@@ -320,9 +320,9 @@ FROM [Products] AS [p]
 WHERE [p].[SupplierID] = -1");
         }
 
-        public override void Average_no_data_cast_to_nullable()
+        public override async Task Average_no_data_cast_to_nullable(bool async)
         {
-            base.Average_no_data_cast_to_nullable();
+            await base.Average_no_data_cast_to_nullable(async);
 
             AssertSql(
                 @"SELECT AVG(CAST([o].[OrderID] AS float))
@@ -330,9 +330,9 @@ FROM [Orders] AS [o]
 WHERE [o].[OrderID] = -1");
         }
 
-        public override void Average_no_data_subquery()
+        public override async Task Average_no_data_subquery(bool async)
         {
-            base.Average_no_data_subquery();
+            await base.Average_no_data_subquery(async);
 
             AssertSql(
                 @"SELECT (
@@ -533,9 +533,9 @@ WHERE [c].[City] = N'London'
 ORDER BY [c].[ContactName]");
         }
 
-        public override void Select_All()
+        public override async Task Select_All(bool async)
         {
-            base.Select_All();
+            await base.Select_All(async);
 
             AssertSql(
                 @"SELECT CASE
@@ -1598,9 +1598,9 @@ END");
             AssertSql();
         }
 
-        public override void OfType_Select()
+        public override async Task OfType_Select(bool async)
         {
-            base.OfType_Select();
+            await base.OfType_Select(async);
 
             AssertSql(
                 @"SELECT TOP(1) [c].[City]
@@ -1609,9 +1609,9 @@ LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 ORDER BY [o].[OrderID]");
         }
 
-        public override void OfType_Select_OfType_Select()
+        public override async Task OfType_Select_OfType_Select(bool async)
         {
-            base.OfType_Select_OfType_Select();
+            await base.OfType_Select_OfType_Select(async);
 
             AssertSql(
                 @"SELECT TOP(1) [c].[City]
@@ -1683,9 +1683,9 @@ FROM (
 ORDER BY [t].[CustomerID] DESC");
         }
 
-        public override void Contains_over_entityType_should_rewrite_to_identity_equality()
+        public override async Task Contains_over_entityType_should_rewrite_to_identity_equality(bool async)
         {
-            base.Contains_over_entityType_should_rewrite_to_identity_equality();
+            await base.Contains_over_entityType_should_rewrite_to_identity_equality(async);
 
             AssertSql(
                 @"SELECT TOP(2) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]


### PR DESCRIPTION
We can use assert methods for individual result operators (min, max, average) as well as AssertSingleResult for ones which use complicated/correlated arguments in the final method.

Fixes #26397