### PR TITLE
Add dotnet-ef JSON config defaults and validation features

### DIFF
--- a/src/dotnet-ef/DotNetEfConfigLoader.cs
+++ b/src/dotnet-ef/DotNetEfConfigLoader.cs
@@ -1,0 +1,124 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore.Tools.Properties;
+
+namespace Microsoft.EntityFrameworkCore.Tools;
+
+internal sealed record DotNetEfConfig(
+    string Path,
+    string? Project,
+    string? StartupProject,
+    string? Context,
+    string? Framework,
+    string? Configuration);
+
+internal static class DotNetEfConfigLoader
+{
+    private const string ConfigDirectoryName = ".config";
+    private const string ConfigFileName = "dotnet-ef.json";
+
+    public static DotNetEfConfig? Load(string currentDirectory)
+    {
+        var configPath = Discover(currentDirectory);
+        return configPath == null ? null : LoadFile(configPath);
+    }
+
+    private static string? Discover(string currentDirectory)
+    {
+        var directory = new DirectoryInfo(Path.GetFullPath(currentDirectory));
+
+        while (directory != null)
+        {
+            var configPath = Path.Combine(directory.FullName, ConfigDirectoryName, ConfigFileName);
+            if (File.Exists(configPath))
+            {
+                return configPath;
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+
+    internal static DotNetEfConfig LoadFile(string configPath)
+    {
+        var fullPath = Path.GetFullPath(configPath);
+
+        JsonDocument document;
+        try
+        {
+            using var stream = File.OpenRead(fullPath);
+            document = JsonDocument.Parse(stream);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            throw new CommandException(Resources.DotNetEfConfigReadFailed(fullPath, exception.Message), exception);
+        }
+        catch (JsonException exception)
+        {
+            throw new CommandException(Resources.DotNetEfConfigInvalidJson(fullPath, exception.Message), exception);
+        }
+
+        using (document)
+        {
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                throw new CommandException(Resources.DotNetEfConfigInvalidRoot(fullPath));
+            }
+
+            var configDirectory = Directory.GetParent(Path.GetDirectoryName(fullPath)!)!.FullName;
+            string? project = null;
+            string? startupProject = null;
+            string? context = null;
+            string? framework = null;
+            string? configuration = null;
+
+            foreach (var property in document.RootElement.EnumerateObject())
+            {
+                var value = ValidateValue(fullPath, property);
+
+                switch (property.Name)
+                {
+                    case "project":
+                        project = ResolvePath(configDirectory, value);
+                        break;
+                    case "startupProject":
+                        startupProject = ResolvePath(configDirectory, value);
+                        break;
+                    case "context":
+                        context = value;
+                        break;
+                    case "framework":
+                        framework = value;
+                        break;
+                    case "configuration":
+                        configuration = value;
+                        break;
+                    case "connection":
+                    case "connectionString":
+                    case "provider":
+                    case "runtime":
+                        throw new CommandException(Resources.DotNetEfConfigForbiddenProperty(fullPath, property.Name));
+                    default:
+                        throw new CommandException(Resources.DotNetEfConfigUnknownProperty(fullPath, property.Name));
+                }
+            }
+
+            return new DotNetEfConfig(fullPath, project, startupProject, context, framework, configuration);
+        }
+    }
+
+    private static string ValidateValue(string fullPath, JsonProperty property)
+        => property.Value.ValueKind == JsonValueKind.String
+            && !string.IsNullOrWhiteSpace(property.Value.GetString())
+                ? property.Value.GetString()!
+                : throw new CommandException(Resources.DotNetEfConfigInvalidValue(fullPath, property.Name));
+
+    private static string ResolvePath(string configDirectory, string path)
+        => Path.IsPathRooted(path)
+            ? path
+            : Path.GetFullPath(Path.Combine(configDirectory, path));
+}

--- a/src/dotnet-ef/DotNetEfConfigLoader.cs
+++ b/src/dotnet-ef/DotNetEfConfigLoader.cs
@@ -12,7 +12,11 @@ internal sealed record DotNetEfConfig(
     string? StartupProject,
     string? Context,
     string? Framework,
-    string? Configuration);
+    string? Configuration,
+    string? Runtime,
+    bool? Verbose,
+    bool? NoColor,
+    bool? PrefixOutput);
 
 internal static class DotNetEfConfigLoader
 {
@@ -75,6 +79,10 @@ internal static class DotNetEfConfigLoader
             string? context = null;
             string? framework = null;
             string? configuration = null;
+            string? runtime = null;
+            bool? verbose = null;
+            bool? noColor = null;
+            bool? prefixOutput = null;
 
             foreach (var property in document.RootElement.EnumerateObject())
             {
@@ -95,17 +103,24 @@ internal static class DotNetEfConfigLoader
                     case "configuration":
                         configuration = ValidateValue(fullPath, property);
                         break;
-                    case "connection":
-                    case "connectionString":
-                    case "provider":
                     case "runtime":
-                        throw new CommandException(Resources.DotNetEfConfigForbiddenProperty(fullPath, property.Name));
+                        runtime = ValidateValue(fullPath, property);
+                        break;
+                    case "verbose":
+                        verbose = ValidateBoolValue(fullPath, property);
+                        break;
+                    case "noColor":
+                        noColor = ValidateBoolValue(fullPath, property);
+                        break;
+                    case "prefixOutput":
+                        prefixOutput = ValidateBoolValue(fullPath, property);
+                        break;
                     default:
                         throw new CommandException(Resources.DotNetEfConfigUnknownProperty(fullPath, property.Name));
                 }
             }
 
-            return new DotNetEfConfig(fullPath, project, startupProject, context, framework, configuration);
+            return new DotNetEfConfig(fullPath, project, startupProject, context, framework, configuration, runtime, verbose, noColor, prefixOutput);
         }
     }
 
