### PR TITLE
[release/8.0] Update branding to 8.0.26

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup Label="Version settings">
-    <VersionPrefix>8.0.25</VersionPrefix>
+    <VersionPrefix>8.0.26</VersionPrefix>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>
     </PreReleaseVersionIteration>


### PR DESCRIPTION
This PR updates version branding on branch `release/8.0`.

**Changes:**
- Repository: efcore
  - PatchVersion: `25` → `26`

**Files Modified:**
- eng/Versions.props (+1 -1)
