### PR TITLE
Mark specification test projects as non-test projects

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/EFCore.Relational.Specification.Tests.csproj
+++ b/test/EFCore.Relational.Specification.Tests/EFCore.Relational.Specification.Tests.csproj
@@ -8,6 +8,9 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
     <IsShipping>true</IsShipping>
+    <!-- This project contains base tests to be used by providers, but is not itself a test project with
+         tests to be executed. Disable test discovery. -->
+    <IsTestProject>false</IsTestProject>
     <IncludeSymbols>true</IncludeSymbols>
     <ImplicitUsings>true</ImplicitUsings>
     <!-- This is a test project, but we ship the package to customers. Avoid skipping in VMR builds

--- a/test/EFCore.Specification.Tests/EFCore.Specification.Tests.csproj
+++ b/test/EFCore.Specification.Tests/EFCore.Specification.Tests.csproj
@@ -8,6 +8,9 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
     <IsShipping>true</IsShipping>
+    <!-- This project contains base tests to be used by providers, but is not itself a test project with
+         tests to be executed. Disable test discovery. -->
+    <IsTestProject>false</IsTestProject>
     <IncludeSymbols>true</IncludeSymbols>
     <ImplicitUsings>true</ImplicitUsings>
     <!-- HACK: Work around dotnet/arcade#13798 -->


### PR DESCRIPTION
Our specification test projects aren't actual test projects in the sense that tests should be run in them directly; they're there so that providers can extend them, and those concrete test projects are indeed "runnable" test projects.

As things are, e.g. VS Code needlessly attempts to perform test discovery on the specification projects and triggers the following:

```
Error:
  An assembly specified in the application dependencies manifest (Microsoft.EntityFrameworkCore.Specification.Tests.deps.json) was not found:
    package: 'Castle.Core', version: '5.2.1'
    path: 'lib/net6.0/Castle.Core.dll'
Testhost process for source(s) '/Users/roji/projects/efcore/artifacts/bin/EFCore.Specification.Tests/Debug/net11.0/Microsoft.EntityFrameworkCore.Specification.Tests.dll' exited with error: Error:
  An assembly specified in the application dependencies manifest (Microsoft.EntityFrameworkCore.Specification.Tests.deps.json) was not found:
    package: 'Castle.Core', version: '5.2.1'
    path: 'lib/net6.0/Castle.Core.dll'
. Please check the diagnostic logs for more information.
  EFCore.Specification.Tests test net11.0 failed with 1 error(s) (0.2s)
```

(this can also be triggered simply by running `dotnet test` on the EFCore.Specification.Tests). I also suspect this may be slowing test discovery considerably as EFCore.Specification.Tests is huge, but doesn't actually contain (runnable) tests.

This adds [`<IsTestProject>`](https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#istestproject) to prevent detecting these projects as test projects.