### PR TITLE
[rc2] Stop transforming complex property access to EF.Property

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosQueryTranslationPostprocessorFactory.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQueryTranslationPostprocessorFactory.cs
@@ -25,6 +25,7 @@ public class CosmosQueryTranslationPostprocessorFactory(
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    [DebuggerStepThrough]
     public virtual QueryTranslationPostprocessor Create(QueryCompilationContext queryCompilationContext)
         => new CosmosQueryTranslationPostprocessor(
             Dependencies,

--- a/src/EFCore.Cosmos/Query/Internal/CosmosQueryTranslationPreprocessorFactory.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQueryTranslationPreprocessorFactory.cs
@@ -23,6 +23,7 @@ public class CosmosQueryTranslationPreprocessorFactory(QueryTranslationPreproces
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    [DebuggerStepThrough]
     public virtual QueryTranslationPreprocessor Create(QueryCompilationContext queryCompilationContext)
         => new CosmosQueryTranslationPreprocessor(Dependencies, (CosmosQueryCompilationContext)queryCompilationContext);
 }

--- a/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitorFactory.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitorFactory.cs
@@ -28,6 +28,7 @@ public class CosmosQueryableMethodTranslatingExpressionVisitorFactory(
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    [DebuggerStepThrough]
     public virtual QueryableMethodTranslatingExpressionVisitor Create(QueryCompilationContext queryCompilationContext)
         => new CosmosQueryableMethodTranslatingExpressionVisitor(
             Dependencies,

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitorFactory.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitorFactory.cs
@@ -28,6 +28,7 @@ public class CosmosShapedQueryCompilingExpressionVisitorFactory(
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    [DebuggerStepThrough]
     public virtual ShapedQueryCompilingExpressionVisitor Create(QueryCompilationContext queryCompilationContext)
         => new CosmosShapedQueryCompilingExpressionVisitor(
             Dependencies,

--- a/src/EFCore.InMemory/Query/Internal/InMemoryQueryTranslationPreprocessorFactory.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryQueryTranslationPreprocessorFactory.cs
@@ -32,6 +32,7 @@ public class InMemoryQueryTranslationPreprocessorFactory : IQueryTranslationPrep
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    [DebuggerStepThrough]
     public virtual QueryTranslationPreprocessor Create(QueryCompilationContext queryCompilationContext)
         => new InMemoryQueryTranslationPreprocessor(Dependencies, queryCompilationContext);
 }

--- a/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitorFactory.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitorFactory.cs
@@ -32,6 +32,7 @@ public class InMemoryQueryableMethodTranslatingExpressionVisitorFactory : IQuery
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    [DebuggerStepThrough]
     public virtual QueryableMethodTranslatingExpressionVisitor Create(QueryCompilationContext queryCompilationContext)
         => new InMemoryQueryableMethodTranslatingExpressionVisitor(Dependencies, queryCompilationContext);
 }

--- a/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryExpressionVisitorFactory.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryExpressionVisitorFactory.cs
@@ -32,6 +32,7 @@ public class InMemoryShapedQueryCompilingExpressionVisitorFactory : IShapedQuery
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    [DebuggerStepThrough]
     public virtual ShapedQueryCompilingExpressionVisitor Create(QueryCompilationContext queryCompilationContext)
         => new InMemoryShapedQueryCompilingExpressionVisitor(Dependencies, queryCompilationContext);
 }

--- a/src/EFCore.Relational/Query/Internal/RelationalQueryTranslationPostprocessorFactory.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalQueryTranslationPostprocessorFactory.cs
@@ -41,6 +41,7 @@ public class RelationalQueryTranslationPostprocessorFactory : IQueryTranslationP
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    [DebuggerStepThrough]
     public virtual QueryTranslationPostprocessor Create(QueryCompilationContext queryCompilationContext)
         => new RelationalQueryTranslationPostprocessor(
             Dependencies,

--- a/src/EFCore.Relational/Query/Internal/RelationalQueryTranslationPreprocessorFactory.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalQueryTranslationPreprocessorFactory.cs
@@ -41,6 +41,7 @@ public class RelationalQueryTranslationPreprocessorFactory : IQueryTranslationPr
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    [DebuggerStepThrough]
     public virtual QueryTranslationPreprocessor Create(QueryCompilationContext queryCompilationContext)
         => new RelationalQueryTranslationPreprocessor(Dependencies, RelationalDependencies, queryCompilationContext);
 }

--- a/src/EFCore.Relational/Query/Internal/RelationalQueryableMethodTranslatingExpressionVisitorFactory.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalQueryableMethodTranslatingExpressionVisitorFactory.cs
@@ -41,6 +41,7 @@ public class RelationalQueryableMethodTranslatingExpressionVisitorFactory : IQue
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    [DebuggerStepThrough]
     public virtual QueryableMethodTranslatingExpressionVisitor Create(QueryCompilationContext queryCompilationContext)
         => new RelationalQueryableMethodTranslatingExpressionVisitor(
             Dependencies,

--- a/src/EFCore.Relational/Query/Internal/RelationalShapedQueryCompilingExpressionVisitorFactory.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalShapedQueryCompilingExpressionVisitorFactory.cs
@@ -41,6 +41,7 @@ public class RelationalShapedQueryCompilingExpressionVisitorFactory : IShapedQue
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    [DebuggerStepThrough]
     public virtual ShapedQueryCompilingExpressionVisitor Create(QueryCompilationContext queryCompilationContext)
         => new RelationalShapedQueryCompilingExpressionVisitor(
             Dependencies,

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQueryTranslationPostprocessorFactory.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQueryTranslationPostprocessorFactory.cs
@@ -41,6 +41,7 @@ public class SqlServerQueryTranslationPostprocessorFactory : IQueryTranslationPo
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    [DebuggerStepThrough]
     public virtual QueryTranslationPostprocessor Create(QueryCompilationContext queryCompilationContext)
         => new SqlServerQueryTranslationPostprocessor(
             Dependencies, RelationalDependencies, (SqlServerQueryCompilationContext)queryCompilationContext);

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitorFactory.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitorFactory.cs
@@ -47,6 +47,7 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitorFactory : IQuer
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    [DebuggerStepThrough]
     public virtual QueryableMethodTranslatingExpressionVisitor Create(QueryCompilationContext queryCompilationContext)
         => new SqlServerQueryableMethodTranslatingExpressionVisitor(
             Dependencies, RelationalDependencies, (SqlServerQueryCompilationContext)queryCompilationContext, _sqlServerSingletonOptions);

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryTranslationPostprocessorFactory.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryTranslationPostprocessorFactory.cs
@@ -41,6 +41,7 @@ public class SqliteQueryTranslationPostprocessorFactory : IQueryTranslationPostp
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    [DebuggerStepThrough]
     public virtual QueryTranslationPostprocessor Create(QueryCompilationContext queryCompilationContext)
         => new SqliteQueryTranslationPostprocessor(
             Dependencies,

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryableMethodTranslatingExpressionVisitorFactory.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryableMethodTranslatingExpressionVisitorFactory.cs
@@ -41,6 +41,7 @@ public class SqliteQueryableMethodTranslatingExpressionVisitorFactory : IQueryab
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    [DebuggerStepThrough]
     public virtual QueryableMethodTranslatingExpressionVisitor Create(QueryCompilationContext queryCompilationContext)
         => new SqliteQueryableMethodTranslatingExpressionVisitor(
             Dependencies, RelationalDependencies, (RelationalQueryCompilationContext)queryCompilationContext);

--- a/src/EFCore/Query/IQueryTranslationPreprocessorFactory.cs
+++ b/src/EFCore/Query/IQueryTranslationPreprocessorFactory.cs
@@ -25,5 +25,6 @@ public interface IQueryTranslationPreprocessorFactory
     /// </summary>
     /// <param name="queryCompilationContext">The query compilation context to use.</param>
     /// <returns>The created visitor.</returns>
+    [DebuggerStepThrough]
     QueryTranslationPreprocessor Create(QueryCompilationContext queryCompilationContext);
 }

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.Expressions.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.Expressions.cs
@@ -477,7 +477,7 @@ public partial class NavigationExpandingExpressionVisitor
     /// <summary>
     ///     Queryable properties are not expanded (similar to <see cref="OwnedNavigationReference" />.
     /// </summary>
-    private sealed class ComplexPropertyReference(Expression parent, IComplexProperty complexProperty)
+    private sealed class ComplexPropertyReference(Expression parent, IComplexProperty complexProperty, Expression originalExpression)
         : Expression, IPrintableExpression
     {
         protected override Expression VisitChildren(ExpressionVisitor visitor)
@@ -489,6 +489,7 @@ public partial class NavigationExpandingExpressionVisitor
 
         public Expression Parent { get; private set; } = parent;
         public new IComplexProperty Property { get; } = complexProperty;
+        public Expression OriginalExpression { get; private set; } = originalExpression;
         public ComplexTypeReference ComplexTypeReference { get; } = new(complexProperty.ComplexType);
 
         public override Type Type

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
@@ -276,7 +276,7 @@ public partial class NavigationExpandingExpressionVisitor : ExpressionVisitor
             } complexPropertyReference
             && complexProperty.ComplexType.FindComplexProperty(memberExpression.Member) is { } nestedComplexProperty)
         {
-            return new ComplexPropertyReference(complexPropertyReference, nestedComplexProperty);
+            return new ComplexPropertyReference(complexPropertyReference, nestedComplexProperty, memberExpression);
         }
 
         // Convert ICollection<T>.Count to Count<T>()

--- a/src/EFCore/Query/Internal/QueryTranslationPostprocessorFactory.cs
+++ b/src/EFCore/Query/Internal/QueryTranslationPostprocessorFactory.cs
@@ -34,6 +34,7 @@ public class QueryTranslationPostprocessorFactory : IQueryTranslationPostprocess
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    [DebuggerStepThrough]
     public virtual QueryTranslationPostprocessor Create(QueryCompilationContext queryCompilationContext)
         => new(Dependencies, queryCompilationContext);
 }

--- a/src/EFCore/Query/Internal/QueryTranslationPreprocessorFactory.cs
+++ b/src/EFCore/Query/Internal/QueryTranslationPreprocessorFactory.cs
@@ -34,6 +34,7 @@ public class QueryTranslationPreprocessorFactory : IQueryTranslationPreprocessor
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    [DebuggerStepThrough]
     public virtual QueryTranslationPreprocessor Create(QueryCompilationContext queryCompilationContext)
         => new(Dependencies, queryCompilationContext);
 }

--- a/src/EFCore/Query/QueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore/Query/QueryableMethodTranslatingExpressionVisitor.cs
@@ -580,9 +580,11 @@ public abstract class QueryableMethodTranslatingExpressionVisitor : ExpressionVi
                         when genericMethod == QueryableMethods.Where:
                         return CheckTranslated(TranslateWhere(shapedQueryExpression, GetLambdaExpressionFromArgument(1)));
 
+                        [DebuggerStepThrough]
                         LambdaExpression GetLambdaExpressionFromArgument(int argumentIndex)
                             => methodCallExpression.Arguments[argumentIndex].UnwrapLambdaFromQuote();
 
+                        [DebuggerStepThrough]
                         Expression CheckTranslated(ShapedQueryExpression? translated)
                         {
                             if (translated is not null)
@@ -604,7 +606,8 @@ public abstract class QueryableMethodTranslatingExpressionVisitor : ExpressionVi
 
         // The method isn't a LINQ operator on Queryable/QueryableExtensions.
 
-        // Identify property access, e.g. primitive collection property (context.Blogs.Where(b => b.Tags.Contains(...)))
+        // Identify property access, i.e. primitive collection property (context.Blogs.Where(b => b.Tags.Contains(...))),
+        // complex collection property...
         if (IsMemberAccess(methodCallExpression, QueryCompilationContext.Model, out var propertyAccessSource, out var propertyName)
             && TranslateMemberAccess(propertyAccessSource, propertyName) is { } translation)
         {
@@ -617,6 +620,25 @@ public abstract class QueryableMethodTranslatingExpressionVisitor : ExpressionVi
                 ? throw new InvalidOperationException(CoreStrings.TranslationFailed(methodCallExpression.Print()))
                 : throw new InvalidOperationException(
                     CoreStrings.TranslationFailedWithDetails(methodCallExpression.Print(), TranslationErrorDetails));
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitMember(MemberExpression memberExpression)
+    {
+        // Identify property access, i.e. primitive collection property (context.Blogs.Where(b => b.Tags.Contains(...))),
+        // complex collection property...
+        if (IsMemberAccess(memberExpression, QueryCompilationContext.Model, out var propertyAccessSource, out var propertyName)
+            && TranslateMemberAccess(propertyAccessSource, propertyName) is { } translation)
+        {
+            return translation;
+        }
+
+        return _subquery
+            ? QueryCompilationContext.NotTranslatedExpression
+            : TranslationErrorDetails is null
+                ? throw new InvalidOperationException(CoreStrings.TranslationFailed(memberExpression.Print()))
+                : throw new InvalidOperationException(
+                    CoreStrings.TranslationFailedWithDetails(memberExpression.Print(), TranslationErrorDetails));
     }
 
     private sealed class EntityShaperNullableMarkingExpressionVisitor : ExpressionVisitor

--- a/test/EFCore.Cosmos.FunctionalTests/Query/Associations/OwnedNavigations/OwnedNavigationsProjectionCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/Associations/OwnedNavigations/OwnedNavigationsProjectionCosmosTest.cs
@@ -23,7 +23,7 @@ FROM root c
 """);
     }
 
-    #region Simple properties
+    #region Scalar properties
 
     public override async Task Select_property_on_required_related(QueryTrackingBehavior queryTrackingBehavior)
     {
@@ -84,9 +84,9 @@ FROM root c
 """);
     }
 
-    #endregion Simple properties
+    #endregion Scalar properties
 
-    #region Non-collection
+    #region Structural properties
 
     public override async Task Select_related(QueryTrackingBehavior queryTrackingBehavior)
     {
@@ -194,9 +194,34 @@ FROM root c
         // We don't support (inter-document) navigations with Cosmos.
         => Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_required_related_via_optional_navigation(queryTrackingBehavior));
 
-    #endregion Non-collection
+    public override async Task Select_unmapped_related_scalar_property(QueryTrackingBehavior queryTrackingBehavior)
+    {
+        await base.Select_unmapped_related_scalar_property(queryTrackingBehavior);
 
-    #region Collection
+        if (queryTrackingBehavior is not QueryTrackingBehavior.TrackAll)
+        {
+            AssertSql(
+                """
+SELECT VALUE c
+FROM root c
+""");
+        }
+    }
+
+    public override async Task Select_untranslatable_method_on_related_scalar_property(QueryTrackingBehavior queryTrackingBehavior)
+    {
+        await base.Select_untranslatable_method_on_related_scalar_property(queryTrackingBehavior);
+
+        AssertSql(
+            """
+SELECT VALUE c["RequiredRelated"]["Int"]
+FROM root c
+""");
+    }
+
+    #endregion Structural properties
+
+    #region Structural collection properties
 
     public override async Task Select_related_collection(QueryTrackingBehavior queryTrackingBehavior)
     {
@@ -280,7 +305,7 @@ ORDER BY c["Id"]
         }
     }
 
-    #endregion Collection
+    #endregion Structural collection properties
 
     #region Multiple
 

--- a/test/EFCore.Relational.Specification.Tests/Query/Associations/ComplexTableSplitting/ComplexTableSplittingProjectionRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/Associations/ComplexTableSplitting/ComplexTableSplittingProjectionRelationalTestBase.cs
@@ -16,14 +16,6 @@ public abstract class ComplexTableSplittingProjectionRelationalTestBase<TFixture
     }
 
     // Collections are not supported with table splitting, only JSON
