### PR TITLE
Translate to NULLIF

### DIFF
--- a/EFCore.slnx.DotSettings
+++ b/EFCore.slnx.DotSettings
@@ -357,6 +357,8 @@ The .NET Foundation licenses this file to you under the MIT license.&#xD;
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=subquery/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=subquery_0027s/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=transactionality/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=uncoalesce/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=uncoalescing/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=unconfigured/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=unignore/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=fixup/@EntryIndexedValue">True</s:Boolean>

--- a/src/EFCore.Cosmos/Query/Internal/SqlExpressionFactory.cs
+++ b/src/EFCore.Cosmos/Query/Internal/SqlExpressionFactory.cs
@@ -707,10 +707,37 @@ public class SqlExpressionFactory(ITypeMappingSource typeMappingSource, IModel m
     {
         var typeMapping = ExpressionExtensions.InferTypeMapping(ifTrue, ifFalse);
 
-        return new SqlConditionalExpression(
-            ApplyTypeMapping(test, _boolTypeMapping),
-            ApplyTypeMapping(ifTrue, typeMapping),
-            ApplyTypeMapping(ifFalse, typeMapping));
+        test = ApplyTypeMapping(test, _boolTypeMapping);
+        ifTrue = ApplyTypeMapping(ifTrue, typeMapping);
+        ifFalse = ApplyTypeMapping(ifFalse, typeMapping);
+
+        // Simplify:
+        //   a == b ? b : a -> a
+        //   a != b ? a : b -> a
+        if (test is SqlBinaryExpression
+            {
+                OperatorType: ExpressionType.Equal or ExpressionType.NotEqual,
+                Left: SqlExpression left,
+                Right: SqlExpression right
+            } binary)
+        {
+            // Swap ifTrue/ifFalse for NotEqual so we can reason uniformly about ifEqual/ifNotEqual.
+            var (ifEqual, ifNotEqual) = binary.OperatorType is ExpressionType.Equal ? (ifTrue, ifFalse) : (ifFalse, ifTrue);
+
+            // 'left' survives: a == b ? b : a -> a
+            if (left.Equals(ifNotEqual) && right.Equals(ifEqual))
+            {
+                return left;
+            }
+
+            // 'right' survives: a == b ? a : b -> b
+            if (right.Equals(ifNotEqual) && left.Equals(ifEqual))
+            {
+                return right;
+            }
+        }
+
+        return new SqlConditionalExpression(test, ifTrue, ifFalse);
     }
 
     /// <summary>

--- a/src/EFCore.Relational/Query/SqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/SqlExpressionFactory.cs
@@ -873,7 +873,7 @@ public class SqlExpressionFactory : ISqlExpressionFactory
                         return left;
                     // a == b ? null : a -> NULLIF(a, b)
                     case SqlConstantExpression { Value: null }:
-                        return Function("NULLIF", [left, right], nullable: true, [true, false], left.Type, left.TypeMapping);
+                        return Function("NULLIF", [left, right], nullable: true, Statics.TrueFalse, left.Type, left.TypeMapping);
                 }
             }
 
@@ -887,7 +887,7 @@ public class SqlExpressionFactory : ISqlExpressionFactory
                         return right;
                     // a == b ? null : b -> NULLIF(b, a)
                     case SqlConstantExpression { Value: null }:
-                        return Function("NULLIF", [right, left], nullable: true, [true, false], right.Type, right.TypeMapping);
+                        return Function("NULLIF", [right, left], nullable: true, Statics.TrueFalse, right.Type, right.TypeMapping);
                 }
             }
         }

--- a/src/EFCore.Relational/Query/SqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/SqlExpressionFactory.cs
@@ -837,6 +837,61 @@ public class SqlExpressionFactory : ISqlExpressionFactory
             elseResult = lastCase.ElseResult;
         }
 
