### PR TITLE
[release/9.0-rc1] Fix OptimisticConcurrencyCosmosTest

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/F1CosmosFixture.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/F1CosmosFixture.cs
@@ -16,20 +16,19 @@ public class F1CosmosFixture<TRowVersion> : F1FixtureBase<TRowVersion>
     public override TestHelpers TestHelpers
         => CosmosTestHelpers.Instance;
 
-    public override async Task ReseedAsync()
+    protected override async Task<bool> ShouldSeedAsync(F1Context context)
     {
-        await base.ReseedAsync();
-
-        using var context = CreateContext();
         try
         {
-            await context.Teams.SingleAsync(t => t.Id == Team.Ferrari);
+            await base.ShouldSeedAsync(context);
         }
         catch
         {
             // Recreating the containers without using CosmosClient causes cached metadata in CosmosClient to be out of sync
             // and causes the first query to fail. This is a workaround for that.
         }
+
+        return await base.ShouldSeedAsync(context);
     }
 
     public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)

--- a/test/EFCore.Specification.Tests/F1FixtureBase.cs
+++ b/test/EFCore.Specification.Tests/F1FixtureBase.cs
@@ -19,7 +19,7 @@ public abstract class F1FixtureBase<TRowVersion> : SharedStoreFixtureBase<F1Cont
             .UseModel(CreateModelExternal())
             .UseSeeding((c, _) =>
             {
-                if (c.Set<EngineSupplier>().Count() != 0)
+                if (!ShouldSeed((F1Context)c))
                 {
                     return;
                 }
@@ -29,7 +29,7 @@ public abstract class F1FixtureBase<TRowVersion> : SharedStoreFixtureBase<F1Cont
             })
             .UseAsyncSeeding(async (c, _, t) =>
             {
-                if (await c.Set<EngineSupplier>().CountAsync(t) != 0)
+                if (!await ShouldSeedAsync((F1Context)c))
                 {
                     return;
                 }
@@ -39,6 +39,12 @@ public abstract class F1FixtureBase<TRowVersion> : SharedStoreFixtureBase<F1Cont
             })
             .ConfigureWarnings(
                 w => w.Ignore(CoreEventId.SaveChangesStarting, CoreEventId.SaveChangesCompleted));
+
+    protected virtual bool ShouldSeed(F1Context context)
+        => context.EngineSuppliers.Count() == 0;
+
+    protected virtual async Task<bool> ShouldSeedAsync(F1Context context)
+        => await context.EngineSuppliers.CountAsync() == 0;
 
     protected override IServiceCollection AddServices(IServiceCollection serviceCollection)
         => base.AddServices(serviceCollection.AddSingleton<ISingletonInterceptor, F1MaterializationInterceptor>());


### PR DESCRIPTION
**Description**
https://github.com/dotnet/efcore/pull/34338 implemented a new seeding mechanism and used it in `OptimisticConcurrencyCosmosTest`. However, on the internal CI we run the tests against an actual Cosmos DB account as opposed to an emulator and use RBAC. This requires us to use the ARM SDK to create the containers, but this causes the Cosmos SDK cached metadata to become out of sync if the same instance of `CosmosClient` is used to query a container that was recreated.

This PR updates the workaround for the new seeding mechanism.

**Customer impact**
The build is broken

**How found**
Internal CI

**Regression**
N/A

**Testing**
Verified in a private run

**Risk**
N/A