### PR TITLE
Allow temporal period properties to be mapped to CLR properties

### DIFF
--- a/src/EFCore.SqlServer/Design/Internal/SqlServerAnnotationCodeGenerator.cs
+++ b/src/EFCore.SqlServer/Design/Internal/SqlServerAnnotationCodeGenerator.cs
@@ -338,7 +338,7 @@ public class SqlServerAnnotationCodeGenerator : AnnotationCodeGenerator
                 : null;
 
             // for the RevEng path, we avoid adding period properties to the entity
-            // because we don't want code for them to be generated - they need to be in shadow state
+            // because we don't want code for them to be generated - they are created as shadow properties
             // so if we don't find property on the entity, we know it's this scenario
             // and in that case period column name is actually the same as the period property name annotation
             // since in RevEng scenario there can't be custom column mapping

--- a/src/EFCore.SqlServer/EFCore.SqlServer.baseline.json
+++ b/src/EFCore.SqlServer/EFCore.SqlServer.baseline.json
@@ -250,6 +250,12 @@
       "Type": "class Microsoft.EntityFrameworkCore.Metadata.Builders.OwnedNavigationTemporalTableBuilder<TOwnerEntity, TDependentEntity> : Microsoft.EntityFrameworkCore.Metadata.Builders.OwnedNavigationTemporalTableBuilder where TOwnerEntity : class where TDependentEntity : class",
       "Methods": [
         {
+          "Member": "virtual Microsoft.EntityFrameworkCore.Metadata.Builders.OwnedNavigationTemporalPeriodPropertyBuilder Microsoft.EntityFrameworkCore.Metadata.Builders.OwnedNavigationTemporalTableBuilder<TOwnerEntity, TDependentEntity>.HasPeriodEnd(System.Linq.Expressions.Expression<System.Func<TDependentEntity, System.DateTime>> propertyExpression);"
+        },
+        {
+          "Member": "virtual Microsoft.EntityFrameworkCore.Metadata.Builders.OwnedNavigationTemporalPeriodPropertyBuilder Microsoft.EntityFrameworkCore.Metadata.Builders.OwnedNavigationTemporalTableBuilder<TOwnerEntity, TDependentEntity>.HasPeriodStart(System.Linq.Expressions.Expression<System.Func<TDependentEntity, System.DateTime>> propertyExpression);"
+        },
+        {
           "Member": "virtual Microsoft.EntityFrameworkCore.Metadata.Builders.OwnedNavigationTemporalTableBuilder<TOwnerEntity, TDependentEntity> Microsoft.EntityFrameworkCore.Metadata.Builders.OwnedNavigationTemporalTableBuilder<TOwnerEntity, TDependentEntity>.UseHistoryTable(string name);"
         },
         {
@@ -2630,7 +2636,7 @@
           "Member": "static System.Linq.IQueryable<Microsoft.EntityFrameworkCore.Query.FullTextSearchResult<TKey>> Microsoft.EntityFrameworkCore.SqlServerQueryableExtensions.FreeTextTable<T, TKey>(this Microsoft.EntityFrameworkCore.DbSet<T> source, string freeText, System.Linq.Expressions.Expression<System.Func<T, object>>? columnSelector = null, string? languageTerm = null, int? topN = null);"
         },
         {
-          "Member": "static System.Linq.IQueryable<Microsoft.EntityFrameworkCore.VectorSearchResult<T>> Microsoft.EntityFrameworkCore.SqlServerQueryableExtensions.VectorSearch<T, TVector>(this Microsoft.EntityFrameworkCore.DbSet<T> source, System.Linq.Expressions.Expression<System.Func<T, TVector>> vectorPropertySelector, TVector similarTo, string metric, int topN);",
+          "Member": "static System.Linq.IQueryable<Microsoft.EntityFrameworkCore.VectorSearchResult<T>> Microsoft.EntityFrameworkCore.SqlServerQueryableExtensions.VectorSearch<T, TVector>(this Microsoft.EntityFrameworkCore.DbSet<T> source, System.Linq.Expressions.Expression<System.Func<T, TVector>> vectorPropertySelector, TVector similarTo, string metric);",
           "Stage": "Experimental"
         }
       ]
@@ -3030,6 +3036,12 @@
     {
       "Type": "class Microsoft.EntityFrameworkCore.Metadata.Builders.TemporalTableBuilder<TEntity> : Microsoft.EntityFrameworkCore.Metadata.Builders.TemporalTableBuilder where TEntity : class",
       "Methods": [
+        {
+          "Member": "virtual Microsoft.EntityFrameworkCore.Metadata.Builders.TemporalPeriodPropertyBuilder Microsoft.EntityFrameworkCore.Metadata.Builders.TemporalTableBuilder<TEntity>.HasPeriodEnd(System.Linq.Expressions.Expression<System.Func<TEntity, System.DateTime>> propertyExpression);"
+        },
+        {
+          "Member": "virtual Microsoft.EntityFrameworkCore.Metadata.Builders.TemporalPeriodPropertyBuilder Microsoft.EntityFrameworkCore.Metadata.Builders.TemporalTableBuilder<TEntity>.HasPeriodStart(System.Linq.Expressions.Expression<System.Func<TEntity, System.DateTime>> propertyExpression);"
+        },
         {
           "Member": "virtual Microsoft.EntityFrameworkCore.Metadata.Builders.TemporalTableBuilder<TEntity> Microsoft.EntityFrameworkCore.Metadata.Builders.TemporalTableBuilder<TEntity>.UseHistoryTable(string name);"
         },

--- a/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerModelValidator.cs
+++ b/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerModelValidator.cs
@@ -449,13 +449,6 @@ public class SqlServerModelValidator(
                     temporalEntityType.DisplayName(), annotationPropertyName));
         }
 
-        if (!periodProperty.IsShadowProperty() && !temporalEntityType.IsPropertyBag)
-        {
-            throw new InvalidOperationException(
-                SqlServerStrings.TemporalPeriodPropertyMustBeInShadowState(
-                    temporalEntityType.DisplayName(), periodProperty.Name));
-        }
-
         if (periodProperty.IsNullable
             || periodProperty.ClrType != typeof(DateTime))
         {

--- a/src/EFCore.SqlServer/Metadata/Builders/OwnedNavigationTemporalTableBuilder``.cs
+++ b/src/EFCore.SqlServer/Metadata/Builders/OwnedNavigationTemporalTableBuilder``.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 /// <summary>
@@ -49,4 +52,36 @@ public class OwnedNavigationTemporalTableBuilder<TOwnerEntity, TDependentEntity>
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
     public new virtual OwnedNavigationTemporalTableBuilder<TOwnerEntity, TDependentEntity> UseHistoryTable(string name, string? schema)
         => (OwnedNavigationTemporalTableBuilder<TOwnerEntity, TDependentEntity>)base.UseHistoryTable(name, schema);
+
+    /// <summary>
+    ///     Returns an object that can be used to configure a period start property of the entity type mapped to a temporal table.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-temporal">Using SQL Server temporal tables with EF Core</see>
+    ///     for more information.
+    /// </remarks>
+    /// <param name="propertyExpression">
+    ///     A lambda expression representing the property to be configured as the period start property
+    ///     (<c>entity => entity.PeriodStart</c>).
+    /// </param>
+    /// <returns>An object that can be used to configure the period start property.</returns>
+    public virtual OwnedNavigationTemporalPeriodPropertyBuilder HasPeriodStart(
+        Expression<Func<TDependentEntity, DateTime>> propertyExpression)
+        => HasPeriodStart(Check.NotNull(propertyExpression).GetMemberAccess().Name);
+
+    /// <summary>
+    ///     Returns an object that can be used to configure a period end property of the entity type mapped to a temporal table.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-temporal">Using SQL Server temporal tables with EF Core</see>
+    ///     for more information.
+    /// </remarks>
+    /// <param name="propertyExpression">
+    ///     A lambda expression representing the property to be configured as the period end property
+    ///     (<c>entity => entity.PeriodEnd</c>).
+    /// </param>
+    /// <returns>An object that can be used to configure the period end property.</returns>
+    public virtual OwnedNavigationTemporalPeriodPropertyBuilder HasPeriodEnd(
+        Expression<Func<TDependentEntity, DateTime>> propertyExpression)
+        => HasPeriodEnd(Check.NotNull(propertyExpression).GetMemberAccess().Name);
 }

--- a/src/EFCore.SqlServer/Metadata/Builders/OwnedNavigationTemporalTableBuilder``.cs
+++ b/src/EFCore.SqlServer/Metadata/Builders/OwnedNavigationTemporalTableBuilder``.cs
@@ -1,9 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Linq.Expressions;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-
 namespace Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 /// <summary>

--- a/src/EFCore.SqlServer/Metadata/Builders/TemporalTableBuilder`.cs
+++ b/src/EFCore.SqlServer/Metadata/Builders/TemporalTableBuilder`.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 /// <summary>
@@ -47,4 +50,34 @@ public class TemporalTableBuilder<TEntity> : TemporalTableBuilder
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
     public new virtual TemporalTableBuilder<TEntity> UseHistoryTable(string name, string? schema)
         => (TemporalTableBuilder<TEntity>)base.UseHistoryTable(name, schema);
+
+    /// <summary>
+    ///     Returns an object that can be used to configure a period start property of the entity type mapped to a temporal table.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-temporal">Using SQL Server temporal tables with EF Core</see>
+    ///     for more information and examples.
+    /// </remarks>
+    /// <param name="propertyExpression">
+    ///     A lambda expression representing the property to be configured as the period start property
+    ///     (<c>blog => blog.PeriodStart</c>).
+    /// </param>
+    /// <returns>An object that can be used to configure the period start property.</returns>
+    public virtual TemporalPeriodPropertyBuilder HasPeriodStart(Expression<Func<TEntity, DateTime>> propertyExpression)
+        => HasPeriodStart(Check.NotNull(propertyExpression).GetMemberAccess().Name);
+
+    /// <summary>
+    ///     Returns an object that can be used to configure a period end property of the entity type mapped to a temporal table.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-temporal">Using SQL Server temporal tables with EF Core</see>
+    ///     for more information and examples.
+    /// </remarks>
+    /// <param name="propertyExpression">
+    ///     A lambda expression representing the property to be configured as the period end property
+    ///     (<c>blog => blog.PeriodEnd</c>).
+    /// </param>
+    /// <returns>An object that can be used to configure the period end property.</returns>
+    public virtual TemporalPeriodPropertyBuilder HasPeriodEnd(Expression<Func<TEntity, DateTime>> propertyExpression)
+        => HasPeriodEnd(Check.NotNull(propertyExpression).GetMemberAccess().Name);
 }

--- a/src/EFCore.SqlServer/Metadata/Builders/TemporalTableBuilder`.cs
+++ b/src/EFCore.SqlServer/Metadata/Builders/TemporalTableBuilder`.cs
@@ -1,9 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Linq.Expressions;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-
 namespace Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 /// <summary>

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
@@ -432,14 +432,6 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
                 entityType, propertyName);
 
         /// <summary>
-        ///     Period property '{entityType}.{propertyName}' must be a shadow property.
-        /// </summary>
-        public static string TemporalPeriodPropertyMustBeInShadowState(object? entityType, object? propertyName)
-            => string.Format(
-                GetString("TemporalPeriodPropertyMustBeInShadowState", nameof(entityType), nameof(propertyName)),
-                entityType, propertyName);
-
-        /// <summary>
         ///     Period property '{entityType}.{propertyName}' must be mapped to a column of type '{columnType}'.
         /// </summary>
         public static string TemporalPeriodPropertyMustBeMappedToDatetime2(object? entityType, object? propertyName, object? columnType)

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
@@ -375,9 +375,6 @@
   <data name="TemporalPeriodPropertyCantHaveDefaultValue" xml:space="preserve">
     <value>Period property '{entityType}.{propertyName}' can't have a default value specified.</value>
   </data>
