### PR TITLE
[release/10.0] Add preReleaseVersion to binskim configuration

### DIFF
--- a/azure-pipelines-internal-tests.yml
+++ b/azure-pipelines-internal-tests.yml
@@ -50,6 +50,7 @@ extends:
       baseline:
         baselineFile: $(Build.SourcesDirectory)\.config\guardian\.gdnbaselines
       binskim:
+        preReleaseVersion: '4.3.1'
         enabled: false
         justificationForDisabling: 'NonProduction'
       policheck:


### PR DESCRIPTION
This avoids the warning, even though binskim is not used