### PR TITLE
[release/10.0] Fix comparison to null for split entities

### DIFF
--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.StructuralEquality.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.StructuralEquality.cs
@@ -15,6 +15,9 @@ namespace Microsoft.EntityFrameworkCore.Query;
 // context.Customers.Where(c => c.ShippingAddress == c.BillingAddress)
 public partial class RelationalSqlTranslatingExpressionVisitor
 {
+    private static readonly bool UseOldBehavior35293 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue35293", out var enabled) && enabled;
+
     private static readonly MethodInfo ParameterValueExtractorMethod =
         typeof(RelationalSqlTranslatingExpressionVisitor).GetTypeInfo().GetDeclaredMethod(nameof(ParameterValueExtractor))!;
 
@@ -159,9 +162,29 @@ public partial class RelationalSqlTranslatingExpressionVisitor
                 if (nullComparedEntityType.GetRootType() == nullComparedEntityType
                     && nullComparedEntityType.GetMappingStrategy() != RelationalAnnotationNames.TpcMappingStrategy)
                 {
-                    var table = nullComparedEntityType.GetViewOrTableMappings().SingleOrDefault()?.Table
-                        ?? nullComparedEntityType.GetDefaultMappings().Single().Table;
-                    if (table.IsOptional(nullComparedEntityType))
+                    ITableBase? table;
+                    if (UseOldBehavior35293)
+                    {
+                        table = nullComparedEntityType.GetViewOrTableMappings().SingleOrDefault()?.Table
+                            ?? nullComparedEntityType.GetDefaultMappings().Single().Table;
+                    }
+                    else
+                    {
+                        table = nullComparedEntityType.GetViewOrTableMappings().ToList() switch
+                        {
+                            [var singleMapping] => singleMapping.Table,
+
+                            // For entity splitting we get multiple table mappings, but can simply choose the principal table.
+                            var multipleMappings when multipleMappings.SingleOrDefault(
+                                    m => m.IsSplitEntityTypePrincipal is true)
+                                is { Table: var principalSplitTable }
+                                => principalSplitTable,
+
+                            _ => null
+                        };
+                    }
+
+                    if (table?.IsOptional(nullComparedEntityType) is true)
                     {
                         Expression? condition = null;
                         // Optional dependent sharing table

--- a/test/EFCore.Relational.Specification.Tests/Query/EntitySplittingQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/EntitySplittingQueryTestBase.cs
@@ -2242,6 +2242,19 @@ public abstract class EntitySplittingQueryTestBase : NonSharedModelTestBase, ICl
             entryCount: 7);
     }
 
+    [ConditionalTheory, MemberData(nameof(IsAsyncData))]
+    public virtual async Task Compare_split_entity_to_null(bool async)
+    {
+        await InitializeContextFactoryAsync(mb => mb
+            .Entity<EntityOne>()
+            .SplitToTable("SplitEntityOnePart", tb => tb.Property(e => e.IntValue3)));
+
+        await AssertQuery(
+            async,
+            ss => ss.Set<EntityOne>().Where(e => e != null),
+            entryCount: 5);
+    }
+
     #region TestHelpers
 
     protected async Task AssertQuery<TResult>(

--- a/test/EFCore.SqlServer.FunctionalTests/Query/EntitySplittingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/EntitySplittingQuerySqlServerTest.cs
@@ -778,4 +778,16 @@ ORDER BY [u].[Id], [s0].[MiddleEntityId]
 
         AssertSql();
     }
+
+    public override async Task Compare_split_entity_to_null(bool async)
+    {
+        await base.Compare_split_entity_to_null(async);
+
+        AssertSql(
+            """
+SELECT [e].[Id], [e].[EntityThreeId], [e].[IntValue1], [e].[IntValue2], [s].[IntValue3], [e].[IntValue4], [e].[StringValue1], [e].[StringValue2], [e].[StringValue3], [e].[StringValue4]
+FROM [EntityOne] AS [e]
+INNER JOIN [SplitEntityOnePart] AS [s] ON [e].[Id] = [s].[Id]
+""");
+    }
 }


### PR DESCRIPTION
Fixes #35293
Backports #37358

**Description**
When an entity uses entity splitting (mapped to multiple tables via `SplitToTable`), comparing it to `null` in a LINQ query throws `InvalidOperationException: Sequence contains more than one element`. The root cause is a call to `SingleOrDefault()` on `GetViewOrTableMappings()`, which returns multiple mappings for split entities. The fix replaces this with a switch expression that handles both single-table and multi-table (entity splitting) scenarios, selecting the principal table for split entities.

**Customer impact**
Users who use entity splitting and compare the split entity (or a navigation to it) to `null` in a LINQ query get an unhandled `InvalidOperationException` at query time. For example:

```csharp
context.Set<InvoiceLine>().Select(x => new
{
    x.Id,
    Name = x.Invoice.Creator != null ? x.Invoice.Creator!.FullName : ""
});
```

A workaround exists: users can compare the key property instead of the entity (e.g. `x.Invoice.CreatorId != null`), but this is not immediately discoverable.

**How found**
User reported on EF Core 8.0.7 / 9.0.0. The issue has 2 upvotes and 3 additional comment authors asking for a fix or workaround, indicating multiple users are affected.

**Regression**
This is not a regression from a previous major version. Entity splitting was introduced in EF Core 7.0, and the bug has been present since then — the code always assumed a single table mapping when checking null comparisons.

**Testing**
1 new test added (`Compare_split_entity_to_null`) with SQL baseline verification on SQL Server.

**Risk**
Very low. The change is limited to a single method that resolves the table for null comparison checks. The fix adds handling for the multi-table case while preserving the existing single-table logic. Quirk added (`Microsoft.EntityFrameworkCore.Issue35293`) to allow opting out of the fix.