@@ -114,6 +129,13 @@ internal static class DotNetEfConfigLoader
             && !string.IsNullOrWhiteSpace(property.Value.GetString())
                 ? property.Value.GetString()!
                 : throw new CommandException(Resources.DotNetEfConfigInvalidValue(fullPath, property.Name));
+
+    private static bool ValidateBoolValue(string fullPath, JsonProperty property)
+        => property.Value.ValueKind == JsonValueKind.True || property.Value.ValueKind == JsonValueKind.False
+            ? property.Value.GetBoolean()
+            : throw new CommandException(Resources.DotNetEfConfigInvalidBoolValue(fullPath, property.Name));
+
+
 
     private static string ResolvePath(string configDirectory, string path)
         => Path.IsPathRooted(path)

--- a/src/dotnet-ef/DotNetEfConfigLoader.cs
+++ b/src/dotnet-ef/DotNetEfConfigLoader.cs
@@ -78,24 +78,22 @@ internal static class DotNetEfConfigLoader
 
             foreach (var property in document.RootElement.EnumerateObject())
             {
-                var value = ValidateValue(fullPath, property);
-
                 switch (property.Name)
                 {
                     case "project":
-                        project = ResolvePath(configDirectory, value);
+                        project = ResolvePath(configDirectory, ValidateValue(fullPath, property));
                         break;
                     case "startupProject":
-                        startupProject = ResolvePath(configDirectory, value);
+                        startupProject = ResolvePath(configDirectory, ValidateValue(fullPath, property));
                         break;
                     case "context":
-                        context = value;
+                        context = ValidateValue(fullPath, property);
                         break;
                     case "framework":
-                        framework = value;
+                        framework = ValidateValue(fullPath, property);
                         break;
                     case "configuration":
-                        configuration = value;
+                        configuration = ValidateValue(fullPath, property);
                         break;
                     case "connection":
                     case "connectionString":

--- a/src/dotnet-ef/Properties/Resources.Designer.cs
+++ b/src/dotnet-ef/Properties/Resources.Designer.cs
@@ -170,6 +170,54 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
             => GetString("DotnetEfFullName");
 
         /// <summary>
+        ///     Unable to read '{configFile}'. The '{propertyName}' property isn't supported in .config/dotnet-ef.json.
+        /// </summary>
+        public static string DotNetEfConfigForbiddenProperty(object? configFile, object? propertyName)
+            => string.Format(
+                GetString("DotNetEfConfigForbiddenProperty", nameof(configFile), nameof(propertyName)),
+                configFile, propertyName);
+
+        /// <summary>
+        ///     Unable to read '{configFile}'. Fix the JSON and try again. {details}
+        /// </summary>
+        public static string DotNetEfConfigInvalidJson(object? configFile, object? details)
+            => string.Format(
+                GetString("DotNetEfConfigInvalidJson", nameof(configFile), nameof(details)),
+                configFile, details);
+
+        /// <summary>
+        ///     Unable to read '{configFile}'. The file must contain a JSON object.
+        /// </summary>
+        public static string DotNetEfConfigInvalidRoot(object? configFile)
+            => string.Format(
+                GetString("DotNetEfConfigInvalidRoot", nameof(configFile)),
+                configFile);
+
+        /// <summary>
+        ///     Unable to read '{configFile}'. The '{propertyName}' property must be a non-empty JSON string.
+        /// </summary>
+        public static string DotNetEfConfigInvalidValue(object? configFile, object? propertyName)
+            => string.Format(
+                GetString("DotNetEfConfigInvalidValue", nameof(configFile), nameof(propertyName)),
+                configFile, propertyName);
+
+        /// <summary>
+        ///     Unable to read '{configFile}'. Ensure the file is accessible and try again. {details}
+        /// </summary>
+        public static string DotNetEfConfigReadFailed(object? configFile, object? details)
+            => string.Format(
+                GetString("DotNetEfConfigReadFailed", nameof(configFile), nameof(details)),
+                configFile, details);
+
+        /// <summary>
+        ///     Unable to read '{configFile}'. Remove the unsupported '{propertyName}' property.
+        /// </summary>
+        public static string DotNetEfConfigUnknownProperty(object? configFile, object? propertyName)
+            => string.Format(
+                GetString("DotNetEfConfigUnknownProperty", nameof(configFile), nameof(propertyName)),
+                configFile, propertyName);
+
+        /// <summary>
         ///     Entity Framework Core Command-line Tools
         /// </summary>
         public static string EFFullName

--- a/src/dotnet-ef/Properties/Resources.Designer.cs
+++ b/src/dotnet-ef/Properties/Resources.Designer.cs
@@ -170,14 +170,6 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
             => GetString("DotnetEfFullName");
 
         /// <summary>
-        ///     Unable to read '{configFile}'. The '{propertyName}' property isn't supported in .config/dotnet-ef.json.
-        /// </summary>
-        public static string DotNetEfConfigForbiddenProperty(object? configFile, object? propertyName)
-            => string.Format(
-                GetString("DotNetEfConfigForbiddenProperty", nameof(configFile), nameof(propertyName)),
-                configFile, propertyName);
-
-        /// <summary>
         ///     Unable to read '{configFile}'. Fix the JSON and try again. {details}
         /// </summary>
         public static string DotNetEfConfigInvalidJson(object? configFile, object? details)
@@ -199,6 +191,14 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
         public static string DotNetEfConfigInvalidValue(object? configFile, object? propertyName)
             => string.Format(
                 GetString("DotNetEfConfigInvalidValue", nameof(configFile), nameof(propertyName)),
+                configFile, propertyName);
+
+        /// <summary>
+        ///     Unable to read '{configFile}'. The '{propertyName}' property must be a boolean.
+        /// </summary>
+        public static string DotNetEfConfigInvalidBoolValue(object? configFile, object? propertyName)
+            => string.Format(
+                GetString("DotNetEfConfigInvalidBoolValue", nameof(configFile), nameof(propertyName)),
                 configFile, propertyName);
 
         /// <summary>

--- a/src/dotnet-ef/Properties/Resources.resx
+++ b/src/dotnet-ef/Properties/Resources.resx
@@ -192,9 +192,6 @@
   <data name="DotnetEfFullName" xml:space="preserve">
     <value>Entity Framework Core .NET Command-line Tools</value>
   </data>
-  <data name="DotNetEfConfigForbiddenProperty" xml:space="preserve">
-    <value>Unable to read '{configFile}'. The '{propertyName}' property isn't supported in .config/dotnet-ef.json.</value>
-  </data>
   <data name="DotNetEfConfigInvalidJson" xml:space="preserve">
     <value>Unable to read '{configFile}'. Fix the JSON and try again. {details}</value>
   </data>
@@ -203,6 +200,9 @@
   </data>
   <data name="DotNetEfConfigInvalidValue" xml:space="preserve">
     <value>Unable to read '{configFile}'. The '{propertyName}' property must be a non-empty JSON string.</value>
+  </data>
+  <data name="DotNetEfConfigInvalidBoolValue" xml:space="preserve">
+    <value>Unable to read '{configFile}'. The '{propertyName}' property must be a boolean.</value>
   </data>
   <data name="DotNetEfConfigReadFailed" xml:space="preserve">
     <value>Unable to read '{configFile}'. Ensure the file is accessible and try again. {details}</value>

--- a/src/dotnet-ef/Properties/Resources.resx
+++ b/src/dotnet-ef/Properties/Resources.resx
@@ -192,6 +192,24 @@
   <data name="DotnetEfFullName" xml:space="preserve">
     <value>Entity Framework Core .NET Command-line Tools</value>
   </data>
+  <data name="DotNetEfConfigForbiddenProperty" xml:space="preserve">
+    <value>Unable to read '{configFile}'. The '{propertyName}' property isn't supported in .config/dotnet-ef.json.</value>
+  </data>
+  <data name="DotNetEfConfigInvalidJson" xml:space="preserve">
+    <value>Unable to read '{configFile}'. Fix the JSON and try again. {details}</value>
+  </data>
+  <data name="DotNetEfConfigInvalidRoot" xml:space="preserve">
+    <value>Unable to read '{configFile}'. The file must contain a JSON object.</value>
+  </data>
+  <data name="DotNetEfConfigInvalidValue" xml:space="preserve">
+    <value>Unable to read '{configFile}'. The '{propertyName}' property must be a non-empty JSON string.</value>
+  </data>
+  <data name="DotNetEfConfigReadFailed" xml:space="preserve">
+    <value>Unable to read '{configFile}'. Ensure the file is accessible and try again. {details}</value>
+  </data>
+  <data name="DotNetEfConfigUnknownProperty" xml:space="preserve">
+    <value>Unable to read '{configFile}'. Remove the unsupported '{propertyName}' property.</value>
+  </data>
   <data name="EFFullName" xml:space="preserve">
     <value>Entity Framework Core Command-line Tools</value>
   </data>

--- a/src/dotnet-ef/RootCommand.cs
+++ b/src/dotnet-ef/RootCommand.cs
@@ -64,8 +64,18 @@ internal class RootCommand : CommandBase
         var startupProjectPath = _startupProject!.Value() ?? config?.StartupProject;
         var framework = _framework!.Value() ?? config?.Framework;
         var configuration = _configuration!.Value() ?? config?.Configuration;
+        var runtime = _runtime!.Value() ?? config?.Runtime;
         var context = ResolveContext(_args!, config?.Context);
         var remainingArguments = CreateRemainingArguments(_args!, context);
+
+        if (config?.Verbose == true && !ContainsOption(_args!, "-v", "--verbose"))
+            Reporter.IsVerbose = true;
+
+        if (config?.NoColor == true && !ContainsOption(_args!, "--no-color"))
+            Reporter.NoColor = true;
+
+        if (config?.PrefixOutput == true && !ContainsOption(_args!, "--prefix-output"))
+            Reporter.PrefixOutput = true;
 
         var (projectFile, startupProjectFile) = ResolveProjects(
             projectPath,
@@ -78,12 +88,12 @@ internal class RootCommand : CommandBase
             projectFile,
             framework,
             configuration,
-            _runtime!.Value());
+            runtime);
         var startupProject = Project.FromFile(
             startupProjectFile,
             framework,
             configuration,
-            _runtime!.Value());
+            runtime);
 
         if (!_noBuild!.HasValue())
         {

--- a/src/dotnet-ef/RootCommand.cs
+++ b/src/dotnet-ef/RootCommand.cs
@@ -59,31 +59,39 @@ internal class RootCommand : CommandBase
             return ShowHelp(_help.HasValue(), commands);
         }
 