+        // Simplify:
+        //   a == b ? b : a -> a
+        //   a != b ? a : b -> a
+        // And lift:
+        //   a == b ? null : a -> NULLIF(a, b)
+        //   a != b ? a : null -> NULLIF(a, b)
+        if (operand is null
+            && typeMappedWhenClauses is
+            [
+                {
+                    Test: SqlBinaryExpression
+                    {
+                        OperatorType: ExpressionType.Equal or ExpressionType.NotEqual,
+                        Left: var left,
+                        Right: var right
+                    } binary,
+                    Result: var result
+                }
+            ])
+        {
+            // Swap result/elseResult for NotEqual so we can reason uniformly about ifEqual/ifNotEqual.
+            // A missing ELSE clause is equivalent to ELSE NULL, so normalize to a null constant for matching.
+            var (ifEqual, ifNotEqual) = binary.OperatorType is ExpressionType.Equal
+                ? (result, elseResult ?? Constant(null, result.Type, result.TypeMapping))
+                : (elseResult ?? Constant(null, result.Type, result.TypeMapping), result);
+
+            // 'left' survives the conditional.
+            if (left.Equals(ifNotEqual))
+            {
+                switch (ifEqual)
+                {
+                    // a == b ? b : a -> a   (also collapses NULLIF(a, NULL) when both are null constants)
+                    case var _ when ifEqual.Equals(right):
+                        return left;
+                    // a == b ? null : a -> NULLIF(a, b)
+                    case SqlConstantExpression { Value: null }:
+                        return Function("NULLIF", [left, right], nullable: true, [true, false], left.Type, left.TypeMapping);
+                }
+            }
+
+            // 'right' survives the conditional (operand-swapped equivalents of the patterns above).
+            if (right.Equals(ifNotEqual))
+            {
+                switch (ifEqual)
+                {
+                    // a == b ? a : b -> b
+                    case var _ when ifEqual.Equals(left):
+                        return right;
+                    // a == b ? null : b -> NULLIF(b, a)
+                    case SqlConstantExpression { Value: null }:
+                        return Function("NULLIF", [right, left], nullable: true, [true, false], right.Type, right.TypeMapping);
+                }
+            }
+        }
+
         return existingExpression is CaseExpression expr
             && operand == expr.Operand
             && typeMappedWhenClauses.SequenceEqual(expr.WhenClauses)

