### PR TITLE
[release/10.0] Fix bucketization for number of values between 2070 and 2100 for SQL Server.

### DIFF
--- a/src/EFCore.SqlServer/Query/Internal/SqlServerSqlNullabilityProcessor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerSqlNullabilityProcessor.cs
@@ -18,6 +18,9 @@ public class SqlServerSqlNullabilityProcessor : SqlNullabilityProcessor
 {
     private const int MaxParameterCount = 2100;
 
+    private static readonly bool UseOldBehavior37151 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue37151", out var enabled) && enabled;
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -291,7 +294,8 @@ public class SqlServerSqlNullabilityProcessor : SqlNullabilityProcessor
             <= 750 => 50,
             <= 2000 => 100,
             <= 2070 => 10, // try not to over-pad as we approach that limit
-            <= MaxParameterCount => 0, // just don't pad between 2070 and 2100, to minimize the crazy
+            <= MaxParameterCount when UseOldBehavior37151 => 0,
+            <= MaxParameterCount => 1, // just don't pad between 2070 and 2100, to minimize the crazy
             _ => 200,
         };
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerTest.cs
@@ -2265,6 +2265,16 @@ WHERE (
     }
 
     [ConditionalFact]
+    public virtual async Task Parameter_collection_of_ints_Contains_int_2071_values()
+    {
+        var ints = Enumerable.Repeat(10, 2071).ToArray();
+        await AssertQuery(ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => ints.Contains(c.Int)));
+
+        // check that 2071 parameter is the last one (and no error happened)
+        Assert.Contains("@ints2071)", Fixture.TestSqlLoggerFactory.SqlStatements[0], StringComparison.Ordinal);
+    }
+
+    [ConditionalFact]
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());
 


### PR DESCRIPTION
Backport of #37197.

### Description
Incorrect logic was present for bucketization (padding) computation when number of values is between 2070 and 2100 where we want to minimize padding near the limit for SQL Server.

### Customer impact
Exception thrown when number of values is between 2070 and 2100.

### How found
Customer reported on 10.0.

### Regression
Yes.

### Testing
Tests added.

### Risk
Low. This is a targeted fix. Quirk added.