### PR TITLE
Use null propagation to optimize away `IS NOT NULL` checks

### DIFF
--- a/src/EFCore.Relational/Query/SqlNullabilityProcessor.cs
+++ b/src/EFCore.Relational/Query/SqlNullabilityProcessor.cs
@@ -511,7 +511,107 @@ public class SqlNullabilityProcessor : ExpressionVisitor
             return elseResult ?? _sqlExpressionFactory.Constant(null, caseExpression.Type, caseExpression.TypeMapping);
         }
 
+        if (IsNull(elseResult))
+        {
+            elseResult = null;
+        }
+
+        // optimize expressions such as expr != null ? expr : null and expr == null ? null : expr
+        if (testIsCondition && whenClauses is [var clause] && (elseResult is null || IsNull(clause.Result)))
+        {
+            HashSet<SqlExpression> nullPropagatedOperands = [];
+
+            var (test, expr) = elseResult is null
+                ? (clause.Test, clause.Result)
+                : (_sqlExpressionFactory.Not(clause.Test), elseResult);
+
+            DetectNullPropagatingNodes(expr, nullPropagatedOperands);
+            test = DropNotNullChecks(test, nullPropagatedOperands);
+
+            if (IsTrue(test))
+            {
+                return expr;
+            }
+
+            if (elseResult != null)
+            {
+                test = _sqlExpressionFactory.Not(test);
+            }
+
+            whenClauses = [new(test, clause.Result)];
+        }
+
         return _sqlExpressionFactory.Case(operand, whenClauses, elseResult, caseExpression);
+
+        SqlExpression DropNotNullChecks(SqlExpression expression, HashSet<SqlExpression> nullPropagatedOperands)
+            => expression switch
+            {
+                SqlUnaryExpression { OperatorType: ExpressionType.NotEqual } isNotNull
+                    when nullPropagatedOperands.Contains(isNotNull.Operand)
+                    => _sqlExpressionFactory.Constant(true, expression.Type, expression.TypeMapping),
+
+                SqlBinaryExpression { OperatorType: ExpressionType.AndAlso } binary
+                    => _sqlExpressionFactory.MakeBinary(
+                        ExpressionType.AndAlso,
+                        DropNotNullChecks(binary.Left, nullPropagatedOperands),
+                        DropNotNullChecks(binary.Right, nullPropagatedOperands),
+                        expression.TypeMapping,
+                        expression)!,
+
+                _ => expression,
+            };
+
+        // TODO: unify nullability computations
+        static void DetectNullPropagatingNodes(SqlExpression expression, HashSet<SqlExpression> operands)
+        {
+            if (!operands.Add(expression))
+            {
+                return;
+            }
+
+            switch (expression)
+            {
+                case AtTimeZoneExpression atTimeZone:
+                    DetectNullPropagatingNodes(atTimeZone.Operand, operands);
+                    DetectNullPropagatingNodes(atTimeZone.TimeZone, operands);
+                    break;
+
+                case CollateExpression collate:
+                    DetectNullPropagatingNodes(collate.Operand, operands);
+                    break;
+
+                case SqlUnaryExpression { OperatorType: not (ExpressionType.Equal or ExpressionType.NotEqual) } unary:
+                    DetectNullPropagatingNodes(unary.Operand, operands);
+                    break;
+
+                case SqlBinaryExpression { OperatorType: not (
+                        ExpressionType.AndAlso or
+                        ExpressionType.OrElse or
+                        ExpressionType.Coalesce
+                    ) } binary:
+                    DetectNullPropagatingNodes(binary.Left, operands);
+                    DetectNullPropagatingNodes(binary.Right, operands);
+                    break;
+
+                case SqlFunctionExpression { IsNullable: true } func:
+                    if (func.InstancePropagatesNullability is true)
+                    {
+                        DetectNullPropagatingNodes(func.Instance!, operands);
+                    }
+
+                    if (!func.IsNiladic)
+                    {
+                        for (var i = 0; i < func.ArgumentsPropagateNullability.Count; i++)
+                        {
+                            if (func.ArgumentsPropagateNullability[i])
+                            {
+                                DetectNullPropagatingNodes(func.Arguments[i], operands);
+                            }
+                        }
+                    }
+                    break;
+            }
+        }
     }
 
     /// <summary>

