### PR TITLE
Simpler null constant checks in Cosmos translator

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
@@ -1075,10 +1075,10 @@ public class CosmosSqlTranslatingExpressionVisitor(
             return false;
         }
 
-        if (IsNullSqlConstantExpression(left)
-            || IsNullSqlConstantExpression(right))
+        if (left is SqlConstantExpression { Value: null }
+            || right is SqlConstantExpression { Value: null })
         {
-            var nonNullEntityReference = (IsNullSqlConstantExpression(left) ? rightEntityReference : leftEntityReference)!;
+            var nonNullEntityReference = (left is SqlConstantExpression { Value: null } ? rightEntityReference : leftEntityReference)!;
             var entityType1 = nonNullEntityReference.EntityType;
             var primaryKeyProperties1 = entityType1.FindPrimaryKey()?.Properties;
             if (primaryKeyProperties1 == null)
@@ -1193,9 +1193,6 @@ public class CosmosSqlTranslatingExpressionVisitor(
         var getter = property.GetGetter();
         return baseListParameter.Select(e => e != null ? (TProperty?)getter.GetClrValue(e) : (TProperty?)(object?)null).ToList();
     }
-
-    private static bool IsNullSqlConstantExpression(Expression expression)
-        => expression is SqlConstantExpression { Value: null };
 
     private static bool TryEvaluateToConstant(Expression expression, [NotNullWhen(true)] out SqlConstantExpression? sqlConstantExpression)
     {


### PR DESCRIPTION
This PR simplifies internal null-constant checks in the Cosmos query expression visitor by inlining pattern matching instead of using a small private helper method. The behavior is preserved while slightly reducing indirection.

## Changes

* In `CosmosSqlTranslatingExpressionVisitor`, inline the `IsNullSqlConstantExpression` helper logic into the entity-equality rewrite path and delete the now-unneeded private helper.

| File | Description |
|------|-------------|
| `src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs` | Inlines null-constant detection for entity-equality rewrites using `is SqlConstantExpression { Value: null }` pattern matching and removes the redundant private helper. |
