### PR TITLE
FIX Insert order bug when using TPC - Issue #35978 

### DIFF
--- a/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
+++ b/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
@@ -726,31 +726,60 @@ public class CommandBatchPreparer : ICommandBatchPreparer
                             predecessorCommands.Add(command);
                         }
                     }
-                }
 
-                foreach (var entry in command.Entries)
-                {
-                    foreach (var foreignKey in entry.EntityType.GetForeignKeys())
+                    // Also handle FKs with no mapped constraints (e.g. TPC with abstract principal mapped to no table)
+                    foreach (var entry in command.Entries)
                     {
-                        if (!CanCreateDependency(foreignKey, command, principal: false)
-                            || !IsModified(foreignKey.Properties, entry)
-                            || foreignKey.GetMappedConstraints().Any(c => c.Table == command.Table))
+                        foreach (var foreignKey in entry.EntityType.GetForeignKeys())
                         {
-                            continue;
-                        }
-
-                        var dependentKeyValue = foreignKey.GetDependentKeyValueFactory()
-                            ?.CreateDependentEquatableKey(entry, fromOriginalValues: true);
-
-                        if (dependentKeyValue != null)
-                        {
-                            if (!originalPredecessorsMap.TryGetValue(dependentKeyValue, out var predecessorCommands))
+                            if (!CanCreateDependency(foreignKey, command, principal: false)
+                                || !IsModified(foreignKey.Properties, entry)
+                                || foreignKey.GetMappedConstraints().Any())
                             {
-                                predecessorCommands = [];
-                                originalPredecessorsMap.Add(dependentKeyValue, predecessorCommands);
+                                continue;
                             }
 
-                            predecessorCommands.Add(command);
+                            var dependentKeyValue = foreignKey.GetDependentKeyValueFactory()
+                                ?.CreateDependentEquatableKey(entry, fromOriginalValues: true);
+
+                            if (dependentKeyValue != null)
+                            {
+                                if (!originalPredecessorsMap.TryGetValue(dependentKeyValue, out var predecessorCommands))
+                                {
+                                    predecessorCommands = [];
+                                    originalPredecessorsMap.Add(dependentKeyValue, predecessorCommands);
+                                }
+
+                                predecessorCommands.Add(command);
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    foreach (var entry in command.Entries)
+                    {
+                        foreach (var foreignKey in entry.EntityType.GetForeignKeys())
+                        {
+                            if (!CanCreateDependency(foreignKey, command, principal: false)
+                                || !IsModified(foreignKey.Properties, entry))
+                            {
+                                continue;
+                            }
+
+                            var dependentKeyValue = foreignKey.GetDependentKeyValueFactory()
+                                ?.CreateDependentEquatableKey(entry, fromOriginalValues: true);
+
+                            if (dependentKeyValue != null)
+                            {
+                                if (!originalPredecessorsMap.TryGetValue(dependentKeyValue, out var predecessorCommands))
+                                {
+                                    predecessorCommands = [];
+                                    originalPredecessorsMap.Add(dependentKeyValue, predecessorCommands);
+                                }
+
+                                predecessorCommands.Add(command);
+                            }
                         }
                     }
                 }
@@ -824,25 +853,47 @@ public class CommandBatchPreparer : ICommandBatchPreparer
                         AddMatchingPredecessorEdge(
                             originalPredecessorsMap, principalKeyValue, command, foreignKey);
                     }
-                }
 
-                // ReSharper disable once ForCanBeConvertedToForeach
-                for (var entryIndex = 0; entryIndex < command.Entries.Count; entryIndex++)
-                {
-                    var entry = command.Entries[entryIndex];
-                    foreach (var foreignKey in entry.EntityType.GetReferencingForeignKeys())
+                    // Also handle FKs with no mapped constraints (e.g. TPC with abstract principal mapped to no table)
+                    // ReSharper disable once ForCanBeConvertedToForeach
+                    for (var entryIndex = 0; entryIndex < command.Entries.Count; entryIndex++)
                     {
-                        if (!CanCreateDependency(foreignKey, command, principal: true)
-                            || foreignKey.GetMappedConstraints().Any(c => c.PrincipalTable == command.Table))
+                        var entry = command.Entries[entryIndex];
+                        foreach (var foreignKey in entry.EntityType.GetReferencingForeignKeys())
                         {
-                            continue;
-                        }
+                            if (!CanCreateDependency(foreignKey, command, principal: true)
+                                || foreignKey.GetMappedConstraints().Any())
+                            {
+                                continue;
+                            }
 
-                        var principalKeyValue = foreignKey.GetDependentKeyValueFactory()
-                            .CreatePrincipalEquatableKey(entry, fromOriginalValues: true);
-                        Check.DebugAssert(principalKeyValue != null, "null principalKeyValue");
-                        AddMatchingPredecessorEdge(
-                            originalPredecessorsMap, principalKeyValue, command, foreignKey);
+                            var principalKeyValue = foreignKey.GetDependentKeyValueFactory()
+                                .CreatePrincipalEquatableKey(entry, fromOriginalValues: true);
+                            Check.DebugAssert(principalKeyValue != null, "null principalKeyValue");
+                            AddMatchingPredecessorEdge(
+                                originalPredecessorsMap, principalKeyValue, command, foreignKey);
+                        }
+                    }
+                }
+                else
+                {
+                    // ReSharper disable once ForCanBeConvertedToForeach
+                    for (var entryIndex = 0; entryIndex < command.Entries.Count; entryIndex++)
+                    {
+                        var entry = command.Entries[entryIndex];
+                        foreach (var foreignKey in entry.EntityType.GetReferencingForeignKeys())
+                        {
+                            if (!CanCreateDependency(foreignKey, command, principal: true))
+                            {
+                                continue;
+                            }
+
+                            var principalKeyValue = foreignKey.GetDependentKeyValueFactory()
+                                .CreatePrincipalEquatableKey(entry, fromOriginalValues: true);
+                            Check.DebugAssert(principalKeyValue != null, "null principalKeyValue");
+                            AddMatchingPredecessorEdge(
+                                originalPredecessorsMap, principalKeyValue, command, foreignKey);
+                        }
                     }
                 }
             }

