### PR TITLE
[GA] Increase AzureCliCredential timeout

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/TestUtilities/TestEnvironment.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/TestUtilities/TestEnvironment.cs
@@ -34,7 +34,8 @@ public static class TestEnvironment
 
     public static bool UseTokenCredential { get; } = Config["UseTokenCredential"] == "true";
 
-    public static TokenCredential TokenCredential { get; } = new AzureCliCredential();
+    public static TokenCredential TokenCredential { get; } = new AzureCliCredential(
+        new AzureCliCredentialOptions { ProcessTimeout = TimeSpan.FromMinutes(5) });
 
     public static string SubscriptionId { get; } = Config["SubscriptionId"];
 


### PR DESCRIPTION
This should make the Cosmos tests less flaky