-    public override Task Select_nested_collection_on_required_related(QueryTrackingBehavior queryTrackingBehavior)
-        => Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_nested_collection_on_required_related(queryTrackingBehavior));
-
-    // Collections are not supported with table splitting, only JSON
-    public override Task Select_nested_collection_on_optional_related(QueryTrackingBehavior queryTrackingBehavior)
-        => Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_nested_collection_on_optional_related(queryTrackingBehavior));
-
-    // Collections are not supported with table splitting, only JSON
     public override Task SelectMany_related_collection(QueryTrackingBehavior queryTrackingBehavior)
         => Assert.ThrowsAsync<InvalidOperationException>(() => base.SelectMany_related_collection(queryTrackingBehavior));
 

--- a/test/EFCore.Relational.Specification.Tests/Query/PrecompiledQueryRelationalFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/PrecompiledQueryRelationalFixture.cs
@@ -102,6 +102,7 @@ public abstract class PrecompiledQueryRelationalFixture
         RelationalShapedQueryCompilingExpressionVisitorDependencies relationalDependencies)
         : IShapedQueryCompilingExpressionVisitorFactory
     {
+        [DebuggerStepThrough]
         public ShapedQueryCompilingExpressionVisitor Create(QueryCompilationContext queryCompilationContext)
             => new NonSqlGeneratingShapedQueryCompilingExpressionVisitor(
                 dependencies,

--- a/test/EFCore.Specification.Tests/Query/Associations/AssociationsModel.cs
+++ b/test/EFCore.Specification.Tests/Query/Associations/AssociationsModel.cs
@@ -45,6 +45,8 @@ public class RelatedType : IEquatable<RelatedType>
     public required string String { get; set; }
     public required List<int> Ints { get; set; }
 
+    public int Unmapped => Int + 1;
+
     public required NestedType RequiredNested { get; set; }
     public NestedType? OptionalNested { get; set; }
     public List<NestedType> NestedCollection { get; set; } = null!;

--- a/test/EFCore.Specification.Tests/Query/Associations/AssociationsProjectionTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Associations/AssociationsProjectionTestBase.cs
@@ -12,7 +12,7 @@ public abstract class AssociationsProjectionTestBase<TFixture>(TFixture fixture)
             ss => ss.Set<RootEntity>(),
             queryTrackingBehavior: queryTrackingBehavior);
 
-    #region Simple properties
+    #region Scalar properties
 
     [ConditionalTheory, MemberData(nameof(TrackingData))]
     public virtual Task Select_property_on_required_related(QueryTrackingBehavior queryTrackingBehavior)
@@ -41,9 +41,9 @@ public abstract class AssociationsProjectionTestBase<TFixture>(TFixture fixture)
             ss => ss.Set<RootEntity>().Select(x => (int?)x.OptionalRelated!.Int),
             queryTrackingBehavior: queryTrackingBehavior);
 
