### PR TITLE
Docs: clarify identity resolution in QueryTrackingBehavior summaries

### DIFF
--- a/src/EFCore/QueryTrackingBehavior.cs
+++ b/src/EFCore/QueryTrackingBehavior.cs
@@ -23,6 +23,7 @@ public enum QueryTrackingBehavior
     ///     The change tracker will not track any of the entities that are returned from a LINQ query. If the
     ///     entity instances are modified, this will not be detected by the change tracker and
     ///     <see cref="DbContext.SaveChanges()" /> will not persist those changes to the database.
+    ///     Identity resolution is not performed.
     /// </summary>
     /// <remarks>
     ///     <para>
@@ -42,6 +43,7 @@ public enum QueryTrackingBehavior
     ///     The change tracker will not track any of the entities that are returned from a LINQ query. If the
     ///     entity instances are modified, this will not be detected by the change tracker and
     ///     <see cref="DbContext.SaveChanges()" /> will not persist those changes to the database.
+    ///     Identity resolution is performed.
     /// </summary>
     /// <remarks>
     ///     <para>


### PR DESCRIPTION
This PR updates the XML documentation summaries for `QueryTrackingBehavior.NoTracking` and
`QueryTrackingBehavior.NoTrackingWithIdentityResolution` to clarify the identity resolution behavior.

Previously, the behavioral difference was documented only in `<remarks>`, which are not surfaced
for enum members in IntelliSense or the generated API docs. This change moves the relevant
information into the `<summary>` while keeping it short and tooltip-friendly, as discussed.

Fixes #31207
