### PR TITLE
[GA] Use temporary memory database connection to quote the password.

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnectionInternal.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnectionInternal.cs
@@ -109,10 +109,7 @@ internal class SqliteConnectionInternal
 
                 // NB: SQLite doesn't support parameters in PRAGMA statements, so we escape the value using the
                 //     quote function before concatenating.
-                var quotedPassword = ExecuteScalar(
-                    "SELECT quote($password);",
-                    connectionOptions.Password,
-                    connectionOptions.DefaultTimeout);
+                var quotedPassword = QuotePassword(connectionOptions.Password);
                 ExecuteNonQuery(
                     "PRAGMA key = " + quotedPassword + ";",
                     connectionOptions.DefaultTimeout);
@@ -194,6 +191,29 @@ internal class SqliteConnectionInternal
     {
         _db.Dispose();
         _pool = null;
+    }
+
+    private string QuotePassword(string password)
+    {
+        SqliteException.ThrowExceptionForRC(sqlite3_open(":memory:", out var db), db);
+        try
+        {
+            SqliteException.ThrowExceptionForRC(sqlite3_prepare_v2(db, "SELECT quote($password);", out var stmt), db);
+            try
+            {
+                sqlite3_bind_text(stmt, 1, password);
+                SqliteException.ThrowExceptionForRC(sqlite3_step(stmt), db);
+                return sqlite3_column_text(stmt, 0).utf8_to_string();
+            }
+            finally
+            {
+                stmt.Dispose();
+            }
+        }
+        finally
+        {
+            db.Dispose();
+        }
     }
 
     private void ExecuteNonQuery(string sql, int timeout)


### PR DESCRIPTION
Backport of #36956 and #36961.

### Description
SQLite introduced change in 3.48.0 in how encrypted databases are allowed to access - now even statements not actually touching database itself have to go through de-encryption. Because we quote the password using `SELECT quote($password)` statement, this started failing. This change uses temporary in-memory database connection to execute this statement.

### Customer impact
Failure when trying to open encrypted database (even with correct password) on 3.48.0 or newer.

### How found
Customer reported.

### Regression
No.

### Testing
Tests already present. This is change is required because of change in underlying SQLite.

### Risk
Low.