-    #endregion Simple properties
+    #endregion Scalar properties
 
-    #region Non-collection
+    #region Structural properties
 
     [ConditionalTheory, MemberData(nameof(TrackingData))]
     public virtual Task Select_related(QueryTrackingBehavior queryTrackingBehavior)
@@ -87,9 +87,23 @@ public abstract class AssociationsProjectionTestBase<TFixture>(TFixture fixture)
             ss => ss.Set<RootReferencingEntity>().Select(e => e.Root!.RequiredRelated),
             queryTrackingBehavior: queryTrackingBehavior);
 
-    #endregion Non-collection
+    [ConditionalTheory, MemberData(nameof(TrackingData))]
+    public virtual Task Select_unmapped_related_scalar_property(QueryTrackingBehavior queryTrackingBehavior)
+        => AssertQuery(
+            ss => ss.Set<RootEntity>().Select(e => e.RequiredRelated.Unmapped),
+            queryTrackingBehavior: queryTrackingBehavior);
 
-    #region Collection
+    [ConditionalTheory, MemberData(nameof(TrackingData))]
+    public virtual Task Select_untranslatable_method_on_related_scalar_property(QueryTrackingBehavior queryTrackingBehavior)
+        => AssertQuery(
+            ss => ss.Set<RootEntity>().Select(e => UntranslatableMethod(e.RequiredRelated.Int)),
+            queryTrackingBehavior: queryTrackingBehavior);
+
+    private static int UntranslatableMethod(int i) => i + 1;
+
+    #endregion Structural properties
+
+    #region Structural collection properties
 
     // Note we order via the Id (server-side) to ensure the collections come back in deterministic order,
     // otherwise it's difficult/unreliable to compare client-side.