--- a/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
+++ b/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
@@ -681,7 +681,8 @@ public class CommandBatchPreparer : ICommandBatchPreparer
                         if (!CanCreateDependency(foreignKey, command, principal: true)
                             || !IsModified(foreignKey.PrincipalKey.Properties, entry)
                             || (command.Table != null
-                                && !IsStoreGenerated(entry, foreignKey.PrincipalKey)))
+                                && !IsStoreGenerated(entry, foreignKey.PrincipalKey)
+                                && foreignKey.GetMappedConstraints().Any()))
                         {
                             continue;
                         }
@@ -726,31 +727,30 @@ public class CommandBatchPreparer : ICommandBatchPreparer
                         }
                     }
                 }
-                else
+
+                foreach (var entry in command.Entries)
                 {
-                    foreach (var entry in command.Entries)
+                    foreach (var foreignKey in entry.EntityType.GetForeignKeys())
                     {
-                        foreach (var foreignKey in entry.EntityType.GetForeignKeys())
+                        if (!CanCreateDependency(foreignKey, command, principal: false)
+                            || !IsModified(foreignKey.Properties, entry)
+                            || foreignKey.GetMappedConstraints().Any(c => c.Table == command.Table))
                         {
-                            if (!CanCreateDependency(foreignKey, command, principal: false)
-                                || !IsModified(foreignKey.Properties, entry))
+                            continue;
+                        }
+
+                        var dependentKeyValue = foreignKey.GetDependentKeyValueFactory()
+                            ?.CreateDependentEquatableKey(entry, fromOriginalValues: true);
+
+                        if (dependentKeyValue != null)
+                        {
+                            if (!originalPredecessorsMap.TryGetValue(dependentKeyValue, out var predecessorCommands))
                             {
-                                continue;
+                                predecessorCommands = [];
+                                originalPredecessorsMap.Add(dependentKeyValue, predecessorCommands);
                             }
 
-                            var dependentKeyValue = foreignKey.GetDependentKeyValueFactory()
-                                ?.CreateDependentEquatableKey(entry, fromOriginalValues: true);
-
-                            if (dependentKeyValue != null)
-                            {
-                                if (!originalPredecessorsMap.TryGetValue(dependentKeyValue, out var predecessorCommands))
-                                {
-                                    predecessorCommands = [];
-                                    originalPredecessorsMap.Add(dependentKeyValue, predecessorCommands);
-                                }
-
-                                predecessorCommands.Add(command);
-                            }
+                            predecessorCommands.Add(command);
                         }
                     }
                 }
@@ -825,25 +825,24 @@ public class CommandBatchPreparer : ICommandBatchPreparer
                             originalPredecessorsMap, principalKeyValue, command, foreignKey);
                     }
                 }
-                else
-                {
-                    // ReSharper disable once ForCanBeConvertedToForeach
-                    for (var entryIndex = 0; entryIndex < command.Entries.Count; entryIndex++)
-                    {
-                        var entry = command.Entries[entryIndex];
-                        foreach (var foreignKey in entry.EntityType.GetReferencingForeignKeys())
-                        {
-                            if (!CanCreateDependency(foreignKey, command, principal: true))
-                            {
-                                continue;
-                            }
 
-                            var principalKeyValue = foreignKey.GetDependentKeyValueFactory()
-                                .CreatePrincipalEquatableKey(entry, fromOriginalValues: true);
-                            Check.DebugAssert(principalKeyValue != null, "null principalKeyValue");
-                            AddMatchingPredecessorEdge(
-                                originalPredecessorsMap, principalKeyValue, command, foreignKey);
+                // ReSharper disable once ForCanBeConvertedToForeach
+                for (var entryIndex = 0; entryIndex < command.Entries.Count; entryIndex++)
+                {
+                    var entry = command.Entries[entryIndex];
+                    foreach (var foreignKey in entry.EntityType.GetReferencingForeignKeys())
+                    {
+                        if (!CanCreateDependency(foreignKey, command, principal: true)
+                            || foreignKey.GetMappedConstraints().Any(c => c.PrincipalTable == command.Table))
+                        {
+                            continue;
                         }
+
+                        var principalKeyValue = foreignKey.GetDependentKeyValueFactory()
+                            .CreatePrincipalEquatableKey(entry, fromOriginalValues: true);
+                        Check.DebugAssert(principalKeyValue != null, "null principalKeyValue");
+                        AddMatchingPredecessorEdge(
+                            originalPredecessorsMap, principalKeyValue, command, foreignKey);
                     }
                 }
             }
@@ -873,6 +872,14 @@ public class CommandBatchPreparer : ICommandBatchPreparer
     {
         if (command.Table != null)
         {
+            // JSON-owned entities are stored inline in their owner's column and never have separate
+            // modification commands, so they cannot participate in inter-command dependency ordering.
+            var otherEntityType = principal ? foreignKey.DeclaringEntityType : foreignKey.PrincipalEntityType;
+            if (otherEntityType.IsMappedToJson())
+            {
+                return false;
+            }
+
             if (foreignKey.IsRowInternal(StoreObjectIdentifier.Table(command.TableName, command.Schema))
                 || (foreignKey.PrincipalEntityType.IsAssignableFrom(foreignKey.DeclaringEntityType)
                     && foreignKey.PrincipalKey.Properties.SequenceEqual(foreignKey.Properties)))

--- a/test/EFCore.Relational.Tests/Update/CommandBatchPreparerTest.cs
+++ b/test/EFCore.Relational.Tests/Update/CommandBatchPreparerTest.cs
@@ -1328,4 +1328,90 @@ FakeEntity [Deleted]"
         public int Id { get; set; }
         public int? AnotherId { get; set; }
     }
+
+    [ConditionalFact]
+    public void BatchCommands_sorts_added_entities_with_TPC_abstract_principal()
+    {
+        var configuration = CreateContextServices(CreateTpcFKModel());
+        var stateManager = configuration.GetRequiredService<IStateManager>();
+
+        var principalEntry = stateManager.GetOrCreateEntry(
+            new ConcretePrincipal { Id = 1 });
+        principalEntry.SetEntityState(EntityState.Added);
+
+        var dependentEntry = stateManager.GetOrCreateEntry(
+            new TpcDependent { Id = 1, PrincipalId = 1 });
+        dependentEntry.SetEntityState(EntityState.Added);
+
+        var modelData = new UpdateAdapter(stateManager);
+
+        var batches = CreateBatches([dependentEntry, principalEntry], modelData);
+        var batch = Assert.Single(batches);
+
+        Assert.Equal(
+            [principalEntry, dependentEntry],
+            batch.ModificationCommands.Select(c => c.Entries.Single()));
+    }
+
+    [ConditionalFact]
+    public void BatchCommands_sorts_deleted_entities_with_TPC_abstract_principal()
+    {
+        var configuration = CreateContextServices(CreateTpcFKModel());
+        var stateManager = configuration.GetRequiredService<IStateManager>();
+
+        var principalEntry = stateManager.GetOrCreateEntry(
+            new ConcretePrincipal { Id = 1 });
+        principalEntry.SetEntityState(EntityState.Deleted);
+
+        var dependentEntry = stateManager.GetOrCreateEntry(
+            new TpcDependent { Id = 1, PrincipalId = 1 });
+        dependentEntry.SetEntityState(EntityState.Deleted);
+
+        var modelData = new UpdateAdapter(stateManager);
+
+        var batches = CreateBatches([principalEntry, dependentEntry], modelData);
+        var batch = Assert.Single(batches);
+
+        Assert.Equal(
+            [dependentEntry, principalEntry],
+            batch.ModificationCommands.Select(c => c.Entries.Single()));
+    }
+
+    private static IModel CreateTpcFKModel()
+    {
+        var modelBuilder = FakeRelationalTestHelpers.Instance.CreateConventionBuilder();
+
+        modelBuilder.Entity<AbstractPrincipal>()
+            .UseTpcMappingStrategy()
+            .ToTable((string)null)
+            .Property(e => e.Id)
+            .ValueGeneratedNever();
+
+        modelBuilder.Entity<ConcretePrincipal>()
+            .ToTable(nameof(ConcretePrincipal));
+
+        modelBuilder.Entity<TpcDependent>(b =>
+        {
+            b.HasOne<AbstractPrincipal>()
+                .WithMany()
+                .HasForeignKey(c => c.PrincipalId);
+        });
+
+        return modelBuilder.Model.FinalizeModel();
+    }
+
+    private abstract class AbstractPrincipal
+    {
+        public int Id { get; set; }
+    }
+
+    private class ConcretePrincipal : AbstractPrincipal
+    {
+    }
+
+    private class TpcDependent
+    {
+        public int Id { get; set; }
+        public int PrincipalId { get; set; }
+    }
 }


### PR DESCRIPTION
When using TPC inheritance with abstract base types, SaveChanges produces an incorrect INSERT order - child entities are inserted before their parents, causing FK constraint violations.

This happens because CommandBatchPreparer.AddForeignKeyEdges() fails to create dependency edges for FKs whose principal is an abstract TPC type mapped to no table. Since no IForeignKeyConstraint is created for such FKs, the table-level constraint path finds nothing.

The model-level FK fallback path should handle this, but for INSERT ordering it was skipped by a guard that assumed table-level constraints would cover it, and for DELETE ordering it was gated behind command.Table == null (unreachable for concrete TPC entities which always have a table).

The fix ensures the model-level FK path participates in dependency edge creation when no mapped table-level constraint exists: an additional foreignKey.GetMappedConstraints().Any() check on the INSERT principal registration guard, and removing the else gates on both DELETE paths so they always run alongside the table-level path (CanCreateDependency already prevents double-counting for FKs that do have mapped constraints).

Fixes https://github.com/dotnet/efcore/issues/35978