+        var config = DotNetEfConfigLoader.Load(Directory.GetCurrentDirectory());
+        var projectPath = _project!.Value() ?? config?.Project;
+        var startupProjectPath = _startupProject!.Value() ?? config?.StartupProject;
+        var framework = _framework!.Value() ?? config?.Framework;
+        var configuration = _configuration!.Value() ?? config?.Configuration;
+        var context = ResolveContext(_args!, config?.Context);
+        var remainingArguments = CreateRemainingArguments(_args!, context);
+
         var (projectFile, startupProjectFile) = ResolveProjects(
-            _project!.Value(),
-            _startupProject!.Value());
+            projectPath,
+            startupProjectPath);
 
         Reporter.WriteVerbose(Resources.UsingProject(projectFile));
         Reporter.WriteVerbose(Resources.UsingStartupProject(startupProjectFile));
 
         var project = Project.FromFile(
             projectFile,
-            _framework!.Value(),
-            _configuration!.Value(),
+            framework,
+            configuration,
             _runtime!.Value());
         var startupProject = Project.FromFile(
             startupProjectFile,
-            _framework!.Value(),
-            _configuration!.Value(),
+            framework,
+            configuration,
             _runtime!.Value());
 
         if (!_noBuild!.HasValue())
         {
             Reporter.WriteInformation(Resources.BuildStarted);
-            var skipOptimization = _args!.Count > 2
-                && _args[0] == "dbcontext"
-                && _args[1] == "optimize"
-                && !_args.Any(a => a == "--no-scaffold");
+            var skipOptimization = remainingArguments.Count > 2
+                && remainingArguments[0] == "dbcontext"
+                && remainingArguments[1] == "optimize"
+                && !remainingArguments.Any(a => a == "--no-scaffold");
             startupProject.Build(skipOptimization ? ["/p:EFScaffoldModelStage=none", "/p:EFPrecompileQueriesStage=none"] : null);
             Reporter.WriteInformation(Resources.BuildSucceeded);
         }
