### PR TITLE
[release/10.0] Fix primitive/complex collection handling on subtypes

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/Query/NonSharedPrimitiveCollectionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NonSharedPrimitiveCollectionsQueryCosmosTest.cs
@@ -362,6 +362,18 @@ WHERE (c["$type"] = "TestEntityWithOwned")
 """);
     }
 
+    public override async Task Subquery_over_primitive_collection_on_inheritance_derived_type()
+    {
+        await base.Subquery_over_primitive_collection_on_inheritance_derived_type();
+
+        AssertSql(
+            """
+SELECT VALUE c
+FROM root c
+WHERE ((c["$type"] = "SubType") AND (ARRAY_LENGTH(c["Ints"]) > 0))
+""");
+    }
+
     [ConditionalFact]
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());

--- a/test/EFCore.Specification.Tests/Query/NonSharedPrimitiveCollectionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NonSharedPrimitiveCollectionsQueryTestBase.cs
@@ -256,6 +256,33 @@ public abstract class NonSharedPrimitiveCollectionsQueryTestBase(NonSharedFixtur
         public int Foo { get; set; }
     }
 
+    [ConditionalFact] // #37478
+    public virtual async Task Subquery_over_primitive_collection_on_inheritance_derived_type()
+    {
+        var contextFactory = await InitializeAsync<TestContext>(
+            onModelCreating: mb =>
+            {
+                mb.Entity<BaseType>();
+                mb.Entity<SubType>();
+            });
+
+        await using var context = contextFactory.CreateContext();
+
+        _ = await context.Set<BaseType>()
+            .Where(x => ((SubType)x).Ints.Any())
+            .ToListAsync();
+    }
+
+    public abstract class BaseType
+    {
+        public int Id { get; set; }
+    }
+
+    public class SubType : BaseType
+    {
+        public required int[] Ints { get; set; }
+    }
+
     /// <summary>
     ///     A utility that allows easy testing of querying out arbitrary element types from a primitive collection, provided two distinct
     ///     element values.

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NonSharedPrimitiveCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NonSharedPrimitiveCollectionsQuerySqlServerTest.cs
@@ -1026,6 +1026,20 @@ WHERE [t].[Id] IN (@ints1, @ints2, @ints3, @ints4, @ints5, @ints6, @ints7, @ints
 """);
     }
 
+    public override async Task Subquery_over_primitive_collection_on_inheritance_derived_type()
+    {
+        await base.Subquery_over_primitive_collection_on_inheritance_derived_type();
+
+        AssertSql(
+            """
+SELECT [b].[Id], [b].[Discriminator], [b].[Ints]
+FROM [BaseType] AS [b]
+WHERE EXISTS (
+    SELECT 1
+    FROM OPENJSON([b].[Ints]) AS [i])
+""");
+    }
+
     [ConditionalFact]
     public virtual async Task Same_parameter_with_different_type_mappings()
     {


### PR DESCRIPTION
Fixes #37478
Simplified/targeted backport of: #37482

**Description**

As part of the JSON complex type work in 10.0, the navigation expansion logic for binding properties/navigations changed; unfortunately, a bug slipped in where we no longer properly take into account inheritance subtypes.

**Customer impact**

Queries which perform subqueries over primitive collection properties on an inheritance subtype in EF queries now fail:

```c#
var query = context.BaseTypes
    .Where(x => ((SubType)x).Ints.Any())
    .ToArray();
```

This isn't an uncommon scenario, and there's unfortunately no good workaround.

**How found**

Customer reported on EF 10.0.0.

**Regression**

Yes.

**Testing**

Test added.

**Risk**

Very low. The fix is very targeted and in code modified in 10.0, quirk added.
