### PR TITLE
Fix indexing on nested complex JSON collections

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/Query/Associations/OwnedNavigations/OwnedNavigationsCollectionCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/Associations/OwnedNavigations/OwnedNavigationsCollectionCosmosTest.cs
@@ -126,6 +126,18 @@ WHERE (c["AssociateCollection"][9999]["Int"] = 8)
 """);
     }
 
+    public override async Task Index_on_nested_collection()
+    {
+        await base.Index_on_nested_collection();
+
+        AssertSql(
+            """
+SELECT VALUE c
+FROM root c
+WHERE (c["RequiredAssociate"]["NestedCollection"][0]["Int"] = 8)
+""");
+    }
+
     #endregion Index
 
     #region GroupBy

--- a/test/EFCore.Specification.Tests/Query/Associations/AssociationsCollectionTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Associations/AssociationsCollectionTestBase.cs
@@ -76,6 +76,14 @@ public abstract class AssociationsCollectionTestBase<TFixture>(TFixture fixture)
             ss => ss.Set<RootEntity>().Where(e => e.AssociateCollection.Count > e.Id - 1 && e.AssociateCollection[e.Id - 1].Int == 8)));
 
     [ConditionalFact]
+    public virtual Task Index_on_nested_collection()
+        => AssertOrderedCollectionQuery(() => AssertQuery(
+            ss => ss.Set<RootEntity>().Where(e => e.RequiredAssociate.NestedCollection[0].Int == 8),
+            ss => ss.Set<RootEntity>().Where(
+                e => e.RequiredAssociate.NestedCollection.Count > 0
+                    && e.RequiredAssociate.NestedCollection[0].Int == 8)));
+
+    [ConditionalFact]
     public virtual Task Index_out_of_bounds()
         => AssertOrderedCollectionQuery(() => AssertQuery(
             ss => ss.Set<RootEntity>().Where(e => e.AssociateCollection[9999].Int == 8),

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Associations/ComplexJson/ComplexJsonCollectionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Associations/ComplexJson/ComplexJsonCollectionSqlServerTest.cs
@@ -244,6 +244,30 @@ WHERE CAST(JSON_VALUE([r].[AssociateCollection], '$[' + CAST([r].[Id] - 1 AS nva
         }
     }
 
+    public override async Task Index_on_nested_collection()
+    {
+        await base.Index_on_nested_collection();
+
+        if (Fixture.UsingJsonType)
+        {
+            AssertSql(
+                """
+SELECT [r].[Id], [r].[Name], [r].[AssociateCollection], [r].[OptionalAssociate], [r].[RequiredAssociate]
+FROM [RootEntity] AS [r]
+WHERE JSON_VALUE([r].[RequiredAssociate], '$.NestedCollection[0].Int' RETURNING int) = 8
+""");
+        }
+        else
+        {
+            AssertSql(
+                """
+SELECT [r].[Id], [r].[Name], [r].[AssociateCollection], [r].[OptionalAssociate], [r].[RequiredAssociate]
+FROM [RootEntity] AS [r]
+WHERE CAST(JSON_VALUE([r].[RequiredAssociate], '$.NestedCollection[0].Int') AS int) = 8
+""");
+        }
+    }
+
     public override async Task Index_out_of_bounds()
     {
         await base.Index_out_of_bounds();

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Associations/Navigations/NavigationsCollectionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Associations/Navigations/NavigationsCollectionSqlServerTest.cs
@@ -199,6 +199,13 @@ ORDER BY [r].[Id], [s].[Id], [s].[Id0], [s].[Id1]
         AssertSql();
     }
 
+    public override async Task Index_on_nested_collection()
+    {
+        await base.Index_on_nested_collection();
+
+        AssertSql();
+    }
+
     public override async Task Index_out_of_bounds()
     {
         await base.Index_out_of_bounds();

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Associations/OwnedJson/OwnedJsonCollectionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Associations/OwnedJson/OwnedJsonCollectionSqlServerTest.cs
@@ -317,6 +317,30 @@ WHERE CAST(JSON_VALUE([r].[AssociateCollection], '$[' + CAST([r].[Id] - 1 AS nva
         }
     }
 
+    public override async Task Index_on_nested_collection()
+    {
+        await base.Index_on_nested_collection();
+
+        if (Fixture.UsingJsonType)
+        {
+            AssertSql(
+                """
+SELECT [r].[Id], [r].[Name], [r].[AssociateCollection], [r].[OptionalAssociate], [r].[RequiredAssociate]
+FROM [RootEntity] AS [r]
+WHERE JSON_VALUE([r].[RequiredAssociate], '$.NestedCollection[0].Int' RETURNING int) = 8
+""");
+        }
+        else
+        {
+            AssertSql(
+                """
+SELECT [r].[Id], [r].[Name], [r].[AssociateCollection], [r].[OptionalAssociate], [r].[RequiredAssociate]
+FROM [RootEntity] AS [r]
+WHERE CAST(JSON_VALUE([r].[RequiredAssociate], '$.NestedCollection[0].Int') AS int) = 8
+""");
+        }
+    }
+
     public override async Task Index_out_of_bounds()
     {
         await base.Index_out_of_bounds();

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Associations/OwnedNavigations/OwnedNavigationsCollectionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Associations/OwnedNavigations/OwnedNavigationsCollectionSqlServerTest.cs
@@ -202,6 +202,13 @@ ORDER BY [r].[Id], [s].[RootEntityId], [s].[Id], [s].[AssociateTypeRootEntityId]
         AssertSql();
     }
 
+    public override async Task Index_on_nested_collection()
+    {
+        await base.Index_on_nested_collection();
+
+        AssertSql();
+    }
+
     public override async Task Index_out_of_bounds()
     {
         await base.Index_out_of_bounds();


### PR DESCRIPTION
This fixes two distinct bugs:
* Our current (hacky) mechanism for pre-visiting and rewriting collection indexing and projection (see [#36335](https://github.com/dotnet/efcore/issues/36335)) did not support accessing non-collection complex properties before the actual collection property (e.g. the Foo in `Where(b => b.Foo.Bar[0].X == 8`).
* The SQL Server ElementAt translation ignored the path on the incoming OPENJSON when transforming it to JSON_VALUE.

Fixes #37016
