### PR TITLE
Fix misc issues found by Copilot

### DIFF
--- a/.agents/skills/analyzers/SKILL.md
+++ b/.agents/skills/analyzers/SKILL.md
@@ -1,5 +1,5 @@
 ---
 name: analyzers
 description: 'Implementation details for EF Core Roslyn analyzers. Use when changing analyzers, fix providers, or diagnostic suppressors.'
-user-invokable: false
+user-invocable: false
 ---

--- a/.agents/skills/bulk-operations/SKILL.md
+++ b/.agents/skills/bulk-operations/SKILL.md
@@ -1,5 +1,5 @@
 ---
 name: bulk-operations
 description: 'Implementation details for EF Core ExecuteUpdate/ExecuteDelete bulk operations. Use when changing UpdateExpression/DeleteExpression LINQ translation or the corresponding SQL AST nodes.'
-user-invokable: false
+user-invocable: false
 ---

--- a/.agents/skills/change-tracking/SKILL.md
+++ b/.agents/skills/change-tracking/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: change-tracking
 description: 'Implementation details for EF Core change tracking. Use when changing InternalEntityEntry, ChangeDetector, SnapshotFactoryFactory, or related entity state, snapshot, or property accessor code.'
-user-invokable: false
+user-invocable: false
 ---
 
 # Change Tracking

--- a/.agents/skills/cosmos-provider/SKILL.md
+++ b/.agents/skills/cosmos-provider/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cosmos-provider
 description: 'Implementation details for the EF Core Azure Cosmos DB provider. Use when changing Cosmos-specific code.'
-user-invokable: false
+user-invocable: false
 ---
 
 # Cosmos DB Provider

--- a/.agents/skills/dbcontext-and-services/SKILL.md
+++ b/.agents/skills/dbcontext-and-services/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dbcontext-and-services
 description: 'Implementation details for EF Core DbContext and the DI service infrastructure. Use when changing context configuration, service registration, service lifetimes, DbContext pooling, or the Dependencies pattern.'
-user-invokable: false
+user-invocable: false
 ---
 
 # DbContext & Services

--- a/.agents/skills/make-custom-agent/SKILL.md
+++ b/.agents/skills/make-custom-agent/SKILL.md
@@ -232,7 +232,7 @@ After creating or modifying an agent, verify:
 | Using `isSticky: true` unnecessarily | Only set sticky if the agent should persist between turns by default |
 | No `extensionDependencies` on `github.copilot-chat` | Add it; otherwise the contribution point may not be available |
 | Agent invoked as subagent unexpectedly | Set `disable-model-invocation: true` |
-| Subagent appears in the dropdown | Set `user-invokable: false` |
+| Subagent appears in the dropdown | Set `user-invocable: false` |
 
 ## References
 

--- a/.agents/skills/make-skill/SKILL.md
+++ b/.agents/skills/make-skill/SKILL.md
@@ -51,7 +51,7 @@ Create the file with required YAML frontmatter:
 ---
 name: <skill-name>
 description: <description of what the skill does and when to use it>
-user-invokable: <Optional, defaults to true. Set to false for background knowledge skills.>
+user-invocable: <Optional, defaults to true. Set to false for background knowledge skills.>
 argument-hint: <Optional, guidance for how agents should format arguments when invoking the skill.>
 disable-model-invocation: <Optional, set to true to prevent agents from invoking the skill and only allow to be used through manual invocation.>
 compatibility: <Optional, specify any environment, tool, or context requirements for the skill.>

--- a/.agents/skills/migrations/SKILL.md
+++ b/.agents/skills/migrations/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: migrations
 description: 'Implementation details for EF Core migrations. Use when changing MigrationsSqlGenerator, model diffing, migration operations, HistoryRepository, the Migrator or related classes.'
-user-invokable: false
+user-invocable: false
 ---
 
 # Migrations

--- a/.agents/skills/model-building/SKILL.md
+++ b/.agents/skills/model-building/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: model-building
 description: 'Implementation details for EF Core model building. Use when changing ConventionSet, ModelBuilder, IConvention implementations, ModelRuntimeInitializer, RuntimeModel, or related classes.'
-user-invokable: false
+user-invocable: false
 ---
 
 # Model Building, Conventions & Initialization

--- a/.agents/skills/query-pipeline/SKILL.md
+++ b/.agents/skills/query-pipeline/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: query-pipeline
 description: 'Implementation details for EF Core LINQ query translation and SQL generation. Use when changing expression visitors, SqlExpressions, QuerySqlGenerator, ShaperProcessingExpressionVisitor, or related classes.'
-user-invokable: false
+user-invocable: false
 ---
 
 # Query Pipeline

--- a/.agents/skills/scaffolding/SKILL.md
+++ b/.agents/skills/scaffolding/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: scaffolding
 description: 'Implementation details for EF Core scaffolding (reverse engineering). Use when changing ef dbcontext scaffold pipeline implementation, database schema reading, CSharpModelGenerator, or related classes.'
-user-invokable: false
+user-invocable: false
 ---
 
 # Scaffolding

--- a/.agents/skills/sqlite-adonet/SKILL.md
+++ b/.agents/skills/sqlite-adonet/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: sqlite-adonet
 description: 'Implementation details for the Microsoft.Data.Sqlite ADO.NET provider. Use when changing files under `src/Microsoft.Data.Sqlite.Core/`.'
-user-invokable: false
+user-invocable: false
 ---
 
 # Microsoft.Data.Sqlite

--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: testing
 description: 'Implementation details for EF Core test infrastructure. Use when changing test fixtures, SQL baseline assertions, test helpers, the test class hierarchy, or when adding new tests.'
-user-invokable: false
+user-invocable: false
 ---
 
 # Testing
