### PR TITLE
[release/10.0] Fix indexing on nested complex JSON collections (#37017)

### DIFF
--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -11,6 +11,9 @@ namespace Microsoft.EntityFrameworkCore.Query;
 /// <inheritdoc />
 public partial class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMethodTranslatingExpressionVisitor
 {
+    private static readonly bool UseOldBehavior37016 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue37016", out var enabled) && enabled;
+
     private const string SqlQuerySingleColumnAlias = "Value";
 
     private readonly RelationalSqlTranslatingExpressionVisitor _sqlTranslator;
@@ -1945,12 +1948,19 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor : Que
             }
 
             source = source.UnwrapTypeConversion(out var convertedType);
-            if (source is not StructuralTypeShaperExpression shaper)
+
+            var type = source switch
+            {
+                StructuralTypeShaperExpression shaper => shaper.StructuralType,
+                JsonQueryExpression jsonQuery when !UseOldBehavior37016 => jsonQuery.StructuralType,
+                _ => null
+            };
+
+            if (type is null)
             {
                 return null;
             }
 
-            var type = shaper.StructuralType;
             if (convertedType != null)
             {
                 Check.DebugAssert(
@@ -1969,22 +1979,65 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor : Que
             var property = type.FindProperty(memberName);
             if (property?.IsPrimitiveCollection is true)
             {
-                return source.CreateEFPropertyExpression(property);
+                return source!.CreateEFPropertyExpression(property);
             }
 
             // See comments on indexing-related hacks in VisitMethodCall above
-            if (_bindComplexProperties
-                && type.FindComplexProperty(memberName) is { IsCollection: true } complexProperty)
+            if (UseOldBehavior37016)
             {
-                Check.DebugAssert(complexProperty.ComplexType.IsMappedToJson());
-
-                if (queryableTranslator._sqlTranslator.TryBindMember(
-                        queryableTranslator._sqlTranslator.Visit(source), MemberIdentity.Create(memberName),
-                        out var translatedExpression, out _)
-                    && translatedExpression is CollectionResultExpression { QueryExpression: JsonQueryExpression jsonQuery })
+                if (_bindComplexProperties && type.FindComplexProperty(memberName) is { IsCollection: true } complexProperty)
                 {
-                    return jsonQuery;
+                    Check.DebugAssert(complexProperty.ComplexType.IsMappedToJson());
+
+                    if (queryableTranslator._sqlTranslator.TryBindMember(
+                            queryableTranslator._sqlTranslator.Visit(source), MemberIdentity.Create(memberName),
+                            out var translatedExpression, out _)
+                        && translatedExpression is CollectionResultExpression { QueryExpression: JsonQueryExpression jsonQuery })
+                    {
+                        return jsonQuery;
+                    }
                 }
+            }
+            else if (_bindComplexProperties && type.FindComplexProperty(memberName) is IComplexProperty complexProperty)
+            {
+                Expression? translatedExpression;
+
+                if (source is JsonQueryExpression jsonSource)
+                {
+                    translatedExpression = jsonSource.BindStructuralProperty(complexProperty);
+                }
+                else if (!queryableTranslator._sqlTranslator.TryBindMember(
+                    queryableTranslator._sqlTranslator.Visit(source), MemberIdentity.Create(memberName),
+                    out translatedExpression, out _))
+                {
+                    return null;
+                }
+
+                // Hack: when returning a StructuralTypeShaperExpression, _sqlTranslator returns it wrapped by a
+                // StructuralTypeReferenceExpression, which is supposed to be a private wrapper only within the SQL translator.
+                // Call TranslateProjection to unwrap it (need to look into getting rid StructuralTypeReferenceExpression altogether).
+                if (translatedExpression is not JsonQueryExpression and not CollectionResultExpression)
+                {
+                    if (queryableTranslator._sqlTranslator.TranslateProjection(translatedExpression) is { } unwrappedTarget)
+                    {
+                        translatedExpression = unwrappedTarget;
+                    }
+                    else
+                    {
+                        return null;
+                    }
+                }
+
+                return complexProperty switch
+                {
+                    { IsCollection: false } when translatedExpression is StructuralTypeShaperExpression { ValueBufferExpression: JsonQueryExpression jsonQuery }
+                        => jsonQuery,
+                    { IsCollection: true } when translatedExpression is CollectionResultExpression { QueryExpression: JsonQueryExpression jsonQuery }
+                        => jsonQuery,
+                    { IsCollection: true } when translatedExpression is JsonQueryExpression jsonQuery
+                        => jsonQuery,
+                    _ => null
+                };
             }
 
             return null;

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
@@ -20,6 +20,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal;
 /// </summary>
 public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQueryableMethodTranslatingExpressionVisitor
 {
+    private static readonly bool UseOldBehavior37016 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue37016", out var enabled) && enabled;
+
     private readonly SqlServerQueryCompilationContext _queryCompilationContext;
     private readonly IRelationalTypeMappingSource _typeMappingSource;
     private readonly ISqlExpressionFactory _sqlExpressionFactory;
@@ -377,7 +380,7 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
                 } selectExpression
                     when TranslateExpression(index) is { } translatedIndex
                     && _sqlServerSingletonOptions.SupportsJsonFunctions
-                    && TryTranslate(selectExpression, valuesParameter, translatedIndex, out var result):
+                    && TryTranslate(selectExpression, valuesParameter, path: null, translatedIndex, out var result):
                     return result;
 
                 // Index on JSON array
@@ -406,7 +409,7 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
                 } selectExpression
                     when orderingTableAlias == openJsonExpression.Alias
                     && TranslateExpression(index) is { } translatedIndex
-                    && TryTranslate(selectExpression, jsonArrayColumn, translatedIndex, out var result):
+                    && TryTranslate(selectExpression, jsonArrayColumn, openJsonExpression.Path, translatedIndex, out var result):
                     return result;
             }
         }
