### PR TITLE
Detect set operations over uncorrelated subqueries in Cosmos

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/Expressions/SourceExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/Expressions/SourceExpression.cs
@@ -105,7 +105,7 @@ public class SourceExpression : Expression, IAccessExpression, IPrintableExpress
     public virtual SourceExpression Update(Expression containerExpression)
         => ReferenceEquals(containerExpression, Expression)
             ? this
-            : new SourceExpression(containerExpression, Alias);
+            : new SourceExpression(containerExpression, Alias, WithIn);
 
     /// <summary>
     ///     Returns whether the given expression type can appear directly within a source expression.

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
@@ -5045,6 +5045,18 @@ WHERE (c["id"] = "ALFKI")
         AssertSql();
     }
 
+    [ConditionalTheory, MemberData(nameof(IsAsyncData))]
+    public virtual async Task Concat_on_entity_queries_throws(bool async)
+    {
+        await AssertTranslationFailedWithDetails(
+            () => AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Concat(ss.Set<Customer>())),
+            CosmosStrings.NonCorrelatedSubqueriesNotSupported);
+
+        AssertSql();
+    }
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Fixes #37583
