### PR TITLE
Default to using SQL Server testcontainer in tests

### DIFF
--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -18,5 +18,6 @@
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryExporterInMemoryVersion)" />
     <PackageVersion Include="SQLitePCLRaw.provider.sqlite3" Version="$(SQLitePCLRawVersion)" />
     <PackageVersion Include="SQLitePCLRaw.provider.winsqlite3" Version="$(SQLitePCLRawVersion)" />
+    <PackageVersion Include="Testcontainers.MsSql" Version="4.10.0" />
   </ItemGroup>
 </Project>

--- a/test/EFCore.AspNet.SqlServer.FunctionalTests/EFCore.AspNet.SqlServer.FunctionalTests.csproj
+++ b/test/EFCore.AspNet.SqlServer.FunctionalTests/EFCore.AspNet.SqlServer.FunctionalTests.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <AssemblyName>Microsoft.EntityFrameworkCore.AspNet.SqlServer.FunctionalTests</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
-    <SkipTests Condition="'$(OS)' != 'Windows_NT' AND '$(Test__SqlServer__DefaultConnection)' == ''">True</SkipTests>
     <ImplicitUsings>true</ImplicitUsings>
     <DefineConstants Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(DefineConstants);EXCLUDE_ON_MAC</DefineConstants>
   </PropertyGroup>

--- a/test/EFCore.OData.FunctionalTests/EFCore.OData.FunctionalTests.csproj
+++ b/test/EFCore.OData.FunctionalTests/EFCore.OData.FunctionalTests.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>Microsoft.EntityFrameworkCore.OData.FunctionalTests</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
     <Nullable>disable</Nullable>
-    <SkipTests Condition="'$(OS)' != 'Windows_NT' AND '$(Test__SqlServer__DefaultConnection)' == ''">True</SkipTests>
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
 

--- a/test/EFCore.SqlServer.FunctionalTests/EFCore.SqlServer.FunctionalTests.csproj
+++ b/test/EFCore.SqlServer.FunctionalTests/EFCore.SqlServer.FunctionalTests.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <SkipTests Condition="'$(OS)' != 'Windows_NT' AND '$(Test__SqlServer__DefaultConnection)' == ''">True</SkipTests>
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
 
@@ -77,5 +76,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+    <PackageReference Include="Testcontainers.MsSql" />
   </ItemGroup>
 </Project>

--- a/test/EFCore.SqlServer.FunctionalTests/config.json
+++ b/test/EFCore.SqlServer.FunctionalTests/config.json
@@ -1,7 +1,7 @@
 {
     "Test": {
       "SqlServer": {
-        "DefaultConnection": "Data Source=(localdb)\\MSSQLLocalDB;Database=master;Integrated Security=True;Connect Timeout=60;ConnectRetryCount=0",
+        "DefaultConnection": null,
         "ElasticPoolName": "",
         "SupportsMemoryOptimized": null
       }

--- a/test/EFCore.SqlServer.HierarchyId.Tests/EFCore.SqlServer.HierarchyId.Tests.csproj
+++ b/test/EFCore.SqlServer.HierarchyId.Tests/EFCore.SqlServer.HierarchyId.Tests.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>Microsoft.EntityFrameworkCore.SqlServer.HierarchyId.Tests</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore.SqlServer</RootNamespace>
     <Nullable>disable</Nullable>
-    <SkipTests Condition="'$(OS)' != 'Windows_NT' AND '$(Test__SqlServer__DefaultConnection)' == ''">True</SkipTests>
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
 

--- a/test/EFCore.VisualBasic.FunctionalTests/EFCore.VisualBasic.FunctionalTests.vbproj
+++ b/test/EFCore.VisualBasic.FunctionalTests/EFCore.VisualBasic.FunctionalTests.vbproj
@@ -4,7 +4,6 @@
     <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <AssemblyName>Microsoft.EntityFrameworkCore.VisualBasic.FunctionalTests</AssemblyName>
-    <SkipTests Condition="'$(OS)' != 'Windows_NT' AND '$(Test__SqlServer__DefaultConnection)' == ''">True</SkipTests>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
See https://github.com/dotnet/efcore/issues/33267#issuecomment-3966227466 for an AI agent motivation for this; not yet 100% sure how it all hangs together but this seems like a good idea regardless.

@AndriySvyryd note that the PR only defaults to testcontains on non-Windows; for now I've left Windows to default to LocalDB. I think it actually might make sense to apply the change to Windows as well for the same reasons (multiple parallel agents with isolated databases - see commented linked to above).

Let me know if this makes sense to you or you prefer to keep LocalDB as a default.

Closes #33267
