### PR TITLE
Support Cosmos VectorDistance options and general cleanup

### DIFF
--- a/src/EFCore.Cosmos/Extensions/CosmosDbFunctionsExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosDbFunctionsExtensions.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.EntityFrameworkCore.Cosmos.Extensions;
+namespace Microsoft.EntityFrameworkCore;
 
 /// <summary>
 ///     Provides CLR methods that get translated to database functions when used in LINQ to Entities queries.
@@ -99,17 +99,7 @@ public static class CosmosDbFunctionsExtensions
     public static double Rrf(this DbFunctions _, params double[] scores)
         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(Rrf)));
 
-    /// <summary>
-    ///     Returns the distance between two vectors, using the distance function and data type defined using
-    ///     <see
-    ///         cref="CosmosPropertyBuilderExtensions.IsVectorProperty(Microsoft.EntityFrameworkCore.Metadata.Builders.PropertyBuilder,Microsoft.Azure.Cosmos.DistanceFunction,int)" />
-    ///     .
-    /// </summary>
-    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
-    /// <param name="vector1">The first vector.</param>
-    /// <param name="vector2">The second vector.</param>
-    public static double VectorDistance(this DbFunctions _, ReadOnlyMemory<byte> vector1, ReadOnlyMemory<byte> vector2)
-        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VectorDistance)));
+    #region VectorDistance
 
     /// <summary>
     ///     Returns the distance between two vectors, given a distance function (aka similarity measure).
@@ -118,115 +108,17 @@ public static class CosmosDbFunctionsExtensions
     /// <param name="vector1">The first vector.</param>
     /// <param name="vector2">The second vector.</param>
     /// <param name="useBruteForce">
-    ///     A <see langword="bool" /> specifying how the computed value is used in an ORDER BY
-    ///     expression. If <see langword="true" />, then brute force is used, otherwise any index defined on the vector
-    ///     property is leveraged.
+    ///     An optional boolean specifying how the computed value is used in an <c>ORDER BY</c> expression.
+    ///     If <see langword="true"/>, then brute force is used. A value of <see langword="false" /> uses any index defined on the vector
+    ///     property, if it exists. Default value is <see langword="false" />.
     /// </param>
-    public static double VectorDistance(
-        this DbFunctions _,
-        ReadOnlyMemory<byte> vector1,
-        ReadOnlyMemory<byte> vector2,
-        [NotParameterized] bool useBruteForce)
-        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VectorDistance)));
-
-    /// <summary>
-    ///     Returns the distance between two vectors, given a distance function (aka similarity measure).
-    /// </summary>
-    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
-    /// <param name="vector1">The first vector.</param>
-    /// <param name="vector2">The second vector.</param>
-    /// <param name="distanceFunction">The distance function to use.</param>
-    /// <param name="useBruteForce">
-    ///     A <see langword="bool" /> specifying how the computed value is used in an ORDER BY
-    ///     expression. If <see langword="true" />, then brute force is used, otherwise any index defined on the vector
-    ///     property is leveraged.
-    /// </param>
-    public static double VectorDistance(
-        this DbFunctions _,
-        ReadOnlyMemory<byte> vector1,
-        ReadOnlyMemory<byte> vector2,
-        [NotParameterized] bool useBruteForce,
-        [NotParameterized] DistanceFunction distanceFunction)
-        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VectorDistance)));
-
-    /// <summary>
-    ///     Returns the distance between two vectors, using the distance function and data type defined using
-    ///     <see
-    ///         cref="CosmosPropertyBuilderExtensions.IsVectorProperty(Microsoft.EntityFrameworkCore.Metadata.Builders.PropertyBuilder,Microsoft.Azure.Cosmos.DistanceFunction,int)" />
-    ///     .
-    /// </summary>
-    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
-    /// <param name="vector1">The first vector.</param>
-    /// <param name="vector2">The second vector.</param>
-    public static double VectorDistance(this DbFunctions _, ReadOnlyMemory<sbyte> vector1, ReadOnlyMemory<sbyte> vector2)
-        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VectorDistance)));
-
-    /// <summary>
-    ///     Returns the distance between two vectors, given a distance function (aka similarity measure).
-    /// </summary>
-    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
-    /// <param name="vector1">The first vector.</param>
-    /// <param name="vector2">The second vector.</param>
-    /// <param name="useBruteForce">
-    ///     A <see langword="bool" /> specifying how the computed value is used in an ORDER BY
-    ///     expression. If <see langword="true" />, then brute force is used, otherwise any index defined on the vector
-    ///     property is leveraged.
-    /// </param>
-    public static double VectorDistance(
-        this DbFunctions _,
-        ReadOnlyMemory<sbyte> vector1,
-        ReadOnlyMemory<sbyte> vector2,
-        [NotParameterized] bool useBruteForce)
-        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VectorDistance)));
-
-    /// <summary>
-    ///     Returns the distance between two vectors, given a distance function (aka similarity measure).
-    /// </summary>
-    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
-    /// <param name="vector1">The first vector.</param>
-    /// <param name="vector2">The second vector.</param>
-    /// <param name="distanceFunction">The distance function to use.</param>
-    /// <param name="useBruteForce">
-    ///     A <see langword="bool" /> specifying how the computed value is used in an ORDER BY
-    ///     expression. If <see langword="true" />, then brute force is used, otherwise any index defined on the vector
-    ///     property is leveraged.
-    /// </param>
-    public static double VectorDistance(
-        this DbFunctions _,
-        ReadOnlyMemory<sbyte> vector1,
-        ReadOnlyMemory<sbyte> vector2,
-        [NotParameterized] bool useBruteForce,
-        [NotParameterized] DistanceFunction distanceFunction)
-        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VectorDistance)));
-
-    /// <summary>
-    ///     Returns the distance between two vectors, using the distance function and data type defined using
-    ///     <see
-    ///         cref="CosmosPropertyBuilderExtensions.IsVectorProperty(Microsoft.EntityFrameworkCore.Metadata.Builders.PropertyBuilder,Microsoft.Azure.Cosmos.DistanceFunction,int)" />
-    ///     .
-    /// </summary>
-    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
-    /// <param name="vector1">The first vector.</param>
-    /// <param name="vector2">The second vector.</param>
-    public static double VectorDistance(this DbFunctions _, ReadOnlyMemory<float> vector1, ReadOnlyMemory<float> vector2)
-        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VectorDistance)));
-
-    /// <summary>
-    ///     Returns the distance between two vectors, given a distance function (aka similarity measure).
-    /// </summary>
-    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
-    /// <param name="vector1">The first vector.</param>
-    /// <param name="vector2">The second vector.</param>
-    /// <param name="useBruteForce">
-    ///     A <see langword="bool" /> specifying how the computed value is used in an ORDER BY
-    ///     expression. If <see langword="true" />, then brute force is used, otherwise any index defined on the vector
-    ///     property is leveraged.
-    /// </param>
+    /// <param name="options">An optional object used to specify options for the vector distance calculation.</param>
     public static double VectorDistance(
         this DbFunctions _,
         ReadOnlyMemory<float> vector1,
         ReadOnlyMemory<float> vector2,
-        [NotParameterized] bool useBruteForce)
+        [NotParameterized] bool? useBruteForce = null,
+        [NotParameterized] VectorDistanceOptions? options = null)
         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VectorDistance)));
 
     /// <summary>
@@ -235,17 +127,39 @@ public static class CosmosDbFunctionsExtensions
     /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
     /// <param name="vector1">The first vector.</param>
     /// <param name="vector2">The second vector.</param>
-    /// <param name="distanceFunction">The distance function to use.</param>
     /// <param name="useBruteForce">
-    ///     A <see langword="bool" /> specifying how the computed value is used in an ORDER BY
-    ///     expression. If <see langword="true" />, then brute force is used, otherwise any index defined on the vector
-    ///     property is leveraged.
+    ///     An optional boolean specifying how the computed value is used in an <c>ORDER BY</c> expression.
+    ///     If <see langword="true"/>, then brute force is used. A value of <see langword="false" /> uses any index defined on the vector
+    ///     property, if it exists. Default value is <see langword="false" />.
     /// </param>
+    /// <param name="options">An optional object used to specify options for the vector distance calculation.</param>
     public static double VectorDistance(
         this DbFunctions _,
-        ReadOnlyMemory<float> vector1,
-        ReadOnlyMemory<float> vector2,
-        [NotParameterized] bool useBruteForce,
-        [NotParameterized] DistanceFunction distanceFunction)
+        ReadOnlyMemory<byte> vector1,
+        ReadOnlyMemory<byte> vector2,
+        [NotParameterized] bool? useBruteForce = null,
+        [NotParameterized] VectorDistanceOptions? options = null)
         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VectorDistance)));
+
+    /// <summary>
+    ///     Returns the distance between two vectors, given a distance function (aka similarity measure).
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="vector1">The first vector.</param>
+    /// <param name="vector2">The second vector.</param>
+    /// <param name="useBruteForce">
+    ///     An optional boolean specifying how the computed value is used in an <c>ORDER BY</c> expression.
+    ///     If <see langword="true"/>, then brute force is used. A value of <see langword="false" /> uses any index defined on the vector
+    ///     property, if it exists. Default value is <see langword="false" />.
+    /// </param>
+    /// <param name="options">An optional object used to specify options for the vector distance calculation.</param>
+    public static double VectorDistance(
+        this DbFunctions _,
+        ReadOnlyMemory<sbyte> vector1,
+        ReadOnlyMemory<sbyte> vector2,
+        [NotParameterized] bool? useBruteForce = null,
+        [NotParameterized] VectorDistanceOptions? options = null)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VectorDistance)));
+
+    #endregion VectorDistance
 }

