### PR TITLE
Fix formatting in XML documentation comment

### DIFF
--- a/src/EFCore/ChangeTracking/PropertyEntry.cs
+++ b/src/EFCore/ChangeTracking/PropertyEntry.cs
@@ -50,7 +50,7 @@ public class PropertyEntry : MemberEntry
     /// <summary>
     ///     Gets or sets a value indicating whether the value of this property is considered a
     ///     temporary value which will be replaced by a value generated from the store when
-    ///     <see cref="DbContext.SaveChanges()" />is called.
+    ///     <see cref="DbContext.SaveChanges()" /> is called.
     /// </summary>
     /// <remarks>
     ///     See <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see> for more information and


### PR DESCRIPTION
Hello EF Core Team,

I noticed a typo in the docs for `PropertyEntry` while working with EF Core. On going through the source, I realised it was due to the way XML documentation works.

```
/// <summary>
///     Gets or sets a value indicating whether the value of this property is considered a
///     temporary value which will be replaced by a value generated from the store when
///     <see cref="DbContext.SaveChanges()" />is called.
/// </summary>
```

comes out as
```
    //
    // Summary:
    //     Gets or sets a value indicating whether the value of this property is considered
    //     a temporary value which will be replaced by a value generated from the store
    //     when Microsoft.EntityFrameworkCore.DbContext.SaveChangesis called.
    //
```

Notice how `SaveChanges` and `is` get clumped together. I read in your contributing guidelines that we can just create pull requests for typos. I suppose I can do a regex search for similar artifacts, if needed and create a pull request for adding the needed spaces across the entire repository - but that might bring a much larger commit.

- [x] I've read the guidelines for [contributing](https://github.com/dotnet/efcore/blob/main/.github/CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [ ] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