@@ -415,7 +418,8 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
 
         bool TryTranslate(
             SelectExpression selectExpression,
-            SqlExpression jsonArrayColumn,
+            SqlExpression jsonColumn,
+            IReadOnlyList<PathSegment>? path,
             SqlExpression translatedIndex,
             [NotNullWhen(true)] out ShapedQueryExpression? result)
         {
@@ -441,16 +445,22 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
                 return false;
             }
 
-            // If the inner expression happens to itself be a JsonScalarExpression, simply append the two paths to avoid creating
+            // If the inner expression happens to itself be a JsonScalarExpression, simply append the paths to avoid creating
             // JSON_VALUE within JSON_VALUE.
-            var (json, path) = jsonArrayColumn is JsonScalarExpression innerJsonScalarExpression
-                ? (innerJsonScalarExpression.Json,
-                    innerJsonScalarExpression.Path.Append(new(translatedIndex)).ToArray())
-                : (jsonArrayColumn, [new(translatedIndex)]);
+            var (json, newPath) = jsonColumn is JsonScalarExpression innerJsonScalarExpression
+                ? (innerJsonScalarExpression.Json, new List<PathSegment>(innerJsonScalarExpression.Path))
+                : (jsonColumn, []);
+
+            if (!UseOldBehavior37016 && path is not null)
+            {
+                newPath.AddRange(path);
+            }
+
+            newPath.Add(new(translatedIndex));
 
             var translation = new JsonScalarExpression(
                 json,
-                path,
+                newPath,
                 projection.Type,
                 projection.TypeMapping,
                 projectionColumn.IsNullable);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/Associations/OwnedNavigations/OwnedNavigationsCollectionCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/Associations/OwnedNavigations/OwnedNavigationsCollectionCosmosTest.cs