--- a/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
@@ -2183,6 +2183,47 @@ public abstract class NullSemanticsQueryTestBase<TFixture>(TFixture fixture) : Q
                     : x.NullableBoolC != x.NullableBoolA)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task Is_not_null_optimizes_unary_op(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<NullSemanticsEntity1>().Select(
+                x => x.NullableIntA != null ? ~x.NullableIntA : null));
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task Is_not_null_optimizes_binary_op(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<NullSemanticsEntity1>().Select(
+                x => x.NullableIntA != null && x.NullableIntB != null
+                    ? x.NullableIntA + x.NullableIntB
+                    : null));
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task Is_not_null_optimizes_binary_op_with_partial_checks(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<NullSemanticsEntity1>().Select(
+                x => x.NullableStringA != null && x.NullableStringB != null
+                    ? x.NullableStringA + x.NullableStringB + x.NullableStringC
+                    : null));
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task Is_not_null_optimizes_binary_op_with_nested_checks(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<NullSemanticsEntity1>().Select(
+                x => x.NullableStringA != null
+                    ? x.NullableStringB != null ? x.NullableStringA + x.NullableStringB : null
+                    : null));
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task Is_not_null_optimizes_binary_op_with_mixed_checks(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<NullSemanticsEntity1>().Select(
+                x => x.NullableStringA != null && x.BoolA ? x.NullableStringA + x.NullableStringB : null));
+
+    [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Sum_function_is_always_considered_non_nullable(bool async)
         => AssertQuery(
             async,

--- a/test/EFCore.SqlServer.FunctionalTests/Query/EntitySplittingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/EntitySplittingQuerySqlServerTest.cs
@@ -208,7 +208,7 @@ LEFT JOIN [OwnedReferenceExtras1] AS [o0] ON [e].[Id] = [o0].[EntityOneId]
         AssertSql(
             """
 SELECT [e].[Id], CASE
-    WHEN [e].[OwnedReference_Id] IS NOT NULL AND [e].[OwnedReference_OwnedIntValue1] IS NOT NULL AND [e].[OwnedReference_OwnedIntValue2] IS NOT NULL AND [o0].[OwnedIntValue3] IS NOT NULL AND [o].[OwnedIntValue4] IS NOT NULL THEN [o].[OwnedIntValue4]
+    WHEN [e].[OwnedReference_Id] IS NOT NULL AND [e].[OwnedReference_OwnedIntValue1] IS NOT NULL AND [e].[OwnedReference_OwnedIntValue2] IS NOT NULL AND [o0].[OwnedIntValue3] IS NOT NULL THEN [o].[OwnedIntValue4]
 END AS [OwnedIntValue4], CASE
     WHEN [e].[OwnedReference_Id] IS NOT NULL AND [e].[OwnedReference_OwnedIntValue1] IS NOT NULL AND [e].[OwnedReference_OwnedIntValue2] IS NOT NULL AND [o0].[OwnedIntValue3] IS NOT NULL AND [o].[OwnedIntValue4] IS NOT NULL THEN [o].[OwnedStringValue4]
 END AS [OwnedStringValue4]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -650,10 +650,7 @@ END = CAST(1 AS bit)
             """
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
-WHERE CASE
-    WHEN [g].[LeaderNickname] IS NULL THEN NULL
-    ELSE CAST(LEN([g].[LeaderNickname]) AS int)
-END = 5
+WHERE CAST(LEN([g].[LeaderNickname]) AS int) = 5
 """);
     }
 
@@ -666,9 +663,7 @@ END = 5
             """
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
-WHERE CASE
-    WHEN [g].[LeaderNickname] IS NOT NULL THEN CAST(LEN([g].[LeaderNickname]) AS int)
-END = 5
+WHERE CAST(LEN([g].[LeaderNickname]) AS int) = 5
 """);
     }
 
@@ -681,9 +676,7 @@ END = 5
             """
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
-WHERE CASE
-    WHEN [g].[LeaderNickname] IS NOT NULL THEN CAST(LEN([g].[LeaderNickname]) AS int)
-END = 5
+WHERE CAST(LEN([g].[LeaderNickname]) AS int) = 5
 """);
     }
 
@@ -694,9 +687,7 @@ END = 5
         // issue #16050
         AssertSql(
             """
-SELECT CASE
-    WHEN [g].[LeaderNickname] IS NOT NULL THEN [g].[LeaderNickname] + [g].[LeaderNickname]
-END
+SELECT [g].[LeaderNickname] + [g].[LeaderNickname]
 FROM [Gears] AS [g]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Inheritance/TPCGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Inheritance/TPCGearsOfWarQuerySqlServerTest.cs
@@ -838,10 +838,7 @@ FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
 ) AS [u]
-WHERE CASE
-    WHEN [u].[LeaderNickname] IS NULL THEN NULL
-    ELSE CAST(LEN([u].[LeaderNickname]) AS int)
-END = 5
+WHERE CAST(LEN([u].[LeaderNickname]) AS int) = 5
 """);
     }
 
@@ -860,9 +857,7 @@ FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
 ) AS [u]
-WHERE CASE
-    WHEN [u].[LeaderNickname] IS NOT NULL THEN CAST(LEN([u].[LeaderNickname]) AS int)
-END = 5
+WHERE CAST(LEN([u].[LeaderNickname]) AS int) = 5
 """);
     }
 
