### PR TITLE
Fix: Cosmos ToList on structural collection is treated as scalar

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosProjectionBindingExpressionVisitor.cs
@@ -619,6 +619,8 @@ public class CosmosProjectionBindingExpressionVisitor : ExpressionVisitor
                             EnumerableMethods.Select.MakeGenericMethod(method.GetGenericArguments()),
                             shaper,
                             lambda);
+                    default:
+                        throw new InvalidOperationException(CoreStrings.TranslationFailed(methodCallExpression.Print()));
                 }
             }
             else if (method is { Name: nameof(Enumerable.ToList), IsGenericMethod: true }
@@ -632,14 +634,19 @@ public class CosmosProjectionBindingExpressionVisitor : ExpressionVisitor
                     throw new InvalidOperationException(CoreStrings.TranslationFailed(methodCallExpression.Print()));
                 }
 
+                if (array is not SqlExpression scalarArray)
+                {
+                    // #34067
+                    return Visit(argument);
+                }
+
                 // If ToList() was composed over a subquery with operators, the result here is an ArrayExpression (ARRAY(SELECT ...)), whose
                 // CLR Type is IEnumerable<T>. This can be directly used in the resulting ProjectingBindingExpression - the shaper will
                 // simply read the JSON results out successfully.
                 // But if ToList() is composed directly over an array property, that property could have type e.g. T[], which will be read
                 // in the shaper, and then the cast from T[] to List<T> will fail. As a result, wrap the array in an additional
                 // "reprojection" subquery, effectively to change the CLR type.
