### PR TITLE
[release/8.0-staging] Fix 0-byte reads/writes on blobs

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteBlob.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteBlob.cs
@@ -206,8 +206,12 @@ namespace Microsoft.Data.Sqlite
                 count = (int)(Length - position);
             }
 
-            var rc = sqlite3_blob_read(_blob, buffer.Slice(0, count), (int)position);
-            SqliteException.ThrowExceptionForRC(rc, _connection.Handle);
+            // Newer sqlite3_blob_read returns error for 0-byte reads.
+            if (count > 0)
+            {
+                var rc = sqlite3_blob_read(_blob, buffer.Slice(0, count), (int)position);
+                SqliteException.ThrowExceptionForRC(rc, _connection.Handle);
+            }
             _position += count;
             return count;
         }
@@ -280,8 +284,12 @@ namespace Microsoft.Data.Sqlite
                 throw new NotSupportedException(Resources.ResizeNotSupported);
             }
 
-            var rc = sqlite3_blob_write(_blob, buffer.Slice(0, count), (int)position);
-            SqliteException.ThrowExceptionForRC(rc, _connection.Handle);
+            // Newer sqlite3_blob_write returns error for 0-byte writes.
+            if (count > 0)
+            {
+                var rc = sqlite3_blob_write(_blob, buffer.Slice(0, count), (int)position);
+                SqliteException.ThrowExceptionForRC(rc, _connection.Handle);
+            }
             _position += count;
         }
 


### PR DESCRIPTION
Backport of #36950.

### Description

Newer versions of macOS come with newer version of SQLite that returns an error on 0-byte reads/writes on blobs.

### Customer impact

A) Customers running on i.e. macOS 15 and doing 0-byte reads/write on blob stream receive error from SQLite.
B) Blocks our ability to update to newer macOS queues. 

### How found

Customer reported.

### Regression

No.

### Testing

Already covered by tests. This depends on underlying SQLite version.

### Risk

Low.