--- a/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
@@ -1221,6 +1221,7 @@ public class CosmosSqlTranslatingExpressionVisitor(
         => expression switch
         {
             ConstantExpression => true,
+            UnaryExpression e => CanEvaluate(e.Operand),
             NewExpression e => e.Arguments.All(CanEvaluate),
             NewArrayExpression e => e.Expressions.All(CanEvaluate),
             MemberInitExpression e => CanEvaluate(e.NewExpression)

--- a/src/EFCore.Cosmos/Query/Internal/Expressions/SelectExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/SelectExpression.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.EntityFrameworkCore.Cosmos.Extensions;
 using Microsoft.EntityFrameworkCore.Cosmos.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 

--- a/src/EFCore.Cosmos/Query/Internal/Translators/CosmosFullTextSearchTranslator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Translators/CosmosFullTextSearchTranslator.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.EntityFrameworkCore.Cosmos.Extensions;
-
 namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 
 /// <summary>

--- a/src/EFCore.Cosmos/Query/Internal/Translators/CosmosTypeCheckingTranslator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Translators/CosmosTypeCheckingTranslator.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.EntityFrameworkCore.Cosmos.Extensions;
-
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 

--- a/src/EFCore.Cosmos/Query/VectorDistanceOptions.cs
+++ b/src/EFCore.Cosmos/Query/VectorDistanceOptions.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore;
+
+/// <summary>
+///     Options to be passed to <see cref="CosmosDbFunctionsExtensions.VectorDistance(DbFunctions, ReadOnlyMemory{float}, ReadOnlyMemory{float}, bool?, VectorDistanceOptions)" />
+/// </summary>
+public sealed class VectorDistanceOptions
+{
+    /// <summary>
+    ///     The metric used to compute distance/similarity.
+    /// </summary>
+    public DistanceFunction? DistanceFunction { get; set; }
+
+    /// <summary>
+    ///     The data type of the vectors. <c>float32</c>, <c>int8</c>, <c>uint8</c> values. Default value is <c>float32</c>.
+    /// </summary>
+    public string? DataType { get; set; }
+
+    /// <summary>
+    ///     An integer specifying the size of the search list when conducting a vector search on the DiskANN index.
+    ///     Increasing this may improve accuracy at the expense of RU cost and latency. Min=1, Default=10, Max=100.
+    /// </summary>
+    public int? SearchListSizeMultiplier { get; set; }
+
+    /// <summary>
+    ///     An integer specifying the size of the search list when conducting a vector search on the quantizedFlat index.
+    ///     Increasing this may improve accuracy at the expense of RU cost and latency. Min=1, Default=5, Max=100.
+    /// </summary>
+    public int? QuantizedVectorListMultiplier { get; set; }
+}

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -1680,6 +1680,7 @@ public partial class RelationalSqlTranslatingExpressionVisitor : ExpressionVisit
         => expression switch
         {
             ConstantExpression => true,
+            UnaryExpression e => CanEvaluate(e.Operand),
             NewExpression e => e.Arguments.All(CanEvaluate),
             NewArrayExpression e => e.Expressions.All(CanEvaluate),
             MemberInitExpression e => CanEvaluate(e.NewExpression)

--- a/test/EFCore.Cosmos.FunctionalTests/FullTextSearchCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/FullTextSearchCosmosTest.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Azure.Cosmos;
-using Microsoft.EntityFrameworkCore.Cosmos.Extensions;
 using Microsoft.EntityFrameworkCore.Cosmos.Internal;
 
 namespace Microsoft.EntityFrameworkCore;

--- a/test/EFCore.Cosmos.FunctionalTests/HybridSearchCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/HybridSearchCosmosTest.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Azure.Cosmos;
-using Microsoft.EntityFrameworkCore.Cosmos.Extensions;
 
 namespace Microsoft.EntityFrameworkCore;
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/PrimitiveCollectionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/PrimitiveCollectionsQueryCosmosTest.cs
@@ -4,7 +4,6 @@
 using System.Net;
 using Microsoft.Azure.Cosmos;
 using Microsoft.EntityFrameworkCore.Cosmos.Diagnostics.Internal;
-using Microsoft.EntityFrameworkCore.Cosmos.Extensions;
 using Microsoft.EntityFrameworkCore.Cosmos.Internal;
 using Xunit.Sdk;
 


### PR DESCRIPTION
* Replace the 3rd parameter to EF.Functions.VectorDistance() to accept a new VectorDistanceOptions type with various options, rather than the previous DistanceFunction only.
* Collapse EF.Functions.VectorDistance() overloads together using optional parameters, with the new C# support for optional parameters in expression tree method invocations.
* Reorganize and cleanup tests

Closes #36447

/cc @artl93 