@@ -70,6 +70,7 @@ Each test gets a fresh model/store. Call `InitializeAsync<TContext>(onModelCreat
 2. **Provider override**: Override in `EFCore.{Provider}.FunctionalTests` with `AssertSql()`
 3. **Unit test**: Add to `EFCore.{Provider}.Tests`
 4. Run with `EF_TEST_REWRITE_BASELINES=1` to capture initial baselines
+5. When testing cross-platform code (e.g., file paths, path separators), verify the fix works on both Windows and Linux/macOS
 
 ## Common Pitfalls
 

--- a/.agents/skills/tooling/SKILL.md
+++ b/.agents/skills/tooling/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tooling
 description: 'Implementation details for the EF Core dotnet-ef CLI and tooling. Use when changing dotnet-ef commands, the ef wrapper, EFCore.Tools (PMC), or EFCore.Tasks MSBuild integration.'
-user-invokable: false
+user-invocable: false
 ---
 
 # Tooling

--- a/.agents/skills/update-pipeline/SKILL.md
+++ b/.agents/skills/update-pipeline/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: update-pipeline
 description: 'Implementation details for EF Core SaveChanges and the update pipeline. Use when changing CommandBatchPreparer, UpdateSqlGenerator, ModificationCommand, or related classes.'
-user-invokable: false
+user-invocable: false
 ---
 
 # Update Pipeline

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -88,11 +88,7 @@ If you are not sure, do not guess, just tell that you don't know or ask clarifyi
 ### Testing
 
 - Follow the existing test patterns in the corresponding test projects
-- Create both unit tests and functional tests where appropriate
-- Fix `SQL` and `C#` baselines for tests when necessary by setting the `EF_TEST_REWRITE_BASELINES` env var to `1`
 - Run tests with project rebuilding enabled (don't use `--no-build`) to ensure code changes are picked up
-- When testing cross-platform code (e.g., file paths, path separators), verify the fix works on both Windows and Linux/macOS
-- When testing `dotnet-ef` tool changes, create a test project and manually run the affected commands to verify behavior
 
 #### Environment Setup
 - **ALWAYS** run `restore.cmd` (Windows) or `. ./restore.sh` (Linux/Mac) first to restore dependencies

--- a/src/EFCore.Cosmos/Diagnostics/Internal/CosmosLoggerExtensions.cs
+++ b/src/EFCore.Cosmos/Diagnostics/Internal/CosmosLoggerExtensions.cs
@@ -245,7 +245,7 @@ public static class CosmosLoggerExtensions
         var d = (EventDefinition<string, string, string, string, string, string?>)definition;
         var p = (CosmosItemCommandExecutedEventData)payload;
         return d.GenerateMessage(
-            p.Elapsed.Milliseconds.ToString(),
+            p.Elapsed.TotalMilliseconds.ToString(),
             p.RequestCharge.ToString(),
             p.ActivityId,
             p.ContainerId,
@@ -304,7 +304,7 @@ public static class CosmosLoggerExtensions
         var d = (EventDefinition<string, string, string, string, string, string?>)definition;
         var p = (CosmosTransactionalBatchExecutedEventData)payload;
         return d.GenerateMessage(
-            p.Elapsed.Milliseconds.ToString(),
+            p.Elapsed.TotalMilliseconds.ToString(),
             p.RequestCharge.ToString(),
             p.ActivityId,
             p.ContainerId,
@@ -364,7 +364,7 @@ public static class CosmosLoggerExtensions
         var d = (EventDefinition<string, string, string, string, string, string?>)definition;
         var p = (CosmosItemCommandExecutedEventData)payload;
         return d.GenerateMessage(
-            p.Elapsed.Milliseconds.ToString(),
+            p.Elapsed.TotalMilliseconds.ToString(),
             p.RequestCharge.ToString(),
             p.ActivityId,
             p.ContainerId,
@@ -424,7 +424,7 @@ public static class CosmosLoggerExtensions
         var d = (EventDefinition<string, string, string, string, string, string?>)definition;
         var p = (CosmosItemCommandExecutedEventData)payload;
         return d.GenerateMessage(
-            p.Elapsed.Milliseconds.ToString(),
+            p.Elapsed.TotalMilliseconds.ToString(),
             p.RequestCharge.ToString(),
             p.ActivityId,
             p.ContainerId,
@@ -484,7 +484,7 @@ public static class CosmosLoggerExtensions
         var d = (EventDefinition<string, string, string, string, string, string?>)definition;
         var p = (CosmosItemCommandExecutedEventData)payload;
         return d.GenerateMessage(
-            p.Elapsed.Milliseconds.ToString(),
+            p.Elapsed.TotalMilliseconds.ToString(),
             p.RequestCharge.ToString(),
             p.ActivityId,
             p.ContainerId,

--- a/src/EFCore.Cosmos/Storage/Internal/CosmosClientWrapper.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosClientWrapper.cs
@@ -368,7 +368,7 @@ public class CosmosClientWrapper : ICosmosClientWrapper
             }
         }
 
-        var response = await container.CreateItemStreamAsync(
+        using var response = await container.CreateItemStreamAsync(
                 stream,
                 partitionKeyValue,
                 itemRequestOptions,

--- a/src/EFCore.Cosmos/Storage/Internal/CosmosDatabaseWrapper.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosDatabaseWrapper.cs
@@ -138,7 +138,7 @@ public class CosmosDatabaseWrapper : Database, IResettableService
                         }
                     }
                 }
-                catch (Exception ex) when (ex is not DbUpdateException and not OperationCanceledException)
+                catch (Exception ex) when (!ex.IsCritical() && ex is not DbUpdateException)
                 {
                     var exception = WrapUpdateException(ex, transaction.Entries.Select(x => x.Entry).ToArray());
                     throw exception;
@@ -523,7 +523,7 @@ public class CosmosDatabaseWrapper : Database, IResettableService
                 _ => throw new UnreachableException(),
             };
         }
-        catch (Exception ex) when (ex is not DbUpdateException and not UnreachableException and not OperationCanceledException)
+        catch (Exception ex) when (!ex.IsCritical() && ex is not DbUpdateException)
         {
             var errorEntries = new[] { updateEntry.Entry };
             var exception = WrapUpdateException(ex, errorEntries);

--- a/src/EFCore.Cosmos/Storage/Internal/CosmosExecutionStrategy.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosExecutionStrategy.cs
@@ -98,13 +98,16 @@ public class CosmosExecutionStrategy : ExecutionStrategy
         {
             CosmosException cosmosException => IsTransient(cosmosException.StatusCode),
             HttpException httpException => IsTransient(httpException.Response.StatusCode),
-            WebException webException => IsTransient(((HttpWebResponse)webException.Response!).StatusCode),
+            WebException webException => IsTransient((webException.Response as HttpWebResponse)?.StatusCode),
             _ => false
         };
 
-        static bool IsTransient(HttpStatusCode statusCode)
-            => statusCode is HttpStatusCode.ServiceUnavailable or HttpStatusCode.TooManyRequests or HttpStatusCode.RequestTimeout
-                or HttpStatusCode.Gone;
+        static bool IsTransient(HttpStatusCode? statusCode)
+            => statusCode is null
+            or HttpStatusCode.ServiceUnavailable
+            or HttpStatusCode.TooManyRequests
+            or HttpStatusCode.RequestTimeout
+            or HttpStatusCode.Gone;
     }
 
     /// <summary>

--- a/src/EFCore.Design/Migrations/Design/MigrationsScaffolder.cs
+++ b/src/EFCore.Design/Migrations/Design/MigrationsScaffolder.cs
@@ -422,11 +422,12 @@ public class MigrationsScaffolder : IMigrationsScaffolder
         if (!dryRun)
         {
             Directory.CreateDirectory(migrationDirectory);
+            Directory.CreateDirectory(modelSnapshotDirectory);
+
             File.WriteAllText(migrationFile, migration.MigrationCode, Encoding.UTF8);
             File.WriteAllText(migrationMetadataFile, migration.MetadataCode, Encoding.UTF8);
 
             Dependencies.OperationReporter.WriteVerbose(DesignStrings.WritingSnapshot(modelSnapshotFile));
-            Directory.CreateDirectory(modelSnapshotDirectory);
             File.WriteAllText(modelSnapshotFile, migration.SnapshotCode, Encoding.UTF8);
         }
 

--- a/src/EFCore.InMemory/Infrastructure/Internal/InMemoryOptionsExtension.cs
+++ b/src/EFCore.InMemory/Infrastructure/Internal/InMemoryOptionsExtension.cs
@@ -176,7 +176,7 @@ public class InMemoryOptionsExtension : IDbContextOptionsExtension
                         builder.Append("DatabaseRoot=").Append(root.GetHashCode()).Append(' ');
                     }
 
-                    if (!Extension._nullabilityCheckEnabled)
+                    if (Extension._nullabilityCheckEnabled)
                     {
                         builder.Append("NullabilityChecksEnabled ");
                     }

--- a/src/EFCore.Proxies/LazyLoadingProxiesOptionsBuilder.cs
+++ b/src/EFCore.Proxies/LazyLoadingProxiesOptionsBuilder.cs
@@ -9,7 +9,7 @@ namespace Microsoft.EntityFrameworkCore;
 ///     Allows SQL Server specific configuration to be performed on <see cref="DbContextOptions" />.
 /// </summary>
 /// <remarks>
-///     Instances of this class are returned from a call to <see cref="O:SqlServerDbContextOptionsExtensions.UseSqlServer" />
+///     Instances of this class are returned from a call to <see cref="O:ProxiesExtensions.UseLazyLoadingProxies" />
 ///     and it is not designed to be directly constructed in your application code.
 /// </remarks>
 public class LazyLoadingProxiesOptionsBuilder

--- a/src/EFCore.Proxies/Proxies/Internal/PropertyChangedInterceptor.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/PropertyChangedInterceptor.cs
@@ -95,14 +95,9 @@ public class PropertyChangedInterceptor : PropertyChangeInterceptorBase, IInterc
             var oldValue = property.GetGetter().GetClrValueUsingContainingEntity(invocation.Proxy);
 
             invocation.Proceed();
-
             if (!(comparer?.Equals(oldValue, newValue) ?? Equals(oldValue, newValue)))
             {
                 NotifyPropertyChanged(property.Name, invocation.Proxy);
-            }
-            else
-            {
-                invocation.Proceed();
             }
         }
         else

