### PR TITLE
Update Helix queues to OSX.15.

### DIFF
--- a/azure-pipelines-internal-tests.yml
+++ b/azure-pipelines-internal-tests.yml
@@ -208,7 +208,7 @@ extends:
               - name: _HelixBuildConfig
                 value: $(_BuildConfig)
               - name: HelixTargetQueues
-                value: Windows.10.Amd64;OSX.13.Amd64;OSX.13.ARM64;Ubuntu.2204.Amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-sqlserver-amd64
+                value: Windows.10.Amd64;OSX.15.Amd64;OSX.15.ARM64;Ubuntu.2204.Amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-sqlserver-amd64
               - name: _HelixAccessToken
                 # Needed for internal queues
                 value: $(HelixApiAccessToken)

--- a/azure-pipelines-public.yml
+++ b/azure-pipelines-public.yml
@@ -152,7 +152,7 @@ stages:
               - name: _HelixBuildConfig
                 value: $(_BuildConfig)
               - name: HelixTargetQueues
-                value: Windows.10.Amd64.Open;OSX.13.Amd64.Open;Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-sqlserver-amd64
+                value: Windows.10.Amd64.Open;OSX.15.Amd64.Open;Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-sqlserver-amd64
               - name: _HelixAccessToken
                 value: '' # Needed for public queues
             steps:


### PR DESCRIPTION
Now as #35440 is in, we can also update Helix queues.