@@ -139,7 +153,7 @@ public abstract class AssociationsProjectionTestBase<TFixture>(TFixture fixture)
                 .SelectMany(x => x.OptionalRelated.Maybe(xx => xx!.NestedCollection) ?? new List<NestedType>()),
             queryTrackingBehavior: queryTrackingBehavior);
 
-    #endregion Collection
+    #endregion Structural collection properties
 
     #region Multiple
 

--- a/test/EFCore.Specification.Tests/Query/Associations/OwnedNavigations/OwnedNavigationsProjectionTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Associations/OwnedNavigations/OwnedNavigationsProjectionTestBase.cs
@@ -6,7 +6,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Associations.OwnedNavigations;
 public abstract class OwnedNavigationsProjectionTestBase<TFixture>(TFixture fixture) : AssociationsProjectionTestBase<TFixture>(fixture)
     where TFixture : OwnedNavigationsFixtureBase, new()
 {
-    #region Non-collection
+    #region Structural properties
 
     public override Task Select_related(QueryTrackingBehavior queryTrackingBehavior)
         => AssertOwnedTrackingQuery(queryTrackingBehavior, () => base.Select_related(queryTrackingBehavior));
@@ -26,9 +26,14 @@ public abstract class OwnedNavigationsProjectionTestBase<TFixture>(TFixture fixt
     public override Task Select_optional_nested_on_optional_related(QueryTrackingBehavior queryTrackingBehavior)
         => AssertOwnedTrackingQuery(queryTrackingBehavior, () => base.Select_optional_nested_on_optional_related(queryTrackingBehavior));
 
-    #endregion Non-collection
+    public override Task Select_unmapped_related_scalar_property(QueryTrackingBehavior queryTrackingBehavior)
+        => AssertOwnedTrackingQuery(
+            queryTrackingBehavior,
+            () => base.Select_unmapped_related_scalar_property(queryTrackingBehavior));
 
-    #region Collection
+    #endregion Structural properties
+
+    #region Structural collection properties
 
     public override Task Select_related_collection(QueryTrackingBehavior queryTrackingBehavior)
         => AssertOwnedTrackingQuery(queryTrackingBehavior, () => base.Select_related_collection(queryTrackingBehavior));
@@ -50,7 +55,7 @@ public abstract class OwnedNavigationsProjectionTestBase<TFixture>(TFixture fixt
         => AssertOwnedTrackingQuery(
             queryTrackingBehavior, () => base.SelectMany_nested_collection_on_optional_related(queryTrackingBehavior));
 
-    #endregion Collection
+    #endregion Structural collection properties
 
     #region Multiple
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Associations/ComplexJson/ComplexJsonProjectionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Associations/ComplexJson/ComplexJsonProjectionSqlServerTest.cs
@@ -17,7 +17,7 @@ FROM [RootEntity] AS [r]
 """);
     }
 
-    #region Simple properties
+    #region Scalar properties
 
     public override async Task Select_property_on_required_related(QueryTrackingBehavior queryTrackingBehavior)
     {
@@ -107,9 +107,9 @@ FROM [RootEntity] AS [r]
         }
     }
 
-    #endregion Simple properties
+    #endregion Scalar properties
 
-    #region Non-collection
+    #region Structural properties
 
     public override async Task Select_related(QueryTrackingBehavior queryTrackingBehavior)
     {
@@ -189,9 +189,42 @@ LEFT JOIN [RootEntity] AS [r0] ON [r].[RootEntityId] = [r0].[Id]
 """);
     }
 
-    #endregion Non-collection
+    public override async Task Select_unmapped_related_scalar_property(QueryTrackingBehavior queryTrackingBehavior)
+    {
+        await base.Select_unmapped_related_scalar_property(queryTrackingBehavior);
 
-    #region Collection
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[Name], [r].[OptionalRelated], [r].[RelatedCollection], [r].[RequiredRelated]
+FROM [RootEntity] AS [r]
+""");
+    }
+
+    public override async Task Select_untranslatable_method_on_related_scalar_property(QueryTrackingBehavior queryTrackingBehavior)
+    {
+        await base.Select_untranslatable_method_on_related_scalar_property(queryTrackingBehavior);
+
+        if (Fixture.UsingJsonType)
+        {
+            AssertSql(
+                """
+SELECT JSON_VALUE([r].[RequiredRelated], '$.Int' RETURNING int)
+FROM [RootEntity] AS [r]
+""");
+        }
+        else
+        {
+            AssertSql(
+                """
+SELECT CAST(JSON_VALUE([r].[RequiredRelated], '$.Int') AS int)
+FROM [RootEntity] AS [r]
+""");
+        }
+    }
+
+    #endregion Structural properties
+
+    #region Structural collection properties
 
     public override async Task Select_related_collection(QueryTrackingBehavior queryTrackingBehavior)
     {
@@ -343,7 +376,7 @@ CROSS APPLY OPENJSON([r].[OptionalRelated], '$.NestedCollection') WITH (
         }
     }
 
-    #endregion Collection
+    #endregion Structural collection properties
 
     #region Multiple
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Associations/ComplexTableSplitting/ComplexTableSplittingProjectionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Associations/ComplexTableSplitting/ComplexTableSplittingProjectionSqlServerTest.cs
@@ -8,30 +8,6 @@ public class ComplexTableSplittingProjectionSqlServerTest(
     ITestOutputHelper testOutputHelper)
     : ComplexTableSplittingProjectionRelationalTestBase<ComplexTableSplittingSqlServerFixture>(fixture, testOutputHelper)
 {
-    public override async Task Select_related_collection(QueryTrackingBehavior queryTrackingBehavior)
-    {
-        await base.Select_related_collection(queryTrackingBehavior);
-
-        AssertSql(
-            """
-SELECT [r].[Id], [r].[Name], [r].[OptionalRelated_Id], [r].[OptionalRelated_Int], [r].[OptionalRelated_Ints], [r].[OptionalRelated_Name], [r].[OptionalRelated_String], [r].[OptionalRelated_OptionalNested_Id], [r].[OptionalRelated_OptionalNested_Int], [r].[OptionalRelated_OptionalNested_Ints], [r].[OptionalRelated_OptionalNested_Name], [r].[OptionalRelated_OptionalNested_String], [r].[OptionalRelated_RequiredNested_Id], [r].[OptionalRelated_RequiredNested_Int], [r].[OptionalRelated_RequiredNested_Ints], [r].[OptionalRelated_RequiredNested_Name], [r].[OptionalRelated_RequiredNested_String], [r].[RequiredRelated_Id], [r].[RequiredRelated_Int], [r].[RequiredRelated_Ints], [r].[RequiredRelated_Name], [r].[RequiredRelated_String], [r].[RequiredRelated_OptionalNested_Id], [r].[RequiredRelated_OptionalNested_Int], [r].[RequiredRelated_OptionalNested_Ints], [r].[RequiredRelated_OptionalNested_Name], [r].[RequiredRelated_OptionalNested_String], [r].[RequiredRelated_RequiredNested_Id], [r].[RequiredRelated_RequiredNested_Int], [r].[RequiredRelated_RequiredNested_Ints], [r].[RequiredRelated_RequiredNested_Name], [r].[RequiredRelated_RequiredNested_String]
-FROM [RootEntity] AS [r]
-ORDER BY [r].[Id]
-""");
-    }
-
-    public override async Task Select_nested_collection_on_required_related(QueryTrackingBehavior queryTrackingBehavior)
-    {
-        await base.Select_nested_collection_on_required_related(queryTrackingBehavior);
-
-        AssertSql(
-            """
-SELECT [r].[Id], [r].[Name], [r].[OptionalRelated_Id], [r].[OptionalRelated_Int], [r].[OptionalRelated_Ints], [r].[OptionalRelated_Name], [r].[OptionalRelated_String], [r].[OptionalRelated_OptionalNested_Id], [r].[OptionalRelated_OptionalNested_Int], [r].[OptionalRelated_OptionalNested_Ints], [r].[OptionalRelated_OptionalNested_Name], [r].[OptionalRelated_OptionalNested_String], [r].[OptionalRelated_RequiredNested_Id], [r].[OptionalRelated_RequiredNested_Int], [r].[OptionalRelated_RequiredNested_Ints], [r].[OptionalRelated_RequiredNested_Name], [r].[OptionalRelated_RequiredNested_String], [r].[RequiredRelated_Id], [r].[RequiredRelated_Int], [r].[RequiredRelated_Ints], [r].[RequiredRelated_Name], [r].[RequiredRelated_String], [r].[RequiredRelated_OptionalNested_Id], [r].[RequiredRelated_OptionalNested_Int], [r].[RequiredRelated_OptionalNested_Ints], [r].[RequiredRelated_OptionalNested_Name], [r].[RequiredRelated_OptionalNested_String], [r].[RequiredRelated_RequiredNested_Id], [r].[RequiredRelated_RequiredNested_Int], [r].[RequiredRelated_RequiredNested_Ints], [r].[RequiredRelated_RequiredNested_Name], [r].[RequiredRelated_RequiredNested_String]
-FROM [RootEntity] AS [r]
-ORDER BY [r].[Id]
-""");
-    }
-
     public override async Task Select_root(QueryTrackingBehavior queryTrackingBehavior)
     {
         await base.Select_root(queryTrackingBehavior);
@@ -42,6 +18,8 @@ SELECT [r].[Id], [r].[Name], [r].[OptionalRelated_Id], [r].[OptionalRelated_Int]
 FROM [RootEntity] AS [r]
 """);
     }