@@ -881,9 +876,7 @@ FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
 ) AS [u]
-WHERE CASE
-    WHEN [u].[LeaderNickname] IS NOT NULL THEN CAST(LEN([u].[LeaderNickname]) AS int)
-END = 5
+WHERE CAST(LEN([u].[LeaderNickname]) AS int) = 5
 """);
     }
 
@@ -894,9 +887,7 @@ END = 5
         // issue #16050
         AssertSql(
             """
-SELECT CASE
-    WHEN [u].[LeaderNickname] IS NOT NULL THEN [u].[LeaderNickname] + [u].[LeaderNickname]
-END
+SELECT [u].[LeaderNickname] + [u].[LeaderNickname]
 FROM (
     SELECT [g].[LeaderNickname]
     FROM [Gears] AS [g]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Inheritance/TPTGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Inheritance/TPTGearsOfWarQuerySqlServerTest.cs
@@ -806,10 +806,7 @@ SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthNa
 END AS [Discriminator]
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId] = [o].[SquadId]
-WHERE CASE
-    WHEN [g].[LeaderNickname] IS NULL THEN NULL
-    ELSE CAST(LEN([g].[LeaderNickname]) AS int)
-END = 5
+WHERE CAST(LEN([g].[LeaderNickname]) AS int) = 5
 """);
     }
 
@@ -825,9 +822,7 @@ SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthNa
 END AS [Discriminator]
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId] = [o].[SquadId]
-WHERE CASE
-    WHEN [g].[LeaderNickname] IS NOT NULL THEN CAST(LEN([g].[LeaderNickname]) AS int)
-END = 5
+WHERE CAST(LEN([g].[LeaderNickname]) AS int) = 5
 """);
     }
 
@@ -843,9 +838,7 @@ SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthNa
 END AS [Discriminator]
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId] = [o].[SquadId]
-WHERE CASE
-    WHEN [g].[LeaderNickname] IS NOT NULL THEN CAST(LEN([g].[LeaderNickname]) AS int)
-END = 5
+WHERE CAST(LEN([g].[LeaderNickname]) AS int) = 5
 """);
     }
 
@@ -856,9 +849,7 @@ END = 5
         // issue #16050
         AssertSql(
             """