--- a/test/EFCore.Cosmos.FunctionalTests/Query/Translations/Operators/MiscellaneousOperatorTranslationsCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/Translations/Operators/MiscellaneousOperatorTranslationsCosmosTest.cs
@@ -24,6 +24,90 @@ WHERE (((c["Int"] = 8) ? c["String"] : "Foo") = "Seattle")
 """);
     }
 
+    public override async Task Conditional_simplifiable_equality()
+    {
+        await base.Conditional_simplifiable_equality();
+
+        AssertSql(
+            """
+SELECT VALUE c
+FROM root c
+WHERE (c["Int"] > 1)
+""");
+    }
+
+    public override async Task Conditional_simplifiable_inequality()
+    {
+        await base.Conditional_simplifiable_inequality();
+
+        AssertSql(
+            """
+SELECT VALUE c
+FROM root c
+WHERE (c["Int"] > 1)
+""");
+    }
+
+    public override async Task Conditional_uncoalesce_with_equality_left()
+    {
+        await base.Conditional_uncoalesce_with_equality_left();
+
+        AssertSql(
+            """
+SELECT VALUE c
+FROM root c
+WHERE (((c["Int"] = 9) ? null : c["Int"]) > 1)
+""");
+    }
+
+    public override async Task Conditional_uncoalesce_with_equality_right()
+    {
+        await base.Conditional_uncoalesce_with_equality_right();
+
+        AssertSql(
+            """
+SELECT VALUE c
+FROM root c
+WHERE (((9 = c["Int"]) ? null : c["Int"]) > 1)
+""");
+    }
+
+    public override async Task Conditional_uncoalesce_with_inequality_left()
+    {
+        await base.Conditional_uncoalesce_with_inequality_left();
+
+        AssertSql(
+            """
+SELECT VALUE c
+FROM root c
+WHERE (((c["Int"] != 9) ? c["Int"] : null) > 1)
+""");
+    }
+
+    public override async Task Conditional_uncoalesce_with_inequality_right()
+    {
+        await base.Conditional_uncoalesce_with_inequality_right();
+
+        AssertSql(
+            """
+SELECT VALUE c
+FROM root c
+WHERE (((9 != c["Int"]) ? c["Int"] : null) > 1)
+""");
+    }
+
+    public override async Task Conditional_uncoalesce_with_string()
+    {
+        await base.Conditional_uncoalesce_with_string();
+
+        AssertSql(
+            """
+SELECT VALUE c
+FROM root c
+WHERE (((c["String"] = "Seattle") ? null : c["String"]) = "London")
+""");
+    }
+
     public override async Task Coalesce()
     {
         await base.Coalesce();

--- a/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
@@ -711,7 +711,7 @@ public abstract class NullSemanticsQueryTestBase<TFixture>(TFixture fixture) : Q
             async,
             ss => ss.Set<NullSemanticsEntity1>().Where(e => (e.NullableStringA == e.NullableStringB
                     ? e.NullableStringA
-                    : e.NullableStringB)
+                    : e.NullableStringC)
                 == e.NullableStringC).Select(e => e.Id));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -721,7 +721,7 @@ public abstract class NullSemanticsQueryTestBase<TFixture>(TFixture fixture) : Q
             ss => ss.Set<NullSemanticsEntity1>().Where(e => e.NullableStringC
                 != (e.NullableStringA == e.NullableStringB
                     ? e.NullableStringA
-                    : e.NullableStringB)).Select(e => e.Id));
+                    : e.NullableStringC)).Select(e => e.Id));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Where_equal_with_conditional_non_nullable(bool async)

--- a/test/EFCore.Specification.Tests/Query/Translations/Operators/MiscellaneousOperatorTranslationsTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Translations/Operators/MiscellaneousOperatorTranslationsTestBase.cs
@@ -13,6 +13,38 @@ public abstract class MiscellaneousOperatorTranslationsTestBase<TFixture>(TFixtu
         => await AssertQuery(ss => ss.Set<BasicTypesEntity>().Where(b => (b.Int == 8 ? b.String : "Foo") == "Seattle"));
 
     [Fact]
+    public virtual async Task Conditional_simplifiable_equality()
+        // ReSharper disable once MergeConditionalExpression
+        => await AssertQuery(ss => ss.Set<NullableBasicTypesEntity>().Where(x => (x.Int == 9 ? 9 : x.Int) > 1));
+
+    [Fact]
+    public virtual async Task Conditional_simplifiable_inequality()
+        // ReSharper disable once MergeConditionalExpression
+        => await AssertQuery(ss => ss.Set<NullableBasicTypesEntity>().Where(x => (x.Int != 8 ? x.Int : 8) > 1));
+
+    // In relational providers, x == a ? null : x ("un-coalescing conditional") is translated to SQL NULLIF
+
+    [Fact]
+    public virtual async Task Conditional_uncoalesce_with_equality_left()
+        => await AssertQuery(ss => ss.Set<BasicTypesEntity>().Where(x => (x.Int == 9 ? null : x.Int) > 1));
+
+    [Fact]
+    public virtual async Task Conditional_uncoalesce_with_equality_right()
+        => await AssertQuery(ss => ss.Set<BasicTypesEntity>().Where(x => (9 == x.Int ? null : x.Int) > 1));
+
+    [Fact]
+    public virtual async Task Conditional_uncoalesce_with_inequality_left()
+        => await AssertQuery(ss => ss.Set<BasicTypesEntity>().Where(x => (x.Int != 9 ? x.Int : null) > 1));
+
+    [Fact]
+    public virtual async Task Conditional_uncoalesce_with_inequality_right()
+        => await AssertQuery(ss => ss.Set<BasicTypesEntity>().Where(x => (9 != x.Int ? x.Int : null) > 1));
+
+    [Fact]
+    public virtual async Task Conditional_uncoalesce_with_string()
+        => await AssertQuery(ss => ss.Set<BasicTypesEntity>().Where(x => (x.String == "Seattle" ? null : x.String) == "London"));
+
+    [Fact]
     public virtual async Task Coalesce()
         => await AssertQuery(ss => ss.Set<NullableBasicTypesEntity>().Where(b => (b.String ?? "Unknown") == "Seattle"));
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -873,9 +873,7 @@ LEFT JOIN [Gears] AS [g] ON [t].[GearNickName] = [g].[Nickname] AND [t].[GearSqu
 
         AssertSql(
             """
-SELECT CASE
-    WHEN [c].[Name] IS NOT NULL THEN [c].[Name]
-END
+SELECT [c].[Name]
 FROM [Tags] AS [t]
 LEFT JOIN [Gears] AS [g] ON [t].[GearNickName] = [g].[Nickname] AND [t].[GearSquadId] = [g].[SquadId]
 LEFT JOIN [Tags] AS [t0] ON ([g].[Nickname] = [t0].[GearNickName] OR ([g].[Nickname] IS NULL AND [t0].[GearNickName] IS NULL)) AND ([g].[SquadId] = [t0].[GearSquadId] OR ([g].[SquadId] IS NULL AND [t0].[GearSquadId] IS NULL))