+
+    #region Scalar properties
 
     public override async Task Select_property_on_required_related(QueryTrackingBehavior queryTrackingBehavior)
     {
@@ -86,6 +64,10 @@ SELECT [r].[OptionalRelated_Int]
 FROM [RootEntity] AS [r]
 """);
     }
+
+    #endregion Scalar properties
+
+    #region Structural properties
 
     public override async Task Select_related(QueryTrackingBehavior queryTrackingBehavior)
     {
@@ -165,10 +147,64 @@ LEFT JOIN [RootEntity] AS [r0] ON [r].[RootEntityId] = [r0].[Id]
 """);
     }
 
+    public override async Task Select_unmapped_related_scalar_property(QueryTrackingBehavior queryTrackingBehavior)
+    {
+        await base.Select_unmapped_related_scalar_property(queryTrackingBehavior);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[Name], [r].[OptionalRelated_Id], [r].[OptionalRelated_Int], [r].[OptionalRelated_Ints], [r].[OptionalRelated_Name], [r].[OptionalRelated_String], [r].[OptionalRelated_OptionalNested_Id], [r].[OptionalRelated_OptionalNested_Int], [r].[OptionalRelated_OptionalNested_Ints], [r].[OptionalRelated_OptionalNested_Name], [r].[OptionalRelated_OptionalNested_String], [r].[OptionalRelated_RequiredNested_Id], [r].[OptionalRelated_RequiredNested_Int], [r].[OptionalRelated_RequiredNested_Ints], [r].[OptionalRelated_RequiredNested_Name], [r].[OptionalRelated_RequiredNested_String], [r].[RequiredRelated_Id], [r].[RequiredRelated_Int], [r].[RequiredRelated_Ints], [r].[RequiredRelated_Name], [r].[RequiredRelated_String], [r].[RequiredRelated_OptionalNested_Id], [r].[RequiredRelated_OptionalNested_Int], [r].[RequiredRelated_OptionalNested_Ints], [r].[RequiredRelated_OptionalNested_Name], [r].[RequiredRelated_OptionalNested_String], [r].[RequiredRelated_RequiredNested_Id], [r].[RequiredRelated_RequiredNested_Int], [r].[RequiredRelated_RequiredNested_Ints], [r].[RequiredRelated_RequiredNested_Name], [r].[RequiredRelated_RequiredNested_String]
+FROM [RootEntity] AS [r]
+""");
+    }
+
+    public override async Task Select_untranslatable_method_on_related_scalar_property(QueryTrackingBehavior queryTrackingBehavior)
+    {
+        await base.Select_untranslatable_method_on_related_scalar_property(queryTrackingBehavior);
+
+        AssertSql(
+            """
+SELECT [r].[RequiredRelated_Int]
+FROM [RootEntity] AS [r]
+""");
+    }
+
+    #endregion Structural properties
+
+    #region Structural collection properties
+
+    public override async Task Select_related_collection(QueryTrackingBehavior queryTrackingBehavior)
+    {
+        await base.Select_related_collection(queryTrackingBehavior);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[Name], [r].[OptionalRelated_Id], [r].[OptionalRelated_Int], [r].[OptionalRelated_Ints], [r].[OptionalRelated_Name], [r].[OptionalRelated_String], [r].[OptionalRelated_OptionalNested_Id], [r].[OptionalRelated_OptionalNested_Int], [r].[OptionalRelated_OptionalNested_Ints], [r].[OptionalRelated_OptionalNested_Name], [r].[OptionalRelated_OptionalNested_String], [r].[OptionalRelated_RequiredNested_Id], [r].[OptionalRelated_RequiredNested_Int], [r].[OptionalRelated_RequiredNested_Ints], [r].[OptionalRelated_RequiredNested_Name], [r].[OptionalRelated_RequiredNested_String], [r].[RequiredRelated_Id], [r].[RequiredRelated_Int], [r].[RequiredRelated_Ints], [r].[RequiredRelated_Name], [r].[RequiredRelated_String], [r].[RequiredRelated_OptionalNested_Id], [r].[RequiredRelated_OptionalNested_Int], [r].[RequiredRelated_OptionalNested_Ints], [r].[RequiredRelated_OptionalNested_Name], [r].[RequiredRelated_OptionalNested_String], [r].[RequiredRelated_RequiredNested_Id], [r].[RequiredRelated_RequiredNested_Int], [r].[RequiredRelated_RequiredNested_Ints], [r].[RequiredRelated_RequiredNested_Name], [r].[RequiredRelated_RequiredNested_String]
+FROM [RootEntity] AS [r]
+ORDER BY [r].[Id]
+""");
+    }
+
+    public override async Task Select_nested_collection_on_required_related(QueryTrackingBehavior queryTrackingBehavior)
+    {
+        // Note that collections are not supported with table splitting, only JSON;
+        // the collection selected here is unmapped, and so the test does client evaluation.
+        await base.Select_nested_collection_on_required_related(queryTrackingBehavior);
+
+        AssertSql(
+            """
+SELECT [r].[Id], [r].[Name], [r].[OptionalRelated_Id], [r].[OptionalRelated_Int], [r].[OptionalRelated_Ints], [r].[OptionalRelated_Name], [r].[OptionalRelated_String], [r].[OptionalRelated_OptionalNested_Id], [r].[OptionalRelated_OptionalNested_Int], [r].[OptionalRelated_OptionalNested_Ints], [r].[OptionalRelated_OptionalNested_Name], [r].[OptionalRelated_OptionalNested_String], [r].[OptionalRelated_RequiredNested_Id], [r].[OptionalRelated_RequiredNested_Int], [r].[OptionalRelated_RequiredNested_Ints], [r].[OptionalRelated_RequiredNested_Name], [r].[OptionalRelated_RequiredNested_String], [r].[RequiredRelated_Id], [r].[RequiredRelated_Int], [r].[RequiredRelated_Ints], [r].[RequiredRelated_Name], [r].[RequiredRelated_String], [r].[RequiredRelated_OptionalNested_Id], [r].[RequiredRelated_OptionalNested_Int], [r].[RequiredRelated_OptionalNested_Ints], [r].[RequiredRelated_OptionalNested_Name], [r].[RequiredRelated_OptionalNested_String], [r].[RequiredRelated_RequiredNested_Id], [r].[RequiredRelated_RequiredNested_Int], [r].[RequiredRelated_RequiredNested_Ints], [r].[RequiredRelated_RequiredNested_Name], [r].[RequiredRelated_RequiredNested_String]
+FROM [RootEntity] AS [r]
+ORDER BY [r].[Id]
+""");
+    }
+
     public override async Task Select_nested_collection_on_optional_related(QueryTrackingBehavior queryTrackingBehavior)
     {
         await base.Select_nested_collection_on_optional_related(queryTrackingBehavior);
 
+        // Note that collections are not supported with table splitting, only JSON;
+        // the collection selected here is unmapped, and so the test does client evaluation.
         AssertSql(
             """
 SELECT [r].[Id], [r].[Name], [r].[OptionalRelated_Id], [r].[OptionalRelated_Int], [r].[OptionalRelated_Ints], [r].[OptionalRelated_Name], [r].[OptionalRelated_String], [r].[OptionalRelated_OptionalNested_Id], [r].[OptionalRelated_OptionalNested_Int], [r].[OptionalRelated_OptionalNested_Ints], [r].[OptionalRelated_OptionalNested_Name], [r].[OptionalRelated_OptionalNested_String], [r].[OptionalRelated_RequiredNested_Id], [r].[OptionalRelated_RequiredNested_Int], [r].[OptionalRelated_RequiredNested_Ints], [r].[OptionalRelated_RequiredNested_Name], [r].[OptionalRelated_RequiredNested_String], [r].[RequiredRelated_Id], [r].[RequiredRelated_Int], [r].[RequiredRelated_Ints], [r].[RequiredRelated_Name], [r].[RequiredRelated_String], [r].[RequiredRelated_OptionalNested_Id], [r].[RequiredRelated_OptionalNested_Int], [r].[RequiredRelated_OptionalNested_Ints], [r].[RequiredRelated_OptionalNested_Name], [r].[RequiredRelated_OptionalNested_String], [r].[RequiredRelated_RequiredNested_Id], [r].[RequiredRelated_RequiredNested_Int], [r].[RequiredRelated_RequiredNested_Ints], [r].[RequiredRelated_RequiredNested_Name], [r].[RequiredRelated_RequiredNested_String]
@@ -198,6 +234,10 @@ ORDER BY [r].[Id]
         AssertSql();
     }
 
+    #endregion Structural collection properties
+
+    #region Multiple
+
     public override async Task Select_root_duplicated(QueryTrackingBehavior queryTrackingBehavior)
     {
         await base.Select_root_duplicated(queryTrackingBehavior);
@@ -208,6 +248,10 @@ SELECT [r].[Id], [r].[Name], [r].[OptionalRelated_Id], [r].[OptionalRelated_Int]
 FROM [RootEntity] AS [r]
 """);
     }
+
+    #endregion Multiple
+
+    #region Subquery
 
     public override async Task Select_subquery_required_related_FirstOrDefault(QueryTrackingBehavior queryTrackingBehavior)
     {
@@ -240,6 +284,8 @@ OUTER APPLY (
 ) AS [r1]
 """);
     }
+
+    #endregion Subquery
 
     #region Value types
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Associations/Navigations/NavigationsProjectionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Associations/Navigations/NavigationsProjectionSqlServerTest.cs
@@ -33,7 +33,7 @@ ORDER BY [r].[Id], [r0].[Id], [n].[Id], [n0].[Id], [r1].[Id], [n1].[Id], [n2].[I
 """);
     }
 
-    #region Simple properties
+    #region Scalar properties
 
     public override async Task Select_property_on_required_related(QueryTrackingBehavior queryTrackingBehavior)
     {
@@ -83,9 +83,9 @@ LEFT JOIN [RelatedType] AS [r0] ON [r].[OptionalRelatedId] = [r0].[Id]
 """);
     }
 
-    #endregion Simple properties
+    #endregion Scalar properties
 
-    #region Non-collection
+    #region Structural properties
 
     public override async Task Select_related(QueryTrackingBehavior queryTrackingBehavior)
     {
@@ -188,9 +188,37 @@ ORDER BY [r].[Id], [r0].[Id], [r1].[Id], [n].[Id], [n0].[Id]
 """);
     }
 
