### PR TITLE
[release/8.0-staging] Handle .NET 10 MemoryExtensions.Contains overload with comparer

### DIFF
--- a/test/EFCore.Specification.Tests/Query/PrimitiveCollectionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/PrimitiveCollectionsQueryTestBase.cs
@@ -371,6 +371,34 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
             async,
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => c.Bools.Contains(true)));
 
+    // C# 14 first-class spans caused MemoryExtensions.Contains to get resolved instead of Enumerable.Contains.
+    // The following tests that the various overloads are all supported.
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Contains_on_Enumerable(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => Enumerable.Contains(new[] { 10, 999 }, c.Int)));
+
+    // C# 14 first-class spans caused MemoryExtensions.Contains to get resolved instead of Enumerable.Contains.
+    // The following tests that the various overloads are all supported.
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Contains_on_MemoryExtensions(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => MemoryExtensions.Contains(new[] { 10, 999 }, c.Int)));
+
+    // Note that we don't test EF 8/9 with .NET 10; this test is here for completeness/documentation purposes.
+#if NET10_0_OR_GREATER
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Contains_with_MemoryExtensions_with_null_comparer(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => MemoryExtensions.Contains(new[] { 10, 999 }, c.Int, comparer: null)));
+#endif
+
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Column_collection_Count_method(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQueryOldSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQueryOldSqlServerTest.cs
@@ -462,6 +462,45 @@ WHERE 0 = 1
                 .SingleAsync());
     }
 
+    public override async Task Contains_on_Enumerable(bool async)
+    {
+        await base.Contains_on_Enumerable(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[Int] IN (10, 999)
+""");
+    }
+
+
+    public override async Task Contains_on_MemoryExtensions(bool async)
+    {
+        await base.Contains_on_MemoryExtensions(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[Int] IN (10, 999)
+""");
+    }
+
+#if NET10_0_OR_GREATER
+    public override async Task Contains_with_MemoryExtensions_with_null_comparer(bool async)
+    {
+        await base.Contains_with_MemoryExtensions_with_null_comparer(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[Int] IN (10, 999)
+""");
+    }
+#endif
+
     public override Task Column_collection_Count_method(bool async)
         => AssertCompatibilityLevelTooLow(() => base.Column_collection_Count_method(async));
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerTest.cs
@@ -635,6 +635,45 @@ WHERE CAST(1 AS bit) IN (
                 .SingleAsync());
     }
 
+    public override async Task Contains_on_Enumerable(bool async)
+    {
+        await base.Contains_on_Enumerable(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[Int] IN (10, 999)
+""");
+    }
+
+
+    public override async Task Contains_on_MemoryExtensions(bool async)
+    {
+        await base.Contains_on_MemoryExtensions(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[Int] IN (10, 999)
+""");
+    }
+
+#if NET10_0_OR_GREATER
+    public override async Task Contains_with_MemoryExtensions_with_null_comparer(bool async)
+    {
+        await base.Contains_with_MemoryExtensions_with_null_comparer(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE [p].[Int] IN (10, 999)
+""");
+    }
+#endif
+
     public override async Task Column_collection_Count_method(bool async)
     {
         await base.Column_collection_Count_method(async);

--- a/test/EFCore.Sqlite.FunctionalTests/Query/PrimitiveCollectionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/PrimitiveCollectionsQuerySqliteTest.cs
@@ -625,6 +625,45 @@ WHERE 1 IN (
 """);
     }
 
+    public override async Task Contains_on_Enumerable(bool async)
+    {
+        await base.Contains_on_Enumerable(async);
+
+        AssertSql(
+            """
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE "p"."Int" IN (10, 999)
+""");
+    }
+
+
+    public override async Task Contains_on_MemoryExtensions(bool async)
+    {
+        await base.Contains_on_MemoryExtensions(async);
+
+        AssertSql(
+            """
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE "p"."Int" IN (10, 999)
+""");
+    }
+
+#if NET10_0_OR_GREATER
+    public override async Task Contains_with_MemoryExtensions_with_null_comparer(bool async)
+    {
+        await base.Contains_with_MemoryExtensions_with_null_comparer(async);
+
+        AssertSql(
+            """
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE "p"."Int" IN (10, 999)
+""");
+    }
+#endif
+
     public override async Task Column_collection_Count_method(bool async)
     {
         await base.Column_collection_Count_method(async);


### PR DESCRIPTION
Fixes #37176 for EF 8.0 (see #37183 for 8.0 fix)

### Description

C# 14 first-class spans causes MemoryExtensions.Contains instead of Enumerable.Contains to be resolved, forcing LINQ providers to identify the former in additional to the latter. In addition, .NET 10 introduced a 3-parameter overload to MemoryExtensions.Contains which accepts a comparer, that gets resolved in some situations. While we already backported support for MemoryExtensions.Contains to EF Core 8 and 9, to allow these versions to work with C# 14, we didn't backport a separate change to also support the new .NET 10 overload.

### Customer impact

Customers upgrading to .NET 10 but staying on EF 8 or 9 start experiencing failures in some LINQ queries that use Contains. The common case is Contains over an enum array:

```c#
_ = await context.Blogs
    .Where(b => new SomeEnum[] { SomeEnum.One, SomeEnum.Too }.Contains(b.SomeEnum))
    .ToListAsync();

```

Customers upgrading to EF 10 are not affected.

### How found

Multiple customers reported on 9.0

### Regression

Partial: occurs only when upgrading to .NET 10 but keeping older EF 8 or 9.

### Testing

Tested manually, as we don't have automated testing for .NET 10 on older EF versions.

### Risk

Very low, targeted change that's very low-risk, and already well-tested in EF 10. Quirk added.