--- a/src/EFCore.Relational/Storage/RelationalConnection.cs
+++ b/src/EFCore.Relational/Storage/RelationalConnection.cs
@@ -1040,9 +1040,6 @@ public abstract class RelationalConnection : IRelationalConnection, ITransaction
 
         _commandTimeout = _defaultCommandTimeout;
 
-        _openedCount = 0;
-        _openedInternally = false;
-
         if (_connectionOwned
             && _connection is not null)
         {

--- a/src/EFCore.Relational/Storage/RelationalDatabaseCreator.cs
+++ b/src/EFCore.Relational/Storage/RelationalDatabaseCreator.cs
@@ -364,7 +364,7 @@ public abstract class RelationalDatabaseCreator : IRelationalDatabaseCreator
         {
             return Exists();
         }
-        catch
+        catch (Exception ex) when (!ex.IsCritical())
         {
             return false;
         }

--- a/src/EFCore.Relational/Update/AffectedCountModificationCommandBatch.cs
+++ b/src/EFCore.Relational/Update/AffectedCountModificationCommandBatch.cs
@@ -134,7 +134,7 @@ public abstract class AffectedCountModificationCommandBatch : ReaderModification
                 }
             }
         }
-        catch (Exception ex) when (ex is not DbUpdateException and not OperationCanceledException)
+        catch (Exception ex) when (!ex.IsCritical() && ex is not DbUpdateException)
         {
             throw new DbUpdateException(
                 RelationalStrings.UpdateStoreException,
@@ -256,7 +256,7 @@ public abstract class AffectedCountModificationCommandBatch : ReaderModification
                 }
             }
         }
