### PR TITLE
[release/10.0] Fix parameter type for ComplexCollection method

### DIFF
--- a/src/EFCore/ChangeTracking/ComplexElementEntry`.cs
+++ b/src/EFCore/ChangeTracking/ComplexElementEntry`.cs
@@ -124,7 +124,7 @@ public class ComplexElementEntry<TEntity, TComplexProperty> : ComplexElementEntr
     /// </param>
     /// <returns>An object that exposes change tracking information and operations for the given property.</returns>
     public virtual ComplexCollectionEntry<TEntity, TElement> ComplexCollection<TElement>(
-        Expression<Func<TEntity, IEnumerable<TElement>?>> propertyExpression)
+        Expression<Func<TComplexProperty, IEnumerable<TElement>?>> propertyExpression)
         where TElement : notnull
     {
         Check.NotNull(propertyExpression, nameof(propertyExpression));

--- a/src/EFCore/ChangeTracking/ComplexPropertyEntry`.cs
+++ b/src/EFCore/ChangeTracking/ComplexPropertyEntry`.cs
@@ -117,7 +117,7 @@ public class ComplexPropertyEntry<TEntity, TComplexProperty> : ComplexPropertyEn
     /// </param>
     /// <returns>An object that exposes change tracking information and operations for the given property.</returns>
     public virtual ComplexCollectionEntry<TEntity, TElement> ComplexCollection<TElement>(
-        Expression<Func<TEntity, IEnumerable<TElement>?>> propertyExpression)
+        Expression<Func<TComplexProperty, IEnumerable<TElement>?>> propertyExpression)
         where TElement : notnull
     {
         Check.NotNull(propertyExpression, nameof(propertyExpression));

--- a/test/EFCore.Tests/ChangeTracking/Internal/InternalComplexEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/InternalComplexEntryTest.cs
@@ -707,7 +707,7 @@ public class InternalComplexEntryTest
         {
             Items =
             [
-                new NestedItem { Name = "bar" },
+                new NestedItem { Name = "bar1" },
                 new NestedItem { Name = "baz" },
                 new NestedItem { Name = "new-bar" }
             ]
@@ -717,6 +717,13 @@ public class InternalComplexEntryTest
         changeDetector.DetectChanges(stateManager);
 
         Assert.Equal(EntityState.Modified, entityEntry.EntityState);
+
+        var nestedJson = new EntityEntry<BlogWithNested>(entityEntry).ComplexProperty(b => b.NestedJson);
+        var items = nestedJson.ComplexCollection(j => j.Items);
+        Assert.Equal(3, items.CurrentValue!.Count);
+        Assert.Equal(EntityState.Modified, items[0].State);
+        Assert.Equal(EntityState.Unchanged, items[1].State);
+        Assert.Equal(EntityState.Added, items[2].State);
     }
 
     private static IModel CreateModel()


### PR DESCRIPTION
Fixes #37064

**Description**

The `ComplexCollection` method declares an incorrect parameter type preventing its indented usage.

**Customer impact**

Calling these methods with the expected argument results in a compiler error, if a different argument is used to avoid a compiler error then an exception will be thrown at runtime. A workaround is to use a `string` overload of these methods.

**How found**

Customer reported on 10.0.0-rc2

**Regression**

No, new feature

**Testing**

Test added

**Risk**

Low. Localized change that only affects the new complex collections feature.
