### PR TITLE
[release/9.0] Handle leaf entity projection in Cosmos

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
@@ -81,10 +81,36 @@ public class CosmosSqlTranslatingExpressionVisitor(
     {
         TranslationErrorDetails = null;
 
-        return TranslateInternal(expression, applyDefaultTypeMapping);
+        return TranslateInternal(expression, applyDefaultTypeMapping) as SqlExpression;
     }
 
-    private SqlExpression? TranslateInternal(Expression expression, bool applyDefaultTypeMapping = true)
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public virtual Expression? TranslateProjection(Expression expression, bool applyDefaultTypeMapping = true)
+    {
+        TranslationErrorDetails = null;
+
+        return TranslateInternal(expression, applyDefaultTypeMapping) switch
+        {
+            // This is the case of a structural type getting projected out via Select()
+            EntityReferenceExpression { Parameter: StructuralTypeShaperExpression shaper }
+                => shaper,
+
+            EntityReferenceExpression { Subquery: ShapedQueryExpression subquery }
+                => subquery,
+
+            SqlExpression s => s,
+
+            _ => null
+        };
+    }
+
+    private Expression? TranslateInternal(Expression expression, bool applyDefaultTypeMapping = true)
     {
         var result = Visit(expression);
 
@@ -106,7 +132,7 @@ public class CosmosSqlTranslatingExpressionVisitor(
             return translation;
         }
 
-        return null;
+        return result;
     }
 
     /// <summary>


### PR DESCRIPTION
Part of #34350, but only when no Includes are present (leaf owned entity)

### Description

Major work went into improving the Cosmos provider for 9.0, especially into the query pipeline. However, various querying scenarios are still blocked, notably various involving projecting out owned entity types via Select. This PR addresses one such scenario, namely projection of a leaf entity type.

### Customer impact

Attempting to project a leaf owned entity type fails in some querying scenarios.

### How found

Applying our standard test suites against Cosmos.

### Regression

No

### Testing

Already exists.

### Risk

Low.