### PR TITLE
Emit all properties on the join type, even when there's no extra configuration

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
@@ -353,12 +353,10 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             foreach (var property in joinEntityType.GetProperties())
             {
                 var propertyFluentApiCalls = property.GetFluentApiCalls(annotationCodeGenerator);
-                if (propertyFluentApiCalls == null)
+                if (propertyFluentApiCalls != null)
                 {
-                    continue;
+                    usings.AddRange(propertyFluentApiCalls.GetRequiredUsings());
                 }
-
-                usings.AddRange(propertyFluentApiCalls.GetRequiredUsings());
 
             this.Write("                        j.IndexerProperty<");
             this.Write(this.ToStringHelper.ToStringWithCulture(code.Reference(property.ClrType)));

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.tt
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.tt
@@ -283,12 +283,10 @@ public partial class <#= Options.ContextName #> : DbContext
             foreach (var property in joinEntityType.GetProperties())
             {
                 var propertyFluentApiCalls = property.GetFluentApiCalls(annotationCodeGenerator);
-                if (propertyFluentApiCalls == null)
+                if (propertyFluentApiCalls != null)
                 {
-                    continue;
+                    usings.AddRange(propertyFluentApiCalls.GetRequiredUsings());
                 }
-
-                usings.AddRange(propertyFluentApiCalls.GetRequiredUsings());
 #>
                         j.IndexerProperty<<#= code.Reference(property.ClrType) #>>(<#= code.Literal(property.Name) #>)<#= code.Fragment(propertyFluentApiCalls, indent: 7) #>;
 <#


### PR DESCRIPTION
Fixes #35524

When scaffolding a many-to-many relationship where the join table has a composite foreign key with 3 or more properties, the generated OnModelCreating code can omit one of them if it had no extra fluent API configuration.