### PR TITLE
Filter out full-text catalog operations from history table creation

### DIFF
--- a/src/EFCore.Relational/Migrations/HistoryRepository.cs
+++ b/src/EFCore.Relational/Migrations/HistoryRepository.cs
@@ -85,7 +85,14 @@ public abstract class HistoryRepository : IHistoryRepository
             .FindProperty(nameof(HistoryRow.MigrationId))!
             .GetColumnName();
 
-    private IModel EnsureModel()
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    protected IModel EnsureModel()
     {
         if (_model == null)
         {

--- a/src/EFCore.Relational/Migrations/HistoryRepository.cs
+++ b/src/EFCore.Relational/Migrations/HistoryRepository.cs
@@ -92,7 +92,7 @@ public abstract class HistoryRepository : IHistoryRepository
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [EntityFrameworkInternal]
-    protected IModel EnsureModel()
+    protected virtual IModel EnsureModel()
     {
         if (_model == null)
         {

--- a/src/EFCore.SqlServer/Migrations/Internal/SqlServerHistoryRepository.cs
+++ b/src/EFCore.SqlServer/Migrations/Internal/SqlServerHistoryRepository.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text;
+using Microsoft.EntityFrameworkCore.SqlServer.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Migrations.Internal;
 
@@ -22,6 +23,36 @@ public class SqlServerHistoryRepository : HistoryRepository
     public SqlServerHistoryRepository(HistoryRepositoryDependencies dependencies)
         : base(dependencies)
     {
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override IReadOnlyList<MigrationCommand> GetCreateCommands()
+    {
+        // TODO: This is a hack around https://github.com/dotnet/efcore/issues/34991: provider-specific conventions may add
+        // database-level annotations (e.g. full-text catalogs) to the model, and the default EF logic causes them to be created
+        // at this point, when the history table is being created. This is too early, and causes the later actual migration to fail.
+        // So we filter out full-text catalog annotations from AlterDatabaseOperation.
+        // This follows the same approach as the Npgsql provider (npgsql/efcore.pg#3713).
+#pragma warning disable EF1001 // Internal EF Core API usage.
+        var model = EnsureModel();
+#pragma warning restore EF1001 // Internal EF Core API usage.
+
+        var operations = Dependencies.ModelDiffer.GetDifferences(null, model.GetRelationalModel());
+
+        foreach (var operation in operations)
+        {
+            if (operation is AlterDatabaseOperation alterDatabaseOperation)
+            {
+                alterDatabaseOperation.RemoveAnnotation(SqlServerAnnotationNames.FullTextCatalogs);
+            }
+        }
+
+        return Dependencies.MigrationsSqlGenerator.Generate(operations, model);
     }
 
     /// <summary>

--- a/test/EFCore.SqlServer.Tests/Migrations/SqlServerHistoryRepositoryTest.cs
+++ b/test/EFCore.SqlServer.Tests/Migrations/SqlServerHistoryRepositoryTest.cs
@@ -25,6 +25,22 @@ CREATE TABLE [__EFMigrationsHistory] (
     }
 
     [ConditionalFact]
+    public void GetCreateScript_works_with_full_text_catalog()
+    {
+        var sql = CreateHistoryRepository(configureModel: b => b.HasFullTextCatalog("MyCatalog")).GetCreateScript();
+
+        Assert.Equal(
+            """
+CREATE TABLE [__EFMigrationsHistory] (
+    [MigrationId] nvarchar(150) NOT NULL,
+    [ProductVersion] nvarchar(32) NOT NULL,
+    CONSTRAINT [PK___EFMigrationsHistory] PRIMARY KEY ([MigrationId])
+);
+
+""", sql, ignoreLineEndingDifferences: true);
+    }
+
+    [ConditionalFact]
     public void GetCreateScript_works_with_schema()
     {
         var sql = CreateHistoryRepository("my").GetCreateScript();
@@ -149,17 +165,18 @@ END;
 """, sql, ignoreLineEndingDifferences: true);
     }
 
-    private static IHistoryRepository CreateHistoryRepository(string schema = null)
+    private static IHistoryRepository CreateHistoryRepository(string schema = null, Action<ModelBuilder> configureModel = null)
         => new TestDbContext(
                 new DbContextOptionsBuilder()
                     .UseInternalServiceProvider(SqlServerTestHelpers.Instance.CreateServiceProvider())
                     .UseSqlServer(
                         new SqlConnection("Database=DummyDatabase"),
                         b => b.MigrationsHistoryTable(HistoryRepository.DefaultTableName, schema))
-                    .Options)
+                    .Options,
+                configureModel)
             .GetService<IHistoryRepository>();
 
-    private class TestDbContext(DbContextOptions options) : DbContext(options)
+    private class TestDbContext(DbContextOptions options, Action<ModelBuilder> configureModel = null) : DbContext(options)
     {
         public DbSet<Blog> Blogs { get; set; }
 
@@ -169,6 +186,7 @@ END;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
+            configureModel?.Invoke(modelBuilder);
         }
     }
 

--- a/test/EFCore.SqlServer.Tests/Migrations/SqlServerHistoryRepositoryTest.cs
+++ b/test/EFCore.SqlServer.Tests/Migrations/SqlServerHistoryRepositoryTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore.SqlServer.Metadata.Internal;
 
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Migrations;
@@ -27,7 +28,10 @@ CREATE TABLE [__EFMigrationsHistory] (
     [ConditionalFact]
     public void GetCreateScript_works_with_full_text_catalog()
     {
-        var sql = CreateHistoryRepository(configureModel: b => b.HasFullTextCatalog("MyCatalog")).GetCreateScript();
+        // Inject a model finalizing convention that adds a full-text catalog to the model, simulating a scenario where
+        // provider conventions add database-level annotations. Without filtering, the history table creation script would
+        // include CREATE FULLTEXT CATALOG.
+        var sql = CreateHistoryRepository(addFullTextCatalogConvention: true).GetCreateScript();
 
         Assert.Equal(
             """
@@ -165,16 +169,26 @@ END;
 """, sql, ignoreLineEndingDifferences: true);
     }
 
-    private static IHistoryRepository CreateHistoryRepository(string schema = null, Action<ModelBuilder> configureModel = null)
-        => new TestDbContext(
+    private static IHistoryRepository CreateHistoryRepository(
+        string schema = null,
+        Action<ModelBuilder> configureModel = null,
+        bool addFullTextCatalogConvention = false)
+    {
+        var serviceProvider = addFullTextCatalogConvention
+            ? SqlServerTestHelpers.Instance.CreateServiceProvider(
+                new ServiceCollection().AddSingleton<IConventionSetPlugin, FullTextCatalogConventionPlugin>())
+            : SqlServerTestHelpers.Instance.CreateServiceProvider();
+
+        return new TestDbContext(
                 new DbContextOptionsBuilder()
-                    .UseInternalServiceProvider(SqlServerTestHelpers.Instance.CreateServiceProvider())
+                    .UseInternalServiceProvider(serviceProvider)
                     .UseSqlServer(
                         new SqlConnection("Database=DummyDatabase"),
                         b => b.MigrationsHistoryTable(HistoryRepository.DefaultTableName, schema))
                     .Options,
                 configureModel)
             .GetService<IHistoryRepository>();
+    }
 
     private class TestDbContext(DbContextOptions options, Action<ModelBuilder> configureModel = null) : DbContext(options)
     {
@@ -188,6 +202,31 @@ END;
         {
             configureModel?.Invoke(modelBuilder);
         }
+    }
+
+    /// <summary>
+    ///     A convention plugin that adds a full-text catalog annotation to the model, simulating what a provider convention
+    ///     might do. This allows testing that <see cref="SqlServerHistoryRepository.GetCreateCommands" /> properly filters
+    ///     out the full-text catalog from the history table creation script.
+    /// </summary>
+    private class FullTextCatalogConventionPlugin : IConventionSetPlugin
+    {
+        public ConventionSet ModifyConventions(ConventionSet conventionSet)
+        {
+            conventionSet.ModelFinalizingConventions.Add(new FullTextCatalogAddingConvention());
+            return conventionSet;
+        }
+    }
+
+    private class FullTextCatalogAddingConvention : IModelFinalizingConvention
+    {
+#pragma warning disable EF1001 // Internal EF Core API usage.
+        public void ProcessModelFinalizing(
+            IConventionModelBuilder modelBuilder,
+            IConventionContext<IConventionModelBuilder> context)
+            => SqlServerFullTextCatalog.AddFullTextCatalog(
+                (IMutableModel)modelBuilder.Metadata, "TestCatalog", ConfigurationSource.Convention);
+#pragma warning restore EF1001 // Internal EF Core API usage.
     }
 
     private class Blog


### PR DESCRIPTION
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

---

PR #37652 added migration support for SQL Server full-text catalogs. Full-text catalogs are stored as database-level annotations (`SqlServerAnnotationNames.FullTextCatalogs`) on the model, and when the migration history table is created, the model differ generates an `AlterDatabaseOperation` that includes these annotations. The SQL generator then emits `CREATE FULLTEXT CATALOG` prematurely — before the actual migration runs — causing the later migration (which also creates the catalog) to fail.

This is the same problem that the Npgsql provider had with PostgreSQL extensions/enums, fixed in npgsql/efcore.pg#3713. The approach here mirrors that fix:

- Override `GetCreateCommands()` in `SqlServerHistoryRepository` to strip `FullTextCatalogs` annotations from `AlterDatabaseOperation` before SQL generation
- Make `EnsureModel()` protected (with `[EntityFrameworkInternal]`) in the base `HistoryRepository` so the SQL Server subclass can call it — avoiding the code duplication that the Npgsql provider had to resort to

This is a workaround for the proper fix tracked in #34991.