### PR TITLE
[release/10.0] Correct [DynamicDependency] reference on ExecuteUpdateAsync (#37194)

### DIFF
--- a/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs
+++ b/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs
@@ -3401,7 +3401,7 @@ public static class EntityFrameworkQueryableExtensions
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
     /// <returns>The total number of rows updated in the database.</returns>
     [DynamicDependency(
-        "ExecuteUpdate``1(System.Linq.IQueryable{``1},System.Collections.Generic.IReadOnlyList{ITuple})",
+        "ExecuteUpdate``1(System.Linq.IQueryable{``0},System.Collections.Generic.IReadOnlyList{System.Runtime.CompilerServices.ITuple})",
         typeof(EntityFrameworkQueryableExtensions))]
     public static Task<int> ExecuteUpdateAsync<TSource>(
         this IQueryable<TSource> source,


### PR DESCRIPTION
Fixes #37192

### Description

In EF 10, ExecuteUpdate received improvements to make it easier to use in dynamic scenarios. Unfortunately, the [DynamicDependency] attribute set on it - which helps users who trim their applications - wasn't specified correctly.

### Customer impact

Users upgrading to 10 and using ExecuteUpdateAsync and using trimming get a linker warning because of the mangled [DynamicDependency], and their application may not work correctly.

### How found

Multiple customers reported on 10.0.

### Regression

Yes.

### Testing

Trimming annotation issue, testing is impractical.

### Risk

Almost non-existent, fix to [DynamicDependency] attribute only.