### PR TITLE
Fix type mapping for GETDATE and GETUTCDATE in SqlServer.

### DIFF
--- a/src/EFCore.SqlServer/Query/Internal/Translators/SqlServerDateTimeMemberTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/Translators/SqlServerDateTimeMemberTranslator.cs
@@ -69,12 +69,24 @@ public class SqlServerDateTimeMemberTranslator(
                     returnType),
 
             nameof(DateTime.Now)
+                when declaringType == typeof(DateTime)
                 => sqlExpressionFactory.Function(
-                    declaringType == typeof(DateTime) ? "GETDATE" : "SYSDATETIMEOFFSET",
+                    "GETDATE",
                     arguments: [],
                     nullable: false,
                     argumentsPropagateNullability: [],
-                    returnType),
+                    typeof(DateTime),
+                    typeMappingSource.FindMapping("datetime")),
+
+            nameof(DateTimeOffset.Now)
+                when declaringType == typeof(DateTimeOffset)
+                => sqlExpressionFactory.Function(
+                    "SYSDATETIMEOFFSET",
+                    arguments: [],
+                    nullable: false,
+                    argumentsPropagateNullability: [],
+                    typeof(DateTimeOffset),
+                    typeMappingSource.FindMapping("datetimeoffset")),
 
             nameof(DateTime.UtcNow)
                 when declaringType == typeof(DateTime)
@@ -83,9 +95,10 @@ public class SqlServerDateTimeMemberTranslator(
                     arguments: [],
                     nullable: false,
                     argumentsPropagateNullability: [],
-                    returnType),
+                    typeof(DateTime),
+                    typeMappingSource.FindMapping("datetime")),
 