@@ -2048,10 +2046,7 @@ WHERE [g].[HasSoulPatch] = CAST(0 AS bit)
 SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note]
 FROM [Tags] AS [t]
 LEFT JOIN [Gears] AS [g] ON [t].[GearNickName] = [g].[Nickname] AND [t].[GearSquadId] = [g].[SquadId]
-WHERE CASE
-    WHEN [g].[HasSoulPatch] = CAST(1 AS bit) THEN CAST(1 AS bit)
-    ELSE [g].[HasSoulPatch]
-END = CAST(0 AS bit)
+WHERE [g].[HasSoulPatch] = CAST(0 AS bit)
 """);
     }
 
@@ -2064,10 +2059,7 @@ END = CAST(0 AS bit)
 SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note]
 FROM [Tags] AS [t]
 LEFT JOIN [Gears] AS [g] ON [t].[GearNickName] = [g].[Nickname] AND [t].[GearSquadId] = [g].[SquadId]
-WHERE CASE
-    WHEN [g].[HasSoulPatch] = CAST(0 AS bit) THEN CAST(0 AS bit)
-    ELSE [g].[HasSoulPatch]
-END = CAST(0 AS bit)
+WHERE [g].[HasSoulPatch] = CAST(0 AS bit)
 """);
     }
 
@@ -3114,9 +3106,7 @@ WHERE [g].[Discriminator] = N'Officer' AND (
 
         AssertSql(
             """
-SELECT CASE
-    WHEN [f].[CommanderName] IS NOT NULL THEN [f].[CommanderName]
-END
+SELECT [f].[CommanderName]
 FROM [Factions] AS [f]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Inheritance/TPCGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Inheritance/TPCGearsOfWarQuerySqlServerTest.cs
@@ -1175,9 +1175,7 @@ LEFT JOIN (
 
         AssertSql(
             """
-SELECT CASE
-    WHEN [c].[Name] IS NOT NULL THEN [c].[Name]
-END
+SELECT [c].[Name]
 FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId]
@@ -2822,10 +2820,7 @@ LEFT JOIN (
     SELECT [o].[Nickname], [o].[SquadId], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
 ) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
-WHERE CASE
-    WHEN [u].[HasSoulPatch] = CAST(1 AS bit) THEN CAST(1 AS bit)
-    ELSE [u].[HasSoulPatch]
-END = CAST(0 AS bit)
+WHERE [u].[HasSoulPatch] = CAST(0 AS bit)
 """);
     }
 
@@ -2844,10 +2839,7 @@ LEFT JOIN (
     SELECT [o].[Nickname], [o].[SquadId], [o].[HasSoulPatch]
     FROM [Officers] AS [o]
 ) AS [u] ON [t].[GearNickName] = [u].[Nickname] AND [t].[GearSquadId] = [u].[SquadId]
-WHERE CASE
-    WHEN [u].[HasSoulPatch] = CAST(0 AS bit) THEN CAST(0 AS bit)
-    ELSE [u].[HasSoulPatch]
-END = CAST(0 AS bit)
+WHERE [u].[HasSoulPatch] = CAST(0 AS bit)
 """);
     }
 
@@ -4143,9 +4135,7 @@ WHERE [u].[Discriminator] = N'Officer' AND (
 
         AssertSql(
             """
-SELECT CASE
-    WHEN [l].[CommanderName] IS NOT NULL THEN [l].[CommanderName]
-END
+SELECT [l].[CommanderName]
 FROM [LocustHordes] AS [l]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Inheritance/TPTGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Inheritance/TPTGearsOfWarQuerySqlServerTest.cs
@@ -1053,9 +1053,7 @@ LEFT JOIN (
 
         AssertSql(
             """
-SELECT CASE
-    WHEN [c].[Name] IS NOT NULL THEN [c].[Name]
-END
+SELECT [c].[Name]
 FROM [Tags] AS [t]
 LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId]
@@ -2434,10 +2432,7 @@ LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[HasSoulPatch]
     FROM [Gears] AS [g]
 ) AS [s] ON [t].[GearNickName] = [s].[Nickname] AND [t].[GearSquadId] = [s].[SquadId]
