### PR TITLE
Adding support for any collection in ExpressionEqualityComparer #37212

### DIFF
--- a/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs
+++ b/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs
@@ -2947,9 +2947,7 @@ public static class EntityFrameworkQueryableExtensions
                 Expression.Call(
                     instance: null,
                     method: new Func<IQueryable<TEntity>, IReadOnlyCollection<string>, IQueryable<TEntity>>(IgnoreQueryFilters).Method,
-                    // converting the collection to an array if it isn't already one to ensure consistent caching. Fixes #37112.
-                    // #37212 may be a possible future solution providing broader capabilities around parameterizing collections.
-                    arguments: [source.Expression, Expression.Constant(filterKeys is string[] ? filterKeys : filterKeys.ToArray())]))
+                    arguments: [source.Expression, Expression.Constant(filterKeys)]))
             : source;
 
     #endregion

--- a/test/EFCore.Specification.Tests/Query/AdHocQueryFiltersQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AdHocQueryFiltersQueryTestBase.cs
@@ -43,7 +43,9 @@ public abstract class AdHocQueryFiltersQueryTestBase(NonSharedFixture fixture)
             builder.EnableSensitiveDataLogging();
             builder.LogTo(cacheLog.Add, filter: (eventid, _) => eventid.Name == CoreEventId.QueryCompilationStarting.Name);
         });
+
         using var context = contextFactory.CreateContext();
+
         _ = context.Entities
             .IgnoreQueryFilters(["ActiveFilter", "NameFilter"])
             .ToList();
@@ -54,8 +56,6 @@ public abstract class AdHocQueryFiltersQueryTestBase(NonSharedFixture fixture)
             .IgnoreQueryFilters(["NameFilter", "ActiveFilter"])
             .ToList();
 
-        // #37212 - ExpressionEqualityComparer doesn't support collections besides an array,
-        // therefore we can't implement caching for different order of ignored filters
         Assert.Equal(2, cacheLog.Count);
     }
 


### PR DESCRIPTION
Extend `GetHashCode` to handle `IEnumerable` objects, ensuring proper hash code generation for collections.

Add support for comparing `IEnumerable` objects using `SequenceEqual`, enhancing robustness for constant value comparisons.

Closes #37212

- [X] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [ ] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [X] The code builds and tests pass locally (also verified by our automated build checks)
- [X] Commit messages follow this format:
- [X] ~~Tests for the changes have been added (for bug fixes / features)~~
Existing test already cover this, removed the old workaround for ignore query filters
- [X] Code follows the same patterns and style as existing code in this repo

