### PR TITLE
[release/10.0] Fix InvalidCastException when query parameter is IEnumerable with mismatched enum types

### DIFF
--- a/src/EFCore/Storage/ValueConversion/ValueConverter`.cs
+++ b/src/EFCore/Storage/ValueConversion/ValueConverter`.cs
@@ -77,13 +77,26 @@ public class ValueConverter<TModel, TProvider> : ValueConverter
                 ? null
                 : convertFunc(Sanitize<TIn>(v));
 
+    private static readonly bool UseOldBehavior38008 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue38008", out var enabled) && enabled;
+
     private static T Sanitize<T>(object value)
     {
         var unwrappedType = typeof(T).UnwrapNullableType();
 
-        return (T)(!unwrappedType.IsInstanceOfType(value)
-            ? Convert.ChangeType(value, unwrappedType)
-            : value);
+        if (unwrappedType.IsInstanceOfType(value))
+        {
+            return (T)value;
+        }
+
+        // Convert.ChangeType cannot convert to enum types; use Enum.ToObject instead, which handles
+        // conversion from different enum types (with the same underlying type) or from integral types.
+        if (!UseOldBehavior38008 && unwrappedType.IsEnum)
+        {
+            return (T)Enum.ToObject(unwrappedType, value);
+        }
+
+        return (T)Convert.ChangeType(value, unwrappedType);
     }
 
     /// <summary>

--- a/test/EFCore.Relational.Specification.Tests/Query/NonSharedPrimitiveCollectionsQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NonSharedPrimitiveCollectionsQueryRelationalTestBase.cs
@@ -250,4 +250,56 @@ public abstract class NonSharedPrimitiveCollectionsQueryRelationalTestBase(NonSh
 
     protected void AssertSql(params string[] expected)
         => TestSqlLoggerFactory.AssertBaseline(expected);
+
+    // #38008
+    [ConditionalTheory, MemberData(nameof(ParameterTranslationModeValues))]
+    public virtual async Task Parameter_collection_of_enum_Cast_from_different_enum_type(ParameterTranslationMode mode)
+    {
+        var contextFactory = await InitializeAsync<Context38008>(
+            onConfiguring: b => SetParameterizedCollectionMode(b, mode),
+            seed: context =>
+            {
+                context.AddRange(
+                    new Context38008.TestEntity38008 { Id = 1, Status = Context38008.EntityEnum.Clean },
+                    new Context38008.TestEntity38008 { Id = 2, Status = Context38008.EntityEnum.Malware });
+                return context.SaveChangesAsync();
+            });
+
+        await using var context = contextFactory.CreateContext();
+
+        // Cast<EntityEnum>() returns a lazy IEnumerable whose boxed values retain the ViewModelEnum runtime type.
+        var filter = new[] { Context38008.ViewModelEnum.Malware }.Cast<Context38008.EntityEnum>();
+        var result = await context.Set<Context38008.TestEntity38008>()
+            .Where(a => filter.Any(f => f == a.Status))
+            .Select(a => a.Id)
+            .ToListAsync();
+
+        Assert.Equivalent(new[] { 2 }, result);
+    }
+
+    protected class Context38008(DbContextOptions options) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<TestEntity38008>().Property(e => e.Id).ValueGeneratedNever();
+
+        public class TestEntity38008
+        {
+            public int Id { get; set; }
+            public EntityEnum Status { get; set; }
+        }
+
+        [Flags]
+        public enum EntityEnum
+        {
+            Clean = 1,
+            Malware = 2
+        }
+
+        [Flags]
+        public enum ViewModelEnum
+        {
+            Clean = 1,
+            Malware = 2
+        }
+    }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NonSharedPrimitiveCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NonSharedPrimitiveCollectionsQuerySqlServerTest.cs
@@ -1201,6 +1201,63 @@ WHERE (
         }
     }
 
