### PR TITLE
Fix query filter parameter naming for primary constructors

### DIFF
--- a/src/EFCore/Query/Internal/ExpressionTreeFuncletizer.cs
+++ b/src/EFCore/Query/Internal/ExpressionTreeFuncletizer.cs
@@ -2145,7 +2145,7 @@ public class ExpressionTreeFuncletizer : ExpressionVisitor
                 if (visited != expression)
                 {
                     parameterName = QueryFilterPrefix
-                        + (RemoveConvert(expression) is MemberExpression { Member.Name: var memberName } ? ("__" + memberName) : "__p");
+                        + (RemoveConvert(expression) is MemberExpression { Member.Name: var memberName } ? ("__" + SanitizeCompilerGeneratedName(memberName)) : "__p");
                     isContextAccessor = true;
 
                     // Context accessors (query filters accessing the context) never get constantized


### PR DESCRIPTION
## Description
This PR fixes a regression introduced in 10.0.6 where queries using `HasQueryFilter` fail when the filter references a primary constructor parameter.

### Root Cause
When a query filter captures a primary constructor parameter, the C# compiler generates a backing field with a name like `<variable>P`. The `ExpressionTreeFuncletizer` was using the raw `Member.Name` for the parameter name without sanitization, resulting in invalid SQL parameter names (e.g., `@ef_filter__<tenantUuid>P`) which causes a `SqlException`.

### Fix
Applied `SanitizeCompilerGeneratedName` to the member name in the `_generateContextAccessors` block within `ExpressionTreeFuncletizer.cs`. This ensures that angle brackets and other compiler-generated characters are stripped before the SQL parameter name is constructed.

Fixes #38132