### PR TITLE
Forcibly sets "en-US" locale.

### DIFF
--- a/test/EFCore.InMemory.FunctionalTests/EFCore.InMemory.FunctionalTests.csproj
+++ b/test/EFCore.InMemory.FunctionalTests/EFCore.InMemory.FunctionalTests.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <Compile Include="..\..\src\Shared\MemberInfoExtensions.cs" Link="MemberInfoExtensions.cs" />
+    <Compile Include="..\Shared\ModuleInitializer.cs" Link="ModuleInitializer.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/EFCore.SqlServer.FunctionalTests/EFCore.SqlServer.FunctionalTests.csproj
+++ b/test/EFCore.SqlServer.FunctionalTests/EFCore.SqlServer.FunctionalTests.csproj
@@ -18,6 +18,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\Shared\ModuleInitializer.cs" Link="ModuleInitializer.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Using Include="System.Data.Common" />
     <Using Include="System.Diagnostics" />
     <Using Include="System.Linq.Expressions" />

--- a/test/EFCore.Sqlite.FunctionalTests/EFCore.Sqlite.FunctionalTests.csproj
+++ b/test/EFCore.Sqlite.FunctionalTests/EFCore.Sqlite.FunctionalTests.csproj
@@ -17,6 +17,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\Shared\ModuleInitializer.cs" Link="ModuleInitializer.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Using Include="System.Data.Common" />
     <Using Include="System.Diagnostics" />
     <Using Include="System.Linq.Expressions" />

--- a/test/EFCore.Tests/EFCore.Tests.csproj
+++ b/test/EFCore.Tests/EFCore.Tests.csproj
@@ -43,6 +43,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\Shared\ModuleInitializer.cs" Link="ModuleInitializer.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\EFCore.InMemory.FunctionalTests\EFCore.InMemory.FunctionalTests.csproj" />
     <ProjectReference Include="..\EFCore.Specification.Tests\EFCore.Specification.Tests.csproj" />
   </ItemGroup>

--- a/test/Shared/ModuleInitializer.cs
+++ b/test/Shared/ModuleInitializer.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using System.Runtime.CompilerServices;
+
+internal static class ModuleInitializer
+{
+    [ModuleInitializer]
+    internal static void Initialize()
+    {
+        InitializeLocale();
+    }
+
+    private static void InitializeLocale()
+    {
+        var culture = new CultureInfo("en-US");
+        CultureInfo.DefaultThreadCurrentCulture = culture;
+        CultureInfo.DefaultThreadCurrentUICulture = culture;
+        Thread.CurrentThread.CurrentCulture = culture;
+        Thread.CurrentThread.CurrentUICulture = culture;
+    }
+}


### PR DESCRIPTION
* English locale is needed for comparisons, string to number parsing, etc. operations to succeed.
* It does not deal with locale on the database side, which might result in i.e. different sorting and hence tests failing.

Only these 4 projects need it (at the moment). I don't think it's worth adding it into all...

This fixes the handful of failures for me on non-English locale.

Note: It needs to be linked file, because it is using `ModuleInitializer`.

See also: #14912, #22901