-WHERE CASE
-    WHEN [s].[HasSoulPatch] = CAST(1 AS bit) THEN CAST(1 AS bit)
-    ELSE [s].[HasSoulPatch]
-END = CAST(0 AS bit)
+WHERE [s].[HasSoulPatch] = CAST(0 AS bit)
 """);
     }
 
@@ -2453,10 +2448,7 @@ LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[HasSoulPatch]
     FROM [Gears] AS [g]
 ) AS [s] ON [t].[GearNickName] = [s].[Nickname] AND [t].[GearSquadId] = [s].[SquadId]
-WHERE CASE
-    WHEN [s].[HasSoulPatch] = CAST(0 AS bit) THEN CAST(0 AS bit)
-    ELSE [s].[HasSoulPatch]
-END = CAST(0 AS bit)
+WHERE [s].[HasSoulPatch] = CAST(0 AS bit)
 """);
     }
 
@@ -3572,9 +3564,7 @@ WHERE [s].[Discriminator] = N'Officer' AND (
 
         AssertSql(
             """
-SELECT CASE
-    WHEN [l].[CommanderName] IS NOT NULL THEN [l].[CommanderName]
-END
+SELECT [l].[CommanderName]
 FROM [Factions] AS [f]
 LEFT JOIN [LocustHordes] AS [l] ON [f].[Id] = [l].[Id]
 WHERE [l].[Id] IS NOT NULL

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -2965,10 +2965,10 @@ SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE CASE
     WHEN [e].[NullableStringA] = [e].[NullableStringB] OR ([e].[NullableStringA] IS NULL AND [e].[NullableStringB] IS NULL) THEN [e].[NullableStringA]
-    ELSE [e].[NullableStringB]
+    ELSE [e].[NullableStringC]
 END = [e].[NullableStringC] OR (CASE
     WHEN [e].[NullableStringA] = [e].[NullableStringB] OR ([e].[NullableStringA] IS NULL AND [e].[NullableStringB] IS NULL) THEN [e].[NullableStringA]
-    ELSE [e].[NullableStringB]
+    ELSE [e].[NullableStringC]
 END IS NULL AND [e].[NullableStringC] IS NULL)
 """);
     }
@@ -2983,13 +2983,13 @@ SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE ([e].[NullableStringC] <> CASE
     WHEN [e].[NullableStringA] = [e].[NullableStringB] OR ([e].[NullableStringA] IS NULL AND [e].[NullableStringB] IS NULL) THEN [e].[NullableStringA]
-    ELSE [e].[NullableStringB]
+    ELSE [e].[NullableStringC]
 END OR [e].[NullableStringC] IS NULL OR CASE
     WHEN [e].[NullableStringA] = [e].[NullableStringB] OR ([e].[NullableStringA] IS NULL AND [e].[NullableStringB] IS NULL) THEN [e].[NullableStringA]
-    ELSE [e].[NullableStringB]
+    ELSE [e].[NullableStringC]
 END IS NULL) AND ([e].[NullableStringC] IS NOT NULL OR CASE
     WHEN [e].[NullableStringA] = [e].[NullableStringB] OR ([e].[NullableStringA] IS NULL AND [e].[NullableStringB] IS NULL) THEN [e].[NullableStringA]
-    ELSE [e].[NullableStringB]
+    ELSE [e].[NullableStringC]
 END IS NOT NULL)
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
@@ -669,10 +669,7 @@ LEFT JOIN (
 SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note], [t].[PeriodEnd], [t].[PeriodStart]
 FROM [Tags] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [t]
 LEFT JOIN [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g] ON [t].[GearNickName] = [g].[Nickname] AND [t].[GearSquadId] = [g].[SquadId]
-WHERE CASE
-    WHEN [g].[HasSoulPatch] = CAST(1 AS bit) THEN CAST(1 AS bit)
-    ELSE [g].[HasSoulPatch]
-END = CAST(0 AS bit)
+WHERE [g].[HasSoulPatch] = CAST(0 AS bit)
 """);
     }
 
@@ -1510,10 +1507,7 @@ WHERE [c].[Location] = 'Unknown'
 SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note], [t].[PeriodEnd], [t].[PeriodStart]
 FROM [Tags] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [t]
 LEFT JOIN [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g] ON [t].[GearNickName] = [g].[Nickname] AND [t].[GearSquadId] = [g].[SquadId]
-WHERE CASE
-    WHEN [g].[HasSoulPatch] = CAST(0 AS bit) THEN CAST(0 AS bit)
-    ELSE [g].[HasSoulPatch]
-END = CAST(0 AS bit)
+WHERE [g].[HasSoulPatch] = CAST(0 AS bit)
 """);
     }
 
