### PR TITLE
Fix typo in Cosmos package README

### DIFF
--- a/src/EFCore.Cosmos/PACKAGE.md
+++ b/src/EFCore.Cosmos/PACKAGE.md
@@ -18,7 +18,7 @@ See [Getting started with EF Core](https://learn.microsoft.com/ef/core/get-start
 
 ## Additional documentation
 
-See [Microsoft SQL Server EF Core Database Provider](https://learn.microsoft.com/ef/core/providers/cosmos/) for more information about the features of this database provider.
+See [EF Core Azure Cosmos DB Provider](https://learn.microsoft.com/ef/core/providers/cosmos/) for more information about the features of this database provider.
 
 ## Feedback
 


### PR DESCRIPTION
Update link title to correct provider for Cosmos DB in NuGet package README.

---

- [x] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [ ] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [ ] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo
