### PR TITLE
Remove unnecessary repo name from dev container file paths

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,12 +10,12 @@
                 "EditorConfig.EditorConfig"
             ],
             "settings": {
-                "dotnet.dotnetPath": "${containerWorkspaceFolder}/efcore/.dotnet"
+                "dotnet.dotnetPath": "${containerWorkspaceFolder}/.dotnet"
             }
         }
     },
     "remoteEnv": {
-        "PATH": "${containerWorkspaceFolder}/efcore/.dotnet:${containerEnv:PATH}"
+        "PATH": "${containerWorkspaceFolder}/.dotnet:${containerEnv:PATH}"
     },
-    "onCreateCommand": "${containerWorkspaceFolder}/efcore/restore.sh"
+    "onCreateCommand": "${containerWorkspaceFolder}/restore.sh"
 }


### PR DESCRIPTION
The repo name is unnecessary as the `${containerWorkspaceFolder}` path will already include the repo name.

Fixes #36426

<!--
Please check whether the PR fulfills these requirements
-->

- [x] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [x] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo