### PR TITLE
Add implicit ORDER BY Distance for VectorSearch translation

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -2030,6 +2030,18 @@ public sealed partial class SelectExpression : TableExpressionBase
     }
 
     /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public void SetOffset(SqlExpression? sqlExpression)
+    {
+        Offset = sqlExpression;
+    }
+
+    /// <summary>
     ///     Applies offset to the <see cref="SelectExpression" /> to skip the number of rows in the result set.
     /// </summary>
     /// <param name="sqlExpression">An expression representing offset row count.</param>

--- a/src/EFCore.SqlServer/Extensions/SqlServerQueryableExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerQueryableExtensions.cs
@@ -30,8 +30,8 @@ public static class SqlServerQueryableExtensions
     /// </param>
     /// <remarks>
     ///     <para>
-    ///         Compose the returned query with <c>OrderBy(r => r.Distance)</c> and <c>Take(...)</c> to limit the results as required
-    ///         for approximate vector search.
+    ///         Results are implicitly ordered by distance ascending. Compose the returned query with <c>Take(...)</c> to limit the
+    ///         number of results as required for approximate vector search.
     ///     </para>
     /// </remarks>
     /// <seealso href="https://learn.microsoft.com/sql/t-sql/functions/vector-search-transact-sql">

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
@@ -147,11 +147,17 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
                     var valueProjectionMember = new ProjectionMember().Append(resultType.GetProperty(nameof(VectorSearchResult<>.Value))!);
                     var distanceProjectionMember = new ProjectionMember().Append(resultType.GetProperty(nameof(VectorSearchResult<>.Distance))!);
 
+                    var distanceColumn = new ColumnExpression("Distance", vectorSearchFunction.Alias, typeof(double), _typeMappingSource.FindMapping(typeof(double)), nullable: false);
+
                     select.ReplaceProjection(new Dictionary<ProjectionMember, Expression>
                     {
                         [valueProjectionMember] = entityProjection,
-                        [distanceProjectionMember] = new ColumnExpression("Distance", vectorSearchFunction.Alias, typeof(double), _typeMappingSource.FindMapping(typeof(double)), nullable: false)
+                        [distanceProjectionMember] = distanceColumn
                     });
+
+                    // VECTOR_SEARCH() results are implicitly ordered by distance ascending; add this ordering so that
+                    // users can compose with Take() without needing an explicit OrderBy(r => r.Distance).
+                    select.AppendOrdering(new OrderingExpression(distanceColumn, ascending: true));
 
                     var shaper = Expression.New(
                         resultType.GetConstructors().Single(),

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
@@ -808,7 +808,11 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     protected override bool IsNaturallyOrdered(SelectExpression selectExpression)
-        => (selectExpression is
+        => selectExpression switch
+        {
+            // OPENJSON rows are naturally ordered by their "key" column (array index), ascending.
+            // EF adds this ordering implicitly when expanding JSON arrays; treat it as natural to avoid spurious
+            // "Distinct after OrderBy without row limiting operator" warnings.
             {
                 Tables: [SqlServerOpenJsonExpression openJsonExpression, ..],
                 Orderings:
@@ -822,9 +826,11 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
                         IsAscending: true
                     }
                     ]
-            }
-                && openJsonOrderingTableAlias == openJsonExpression.Alias)
-        || (selectExpression is
+            } when openJsonOrderingTableAlias == openJsonExpression.Alias => true,
+
+            // VECTOR_SEARCH() results are naturally ordered by Distance ascending.
+            // EF adds this ordering implicitly during VectorSearch translation; treat it as natural to avoid spurious
+            // "Distinct after OrderBy without row limiting operator" warnings.
             {
                 Tables: [TableValuedFunctionExpression { Name: "VECTOR_SEARCH" } vectorSearchFunction, ..],
                 Orderings:
@@ -834,8 +840,10 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
                         IsAscending: true
                     }
                     ]
-            }
-                && vectorSearchOrderingTableAlias == vectorSearchFunction.Alias);
+            } when vectorSearchOrderingTableAlias == vectorSearchFunction.Alias => true,
+
+            _ => false
+        };
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
@@ -807,6 +807,49 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    protected override ShapedQueryExpression? TranslateTake(ShapedQueryExpression source, Expression count)
+    {
+        var selectExpression = (SelectExpression)source.QueryExpression;
+
+        // When VECTOR_SEARCH() is present and an Offset has already been applied (i.e. Skip().Take()), we need to ensure that the
+        // generated SQL uses TOP WITH APPROXIMATE in a subquery, rather than the default OFFSET...FETCH which doesn't use the
+        // vector index. We push down a subquery with TOP(Skip + Take) WITH APPROXIMATE, and apply OFFSET...FETCH on the outer query.
+        if (selectExpression is { Offset: { } existingOffset }
+            && selectExpression.Tables.Any(t => t.UnwrapJoin() is TableValuedFunctionExpression { Name: "VECTOR_SEARCH" }))
+        {
+            var translation = TranslateExpression(count);
+            if (translation == null)
+            {
+                return null;
+            }
+
+            var combinedLimit = _sqlExpressionFactory.Add(existingOffset, translation);
+
+#pragma warning disable EF1001 // Internal EF Core API usage.
+            // Clear the offset so the inner subquery uses TOP(M+N) instead of OFFSET...FETCH
+            selectExpression.SetOffset(null);
+            selectExpression.SetLimit(combinedLimit);
+
+            // Push down: inner gets TOP(Skip+Take) WITH APPROXIMATE, outer is clean
+            selectExpression.PushdownIntoSubquery();
+
+            // Apply the original offset and take on the outer query as OFFSET...FETCH
+            selectExpression.ApplyOffset(existingOffset);
+            selectExpression.SetLimit(translation);
+#pragma warning restore EF1001 // Internal EF Core API usage.
+
+            return source;
+        }
+
+        return base.TranslateTake(source, count);
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     protected override bool IsNaturallyOrdered(SelectExpression selectExpression)
         => selectExpression switch
         {

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
@@ -808,22 +808,34 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     protected override bool IsNaturallyOrdered(SelectExpression selectExpression)
-        => selectExpression is
-        {
-            Tables: [SqlServerOpenJsonExpression openJsonExpression, ..],
-            Orderings:
-                [
-                {
-                    Expression: SqlUnaryExpression
+        => (selectExpression is
+            {
+                Tables: [SqlServerOpenJsonExpression openJsonExpression, ..],
+                Orderings:
+                    [
                     {
-                        OperatorType: ExpressionType.Convert,
-                        Operand: ColumnExpression { Name: "key", TableAlias: var orderingTableAlias }
-                    },
-                    IsAscending: true
-                }
-                ]
-        }
-            && orderingTableAlias == openJsonExpression.Alias;
+                        Expression: SqlUnaryExpression
+                        {
+                            OperatorType: ExpressionType.Convert,
+                            Operand: ColumnExpression { Name: "key", TableAlias: var openJsonOrderingTableAlias }
+                        },
+                        IsAscending: true
+                    }
+                    ]
+            }
+                && openJsonOrderingTableAlias == openJsonExpression.Alias)
+        || (selectExpression is
+            {
+                Tables: [TableValuedFunctionExpression { Name: "VECTOR_SEARCH" } vectorSearchFunction, ..],
+                Orderings:
+                    [
+                    {
+                        Expression: ColumnExpression { Name: "Distance", TableAlias: var vectorSearchOrderingTableAlias },
+                        IsAscending: true
+                    }
+                    ]
+            }
+                && vectorSearchOrderingTableAlias == vectorSearchFunction.Alias);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Translations/VectorTranslationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Translations/VectorTranslationsSqlServerTest.cs
@@ -77,7 +77,6 @@ ORDER BY VECTOR_DISTANCE('cosine', [v].[Vector], CAST('[1,2,100]' AS VECTOR(3)))
 
         var results = await ctx.VectorEntities
             .VectorSearch(e => e.Vector, similarTo: vector, "cosine")
-            .OrderBy(e => e.Distance)
             .Take(1)
             .ToListAsync();
 
@@ -112,7 +111,6 @@ ORDER BY [v0].[Distance]
         var results = await ctx.VectorEntities
             .VectorSearch(e => e.Vector, similarTo: vector, "cosine")
             .Where(e => e.Distance < 0.01)
-            .OrderBy(e => e.Distance)
             .Select(e => e.Value)
             .Take(3)
             .ToListAsync();
@@ -151,7 +149,6 @@ ORDER BY [v0].[Distance]
 
         var results = await ctx.VectorEntities
             .VectorSearch(e => e.Vector, similarTo: vector, "cosine")
-            .OrderBy(e => e.Distance)
             .Take(3)
             .Select(e => new { e.Value.Id, e.Distance })
             .Where(e => e.Distance < 0.01)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Translations/VectorTranslationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Translations/VectorTranslationsSqlServerTest.cs
@@ -102,7 +102,7 @@ ORDER BY [v0].[Distance]
     [ConditionalFact]
     [SqlServerCondition(SqlServerCondition.IsAzureSql)]
     [Experimental("EF9105")]
-    public async Task VectorSearch_project_entity_only_with_distance_filter_and_ordering()
+    public async Task VectorSearch_project_entity_only_with_distance_filter()
     {
         using var ctx = CreateContext();
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Translations/VectorTranslationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Translations/VectorTranslationsSqlServerTest.cs
@@ -180,6 +180,86 @@ ORDER BY [v1].[Distance]
 """);
     }
 
+    // The latest vector index version (required for VECTOR_SEARCH) is only available on Azure SQL (#36384).
+    [ConditionalFact]
+    [SqlServerCondition(SqlServerCondition.IsAzureSql)]
+    [Experimental("EF9105")]
+    public async Task VectorSearch_with_Skip_and_Take()
+    {
+        using var ctx = CreateContext();
+
+        var vector = new SqlVector<float>(new float[] { 1, 2, 100 });
+
+        var results = await ctx.VectorEntities
+            .VectorSearch(e => e.Vector, similarTo: vector, "cosine")
+            .Skip(1)
+            .Take(2)
+            .ToListAsync();
+
+        Assert.Equal(2, results.Count);
+
+        AssertSql(
+            """
+@p1='1'
+@p2='2'
+@p='Microsoft.Data.SqlTypes.SqlVector`1[System.Single]' (Size = 20) (DbType = Binary)
+
+SELECT [v1].[Id], [v1].[Distance]
+FROM (
+    SELECT TOP(@p1 + @p2) WITH APPROXIMATE [v].[Id], [v0].[Distance]
+    FROM VECTOR_SEARCH(
+        TABLE = [VectorEntities] AS [v],
+        COLUMN = [Vector],
+        SIMILAR_TO = @p,
+        METRIC = 'cosine'
+    ) AS [v0]
+    ORDER BY [v0].[Distance]
+) AS [v1]
+ORDER BY [v1].[Distance]
+OFFSET @p1 ROWS FETCH NEXT @p2 ROWS ONLY
+""");
+    }
+
+    // The latest vector index version (required for VECTOR_SEARCH) is only available on Azure SQL (#36384).
+    [ConditionalFact]
+    [SqlServerCondition(SqlServerCondition.IsAzureSql)]
+    [Experimental("EF9105")]
+    public async Task VectorSearch_with_Take_and_Skip()
+    {
+        using var ctx = CreateContext();
+
+        var vector = new SqlVector<float>(new float[] { 1, 2, 100 });
+
+        var results = await ctx.VectorEntities
+            .VectorSearch(e => e.Vector, similarTo: vector, "cosine")
+            .Take(3)
+            .Skip(1)
+            .ToListAsync();
+
+        Assert.Equal(2, results.Count);
+
+        AssertSql(
+            """
+@p1='3'
+@p='Microsoft.Data.SqlTypes.SqlVector`1[System.Single]' (Size = 20) (DbType = Binary)
+@p2='1'
+
+SELECT [v1].[Id], [v1].[Distance]
+FROM (
+    SELECT TOP(@p1) WITH APPROXIMATE [v].[Id], [v0].[Distance]
+    FROM VECTOR_SEARCH(
+        TABLE = [VectorEntities] AS [v],
+        COLUMN = [Vector],
+        SIMILAR_TO = @p,
+        METRIC = 'cosine'
+    ) AS [v0]
+    ORDER BY [v0].[Distance]
+) AS [v1]
+ORDER BY [v1].[Distance]
+OFFSET @p2 ROWS
+""");
+    }
+
     [ConditionalFact]
     public async Task Length()
     {


### PR DESCRIPTION
Tiny follow-up to #38075.

VECTOR_SEARCH() results are inherently ordered by distance ascending. This adds the ordering implicitly during translation so users can compose with `Take()` without needing an explicit `OrderBy(r => r.Distance)`.

Before:
```csharp
ctx.VectorEntities
    .VectorSearch(e => e.Vector, similarTo: vector, "cosine")
    .OrderBy(e => e.Distance)  // required boilerplate
    .Take(3)
    .ToListAsync();
```

After:
```csharp
ctx.VectorEntities
    .VectorSearch(e => e.Vector, similarTo: vector, "cosine")
    .Take(3)  // implicit ORDER BY Distance ASC
    .ToListAsync();
```

An explicit `.OrderBy()` or `.OrderByDescending()` still overrides the implicit ordering.

We could adopt a more low-level/conservative approach, saying that since SQL Server requires the explicit ORDER BY at the SQL level, we should continue requiring it at the LINQ level. However, we already add implicit orderings elsewhere (especially when transforming JSON arrays to resultsets with OPENJSON), and I don't see the point of having a mandatory, explicit gesture where we can save users the trouble.