@@ -162,7 +170,7 @@ internal class RootCommand : CommandBase
                 Resources.UnsupportedFramework(startupProject.ProjectName, targetFramework.Identifier));
         }
 
-        args.AddRange(_args!);
+        args.AddRange(remainingArguments);
         args.Add("--assembly");
         args.Add(targetPath);
         args.Add("--project");
@@ -187,10 +195,10 @@ internal class RootCommand : CommandBase
             args.Add(designAssembly);
         }
 
-        if (_configuration.HasValue())
+        if (configuration != null)
         {
             args.Add("--configuration");
-            args.Add(_configuration.Value()!);
+            args.Add(configuration);
         }
 
         if (string.Equals(project.Nullable, "enable", StringComparison.OrdinalIgnoreCase)
@@ -304,6 +312,54 @@ internal class RootCommand : CommandBase
 
         return projectFiles;
     }
+
+    internal static string? ResolveContext(IList<string> args, string? configValue)
+        => configValue != null
+            && AppliesToContext(args)
+            && !ContainsOption(args, "-c", "--context")
+                ? configValue
+                : null;
+
+    internal static List<string> CreateRemainingArguments(
+        IList<string> args,
+        string? context)
+    {
+        var remainingArguments = new List<string>(args);
+
+        if (context != null)
+        {
+            remainingArguments.Add("--context");
+            remainingArguments.Add(context);
+        }
+
+        return remainingArguments;
+    }
+
+    private static bool AppliesToContext(IList<string> args)
+        => args.Count >= 2
+            && (args[0], args[1]) switch
+            {
+                ("database", "drop") => true,
+                ("database", "update") => true,
+                ("dbcontext", "info") => true,
+                ("dbcontext", "optimize") => true,
+                ("dbcontext", "script") => true,
+                ("migrations", "add") => true,
+                ("migrations", "bundle") => true,
+                ("migrations", "has-pending-model-changes") => true,
+                ("migrations", "list") => true,
+                ("migrations", "remove") => true,
+                ("migrations", "script") => true,
+                _ => false
+            };
+
+    private static bool ContainsOption(
+        IList<string> args,
+        params string[] names)
+        => args.Any(
+            argument => names.Any(
+                name => string.Equals(argument, name, StringComparison.Ordinal)
+                    || argument.StartsWith(name + "=", StringComparison.Ordinal)));
 
     private static string GetVersion()
         => typeof(RootCommand).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!

