### PR TITLE
[release/10.0] Fix ExecuteUpdate over scalar projections

### DIFF
--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
@@ -61,6 +61,9 @@ public partial class NavigationExpandingExpressionVisitor : ExpressionVisitor
     private static readonly bool UseOldBehavior37247 =
         AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue37247", out var enabled) && enabled;
 
+    private static readonly bool UseOldBehavior37771 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue37771", out var enabled) && enabled;
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -1071,11 +1074,18 @@ public partial class NavigationExpandingExpressionVisitor : ExpressionVisitor
         {
             // Apply any pending selector before processing the ExecuteUpdate setters; this adds a Select() (if necessary) before
             // ExecuteUpdate, to avoid the pending selector flowing into each setter lambda and making it more complicated.
+            // However, only do this when the pending selector produces entity/structural type references (i.e. the snapshot is not just
+            // a DefaultExpression). When the pending selector projects only scalar values (e.g. select new { p.Used, n.Qty }),
+            // applying it would lose the connection between the projected scalar and the original entity property, breaking
+            // ExecuteUpdate's property selector recognition (#37771).
             var newStructure = SnapshotExpression(source.PendingSelector);
-            var queryable = Reduce(source);
-            var navigationTree = new NavigationTreeExpression(newStructure);
-            var parameterName = source.CurrentParameter.Name ?? GetParameterName("e");
-            source = new NavigationExpansionExpression(queryable, navigationTree, navigationTree, parameterName);
+            if (newStructure is not DefaultExpression || UseOldBehavior37771)
+            {
+                var queryable = Reduce(source);
+                var navigationTree = new NavigationTreeExpression(newStructure);
+                var parameterName = source.CurrentParameter.Name ?? GetParameterName("e");
+                source = new NavigationExpansionExpression(queryable, navigationTree, navigationTree, parameterName);
+            }
         }
 
         NewArrayExpression settersArray;

--- a/test/EFCore.Relational.Specification.Tests/BulkUpdates/NorthwindBulkUpdatesRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/BulkUpdates/NorthwindBulkUpdatesRelationalTestBase.cs
@@ -99,6 +99,44 @@ WHERE [CustomerID] LIKE 'A%'"));
                 }
             });
 
+    [ConditionalTheory, MemberData(nameof(IsAsyncData))] // #37771
+    public virtual Task Update_with_select_mixed_entity_scalar_anonymous_projection(bool async)
+        => TestHelpers.ExecuteWithStrategyInTransactionAsync(
+            () => Fixture.CreateContext(),
+            (facade, transaction) => Fixture.UseTransaction(facade, transaction),
+            async context =>
+            {
+                var queryable = context.Set<Customer>().Select(c => new { Entity = c, c.ContactName });
+
+                if (async)
+                {
+                    await queryable.ExecuteUpdateAsync(s => s.SetProperty(c => c.Entity.ContactName, "Updated"));
+                }
+                else
+                {
+                    queryable.ExecuteUpdate(s => s.SetProperty(c => c.Entity.ContactName, "Updated"));
+                }
+            });
+
+    [ConditionalTheory, MemberData(nameof(IsAsyncData))] // #37771
+    public virtual Task Update_with_select_scalar_anonymous_projection(bool async)
+        => TestHelpers.ExecuteWithStrategyInTransactionAsync(
+            () => Fixture.CreateContext(),
+            (facade, transaction) => Fixture.UseTransaction(facade, transaction),
+            async context =>
+            {
+                var queryable = context.Set<Customer>().Select(c => new { c.ContactName, c.City });
+
+                if (async)
+                {
+                    await queryable.ExecuteUpdateAsync(s => s.SetProperty(c => c.ContactName, "Updated"));
+                }
+                else
+                {
+                    queryable.ExecuteUpdate(s => s.SetProperty(c => c.ContactName, "Updated"));
+                }
+            });
+
     protected static async Task AssertTranslationFailed(string details, Func<Task> query)
         => Assert.Contains(
             CoreStrings.NonQueryTranslationFailedWithDetails("", details)[21..],

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqlServerTest.cs
@@ -1651,6 +1651,34 @@ INNER JOIN (
 """);
     }
 
+    public override async Task Update_with_select_mixed_entity_scalar_anonymous_projection(bool async)
+    {
+        await base.Update_with_select_mixed_entity_scalar_anonymous_projection(async);
+
+        AssertSql(
+            """
+@p='Updated' (Size = 30)
+
+UPDATE [c]
+SET [c].[ContactName] = @p
+FROM [Customers] AS [c]
+""");
+    }
+
+    public override async Task Update_with_select_scalar_anonymous_projection(bool async)
+    {
+        await base.Update_with_select_scalar_anonymous_projection(async);
+
+        AssertSql(
+            """
+@p='Updated' (Size = 30)
+
+UPDATE [c]
+SET [c].[ContactName] = @p
+FROM [Customers] AS [c]
+""");
+    }
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqliteTest.cs
@@ -1558,6 +1558,32 @@ WHERE "o2"."OrderID" = "s"."OrderID" AND "o2"."ProductID" = "s"."ProductID"
 """);
     }
 
+    public override async Task Update_with_select_mixed_entity_scalar_anonymous_projection(bool async)
+    {
+        await base.Update_with_select_mixed_entity_scalar_anonymous_projection(async);
+
+        AssertSql(
+            """
+@p='Updated' (Size = 7)
+
+UPDATE "Customers" AS "c"
+SET "ContactName" = @p
+""");
+    }
+
+    public override async Task Update_with_select_scalar_anonymous_projection(bool async)
+    {
+        await base.Update_with_select_scalar_anonymous_projection(async);
+
+        AssertSql(
+            """
+@p='Updated' (Size = 7)
+
+UPDATE "Customers" AS "c"
+SET "ContactName" = @p
+""");
+    }
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Fixes #37771

**Description**

When ExecuteUpdate is preceded by a Select that projects to a scalar-only anonymous type (e.g. select new { p.Used, n.Qty }), the query fails with "The following lambda argument to 'SetProperty' does not represent a valid property to be set". This happens because the fix for #37247 (PR #37262) unconditionally applies the pending selector before processing ExecuteUpdate setters. When the pending selector contains only scalar values (no entity references), applying it loses the connection between the projected scalars and the original entity properties, so ExecuteUpdate can no longer resolve which column to update.

The fix guards this pending selector application: it is only applied when the snapshot of the pending selector contains entity/structural type references (i.e. is not a DefaultExpression). When all projected members are scalars, the pending selector is skipped, preserving the original entity property binding.

Customer impact

Any ExecuteUpdate query that is preceded by a Select projecting to an anonymous type containing only scalar properties fails at query translation time. No data corruption occurs — the query throws before executing. There is no feasible workaround other than using the quirk to disable #37247, downgrading to 10.0.1 or restructuring the query to avoid the scalar projection.

How found

User reported on 10.0.2/10.0.3. A second user reported a potentially related issue in the comments. 1 upvote, 2 comment authors affected.

Regression

Yes. Regression from 10.0.1, introduced in 10.0.2 by PR #37262 (fix for #37247).

Testing

4 new tests added (2 test methods × sync/async): one for scalar-only anonymous projection, one for mixed entity+scalar anonymous projection.

Risk

Very low. The product code change is a single conditional guard (wrapping existing code in if (newStructure is not DefaultExpression)). The original #37247 fix continues to work — its existing test still passes. Quirk added.