-SELECT CASE
-    WHEN [g].[LeaderNickname] IS NOT NULL THEN [g].[LeaderNickname] + [g].[LeaderNickname]
-END
+SELECT [g].[LeaderNickname] + [g].[LeaderNickname]
 FROM [Gears] AS [g]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -2543,9 +2543,7 @@ GROUP BY [o].[CustomerID]
 
         AssertSql(
             """
-SELECT [o].[CustomerID] AS [Key], MAX(CASE
-    WHEN [o].[OrderDate] IS NOT NULL THEN [o].[OrderDate]
-END) AS [Max]
+SELECT [o].[CustomerID] AS [Key], MAX([o].[OrderDate]) AS [Max]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -5122,6 +5122,73 @@ END = CAST(1 AS bit)
 """);
     }
 
+    public override async Task Is_not_null_optimizes_unary_op(bool async)
+    {
+        await base.Is_not_null_optimizes_unary_op(async);
+
+        AssertSql(
+            """
+SELECT CASE
+    WHEN [e].[NullableIntA] IS NOT NULL THEN ~[e].[NullableIntA]
+END
+FROM [Entities1] AS [e]
+""");
+    }
+
+    public override async Task Is_not_null_optimizes_binary_op(bool async)
+    {
+        await base.Is_not_null_optimizes_binary_op(async);
+
+        AssertSql(
+            """
+SELECT CASE
+    WHEN [e].[NullableIntA] IS NOT NULL AND [e].[NullableIntB] IS NOT NULL THEN [e].[NullableIntA] + [e].[NullableIntB]
+END
+FROM [Entities1] AS [e]
+""");
+    }
+
+    public override async Task Is_not_null_optimizes_binary_op_with_partial_checks(bool async)
+    {
+        await base.Is_not_null_optimizes_binary_op_with_partial_checks(async);
+
+        AssertSql(
+            """
+SELECT CASE
+    WHEN [e].[NullableStringA] IS NOT NULL AND [e].[NullableStringB] IS NOT NULL THEN [e].[NullableStringA] + [e].[NullableStringB] + COALESCE([e].[NullableStringC], N'')
+END
+FROM [Entities1] AS [e]
+""");
+    }
+
+    public override async Task Is_not_null_optimizes_binary_op_with_nested_checks(bool async)
+    {
+        await base.Is_not_null_optimizes_binary_op_with_nested_checks(async);
+
+        AssertSql(
+            """
+SELECT CASE
+    WHEN [e].[NullableStringA] IS NOT NULL THEN CASE
+        WHEN [e].[NullableStringB] IS NOT NULL THEN [e].[NullableStringA] + [e].[NullableStringB]
+    END
+END
+FROM [Entities1] AS [e]
+""");
+    }
+
+    public override async Task Is_not_null_optimizes_binary_op_with_mixed_checks(bool async)
+    {
+        await base.Is_not_null_optimizes_binary_op_with_mixed_checks(async);
+
+        AssertSql(
+            """
+SELECT CASE
+    WHEN [e].[NullableStringA] IS NOT NULL AND [e].[BoolA] = CAST(1 AS bit) THEN [e].[NullableStringA] + COALESCE([e].[NullableStringB], N'')
+END
+FROM [Entities1] AS [e]
+""");
+    }
+
     public override async Task Sum_function_is_always_considered_non_nullable(bool async)
     {
         await base.Sum_function_is_always_considered_non_nullable(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -5128,9 +5128,7 @@ END = CAST(1 AS bit)
 
         AssertSql(
             """
-SELECT CASE
-    WHEN [e].[NullableIntA] IS NOT NULL THEN ~[e].[NullableIntA]
-END
+SELECT ~[e].[NullableIntA]
 FROM [Entities1] AS [e]
 """);
     }
@@ -5141,9 +5139,7 @@ FROM [Entities1] AS [e]
 
         AssertSql(
             """
-SELECT CASE
-    WHEN [e].[NullableIntA] IS NOT NULL AND [e].[NullableIntB] IS NOT NULL THEN [e].[NullableIntA] + [e].[NullableIntB]
-END
+SELECT [e].[NullableIntA] + [e].[NullableIntB]
 FROM [Entities1] AS [e]
 """);
     }