+    public override async Task Parameter_collection_of_enum_Cast_from_different_enum_type(ParameterTranslationMode mode)
+    {
+        await base.Parameter_collection_of_enum_Cast_from_different_enum_type(mode);
+
+        switch (mode)
+        {
+            case ParameterTranslationMode.Constant:
+            {
+                AssertSql(
+                    """
+SELECT [t].[Id]
+FROM [TestEntity38008] AS [t]
+WHERE EXISTS (
+    SELECT 1
+    FROM (VALUES (CAST(2 AS int))) AS [f]([Value])
+    WHERE [f].[Value] = [t].[Status])
+""");
+                break;
+            }
+
+            case ParameterTranslationMode.Parameter:
+            {
+                AssertSql(
+                    """
+@filter='[2]' (Size = 4000)
+
+SELECT [t].[Id]
+FROM [TestEntity38008] AS [t]
+WHERE EXISTS (
+    SELECT 1
+    FROM OPENJSON(@filter) WITH ([value] int '$') AS [f]
+    WHERE [f].[value] = [t].[Status])
+""");
+                break;
+            }
+
+            case ParameterTranslationMode.MultipleParameters:
+            {
+                AssertSql(
+                    """
+@filter1='2'
+
+SELECT [t].[Id]
+FROM [TestEntity38008] AS [t]
+WHERE EXISTS (
+    SELECT 1
+    FROM (VALUES (@filter1)) AS [f]([Value])
+    WHERE [f].[Value] = [t].[Status])
+""");
+                break;
+            }
+
+            default:
+                throw new NotImplementedException();
+        }
+    }
+
     [ConditionalFact]
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());


### PR DESCRIPTION
Fixes #38008

**Description**

`ValueConverter.Sanitize<T>()` uses `Convert.ChangeType()` when the runtime type of a value does not match the expected type. However, `Convert.ChangeType()` cannot convert between different enum types (e.g. from `ViewModelEnum` to `EntityEnum`), even when they share the same underlying integral type and identical member values. This causes an `InvalidCastException`.

The issue was exposed by PR #36157 / #36358 which changed the default `ParameterTranslationMode` to `MultipleParameters`. In this mode, primitive collection parameters (e.g. `IEnumerable<TEnum>`) are expanded into individual SQL parameters. When the collection is produced by `Enumerable.Cast<TEnum>()` (a lazy operation), the boxed values retain their original runtime enum type, which then fails in `Sanitize`.

The fix uses `Enum.ToObject()` instead of `Convert.ChangeType()` when the target type is an enum, which correctly handles conversion from different enum types or integral types.

**Customer impact**

Any query using an `IEnumerable<TEnum>` parameter produced via `.Cast<TEnum>()` (without materializing via `.ToArray()`) throws `InvalidCastException` at query execution time with the default `MultipleParameters` mode. Example:

```csharp
var filter = new[] { ViewModelEnum.Value }.Cast<EntityEnum>();
db.Entities.Where(e => filter.Any(f => f == e.Status)).ToList();
// Throws: InvalidCastException: Invalid cast from 'ViewModelEnum' to 'EntityEnum'
```

Workarounds exist: materialize the collection with `.ToArray()`, or set `UseParameterizedCollectionMode(ParameterTranslationMode.Parameter)` to use the OPENJSON path. The `.ToArray()` workaround is fairly discoverable from the exception message.

**How found**

User reported on 10.0.5 (1 report, 0 upvotes at time of triage).

**Regression**

Yes — this is a regression from EF Core 9. The bug was introduced in 10.0.0-preview.7 by #36157 / #36358 which changed the default parameterized collection translation mode from JSON/OPENJSON to `MultipleParameters`.

**Testing**

1 new test (`Parameter_collection_of_enum_Cast_from_different_enum_type`) added in the relational specification test base, running across all 3 `ParameterTranslationMode` values. Verified passing on both SQL Server and SQLite.

**Risk**

Very low. The change is a one-liner in `ValueConverter.Sanitize<T>()`: when the target type is an enum, use `Enum.ToObject()` instead of `Convert.ChangeType()`. `Enum.ToObject()` is the standard .NET API for this conversion. Quirk added (`Microsoft.EntityFrameworkCore.Issue38008`) to allow reverting to old behavior.