### PR TITLE
Fix View Indexes not Scaffolded in Sql Server

### DIFF
--- a/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
+++ b/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
@@ -1039,6 +1039,13 @@ LEFT JOIN [sys].[default_constraints] AS [dc] ON [c].[object_id] = [dc].[parent_
     {
         using var command = connection.CreateCommand();
         var commandText = @"
+WITH [TablesAndViews] AS (
+    SELECT [object_id], [schema_id], [name], [type], [is_ms_shipped], [temporal_type] 
+    FROM [sys].[tables]
+    UNION ALL
+    SELECT [object_id], [schema_id], [name], [type], [is_ms_shipped], 0 AS [temporal_type] 
+    FROM [sys].[views]
+)
 SELECT
     SCHEMA_NAME([t].[schema_id]) AS [table_schema],
     [t].[name] AS [table_name],
@@ -1054,7 +1061,7 @@ SELECT
     [ic].[is_descending_key],
     [ic].[is_included_column]
 FROM [sys].[indexes] AS [i]
-JOIN [sys].[tables] AS [t] ON [i].[object_id] = [t].[object_id]
+JOIN [TablesAndViews] AS [t] ON [i].[object_id] = [t].[object_id]
 JOIN [sys].[index_columns] AS [ic] ON [i].[object_id] = [ic].[object_id] AND [i].[index_id] = [ic].[index_id]
 JOIN [sys].[columns] AS [c] ON [ic].[object_id] = [c].[object_id] AND [ic].[column_id] = [c].[column_id]
 WHERE [i].[is_hypothetical] = 0


### PR DESCRIPTION
<!--
Please check whether the PR fulfills these requirements
-->

- [x] I've read the guidelines for [contributing](https://github.com/dotnet/efcore/blob/main/.github/CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [x] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

Summary of the changes
- This PR adds a fix so that view indexes in SQL Server are correctly included when scaffolding a database schema.
- A CTE was required here since the column temporal_type was not present either in sys.views or sys.object, and the column was required to be present since it was part of the table filter.

Fixes #37345 