### PR TITLE
[TINY] Tweak Cosmos CI testing for easier access to test logs

### DIFF
--- a/.github/workflows/TestCosmos.yaml
+++ b/.github/workflows/TestCosmos.yaml
@@ -31,12 +31,8 @@ jobs:
         run: restore.cmd
         shell: cmd
 
-      - name: Build
-        run: build.cmd /p:Projects=${{ github.workspace }}\test\EFCore.Cosmos.FunctionalTests\EFCore.Cosmos.FunctionalTests.csproj
-        shell: cmd
-
       - name: Test on Cosmos
-        run: test.cmd /p:Projects=${{ github.workspace }}\test\EFCore.Cosmos.FunctionalTests\EFCore.Cosmos.FunctionalTests.csproj
+        run: dotnet test test/EFCore.Cosmos.FunctionalTests/EFCore.Cosmos.FunctionalTests.csproj
         shell: cmd
 
       - name: Publish Test Results


### PR DESCRIPTION
Just run dotnet test instead of test.cmd, which hides test outputs and stores them in a file only (which then needs to be downloaded etc.)