### PR TITLE
[release/10.0] Fixing named query cache misses by adding support for collections in constant expression comparer

### DIFF
--- a/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs
+++ b/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs
@@ -25,6 +25,9 @@ namespace Microsoft.EntityFrameworkCore;
          + "from user code - so it's never trimmed.")]
 public static class EntityFrameworkQueryableExtensions
 {
+    private static readonly bool UseOldBehavior37112 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue37112", out var enabled) && enabled;
+
     /// <summary>
     ///     Generates a string representation of the query used. This string may not be suitable for direct execution and is intended only
     ///     for use in debugging.
@@ -2710,7 +2713,9 @@ public static class EntityFrameworkQueryableExtensions
                 Expression.Call(
                     instance: null,
                     method: IgnoreNamedQueryFiltersMethodInfo.MakeGenericMethod(typeof(TEntity)),
-                    arguments: [source.Expression, Expression.Constant(filterKeys)]))
+                    arguments: UseOldBehavior37112
+                        ? [source.Expression, Expression.Constant(filterKeys)]
+                        : [source.Expression, Expression.Constant(filterKeys is string[]? filterKeys : filterKeys.ToArray())]))
             : source;
 
     #endregion


### PR DESCRIPTION
Backport of #37150.

### Description
In EF 10 we added support for named query filters. Also with that `IgnoreQueryFilters(IReadOnlyCollection<string>)` method was added. Sadly we missed the fact that our structural comparison for query caching does not handle properly `IReadOnlyCollection<string>`.

### Customer impact
Queries that use above mentioned method are never cached in EF, resulting in subpar performance.

### How found
Customer reported on 10.0 RC2.

### Regression
No.

### Testing
Tests added.

### Risk
Low. Quirk added.