### PR TITLE
[release/10.0] Fix duplicate DbParameter naming uniquification

### DIFF
--- a/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlQuerySqlServerTest.cs
@@ -994,6 +994,35 @@ FROM (
 """);
     }
 
+    public override async Task FromSql_GroupBy_non_reducing_Select(bool async)
+    {
+        await base.FromSql_GroupBy_non_reducing_Select(async);
+
+        AssertSql(
+            """
+city='Seattle' (Nullable = false) (Size = 7)
+
+SELECT [m3].[CustomerID], [m3].[Address], [m3].[City], [m3].[CompanyName], [m3].[ContactName], [m3].[ContactTitle], [m3].[Country], [m3].[Fax], [m3].[Phone], [m3].[PostalCode], [m3].[Region]
+FROM (
+    SELECT [m].[CustomerID]
+    FROM (
+        SELECT * FROM "Customers" WHERE "City" = @city
+    ) AS [m]
+    GROUP BY [m].[CustomerID]
+) AS [m1]
+LEFT JOIN (
+    SELECT [m2].[CustomerID], [m2].[Address], [m2].[City], [m2].[CompanyName], [m2].[ContactName], [m2].[ContactTitle], [m2].[Country], [m2].[Fax], [m2].[Phone], [m2].[PostalCode], [m2].[Region]
+    FROM (
+        SELECT [m0].[CustomerID], [m0].[Address], [m0].[City], [m0].[CompanyName], [m0].[ContactName], [m0].[ContactTitle], [m0].[Country], [m0].[Fax], [m0].[Phone], [m0].[PostalCode], [m0].[Region], ROW_NUMBER() OVER(PARTITION BY [m0].[CustomerID] ORDER BY [m0].[CustomerID]) AS [row]
+        FROM (
+            SELECT * FROM "Customers" WHERE "City" = @city
+        ) AS [m0]
+    ) AS [m2]
+    WHERE [m2].[row] <= 1
+) AS [m3] ON [m1].[CustomerID] = [m3].[CustomerID]
+""");
+    }
+
     public override async Task FromSqlRaw_composed_with_common_table_expression(bool async)
     {
         var exception =


### PR DESCRIPTION
Backports #37430
Fixes #37409

**Description**

When using `Database.SqlQueryRaw<T>()` or `FromSqlRaw()` with `DbParameter` instances followed by `GroupBy` and a `Select` projection, EF Core 10.x generates invalid SQL where the parameter is renamed at the outer query level but the inner subqueries still reference the original parameter name. This also affects simpler scenarios where the same DbParameter is referenced multiple times in a FromSql query.

The issue occurs because when EF Core duplicates SQL tree fragments (e.g., in GroupBy translation), the same DbParameter instance gets referenced from multiple FromSqlExpressions, and its name gets uniquified multiple times, causing the parameter name to be modified repeatedly.

In addition, simpler scenarios have been flagged that make this more suitable for patching.

**Customer impact**

Applications using `SqlQueryRaw` or `FromSqlRaw` with DbParameter instances in combination with GroupBy or when the same DbParameter is referenced multiple times will encounter runtime failures with errors like "column does not exist" or "parameter not found". 

Workarounds exist but are enough of a pain (as well as undiscoverable) so as to IMHO justify this for patching.

**How found**

Customer reported via GitHub issue #37409. Multiple customers have been affected based on issue comments and related reports (npgsql/efcore.pg#3703).

**Regression**

Yes, this is a regression introduced in EF Core 10.0 by the parameter handling changes in PR #35200. The same code works correctly in EF Core 9.0.10.

**Testing**

Added.

**Risk**

Low. The fix is minimal and targeted. Quirk implemented.