-            nameof(DateTime.UtcNow)
+            nameof(DateTimeOffset.UtcNow)
                 when declaringType == typeof(DateTimeOffset)
                 => sqlExpressionFactory.Convert(
                     sqlExpressionFactory.Function(
@@ -93,7 +106,10 @@ public class SqlServerDateTimeMemberTranslator(
                         arguments: [],
                         nullable: false,
                         argumentsPropagateNullability: [],
-                        returnType), returnType),
+                        typeof(DateTime),
+                        typeMappingSource.FindMapping("datetime2")),
+                    typeof(DateTimeOffset),
+                    typeMappingSource.FindMapping("datetimeoffset")),
 
             nameof(DateTime.Today)
                 => sqlExpressionFactory.Function(

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Translations/Temporal/DateTimeOffsetTranslationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Translations/Temporal/DateTimeOffsetTranslationsSqlServerTest.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.EntityFrameworkCore.TestModels.BasicTypesModel;
+
 namespace Microsoft.EntityFrameworkCore.Query.Translations.Temporal;
 
 public class DateTimeOffsetTranslationsSqlServerTest : DateTimeOffsetTranslationsTestBase<BasicTypesQuerySqlServerFixture>
@@ -295,6 +297,34 @@ WHERE DATEDIFF_BIG(second, '1970-01-01T00:00:00.0000000+00:00', [b].[DateTimeOff
 SELECT COUNT(*)
 FROM [BasicTypesEntities] AS [b]
 WHERE [b].[DateTimeOffset] = '1902-01-02T10:00:00.1234567+01:30'
+""");
+    }
+
+    [ConditionalFact]
+    public virtual async Task Now_has_proper_type_mapping_for_constant_comparison()
+    {
+        await AssertQuery(
+            ss => ss.Set<BasicTypesEntity>().Where(x => DateTimeOffset.Now > new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)));
+
+        AssertSql(
+            """
+SELECT [b].[Id], [b].[Bool], [b].[Byte], [b].[ByteArray], [b].[DateOnly], [b].[DateTime], [b].[DateTimeOffset], [b].[Decimal], [b].[Double], [b].[Enum], [b].[FlagsEnum], [b].[Float], [b].[Guid], [b].[Int], [b].[Long], [b].[Short], [b].[String], [b].[TimeOnly], [b].[TimeSpan]
+FROM [BasicTypesEntities] AS [b]
+WHERE SYSDATETIMEOFFSET() > '2025-01-01T00:00:00.0000000+00:00'
+""");
+    }
+
+    [ConditionalFact]
+    public virtual async Task UtcNow_has_proper_type_mapping_for_constant_comparison()
+    {
+        await AssertQuery(
+            ss => ss.Set<BasicTypesEntity>().Where(x => DateTimeOffset.UtcNow > new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)));
+
+        AssertSql(
+            """
+SELECT [b].[Id], [b].[Bool], [b].[Byte], [b].[ByteArray], [b].[DateOnly], [b].[DateTime], [b].[DateTimeOffset], [b].[Decimal], [b].[Double], [b].[Enum], [b].[FlagsEnum], [b].[Float], [b].[Guid], [b].[Int], [b].[Long], [b].[Short], [b].[String], [b].[TimeOnly], [b].[TimeSpan]
+FROM [BasicTypesEntities] AS [b]
+WHERE CAST(SYSUTCDATETIME() AS datetimeoffset) > '2025-01-01T00:00:00.0000000+00:00'
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Translations/Temporal/DateTimeTranslationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Translations/Temporal/DateTimeTranslationsSqlServerTest.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.EntityFrameworkCore.TestModels.BasicTypesModel;
+
 namespace Microsoft.EntityFrameworkCore.Query.Translations.Temporal;
 
 public class DateTimeTranslationsSqlServerTest : DateTimeTranslationsTestBase<BasicTypesQuerySqlServerFixture>
@@ -18,7 +20,7 @@ public class DateTimeTranslationsSqlServerTest : DateTimeTranslationsTestBase<Ba
 
         AssertSql(
             """
-@myDatetime='2015-04-10T00:00:00.0000000'
+@myDatetime='2015-04-10T00:00:00.0000000' (DbType = DateTime)
 
 SELECT [b].[Id], [b].[Bool], [b].[Byte], [b].[ByteArray], [b].[DateOnly], [b].[DateTime], [b].[DateTimeOffset], [b].[Decimal], [b].[Double], [b].[Enum], [b].[FlagsEnum], [b].[Float], [b].[Guid], [b].[Int], [b].[Long], [b].[Short], [b].[String], [b].[TimeOnly], [b].[TimeSpan]
 FROM [BasicTypesEntities] AS [b]
@@ -32,7 +34,7 @@ WHERE GETDATE() <> @myDatetime
 
         AssertSql(
             """
-@myDatetime='2015-04-10T00:00:00.0000000'
+@myDatetime='2015-04-10T00:00:00.0000000' (DbType = DateTime)
 
 SELECT [b].[Id], [b].[Bool], [b].[Byte], [b].[ByteArray], [b].[DateOnly], [b].[DateTime], [b].[DateTimeOffset], [b].[Decimal], [b].[Double], [b].[Enum], [b].[FlagsEnum], [b].[Float], [b].[Guid], [b].[Int], [b].[Long], [b].[Short], [b].[String], [b].[TimeOnly], [b].[TimeSpan]
 FROM [BasicTypesEntities] AS [b]
@@ -238,6 +240,34 @@ WHERE [b].[DateTime] = '1998-05-04T15:30:10.0000000'
 SELECT [b].[Id], [b].[Bool], [b].[Byte], [b].[ByteArray], [b].[DateOnly], [b].[DateTime], [b].[DateTimeOffset], [b].[Decimal], [b].[Double], [b].[Enum], [b].[FlagsEnum], [b].[Float], [b].[Guid], [b].[Int], [b].[Long], [b].[Short], [b].[String], [b].[TimeOnly], [b].[TimeSpan]
 FROM [BasicTypesEntities] AS [b]
 WHERE [b].[DateTime] = @p
+""");
+    }
+
+    [ConditionalFact]
+    public virtual async Task Now_has_proper_type_mapping_for_constant_comparison()
+    {
+        await AssertQuery(
+            ss => ss.Set<BasicTypesEntity>().Where(x => DateTime.Now > new DateTime(2025, 1, 1)));
+
+        AssertSql(
+            """
+SELECT [b].[Id], [b].[Bool], [b].[Byte], [b].[ByteArray], [b].[DateOnly], [b].[DateTime], [b].[DateTimeOffset], [b].[Decimal], [b].[Double], [b].[Enum], [b].[FlagsEnum], [b].[Float], [b].[Guid], [b].[Int], [b].[Long], [b].[Short], [b].[String], [b].[TimeOnly], [b].[TimeSpan]
+FROM [BasicTypesEntities] AS [b]
+WHERE GETDATE() > '2025-01-01T00:00:00.000'
+""");
+    }
+
+    [ConditionalFact]
+    public virtual async Task UtcNow_has_proper_type_mapping_for_constant_comparison()
+    {
+        await AssertQuery(
+            ss => ss.Set<BasicTypesEntity>().Where(x => DateTime.UtcNow > new DateTime(2025, 1, 1)));
+
+        AssertSql(
+            """
+SELECT [b].[Id], [b].[Bool], [b].[Byte], [b].[ByteArray], [b].[DateOnly], [b].[DateTime], [b].[DateTimeOffset], [b].[Decimal], [b].[Double], [b].[Enum], [b].[FlagsEnum], [b].[Float], [b].[Guid], [b].[Int], [b].[Long], [b].[Short], [b].[String], [b].[TimeOnly], [b].[TimeSpan]
+FROM [BasicTypesEntities] AS [b]
+WHERE GETUTCDATE() > '2025-01-01T00:00:00.000'
 """);
     }
 


### PR DESCRIPTION
Fixes #36479.

### Description

Fixes type mapping for GETDATE and GETUTCDATE in SqlServer, which is especially important when comparing with non-column (i.e. constant).

### Customer impact

Generated query is rejected by SQL Server and throws error.

### How found

Customer reported on 9.

### Regression

No.

### Testing

Tests added.

### Risk

Low. This is a specific case for only these two functions.