### PR TITLE
[release/10.0] Fix projection of required complex type via left join

### DIFF
--- a/src/EFCore/Query/Internal/StructuralTypeMaterializerSource.cs
+++ b/src/EFCore/Query/Internal/StructuralTypeMaterializerSource.cs
@@ -34,6 +34,9 @@ public class StructuralTypeMaterializerSource : IStructuralTypeMaterializerSourc
     private static readonly bool UseOldBehavior37162 =
         AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue37162", out var enabled37162) && enabled37162;
 
+    private static readonly bool UseOldBehavior37304 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue37304", out var enabled37304) && enabled37304;
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -207,7 +210,12 @@ public class StructuralTypeMaterializerSource : IStructuralTypeMaterializerSourc
 
             IComplexProperty complexProperty
                 => CreateMaterializeExpression(
-                    new StructuralTypeMaterializerSourceParameters(complexProperty.ComplexType, "complexType", complexProperty.ClrType, nullable || complexProperty.IsNullable, QueryTrackingBehavior: null),
+                    new StructuralTypeMaterializerSourceParameters(
+                        complexProperty.ComplexType,
+                        "complexType",
+                        complexProperty.ClrType,
+                        UseOldBehavior37304 ? nullable || complexProperty.IsNullable : complexProperty.IsNullable,
+                        QueryTrackingBehavior: null),
                     bindingInfo.MaterializationContextExpression),
 
             _ => throw new UnreachableException()

--- a/test/EFCore.Specification.Tests/Query/AdHocComplexTypeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AdHocComplexTypeQueryTestBase.cs
@@ -268,6 +268,80 @@ public abstract class AdHocComplexTypeQueryTestBase(NonSharedFixture fixture)
 
     #endregion 37162
 
+    #region 37304
+
+    [ConditionalFact]
+    public virtual async Task Non_optional_complex_type_with_all_nullable_properties_via_left_join()
+    {
+        var contextFactory = await InitializeAsync<Context37304>(
+            seed: context =>
+            {
+                context.Add(
+                    new Context37304.Parent
+                    {
+                        Id = 1,
+                        Children =
+                        [
+                            new Context37304.Child
+                            {
+                                Id = 1,
+                                ComplexType = new Context37304.ComplexTypeWithAllNulls()
+                            }
+                        ]
+                    });
+                return context.SaveChangesAsync();
+            });
+
+        await using var context = contextFactory.CreateContext();
+
+        var parent = await context.Set<Context37304.Parent>().Include(p => p.Children).SingleAsync();
+
+        var child = parent.Children.Single();
+        Assert.NotNull(child.ComplexType);
+        Assert.Null(child.ComplexType.NullableString);
+        Assert.Null(child.ComplexType.NullableDateTime);
+    }
+
+    private class Context37304(DbContextOptions options) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Parent>(b =>
+            {
+                b.Property(p => p.Id).ValueGeneratedNever();
+            });
+
+            modelBuilder.Entity<Child>(b =>
+            {
+                b.Property(c => c.Id).ValueGeneratedNever();
+                b.HasOne(c => c.Parent).WithMany(p => p.Children).HasForeignKey(c => c.ParentId);
+                b.ComplexProperty(c => c.ComplexType);
+            });
+        }
+
+        public class Parent
+        {
+            public int Id { get; set; }
+            public List<Child> Children { get; set; } = [];
+        }
+
+        public class Child
+        {
+            public int Id { get; set; }
+            public int ParentId { get; set; }
+            public Parent Parent { get; set; } = null!;
+            public ComplexTypeWithAllNulls ComplexType { get; set; } = null!;
+        }
+
+        public class ComplexTypeWithAllNulls
+        {
+            public string? NullableString { get; set; }
+            public DateTime? NullableDateTime { get; set; }
+        }
+    }
+
+    #endregion 37304
+
     #region Issue37337
 
     [ConditionalFact]


### PR DESCRIPTION
Fixes #37304

**Description**

PR #37196 fixed #37162 by adding an IsNullable flag to StructuralTypeMaterializerSourceParameters to correctly distinguish optional vs required complex types during materialization. However, in StructuralTypeMaterializerSource.AddInitializeExpression, the IsNullable for nested complex properties was computed as nullable || complexProperty.IsNullable, where nullable is the parent entity/type's nullability. When an entity is loaded via a LEFT JOIN (e.g. Include on a nullable navigation), its IsNullable is true, and this incorrectly cascades down to all its required complex types, causing HandleNullableComplexTypeMaterialization to check their scalar properties and return null when all are null.

The fix removes the nullable || from the expression, using only complexProperty.IsNullable to determine the complex property's nullability. The parent's nullability is already handled at the entity level (discriminator/key check); once the entity is confirmed to exist, its required complex types must always be materialized as non-null.

**Customer impact**

When loading a non-optional complex type (with all-nullable properties) on an entity accessed via a LEFT JOIN — such as through Include on a collection navigation or a nullable reference navigation — EF Core 10 incorrectly returns null for the complex type instead of a non-null instance with null properties. This is a regression from EF 8/9 and violates the user's non-nullable configuration.

**How found**

Multiple customers reported on 10.0 (#37304)

**Regression**

Yes — introduced by the fix for #37162 (PR #37196) in 10.0.1.

**Testing**

Added regression test Non_optional_complex_type_with_all_nullable_properties_via_left_join in AdHocComplexTypeQueryTestBase.cs.

**Risk**

Very low. Single-character change (nullable || complexProperty.IsNullable → complexProperty.IsNullable). The parent entity's nullability was never needed here — entity-level null checks already prevent complex type materialization from being reached when the entity doesn't exist. Quirk added just in case.