@@ -5154,9 +5150,7 @@ FROM [Entities1] AS [e]
 
         AssertSql(
             """
-SELECT CASE
-    WHEN [e].[NullableStringA] IS NOT NULL AND [e].[NullableStringB] IS NOT NULL THEN [e].[NullableStringA] + [e].[NullableStringB] + COALESCE([e].[NullableStringC], N'')
-END
+SELECT [e].[NullableStringA] + [e].[NullableStringB] + COALESCE([e].[NullableStringC], N'')
 FROM [Entities1] AS [e]
 """);
     }
@@ -5167,11 +5161,7 @@ FROM [Entities1] AS [e]
 
         AssertSql(
             """
-SELECT CASE
-    WHEN [e].[NullableStringA] IS NOT NULL THEN CASE
-        WHEN [e].[NullableStringB] IS NOT NULL THEN [e].[NullableStringA] + [e].[NullableStringB]
-    END
-END
+SELECT [e].[NullableStringA] + [e].[NullableStringB]
 FROM [Entities1] AS [e]
 """);
     }
@@ -5183,7 +5173,7 @@ FROM [Entities1] AS [e]
         AssertSql(
             """
 SELECT CASE
-    WHEN [e].[NullableStringA] IS NOT NULL AND [e].[BoolA] = CAST(1 AS bit) THEN [e].[NullableStringA] + COALESCE([e].[NullableStringB], N'')
+    WHEN [e].[BoolA] = CAST(1 AS bit) THEN [e].[NullableStringA] + COALESCE([e].[NullableStringB], N'')
 END
 FROM [Entities1] AS [e]
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeographyTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeographyTest.cs
@@ -88,10 +88,7 @@ FROM [PointEntity] AS [p]
 
         AssertSql(
             """
-SELECT [p].[Id], CASE
-    WHEN [p].[Point] IS NULL THEN NULL
-    ELSE [p].[Point].STAsBinary()
-END AS [Binary]
+SELECT [p].[Id], [p].[Point].STAsBinary() AS [Binary]
 FROM [PointEntity] AS [p]
 """);
     }
@@ -284,10 +281,7 @@ FROM [PolygonEntity] AS [p]
             """
 @point='0xE6100000010C000000000000F03F000000000000F03F' (Size = 22) (DbType = Object)
 
-SELECT [p].[Id], CASE
-    WHEN [p].[Polygon] IS NULL THEN NULL
-    ELSE [p].[Polygon].STDisjoint(@point)
-END AS [Disjoint]
+SELECT [p].[Id], [p].[Polygon].STDisjoint(@point) AS [Disjoint]
 FROM [PolygonEntity] AS [p]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeometryTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeometryTest.cs
@@ -83,10 +83,7 @@ FROM [PointEntity] AS [p]
 
         AssertSql(
             """
-SELECT [p].[Id], CASE
-    WHEN [p].[Point] IS NULL THEN NULL
-    ELSE [p].[Point].STAsBinary()
-END AS [Binary]
+SELECT [p].[Id], [p].[Point].STAsBinary() AS [Binary]
 FROM [PointEntity] AS [p]
 """);
     }
