### PR TITLE
Infer version from tags/branches instead of Versions.props

### DIFF
--- a/.github/workflows/label-and-milestone-issues.yml
+++ b/.github/workflows/label-and-milestone-issues.yml
@@ -66,11 +66,15 @@ jobs:
               const major = releaseBranchMatch[1];
               const minor = releaseBranchMatch[2];
 
-              const { data: tagRefs } = await github.rest.git.listMatchingRefs({
-                owner,
-                repo,
-                ref: `tags/v${major}.${minor}.`
-              });
+              const tagRefs = await github.paginate(
+                github.rest.git.listMatchingRefs,
+                {
+                  owner,
+                  repo,
+                  ref: `tags/v${major}.${minor}.`,
+                  per_page: 100
+                }
+              );
 
               let highestPatch = -1;
               for (const ref of tagRefs) {
@@ -105,11 +109,15 @@ jobs:
               targetMilestoneName = `${major}.${minor}.0`;
 
               // List release branches for this major.minor to find what's already been branched
-              const { data: branchRefs } = await github.rest.git.listMatchingRefs({
-                owner,
-                repo,
-                ref: `heads/release/${major}.${minor}-`
-              });
+              const branchRefs = await github.paginate(
+                github.rest.git.listMatchingRefs,
+                {
+                  owner,
+                  repo,
+                  ref: `heads/release/${major}.${minor}-`,
+                  per_page: 100
+                }
+              );
 
               let highestPreview = 0;
               let highestRc = 0;


### PR DESCRIPTION
Replace the `eng/Versions.props`-based version detection in the label-and-milestone-issues workflow with logic that infers versions from tags and branches present in the repo:

- **`release/X.Y`** (servicing): Lists `vX.Y.*` tags via GitHub API, finds the highest GA patch (< 100), and sets milestone to `X.Y.(patch+1)`. No preview/rc label.
- **`main`**: Reads only `major.minor` from `Versions.props`, then lists `release/X.Y-*` branches to find the highest preview/rc branch. The next version is inferred: preview7→rc-1, rc1→rc-2, rc2→GA (no label). Milestone is `X.Y.0`.

This fixes the issue where `Versions.props` was frequently updated too late and didn't represent the correct version at merge time.