### PR TITLE
Temporarily disable the JSON data type on Azure SQL

### DIFF
--- a/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerSingletonOptions.cs
+++ b/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerSingletonOptions.cs
@@ -70,7 +70,11 @@ public class SqlServerSingletonOptions : ISqlServerSingletonOptions
         => EngineType switch
         {
             SqlServerEngineType.SqlServer => SqlServerCompatibilityLevel >= 170,
-            SqlServerEngineType.AzureSql => AzureSqlCompatibilityLevel >= 170,
+            // TODO: #36460
+            // At the time of writing, Azure SQL Database does not yet support OPENJSON over the JSON data type.
+            // This should get reenabled by the time we GA.
+            SqlServerEngineType.AzureSql => false,
+            // SqlServerEngineType.AzureSql => AzureSqlCompatibilityLevel >= 170,
             SqlServerEngineType.AzureSynapse => false,
             SqlServerEngineType.Unknown => false, // TODO: We shouldn't observe Unknown here, #36477
             _ => throw new UnreachableException()

--- a/test/EFCore.SqlServer.Tests/Storage/SqlServerTypeMappingSourceTest.cs
+++ b/test/EFCore.SqlServer.Tests/Storage/SqlServerTypeMappingSourceTest.cs
@@ -1588,8 +1588,13 @@ public class SqlServerTypeMappingSourceTest : RelationalTypeMappingSourceTestBas
     {
         var typeMappingSource = CreateTypeMappingSource(o => o.UseAzureSql());
 
-        Assert.Equal("json", typeMappingSource.GetMapping(typeof(JsonTypePlaceholder)).StoreType);
-        Assert.Equal("json", typeMappingSource.GetMapping(typeof(int[])).StoreType);
+        // TODO: #36460
+        // At the time of writing, Azure SQL Database does not yet support OPENJSON over the JSON data type.
+        // This should get reenabled by the time we GA.
+        Assert.Equal("nvarchar(max)", typeMappingSource.GetMapping(typeof(JsonTypePlaceholder)).StoreType);
+        Assert.Equal("nvarchar(max)", typeMappingSource.GetMapping(typeof(int[])).StoreType);
+        // Assert.Equal("json", typeMappingSource.GetMapping(typeof(JsonTypePlaceholder)).StoreType);
+        // Assert.Equal("json", typeMappingSource.GetMapping(typeof(int[])).StoreType);
     }
 
     [ConditionalFact]


### PR DESCRIPTION
At this specific time, Azure SQL Database does not yet support passing the new JSON data type to the OPENJSON() function; the preview version of SQL Server 2025 does support it. Support is expected to appear very soon on Azure SQL, but we shouldn't take the risk of releasing an rc.1 which is effectively broken on Azure SQL.

This is a one-line, zero-risk PR which temporarily reverts defaulting to the new JSON data type, on Azure SQL only. My expectation is that we'll reenable this for rc.2.

/cc @sampatel @artl93 