### PR TITLE
[release/10.0] Apply pending selector before ExecuteUpdate

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/BulkUpdates/NorthwindBulkUpdatesRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/BulkUpdates/NorthwindBulkUpdatesRelationalTestBase.cs
@@ -68,7 +68,7 @@ WHERE [OrderID] < 10300"));
 
     public override Task Update_multiple_tables_throws(bool async)
         => AssertTranslationFailed(
-            RelationalStrings.MultipleTablesInExecuteUpdate("o => o.Outer.OrderDate", "o => o.Inner.ContactName"),
+            RelationalStrings.MultipleTablesInExecuteUpdate("o => o.e.OrderDate", "o => o.Customer.ContactName"),
             () => base.Update_multiple_tables_throws(async));
 
     public override Task Update_unmapped_property_throws(bool async)


### PR DESCRIPTION
Closes #37247

### Description

EF 10 brought various improvements to ExecuteUpdate; among them was #36723, which brought full processing of ExecuteUpdate in our navigation expansion, like any other LINQ operator (previously it was processed as an unknown method, and navigations inside the setter lambdas were not expanded). Unfortunately, with the current implementation, that also means that any pending selector (the Select about just before ExecuteUpdate) flows into the ExecuteUpdate setters. The more complicated setters caused a failure in later processing, specifically in PK-based subquery handling, for natively-unsupported LINQ operators.

See below for an in-depth analysis, for reference.

### Customer impact

This bug affects cases where:

* There's a join before the ExecuteUpdate (possibly some other pending selector types as well).
* The tree contains operators which aren't natively supported by UPDATE, and so require a PK-based subquery pushdown.
* There's more than one selector (this triggers the problem in the code handling PK-based subquery pushdown). 

Such invocations of ExecuteUpdate throw an exception.

### How found

Customer reported on 10.0.0

### Regression

Yes.

### Testing

Added.

### Risk

Low: short, targeted fix to code already significantly modified in 10.0. Quirk added.

