### PR TITLE
Fix up and reenable analyzer tests

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -25,8 +25,9 @@
     <MicrosoftCodeAnalysisWorkspacesMSBuildVersion>5.0.0</MicrosoftCodeAnalysisWorkspacesMSBuildVersion>
   </PropertyGroup>
   <PropertyGroup Label="Test dependencies">
-    <MicrosoftCodeAnalysisAnalyzerTestingVersion>1.1.3-beta1.24423.1</MicrosoftCodeAnalysisAnalyzerTestingVersion>
-    <MicrosoftCodeAnalysisCSharpTestingVersion>1.1.3-beta1.24352.1</MicrosoftCodeAnalysisCSharpTestingVersion>
+    <!-- For this prerelease version, see https://github.com/dotnet/roslyn-sdk/issues/1175 -->
+    <MicrosoftCodeAnalysisAnalyzerTestingVersion>1.1.3-beta1.25564.1</MicrosoftCodeAnalysisAnalyzerTestingVersion>
+    <MicrosoftCodeAnalysisCSharpTestingVersion>1.1.3-beta1.25564.1</MicrosoftCodeAnalysisCSharpTestingVersion>
     <AzureIdentityVersion>1.14.2</AzureIdentityVersion>
     <AzureResourceManagerCosmosDBVersion>1.3.2</AzureResourceManagerCosmosDBVersion>
     <OpenTelemetryExporterInMemoryVersion>1.12.0</OpenTelemetryExporterInMemoryVersion>

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -3,11 +3,9 @@
 
   <!-- Dependencies used only in tests -->
   <ItemGroup>
-    <!-- See https://github.com/dotnet/roslyn-sdk/issues/1175 -->
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzer.Testing" Version="$(MicrosoftCodeAnalysisAnalyzerTestingVersion)" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="$(MicrosoftCodeAnalysisCSharpTestingVersion)" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="$(MicrosoftCodeAnalysisCSharpTestingVersion)" />
-
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="$(MicrosoftCodeAnalysisCSharpTestingVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="$(MicrosoftCodeAnalysisCSharpTestingVersion)" />
     <PackageVersion Include="Azure.Identity" Version="$(AzureIdentityVersion)" />
     <PackageVersion Include="Azure.ResourceManager.CosmosDB" Version="$(AzureResourceManagerCosmosDBVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.5" />

--- a/test/EFCore.Analyzers.Tests/EFCore.Analyzers.Tests.csproj
+++ b/test/EFCore.Analyzers.Tests/EFCore.Analyzers.Tests.csproj
@@ -45,8 +45,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyModel" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzer.Testing" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces"  />

--- a/test/EFCore.Analyzers.Tests/InternalUsageDiagnosticAnalyzerTests.cs
+++ b/test/EFCore.Analyzers.Tests/InternalUsageDiagnosticAnalyzerTests.cs
@@ -7,8 +7,7 @@ namespace Microsoft.EntityFrameworkCore;
 
 using VerifyCS = CSharpAnalyzerVerifier<InternalUsageDiagnosticAnalyzer>;
 