@@ -126,6 +126,18 @@ WHERE (c["AssociateCollection"][9999]["Int"] = 8)
 """);
     }
 
+    public override async Task Index_on_nested_collection()
+    {
+        await base.Index_on_nested_collection();
+
+        AssertSql(
+            """
+SELECT VALUE c
+FROM root c
+WHERE (c["RequiredAssociate"]["NestedCollection"][0]["Int"] = 8)
+""");
+    }
+
     #endregion Index
 
     #region GroupBy

--- a/test/EFCore.Specification.Tests/Query/Associations/AssociationsCollectionTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Associations/AssociationsCollectionTestBase.cs
@@ -76,6 +76,14 @@ public abstract class AssociationsCollectionTestBase<TFixture>(TFixture fixture)
             ss => ss.Set<RootEntity>().Where(e => e.AssociateCollection.Count > e.Id - 1 && e.AssociateCollection[e.Id - 1].Int == 8)));
 
     [ConditionalFact]
+    public virtual Task Index_on_nested_collection()
+        => AssertOrderedCollectionQuery(() => AssertQuery(
+            ss => ss.Set<RootEntity>().Where(e => e.RequiredAssociate.NestedCollection[0].Int == 8),
+            ss => ss.Set<RootEntity>().Where(
+                e => e.RequiredAssociate.NestedCollection.Count > 0
+                    && e.RequiredAssociate.NestedCollection[0].Int == 8)));
+
+    [ConditionalFact]
     public virtual Task Index_out_of_bounds()
         => AssertOrderedCollectionQuery(() => AssertQuery(
             ss => ss.Set<RootEntity>().Where(e => e.AssociateCollection[9999].Int == 8),

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Associations/ComplexJson/ComplexJsonCollectionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Associations/ComplexJson/ComplexJsonCollectionSqlServerTest.cs
@@ -244,6 +244,30 @@ WHERE CAST(JSON_VALUE([r].[AssociateCollection], '$[' + CAST([r].[Id] - 1 AS nva
         }
     }
 
+    public override async Task Index_on_nested_collection()
+    {
+        await base.Index_on_nested_collection();
+
+        if (Fixture.UsingJsonType)
+        {
+            AssertSql(
+                """
+SELECT [r].[Id], [r].[Name], [r].[AssociateCollection], [r].[OptionalAssociate], [r].[RequiredAssociate]
+FROM [RootEntity] AS [r]
+WHERE JSON_VALUE([r].[RequiredAssociate], '$.NestedCollection[0].Int' RETURNING int) = 8
+""");
+        }
+        else
+        {
+            AssertSql(
+                """
+SELECT [r].[Id], [r].[Name], [r].[AssociateCollection], [r].[OptionalAssociate], [r].[RequiredAssociate]
+FROM [RootEntity] AS [r]
+WHERE CAST(JSON_VALUE([r].[RequiredAssociate], '$.NestedCollection[0].Int') AS int) = 8
+""");
+        }
+    }
+
     public override async Task Index_out_of_bounds()
     {
         await base.Index_out_of_bounds();

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Associations/Navigations/NavigationsCollectionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Associations/Navigations/NavigationsCollectionSqlServerTest.cs
@@ -199,6 +199,13 @@ ORDER BY [r].[Id], [s].[Id], [s].[Id0], [s].[Id1]
         AssertSql();
     }
 
+    public override async Task Index_on_nested_collection()
+    {
+        await base.Index_on_nested_collection();
+
+        AssertSql();
+    }
+
     public override async Task Index_out_of_bounds()
     {
         await base.Index_out_of_bounds();

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Associations/OwnedJson/OwnedJsonCollectionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Associations/OwnedJson/OwnedJsonCollectionSqlServerTest.cs
@@ -317,6 +317,30 @@ WHERE CAST(JSON_VALUE([r].[AssociateCollection], '$[' + CAST([r].[Id] - 1 AS nva
         }
     }
 
+    public override async Task Index_on_nested_collection()
+    {
+        await base.Index_on_nested_collection();
+
+        if (Fixture.UsingJsonType)
+        {
+            AssertSql(
+                """
+SELECT [r].[Id], [r].[Name], [r].[AssociateCollection], [r].[OptionalAssociate], [r].[RequiredAssociate]
+FROM [RootEntity] AS [r]
+WHERE JSON_VALUE([r].[RequiredAssociate], '$.NestedCollection[0].Int' RETURNING int) = 8
+""");
+        }
+        else
+        {
+            AssertSql(
+                """
+SELECT [r].[Id], [r].[Name], [r].[AssociateCollection], [r].[OptionalAssociate], [r].[RequiredAssociate]
+FROM [RootEntity] AS [r]
+WHERE CAST(JSON_VALUE([r].[RequiredAssociate], '$.NestedCollection[0].Int') AS int) = 8
+""");
+        }
+    }
+
     public override async Task Index_out_of_bounds()
     {
         await base.Index_out_of_bounds();

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Associations/OwnedNavigations/OwnedNavigationsCollectionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Associations/OwnedNavigations/OwnedNavigationsCollectionSqlServerTest.cs
@@ -202,6 +202,13 @@ ORDER BY [r].[Id], [s].[RootEntityId], [s].[Id], [s].[AssociateTypeRootEntityId]
         AssertSql();
     }
 
+    public override async Task Index_on_nested_collection()
+    {
+        await base.Index_on_nested_collection();
+
+        AssertSql();
+    }
+
     public override async Task Index_out_of_bounds()
     {
         await base.Index_out_of_bounds();


### PR DESCRIPTION
Fixes #37016
Port of #37017

### Description
The new support for complex JSON mapping in EF 10 accidentally left out test coverage for indexing on nested collections (e.g. `Where(b => b.JsonColumn.Something.Coll[0] == 8)`; as a result, this scenario had two bugs which are fixed by this PR. Unfortunately, this bug was discovered too late to get the fix into 10.0.0.

### Customer Impact
Any LINQ query attempting to index into a nested JSON collection fails. Non-nested collections work fine.

### How found
Found during verification/smoke testing.

### Regression
No, complex JSON is a new feature.

### Testing
Tests added.

### Risk
Low - the changes affect code which was already changed significantly in 10.0 (to support complex JSON). Changes are relatively surgical and scope is limited. Quirk added.