--- a/src/dotnet-ef/RootCommand.cs
+++ b/src/dotnet-ef/RootCommand.cs
@@ -88,10 +88,7 @@ internal class RootCommand : CommandBase
         if (!_noBuild!.HasValue())
         {
             Reporter.WriteInformation(Resources.BuildStarted);
-            var skipOptimization = remainingArguments.Count > 2
-                && remainingArguments[0] == "dbcontext"
-                && remainingArguments[1] == "optimize"
-                && !remainingArguments.Any(a => a == "--no-scaffold");
+            var skipOptimization = ShouldSkipOptimization(_args!);
             startupProject.Build(skipOptimization ? ["/p:EFScaffoldModelStage=none", "/p:EFPrecompileQueriesStage=none"] : null);
             Reporter.WriteInformation(Resources.BuildSucceeded);
         }
@@ -359,7 +356,14 @@ internal class RootCommand : CommandBase
         => args.Any(
             argument => names.Any(
                 name => string.Equals(argument, name, StringComparison.Ordinal)
-                    || argument.StartsWith(name + "=", StringComparison.Ordinal)));
+                    || argument.StartsWith(name + "=", StringComparison.Ordinal)
+                    || argument.StartsWith(name + ":", StringComparison.Ordinal)));
+
+    internal static bool ShouldSkipOptimization(IList<string> args)
+        => args.Count > 2
+            && args[0] == "dbcontext"
+            && args[1] == "optimize"
+            && !args.Any(a => a == "--no-scaffold");
 
     private static string GetVersion()
         => typeof(RootCommand).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!

--- a/test/dotnet-ef.Tests/DotNetEfConfigTest.cs
+++ b/test/dotnet-ef.Tests/DotNetEfConfigTest.cs
@@ -24,7 +24,11 @@ public class DotNetEfConfigTest
               "startupProject": "src/App.Api",
               "context": "AppDbContext",
               "framework": "net9.0",
