### PR TITLE
[release/10.0] Fix SetProperty discard lambda failing for nullable value type properties in ExecuteUpdate

### DIFF
--- a/src/EFCore/Query/Internal/ExpressionTreeFuncletizer.cs
+++ b/src/EFCore/Query/Internal/ExpressionTreeFuncletizer.cs
@@ -28,6 +28,9 @@ public class ExpressionTreeFuncletizer : ExpressionVisitor
     private static readonly bool UseOldBehavior37465 =
         AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue37465", out var enabled37465) && enabled37465;
 
+    private static readonly bool UseOldBehavior37974 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue37974", out var enabled37974) && enabled37974;
+
     // The general algorithm here is the following.
     // 1. First, for each node type, visit that node's children and get their states (evaluatable, contains evaluatable, no evaluatable).
     // 2. Calculate the parent node's aggregate state from its children; a container node whose children are all evaluatable is itself
@@ -2012,9 +2015,17 @@ public class ExpressionTreeFuncletizer : ExpressionVisitor
             return evaluatableRoot;
         }
 
-        return ConvertIfNeeded(
+        var constantExpression = ConvertIfNeeded(
             Constant(value, value is null ? evaluatableRoot.Type : value.GetType()),
             evaluatableRoot.Type);
+
+        // ConvertIfNeeded calls Visit which may have modified _state; reset it since we've already evaluated this root as a constant.
+        if (!UseOldBehavior37974)
+        {
+            state = State.NoEvaluatability;
+        }
+
+        return constantExpression;
 
         bool TryHandleNonEvaluatableAsRoot(Expression root, State state, bool asParameter, [NotNullWhen(true)] out Expression? result)
         {

--- a/test/EFCore.Specification.Tests/BulkUpdates/NorthwindBulkUpdatesTestBase.cs
+++ b/test/EFCore.Specification.Tests/BulkUpdates/NorthwindBulkUpdatesTestBase.cs
@@ -383,6 +383,16 @@ public abstract class NorthwindBulkUpdatesTestBase<TFixture>(TFixture fixture) :
             (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
 
     [ConditionalTheory, MemberData(nameof(IsAsyncData))]
+    public virtual Task Update_Where_set_nullable_int_constant_via_discard_lambda(bool async)
+        => AssertUpdate(
+            async,
+            ss => ss.Set<Product>().Where(p => p.ProductID < 5),
+            e => e,
+            s => s.SetProperty(c => c.SupplierID, _ => 1),
+            rowsAffectedCount: 4,
+            (b, a) => Assert.All(a, p => Assert.Equal(1, p.SupplierID)));
+
+    [ConditionalTheory, MemberData(nameof(IsAsyncData))]
     public virtual async Task Update_Where_parameter_set_constant(bool async)
     {
         var customer = "ALFKI";

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqlServerTest.cs
@@ -694,6 +694,19 @@ WHERE [c].[CustomerID] LIKE N'F%'
 """);
     }
 
+    public override async Task Update_Where_set_nullable_int_constant_via_discard_lambda(bool async)
+    {
+        await base.Update_Where_set_nullable_int_constant_via_discard_lambda(async);
+
+        AssertExecuteUpdateSql(
+            """
+UPDATE [p]
+SET [p].[SupplierID] = 1
+FROM [Products] AS [p]
+WHERE [p].[ProductID] < 5
+""");
+    }
+
     public override async Task Update_Where_parameter_set_constant(bool async)
     {
         await base.Update_Where_parameter_set_constant(async);

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqliteTest.cs
@@ -674,6 +674,18 @@ WHERE "c"."CustomerID" LIKE 'F%'
 """);
     }
 
+    public override async Task Update_Where_set_nullable_int_constant_via_discard_lambda(bool async)
+    {
+        await base.Update_Where_set_nullable_int_constant_via_discard_lambda(async);
+
+        AssertExecuteUpdateSql(
+            """
+UPDATE "Products" AS "p"
+SET "SupplierID" = 1
+WHERE "p"."ProductID" < 5
+""");
+    }
+
     public override async Task Update_Where_parameter_set_constant(bool async)
     {
         await base.Update_Where_parameter_set_constant(async);


### PR DESCRIPTION
Fixes #37974
Backports #37975

**Description**
When using `ExecuteUpdate` with `SetProperty` to assign a constant or literal value to a nullable value type property (e.g. `int?`) via a discard lambda (`_ => 1`), EF Core throws `InvalidOperationException: No coercion operator is defined between types Func<Entity, int?> and int`. This was introduced by the EF Core 10 refactoring of `ExecuteUpdate` from `Expression<Func<...>>` to `Func<...>` for the setter parameter.

The root cause is in `ExpressionTreeFuncletizer.ProcessEvaluatableRoot`: when constantizing a value that needs a nullable conversion (e.g. `int` → `int?`), `ConvertIfNeeded` internally calls `Visit`, which corrupts the `_state` field back to `EvaluatableWithoutCapturedVariable`. This causes the parent `VisitLambda` to incorrectly treat the entire lambda as evaluatable, compiling it into a `Func<Entity, int?>` delegate. The downstream `TranslateSetterValueSelector` then receives a `QueryParameterExpression` instead of a `LambdaExpression` and throws.

**Customer impact**
Users calling `ExecuteUpdateAsync` with a constant/literal value assigned to a nullable value type property via a discard lambda get an `InvalidOperationException` at query compilation time. This is a common pattern:

```csharp
const int SystemUserId = 1;
await ctx.Orders.ExecuteUpdateAsync(s =>
    s.SetProperty(p => p.UpdatedById, _ => SystemUserId)); // UpdatedById is int?, throws
```

Workarounds exist: cast the value to `int?` explicitly, or use a named parameter (`p =>`) instead of a discard (`_ =>`). Both workarounds are somewhat discoverable from the error message but unintuitive.

**How found**
User reported on EF Core 10.0.0. One additional user has also reported being affected. The issue has 2 reactions (+1 and eyes).

**Regression**
Yes, this is a regression from EF Core 9 to EF Core 10. It was introduced as a side effect of the `ExecuteUpdate` refactoring that changed the setter parameter from `Expression<Func<...>>` to `Func<...>` (the breaking change documented at https://learn.microsoft.com/en-us/ef/core/what-is-new/ef-core-10.0/breaking-changes#execute-update-expression).

**Testing**
Added 1 new test (`Update_Where_set_nullable_int_constant_via_discard_lambda`) with SQL baseline assertions in both SQLite and SQL Server test classes.

**Risk**
Extremely low. The fix is a single-line state reset (`state = State.NoEvaluatability`) after `ConvertIfNeeded` returns, restoring the state that was already set earlier in the method but got corrupted by the internal `Visit` call. Quirk added (`Microsoft.EntityFrameworkCore.Issue37974`) to opt out.