### PR TITLE
[release/10.0] Fix complex collection within left join subquery

### DIFF
--- a/src/EFCore.Relational/Query/StructuralTypeProjectionExpression.cs
+++ b/src/EFCore.Relational/Query/StructuralTypeProjectionExpression.cs
@@ -20,6 +20,9 @@ public class StructuralTypeProjectionExpression : Expression
     private readonly Dictionary<INavigation, StructuralTypeShaperExpression> _ownedNavigationMap;
     private Dictionary<IComplexProperty, Expression>? _complexPropertyCache;
 
+    private static readonly bool UseOldBehavior37205 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue37205", out var enabled) && enabled;
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -202,6 +205,11 @@ public class StructuralTypeProjectionExpression : Expression
                 if (complexShaper is StructuralTypeShaperExpression nonCollectionComplexShaper)
                 {
                     complexPropertyCache[complexProperty] = nonCollectionComplexShaper.MakeNullable();
+                }
+
+                if (!UseOldBehavior37205 && complexShaper is CollectionResultExpression collectionComplexShaper)
+                {
+                    complexPropertyCache[complexProperty] = collectionComplexShaper;
                 }
             }
         }

--- a/test/EFCore.Relational.Specification.Tests/Query/AdHocComplexTypeQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/AdHocComplexTypeQueryRelationalTestBase.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public abstract class AdHocComplexTypeQueryRelationalTestBase(NonSharedFixture fixture) : AdHocComplexTypeQueryTestBase(fixture)
+{
+    #region 37205
+
+    [ConditionalFact]
+    public virtual async Task Complex_json_collection_inside_left_join_subquery()
+    {
+        var contextFactory = await InitializeAsync<Context37205>();
+
+        await using var context = contextFactory.CreateContext();
+
+        _ = await context.Set<Context37205.Parent>().Include(p => p.Child).ToListAsync();
+    }
+
+    private class Context37205(DbContextOptions options) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Parent>();
+            modelBuilder.Entity<Child>(b =>
+            {
+                b.ComplexCollection(e => e.CareNeeds, cb => cb.ToJson());
+                b.HasQueryFilter(child => child.IsPublic);
+            });
+        }
+
+        public class Parent
+        {
+            public int Id { get; set; }
+            public Child? Child { get; set; }
+            public int? ChildId { get; set; }
+        }
+
+        public class Child
+        {
+            public int Id { get; set; }
+            public Parent Parent { get; set; } = null!;
+            public bool IsPublic { get; set; }
+            public required List<CareNeedAnswer> CareNeeds { get; set; }
+        }
+
+        public record CareNeedAnswer
+        {
+            public required string Topic { get; set; }
+        }
+    }
+
+    #endregion 37205
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocComplexTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocComplexTypeQuerySqlServerTest.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public class AdHocComplexTypeQuerySqlServerTest(NonSharedFixture fixture) : AdHocComplexTypeQueryTestBase(fixture)
+public class AdHocComplexTypeQuerySqlServerTest(NonSharedFixture fixture) : AdHocComplexTypeQueryRelationalTestBase(fixture)
 {
     public override async Task Complex_type_equals_parameter_with_nested_types_with_property_of_same_name()
     {

--- a/test/EFCore.Sqlite.FunctionalTests/Query/AdHocComplexTypeQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/AdHocComplexTypeQuerySqliteTest.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-public class AdHocComplexTypeQuerySqliteTest(NonSharedFixture fixture) : AdHocComplexTypeQueryTestBase(fixture)
+public class AdHocComplexTypeQuerySqliteTest(NonSharedFixture fixture) : AdHocComplexTypeQueryRelationalTestBase(fixture)
 {
     protected override ITestStoreFactory TestStoreFactory
         => SqliteTestStoreFactory.Instance;


### PR DESCRIPTION
Backports #37238
Fixes #37205

### Description

Complex JSON collection support was added for 10.0, including full querying capabilities. Unfortunately, a bug slipped into the implementation, where projecting an entity having a JSON collection out of a left join subquery causes the wrong SQL to get generated.

### Customer impact

When a LINQ query meeting certain non-contrived conditions is executed, the SQL is incorrect and the query fails.

### How found

Customer reported on 10.0.0

### Regression

No.

### Testing

Added.

### Risk

Very low, one-line trivial targeted fix. Quirk added.