-        catch (Exception ex) when (ex is not DbUpdateException and not OperationCanceledException)
+        catch (Exception ex) when (!ex.IsCritical() && ex is not DbUpdateException)
         {
             throw new DbUpdateException(
                 RelationalStrings.UpdateStoreException,
@@ -317,7 +317,7 @@ public abstract class AffectedCountModificationCommandBatch : ReaderModification
 
             return commandIndex - 1;
         }
-        catch (Exception ex) when (ex is not DbUpdateException and not OperationCanceledException)
+        catch (Exception ex) when (!ex.IsCritical() && ex is not DbUpdateException)
         {
             throw new DbUpdateException(
                 RelationalStrings.UpdateStoreException,
@@ -387,7 +387,7 @@ public abstract class AffectedCountModificationCommandBatch : ReaderModification
 
             return commandIndex - 1;
         }
-        catch (Exception ex) when (ex is not DbUpdateException and not OperationCanceledException)
+        catch (Exception ex) when (!ex.IsCritical() && ex is not DbUpdateException)
         {
             throw new DbUpdateException(
                 RelationalStrings.UpdateStoreException,

--- a/src/EFCore.Relational/Update/ReaderModificationCommandBatch.cs
+++ b/src/EFCore.Relational/Update/ReaderModificationCommandBatch.cs
@@ -352,7 +352,7 @@ public abstract class ReaderModificationCommandBatch : ModificationCommandBatch
 
             Consume(dataReader);
         }
-        catch (Exception ex) when (ex is not DbUpdateException and not OperationCanceledException)
+        catch (Exception ex) when (!ex.IsCritical() && ex is not DbUpdateException)
         {
             throw new DbUpdateException(
                 RelationalStrings.UpdateStoreException,
@@ -392,7 +392,7 @@ public abstract class ReaderModificationCommandBatch : ModificationCommandBatch
 
             await ConsumeAsync(dataReader, cancellationToken).ConfigureAwait(false);
         }
-        catch (Exception ex) when (ex is not DbUpdateException and not OperationCanceledException and not UnreachableException)
+        catch (Exception ex) when (!ex.IsCritical() && ex is not DbUpdateException)
         {
             throw new DbUpdateException(
                 RelationalStrings.UpdateStoreException,

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteRelationalConnection.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteRelationalConnection.cs
@@ -100,16 +100,11 @@ public class SqliteRelationalConnection : RelationalConnection, ISqliteRelationa
 
             sqliteConnection.CreateFunction<string, string, bool?>(
                 "regexp",
-                (pattern, input) =>
-                {
-                    if (input == null
-                        || pattern == null)
-                    {
-                        return null;
-                    }
-
-                    return Regex.IsMatch(input, pattern);
-                },
+                (pattern, input)
+                    => input == null
+                        || pattern == null
+                        ? null
+                        : Regex.IsMatch(input, pattern, RegexOptions.NonBacktracking, TimeSpan.FromMilliseconds(1000)),
                 isDeterministic: true);
 
             sqliteConnection.CreateFunction(

--- a/src/EFCore.Tools/EFCore.Tools.csproj
+++ b/src/EFCore.Tools/EFCore.Tools.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Build.NoTargets">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(NetMinimum)</TargetFramework>

--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -1058,7 +1058,7 @@ public class DbContext :
     public virtual void Dispose()
     {
         var lease = _lease;
-        var contextShouldBeDisposed = lease.IsActive && _lease.IsStandalone;
+        var contextShouldBeDisposed = lease.IsActive && lease.IsStandalone;
 
         if (DisposeSync(lease.IsActive, contextShouldBeDisposed))
         {

--- a/src/EFCore/DbContextOptionsBuilder.cs
+++ b/src/EFCore/DbContextOptionsBuilder.cs
@@ -176,14 +176,18 @@ public class DbContextOptionsBuilder : IDbContextOptionsBuilderInfrastructure
         Check.NotNull(events);
 
         var eventsArray = events.ToArray();
-
-        return eventsArray.Length switch
+        switch (eventsArray.Length)
         {
-            0 => this,
-            1 => LogTo(action, (eventId, level) => level >= minimumLevel && eventId == eventsArray[0], options),
-            < 6 => LogTo(action, (eventId, level) => level >= minimumLevel && eventsArray.Contains(eventId), options),
-            _ => LogTo(action, (eventId, level) => level >= minimumLevel && eventsArray.ToHashSet().Contains(eventId), options)
-        };
+            case 0:
+                return this;
+            case 1:
+                return LogTo(action, (eventId, level) => level >= minimumLevel && eventId == eventsArray[0], options);
+            case < 6:
+                return LogTo(action, (eventId, level) => level >= minimumLevel && eventsArray.Contains(eventId), options);
+            default:
+                var eventsSet = eventsArray.ToHashSet();
+                return LogTo(action, (eventId, level) => level >= minimumLevel && eventsSet.Contains(eventId), options);
+        }
     }
 
     /// <summary>
@@ -223,16 +227,17 @@ public class DbContextOptionsBuilder : IDbContextOptionsBuilderInfrastructure
 
         var categoriesArray = categories.ToArray();
 
-        if (categoriesArray.Length == 0)
+        // One category is common, but even when there are more the number should be low because
+        // the number of available categories is low. So no HashSet here.
+        return categoriesArray.Length switch
         {
-            return this;
-        }
-
-        if (categoriesArray.Length != 1)
-        {
-            // One category is common, but even when there are more the number should be low because
-            // the number of available categories is low. So no HashSet here.
-            return LogTo(
+            0 => this,
+            1 => LogTo(
+                action,
+                (eventId, level) => level >= minimumLevel
+                    && eventId.Name!.StartsWith(categoriesArray[0], StringComparison.OrdinalIgnoreCase),
+                options),
+            _ => LogTo(
                 action,
                 (eventId, level) =>
                 {
@@ -249,15 +254,8 @@ public class DbContextOptionsBuilder : IDbContextOptionsBuilderInfrastructure
 
                     return false;
                 },
-                options);
-        }
-
-        var singleCategory = categoriesArray[0];
-        return LogTo(
-            action,
-            (eventId, level) => level >= minimumLevel
-                && eventId.Name!.StartsWith(singleCategory, StringComparison.OrdinalIgnoreCase),
-            options);
+                options)
+        };
     }
 
     /// <summary>

--- a/src/EFCore/Diagnostics/Internal/FormattingDbContextLogger.cs
+++ b/src/EFCore/Diagnostics/Internal/FormattingDbContextLogger.cs
@@ -56,7 +56,8 @@ public class FormattingDbContextLogger : IDbContextLogger
 
             if ((_options & DbContextLoggerOptions.LocalTime) != 0)
             {
-                messageBuilder.Append(DateTime.Now.ToShortDateString()).Append(DateTime.Now.ToString(" HH:mm:ss.fff "));
+                var now = DateTime.Now;
+                messageBuilder.Append(now.ToShortDateString()).Append(now.ToString(" HH:mm:ss.fff "));
             }
 
             if ((_options & DbContextLoggerOptions.UtcTime) != 0)

--- a/src/EFCore/Infrastructure/CoreOptionsExtension.cs
+++ b/src/EFCore/Infrastructure/CoreOptionsExtension.cs
@@ -39,8 +39,8 @@ public class CoreOptionsExtension : IDbContextOptionsExtension
     private int? _maxPoolSize;
     private TimeSpan _loggingCacheTime = DefaultLoggingCacheTime;
     private bool _serviceProviderCachingEnabled = true;
-    private IEnumerable<IInterceptor>? _interceptors;
-    private IEnumerable<ISingletonInterceptor>? _singletonInterceptors;
+    private List<IInterceptor>? _interceptors;
+    private List<ISingletonInterceptor>? _singletonInterceptors;
     private Action<DbContext, bool>? _seed;
     private Func<DbContext, bool, CancellationToken, Task>? _seedAsync;
 
@@ -388,8 +388,8 @@ public class CoreOptionsExtension : IDbContextOptionsExtension
         var clone = Clone();
 
         clone._interceptors = _interceptors == null
-            ? interceptors
-            : _interceptors.Concat(interceptors);
+            ? [..interceptors]
+            : [.._interceptors, ..interceptors];
 
         return clone;
     }
@@ -405,8 +405,8 @@ public class CoreOptionsExtension : IDbContextOptionsExtension
         var clone = Clone();
 
         clone._singletonInterceptors = _singletonInterceptors == null
-            ? interceptors
-            : _singletonInterceptors.Concat(interceptors);
+            ? [..interceptors]
+            : [.._singletonInterceptors, ..interceptors];
 
         return clone;
     }

--- a/src/EFCore/Metadata/Internal/ElementType.cs
+++ b/src/EFCore/Metadata/Internal/ElementType.cs
@@ -385,7 +385,7 @@ public class ElementType : ConventionAnnotatable, IMutableElementType, IConventi
             {
                 converter = (ValueConverter?)Activator.CreateInstance(converterType);
             }
-            catch (Exception e)
+            catch (Exception e) when (!e.IsCritical())
             {
                 throw new InvalidOperationException(
                     CoreStrings.CannotCreateValueConverter(
@@ -546,7 +546,7 @@ public class ElementType : ConventionAnnotatable, IMutableElementType, IConventi
             {
                 comparer = (ValueComparer?)Activator.CreateInstance(comparerType);
             }
-            catch (Exception e)
+            catch (Exception e) when (!e.IsCritical())
             {
                 throw new InvalidOperationException(
                     CoreStrings.CannotCreateValueComparer(

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -1924,8 +1924,6 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
         Check.HasNoNulls(properties);
         EnsureMutable();
 
-        CheckIndexProperties(properties);
-
         var duplicateIndex = FindIndexesInHierarchy(properties).FirstOrDefault();
         if (duplicateIndex != null)
         {
@@ -1957,8 +1955,6 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
         Check.NotEmpty(name);
         EnsureMutable();
 
-        CheckIndexProperties(properties);
-
         var duplicateIndex = FindIndexesInHierarchy(name).FirstOrDefault();
         if (duplicateIndex != null)
         {
@@ -1976,27 +1972,6 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
         UpdatePropertyIndexes(properties, index);
 
         return (Index?)Model.ConventionDispatcher.OnIndexAdded(index.Builder)?.Metadata;
-    }
-
-    private void CheckIndexProperties(IReadOnlyList<Property> properties)
-    {
-        for (var i = 0; i < properties.Count; i++)
-        {
-            var property = properties[i];
-            for (var j = i + 1; j < properties.Count; j++)
-            {
-                if (property == properties[j])
-                {
-                    throw new InvalidOperationException(CoreStrings.DuplicatePropertyInIndex(properties.Format(), property.Name));
-                }
-            }
-
-            if (FindProperty(property.Name) != property
-                || !property.IsInModel)
-            {
-                throw new InvalidOperationException(CoreStrings.IndexPropertiesWrongEntity(properties.Format(), DisplayName()));
-            }
-        }
     }
 
     private static void UpdatePropertyIndexes(IReadOnlyList<Property> properties, Index index)
@@ -2640,7 +2615,7 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
                                 {
                                     value = propertyInfo.GetValue(rawSeed, [propertyBase.Name]);
                                 }
-                                catch
+                                catch (Exception ex) when (!ex.IsCritical())
                                 {
                                     // Swallow if the property value is not set on the seed data
                                 }

--- a/src/EFCore/Metadata/Internal/Index.cs
+++ b/src/EFCore/Metadata/Internal/Index.cs
@@ -37,6 +37,24 @@ public class Index : ConventionAnnotatable, IMutableIndex, IConventionIndex, IIn
         EntityType declaringEntityType,
         ConfigurationSource configurationSource)
     {
+        for (var i = 0; i < properties.Count; i++)
+        {
+            var property = properties[i];
+            for (var j = i + 1; j < properties.Count; j++)
+            {
+                if (property == properties[j])
+                {
+                    throw new InvalidOperationException(CoreStrings.DuplicatePropertyInIndex(properties.Format(), property.Name));
+                }
+            }
+
+            if (declaringEntityType.FindProperty(property.Name) != property
+                || !property.IsInModel)
+            {
+                throw new InvalidOperationException(CoreStrings.IndexPropertiesWrongEntity(properties.Format(), declaringEntityType.DisplayName()));
+            }
+        }
+
         Properties = properties;
         DeclaringEntityType = declaringEntityType;
         _configurationSource = configurationSource;

--- a/src/EFCore/Metadata/Internal/InternalPropertyBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalPropertyBuilder.cs
@@ -458,7 +458,7 @@ public class InternalPropertyBuilder
                 {
                     return (ValueGenerator)Activator.CreateInstance(valueGeneratorType)!;
                 }
-                catch (Exception e)
+                catch (Exception e) when (!e.IsCritical())
                 {
                     throw new InvalidOperationException(
                         CoreStrings.CannotCreateValueGenerator(

--- a/src/EFCore/Metadata/Internal/Property.cs
+++ b/src/EFCore/Metadata/Internal/Property.cs
@@ -803,7 +803,7 @@ public class Property : PropertyBase, IMutableProperty, IConventionProperty, IRu
             {
                 converter = (ValueConverter?)Activator.CreateInstance(converterType);
             }
-            catch (Exception e)
+            catch (Exception e) when (!e.IsCritical())
             {
                 throw new InvalidOperationException(
                     CoreStrings.CannotCreateValueConverter(
@@ -1176,7 +1176,7 @@ public class Property : PropertyBase, IMutableProperty, IConventionProperty, IRu
             {
                 comparer = (ValueComparer?)Activator.CreateInstance(comparerType);
             }
-            catch (Exception e)
+            catch (Exception e) when (!e.IsCritical())
             {
                 throw new InvalidOperationException(
                     CoreStrings.CannotCreateValueComparer(
@@ -1285,7 +1285,7 @@ public class Property : PropertyBase, IMutableProperty, IConventionProperty, IRu
             {
                 comparer = (ValueComparer?)Activator.CreateInstance(comparerType);
             }
-            catch (Exception e)
+            catch (Exception e) when (!e.IsCritical())
             {
                 throw new InvalidOperationException(
                     CoreStrings.CannotCreateValueComparer(

--- a/src/EFCore/Metadata/Internal/SkipNavigation.cs
+++ b/src/EFCore/Metadata/Internal/SkipNavigation.cs
@@ -271,6 +271,12 @@ public class SkipNavigation : PropertyBase, IMutableSkipNavigation, IConventionS
                 : inverse;
         }
 
+        if (inverse == this)
+        {
+            throw new InvalidOperationException(
+                CoreStrings.SkipNavigationSelfInverse(Name, DeclaringEntityType.DisplayName()));
+        }
+
         if (inverse.DeclaringEntityType != TargetEntityType)
         {
             throw new InvalidOperationException(

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -647,20 +647,20 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType, collection);
 
         /// <summary>
-        ///     The ordinal {ordinal} is out of range for the complex type collection '{entityType}.{collection}' which has {count} element(s).
-        /// </summary>
-        public static string ComplexCollectionOrdinalOutOfRange(object? ordinal, object? entityType, object? collection, object? count)
-            => string.Format(
-                GetString("ComplexCollectionOrdinalOutOfRange", nameof(ordinal), nameof(entityType), nameof(collection), nameof(count)),
-                ordinal, entityType, collection, count);
-
-        /// <summary>
         ///     The value for the property '{complexType}.{property}' cannot be set, because it's on the complex type collection element '{collectionDeclaringType}.{collection}[{ordinal}]' that contains a 'null' value.
         /// </summary>
         public static string ComplexCollectionNullElementSetter(object? complexType, object? property, object? collectionDeclaringType, object? collection, object? ordinal)
             => string.Format(
                 GetString("ComplexCollectionNullElementSetter", nameof(complexType), nameof(property), nameof(collectionDeclaringType), nameof(collection), nameof(ordinal)),
                 complexType, property, collectionDeclaringType, collection, ordinal);
+
+        /// <summary>
+        ///     The ordinal {ordinal} is out of range for the complex type collection '{entityType}.{collection}' which has {count} element(s).
+        /// </summary>
+        public static string ComplexCollectionOrdinalOutOfRange(object? ordinal, object? entityType, object? collection, object? count)
+            => string.Format(
+                GetString("ComplexCollectionOrdinalOutOfRange", nameof(ordinal), nameof(entityType), nameof(collection), nameof(count)),
+                ordinal, entityType, collection, count);
 
         /// <summary>
         ///     The complex entry at the original ordinal '{ordinal}' for the collection '{declaringType}.{collection}' cannot be accessed as the containing entry is in the added state.
@@ -3300,6 +3300,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 navigation, entityType);
 
         /// <summary>
+        ///     The skip navigation '{navigation}' on entity type '{entityType}' cannot be set as its own inverse.
+        /// </summary>
+        public static string SkipNavigationSelfInverse(object? navigation, object? entityType)
+            => string.Format(
+                GetString("SkipNavigationSelfInverse", nameof(navigation), nameof(entityType)),
+                navigation, entityType);
+
+        /// <summary>
         ///     The skip navigation '{inverse}' declared on the entity type '{inverseEntityType}' cannot be set as the inverse of '{navigation}', which targets '{targetEntityType}'. The inverse navigation should be declared on the target entity type.
         /// </summary>
         public static string SkipNavigationWrongInverse(object? inverse, object? inverseEntityType, object? navigation, object? targetEntityType)
@@ -3800,6 +3808,31 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
                             level,
                             CoreEventId.CollectionWithoutComparer,
                             _resourceManager.GetString("LogCollectionWithoutComparer")!)));
+            }
+
+            return (EventDefinition<string, string>)definition;
+        }
+
+        /// <summary>
+        ///     A compiled model was found but it was built for the database provider '{compiledProviderName}'. The current context is using the database provider '{currentProviderName}'. The compiled model was ignored. Regenerate the compiled model with the correct provider.
+        /// </summary>
+        public static EventDefinition<string, string> LogCompiledModelProviderMismatch(IDiagnosticsLogger logger)
+        {
+            var definition = ((LoggingDefinitions)logger.Definitions).LogCompiledModelProviderMismatch;
+            if (definition == null)
+            {
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
+                    ref ((LoggingDefinitions)logger.Definitions).LogCompiledModelProviderMismatch,
+                    logger,
+                    static logger => new EventDefinition<string, string>(
+                        logger.Options,
+                        CoreEventId.CompiledModelProviderMismatchWarning,
+                        LogLevel.Warning,
+                        "CoreEventId.CompiledModelProviderMismatchWarning",
+                        level => LoggerMessage.Define<string, string>(
+                            level,
+                            CoreEventId.CompiledModelProviderMismatchWarning,
+                            _resourceManager.GetString("LogCompiledModelProviderMismatch")!)));
             }
 
             return (EventDefinition<string, string>)definition;
@@ -4725,31 +4758,6 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
                             level,
                             CoreEventId.OldModelVersionWarning,
                             _resourceManager.GetString("LogOldModelVersion")!)));
-            }
-
-            return (EventDefinition<string, string>)definition;
-        }
-
-        /// <summary>
-        ///     A compiled model was found but was built for the database provider '{compiledProviderName}'. The current context is using the database provider '{currentProviderName}'. The compiled model was ignored. Regenerate the compiled model to use the correct provider.
-        /// </summary>
-        public static EventDefinition<string, string> LogCompiledModelProviderMismatch(IDiagnosticsLogger logger)
-        {
-            var definition = ((LoggingDefinitions)logger.Definitions).LogCompiledModelProviderMismatch;
-            if (definition == null)
-            {
-                definition = NonCapturingLazyInitializer.EnsureInitialized(
-                    ref ((LoggingDefinitions)logger.Definitions).LogCompiledModelProviderMismatch,
-                    logger,
-                    static logger => new EventDefinition<string, string>(
-                        logger.Options,
-                        CoreEventId.CompiledModelProviderMismatchWarning,
-                        LogLevel.Warning,
-                        "CoreEventId.CompiledModelProviderMismatchWarning",
-                        level => LoggerMessage.Define<string, string>(
-                            level,
-                            CoreEventId.CompiledModelProviderMismatchWarning,
-                            _resourceManager.GetString("LogCompiledModelProviderMismatch")!)));
             }
 
             return (EventDefinition<string, string>)definition;

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -351,11 +351,11 @@
   <data name="ComplexCollectionNotInitialized" xml:space="preserve">
     <value>The complex type collection '{entityType}.{collection}' must be initialized to a non-null value before the elements can be accessed.</value>
   </data>
-  <data name="ComplexCollectionOrdinalOutOfRange" xml:space="preserve">
-    <value>The ordinal {ordinal} is out of range for the complex type collection '{entityType}.{collection}' which has {count} element(s).</value>
-  </data>
   <data name="ComplexCollectionNullElementSetter" xml:space="preserve">
     <value>The value for the property '{complexType}.{property}' cannot be set, because it's on the complex type collection element '{collectionDeclaringType}.{collection}[{ordinal}]' that contains a 'null' value.</value>
+  </data>
+  <data name="ComplexCollectionOrdinalOutOfRange" xml:space="preserve">
+    <value>The ordinal {ordinal} is out of range for the complex type collection '{entityType}.{collection}' which has {count} element(s).</value>
   </data>
   <data name="ComplexCollectionOriginalEntryAddedEntity" xml:space="preserve">
     <value>The complex entry at the original ordinal '{ordinal}' for the collection '{declaringType}.{collection}' cannot be accessed as the containing entry is in the added state.</value>
@@ -923,6 +923,10 @@
     <value>The property '{entityType}.{property}' is a collection or enumeration type with a value converter but with no value comparer. Set a value comparer to ensure the collection/enumeration elements are compared correctly.</value>
     <comment>Warning CoreEventId.CollectionWithoutComparer string string</comment>
   </data>
+  <data name="LogCompiledModelProviderMismatch" xml:space="preserve">
+    <value>A compiled model was found but it was built for the database provider '{compiledProviderName}'. The current context is using the database provider '{currentProviderName}'. The compiled model was ignored. Regenerate the compiled model with the correct provider.</value>
+    <comment>Warning CoreEventId.CompiledModelProviderMismatchWarning string string</comment>
+  </data>
   <data name="LogComplexElementPropertyChangeDetected" xml:space="preserve">
     <value>The unchanged property '{typePath}.{property}' was detected as changed and will be marked as modified. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see property values.</value>
     <comment>Debug CoreEventId.ComplexElementPropertyChangeDetected string string</comment>
@@ -1070,10 +1074,6 @@
   <data name="LogOldModelVersion" xml:space="preserve">
     <value>The model supplied in the context options was created with EF Core version '{oldVersion}', but the context is from version '{newVersion}'. Update the externally built model.</value>
     <comment>Warning CoreEventId.OldModelVersionWarning string string</comment>
-  </data>
-  <data name="LogCompiledModelProviderMismatch" xml:space="preserve">
-    <value>A compiled model was found but it was built for the database provider '{compiledProviderName}'. The current context is using the database provider '{currentProviderName}'. The compiled model was ignored. Regenerate the compiled model with the correct provider.</value>
-    <comment>Warning CoreEventId.CompiledModelProviderMismatchWarning string string</comment>
   </data>
   <data name="LogOptimisticConcurrencyException" xml:space="preserve">
     <value>{error}</value>
@@ -1727,6 +1727,9 @@
   </data>
   <data name="SkipNavigationNonCollection" xml:space="preserve">
     <value>The skip navigation '{1_entityType}.{0_navigation}' is not a collection. Only collection skip navigations are currently supported.</value>
+  </data>
+  <data name="SkipNavigationSelfInverse" xml:space="preserve">
+    <value>The skip navigation '{navigation}' on entity type '{entityType}' cannot be set as its own inverse.</value>
   </data>
   <data name="SkipNavigationWrongInverse" xml:space="preserve">
     <value>The skip navigation '{inverse}' declared on the entity type '{inverseEntityType}' cannot be set as the inverse of '{navigation}', which targets '{targetEntityType}'. The inverse navigation should be declared on the target entity type.</value>

--- a/src/EFCore/Storage/ExecutionStrategy.cs
+++ b/src/EFCore/Storage/ExecutionStrategy.cs
@@ -251,7 +251,7 @@ public abstract class ExecutionStrategy : IExecutionStrategy
                     throw new RetryLimitExceededException(CoreStrings.RetryLimitExceeded(MaxRetryCount, GetType().Name), ex);
                 }
 
-                Dependencies.Logger.ExecutionStrategyRetrying(ExceptionsEncountered, delay.Value, async: true);
+                Dependencies.Logger.ExecutionStrategyRetrying(ExceptionsEncountered, delay.Value, async: false);
 
                 OnRetry();
 
@@ -383,9 +383,9 @@ public abstract class ExecutionStrategy : IExecutionStrategy
         if (RetriesOnFailure
             && (Dependencies.CurrentContext.Context.Database.CurrentTransaction is not null
                 || Dependencies.CurrentContext.Context.Database.GetEnlistedTransaction() is not null
-                || (((IDatabaseFacadeDependenciesAccessor)Dependencies.CurrentContext.Context.Database).Dependencies
-                    .TransactionManager as
-                    ITransactionEnlistmentManager)?.CurrentAmbientTransaction is not null))
+                || ((IDatabaseFacadeDependenciesAccessor)Dependencies.CurrentContext.Context.Database).Dependencies
+                    .TransactionManager is
+                    ITransactionEnlistmentManager { CurrentAmbientTransaction: not null }))
         {
             throw new InvalidOperationException(
                 CoreStrings.ExecutionStrategyExistingTransaction(

--- a/src/EFCore/Storage/ValueBuffer.cs
+++ b/src/EFCore/Storage/ValueBuffer.cs
@@ -94,7 +94,15 @@ public readonly struct ValueBuffer : IEquatable<ValueBuffer>
     /// </returns>
     public bool Equals(ValueBuffer other)
     {
-        if (_values.Length != other._values.Length)
+        if (_values == null
+            && other._values == null)
+        {
+            return true;
+        }
+
+        if (_values == null
+            || other._values == null
+            || _values.Length != other._values.Length)
         {
             return false;
         }

--- a/src/Shared/ExceptionExtensions.cs
+++ b/src/Shared/ExceptionExtensions.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Utilities;
+
+internal static class ExceptionExtensions
+{
+    /// <summary>
+    ///     Returns <see langword="true" /> if the exception should not be caught, e.g.
+    ///     <see cref="OutOfMemoryException" />, <see cref="UnreachableException" />, or <see cref="OperationCanceledException" />.
+    /// </summary>
+    public static bool IsCritical(this Exception exception)
+        => exception is OutOfMemoryException or UnreachableException or OperationCanceledException;
+}

--- a/src/ef/Json.cs
+++ b/src/ef/Json.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.EntityFrameworkCore.Tools.Properties;
 
@@ -12,9 +13,40 @@ internal static class Json
         => command.Option("--json", Resources.JsonDescription);
 
     public static string Literal(string? text)
-        => text != null
-            ? "\"" + text.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
-            : "null";
+    {
+        if (text == null)
+        {
+            return "null";
+        }
+
+        var builder = new StringBuilder("\"", text.Length + 2);
+        foreach (var c in text)
+        {
+            switch (c)
+            {
+                case '\\': builder.Append("\\\\"); break;
+                case '"':  builder.Append("\\\""); break;
+                case '\b': builder.Append("\\b"); break;
+                case '\f': builder.Append("\\f"); break;
+                case '\n': builder.Append("\\n"); break;
+                case '\r': builder.Append("\\r"); break;
+                case '\t': builder.Append("\\t"); break;
+                default:
+                    if (char.IsControl(c))
+                    {
+                        builder.Append($"\\u{(int)c:x4}");
+                    }
+                    else
+                    {
+                        builder.Append(c);
+                    }
+                    break;
+            }
+        }
+
+        builder.Append('"');
+        return builder.ToString();
+    }
 
     public static string Literal(bool? value)
         => value.HasValue

--- a/test/EFCore.Design.Tests/Design/Internal/DbContextOperationsTest.cs
+++ b/test/EFCore.Design.Tests/Design/Internal/DbContextOperationsTest.cs
@@ -314,7 +314,7 @@ public class DbContextOperationsTest
 
         Assert.Equal(DesignStrings.NoRelationalConnection, info.DatabaseName);
         Assert.Equal(DesignStrings.NoRelationalConnection, info.DataSource);
-        Assert.Equal("StoreName=In-memory test database", info.Options);
+        Assert.Equal("StoreName=In-memory test database NullabilityChecksEnabled", info.Options);
         Assert.Equal("Microsoft.EntityFrameworkCore.InMemory", info.ProviderName);
     }
 

--- a/test/EFCore.InMemory.FunctionalTests/LoggingInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/LoggingInMemoryTest.cs
@@ -24,5 +24,5 @@ public class LoggingInMemoryTest : LoggingTestBase
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
 
     protected override string DefaultOptions
-        => "StoreName=LoggingInMemoryTest ";
+        => "StoreName=LoggingInMemoryTest NullabilityChecksEnabled ";
 }

--- a/test/EFCore.Tests/DbContextLoggerTests.cs
+++ b/test/EFCore.Tests/DbContextLoggerTests.cs
@@ -7,7 +7,7 @@ public class DbContextLoggerTests
 {
     private const string ContextInitialized =
         @"info: <Local Date> HH:mm:ss.fff CoreEventId.ContextInitialized[10403] (Microsoft.EntityFrameworkCore.Infrastructure) "
-        + @"      Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory:X.X.X-any' with options: StoreName=DbContextLoggerTests ";
+        + @"      Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory:X.X.X-any' with options: StoreName=DbContextLoggerTests NullabilityChecksEnabled ";
 
     private const string SaveChangesStarting =
         @"dbug: <Local Date> HH:mm:ss.fff CoreEventId.SaveChangesStarting[10004] (Microsoft.EntityFrameworkCore.Update) "
@@ -201,7 +201,7 @@ public class DbContextLoggerTests
 
         AssertLog(
             actual,
-            @"Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory:X.X.X-any' with options: StoreName=DbContextLoggerTests ");
+            @"Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory:X.X.X-any' with options: StoreName=DbContextLoggerTests NullabilityChecksEnabled ");
     }
 
     [ConditionalTheory, InlineData(true), InlineData(false)]
@@ -213,7 +213,7 @@ public class DbContextLoggerTests
 
         AssertLog(
             actual,
-            @"Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory:X.X.X-any' with options: StoreName=DbContextLoggerTests ");
+            @"Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory:X.X.X-any' with options: StoreName=DbContextLoggerTests NullabilityChecksEnabled ");
     }
 
     [ConditionalTheory, InlineData(true), InlineData(false)]
@@ -228,7 +228,7 @@ public class DbContextLoggerTests
 
         AssertLog(
             actual,
-            @"info: <Local Date> HH:mm:ss.fff CoreEventId.ContextInitialized[10403] (Microsoft.EntityFrameworkCore.Infrastructure) -> Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory:X.X.X-any' with options: StoreName=DbContextLoggerTests ");
+            @"info: <Local Date> HH:mm:ss.fff CoreEventId.ContextInitialized[10403] (Microsoft.EntityFrameworkCore.Infrastructure) -> Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory:X.X.X-any' with options: StoreName=DbContextLoggerTests NullabilityChecksEnabled ");
     }
 
     [ConditionalTheory, InlineData(true), InlineData(false)]
@@ -241,7 +241,7 @@ public class DbContextLoggerTests
         AssertLog(
             actual,
             @"info:
-      Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory:X.X.X-any' with options: StoreName=DbContextLoggerTests ");
+      Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory:X.X.X-any' with options: StoreName=DbContextLoggerTests NullabilityChecksEnabled ");
     }
 
     [ConditionalTheory, InlineData(true), InlineData(false)]
@@ -254,7 +254,7 @@ public class DbContextLoggerTests
         AssertLog(
             actual,
             @"<Local Date> HH:mm:ss.fff
-      Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory:X.X.X-any' with options: StoreName=DbContextLoggerTests ");
+      Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory:X.X.X-any' with options: StoreName=DbContextLoggerTests NullabilityChecksEnabled ");
     }
 
     [ConditionalTheory, InlineData(true), InlineData(false)]
@@ -267,7 +267,7 @@ public class DbContextLoggerTests
         AssertLog(
             actual,
             @"YYYY-MM-DDTHH:MM:SS.MMMMMMTZ
-      Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory:X.X.X-any' with options: StoreName=DbContextLoggerTests ");
+      Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory:X.X.X-any' with options: StoreName=DbContextLoggerTests NullabilityChecksEnabled ");
     }
 
     [ConditionalTheory, InlineData(true), InlineData(false)]
@@ -280,7 +280,7 @@ public class DbContextLoggerTests
         AssertLog(
             actual,
             @"CoreEventId.ContextInitialized[10403]
-      Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory:X.X.X-any' with options: StoreName=DbContextLoggerTests ");
+      Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory:X.X.X-any' with options: StoreName=DbContextLoggerTests NullabilityChecksEnabled ");
     }
 
     [ConditionalTheory, InlineData(true), InlineData(false)]
@@ -293,7 +293,7 @@ public class DbContextLoggerTests
         AssertLog(
             actual,
             @"(Microsoft.EntityFrameworkCore.Infrastructure) "
-            + @"      Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory:X.X.X-any' with options: StoreName=DbContextLoggerTests ");
+            + @"      Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory:X.X.X-any' with options: StoreName=DbContextLoggerTests NullabilityChecksEnabled ");
     }
 
     [ConditionalTheory, InlineData(true), InlineData(false)]
@@ -307,7 +307,7 @@ public class DbContextLoggerTests
         AssertLog(
             actual,
             @"info: CoreEventId.ContextInitialized[10403] "
-            + @"      Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory:X.X.X-any' with options: StoreName=DbContextLoggerTests ");
+            + @"      Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory:X.X.X-any' with options: StoreName=DbContextLoggerTests NullabilityChecksEnabled ");
     }
 
     [ConditionalTheory, InlineData(true), InlineData(false)]
@@ -324,7 +324,7 @@ public class DbContextLoggerTests
         AssertLog(
             actual,
             @"info: YYYY-MM-DDTHH:MM:SS.MMMMMMTZ "
-            + @"      Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory:X.X.X-any' with options: StoreName=DbContextLoggerTests ");
+            + @"      Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory:X.X.X-any' with options: StoreName=DbContextLoggerTests NullabilityChecksEnabled ");
     }
 
     [ConditionalTheory, InlineData(true), InlineData(false)]