@@ -403,10 +400,7 @@ FROM [PolygonEntity] AS [p]
             """
 @point='0x00000000010C000000000000F03F000000000000F03F' (Size = 22) (DbType = Object)
 
-SELECT [p].[Id], CASE
-    WHEN [p].[Polygon] IS NULL THEN NULL
-    ELSE [p].[Polygon].STDisjoint(@point)
-END AS [Disjoint]
+SELECT [p].[Id], [p].[Polygon].STDisjoint(@point) AS [Disjoint]
 FROM [PolygonEntity] AS [p]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalComplexNavigationsCollectionsSharedTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalComplexNavigationsCollectionsSharedTypeQuerySqlServerTest.cs
@@ -1849,9 +1849,9 @@ ORDER BY [l].[Id]
 
 SELECT CASE
     WHEN [s].[OneToOne_Required_PK_Date] IS NULL OR [s].[Level1_Required_Id] IS NULL OR [s].[OneToMany_Required_Inverse2Id] IS NULL OR CASE
-        WHEN [s].[PeriodEnd0] IS NOT NULL AND [s].[PeriodStart0] IS NOT NULL THEN [s].[PeriodEnd0]
+        WHEN [s].[PeriodStart0] IS NOT NULL THEN [s].[PeriodEnd0]
     END IS NULL OR CASE
-        WHEN [s].[PeriodEnd0] IS NOT NULL AND [s].[PeriodStart0] IS NOT NULL THEN [s].[PeriodStart0]
+        WHEN [s].[PeriodEnd0] IS NOT NULL THEN [s].[PeriodStart0]
     END IS NULL THEN 0
     WHEN [s].[OneToOne_Required_PK_Date] IS NOT NULL AND [s].[Level1_Required_Id] IS NOT NULL AND [s].[OneToMany_Required_Inverse2Id] IS NOT NULL AND [s].[PeriodEnd0] IS NOT NULL AND [s].[PeriodStart0] IS NOT NULL THEN [s].[Id0]
 END, [l].[Id], [s].[Id], [l4].[Id], [l4].[Level2_Optional_Id], [l4].[Level2_Required_Id], [l4].[Level3_Name], [l4].[OneToMany_Optional_Inverse3Id], [l4].[OneToMany_Required_Inverse3Id], [l4].[OneToOne_Optional_PK_Inverse3Id], [l4].[PeriodEnd], [l4].[PeriodStart]
@@ -1867,9 +1867,9 @@ LEFT JOIN (
         WHEN [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [l2].[Id]
     END
     WHERE [l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL AND CASE
-        WHEN [l2].[PeriodEnd] IS NOT NULL AND [l2].[PeriodStart] IS NOT NULL THEN [l2].[PeriodEnd]
+        WHEN [l2].[PeriodStart] IS NOT NULL THEN [l2].[PeriodEnd]
     END IS NOT NULL AND CASE
-        WHEN [l2].[PeriodEnd] IS NOT NULL AND [l2].[PeriodStart] IS NOT NULL THEN [l2].[PeriodStart]
+        WHEN [l2].[PeriodEnd] IS NOT NULL THEN [l2].[PeriodStart]
     END IS NOT NULL
 ) AS [s] ON [l].[Id] = [s].[Level1_Required_Id]
 LEFT JOIN (
@@ -2249,9 +2249,9 @@ FROM [Level1] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
 LEFT JOIN (
     SELECT CASE
         WHEN [l2].[Level2_Required_Id] IS NULL OR [l2].[OneToMany_Required_Inverse3Id] IS NULL OR CASE
-            WHEN [l2].[PeriodEnd] IS NOT NULL AND [l2].[PeriodStart] IS NOT NULL THEN [l2].[PeriodEnd]
+            WHEN [l2].[PeriodStart] IS NOT NULL THEN [l2].[PeriodEnd]
         END IS NULL OR CASE
-            WHEN [l2].[PeriodEnd] IS NOT NULL AND [l2].[PeriodStart] IS NOT NULL THEN [l2].[PeriodStart]
+            WHEN [l2].[PeriodEnd] IS NOT NULL THEN [l2].[PeriodStart]
         END IS NULL THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c], [l2].[Level3_Name], [l0].[Id], [l0].[OneToMany_Optional_Inverse2Id]
@@ -2280,9 +2280,9 @@ FROM [Level1] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
 LEFT JOIN (
     SELECT CASE
         WHEN [l2].[Level2_Required_Id] IS NULL OR [l2].[OneToMany_Required_Inverse3Id] IS NULL OR CASE
-            WHEN [l2].[PeriodEnd] IS NOT NULL AND [l2].[PeriodStart] IS NOT NULL THEN [l2].[PeriodEnd]
+            WHEN [l2].[PeriodStart] IS NOT NULL THEN [l2].[PeriodEnd]
         END IS NULL OR CASE
-            WHEN [l2].[PeriodEnd] IS NOT NULL AND [l2].[PeriodStart] IS NOT NULL THEN [l2].[PeriodStart]
+            WHEN [l2].[PeriodEnd] IS NOT NULL THEN [l2].[PeriodStart]
         END IS NULL THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c], [l2].[Level3_Name], [l0].[Id], [l0].[OneToMany_Optional_Inverse2Id]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
@@ -1149,9 +1149,7 @@ LEFT JOIN [LocustHighCommands] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.000000
             """
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
-WHERE CASE
-    WHEN [g].[LeaderNickname] IS NOT NULL THEN CAST(LEN([g].[LeaderNickname]) AS int)
-END = 5
+WHERE CAST(LEN([g].[LeaderNickname]) AS int) = 5
 """);
     }
 
@@ -3561,9 +3559,7 @@ ORDER BY [s0].[Id], [s1].[Nickname], [s1].[FullName], [s1].[HasSoulPatch]
             """
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
-WHERE CASE
-    WHEN [g].[LeaderNickname] IS NOT NULL THEN CAST(LEN([g].[LeaderNickname]) AS int)
-END = 5
+WHERE CAST(LEN([g].[LeaderNickname]) AS int) = 5
 """);
     }
 
@@ -4375,10 +4371,7 @@ FROM [Squads] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [s]
             """
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
-WHERE CASE
-    WHEN [g].[LeaderNickname] IS NULL THEN NULL
-    ELSE CAST(LEN([g].[LeaderNickname]) AS int)
-END = 5
+WHERE CAST(LEN([g].[LeaderNickname]) AS int) = 5
 """);
     }
 
@@ -4484,9 +4477,7 @@ FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
 
         AssertSql(
             """
