### PR TITLE
Add a CreateSpanCollation method on SqliteConnection

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
@@ -558,10 +558,10 @@ namespace Microsoft.Data.Sqlite
         /// <summary>
         /// Represents a method signature for a custom collation delegate that compares two read-only spans of characters.
         /// </summary>
+        /// <typeparam name="T">The type of the state object.</typeparam>
         /// <param name="state">An optional user-defined state object to be passed to the comparison function.</param>
         /// <param name="s1">The first read-only span of characters to compare.</param>
         /// <param name="s2">The second read-only span of characters to compare.</param>
-        /// <typeparam name="T">state type</typeparam>
         /// <returns>
         /// A signed integer indicating the relative order of the strings being compared:
         /// Less than zero if <paramref name="s1"/> precedes <paramref name="s2"/>;

--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
@@ -522,7 +522,7 @@ namespace Microsoft.Data.Sqlite
         /// <param name="state">State object passed to each invocation of the collation.</param>
         /// <param name="comparison">Method that compares two char spans, using additional state.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/collation">Collation</seealso>
-        public virtual void CreateSpanCollation<T>(string name, T state, SpanDelegateCollation? comparison)
+        public virtual void CreateSpanCollation<T>(string name, T state, SpanDelegateCollation<T>? comparison)
         {
             if (string.IsNullOrEmpty(name))
             {
@@ -561,13 +561,14 @@ namespace Microsoft.Data.Sqlite
         /// <param name="state">An optional user-defined state object to be passed to the comparison function.</param>
         /// <param name="s1">The first read-only span of characters to compare.</param>
         /// <param name="s2">The second read-only span of characters to compare.</param>
+        /// <typeparam name="T">state type</typeparam>
         /// <returns>
         /// A signed integer indicating the relative order of the strings being compared:
         /// Less than zero if <paramref name="s1"/> precedes <paramref name="s2"/>;
         /// Zero if <paramref name="s1"/> is equal to <paramref name="s2"/>;
         /// Greater than zero if <paramref name="s1"/> follows <paramref name="s2"/>.
         /// </returns>
-        public delegate int SpanDelegateCollation(in object? state, in ReadOnlySpan<char> s1, in ReadOnlySpan<char> s2);
+        public delegate int SpanDelegateCollation<in T>(T state, ReadOnlySpan<char> s1, ReadOnlySpan<char> s2);
 
         /// <summary>
         ///     Begins a transaction on the connection.


### PR DESCRIPTION
closes #35236 

Adds a new method to SqliteConnection which enables creating allocation free collation methods. Here's an example of using it:
```C#
var compareInfo = cultureProvider.GetCompareInfo(writingSystem);
connection.CreateSpanCollation(
    writingSystem,
    compareInfo,
    static (compareInfo, x, y) => compareInfo.Compare(x, y, CompareOptions.IgnoreCase)
);
```

<!--
Please check whether the PR fulfills these requirements
-->

- [x] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [x] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

There are no tests for the existing `CreateCollation` method, so it's unclear how or even if this new version should be tested also.