-    #endregion Non-collection
+    public override async Task Select_unmapped_related_scalar_property(QueryTrackingBehavior queryTrackingBehavior)
+    {
+        await base.Select_unmapped_related_scalar_property(queryTrackingBehavior);
 
-    #region Collection
+        AssertSql(
+            """
+SELECT [r0].[Id], [r0].[CollectionRootId], [r0].[Int], [r0].[Ints], [r0].[Name], [r0].[OptionalNestedId], [r0].[RequiredNestedId], [r0].[String], [r].[Id], [n].[Id], [n0].[Id], [n1].[Id], [n1].[CollectionRelatedId], [n1].[Int], [n1].[Ints], [n1].[Name], [n1].[String], [n].[CollectionRelatedId], [n].[Int], [n].[Ints], [n].[Name], [n].[String], [n0].[CollectionRelatedId], [n0].[Int], [n0].[Ints], [n0].[Name], [n0].[String]
+FROM [RootEntity] AS [r]
+INNER JOIN [RelatedType] AS [r0] ON [r].[RequiredRelatedId] = [r0].[Id]
+LEFT JOIN [NestedType] AS [n] ON [r0].[OptionalNestedId] = [n].[Id]
+INNER JOIN [NestedType] AS [n0] ON [r0].[RequiredNestedId] = [n0].[Id]
+LEFT JOIN [NestedType] AS [n1] ON [r0].[Id] = [n1].[CollectionRelatedId]
+ORDER BY [r].[Id], [r0].[Id], [n].[Id], [n0].[Id]
+""");
+    }
+
+    public override async Task Select_untranslatable_method_on_related_scalar_property(QueryTrackingBehavior queryTrackingBehavior)
+    {
+        await base.Select_untranslatable_method_on_related_scalar_property(queryTrackingBehavior);
+
+        AssertSql(
+            """
+SELECT [r0].[Int]
+FROM [RootEntity] AS [r]
+INNER JOIN [RelatedType] AS [r0] ON [r].[RequiredRelatedId] = [r0].[Id]
+""");
+    }
+
+    #endregion Structural properties
+
+    #region Structural collection properties
 
     public override async Task Select_related_collection(QueryTrackingBehavior queryTrackingBehavior)
     {
@@ -281,7 +309,7 @@ INNER JOIN [NestedType] AS [n] ON [r0].[Id] = [n].[CollectionRelatedId]
 """);
     }
 
-    #endregion Collection
+    #endregion Structural collection properties
 
     #region Multiple
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Associations/OwnedJson/OwnedJsonProjectionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Associations/OwnedJson/OwnedJsonProjectionSqlServerTest.cs
@@ -17,7 +17,7 @@ FROM [RootEntity] AS [r]
 """);
     }
 
-    #region Simple properties
+    #region Scalar properties
 
     public override async Task Select_property_on_required_related(QueryTrackingBehavior queryTrackingBehavior)
     {
@@ -107,9 +107,9 @@ FROM [RootEntity] AS [r]
         }
     }
 
-    #endregion Simple properties
+    #endregion Scalar properties
 
-    #region Non-collection
+    #region Structural properties
 
     public override async Task Select_related(QueryTrackingBehavior queryTrackingBehavior)
     {
@@ -210,9 +210,45 @@ LEFT JOIN [RootEntity] AS [r0] ON [r].[RootEntityId] = [r0].[Id]
         }
     }
 
-    #endregion Non-collection
+    public override async Task Select_unmapped_related_scalar_property(QueryTrackingBehavior queryTrackingBehavior)
+    {
+        await base.Select_unmapped_related_scalar_property(queryTrackingBehavior);
 
-    #region Collection
+        if (queryTrackingBehavior is not QueryTrackingBehavior.TrackAll)
+        {
+            AssertSql(
+                """
+SELECT [r].[RequiredRelated], [r].[Id]
+FROM [RootEntity] AS [r]
+""");
+        }
+    }
+
+    public override async Task Select_untranslatable_method_on_related_scalar_property(QueryTrackingBehavior queryTrackingBehavior)
+    {
+        await base.Select_untranslatable_method_on_related_scalar_property(queryTrackingBehavior);
+
+        if (Fixture.UsingJsonType)
+        {
+            AssertSql(
+                """
+SELECT JSON_VALUE([r].[RequiredRelated], '$.Int' RETURNING int)
+FROM [RootEntity] AS [r]
+""");
+        }
+        else
+        {
+            AssertSql(
+                """
+SELECT CAST(JSON_VALUE([r].[RequiredRelated], '$.Int') AS int)
+FROM [RootEntity] AS [r]
+""");
+        }
+    }
+
+    #endregion Structural properties
+
+    #region Structural collection properties
 
     public override async Task Select_related_collection(QueryTrackingBehavior queryTrackingBehavior)
     {
@@ -382,7 +418,7 @@ CROSS APPLY OPENJSON([r].[OptionalRelated], '$.NestedCollection') WITH (
         }
     }
 
-    #endregion Collection
+    #endregion Structural collection properties
 
     #region Multiple
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Associations/OwnedNavigations/OwnedNavigationsProjectionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Associations/OwnedNavigations/OwnedNavigationsProjectionSqlServerTest.cs
@@ -33,7 +33,7 @@ ORDER BY [r].[Id], [o].[RootEntityId], [o0].[RelatedTypeRootEntityId], [o1].[Rel
 """);
     }
 
-    #region Simple properties
+    #region Scalar properties
 
     public override async Task Select_property_on_required_related(QueryTrackingBehavior queryTrackingBehavior)
     {
@@ -83,9 +83,9 @@ LEFT JOIN [OptionalRelated] AS [o] ON [r].[Id] = [o].[RootEntityId]
 """);
     }
 
-    #endregion Simple properties
+    #endregion Scalar properties
 
-    #region Non-collection
+    #region Structural properties
 
     public override async Task Select_related(QueryTrackingBehavior queryTrackingBehavior)
     {
@@ -209,9 +209,40 @@ ORDER BY [r].[Id], [r0].[Id], [r1].[RootEntityId], [r2].[RelatedTypeRootEntityId
         }
     }
 