-                if (array is SqlExpression scalarArray
-                    && !(array.Type.IsGenericType && array.Type.GetGenericTypeDefinition() == typeof(IEnumerable<>)))
+                if (!(array.Type.IsGenericType && array.Type.GetGenericTypeDefinition() == typeof(IEnumerable<>)))
                 {
                     Check.DebugAssert(
                         array is not ScalarArrayExpression and not ObjectArrayExpression, "ArrayExpression should be IEnumerable");

--- a/test/EFCore.Cosmos.FunctionalTests/Query/Associations/ComplexProperties/ComplexPropertiesCollectionCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/Associations/ComplexProperties/ComplexPropertiesCollectionCosmosTest.cs
@@ -111,19 +111,8 @@ WHERE (ARRAY(
     public override Task Distinct()
         => AssertTranslationFailed(base.Distinct);
 
-    public override async Task Distinct_projected(QueryTrackingBehavior queryTrackingBehavior)
-    {
-        await base.Distinct_projected(queryTrackingBehavior);
-
-        AssertSql(
-            """
-SELECT VALUE ARRAY(
-    SELECT DISTINCT VALUE a
-    FROM a IN c["AssociateCollection"])
-FROM root c
-ORDER BY c["Id"]
-""");
-    }
+    public override Task Distinct_projected(QueryTrackingBehavior queryTrackingBehavior)
+        => AssertTranslationFailed(() => base.Distinct_projected(queryTrackingBehavior));
 
     public override Task Distinct_over_projected_nested_collection()
         => AssertTranslationFailed(base.Distinct_over_projected_nested_collection);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/Associations/ComplexProperties/ComplexPropertiesCollectionCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/Associations/ComplexProperties/ComplexPropertiesCollectionCosmosTest.cs
@@ -110,19 +110,8 @@ WHERE (ARRAY(
     public override Task Distinct()
         => AssertTranslationFailed(base.Distinct);
 
-    public override async Task Distinct_projected(QueryTrackingBehavior queryTrackingBehavior)
-    {
-        await base.Distinct_projected(queryTrackingBehavior);
-
-        AssertSql(
-            """
-SELECT VALUE ARRAY(
-    SELECT DISTINCT VALUE a
-    FROM a IN c["AssociateCollection"])
-FROM root c
-ORDER BY c["Id"]
-""");
-    }
+    public override Task Distinct_projected(QueryTrackingBehavior queryTrackingBehavior)
+        => AssertTranslationFailed(() => base.Distinct_projected(queryTrackingBehavior));
 
     public override Task Distinct_over_projected_nested_collection()
         => AssertTranslationFailed(base.Distinct_over_projected_nested_collection);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/JsonQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/JsonQueryCosmosTest.cs
@@ -877,22 +877,7 @@ ORDER BY c["Id"]
         => base.Json_collection_in_projection_with_composition_where_and_anonymous_projection_of_scalars(async);
 
     public override Task Json_collection_leaf_filter_in_projection(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Json_collection_leaf_filter_in_projection(a);
-
-                AssertSql(
-                    """
-SELECT VALUE ARRAY(
-    SELECT VALUE o
-    FROM o IN c["OwnedReferenceRoot"]["OwnedReferenceBranch"]["OwnedCollectionLeaf"]
-    WHERE (o["SomethingSomething"] != "Baz"))
-FROM root c
-WHERE (c["Discriminator"] = "Basic")
-ORDER BY c["Id"]
-""");
-            });
+        => AssertTranslationFailed(() => base.Json_collection_leaf_filter_in_projection(async));
 
     public override Task Json_collection_of_primitives_contains_in_predicate(bool async)
         => Fixture.NoSyncTest(

--- a/test/EFCore.Cosmos.FunctionalTests/Query/JsonQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/JsonQueryCosmosTest.cs
@@ -881,22 +881,7 @@ ORDER BY c["Id"]
         => base.Json_collection_in_projection_with_composition_where_and_anonymous_projection_of_scalars(async);
 
     public override Task Json_collection_leaf_filter_in_projection(bool async)
-        => Fixture.NoSyncTest(
-            async, async a =>
-            {
-                await base.Json_collection_leaf_filter_in_projection(a);
-
-                AssertSql(
-                    """
-SELECT VALUE ARRAY(
-    SELECT VALUE o
-    FROM o IN c["OwnedReferenceRoot"]["OwnedReferenceBranch"]["OwnedCollectionLeaf"]
-    WHERE (o["SomethingSomething"] != "Baz"))
-FROM root c
-WHERE (c["Discriminator"] = "Basic")
-ORDER BY c["Id"]
-""");
-            });
+        => AssertTranslationFailed(() => base.Json_collection_leaf_filter_in_projection(async));
 
     public override Task Json_collection_of_primitives_contains_in_predicate(bool async)
         => Fixture.NoSyncTest(

--- a/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
@@ -464,7 +464,7 @@ WHERE c["Terminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 
                 AssertSql(
                     """
-SELECT VALUE o["Details"]
+SELECT VALUE o
 FROM root c
 JOIN o IN c["Orders"]
 WHERE (c["Terminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (ARRAY_LENGTH(o["Details"]) = 1))
@@ -545,7 +545,7 @@ ORDER BY c["Id"]
 
                 AssertSql(
                     """
-SELECT VALUE o["Details"]
+SELECT VALUE o
 FROM root c
 JOIN o IN c["Orders"]
 WHERE (c["Terminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (ARRAY_LENGTH(o["Details"]) = 1))

--- a/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
@@ -465,7 +465,7 @@ WHERE c["Terminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 
                 AssertSql(
                     """
-SELECT VALUE o["Details"]
+SELECT VALUE o
 FROM root c
 JOIN o IN c["Orders"]
 WHERE (c["Terminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (ARRAY_LENGTH(o["Details"]) = 1))
@@ -546,7 +546,7 @@ ORDER BY c["Id"]
 
                 AssertSql(
                     """
-SELECT VALUE o["Details"]
+SELECT VALUE o
 FROM root c
 JOIN o IN c["Orders"]
 WHERE (c["Terminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (ARRAY_LENGTH(o["Details"]) = 1))


### PR DESCRIPTION
Don't bind non scalar subquery results for ToList projections
**This would change behaviour from 10.0.0, where some queries compiled and might have worked, but actually didn't use a real materializer. If the user didn't have any custom ef config and their model matches the json**
Closes: #38121 