### PR TITLE
Temporary fix for DropTable/CreateTable issue around temporal tables

### DIFF
--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -2606,9 +2606,8 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
                         operations.Add(operation);
                     }
 
-                    // we removed the table, so we no longer need it's temporal information
-                    // there will be no more operations involving this table
-                    temporalTableInformationMap.Remove((tableName, schema));
+                    // Note that we leave the information in temporalTableInformationMap in case there's a later CreateTable operation
+                    // on the same table name (see #35162).
 
                     break;
                 }


### PR DESCRIPTION
@maumar this is a bug in #32239, which I think is the result of a wider design issue in that PR; the trigger is simply having a DropTable followed by a CreateTable in the same migration. Your second processing loop for temporal tables ([code](https://github.com/dotnet/efcore/pull/32239/files#r1860979159)) removes the temporal data from the table when it sees the DropTable, and when we get to the CreateTable we get an exception since there's no data at that point ([code](https://github.com/dotnet/efcore/pull/32239/files#diff-c80a80f96194920fd36fd4daaa22d80408aaa7f083128172c4c05331f0b92de0R2483)).

The hacky fix proposed here - which is probably OK for patching - is to simply not remove the data when we see DropTable, ensuring that it's still there when the CreateTable is processed. We've got two user reports on #35162; am waiting to hear how they got to having DropTable/CreateTable in the same migration in order to better understand how critical this bug is.

However, I think the design here is fundamentally problematic; you can't really do a pass over all operations (and then over the model for missing ones), storing the temporal data in a single dictionary; a single migration can create and drop the same table multiple times, each time with completely different temporal data. The current design flattens all that out, so that when you process e.g. the 1st CreateTable, you actually see the temporal data from the last CreateTable. IMHO the correct design here would be to have a single pass, extracting the temporal data when you see e.g. CreateTable, and remember it in the dictionary. If you have reach a table operation which **doesn't** contain temporal data, and don't have data in the dictionary (no e.g. CreateTable was present in the migration before), at that point you can consult the model, and again store the data in the dictionary. This way you always have the correct, up-to-date temporal data in the dictionary, as you're advancing in a single pass through all migration operations.


Fixes #35162