-              "configuration": "Debug"
+              "configuration": "Debug",
+              "runtime": "win-x64",
+              "verbose": true,
+              "noColor": true,
+              "prefixOutput": false
             }
             """);
 
@@ -37,6 +41,10 @@ public class DotNetEfConfigTest
         Assert.Equal("AppDbContext", config.Context);
         Assert.Equal("net9.0", config.Framework);
         Assert.Equal("Debug", config.Configuration);
+        Assert.Equal("win-x64", config.Runtime);
+        Assert.True(config.Verbose);
+        Assert.True(config.NoColor);
+        Assert.False(config.PrefixOutput);
     }
 
     [Fact]
@@ -123,11 +131,15 @@ public class DotNetEfConfigTest
     [InlineData("""{ "framework": "   " }""", "must be a non-empty JSON string")]
     [InlineData("""{ "extra": "value" }""", "Remove the unsupported 'extra' property")]
     [InlineData("""{ "extra": 1 }""", "Remove the unsupported 'extra' property")]
-    [InlineData("""{ "connection": "Data Source=test.db" }""", "The 'connection' property isn't supported")]
-    [InlineData("""{ "connection": 1 }""", "The 'connection' property isn't supported")]
-    [InlineData("""{ "connectionString": "Data Source=test.db" }""", "The 'connectionString' property isn't supported")]
-    [InlineData("""{ "provider": "SqlServer" }""", "The 'provider' property isn't supported")]
-    [InlineData("""{ "runtime": "win-x64" }""", "The 'runtime' property isn't supported")]
+    [InlineData("""{ "connection": "Data Source=test.db" }""", "Remove the unsupported")]
+    [InlineData("""{ "connection": 1 }""", "Remove the unsupported")]
+    [InlineData("""{ "connectionString": "Data Source=test.db" }""", "Remove the unsupported")]
+    [InlineData("""{ "provider": "SqlServer" }""", "Remove the unsupported")]
+    [InlineData("""{ "runtime": 1 }""", "must be a non-empty JSON string")]
+    [InlineData("""{ "runtime": "" }""", "must be a non-empty JSON string")]
+    [InlineData("""{ "verbose": "true" }""", "must be a boolean")]
+    [InlineData("""{ "noColor": "false" }""", "must be a boolean")]
+    [InlineData("""{ "prefixOutput": 1 }""", "must be a boolean")]
     public void Load_rejects_invalid_config(string contents, string messageFragment)
     {
         using var directory = new TestDirectory();

--- a/test/dotnet-ef.Tests/DotNetEfConfigTest.cs
+++ b/test/dotnet-ef.Tests/DotNetEfConfigTest.cs
@@ -1,0 +1,233 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Tools;
+
+public class DotNetEfConfigTest
+{
+    [Fact]
+    public void Load_returns_null_when_config_is_absent()
+    {
+        using var directory = new TestDirectory();
+
+        Assert.Null(DotNetEfConfigLoader.Load(directory.Path));
+    }
+
+    [Fact]
+    public void Load_discovers_and_applies_config_in_current_directory()
+    {
+        using var directory = new TestDirectory();
+        var configFile = directory.CreateConfig(
+            """
+            {
+              "project": "src/App.Infrastructure",
+              "startupProject": "src/App.Api",
+              "context": "AppDbContext",
+              "framework": "net9.0",
+              "configuration": "Debug"
+            }
+            """);
+
+        var config = DotNetEfConfigLoader.Load(directory.Path);
+
+        Assert.NotNull(config);
+        Assert.Equal(Path.GetFullPath(configFile), config!.Path);
+        Assert.Equal(Path.Combine(directory.Path, "src", "App.Infrastructure"), config.Project);
+        Assert.Equal(Path.Combine(directory.Path, "src", "App.Api"), config.StartupProject);
+        Assert.Equal("AppDbContext", config.Context);
+        Assert.Equal("net9.0", config.Framework);
+        Assert.Equal("Debug", config.Configuration);
+    }
+
+    [Fact]
+    public void Load_discovers_config_in_parent_directory()
+    {
+        using var directory = new TestDirectory();
+        var parentConfig = directory.CreateConfig("""{ "framework": "net9.0" }""");
+        var workingDirectory = Directory.CreateDirectory(Path.Combine(directory.Path, "src", "App")).FullName;
+
+        var config = DotNetEfConfigLoader.Load(workingDirectory);
+
+        Assert.NotNull(config);
+        Assert.Equal(Path.GetFullPath(parentConfig), config!.Path);
+        Assert.Equal("net9.0", config.Framework);
+    }
+
+    [Fact]
+    public void Load_prefers_nearest_config()
+    {
+        using var directory = new TestDirectory();
+        directory.CreateConfig("""{ "framework": "net8.0" }""");
+        var nestedDirectory = Directory.CreateDirectory(Path.Combine(directory.Path, "src", "App")).FullName;
+        var nestedConfigDirectory = Directory.CreateDirectory(Path.Combine(nestedDirectory, ".config")).FullName;
+        var nestedConfigFile = Path.Combine(nestedConfigDirectory, "dotnet-ef.json");
+        File.WriteAllText(nestedConfigFile, """{ "framework": "net9.0" }""");
+
+        var config = DotNetEfConfigLoader.Load(nestedDirectory);
+
+        Assert.NotNull(config);
+        Assert.Equal(Path.GetFullPath(nestedConfigFile), config!.Path);
+        Assert.Equal("net9.0", config.Framework);
+    }
+
+    [Fact]
+    public void Load_resolves_relative_paths_against_config_directory()
+    {
+        using var directory = new TestDirectory();
+        var repositoryDirectory = Directory.CreateDirectory(Path.Combine(directory.Path, "repo")).FullName;
+        var currentDirectory = Directory.CreateDirectory(Path.Combine(repositoryDirectory, "tools")).FullName;
+        var configFile = CreateConfig(
+            repositoryDirectory,
+            """
+            {
+              "project": "src/App.Infrastructure",
+              "startupProject": "src/App.Api"
+            }
+            """);
+
+        var config = DotNetEfConfigLoader.Load(currentDirectory);
+
+        Assert.NotNull(config);
+        Assert.Equal(Path.Combine(repositoryDirectory, "src", "App.Infrastructure"), config!.Project);
+        Assert.Equal(Path.Combine(repositoryDirectory, "src", "App.Api"), config.StartupProject);
+    }
+
+    [Fact]
+    public void Load_preserves_absolute_paths()
+    {
+        using var directory = new TestDirectory();
+        var projectPath = Path.Combine(directory.Path, "src", "App.Infrastructure", "App.Infrastructure.csproj");
+        var startupProjectPath = Path.Combine(directory.Path, "src", "App.Api", "App.Api.csproj");
+        directory.CreateConfig(
+            $$"""
+            {
+              "project": "{{projectPath.Replace("\\", "\\\\")}}",
+              "startupProject": "{{startupProjectPath.Replace("\\", "\\\\")}}"
+            }
+            """);
+
+        var config = DotNetEfConfigLoader.Load(directory.Path);
+
+        Assert.NotNull(config);
+        Assert.Equal(projectPath, config!.Project);
+        Assert.Equal(startupProjectPath, config.StartupProject);
+    }
+
+    [Theory]
+    [InlineData("", "Fix the JSON and try again.")]
+    [InlineData("{", "Fix the JSON and try again.")]
+    [InlineData("null", "must contain a JSON object")]
+    [InlineData("[]", "must contain a JSON object")]
+    [InlineData("""{ "framework": 1 }""", "must be a non-empty JSON string")]
+    [InlineData("""{ "framework": "" }""", "must be a non-empty JSON string")]
+    [InlineData("""{ "framework": "   " }""", "must be a non-empty JSON string")]
+    [InlineData("""{ "extra": "value" }""", "Remove the unsupported 'extra' property")]
+    [InlineData("""{ "connection": "Data Source=test.db" }""", "The 'connection' property isn't supported")]
+    [InlineData("""{ "connectionString": "Data Source=test.db" }""", "The 'connectionString' property isn't supported")]
+    [InlineData("""{ "provider": "SqlServer" }""", "The 'provider' property isn't supported")]
+    [InlineData("""{ "runtime": "win-x64" }""", "The 'runtime' property isn't supported")]
+    public void Load_rejects_invalid_config(string contents, string messageFragment)
+    {
+        using var directory = new TestDirectory();
+        var configFile = directory.CreateConfig(contents);
+
+        var exception = Assert.Throws<CommandException>(() => DotNetEfConfigLoader.Load(directory.Path));
+
+        Assert.Contains(Path.GetFullPath(configFile), exception.Message);
+        Assert.Contains(messageFragment, exception.Message);
+    }
+
+    [Fact]
+    public void Load_rejects_unreadable_config()
+    {
+        using var directory = new TestDirectory();
+        var configFile = directory.CreateConfig("""{ "framework": "net9.0" }""");
+
+        using var stream = new FileStream(configFile, FileMode.Open, FileAccess.Read, FileShare.None);
+
+        var exception = Assert.Throws<CommandException>(() => DotNetEfConfigLoader.Load(directory.Path));
+
+        Assert.Contains(Path.GetFullPath(configFile), exception.Message);
+        Assert.Contains("Ensure the file is accessible and try again.", exception.Message);
+    }
+
+    [Fact]
+    public void Resolve_context_uses_config_for_supported_commands()
+    {
+        var context = RootCommand.ResolveContext(["migrations", "add", "InitialCreate"], "AppDbContext");
+
+        Assert.Equal("AppDbContext", context);
+    }
+
+    [Theory]
+    [InlineData("migrations", "add", "-c", "ExplicitContext")]
+    [InlineData("migrations", "add", "--context", "ExplicitContext")]
+    [InlineData("dbcontext", "scaffold", "--provider", "SqlServer")]
+    public void Resolve_context_does_not_apply_when_explicit_or_unsupported(
+        string command,
+        string subcommand,
+        string optionName,
+        string optionValue)
+    {
+        var context = RootCommand.ResolveContext([command, subcommand, optionName, optionValue], "AppDbContext");
+
+        Assert.Null(context);
+    }
+
+    [Fact]
+    public void Create_remaining_arguments_adds_only_missing_config_defaults()
+    {
+        var args = RootCommand.CreateRemainingArguments(
+            ["migrations", "add", "InitialCreate"],
+            "AppDbContext");
+
+        Assert.Equal(
+        [
+            "migrations",
+            "add",
+            "InitialCreate",
+            "--context",
+            "AppDbContext"
+        ], args);
+    }
+
+    [Fact]
+    public void Create_remaining_arguments_preserves_existing_arguments_when_config_is_absent()
+    {
+        var args = RootCommand.CreateRemainingArguments(
+            ["database", "update", "--runtime", "win-x64"],
+            null);
+
+        Assert.Equal(["database", "update", "--runtime", "win-x64"], args);
+    }
+
+    private static string CreateConfig(string directory, string contents)
+    {
+        var configDirectory = Directory.CreateDirectory(Path.Combine(directory, ".config")).FullName;
+        var configFile = Path.Combine(configDirectory, "dotnet-ef.json");
+        File.WriteAllText(configFile, contents);
+        return configFile;
+    }
+
+    private sealed class TestDirectory : IDisposable
+    {
+        public TestDirectory()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.IO.Path.GetRandomFileName());
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public string CreateConfig(string contents)
+            => DotNetEfConfigTest.CreateConfig(Path, contents);
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+        }
+    }
+}

--- a/test/dotnet-ef.Tests/DotNetEfConfigTest.cs
+++ b/test/dotnet-ef.Tests/DotNetEfConfigTest.cs
@@ -122,7 +122,9 @@ public class DotNetEfConfigTest
     [InlineData("""{ "framework": "" }""", "must be a non-empty JSON string")]
     [InlineData("""{ "framework": "   " }""", "must be a non-empty JSON string")]
     [InlineData("""{ "extra": "value" }""", "Remove the unsupported 'extra' property")]
+    [InlineData("""{ "extra": 1 }""", "Remove the unsupported 'extra' property")]
     [InlineData("""{ "connection": "Data Source=test.db" }""", "The 'connection' property isn't supported")]
+    [InlineData("""{ "connection": 1 }""", "The 'connection' property isn't supported")]
     [InlineData("""{ "connectionString": "Data Source=test.db" }""", "The 'connectionString' property isn't supported")]
     [InlineData("""{ "provider": "SqlServer" }""", "The 'provider' property isn't supported")]
     [InlineData("""{ "runtime": "win-x64" }""", "The 'runtime' property isn't supported")]
@@ -173,6 +175,47 @@ public class DotNetEfConfigTest
 
         Assert.Null(context);
     }
+
+    [Theory]
+    [InlineData("--context=ExplicitContext")]
+    [InlineData("--context:ExplicitContext")]
+    [InlineData("-c=ExplicitContext")]
+    [InlineData("-c:ExplicitContext")]
+    public void Resolve_context_does_not_apply_when_context_is_explicit_inline(string option)
+    {
+        var context = RootCommand.ResolveContext(["migrations", "add", option], "AppDbContext");
+
+        Assert.Null(context);
+    }
+
+    [Theory]
+    [InlineData("dbcontext", "optimize", "MyContext")]
+    [InlineData("dbcontext", "optimize", "--precompile-queries")]
+    [InlineData("dbcontext", "optimize", "--context:MyContext")]
+    [InlineData("dbcontext", "optimize", "--context=MyContext")]
+    [InlineData("dbcontext", "optimize", "--context", "MyContext")]
+    public void Should_skip_optimization_for_dbcontext_optimize_with_extra_user_args(params string[] args)
+        => Assert.True(RootCommand.ShouldSkipOptimization(args));
+
+    [Fact]
+    public void Should_not_skip_optimization_for_dbcontext_optimize_without_extra_user_args()
+        => Assert.False(RootCommand.ShouldSkipOptimization(["dbcontext", "optimize"]));
+
+    [Fact]
+    public void Config_injected_context_does_not_cause_skip_optimization()
+    {
+        var args = RootCommand.CreateRemainingArguments(["dbcontext", "optimize"], "MyContext");
+
+        Assert.False(RootCommand.ShouldSkipOptimization(["dbcontext", "optimize"]));
+        Assert.Equal(["dbcontext", "optimize", "--context", "MyContext"], args);
+    }
+
+    [Theory]
+    [InlineData("dbcontext", "optimize", "--no-scaffold")]
+    [InlineData("dbcontext", "optimize", "--no-scaffold", "--context", "MyContext")]
+    [InlineData("migrations", "add", "InitialCreate")]
+    public void Should_not_skip_optimization_when_conditions_are_not_met(params string[] args)
+        => Assert.False(RootCommand.ShouldSkipOptimization(args));
 
     [Fact]
     public void Create_remaining_arguments_adds_only_missing_config_defaults()


### PR DESCRIPTION
Fixes #35231

## Summary
This PR adds support for loading default `dotnet ef` options from `.config/dotnet-ef.json`.

Config is discovered by walking up from the current working directory. When a matching CLI option is not provided, values from config are used.

Supported config properties:
- `project`
- `startupProject`
- `framework`
- `configuration`
- `context`
- `runtime`
- `verbose`
- `noColor`
- `prefixOutput`

CLI options continue to take precedence.

## Changes
- Added config discovery/loading in `src/dotnet-ef/DotNetEfConfigLoader.cs`.
- Updated `src/dotnet-ef/RootCommand.cs` to apply config defaults for root options and context forwarding behavior.
- Added resource-backed user-facing errors in:
  - `src/dotnet-ef/Properties/Resources.resx`
  - `src/dotnet-ef/Properties/Resources.Designer.cs`
- Added tests in `test/dotnet-ef.Tests/DotNetEfConfigTest.cs` for:
  - discovery and nearest-config behavior
  - CLI-over-config precedence
  - relative/absolute path handling
  - argument propagation
  - invalid/unreadable config handling

## Config snapshot
```json
{
  "project": "src/App.Infrastructure",
  "startupProject": "src/App.Api",
  "framework": "net9.0",
  "configuration": "Debug",
  "context": "AppDbContext",
  "runtime": "win-x64",
  "verbose": true,
  "noColor": false,
  "prefixOutput": false
}
```

## Validation
- `.\restore.cmd`
- `. .\activate.ps1`
- `dotnet test test/dotnet-ef.Tests/dotnet-ef.Tests.csproj`

Result: passed locally.

## Impact
- Reduces repeated `dotnet ef` arguments in repo workflows.
- Preserves existing behavior by keeping explicit CLI options authoritative.
- Improves failure diagnostics for malformed/unsupported config content.

---

## Review updates
- Fixed `dbcontext optimize` so config-injected `--context` no longer changes skip-optimization behavior.
- Fixed explicit context detection to handle both `=` and `:` forms, such as `--context:Foo` and `-c:Foo`.
- Fixed config validation order so forbidden/unknown properties report the right error even when the JSON value is non-string.
- Added tests covering the new option forms, the optimize behavior, and non-string unsupported properties.

### Review update 2
- Added config file support for CLI output and runtime options:
  - `runtime`: target .NET runtime identifier (string, non-empty)
  - `verbose`: enable verbose output during execution (boolean)
  - `noColor`: disable colored console output (boolean)
  - `prefixOutput`: prefix output lines with severity level (boolean)