-  <data name="TemporalPeriodPropertyMustBeInShadowState" xml:space="preserve">
-    <value>Period property '{entityType}.{propertyName}' must be a shadow property.</value>
-  </data>
   <data name="TemporalPeriodPropertyMustBeMappedToDatetime2" xml:space="preserve">
     <value>Period property '{entityType}.{propertyName}' must be mapped to a column of type '{columnType}'.</value>
   </data>

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
@@ -1093,25 +1093,21 @@ public partial class TestDbContext : DbContext
                 skipBuild: true);
 
         [ConditionalFact]
-        public async Task Temporal_table_works()
-            // Shadow properties. Issue #26007.
-            => Assert.Equal(
-                SqlServerStrings.TemporalPeriodPropertyMustBeInShadowState("Customer", "PeriodStart"),
-                (await Assert.ThrowsAsync<InvalidOperationException>(() =>
-                    TestAsync(
-                        modelBuilder => modelBuilder.Entity(
-                            "Customer", e =>
-                            {
-                                e.Property<int>("Id");
-                                e.Property<string>("Name");
-                                e.HasKey("Id");
-                                e.ToTable(tb => tb.IsTemporal());
-                            }),
-                        new ModelCodeGenerationOptions { UseDataAnnotations = false },
-                        code =>
-                        {
-                            AssertFileContents(
-                                $$"""
+        public Task Temporal_table_works()
+            => TestAsync(
+                modelBuilder => modelBuilder.Entity(
+                    "Customer", e =>
+                    {
+                        e.Property<int>("Id");
+                        e.Property<string>("Name");
+                        e.HasKey("Id");
+                        e.ToTable(tb => tb.IsTemporal());
+                    }),
+                new ModelCodeGenerationOptions { UseDataAnnotations = false },
+                code =>
+                {
+                    AssertFileContents(
+                        $$"""
 using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
@@ -1157,12 +1153,15 @@ public partial class TestDbContext : DbContext
     partial void OnModelCreatingPartial(ModelBuilder modelBuilder);
 }
 """,
-                                code.ContextFile);
-                        },
-                        model =>
-                        {
-                            // TODO
-                        }))).Message);
+                        code.ContextFile);
+                },
+                model =>
+                {
+                    var entityType = model.FindEntityType("TestNamespace.Customer")!;
+                    Assert.True(entityType.IsTemporal());
+                    Assert.Equal("PeriodStart", entityType.GetPeriodStartPropertyName());
+                    Assert.Equal("PeriodEnd", entityType.GetPeriodEndPropertyName());
+                });
 
         [ConditionalFact]
         public Task Sequences_work()

--- a/test/EFCore.SqlServer.FunctionalTests/ModelBuilding/SqlServerModelBuilderTestBase.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ModelBuilding/SqlServerModelBuilderTestBase.cs
@@ -4,6 +4,7 @@
 using System.Collections.ObjectModel;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
 using Microsoft.Data.SqlTypes;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -1674,6 +1675,68 @@ public class SqlServerModelBuilderTestBase : RelationalModelBuilderTest
             Assert.True(joinEntity.IsTemporal());
         }
 
+        [ConditionalFact]
+        public virtual void Temporal_table_with_period_mapped_to_CLR_property()
+        {
+            var modelBuilder = CreateModelBuilder();
+            var model = modelBuilder.Model;
+
+            modelBuilder.Entity<TemporalCustomer>().ToTable(tb => tb.IsTemporal(ttb =>
+            {
+                ttb.HasPeriodStart("PeriodStart");
+                ttb.HasPeriodEnd("PeriodEnd");
+            }));
+
+            modelBuilder.FinalizeModel();
+
+            var entity = model.FindEntityType(typeof(TemporalCustomer))!;
+            Assert.True(entity.IsTemporal());
+
+            var periodStart = entity.GetProperty(entity.GetPeriodStartPropertyName()!);
+            var periodEnd = entity.GetProperty(entity.GetPeriodEndPropertyName()!);
+
+            Assert.Equal("PeriodStart", periodStart.Name);
+            Assert.False(periodStart.IsShadowProperty());
+            Assert.Equal(typeof(DateTime), periodStart.ClrType);
+            Assert.Equal(ValueGenerated.OnAddOrUpdate, periodStart.ValueGenerated);
+
+            Assert.Equal("PeriodEnd", periodEnd.Name);
+            Assert.False(periodEnd.IsShadowProperty());
+            Assert.Equal(typeof(DateTime), periodEnd.ClrType);
+            Assert.Equal(ValueGenerated.OnAddOrUpdate, periodEnd.ValueGenerated);
+        }
+
+        [ConditionalFact]
+        public virtual void Temporal_table_with_period_mapped_to_CLR_property_via_lambda()
+        {
+            var modelBuilder = CreateModelBuilder();
+            var model = modelBuilder.Model;
+
+            modelBuilder.Entity<TemporalCustomer>().ToTable(tb => tb.IsTemporal(ttb =>
+            {
+                ttb.HasPeriodStart(e => e.PeriodStart);
+                ttb.HasPeriodEnd(e => e.PeriodEnd);
+            }));
+
+            modelBuilder.FinalizeModel();
+
+            var entity = model.FindEntityType(typeof(TemporalCustomer))!;
+            Assert.True(entity.IsTemporal());
+
+            var periodStart = entity.GetProperty(entity.GetPeriodStartPropertyName()!);
+            var periodEnd = entity.GetProperty(entity.GetPeriodEndPropertyName()!);
+
+            Assert.Equal("PeriodStart", periodStart.Name);
+            Assert.False(periodStart.IsShadowProperty());
+            Assert.Equal(typeof(DateTime), periodStart.ClrType);
+            Assert.Equal(ValueGenerated.OnAddOrUpdate, periodStart.ValueGenerated);
+
+            Assert.Equal("PeriodEnd", periodEnd.Name);
+            Assert.False(periodEnd.IsShadowProperty());
+            Assert.Equal(typeof(DateTime), periodEnd.ClrType);
+            Assert.Equal(ValueGenerated.OnAddOrUpdate, periodEnd.ValueGenerated);
+        }
+
 #pragma warning disable EF8001 // Owned JSON entities are obsolete
         [ConditionalFact]
         public virtual void Json_entity_and_normal_owned_can_exist_side_by_side_on_same_entity()
@@ -2214,6 +2277,8 @@ public class SqlServerModelBuilderTestBase : RelationalModelBuilderTest
         public abstract TestTemporalTableBuilder<TEntity> UseHistoryTable(string name, string? schema);
         public abstract TestTemporalPeriodPropertyBuilder HasPeriodStart(string propertyName);
         public abstract TestTemporalPeriodPropertyBuilder HasPeriodEnd(string propertyName);
+        public abstract TestTemporalPeriodPropertyBuilder HasPeriodStart(Expression<Func<TEntity, DateTime>> propertyExpression);
+        public abstract TestTemporalPeriodPropertyBuilder HasPeriodEnd(Expression<Func<TEntity, DateTime>> propertyExpression);
     }
 
     public class GenericTestTemporalTableBuilder<TEntity>(TemporalTableBuilder<TEntity> temporalTableBuilder)
@@ -2237,6 +2302,12 @@ public class SqlServerModelBuilderTestBase : RelationalModelBuilderTest
 
         public override TestTemporalPeriodPropertyBuilder HasPeriodEnd(string propertyName)
             => new(TemporalTableBuilder.HasPeriodEnd(propertyName));
+
+        public override TestTemporalPeriodPropertyBuilder HasPeriodStart(Expression<Func<TEntity, DateTime>> propertyExpression)
+            => new(TemporalTableBuilder.HasPeriodStart(propertyExpression));
+
+        public override TestTemporalPeriodPropertyBuilder HasPeriodEnd(Expression<Func<TEntity, DateTime>> propertyExpression)
+            => new(TemporalTableBuilder.HasPeriodEnd(propertyExpression));
     }
 
     public class NonGenericTestTemporalTableBuilder<TEntity>(TemporalTableBuilder temporalTableBuilder)
@@ -2259,6 +2330,12 @@ public class SqlServerModelBuilderTestBase : RelationalModelBuilderTest
 
         public override TestTemporalPeriodPropertyBuilder HasPeriodEnd(string propertyName)
             => new(TemporalTableBuilder.HasPeriodEnd(propertyName));
+
+        public override TestTemporalPeriodPropertyBuilder HasPeriodStart(Expression<Func<TEntity, DateTime>> propertyExpression)
+            => HasPeriodStart(propertyExpression.GetMemberAccess().Name);
+
+        public override TestTemporalPeriodPropertyBuilder HasPeriodEnd(Expression<Func<TEntity, DateTime>> propertyExpression)
+            => HasPeriodEnd(propertyExpression.GetMemberAccess().Name);
     }
 
     public abstract class TestOwnedNavigationTemporalTableBuilder<TOwnerEntity, TDependentEntity>
@@ -2270,6 +2347,12 @@ public class SqlServerModelBuilderTestBase : RelationalModelBuilderTest
 
         public abstract TestOwnedNavigationTemporalPeriodPropertyBuilder HasPeriodStart(string propertyName);
         public abstract TestOwnedNavigationTemporalPeriodPropertyBuilder HasPeriodEnd(string propertyName);
+
+        public abstract TestOwnedNavigationTemporalPeriodPropertyBuilder HasPeriodStart(
+            Expression<Func<TDependentEntity, DateTime>> propertyExpression);
+
+        public abstract TestOwnedNavigationTemporalPeriodPropertyBuilder HasPeriodEnd(
+            Expression<Func<TDependentEntity, DateTime>> propertyExpression);
     }
 
     public class GenericTestOwnedNavigationTemporalTableBuilder<TOwnerEntity, TDependentEntity>(
@@ -2297,6 +2380,14 @@ public class SqlServerModelBuilderTestBase : RelationalModelBuilderTest
 
         public override TestOwnedNavigationTemporalPeriodPropertyBuilder HasPeriodEnd(string propertyName)
             => new(TemporalTableBuilder.HasPeriodEnd(propertyName));
+
+        public override TestOwnedNavigationTemporalPeriodPropertyBuilder HasPeriodStart(
+            Expression<Func<TDependentEntity, DateTime>> propertyExpression)
+            => new(TemporalTableBuilder.HasPeriodStart(propertyExpression));
+
+        public override TestOwnedNavigationTemporalPeriodPropertyBuilder HasPeriodEnd(
+            Expression<Func<TDependentEntity, DateTime>> propertyExpression)
+            => new(TemporalTableBuilder.HasPeriodEnd(propertyExpression));
     }
 
     public class NonGenericTestOwnedNavigationTemporalTableBuilder<TOwnerEntity, TDependentEntity>(
@@ -2323,6 +2414,14 @@ public class SqlServerModelBuilderTestBase : RelationalModelBuilderTest
 
         public override TestOwnedNavigationTemporalPeriodPropertyBuilder HasPeriodEnd(string propertyName)
             => new(TemporalTableBuilder.HasPeriodEnd(propertyName));
+
+        public override TestOwnedNavigationTemporalPeriodPropertyBuilder HasPeriodStart(
+            Expression<Func<TDependentEntity, DateTime>> propertyExpression)
+            => HasPeriodStart(propertyExpression.GetMemberAccess().Name);
+
+        public override TestOwnedNavigationTemporalPeriodPropertyBuilder HasPeriodEnd(
+            Expression<Func<TDependentEntity, DateTime>> propertyExpression)
+            => HasPeriodEnd(propertyExpression.GetMemberAccess().Name);
     }
 
     public class TestTemporalPeriodPropertyBuilder(TemporalPeriodPropertyBuilder temporalPeriodPropertyBuilder)
@@ -2492,5 +2591,13 @@ public class SqlServerModelBuilderTestBase : RelationalModelBuilderTest
 
         private TestFullTextCatalogBuilder Wrap(SqlServerFullTextCatalogBuilder catalogBuilder)
             => new(catalogBuilder);
+    }
+
+    protected class TemporalCustomer
+    {
+        public int Id { get; set; }
+        public string? Name { get; set; }
+        public DateTime PeriodStart { get; set; }
+        public DateTime PeriodEnd { get; set; }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalTableSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalTableSqlServerTest.cs
@@ -433,6 +433,110 @@ ORDER BY [u].[Id], [o].[MainEntityManyId]
         }
     }
 
+    [ConditionalTheory, MemberData(nameof(IsAsyncData))]
+    public virtual async Task Temporal_with_CLR_period_properties(bool async)
+    {
+        var contextFactory = await InitializeNonSharedTest<ContextWithClrPeriodProperties>(
+            seed: async c =>
+            {
+                c.Customers.Add(new TemporalCustomerWithClrPeriods { Name = "Customer1" });
+                await c.SaveChangesAsync();
+            });
+
+        using var context = contextFactory.CreateDbContext();
+
+        var query = context.Customers.OrderBy(c => c.Id);
+        var result = async ? await query.ToListAsync() : query.ToList();
+
+        Assert.Single(result);
+        Assert.Equal("Customer1", result[0].Name);
+        // Period properties should be populated with non-default values by SQL Server
+        Assert.NotEqual(default, result[0].PeriodStart);
+        Assert.NotEqual(default, result[0].PeriodEnd);
+    }
+
+    [ConditionalTheory, MemberData(nameof(IsAsyncData))]
+    public virtual async Task Temporal_with_CLR_period_properties_and_TemporalAll(bool async)
+    {
+        var contextFactory = await InitializeNonSharedTest<ContextWithClrPeriodProperties>(
+            seed: async c =>
+            {
+                c.Customers.Add(new TemporalCustomerWithClrPeriods { Name = "Customer1" });
+                await c.SaveChangesAsync();
+            });
+
+        using var context = contextFactory.CreateDbContext();
+
+        var query = context.Customers.TemporalAll().OrderBy(c => c.Id);
+        var result = async ? await query.ToListAsync() : query.ToList();
+
+        Assert.Single(result);
+        Assert.Equal("Customer1", result[0].Name);
+        Assert.NotEqual(default, result[0].PeriodStart);
+        Assert.NotEqual(default, result[0].PeriodEnd);
+    }
+
+    [ConditionalTheory, MemberData(nameof(IsAsyncData))]
+    public virtual async Task Temporal_with_CLR_period_properties_configured_via_lambda(bool async)
+    {
+        var contextFactory = await InitializeNonSharedTest<ContextWithClrPeriodPropertiesLambda>(
+            seed: async c =>
+            {
+                c.Customers.Add(new TemporalCustomerWithClrPeriods { Name = "Customer1" });
+                await c.SaveChangesAsync();
+            });
+
+        using var context = contextFactory.CreateDbContext();
+
+        var query = context.Customers.OrderBy(c => c.Id);
+        var result = async ? await query.ToListAsync() : query.ToList();
+
+        Assert.Single(result);
+        Assert.Equal("Customer1", result[0].Name);
+        Assert.NotEqual(default, result[0].PeriodStart);
+        Assert.NotEqual(default, result[0].PeriodEnd);
+    }
+
+    public class TemporalCustomerWithClrPeriods
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public DateTime PeriodStart { get; set; }
+        public DateTime PeriodEnd { get; set; }
+    }
+
+    public class ContextWithClrPeriodProperties(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<TemporalCustomerWithClrPeriods> Customers { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<TemporalCustomerWithClrPeriods>().ToTable(
+                "TemporalCustomerWithClrPeriods", tb => tb.IsTemporal(ttb =>
+                {
+                    ttb.HasPeriodStart("PeriodStart");
+                    ttb.HasPeriodEnd("PeriodEnd");
+                }));
+            modelBuilder.Entity<TemporalCustomerWithClrPeriods>().Property(me => me.Id).UseIdentityColumn();
+        }
+    }
+
+    public class ContextWithClrPeriodPropertiesLambda(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<TemporalCustomerWithClrPeriods> Customers { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<TemporalCustomerWithClrPeriods>().ToTable(
+                "TemporalCustomerWithClrPeriods", tb => tb.IsTemporal(ttb =>
+                {
+                    ttb.HasPeriodStart(e => e.PeriodStart);
+                    ttb.HasPeriodEnd(e => e.PeriodEnd);
+                }));
+            modelBuilder.Entity<TemporalCustomerWithClrPeriods>().Property(me => me.Id).UseIdentityColumn();
+        }
+    }
+
     [ConditionalTheory, InlineData(true), InlineData(false)]
     public virtual async Task Temporal_can_query_shared_derived_hierarchy(bool async)
     {

--- a/test/EFCore.SqlServer.Tests/Infrastructure/SqlServerModelValidatorTest.cs
+++ b/test/EFCore.SqlServer.Tests/Infrastructure/SqlServerModelValidatorTest.cs
@@ -946,12 +946,12 @@ public class SqlServerModelValidatorTest : RelationalModelValidatorTest
     }
 
     [ConditionalFact]
-    public void Temporal_period_property_must_be_in_shadow_state()
+    public void Temporal_period_property_mapped_to_CLR_property_is_allowed()
     {
         var modelBuilder = CreateConventionModelBuilder();
         modelBuilder.Entity<Human>().ToTable(tb => tb.IsTemporal(ttb => ttb.HasPeriodStart("DateOfBirth")));
 
-        VerifyError(SqlServerStrings.TemporalPeriodPropertyMustBeInShadowState(nameof(Human), "DateOfBirth"), modelBuilder);
+        Validate(modelBuilder);
     }
 
     [ConditionalFact]


### PR DESCRIPTION
Fixes #26463

## Summary

Temporal period properties (`PeriodStart`/`PeriodEnd`) were previously required to be shadow properties. This PR removes that restriction, allowing them to be mapped to CLR properties on the entity type.

## Changes

### Product code
- **Removed shadow-property validation** in `SqlServerModelValidator` — the `IsShadowProperty()` check on period properties is no longer enforced.
- **Added lambda-based `HasPeriodStart`/`HasPeriodEnd` overloads** on `TemporalTableBuilder<TEntity>` and `OwnedNavigationTemporalTableBuilder<TOwner, TDependentEntity>` for strongly-typed configuration:
  ```csharp
  entity.ToTable(tb => tb.IsTemporal(ttb =>
  {
      ttb.HasPeriodStart(e => e.PeriodStart);
      ttb.HasPeriodEnd(e => e.PeriodEnd);
  }));
  ```

### Scaffolding
No change — period columns are still excluded from the scaffolding column query and generated as shadow properties by default.

### Why it just works
- `SqlServerTemporalConvention` already discovers existing CLR properties via `entityTypeBuilder.Property(typeof(DateTime), periodPropertyName)`.
- Period properties are configured with `ValueGenerated.OnAddOrUpdate`, which sets `BeforeSaveBehavior` to `Ignore` — so they're automatically excluded from INSERT/UPDATE even as CLR properties.

### Tests
- Updated validator test to expect success for CLR period properties
- Added model building tests (string-based and lambda-based CLR period configuration)
- Updated scaffolding round-trip test (now succeeds instead of throwing)
- Added E2E functional tests exercising CLR period properties with temporal queries