### PR TITLE
Fix handling of constant join predicates

### DIFF
--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -2006,8 +2006,8 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
                 .Take(10)
                 .Select(l3 => l3.Name));
 
-    [ConditionalTheory, MemberData(nameof(IsAsyncData))]
-    public virtual Task Join_condition_optimizations_applied_correctly_when_anonymous_type_with_single_property(bool async)
+    [ConditionalTheory, MemberData(nameof(IsAsyncData))] // #18808
+    public virtual Task Join_on_anonymous_type_with_single_property(bool async)
         => AssertQuery(
             async,
             ss => from l1 in ss.Set<Level1>()
@@ -2017,7 +2017,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
                   select l1);
 
     [ConditionalTheory, MemberData(nameof(IsAsyncData))]
-    public virtual Task Join_condition_optimizations_applied_correctly_when_anonymous_type_with_multiple_properties(bool async)
+    public virtual Task Join_on_anonymous_type_with_multiple_properties(bool async)
         => AssertQuery(
             async,
             ss =>
@@ -2030,7 +2030,8 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
                     }
                     equals new
                     {
-                        A = EF.Property<int?>(l2, "Level1_Optional_Id"), B = EF.Property<int?>(l2, "OneToMany_Optional_Self_Inverse2Id")
+                        A = EF.Property<int?>(l2, "Level1_Optional_Id"),
+                        B = EF.Property<int?>(l2, "OneToMany_Optional_Self_Inverse2Id")
                     }
                 select l1);
 

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsSharedTypeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsSharedTypeQueryTestBase.cs
@@ -10,13 +10,13 @@ public abstract class ComplexNavigationsSharedTypeQueryTestBase<TFixture>(TFixtu
     public override Task Join_navigation_self_ref(bool async)
         => AssertTranslationFailed(() => base.Join_navigation_self_ref(async));
 
-    public override Task Join_condition_optimizations_applied_correctly_when_anonymous_type_with_multiple_properties(bool async)
+    public override Task Join_on_anonymous_type_with_multiple_properties(bool async)
         => AssertUnableToTranslateEFProperty(()
-            => base.Join_condition_optimizations_applied_correctly_when_anonymous_type_with_multiple_properties(async));
+            => base.Join_on_anonymous_type_with_multiple_properties(async));
 
-    public override Task Join_condition_optimizations_applied_correctly_when_anonymous_type_with_single_property(bool async)
+    public override Task Join_on_anonymous_type_with_single_property(bool async)
         => AssertUnableToTranslateEFProperty(()
-            => base.Join_condition_optimizations_applied_correctly_when_anonymous_type_with_single_property(async));
+            => base.Join_on_anonymous_type_with_single_property(async));
 
     public override Task Multiple_SelectMany_with_nested_navigations_and_explicit_DefaultIfEmpty_joined_together(bool async)
         => AssertTranslationFailed(()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServer160Test.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServer160Test.cs
@@ -2645,9 +2645,9 @@ OFFSET @p ROWS FETCH NEXT @p1 ROWS ONLY
 """);
     }
 
-    public override async Task Join_condition_optimizations_applied_correctly_when_anonymous_type_with_single_property(bool async)
+    public override async Task Join_on_anonymous_type_with_single_property(bool async)
     {
-        await base.Join_condition_optimizations_applied_correctly_when_anonymous_type_with_single_property(async);
+        await base.Join_on_anonymous_type_with_single_property(async);
 
         AssertSql(
             """
@@ -2657,9 +2657,9 @@ INNER JOIN [LevelTwo] AS [l0] ON [l].[OneToMany_Optional_Self_Inverse1Id] = [l0]
 """);
     }
 
-    public override async Task Join_condition_optimizations_applied_correctly_when_anonymous_type_with_multiple_properties(bool async)
+    public override async Task Join_on_anonymous_type_with_multiple_properties(bool async)
     {
-        await base.Join_condition_optimizations_applied_correctly_when_anonymous_type_with_multiple_properties(async);
+        await base.Join_on_anonymous_type_with_multiple_properties(async);
 
         AssertSql(
             """

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -2645,9 +2645,9 @@ OFFSET @p ROWS FETCH NEXT @p1 ROWS ONLY
 """);
     }
 
-    public override async Task Join_condition_optimizations_applied_correctly_when_anonymous_type_with_single_property(bool async)
+    public override async Task Join_on_anonymous_type_with_single_property(bool async)
     {
-        await base.Join_condition_optimizations_applied_correctly_when_anonymous_type_with_single_property(async);
+        await base.Join_on_anonymous_type_with_single_property(async);
 
         AssertSql(
             """
@@ -2657,9 +2657,9 @@ INNER JOIN [LevelTwo] AS [l0] ON [l].[OneToMany_Optional_Self_Inverse1Id] = [l0]
 """);
     }
 
-    public override async Task Join_condition_optimizations_applied_correctly_when_anonymous_type_with_multiple_properties(bool async)
+    public override async Task Join_on_anonymous_type_with_multiple_properties(bool async)
     {
-        await base.Join_condition_optimizations_applied_correctly_when_anonymous_type_with_multiple_properties(async);
+        await base.Join_on_anonymous_type_with_multiple_properties(async);
 
         AssertSql(
             """

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqlServer160Test.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqlServer160Test.cs
@@ -1406,16 +1406,16 @@ END
         AssertSql();
     }
 
-    public override async Task Join_condition_optimizations_applied_correctly_when_anonymous_type_with_multiple_properties(bool async)
+    public override async Task Join_on_anonymous_type_with_multiple_properties(bool async)
     {
-        await base.Join_condition_optimizations_applied_correctly_when_anonymous_type_with_multiple_properties(async);
+        await base.Join_on_anonymous_type_with_multiple_properties(async);
 
         AssertSql();
     }
 
-    public override async Task Join_condition_optimizations_applied_correctly_when_anonymous_type_with_single_property(bool async)
+    public override async Task Join_on_anonymous_type_with_single_property(bool async)
     {
-        await base.Join_condition_optimizations_applied_correctly_when_anonymous_type_with_single_property(async);
+        await base.Join_on_anonymous_type_with_single_property(async);
 
         AssertSql();
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqlServerTest.cs
@@ -1408,16 +1408,16 @@ END
         AssertSql();
     }
 
-    public override async Task Join_condition_optimizations_applied_correctly_when_anonymous_type_with_multiple_properties(bool async)
+    public override async Task Join_on_anonymous_type_with_multiple_properties(bool async)
     {
-        await base.Join_condition_optimizations_applied_correctly_when_anonymous_type_with_multiple_properties(async);
+        await base.Join_on_anonymous_type_with_multiple_properties(async);
 
         AssertSql();
     }
 
-    public override async Task Join_condition_optimizations_applied_correctly_when_anonymous_type_with_single_property(bool async)
+    public override async Task Join_on_anonymous_type_with_single_property(bool async)
     {
-        await base.Join_condition_optimizations_applied_correctly_when_anonymous_type_with_single_property(async);
+        await base.Join_on_anonymous_type_with_single_property(async);
 
         AssertSql();
     }


### PR DESCRIPTION
Not adding a test as reproducing would rely on another unrelated bug (#15586), even if the fix here may fix various other cases where a constant true/false ends up in a join predicate because of arbitrary simplifications.

Fixes #37300