-    #endregion Non-collection
+    public override async Task Select_unmapped_related_scalar_property(QueryTrackingBehavior queryTrackingBehavior)
+    {
+        await base.Select_unmapped_related_scalar_property(queryTrackingBehavior);
 
-    #region Collection
+        if (queryTrackingBehavior is not QueryTrackingBehavior.TrackAll)
+        {
+            AssertSql(
+                """
+SELECT [r0].[RootEntityId], [r0].[Id], [r0].[Int], [r0].[Ints], [r0].[Name], [r0].[String], [r].[Id], [r1].[RelatedTypeRootEntityId], [r2].[RelatedTypeRootEntityId], [r3].[RelatedTypeRootEntityId], [r3].[Id], [r3].[Int], [r3].[Ints], [r3].[Name], [r3].[String], [r1].[Id], [r1].[Int], [r1].[Ints], [r1].[Name], [r1].[String], [r2].[Id], [r2].[Int], [r2].[Ints], [r2].[Name], [r2].[String]
+FROM [RootEntity] AS [r]
+LEFT JOIN [RequiredRelated] AS [r0] ON [r].[Id] = [r0].[RootEntityId]
+LEFT JOIN [RequiredRelated_OptionalNested] AS [r1] ON [r0].[RootEntityId] = [r1].[RelatedTypeRootEntityId]
+LEFT JOIN [RequiredRelated_RequiredNested] AS [r2] ON [r0].[RootEntityId] = [r2].[RelatedTypeRootEntityId]
+LEFT JOIN [RequiredRelated_NestedCollection] AS [r3] ON [r0].[RootEntityId] = [r3].[RelatedTypeRootEntityId]
+ORDER BY [r].[Id], [r0].[RootEntityId], [r1].[RelatedTypeRootEntityId], [r2].[RelatedTypeRootEntityId], [r3].[RelatedTypeRootEntityId]
+""");
+        }
+    }
+
+    public override async Task Select_untranslatable_method_on_related_scalar_property(QueryTrackingBehavior queryTrackingBehavior)
+    {
+        await base.Select_untranslatable_method_on_related_scalar_property(queryTrackingBehavior);
+
+        AssertSql(
+            """
+SELECT [r0].[Int]
+FROM [RootEntity] AS [r]
+LEFT JOIN [RequiredRelated] AS [r0] ON [r].[Id] = [r0].[RootEntityId]
+""");
+    }
+
+    #endregion Structural properties
+
+    #region Structural collection properties
 
     public override async Task Select_related_collection(QueryTrackingBehavior queryTrackingBehavior)
     {
@@ -320,7 +351,7 @@ INNER JOIN [OptionalRelated_NestedCollection] AS [o0] ON [o].[RootEntityId] = [o
         }
     }
 
-    #endregion Collection
+    #endregion Structural collection properties
 
     #region Multiple
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Associations/OwnedTableSplitting/OwnedTableSplittingProjectionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Associations/OwnedTableSplitting/OwnedTableSplittingProjectionSqlServerTest.cs
@@ -27,7 +27,7 @@ ORDER BY [r].[Id], [o].[RelatedTypeRootEntityId], [o].[Id], [s].[RootEntityId], 
 """);
     }
 
-    #region Simple properties
+    #region Scalar properties
 
     public override async Task Select_property_on_required_related(QueryTrackingBehavior queryTrackingBehavior)
     {
@@ -73,9 +73,9 @@ FROM [RootEntity] AS [r]
 """);
     }
 
-    #endregion Simple properties
+    #endregion Scalar properties
 
-    #region Non-collection
+    #region Structural properties
 
     public override async Task Select_related(QueryTrackingBehavior queryTrackingBehavior)
     {
@@ -184,9 +184,36 @@ ORDER BY [r].[Id], [r0].[Id], [r1].[RelatedTypeRootEntityId]
         }
     }
 
-    #endregion Non-collection
+    public override async Task Select_unmapped_related_scalar_property(QueryTrackingBehavior queryTrackingBehavior)
+    {
+        await base.Select_unmapped_related_scalar_property(queryTrackingBehavior);
 
-    #region Collection
+        if (queryTrackingBehavior is not QueryTrackingBehavior.TrackAll)
+        {
+            AssertSql(
+                """
+SELECT [r].[Id], [r].[RequiredRelated_Id], [r].[RequiredRelated_Int], [r].[RequiredRelated_Ints], [r].[RequiredRelated_Name], [r].[RequiredRelated_String], [r0].[RelatedTypeRootEntityId], [r0].[Id], [r0].[Int], [r0].[Ints], [r0].[Name], [r0].[String], [r].[RequiredRelated_OptionalNested_Id], [r].[RequiredRelated_OptionalNested_Int], [r].[RequiredRelated_OptionalNested_Ints], [r].[RequiredRelated_OptionalNested_Name], [r].[RequiredRelated_OptionalNested_String], [r].[RequiredRelated_RequiredNested_Id], [r].[RequiredRelated_RequiredNested_Int], [r].[RequiredRelated_RequiredNested_Ints], [r].[RequiredRelated_RequiredNested_Name], [r].[RequiredRelated_RequiredNested_String]
+FROM [RootEntity] AS [r]
+LEFT JOIN [RequiredRelated_NestedCollection] AS [r0] ON [r].[Id] = [r0].[RelatedTypeRootEntityId]
+ORDER BY [r].[Id], [r0].[RelatedTypeRootEntityId]
+""");
+        }
+    }
+
+    public override async Task Select_untranslatable_method_on_related_scalar_property(QueryTrackingBehavior queryTrackingBehavior)
+    {
+        await base.Select_untranslatable_method_on_related_scalar_property(queryTrackingBehavior);
+
+        AssertSql(
+            """
+SELECT [r].[RequiredRelated_Int]
+FROM [RootEntity] AS [r]
+""");
+    }
+
+    #endregion Structural properties
+
+    #region Structural collection properties
 
     public override async Task Select_related_collection(QueryTrackingBehavior queryTrackingBehavior)
     {
@@ -291,7 +318,7 @@ END = [o].[RelatedTypeRootEntityId]
         }
     }
 
-    #endregion Collection
+    #endregion Structural collection properties
 
     #region Multiple
 


### PR DESCRIPTION
Fixes #36761

**Description**
As part of the considerable work that went into complex types in 10, complex property accesses in queries started getting systematically transformed into EF.Property, as (was) standard in the query pipeline. This causes query failure when an unmapped property access is composed on top.

**Customer impact**
Queries accessing unmapped properties via complex properties now fail:

```c#
var v = await context.Entities
    .Select(p => p.ComplexProperty.Unmapped)
    .ToListAsync();
```

**How found**
Customer reported.

**Regression**
Yes

**Testing**
Test added

**Risk**
Low, affects mainly new code introduced in EF 10, and in any case only complex type support, which was very limited before 10 and so doesn't risk breaking many people.
