### PR TITLE
Correct naming for for switch/case pattern-matched captured variables

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
@@ -2034,6 +2034,18 @@ WHERE (c["$type"] = "Order")
 """);
             });
 
+    public override Task Captured_variable_from_switch_case_pattern_matching(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Captured_variable_from_switch_case_pattern_matching(a);
+
+                AssertSql(
+                    """
+ReadItem(None, ALFKI)
+""");
+            });
+
     public override async Task Subquery_member_pushdown_does_not_change_original_subquery_model(bool async)
     {
         // Cosmos client evaluation. Issue #17246.

--- a/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
@@ -2994,6 +2994,23 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
     }
 
     [ConditionalTheory, MemberData(nameof(IsAsyncData))]
+    public virtual async Task Captured_variable_from_switch_case_pattern_matching(bool async)
+    {
+        object customerIdAsObject = "ALFKI";
+
+        switch (customerIdAsObject)
+        {
+            case string customerId:
+            {
+                await AssertQuery(
+                    async,
+                    ss => ss.Set<Customer>().Where(c => c.CustomerID == customerId));
+                break;
+            }
+        }
+    }
+
+    [ConditionalTheory, MemberData(nameof(IsAsyncData))]
     public virtual Task Subquery_member_pushdown_does_not_change_original_subquery_model(bool async)
         => AssertQuery(
             async,

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -3236,6 +3236,20 @@ FROM [Orders] AS [o]
 """);
     }
 
+    public override async Task Captured_variable_from_switch_case_pattern_matching(bool async)
+    {
+        await base.Captured_variable_from_switch_case_pattern_matching(async);
+
+        AssertSql(
+            """
+@customerId='ALFKI' (Size = 5) (DbType = StringFixedLength)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = @customerId
+""");
+    }
+
     public override async Task Subquery_member_pushdown_does_not_change_original_subquery_model(bool async)
     {
         await base.Subquery_member_pushdown_does_not_change_original_subquery_model(async);


### PR DESCRIPTION
Fixes #37465