@@ -338,7 +338,7 @@ public class DbContextLoggerTests
         AssertLog(
             actual,
             @"info: YYYY-MM-DDTHH:MM:SS.MMMMMMTZ CoreEventId.ContextInitialized[10403] (Microsoft.EntityFrameworkCore.Infrastructure) "
-            + @"      Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory:X.X.X-any' with options: StoreName=DbContextLoggerTests ");
+            + @"      Entity Framework Core X.X.X-any initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.InMemory:X.X.X-any' with options: StoreName=DbContextLoggerTests NullabilityChecksEnabled ");
     }
 
     private static void AssertLog(string actual, params string[] lines)


### PR DESCRIPTION
This pull request primarily updates the YAML frontmatter and documentation for agent skill files to use the correct property name, and makes several improvements and fixes in the Cosmos provider and migration scaffolding code. The most important changes are grouped below.

### Documentation and YAML frontmatter consistency

* Changed the property name from `user-invokable` to `user-invocable` across all agent skill files and related documentation, ensuring consistent terminology and preventing confusion or misconfiguration. [[1]](diffhunk://#diff-9a0123b374e6dc2a2eec76c4096975abf3a09763c49da586c67cbd68daf650cfL4-R4) [[2]](diffhunk://#diff-d9eb856c0da01eb13e6dcdccc2666bcbeabbfa325377cf8f5b1bdb617bdf37dcL4-R4) [[3]](diffhunk://#diff-814394d41fb553dab746ecd2cda811ab6313e389dde4361c4fba331927af0370L4-R4) [[4]](diffhunk://#diff-26ae19ee5be18fffc717706d0e61f6f8a5a84de3984ec3a5e9cf9f788da6fed9L4-R4) [[5]](diffhunk://#diff-17f87cc068c9db7e88fe7fa3228acc287db70da00671d68df736b7f7146dfba4L4-R4) [[6]](diffhunk://#diff-0582803927d94d115616caa1a704b390d782e1ac74401ac50840875d88bccb20L235-R235) [[7]](diffhunk://#diff-0a232b7ff81a9c9555d5d20a6c3eee69ff9db26c2653efa94d59fbe247171853L54-R54) [[8]](diffhunk://#diff-1f37dce3910caea3f9e8b8b3c1da84ef3ccbe88f5172cb124ff423b9eb4c09d1L4-R4) [[9]](diffhunk://#diff-3a1d45ec5af1b75d608db0d429aeb87a5ef3cb5c8ea3498dba5d82cd5aaa0edbL4-R4) [[10]](diffhunk://#diff-1e608208ee4902865ce87c52ecafa192c3105bebb85cb8017ae5631e3b9e0178L4-R4) [[11]](diffhunk://#diff-888e3b8898d009724d921769bce1fea73405843ba39b594e5cfdb00f745cdb09L4-R4) [[12]](diffhunk://#diff-824f78ca6005b802bfd204c39ec7db1a0376f2f635b69e647434556592c4cbb0L4-R4) [[13]](diffhunk://#diff-e5fdca11064a0b8e16e74a9478e22b3ae0474c84405c1cc0a46018a57ba1d7a2L4-R4) [[14]](diffhunk://#diff-1e7e2bd2068355d0e2f62d896c44e4b98398d8df03b92c9438085ead0fed92f6L4-R4) [[15]](diffhunk://#diff-871217fce64de43359dd6cc4dcdd1861a775b6e541743bb0c152ba7cdca5c90bL4-R4)

* Added a testing guideline for cross-platform code in `.agents/skills/testing/SKILL.md`, instructing agents to verify fixes on both Windows and Linux/macOS.

### Cosmos provider improvements

* Updated logging code in `CosmosLoggerExtensions.cs` to use `TotalMilliseconds` instead of `Milliseconds` for elapsed time, improving accuracy in diagnostics messages. [[1]](diffhunk://#diff-0a6cc05e98167941035739c180c4dbca28e7da81f3d3d725114a76847669bf7bL248-R248) [[2]](diffhunk://#diff-0a6cc05e98167941035739c180c4dbca28e7da81f3d3d725114a76847669bf7bL307-R307) [[3]](diffhunk://#diff-0a6cc05e98167941035739c180c4dbca28e7da81f3d3d725114a76847669bf7bL367-R367) [[4]](diffhunk://#diff-0a6cc05e98167941035739c180c4dbca28e7da81f3d3d725114a76847669bf7bL427-R427) [[5]](diffhunk://#diff-0a6cc05e98167941035739c180c4dbca28e7da81f3d3d725114a76847669bf7bL487-R487)
* Fixed resource management in `CosmosClientWrapper.cs` by disposing the response from `CreateItemStreamAsync` properly using a `using` statement.
* Improved exception handling in `CosmosExecutionStrategy.cs` to safely handle null `HttpWebResponse` and treat null status codes as transient, preventing potential crashes and improving retry logic.

### Migration scaffolding fix

* Ensured that the model snapshot directory is created before writing the snapshot file in `MigrationsScaffolder.cs`, preventing errors during migration scaffolding.