### PR TITLE
[release/10.0] Fix materialization of non-nullable complex type with all-null properties

### DIFF
--- a/src/EFCore/Query/EntityMaterializerSourceParameters.cs
+++ b/src/EFCore/Query/EntityMaterializerSourceParameters.cs
@@ -8,7 +8,15 @@ namespace Microsoft.EntityFrameworkCore.Query;
 /// </summary>
 /// <param name="StructuralType">The entity or complex type being materialized.</param>
 /// <param name="InstanceName">The name of the instance being materialized.</param>
-/// <param name="ClrType">CLR type of the result.</param>
+/// <param name="ClrType">
+///     CLR type of the result.
+///     Note that this differs from <see cref="IReadOnlyTypeBase.ClrType "/> on <paramref name="StructuralType" />
+///     when a nullable value type is being projected out.
+/// </param>
+/// <param name="IsNullable">
+///     Whether the type being materialized is nullable.
+///     A complex type may be non-nullable even if its CLR type is nullable (i.e. a class), based on model configuration.
+/// </param>
 /// <param name="QueryTrackingBehavior">
 ///     The query tracking behavior, or <see langword="null" /> if this materialization is not from a query.
 /// </param>
@@ -16,6 +24,7 @@ public readonly record struct StructuralTypeMaterializerSourceParameters(
     ITypeBase StructuralType,
     string InstanceName,
     Type ClrType,
+    bool IsNullable,
     QueryTrackingBehavior? QueryTrackingBehavior);
 
 /// <summary>

--- a/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
@@ -642,7 +642,7 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
                 valueBufferExpression,
                 shaper.MaterializationCondition.Body);
 
-            var expressionContext = (returnType, materializationContextVariable, concreteEntityTypeVariable, shadowValuesVariable);
+            var expressionContext = (returnType, shaper.IsNullable, materializationContextVariable, concreteEntityTypeVariable, shadowValuesVariable);
             expressions.Add(Assign(concreteEntityTypeVariable, materializationConditionBody));
 
             var (primaryKey, concreteStructuralTypes) = structuralType is IEntityType entityType
@@ -708,11 +708,13 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
         private BlockExpression CreateFullMaterializeExpression(
             ITypeBase concreteStructuralType,
             (Type ReturnType,
+                bool IsNullable,
                 ParameterExpression MaterializationContextVariable,
                 ParameterExpression ConcreteEntityTypeVariable,
                 ParameterExpression ShadowValuesVariable) materializeExpressionContext)
         {
             var (returnType,
+                nullable,
                 materializationContextVariable,
                 _,
                 shadowValuesVariable) = materializeExpressionContext;
@@ -722,7 +724,7 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
             var materializer = materializerSource
                 .CreateMaterializeExpression(
                     new StructuralTypeMaterializerSourceParameters(
-                        concreteStructuralType, "instance", returnType, queryTrackingBehavior), materializationContextVariable);
+                        concreteStructuralType, "instance", returnType, nullable, queryTrackingBehavior), materializationContextVariable);
 
             if (_queryStateManager
                 && concreteStructuralType is IRuntimeEntityType { ShadowPropertyCount: > 0 } runtimeEntityType)

--- a/test/EFCore.Specification.Tests/Query/AdHocComplexTypeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AdHocComplexTypeQueryTestBase.cs
@@ -220,6 +220,54 @@ public abstract class AdHocComplexTypeQueryTestBase(NonSharedFixture fixture)
 
     #endregion 36837
 
+    #region 37162
+
+    [ConditionalFact]
+    public virtual async Task Non_optional_complex_type_with_all_nullable_properties()
+    {
+        var contextFactory = await InitializeAsync<Context37162>(
+            seed: context =>
+            {
+                context.Add(
+                    new Context37162.EntityType
+                    {
+                        NonOptionalComplexType = new Context37162.ComplexTypeWithAllNulls
+                        {
+                            // All properties are null
+                        }
+                    });
+                return context.SaveChangesAsync();
+            });
+
+        await using var context = contextFactory.CreateContext();
+
+        var entity = await context.Set<Context37162.EntityType>().SingleAsync();
+
+        Assert.NotNull(entity.NonOptionalComplexType);
+        Assert.Null(entity.NonOptionalComplexType.NullableString);
+        Assert.Null(entity.NonOptionalComplexType.NullableDateTime);
+    }
+
+    private class Context37162(DbContextOptions options) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<EntityType>().ComplexProperty(b => b.NonOptionalComplexType);
+
+        public class EntityType
+        {
+            public int Id { get; set; }
+            public ComplexTypeWithAllNulls NonOptionalComplexType { get; set; } = null!;
+        }
+
+        public class ComplexTypeWithAllNulls
+        {
+            public string? NullableString { get; set; }
+            public DateTime? NullableDateTime { get; set; }
+        }
+    }
+
+    #endregion 37162
+
     protected override string StoreName
         => "AdHocComplexTypeQueryTest";
 }

--- a/test/EFCore.Tests/Query/EntityMaterializerSourceTest.cs
+++ b/test/EFCore.Tests/Query/EntityMaterializerSourceTest.cs
@@ -26,7 +26,7 @@ public class EntityMaterializerSourceTest
             CoreStrings.CannotMaterializeAbstractType(nameof(SomeAbstractEntity)),
             Assert.Throws<InvalidOperationException>(
                     () => source.CreateMaterializeExpression(
-                        new StructuralTypeMaterializerSourceParameters((IEntityType)entityType, "", entityType.ClrType, null), null!))
+                        new StructuralTypeMaterializerSourceParameters((IEntityType)entityType, "", entityType.ClrType, IsNullable: false, null), null!))
                 .Message);
     }
 
@@ -547,7 +547,7 @@ public class EntityMaterializerSourceTest
         IReadOnlyEntityType entityType)
         => Expression.Lambda<Func<MaterializationContext, object>>(
                 source.CreateMaterializeExpression(
-                    new StructuralTypeMaterializerSourceParameters((IEntityType)entityType, "instance", entityType.ClrType, null),
+                    new StructuralTypeMaterializerSourceParameters((IEntityType)entityType, "instance", entityType.ClrType, IsNullable: false, null),
                     _contextParameter),
                 _contextParameter)
             .Compile();


### PR DESCRIPTION
Fixes #37162

### Description

When EF loads a complex type from the database (in table splitting mode), when that type is nullable, checks are added on its individual properties to know whether the type is absent or present (i.e. materialize null or not). As part of our complex type work in 10.0, logic was changed/improved in this area to support optional complex types; however, we unfortunately introduced a bug where classes were always considered as optional complex types in materialization (because they're nullable CLR types), leading us to materialize them incorrectly as optional even when they're configured as non-optional.

### Customer impact

When loading a non-nullable complex type that has only nullable properties which all contain null, EF 10 returns null for the complex type instead of a non-null instance with all properties set to null. This violates the user's non-nullable configuration, NRT annotations, etc.

### How found

Customer reported on 10.0

### Regression

Yes

### Testing

Added

### Risk

Low. Although the PR appears to touch a lot of product code, it effectively flows down an additional piece of missing information (the nullability) that only gets used in a single place; so the change is actually quite targeted. Added a quirk for where the new information actually gets used in decision-making.

