### PR TITLE
Introduce relational EF.Functions.JsonPathExists

### DIFF
--- a/src/EFCore.Relational/Extensions/RelationalDbFunctionsExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalDbFunctionsExtensions.cs
@@ -56,6 +56,6 @@ public static class RelationalDbFunctionsExtensions
     /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
     /// <param name="json">The JSON value to check.</param>
     /// <param name="path">The JSON path to look for.</param>
-    public static bool JsonExists(this DbFunctions _, object json, string path)
-        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(JsonExists)));
+    public static bool JsonPathExists(this DbFunctions _, object json, string path)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(JsonPathExists)));
 }

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -2072,7 +2072,6 @@ public sealed partial class SelectExpression : TableExpressionBase
         SelectExpression select2,
         bool distinct)
     {
-        // TODO: Introduce clone method? See issue#24460
         var select1 = new SelectExpression(
             alias: null, tables: _tables.ToList(), groupBy: _groupBy.ToList(), projections: [], orderings: _orderings.ToList(),
             annotations: Annotations, sqlAliasManager: _sqlAliasManager)

--- a/src/EFCore.Relational/Query/SqlNullabilityProcessor.cs
+++ b/src/EFCore.Relational/Query/SqlNullabilityProcessor.cs
@@ -1957,7 +1957,7 @@ public class SqlNullabilityProcessor : ExpressionVisitor
             var rewrittenCollectionTable = UpdateParameterCollection(collectionTable, rewrittenParameter);
 
             // We clone the select expression since Update below doesn't create a pure copy, mutating the original as well (because of
-            // TableReferenceExpression). TODO: Remove this after #31327.
+            // TableReferenceExpression). TODO: Remove this after SelectExpression becomes fully mutable (#32927).
 #pragma warning disable EF1001
             rewrittenSelectExpression = selectExpression.Clone();
 #pragma warning restore EF1001

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitor.cs
@@ -315,9 +315,9 @@ public class SqlServerSqlTranslatingExpressionVisitor(
                     typeof(int));
             }
 
-            // We translate EF.Functions.JsonExists here and not in a method translator since we need to support JsonExists over
+            // We translate EF.Functions.JsonPathExists here and not in a method translator since we need to support JsonPathExists over
             // complex and owned JSON properties, which requires special handling.
-            case nameof(RelationalDbFunctionsExtensions.JsonExists)
+            case nameof(RelationalDbFunctionsExtensions.JsonPathExists)
                 when declaringType == typeof(RelationalDbFunctionsExtensions)
                     && @object is null
                     && arguments is [_, var json, var path]:

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlTranslatingExpressionVisitor.cs
@@ -236,9 +236,9 @@ public class SqliteSqlTranslatingExpressionVisitor(
                     method.Name is nameof(string.StartsWith));
             }
 
-            // We translate EF.Functions.JsonExists here and not in a method translator since we need to support JsonExists over
+            // We translate EF.Functions.JsonPathExists here and not in a method translator since we need to support JsonPathExists over
             // complex and owned JSON properties, which requires special handling.
-            case nameof(RelationalDbFunctionsExtensions.JsonExists)
+            case nameof(RelationalDbFunctionsExtensions.JsonPathExists)
                 when declaringType == typeof(RelationalDbFunctionsExtensions)
                     && @object is null
                     && arguments is [_, var json, var path]:

--- a/test/EFCore.Relational.Specification.Tests/Query/Translations/JsonTranslationsRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/Translations/JsonTranslationsRelationalTestBase.cs
@@ -7,32 +7,32 @@ using System.Text.Json.Nodes;
 
 namespace Microsoft.EntityFrameworkCore.Query.Translations;
 
