### PR TITLE
[RC2 ] Apply inferred type mappings in complex type recursive equality

### DIFF
--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.StructuralEquality.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.StructuralEquality.cs
@@ -522,10 +522,20 @@ public partial class RelationalSqlTranslatingExpressionVisitor
         }
     }
 
-    private bool TryTranslatePropertyAccess(Expression target, IPropertyBase property, [NotNullWhen(true)] out SqlExpression? translation)
+    private bool TryTranslatePropertyAccess(Expression target, IProperty property, [NotNullWhen(true)] out SqlExpression? translation)
     {
         var expression = CreatePropertyAccessExpression(target, property);
-        translation = Translate(expression);
+
+        if (property.GetTypeMapping() is RelationalTypeMapping relationalTypeMapping)
+        {
+            translation = Translate(expression, applyDefaultTypeMapping: false);
+            translation = _sqlExpressionFactory.ApplyTypeMapping(translation, relationalTypeMapping);
+        }
+        else
+        {
+            translation = Translate(expression);
+        }
+
         return translation is not null;
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocComplexTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocComplexTypeQuerySqlServerTest.cs
@@ -32,6 +32,18 @@ FROM [EntityType] AS [e]
 """);
     }
 
+    public override async Task Complex_type_equality_with_non_default_type_mapping()
+    {
+        await base.Complex_type_equality_with_non_default_type_mapping();
+
+        AssertSql(
+            """
+SELECT COUNT(*)
+FROM [EntityType] AS [e]
+WHERE [e].[ComplexThing_DateTime] = '2020-01-01T01:01:01.999'
+""");
+    }
+
     protected TestSqlLoggerFactory TestSqlLoggerFactory
         => (TestSqlLoggerFactory)ListLoggerFactory;
 


### PR DESCRIPTION
Fixes #36837

**Description**
Database types weren't being correctly inferred in queries comparing complex types - see #36837 for a full description.

**Customer impact**
When performing queries that compare complex types, the user may get incorrect results (data corruption):

```c#
var foo = new Foo { ... };
_ = context.Blogs.Where(b => b.Foo == foo).ToListAsync();
```

(when the type Foo contains a property that's mapped to a non-default type in the database, e.g. DateTime to SQL Server `datetime`).

This also blocks some mainline scenarios in 10.0 for PostgreSQL.

**How found**
While updating the PostgreSQL provider to use the latest EF bits.

**Regression**
No

**Testing**
Test added

**Risk**
Very low, targeted 2-line fix.