-SELECT CASE
-    WHEN [g].[LeaderNickname] IS NOT NULL THEN [g].[LeaderNickname] + [g].[LeaderNickname]
-END
+SELECT [g].[LeaderNickname] + [g].[LeaderNickname]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
 """);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -559,9 +559,7 @@ FROM "Factions" AS "f"
             """
 SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank"
 FROM "Gears" AS "g"
-WHERE CASE
-    WHEN "g"."LeaderNickname" IS NOT NULL THEN length("g"."LeaderNickname")
-END = 5
+WHERE length("g"."LeaderNickname") = 5
 """);
     }
 
@@ -4919,9 +4917,7 @@ WHERE "g"."Nickname" = "g0"."Nickname" AND "g"."SquadId" = "g0"."SquadId"
 
         AssertSql(
             """
-SELECT CASE
-    WHEN "g"."LeaderNickname" IS NOT NULL THEN "g"."LeaderNickname" || "g"."LeaderNickname"
-END
+SELECT "g"."LeaderNickname" || "g"."LeaderNickname"
 FROM "Gears" AS "g"
 """);
     }
@@ -6627,9 +6623,7 @@ ORDER BY "g0"."Nickname"
             """
 SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank"
 FROM "Gears" AS "g"
-WHERE CASE
-    WHEN "g"."LeaderNickname" IS NOT NULL THEN length("g"."LeaderNickname")
-END = 5
+WHERE length("g"."LeaderNickname") = 5
 """);
     }
 
@@ -7372,10 +7366,7 @@ ORDER BY "g"."Nickname", "g"."SquadId"
             """
 SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank"
 FROM "Gears" AS "g"
-WHERE CASE
-    WHEN "g"."LeaderNickname" IS NULL THEN NULL
-    ELSE length("g"."LeaderNickname")
-END = 5
+WHERE length("g"."LeaderNickname") = 5
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SpatialQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SpatialQuerySqliteTest.cs
@@ -128,10 +128,7 @@ FROM "PointEntity" AS "p"
 
         AssertSql(
             """
-SELECT "p"."Id", CASE
-    WHEN "p"."Point" IS NULL THEN NULL
-    ELSE AsBinary("p"."Point")
-END AS "Binary"
+SELECT "p"."Id", AsBinary("p"."Point") AS "Binary"
 FROM "PointEntity" AS "p"
 """);
     }


### PR DESCRIPTION
When a CASE expression simply replicates SQL null propagation, simplify it.

Contributes to #34126.