### PR TITLE
Implement SQLite TimeSpan translation

### DIFF
--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteMemberTranslatorProvider.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteMemberTranslatorProvider.cs
@@ -26,7 +26,8 @@ public class SqliteMemberTranslatorProvider : RelationalMemberTranslatorProvider
         [
             new SqliteDateTimeMemberTranslator(sqlExpressionFactory),
             new SqliteStringLengthTranslator(sqlExpressionFactory),
-            new SqliteDateOnlyMemberTranslator(sqlExpressionFactory)
+            new SqliteDateOnlyMemberTranslator(sqlExpressionFactory),
+            new SqliteTimeSpanMemberTranslator(sqlExpressionFactory)
         ]);
     }
 }

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteMethodCallTranslatorProvider.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteMethodCallTranslatorProvider.cs
@@ -35,7 +35,8 @@ public class SqliteMethodCallTranslatorProvider : RelationalMethodCallTranslator
             new SqliteRandomTranslator(sqlExpressionFactory),
             new SqliteRegexMethodTranslator(sqlExpressionFactory),
             new SqliteStringMethodTranslator(sqlExpressionFactory),
-            new SqliteSubstrMethodTranslator(sqlExpressionFactory)
+            new SqliteSubstrMethodTranslator(sqlExpressionFactory),
+            new SqliteTimeSpanMethodTranslator(sqlExpressionFactory)
         ]);
     }
 }

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlExpressionFactory.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlExpressionFactory.cs
@@ -111,6 +111,35 @@ public class SqliteSqlExpressionFactory : SqlExpressionFactory
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    public virtual SqlExpression EfDays(SqlExpression timeSpanExpression)
+        => Function(
+            "ef_days",
+            [timeSpanExpression],
+            nullable: true,
+            argumentsPropagateNullability: [true],
+            typeof(double));
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual SqlExpression EfTimespan(SqlExpression daysExpression)
+        => Function(
+            "ef_timespan",
+            [daysExpression],
+            nullable: true,
+            argumentsPropagateNullability: [true],
+            typeof(TimeSpan),
+            Dependencies.TypeMappingSource.FindMapping(typeof(TimeSpan), Dependencies.Model));
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     public virtual GlobExpression Glob(SqlExpression match, SqlExpression pattern)
     {
         var inferredTypeMapping = ExpressionExtensions.InferTypeMapping(match, pattern)

--- a/src/EFCore.Sqlite.Core/Query/Internal/Translators/SqliteQueryableAggregateMethodTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/Translators/SqliteQueryableAggregateMethodTranslator.cs
@@ -66,11 +66,11 @@ public class SqliteQueryableAggregateMethodTranslator(ISqlExpressionFactory sqlE
                     }
 
                     if (maxArgumentType == typeof(TimeSpan)
-                        && _sqlExpressionFactory is SqliteSqlExpressionFactory maxSqliteFactory)
+                        && sqlExpressionFactory is SqliteSqlExpressionFactory maxSqliteFactory)
                     {
                         maxSqlExpression = CombineTerms(source, maxSqlExpression);
                         var maxDaysExpression = maxSqliteFactory.EfDays(maxSqlExpression);
-                        var maxAggregate = _sqlExpressionFactory.Function(
+                        var maxAggregate = sqlExpressionFactory.Function(
                             "max",
                             [maxDaysExpression],
                             nullable: true,
@@ -106,11 +106,11 @@ public class SqliteQueryableAggregateMethodTranslator(ISqlExpressionFactory sqlE
                     }
 
                     if (minArgumentType == typeof(TimeSpan)
-                        && _sqlExpressionFactory is SqliteSqlExpressionFactory minSqliteFactory)
+                        && sqlExpressionFactory is SqliteSqlExpressionFactory minSqliteFactory)
                     {
                         minSqlExpression = CombineTerms(source, minSqlExpression);
                         var minDaysExpression = minSqliteFactory.EfDays(minSqlExpression);
-                        var minAggregate = _sqlExpressionFactory.Function(
+                        var minAggregate = sqlExpressionFactory.Function(
                             "min",
                             [minDaysExpression],
                             nullable: true,

--- a/src/EFCore.Sqlite.Core/Query/Internal/Translators/SqliteQueryableAggregateMethodTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/Translators/SqliteQueryableAggregateMethodTranslator.cs
@@ -59,11 +59,24 @@ public class SqliteQueryableAggregateMethodTranslator(ISqlExpressionFactory sqlE
                     && source.Selector is SqlExpression maxSqlExpression:
                     var maxArgumentType = GetProviderType(maxSqlExpression);
                     if (maxArgumentType == typeof(DateTimeOffset)
-                        || maxArgumentType == typeof(TimeSpan)
                         || maxArgumentType == typeof(ulong))
                     {
                         throw new NotSupportedException(
                             SqliteStrings.AggregateOperationNotSupported(nameof(Queryable.Max), maxArgumentType.ShortDisplayName()));
+                    }
+
+                    if (maxArgumentType == typeof(TimeSpan)
+                        && _sqlExpressionFactory is SqliteSqlExpressionFactory maxSqliteFactory)
+                    {
+                        maxSqlExpression = CombineTerms(source, maxSqlExpression);
+                        var maxDaysExpression = maxSqliteFactory.EfDays(maxSqlExpression);
+                        var maxAggregate = _sqlExpressionFactory.Function(
+                            "max",
+                            [maxDaysExpression],
+                            nullable: true,
+                            argumentsPropagateNullability: Statics.FalseArrays[1],
+                            typeof(double));
+                        return maxSqliteFactory.EfTimespan(maxAggregate);
                     }
 
                     if (maxArgumentType == typeof(decimal))
@@ -86,11 +99,24 @@ public class SqliteQueryableAggregateMethodTranslator(ISqlExpressionFactory sqlE
                     && source.Selector is SqlExpression minSqlExpression:
                     var minArgumentType = GetProviderType(minSqlExpression);
                     if (minArgumentType == typeof(DateTimeOffset)
-                        || minArgumentType == typeof(TimeSpan)
                         || minArgumentType == typeof(ulong))
                     {
                         throw new NotSupportedException(
                             SqliteStrings.AggregateOperationNotSupported(nameof(Queryable.Min), minArgumentType.ShortDisplayName()));
+                    }
+
+                    if (minArgumentType == typeof(TimeSpan)
+                        && _sqlExpressionFactory is SqliteSqlExpressionFactory minSqliteFactory)
+                    {
+                        minSqlExpression = CombineTerms(source, minSqlExpression);
+                        var minDaysExpression = minSqliteFactory.EfDays(minSqlExpression);
+                        var minAggregate = _sqlExpressionFactory.Function(
+                            "min",
+                            [minDaysExpression],
+                            nullable: true,
+                            argumentsPropagateNullability: Statics.FalseArrays[1],
+                            typeof(double));
+                        return minSqliteFactory.EfTimespan(minAggregate);
                     }
 
                     if (minArgumentType == typeof(decimal))

--- a/src/EFCore.Sqlite.Core/Query/Internal/Translators/SqliteTimeSpanMemberTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/Translators/SqliteTimeSpanMemberTranslator.cs
@@ -1,0 +1,95 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class SqliteTimeSpanMemberTranslator(SqliteSqlExpressionFactory sqlExpressionFactory) : IMemberTranslator
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual SqlExpression? Translate(
+        SqlExpression? instance,
+        MemberInfo member,
+        Type returnType,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+    {
+        if (member.DeclaringType != typeof(TimeSpan) || instance is null)
+        {
+            return null;
+        }
+
+        var daysExpression = sqlExpressionFactory.EfDays(instance);
+
+        return member.Name switch
+        {
+            nameof(TimeSpan.Days)
+                => sqlExpressionFactory.Convert(daysExpression, typeof(int)),
+            nameof(TimeSpan.Hours)
+                => sqlExpressionFactory.Convert(
+                    sqlExpressionFactory.Modulo(
+                        sqlExpressionFactory.Multiply(daysExpression, sqlExpressionFactory.Constant(24.0)),
+                        sqlExpressionFactory.Constant(24.0)),
+                    returnType),
+            nameof(TimeSpan.Minutes)
+                => sqlExpressionFactory.Convert(
+                    sqlExpressionFactory.Modulo(
+                        sqlExpressionFactory.Multiply(daysExpression, sqlExpressionFactory.Constant(1440.0)),
+                        sqlExpressionFactory.Constant(60.0)),
+                    returnType),
+            nameof(TimeSpan.Seconds)
+                => sqlExpressionFactory.Convert(
+                    sqlExpressionFactory.Modulo(
+                        sqlExpressionFactory.Multiply(daysExpression, sqlExpressionFactory.Constant(86400.0)),
+                        sqlExpressionFactory.Constant(60.0)),
+                    returnType),
+            nameof(TimeSpan.Milliseconds)
+                => sqlExpressionFactory.Convert(
+                    sqlExpressionFactory.Modulo(
+                        sqlExpressionFactory.Multiply(daysExpression, sqlExpressionFactory.Constant(86400000.0)),
+                        sqlExpressionFactory.Constant(1000.0)),
+                    returnType),
+            nameof(TimeSpan.Microseconds)
+                => sqlExpressionFactory.Convert(
+                    sqlExpressionFactory.Modulo(
+                        sqlExpressionFactory.Multiply(daysExpression, sqlExpressionFactory.Constant(86400000000.0)),
+                        sqlExpressionFactory.Constant(1000.0)),
+                    returnType),
+            nameof(TimeSpan.Nanoseconds)
+                => sqlExpressionFactory.Convert(
+                    sqlExpressionFactory.Modulo(
+                        sqlExpressionFactory.Multiply(daysExpression, sqlExpressionFactory.Constant(86400000000000.0)),
+                        sqlExpressionFactory.Constant(1000.0)),
+                    returnType),
+            nameof(TimeSpan.Ticks)
+                => sqlExpressionFactory.Convert(
+                    sqlExpressionFactory.Multiply(
+                        daysExpression,
+                        sqlExpressionFactory.Constant((double)TimeSpan.TicksPerDay)),
+                    typeof(long)),
+            nameof(TimeSpan.TotalDays)
+                => daysExpression,
+            nameof(TimeSpan.TotalHours)
+                => sqlExpressionFactory.Multiply(daysExpression, sqlExpressionFactory.Constant(24.0)),
+            nameof(TimeSpan.TotalMinutes)
+                => sqlExpressionFactory.Multiply(daysExpression, sqlExpressionFactory.Constant(1440.0)),
+            nameof(TimeSpan.TotalSeconds)
+                => sqlExpressionFactory.Multiply(daysExpression, sqlExpressionFactory.Constant(86400.0)),
+            nameof(TimeSpan.TotalMilliseconds)
+                => sqlExpressionFactory.Multiply(daysExpression, sqlExpressionFactory.Constant(86400000.0)),
+            _ => null
+        };
+    }
+}

--- a/src/EFCore.Sqlite.Core/Query/Internal/Translators/SqliteTimeSpanMethodTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/Translators/SqliteTimeSpanMethodTranslator.cs
@@ -1,0 +1,111 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class SqliteTimeSpanMethodTranslator(SqliteSqlExpressionFactory sqlExpressionFactory) : IMethodCallTranslator
+{
+    private static readonly MethodInfo DurationMethod
+        = typeof(TimeSpan).GetRuntimeMethod(nameof(TimeSpan.Duration), Type.EmptyTypes)!;
+
+    private static readonly MethodInfo FromDaysMethod
+        = typeof(TimeSpan).GetRuntimeMethod(nameof(TimeSpan.FromDays), [typeof(double)])!;
+
+    private static readonly MethodInfo FromHoursMethod
+        = typeof(TimeSpan).GetRuntimeMethod(nameof(TimeSpan.FromHours), [typeof(double)])!;
+
+    private static readonly MethodInfo FromMinutesMethod
+        = typeof(TimeSpan).GetRuntimeMethod(nameof(TimeSpan.FromMinutes), [typeof(double)])!;
+
+    private static readonly MethodInfo FromSecondsMethod
+        = typeof(TimeSpan).GetRuntimeMethod(nameof(TimeSpan.FromSeconds), [typeof(double)])!;
+
+    private static readonly MethodInfo FromMillisecondsMethod
+        = typeof(TimeSpan).GetRuntimeMethod(nameof(TimeSpan.FromMilliseconds), [typeof(double)])!;
+
+    private static readonly MethodInfo FromTicksMethod
+        = typeof(TimeSpan).GetRuntimeMethod(nameof(TimeSpan.FromTicks), [typeof(long)])!;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual SqlExpression? Translate(
+        SqlExpression? instance,
+        MethodInfo method,
+        IReadOnlyList<SqlExpression> arguments,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+    {
+        if (method.DeclaringType != typeof(TimeSpan))
+        {
+            return null;
+        }
+
+        if (DurationMethod.Equals(method) && instance != null)
+        {
+            var daysExpression = sqlExpressionFactory.EfDays(instance);
+            var absExpression = sqlExpressionFactory.Function(
+                "abs",
+                [daysExpression],
+                nullable: true,
+                argumentsPropagateNullability: Statics.TrueArrays[1],
+                typeof(double));
+            return sqlExpressionFactory.EfTimespan(absExpression);
+        }
+
+        if (instance != null)
+        {
+            return null;
+        }
+
+        if (FromDaysMethod.Equals(method) && arguments.Count == 1)
+        {
+            return sqlExpressionFactory.EfTimespan(arguments[0]);
+        }
+
+        if (FromHoursMethod.Equals(method) && arguments.Count == 1)
+        {
+            return sqlExpressionFactory.EfTimespan(
+                sqlExpressionFactory.Divide(arguments[0], sqlExpressionFactory.Constant(24.0)));
+        }
+
+        if (FromMinutesMethod.Equals(method) && arguments.Count == 1)
+        {
+            return sqlExpressionFactory.EfTimespan(
+                sqlExpressionFactory.Divide(arguments[0], sqlExpressionFactory.Constant(1440.0)));
+        }
+
+        if (FromSecondsMethod.Equals(method) && arguments.Count == 1)
+        {
+            return sqlExpressionFactory.EfTimespan(
+                sqlExpressionFactory.Divide(arguments[0], sqlExpressionFactory.Constant(86400.0)));
+        }
+
+        if (FromMillisecondsMethod.Equals(method) && arguments.Count == 1)
+        {
+            return sqlExpressionFactory.EfTimespan(
+                sqlExpressionFactory.Divide(arguments[0], sqlExpressionFactory.Constant(86400000.0)));
+        }
+
+        if (FromTicksMethod.Equals(method) && arguments.Count == 1)
+        {
+            return sqlExpressionFactory.EfTimespan(
+                sqlExpressionFactory.Divide(
+                    sqlExpressionFactory.Convert(arguments[0], typeof(double)),
+                    sqlExpressionFactory.Constant(864000000000.0)));
+        }
+
+        return null;
+    }
+}

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteRelationalConnection.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteRelationalConnection.cs
@@ -190,6 +190,31 @@ public class SqliteRelationalConnection : RelationalConnection, ISqliteRelationa
                 (x, y) => decimal.Compare(
                     decimal.Parse(x, NumberStyles.Number, CultureInfo.InvariantCulture),
                     decimal.Parse(y, NumberStyles.Number, CultureInfo.InvariantCulture)));
+
+            sqliteConnection.CreateFunction<TimeSpan?, double?>(
+                "ef_days",
+                value => value == null ? null : value.Value.TotalDays,
+                isDeterministic: true);
+
+            sqliteConnection.CreateFunction<string?, double?>(
+                "ef_days",
+                value => value == null ? null : TimeSpan.Parse(value).TotalDays,
+                isDeterministic: true);
+
+            sqliteConnection.CreateFunction<double?, TimeSpan?>(
+                "ef_timespan",
+                value =>
+                {
+                    if (value == null)
+                    {
+                        return null;
+                    }
+
+                    var totalDays = value.Value;
+                    var ticks = (long)Math.Round(totalDays * TimeSpan.TicksPerDay);
+                    return new TimeSpan(ticks);
+                },
+                isDeterministic: true);
         }
         else
         {

--- a/test/EFCore.Cosmos.FunctionalTests/Query/Translations/Temporal/DateTimeTranslationsCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/Translations/Temporal/DateTimeTranslationsCosmosTest.cs
@@ -162,10 +162,10 @@ WHERE (DateTimePart("ms", c["DateTime"]) = 123)
         AssertSql();
     }
 
-    public override async Task subtract_and_TotalDays()
+    public override async Task Subtract_and_TotalDays()
     {
         // Cosmos client evaluation. Issue #17246.
-        await AssertTranslationFailed(() => base.subtract_and_TotalDays());
+        await AssertTranslationFailed(() => base.Subtract_and_TotalDays());
 
         AssertSql();
     }

--- a/test/EFCore.Specification.Tests/Query/Translations/Temporal/DateTimeTranslationsTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Translations/Temporal/DateTimeTranslationsTestBase.cs
@@ -79,7 +79,7 @@ public abstract class DateTimeTranslationsTestBase<TFixture>(TFixture fixture) :
         => AssertQuery(ss => ss.Set<BasicTypesEntity>().Where(o => o.DateTime.TimeOfDay == TimeSpan.Zero));
 
     [ConditionalFact]
-    public virtual Task subtract_and_TotalDays()
+    public virtual Task Subtract_and_TotalDays()
     {
         var date = new DateTime(1997, 1, 1);
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Translations/Temporal/DateTimeTranslationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Translations/Temporal/DateTimeTranslationsSqlServerTest.cs
@@ -188,8 +188,8 @@ WHERE CONVERT(time, [b].[DateTime]) = '00:00:00'
 """);
     }
 
-    public override Task subtract_and_TotalDays()
-        => AssertTranslationFailed(() => base.subtract_and_TotalDays());
+    public override Task Subtract_and_TotalDays()
+        => AssertTranslationFailed(() => base.Subtract_and_TotalDays());
 
     public override async Task Parse_with_constant()
     {

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Translations/Temporal/DateTimeTranslationsSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Translations/Temporal/DateTimeTranslationsSqliteTest.cs
@@ -186,8 +186,19 @@ WHERE rtrim(rtrim(strftime('%H:%M:%f', "b"."DateTime"), '0'), '.') = '00:00:00'
 """);
     }
 
-    public override Task subtract_and_TotalDays()
-        => AssertTranslationFailed(() => base.subtract_and_TotalDays());
+    public override async Task Subtract_and_TotalDays()
+    {
+        await base.Subtract_and_TotalDays();
+
+        AssertSql(
+            """
+@date='1997-01-01T00:00:00.0000000' (DbType = DateTime)
+
+SELECT "b"."Id", "b"."Bool", "b"."Byte", "b"."ByteArray", "b"."DateOnly", "b"."DateTime", "b"."DateTimeOffset", "b"."Decimal", "b"."Double", "b"."Enum", "b"."FlagsEnum", "b"."Float", "b"."Guid", "b"."Int", "b"."Long", "b"."Short", "b"."String", "b"."TimeOnly", "b"."TimeSpan"
+FROM "BasicTypesEntities" AS "b"
+WHERE ef_days(ef_timespan(julianday("b"."DateTime") - julianday(@date))) > 365.0
+""");
+    }
 
     public override async Task Parse_with_constant()
     {

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Translations/Temporal/TimeSpanTranslationsSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Translations/Temporal/TimeSpanTranslationsSqliteTest.cs
@@ -12,51 +12,76 @@ public class TimeSpanTranslationsSqliteTest : TimeSpanTranslationsTestBase<Basic
         Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
 
-    // Translate TimeSpan members, #18844
     public override async Task Hours()
     {
-        await AssertTranslationFailed(() => base.Hours());
+        await base.Hours();
 
-        AssertSql();
+        AssertSql(
+            """
+SELECT "b"."Id", "b"."Bool", "b"."Byte", "b"."ByteArray", "b"."DateOnly", "b"."DateTime", "b"."DateTimeOffset", "b"."Decimal", "b"."Double", "b"."Enum", "b"."FlagsEnum", "b"."Float", "b"."Guid", "b"."Int", "b"."Long", "b"."Short", "b"."String", "b"."TimeOnly", "b"."TimeSpan"
+FROM "BasicTypesEntities" AS "b"
+WHERE CAST((ef_days("b"."TimeSpan") * 24.0) % 24.0 AS INTEGER) = 3
+""");
     }
 
-    // Translate TimeSpan members, #18844
     public override async Task Minutes()
     {
-        await AssertTranslationFailed(() => base.Minutes());
+        await base.Minutes();
 
-        AssertSql();
+        AssertSql(
+            """
+SELECT "b"."Id", "b"."Bool", "b"."Byte", "b"."ByteArray", "b"."DateOnly", "b"."DateTime", "b"."DateTimeOffset", "b"."Decimal", "b"."Double", "b"."Enum", "b"."FlagsEnum", "b"."Float", "b"."Guid", "b"."Int", "b"."Long", "b"."Short", "b"."String", "b"."TimeOnly", "b"."TimeSpan"
+FROM "BasicTypesEntities" AS "b"
+WHERE CAST((ef_days("b"."TimeSpan") * 1440.0) % 60.0 AS INTEGER) = 4
+""");
     }
 
     public override async Task Seconds()
     {
-        await AssertTranslationFailed(() => base.Seconds());
+        await base.Seconds();
 
-        AssertSql();
+        AssertSql(
+            """
+SELECT "b"."Id", "b"."Bool", "b"."Byte", "b"."ByteArray", "b"."DateOnly", "b"."DateTime", "b"."DateTimeOffset", "b"."Decimal", "b"."Double", "b"."Enum", "b"."FlagsEnum", "b"."Float", "b"."Guid", "b"."Int", "b"."Long", "b"."Short", "b"."String", "b"."TimeOnly", "b"."TimeSpan"
+FROM "BasicTypesEntities" AS "b"
+WHERE CAST((ef_days("b"."TimeSpan") * 86400.0) % 60.0 AS INTEGER) = 5
+""");
     }
 
-    // Translate TimeSpan members, #18844
     public override async Task Milliseconds()
     {
-        await AssertTranslationFailed(() => base.Milliseconds());
+        await base.Milliseconds();
 
-        AssertSql();
+        AssertSql(
+            """
+SELECT "b"."Id", "b"."Bool", "b"."Byte", "b"."ByteArray", "b"."DateOnly", "b"."DateTime", "b"."DateTimeOffset", "b"."Decimal", "b"."Double", "b"."Enum", "b"."FlagsEnum", "b"."Float", "b"."Guid", "b"."Int", "b"."Long", "b"."Short", "b"."String", "b"."TimeOnly", "b"."TimeSpan"
+FROM "BasicTypesEntities" AS "b"
+WHERE CAST((ef_days("b"."TimeSpan") * 86400000.0) % 1000.0 AS INTEGER) = 678
+""");
     }
 
-    // Translate TimeSpan members, #18844
     public override async Task Microseconds()
     {
-        await AssertTranslationFailed(() => base.Microseconds());
+        await base.Microseconds();
 
-        AssertSql();
+        AssertSql(
+            """
+SELECT "b"."Id", "b"."Bool", "b"."Byte", "b"."ByteArray", "b"."DateOnly", "b"."DateTime", "b"."DateTimeOffset", "b"."Decimal", "b"."Double", "b"."Enum", "b"."FlagsEnum", "b"."Float", "b"."Guid", "b"."Int", "b"."Long", "b"."Short", "b"."String", "b"."TimeOnly", "b"."TimeSpan"
+FROM "BasicTypesEntities" AS "b"
+WHERE CAST((ef_days("b"."TimeSpan") * 86400000000.0) % 1000.0 AS INTEGER) = 912
+""");
     }
 
-    // Translate TimeSpan members, #18844
     public override async Task Nanoseconds()
     {
-        await AssertTranslationFailed(() => base.Nanoseconds());
+        await base.Nanoseconds();
 
-        AssertSql();
+        AssertSql(
+            """
+SELECT "b"."Id", "b"."Bool", "b"."Byte", "b"."ByteArray", "b"."DateOnly", "b"."DateTime", "b"."DateTimeOffset", "b"."Decimal", "b"."Double", "b"."Enum", "b"."FlagsEnum", "b"."Float", "b"."Guid", "b"."Int", "b"."Long", "b"."Short", "b"."String", "b"."TimeOnly", "b"."TimeSpan"
+FROM "BasicTypesEntities" AS "b"
+WHERE CAST((ef_days("b"."TimeSpan") * 86400000000000.0) % 1000.0 AS INTEGER) = 400
+""");
     }
 
     [ConditionalFact]


### PR DESCRIPTION
- Add `ef_days` and `ef_timespan` UDFs in `SqliteRelationalConnection`
- Add `SqliteTimeSpanMemberTranslator` and `SqliteTimeSpanMethodTranslator`
- Translate `TimeSpan` binary ops and `DateTime` ± `TimeSpan` in `SqliteSqlTranslatingExpressionVisitor`
- Translate `Max/Min(TimeSpan)` in `SqliteQueryableAggregateMethodTranslator`
- Add `TimeSpan` and `DateTime` `Subtract_and_TotalDays` SQLite tests

Fixes #18844