@@ -5078,9 +5072,7 @@ ORDER BY [f].[Id], [g0].[Nickname]
 
         AssertSql(
             """
-SELECT CASE
-    WHEN [c].[Name] IS NOT NULL THEN [c].[Name]
-END
+SELECT [c].[Name]
 FROM [Tags] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [t]
 LEFT JOIN [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g] ON [t].[GearNickName] = [g].[Nickname] AND [t].[GearSquadId] = [g].[SquadId]
 LEFT JOIN [Tags] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [t0] ON ([g].[Nickname] = [t0].[GearNickName] OR ([g].[Nickname] IS NULL AND [t0].[GearNickName] IS NULL)) AND ([g].[SquadId] = [t0].[GearSquadId] OR ([g].[SquadId] IS NULL AND [t0].[GearSquadId] IS NULL))
@@ -6993,9 +6985,7 @@ WHERE [g].[Nickname] = [g0].[Nickname] AND [g].[SquadId] = [g0].[SquadId]
 
         AssertSql(
             """
-SELECT CASE
-    WHEN [f].[CommanderName] IS NOT NULL THEN [f].[CommanderName]
-END
+SELECT [f].[CommanderName]
 FROM [Factions] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [f]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Translations/Operators/MiscellaneousOperatorTranslationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Translations/Operators/MiscellaneousOperatorTranslationsSqlServerTest.cs
@@ -27,6 +27,90 @@ END = N'Seattle'
 """);
     }
 
+    public override async Task Conditional_simplifiable_equality()
+    {
+        await base.Conditional_simplifiable_equality();
+
+        AssertSql(
+            """
+SELECT [n].[Id], [n].[Bool], [n].[Byte], [n].[ByteArray], [n].[DateOnly], [n].[DateTime], [n].[DateTimeOffset], [n].[Decimal], [n].[Double], [n].[Enum], [n].[FlagsEnum], [n].[Float], [n].[Guid], [n].[Int], [n].[Long], [n].[Short], [n].[String], [n].[TimeOnly], [n].[TimeSpan]
+FROM [NullableBasicTypesEntities] AS [n]
+WHERE [n].[Int] > 1
+""");
+    }
+
+    public override async Task Conditional_simplifiable_inequality()
+    {
+        await base.Conditional_simplifiable_inequality();
+
+        AssertSql(
+            """
+SELECT [n].[Id], [n].[Bool], [n].[Byte], [n].[ByteArray], [n].[DateOnly], [n].[DateTime], [n].[DateTimeOffset], [n].[Decimal], [n].[Double], [n].[Enum], [n].[FlagsEnum], [n].[Float], [n].[Guid], [n].[Int], [n].[Long], [n].[Short], [n].[String], [n].[TimeOnly], [n].[TimeSpan]
+FROM [NullableBasicTypesEntities] AS [n]
+WHERE [n].[Int] > 1
+""");
+    }
+
+    public override async Task Conditional_uncoalesce_with_equality_left()
+    {
+        await base.Conditional_uncoalesce_with_equality_left();
+
+        AssertSql(
+            """
+SELECT [b].[Id], [b].[Bool], [b].[Byte], [b].[ByteArray], [b].[DateOnly], [b].[DateTime], [b].[DateTimeOffset], [b].[Decimal], [b].[Double], [b].[Enum], [b].[FlagsEnum], [b].[Float], [b].[Guid], [b].[Int], [b].[Long], [b].[Short], [b].[String], [b].[TimeOnly], [b].[TimeSpan]
+FROM [BasicTypesEntities] AS [b]
+WHERE NULLIF([b].[Int], 9) > 1
+""");
+    }
+
+    public override async Task Conditional_uncoalesce_with_equality_right()
+    {
+        await base.Conditional_uncoalesce_with_equality_right();
+
+        AssertSql(
+            """
+SELECT [b].[Id], [b].[Bool], [b].[Byte], [b].[ByteArray], [b].[DateOnly], [b].[DateTime], [b].[DateTimeOffset], [b].[Decimal], [b].[Double], [b].[Enum], [b].[FlagsEnum], [b].[Float], [b].[Guid], [b].[Int], [b].[Long], [b].[Short], [b].[String], [b].[TimeOnly], [b].[TimeSpan]
+FROM [BasicTypesEntities] AS [b]
+WHERE NULLIF([b].[Int], 9) > 1
+""");
+    }
+
+    public override async Task Conditional_uncoalesce_with_inequality_left()
+    {
+        await base.Conditional_uncoalesce_with_inequality_left();
+
+        AssertSql(
+            """
+SELECT [b].[Id], [b].[Bool], [b].[Byte], [b].[ByteArray], [b].[DateOnly], [b].[DateTime], [b].[DateTimeOffset], [b].[Decimal], [b].[Double], [b].[Enum], [b].[FlagsEnum], [b].[Float], [b].[Guid], [b].[Int], [b].[Long], [b].[Short], [b].[String], [b].[TimeOnly], [b].[TimeSpan]
+FROM [BasicTypesEntities] AS [b]
+WHERE NULLIF([b].[Int], 9) > 1
+""");
+    }
+
+    public override async Task Conditional_uncoalesce_with_inequality_right()
+    {
+        await base.Conditional_uncoalesce_with_inequality_right();
+
+        AssertSql(
+            """
+SELECT [b].[Id], [b].[Bool], [b].[Byte], [b].[ByteArray], [b].[DateOnly], [b].[DateTime], [b].[DateTimeOffset], [b].[Decimal], [b].[Double], [b].[Enum], [b].[FlagsEnum], [b].[Float], [b].[Guid], [b].[Int], [b].[Long], [b].[Short], [b].[String], [b].[TimeOnly], [b].[TimeSpan]
+FROM [BasicTypesEntities] AS [b]
+WHERE NULLIF([b].[Int], 9) > 1
+""");
+    }
+
+    public override async Task Conditional_uncoalesce_with_string()
+    {
+        await base.Conditional_uncoalesce_with_string();
+
+        AssertSql(
+            """
+SELECT [b].[Id], [b].[Bool], [b].[Byte], [b].[ByteArray], [b].[DateOnly], [b].[DateTime], [b].[DateTimeOffset], [b].[Decimal], [b].[Double], [b].[Enum], [b].[FlagsEnum], [b].[Float], [b].[Guid], [b].[Int], [b].[Long], [b].[Short], [b].[String], [b].[TimeOnly], [b].[TimeSpan]
+FROM [BasicTypesEntities] AS [b]
+WHERE NULLIF([b].[String], N'Seattle') = N'London'
+""");
+    }
+
     public override async Task Coalesce()
     {
         await base.Coalesce();

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -2536,9 +2536,7 @@ FROM "Squads" AS "s"
 
         AssertSql(
             """
-SELECT CASE
-    WHEN "c"."Name" IS NOT NULL THEN "c"."Name"
-END
+SELECT "c"."Name"
 FROM "Tags" AS "t"
 LEFT JOIN "Gears" AS "g" ON "t"."GearNickName" = "g"."Nickname" AND "t"."GearSquadId" = "g"."SquadId"
 LEFT JOIN "Tags" AS "t0" ON ("g"."Nickname" = "t0"."GearNickName" OR ("g"."Nickname" IS NULL AND "t0"."GearNickName" IS NULL)) AND ("g"."SquadId" = "t0"."GearSquadId" OR ("g"."SquadId" IS NULL AND "t0"."GearSquadId" IS NULL))
@@ -5572,9 +5570,7 @@ LEFT JOIN (
 
         AssertSql(
             """
-SELECT CASE
-    WHEN "f"."CommanderName" IS NOT NULL THEN "f"."CommanderName"
-END
+SELECT "f"."CommanderName"
 FROM "Factions" AS "f"
 """);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Translations/Operators/MiscellaneousOperatorTranslationsSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Translations/Operators/MiscellaneousOperatorTranslationsSqliteTest.cs
@@ -27,6 +27,90 @@ END = 'Seattle'
 """);
     }
 
+    public override async Task Conditional_simplifiable_equality()
+    {
+        await base.Conditional_simplifiable_equality();
+
+        AssertSql(
+            """
+SELECT "n"."Id", "n"."Bool", "n"."Byte", "n"."ByteArray", "n"."DateOnly", "n"."DateTime", "n"."DateTimeOffset", "n"."Decimal", "n"."Double", "n"."Enum", "n"."FlagsEnum", "n"."Float", "n"."Guid", "n"."Int", "n"."Long", "n"."Short", "n"."String", "n"."TimeOnly", "n"."TimeSpan"
+FROM "NullableBasicTypesEntities" AS "n"
+WHERE "n"."Int" > 1
+""");
+    }
+
+    public override async Task Conditional_simplifiable_inequality()
+    {
+        await base.Conditional_simplifiable_inequality();
+
+        AssertSql(
+            """
+SELECT "n"."Id", "n"."Bool", "n"."Byte", "n"."ByteArray", "n"."DateOnly", "n"."DateTime", "n"."DateTimeOffset", "n"."Decimal", "n"."Double", "n"."Enum", "n"."FlagsEnum", "n"."Float", "n"."Guid", "n"."Int", "n"."Long", "n"."Short", "n"."String", "n"."TimeOnly", "n"."TimeSpan"
+FROM "NullableBasicTypesEntities" AS "n"
+WHERE "n"."Int" > 1
+""");
+    }
+
+    public override async Task Conditional_uncoalesce_with_equality_left()
+    {
+        await base.Conditional_uncoalesce_with_equality_left();
+
+        AssertSql(
+            """
+SELECT "b"."Id", "b"."Bool", "b"."Byte", "b"."ByteArray", "b"."DateOnly", "b"."DateTime", "b"."DateTimeOffset", "b"."Decimal", "b"."Double", "b"."Enum", "b"."FlagsEnum", "b"."Float", "b"."Guid", "b"."Int", "b"."Long", "b"."Short", "b"."String", "b"."TimeOnly", "b"."TimeSpan"
+FROM "BasicTypesEntities" AS "b"
+WHERE NULLIF("b"."Int", 9) > 1
+""");
+    }
+
+    public override async Task Conditional_uncoalesce_with_equality_right()
+    {
+        await base.Conditional_uncoalesce_with_equality_right();
+
+        AssertSql(
+            """
+SELECT "b"."Id", "b"."Bool", "b"."Byte", "b"."ByteArray", "b"."DateOnly", "b"."DateTime", "b"."DateTimeOffset", "b"."Decimal", "b"."Double", "b"."Enum", "b"."FlagsEnum", "b"."Float", "b"."Guid", "b"."Int", "b"."Long", "b"."Short", "b"."String", "b"."TimeOnly", "b"."TimeSpan"
+FROM "BasicTypesEntities" AS "b"
+WHERE NULLIF("b"."Int", 9) > 1
+""");
+    }
+
+    public override async Task Conditional_uncoalesce_with_inequality_left()
+    {
+        await base.Conditional_uncoalesce_with_inequality_left();
+
+        AssertSql(
+            """
+SELECT "b"."Id", "b"."Bool", "b"."Byte", "b"."ByteArray", "b"."DateOnly", "b"."DateTime", "b"."DateTimeOffset", "b"."Decimal", "b"."Double", "b"."Enum", "b"."FlagsEnum", "b"."Float", "b"."Guid", "b"."Int", "b"."Long", "b"."Short", "b"."String", "b"."TimeOnly", "b"."TimeSpan"
+FROM "BasicTypesEntities" AS "b"
+WHERE NULLIF("b"."Int", 9) > 1
+""");
+    }
+
+    public override async Task Conditional_uncoalesce_with_inequality_right()
+    {
+        await base.Conditional_uncoalesce_with_inequality_right();
+
+        AssertSql(
+            """
+SELECT "b"."Id", "b"."Bool", "b"."Byte", "b"."ByteArray", "b"."DateOnly", "b"."DateTime", "b"."DateTimeOffset", "b"."Decimal", "b"."Double", "b"."Enum", "b"."FlagsEnum", "b"."Float", "b"."Guid", "b"."Int", "b"."Long", "b"."Short", "b"."String", "b"."TimeOnly", "b"."TimeSpan"
+FROM "BasicTypesEntities" AS "b"
+WHERE NULLIF("b"."Int", 9) > 1
+""");
+    }
+
+    public override async Task Conditional_uncoalesce_with_string()
+    {
+        await base.Conditional_uncoalesce_with_string();
+
+        AssertSql(
+            """
+SELECT "b"."Id", "b"."Bool", "b"."Byte", "b"."ByteArray", "b"."DateOnly", "b"."DateTime", "b"."DateTimeOffset", "b"."Decimal", "b"."Double", "b"."Enum", "b"."FlagsEnum", "b"."Float", "b"."Guid", "b"."Int", "b"."Long", "b"."Short", "b"."String", "b"."TimeOnly", "b"."TimeSpan"
+FROM "BasicTypesEntities" AS "b"
+WHERE NULLIF("b"."String", 'Seattle') = 'London'
+""");
+    }
+
     public override async Task Coalesce()
     {
         await base.Coalesce();


### PR DESCRIPTION
Originally done for PostgreSQL by @WhatzGames in https://github.com/npgsql/efcore.pg/pull/3403. Since all relational databases support it, moved this to EFCore.Relational and implemented as a construction-time optimization (in  SqlExpressionFactory), so that it potentially applies in scenarios other than just translation.

Closes #31682
