### PR TITLE
Inject SQL Server Application Name in a more robust way

### DIFF
--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerConnection.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerConnection.cs
@@ -177,7 +177,7 @@ public class SqlServerConnection : RelationalConnection, ISqlServerConnection
                     .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
 
                 _defaultApplicationName ??=
-                    $"EFCore/{efVersion} ({RuntimeInformation.OSDescription} {RuntimeInformation.OSArchitecture})";
+                    $"EFCore/{efVersion ?? "unknown"} ({RuntimeInformation.OSDescription} {RuntimeInformation.OSArchitecture})";
 
                 connectionStringBuilder.ApplicationName = _defaultApplicationName;
 


### PR DESCRIPTION
Fixes #37115

Thanks to @0xced for proposing this in https://github.com/dotnet/efcore/pull/36548#discussion_r2505486625.

Verified via test ApplicationName_is_injected_when_not_defined_with_connection_string that the injected Application Name is the same before and after this change.