-// This test suite covers translations of JSON functions on EF.Functions (e.g. EF.Functions.JsonExists).
+// This test suite covers translations of JSON functions on EF.Functions (e.g. EF.Functions.JsonPathExists).
 // It does not cover general, built-in JSON support via complex type mapping, etc.
 public abstract class JsonTranslationsRelationalTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : JsonTranslationsRelationalTestBase<TFixture>.JsonTranslationsQueryFixtureBase, new()
 {
     [ConditionalFact]
-    public virtual Task JsonExists_on_scalar_string_column()
+    public virtual Task JsonPathExists_on_scalar_string_column()
         => AssertQuery(
             ss => ss.Set<JsonTranslationsEntity>()
-                .Where(b => EF.Functions.JsonExists(b.JsonString, "$.OptionalInt")),
+                .Where(b => EF.Functions.JsonPathExists(b.JsonString, "$.OptionalInt")),
             ss => ss.Set<JsonTranslationsEntity>()
                 .Where(b => ((IDictionary<string, JsonNode>)JsonNode.Parse(b.JsonString)!).ContainsKey("OptionalInt")));
 
     [ConditionalFact]
-    public virtual Task JsonExists_on_complex_property()
+    public virtual Task JsonPathExists_on_complex_property()
         => AssertQuery(
             ss => ss.Set<JsonTranslationsEntity>()
-                .Where(b => EF.Functions.JsonExists(b.JsonComplexType, "$.OptionalInt")),
+                .Where(b => EF.Functions.JsonPathExists(b.JsonComplexType, "$.OptionalInt")),
             ss => ss.Set<JsonTranslationsEntity>()
                 .Where(b => ((IDictionary<string, JsonNode>)JsonNode.Parse(b.JsonString)!).ContainsKey("OptionalInt")));
 
     [ConditionalFact]
-    public virtual Task JsonExists_on_owned_entity()
+    public virtual Task JsonPathExists_on_owned_entity()
         => AssertQuery(
             ss => ss.Set<JsonTranslationsEntity>()
-                .Where(b => EF.Functions.JsonExists(b.JsonOwnedType, "$.OptionalInt")),
+                .Where(b => EF.Functions.JsonPathExists(b.JsonOwnedType, "$.OptionalInt")),
             ss => ss.Set<JsonTranslationsEntity>()
                 .Where(b => ((IDictionary<string, JsonNode>)JsonNode.Parse(b.JsonString)!).ContainsKey("OptionalInt")));
 
@@ -103,12 +103,12 @@ public abstract class JsonTranslationsRelationalTestBase<TFixture>(TFixture fixt
 
             await context.Database.ExecuteSqlRawAsync(
                 $$"""
-                UPDATE {{table}} SET {{complexTypeColumn}} = {{RemoveJsonProperty(complexTypeColumn, "$.OptionalInt")}} WHERE {{idColumn}} = 4;
-                UPDATE {{table}} SET {{ownedColumn}} = {{RemoveJsonProperty(ownedColumn, "$.OptionalInt")}} WHERE {{idColumn}} = 4;
+                UPDATE {{table}} SET {{complexTypeColumn}} = {{RemoveJsonProperty(complexTypeColumn, "OptionalInt")}} WHERE {{idColumn}} = 4;
+                UPDATE {{table}} SET {{ownedColumn}} = {{RemoveJsonProperty(ownedColumn, "OptionalInt")}} WHERE {{idColumn}} = 4;
                 """);
         }
 
-        protected abstract string RemoveJsonProperty(string column, string jsonPath);
+        protected abstract string RemoveJsonProperty(string column, string property);
 
         public virtual ISetSource GetExpectedData()
             => _expectedData ??= new JsonTranslationsData();

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Translations/JsonTranslationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Translations/JsonTranslationsSqlServerTest.cs
@@ -15,9 +15,9 @@ public class JsonTranslationsSqlServerTest : JsonTranslationsRelationalTestBase<
     }
 
     [ConditionalFact, SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
-    public override async Task JsonExists_on_scalar_string_column()
+    public override async Task JsonPathExists_on_scalar_string_column()
     {
-        await base.JsonExists_on_scalar_string_column();
+        await base.JsonPathExists_on_scalar_string_column();
 
         AssertSql(
             """
@@ -28,9 +28,9 @@ WHERE JSON_PATH_EXISTS([j].[JsonString], N'$.OptionalInt') = 1
     }
 
     [ConditionalFact, SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
-    public override async Task JsonExists_on_complex_property()
+    public override async Task JsonPathExists_on_complex_property()
     {
-        await base.JsonExists_on_complex_property();
+        await base.JsonPathExists_on_complex_property();
 
         AssertSql(
             """
@@ -41,9 +41,9 @@ WHERE JSON_PATH_EXISTS([j].[JsonComplexType], N'$.OptionalInt') = 1
     }
 
     [ConditionalFact, SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
-    public override async Task JsonExists_on_owned_entity()
+    public override async Task JsonPathExists_on_owned_entity()
     {
-        await base.JsonExists_on_owned_entity();
+        await base.JsonPathExists_on_owned_entity();
 
         AssertSql(
             """
@@ -133,8 +133,8 @@ WHERE JSON_CONTAINS([j].[JsonOwnedType], 8, N'$.OptionalInt') = 1
             }
         }
 
-        protected override string RemoveJsonProperty(string column, string jsonPath)
-            => $"JSON_MODIFY({column}, '{jsonPath}', NULL)";
+        protected override string RemoveJsonProperty(string column, string property)
+            => $"JSON_MODIFY({column}, '$.{property}', NULL)";
     }
 
     [ConditionalFact]

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Translations/JsonTranslationsSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Translations/JsonTranslationsSqliteTest.cs
@@ -13,9 +13,9 @@ public class JsonTranslationsSqliteTest : JsonTranslationsRelationalTestBase<Jso
     }
 
     [ConditionalFact]
-    public override async Task JsonExists_on_scalar_string_column()
+    public override async Task JsonPathExists_on_scalar_string_column()
     {
-        await base.JsonExists_on_scalar_string_column();
+        await base.JsonPathExists_on_scalar_string_column();
 
         AssertSql(
             """
@@ -26,9 +26,9 @@ WHERE json_type("j"."JsonString", '$.OptionalInt') IS NOT NULL
     }
 
     [ConditionalFact]
-    public override async Task JsonExists_on_complex_property()
+    public override async Task JsonPathExists_on_complex_property()
     {
-        await base.JsonExists_on_complex_property();
+        await base.JsonPathExists_on_complex_property();
 
         AssertSql(
             """
@@ -39,9 +39,9 @@ WHERE json_type("j"."JsonComplexType", '$.OptionalInt') IS NOT NULL
     }
 
     [ConditionalFact]
-    public override async Task JsonExists_on_owned_entity()
+    public override async Task JsonPathExists_on_owned_entity()
     {
-        await base.JsonExists_on_owned_entity();
+        await base.JsonPathExists_on_owned_entity();
 
         AssertSql(
             """
@@ -56,8 +56,8 @@ WHERE json_type("j"."JsonOwnedType", '$.OptionalInt') IS NOT NULL
         protected override ITestStoreFactory TestStoreFactory
             => SqliteTestStoreFactory.Instance;
 
-        protected override string RemoveJsonProperty(string column, string jsonPath)
-            => $"json_remove({column}, '{jsonPath}')";
+        protected override string RemoveJsonProperty(string column, string property)
+            => $"json_remove({column}, '$.{property}')";
     }
 
     [ConditionalFact]


### PR DESCRIPTION
As part of syncing EFCore.PG, I noticed that the new EF.Functions.JsonExists introduced in #31136 (preview.2) conflicts with an existing function in EFCore.PG, which takes a key name (not a jsonpath). In addition, both the PG and SQL Server functions are actually called jsonb_path_exists()/JSON_PATH_EXISTS(), and including "path" in the name makes it more explicit that the argument represents a jsonpath rather than a simple property/key. The other databases also diverge quite widely around this, so while the capability exists everywhere, it's named differently.

So this PR renames EF.Function.JsonExists to JsonPathExists.

Database   | Function
---------- | --------
PG         | [jsonb_path_exists](https://www.postgresql.org/docs/current/functions-json.html)
SQL Server | [JSON_PATH_EXISTS](https://learn.microsoft.com/en-us/sql/t-sql/functions/json-path-exists-transact-sql) (since SQL Server 2022)
SQLite     | [json_type](https://www.sqlite.org/json1.html#the_json_type_function) (returns NULL for non-existing path, as opposed to 'null' for JSON null values)
MariaDB    | [JSON_EXISTS](https://mariadb.com/kb/en/json_exists/)
MySQL      | [JSON_CONTAINS_PATH](https://dev.mysql.com/doc/refman/8.0/en/json-search-functions.html#function_json-contains-path)
Oracle     | [JSON_EXISTS](https://docs.oracle.com/en/database/oracle/oracle-database/12.2/adjsn/condition-JSON_EXISTS.html#GUID-8A0043D5-95F8-4918-9126-F86FB0E203F0)

Part of #31136
