### PR TITLE
[release/10.0] Fix parameter limit (because of sp_executesql).

### DIFF
--- a/src/EFCore.SqlServer/Query/Internal/SqlServerSqlNullabilityProcessor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerSqlNullabilityProcessor.cs
@@ -16,13 +16,16 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal;
 /// </summary>
 public class SqlServerSqlNullabilityProcessor : SqlNullabilityProcessor
 {
-    private const int MaxParameterCount = 2100 - 2;
+    private int MaxParameterCount => UseOldBehavior37336 ? 2100 : 2100 - 2;
 
     private static readonly bool UseOldBehavior37151 =
         AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue37151", out var enabled) && enabled;
 
     private static readonly bool UseOldBehavior37185 =
         AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue37185", out var enabled) && enabled;
+
+    private static readonly bool UseOldBehavior37336 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue37336", out var enabled) && enabled;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -303,17 +306,16 @@ public class SqlServerSqlNullabilityProcessor : SqlNullabilityProcessor
 
     /// <inheritdoc />
     protected override int CalculateParameterBucketSize(int count, RelationalTypeMapping elementTypeMapping)
-        => count switch
-        {
-            <= 5 => 1,
-            <= 150 => 10,
-            <= 750 => 50,
-            <= 2000 => 100,
-            <= 2070 => 10, // try not to over-pad as we approach that limit
-            <= MaxParameterCount when UseOldBehavior37151 => 0,
-            <= MaxParameterCount => 1, // just don't pad between 2070 and 2100, to minimize the crazy
-            _ => 200,
-        };
+    {
+        if (count <= 5) return 1;
+        if (count <= 150) return 10;
+        if (count <= 750) return 50;
+        if (count <= 2000) return 100;
+        if (count <= 2070) return 10; // try not to over-pad as we approach that limit
+        if (count <= MaxParameterCount && UseOldBehavior37151) return 0;
+        if (count <= MaxParameterCount) return 1; // just don't pad between 2070 and 2100, to minimize the crazy
+        return 200;
+    }
 
     private bool TryHandleOverLimitParameters(
         SqlParameterExpression valuesParameter,

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerTest.cs
@@ -2420,6 +2420,30 @@ WHERE (
         Assert.Contains("@ints2071)", Fixture.TestSqlLoggerFactory.SqlStatements[0], StringComparison.Ordinal);
     }
 
+    [ConditionalTheory]
+    [InlineData(2098)]
+    [InlineData(2099)]
+    [InlineData(2100)]
+    public virtual Task Parameter_collection_of_ints_Contains_int_parameters_limit(int count)
+    {
+        var ints = Enumerable.Range(10, count);
+
+        // no exception from SQL Server is a pass
+        return AssertQuery(ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => ints.Contains(c.Int)));
+    }
+
+    [ConditionalTheory]
+    [InlineData(2098)]
+    [InlineData(2099)]
+    [InlineData(2100)]
+    public virtual Task Parameter_collection_Count_parameters_limit(int count)
+    {
+        var ids = Enumerable.Range(1000, count);
+
+        // no exception from SQL Server is a pass
+        return AssertQuery(ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => ids.Count(i => i > c.Id) > 0));
+    }
+
     [ConditionalFact]
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());


### PR DESCRIPTION
Fixes #37336.

### Description
This change fixes an incorrect maximum limit for SQL Server parameters. Although usually the error states 2100, SqlClient uses `sp_executesql` which takes 2 parameters and hence the count needs to be adjusted.

### Customer impact
Query fails to execute when collection with 2099 or 2100 parameters (exactly) is present in the query.

### How found
Customer reported on 10.0.

### Regression
Yes.

### Testing
Tests added.

### Risk
Low. Quirk added.