### PR TITLE
Add support for BigInteger, Int128, and UInt128 in SqliteValueBinder

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteValueBinder.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteValueBinder.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Numerics;
 using Microsoft.Data.Sqlite.Properties;
 
 namespace Microsoft.Data.Sqlite;
@@ -228,6 +229,22 @@ internal abstract class SqliteValueBinder(object? value, SqliteType? sqliteType)
             var value1 = (long)(ushort)value;
             BindInt64(value1);
         }
+        else if (type == typeof(BigInteger))
+        {
+            BindText(((BigInteger)value).ToString(CultureInfo.InvariantCulture));
+        }
+#if NET7_0_OR_GREATER
+        else if (type == typeof(Int128))
+        {
+            var value1 = (Int128)value;   
+            BindText((value1).ToString(CultureInfo.InvariantCulture));
+        }
+        else if (type == typeof(UInt128))
+        {
+            var value1 = (UInt128)value;
+            BindText((value1).ToString(CultureInfo.InvariantCulture));
+        }
+#endif
         else
         {
             throw new InvalidOperationException(Resources.UnknownDataType(type));
@@ -247,7 +264,13 @@ internal abstract class SqliteValueBinder(object? value, SqliteType? sqliteType)
             { typeof(DateOnly), SqliteType.Text },
             { typeof(TimeOnly), SqliteType.Text },
 #endif
+
             { typeof(DBNull), SqliteType.Text },
+            { typeof(BigInteger), SqliteType.Text },
+#if NET7_0_OR_GREATER
+            { typeof(Int128), SqliteType.Text },
+            { typeof(UInt128), SqliteType.Text },
+#endif
             { typeof(decimal), SqliteType.Text },
             { typeof(double), SqliteType.Real },
             { typeof(float), SqliteType.Real },

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteParameterTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteParameterTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
+using System.Numerics;
 using Microsoft.Data.Sqlite.Properties;
 using Microsoft.Data.Sqlite.TestUtilities;
 using Xunit;
@@ -569,6 +570,54 @@ public class SqliteParameterTest
             }
         }
     }
+
+    [Fact]
+    public void Bind_BigInteger_parameter_as_text()
+    {
+        using (var connection = new SqliteConnection("Data Source=:memory:"))
+        {
+            var command = connection.CreateCommand();
+            command.CommandText = "SELECT @Parameter;";
+            var value = BigInteger.Parse("1234567890123456789012345678901234567890");
+            command.Parameters.AddWithValue("@Parameter", value);
+            connection.Open();
+            var result = (string)command.ExecuteScalar()!;
+            Assert.Equal("1234567890123456789012345678901234567890", result);
+        }
+    }
+
+
+#if NET7_0_OR_GREATER
+    [Fact]
+    public void Bind_Int128_parameter_as_text()
+    {
+        using (var connection = new SqliteConnection("Data Source=:memory:"))
+        {
+            var command = connection.CreateCommand();
+            command.CommandText = "SELECT @Parameter;";
+            var value = Int128.Parse("170141183460469231731687303715884105727");
+            command.Parameters.AddWithValue("@Parameter", value);
+            connection.Open();
+            var result = (string)command.ExecuteScalar()!;
+            Assert.Equal("170141183460469231731687303715884105727", result);
+        }
+    }
+
+    [Fact]
+    public void Bind_UInt128_parameter_as_text()
+    {
+        using (var connection = new SqliteConnection("Data Source=:memory:"))
+        {
+            var command = connection.CreateCommand();
+            command.CommandText = "SELECT @Parameter;";
+            var value = UInt128.Parse("340282366920938463463374607431768211455");
+            command.Parameters.AddWithValue("@Parameter", value);
+            connection.Open();
+            var result = (string)command.ExecuteScalar()!;
+            Assert.Equal("340282366920938463463374607431768211455", result);
+        }
+    }
+#endif
 
     public static IEnumerable<object[]> TypesData
         => new List<object[]>


### PR DESCRIPTION
- Bind Int128, UInt128, and BigInteger parameters as TEXT in SQLite.
- Add provider-level tests to verify correct binding of these large numeric types.
- This change only affects parameter binding; reading values back still returns string.

<!--
Please check whether the PR fulfills these requirements
-->

- [ ] I've read the guidelines for [contributing](https://github.com/dotnet/efcore/blob/main/.github/CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [ ] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [ ] The code builds and tests pass locally (also verified by our automated build checks)
- [ ] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code follows the same patterns and style as existing code in this repo