-//Issue #37106
-internal class InternalUsageDiagnosticAnalyzerTests
+public class InternalUsageDiagnosticAnalyzerTests
 {
     [ConditionalFact]
     public Task Invocation_on_type_in_internal_namespace()

--- a/test/EFCore.Analyzers.Tests/StringConcatenationInRawQueriesAnalyzerTests.cs
+++ b/test/EFCore.Analyzers.Tests/StringConcatenationInRawQueriesAnalyzerTests.cs
@@ -7,8 +7,7 @@ namespace Microsoft.EntityFrameworkCore;
 
 using Verify = CSharpAnalyzerVerifier<StringsUsageInRawQueriesDiagnosticAnalyzer>;
 
-//Issue #37106
-internal class StringConcatenationInRawQueriesAnalyzerTests
+public class StringConcatenationInRawQueriesAnalyzerTests
 {
     public static readonly TheoryData<string> DoNotReportData =
     [

--- a/test/EFCore.Analyzers.Tests/StringInterpolationInRawQueriesAnalyzerTests.cs
+++ b/test/EFCore.Analyzers.Tests/StringInterpolationInRawQueriesAnalyzerTests.cs
@@ -7,8 +7,7 @@ namespace Microsoft.EntityFrameworkCore;
 
 using Verify = CSharpCodeFixVerifier<StringsUsageInRawQueriesDiagnosticAnalyzer, InterpolatedStringUsageInRawQueriesCodeFixProvider>;
 
-//Issue #37106
-internal class StringInterpolationInRawQueriesAnalyzerTests
+public class StringInterpolationInRawQueriesAnalyzerTests
 {
     public static readonly TheoryData<string> DoNotReportData =
     [

--- a/test/EFCore.Analyzers.Tests/TestUtilities/CSharpAnalyzerVerifier.cs
+++ b/test/EFCore.Analyzers.Tests/TestUtilities/CSharpAnalyzerVerifier.cs
@@ -1,14 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.Model;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 using Microsoft.Extensions.DependencyModel;
 using CompilationOptions = Microsoft.CodeAnalysis.CompilationOptions;
 
@@ -18,9 +15,7 @@ public static class CSharpAnalyzerVerifier<TAnalyzer>
     where TAnalyzer : DiagnosticAnalyzer, new()
 {
     public static DiagnosticResult Diagnostic(string diagnosticId)
-#pragma warning disable CS0618 // Type or member is obsolete
-        => CSharpAnalyzerVerifier<TAnalyzer, XUnitVerifier>.Diagnostic(diagnosticId);
-#pragma warning restore CS0618 // Type or member is obsolete
+        => CSharpAnalyzerVerifier<TAnalyzer, DefaultVerifier>.Diagnostic(diagnosticId);
 
     public static Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
     {
@@ -29,37 +24,31 @@ public static class CSharpAnalyzerVerifier<TAnalyzer>
         return test.RunAsync();
     }
 
-#pragma warning disable CS0618 // Type or member is obsolete
-    public class Test : CSharpAnalyzerTest<TAnalyzer, XUnitVerifier>
-#pragma warning restore CS0618 // Type or member is obsolete
+    public class Test : CSharpAnalyzerTest<TAnalyzer, DefaultVerifier>
     {
-        protected override CompilationOptions CreateCompilationOptions()
+        public Test()
         {
-            var cSharpOptions = (CSharpCompilationOptions)base.CreateCompilationOptions();
-            return cSharpOptions
-                .WithNullableContextOptions(NullableContextOptions.Enable)
-                .WithSpecificDiagnosticOptions(
-                    new Dictionary<string, ReportDiagnostic>
-                    {
-                        { "CS1701", ReportDiagnostic.Suppress }, { "CS1591", ReportDiagnostic.Suppress }
-                    });
-        }
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net100;
 
-        protected override async Task<Project> CreateProjectImplAsync(
-            EvaluatedProjectState primaryProject,
-            ImmutableArray<EvaluatedProjectState> additionalProjects,
-            CancellationToken cancellationToken)
-        {
-            var metadataReferences
-                = DependencyContext.Load(GetType().Assembly)!
+            if (NugetConfigFinder.Find() is string nuGetConfigFilePath)
+            {
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net100.WithNuGetConfigFilePath(nuGetConfigFilePath);
+            }
+
+            TestState.AdditionalReferences.AddRange(
+                DependencyContext.Load(GetType().Assembly)!
                     .CompileLibraries
                     .SelectMany(c => c.ResolveReferencePaths())
                     .Select(path => MetadataReference.CreateFromFile(path))
-                    .Cast<MetadataReference>()
-                    .ToList();
+                    .Cast<MetadataReference>());
 
-            var project = await base.CreateProjectImplAsync(primaryProject, additionalProjects, cancellationToken).ConfigureAwait(false);
-            return project.WithMetadataReferences(metadataReferences);
+            DisabledDiagnostics.AddRange(
+                "CS1701", // Assuming assembly reference '...' used by '...' matches identity '...' of '...', you may need to supply runtime policy
+                "CS1591"  // Missing XML comment for publicly visible type or member '...'
+            );
         }
+
+        protected override CompilationOptions CreateCompilationOptions()
+            => ((CSharpCompilationOptions)base.CreateCompilationOptions()).WithNullableContextOptions(NullableContextOptions.Enable);
     }
 }

--- a/test/EFCore.Analyzers.Tests/TestUtilities/CSharpCodeFixVerifier.cs
+++ b/test/EFCore.Analyzers.Tests/TestUtilities/CSharpCodeFixVerifier.cs
@@ -1,15 +1,14 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.Model;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 using Microsoft.Extensions.DependencyModel;
+using CompilationOptions = Microsoft.CodeAnalysis.CompilationOptions;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities;
 
@@ -18,9 +17,7 @@ public static class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
     where TCodeFix : CodeFixProvider, new()
 {
     public static DiagnosticResult Diagnostic(string diagnosticId)
-#pragma warning disable CS0618 // Type or member is obsolete
-        => CSharpAnalyzerVerifier<TAnalyzer, XUnitVerifier>.Diagnostic(diagnosticId);
-#pragma warning restore CS0618 // Type or member is obsolete
+        => CSharpAnalyzerVerifier<TAnalyzer, DefaultVerifier>.Diagnostic(diagnosticId);
 
     public static Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
     {
@@ -36,25 +33,31 @@ public static class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
         await test.RunAsync();
     }
 
-#pragma warning disable CS0618 // Type or member is obsolete
-    public class Test : CSharpCodeFixTest<TAnalyzer, TCodeFix, XUnitVerifier>
-#pragma warning restore CS0618 // Type or member is obsolete
+    public class Test : CSharpCodeFixTest<TAnalyzer, TCodeFix, DefaultVerifier>
     {
-        protected override async Task<Project> CreateProjectImplAsync(
-            EvaluatedProjectState primaryProject,
-            ImmutableArray<EvaluatedProjectState> additionalProjects,
-            CancellationToken cancellationToken)
+        public Test()
         {
-            var metadataReferences
-                = DependencyContext.Load(GetType().Assembly)!
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net100;
+
+            if (NugetConfigFinder.Find() is string nuGetConfigFilePath)
+            {
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net100.WithNuGetConfigFilePath(nuGetConfigFilePath);
+            }
+
+            TestState.AdditionalReferences.AddRange(
+                DependencyContext.Load(GetType().Assembly)!
                     .CompileLibraries
                     .SelectMany(c => c.ResolveReferencePaths())
                     .Select(path => MetadataReference.CreateFromFile(path))
-                    .Cast<MetadataReference>()
-                    .ToList();
+                    .Cast<MetadataReference>());
 
-            var project = await base.CreateProjectImplAsync(primaryProject, additionalProjects, cancellationToken).ConfigureAwait(false);
-            return project.WithMetadataReferences(metadataReferences);
+            DisabledDiagnostics.AddRange(
+                "CS1701", // Assuming assembly reference '...' used by '...' matches identity '...' of '...', you may need to supply runtime policy
+                "CS1591"  // Missing XML comment for publicly visible type or member '...'
+            );
         }
+
+        protected override CompilationOptions CreateCompilationOptions()
+            => ((CSharpCompilationOptions)base.CreateCompilationOptions()).WithNullableContextOptions(NullableContextOptions.Enable);
     }
 }

--- a/test/EFCore.Analyzers.Tests/TestUtilities/NugetConfigFinder.cs
+++ b/test/EFCore.Analyzers.Tests/TestUtilities/NugetConfigFinder.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities;
+
+internal static class NugetConfigFinder
+{
+    private static bool _searched;
+    private static string? _nugetConfigPath;
+
+    public static string? Find()
+    {
+        if (_searched)
+        {
+            return _nugetConfigPath;
+        }
+
+        var path = AppContext.BaseDirectory;
+        var currentDirectory = path;
+        while (currentDirectory is not null)
+        {
+            var nugetConfigPath = Path.Combine(currentDirectory, "NuGet.config");
+
+            if (File.Exists(nugetConfigPath))
+            {
+                _nugetConfigPath = nugetConfigPath;
+                break;
+            }
+
+            currentDirectory = Directory.GetParent(currentDirectory)?.ToString();
+        }
+
+        _searched = true;
+        return _nugetConfigPath;
+    }
+}

--- a/test/EFCore.Analyzers.Tests/UninitializedDbSetDiagnosticSuppressorTests.cs
+++ b/test/EFCore.Analyzers.Tests/UninitializedDbSetDiagnosticSuppressorTests.cs
@@ -7,8 +7,7 @@ namespace Microsoft.EntityFrameworkCore;
 
 using VerifyCS = CSharpAnalyzerVerifier<UninitializedDbSetDiagnosticSuppressor>;
 
-//Issue #37106
-internal class UninitializedDbSetDiagnosticSuppressorTests
+public class UninitializedDbSetDiagnosticSuppressorTests
 {
     [ConditionalFact]
     public Task DbSet_property_on_DbContext_is_suppressed()


### PR DESCRIPTION
See https://github.com/dotnet/roslyn-sdk/tree/main/src/Microsoft.CodeAnalysis.Testing#obsolete-packages

Closes #35768
Closes #37106
