### PR TITLE
[release/10.0] Fix query filter parameter names with primary constructor parameters

### DIFF
--- a/src/EFCore/Query/Internal/ExpressionTreeFuncletizer.cs
+++ b/src/EFCore/Query/Internal/ExpressionTreeFuncletizer.cs
@@ -31,6 +31,9 @@ public class ExpressionTreeFuncletizer : ExpressionVisitor
     private static readonly bool UseOldBehavior37974 =
         AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue37974", out var enabled37974) && enabled37974;
 
+    private static readonly bool UseOldBehavior38132 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue38132", out var enabled38132) && enabled38132;
+
     // The general algorithm here is the following.
     // 1. First, for each node type, visit that node's children and get their states (evaluatable, contains evaluatable, no evaluatable).
     // 2. Calculate the parent node's aggregate state from its children; a container node whose children are all evaluatable is itself
@@ -2129,6 +2132,19 @@ public class ExpressionTreeFuncletizer : ExpressionVisitor
                 }
             }
 
+            if (!UseOldBehavior38132)
+            {
+                // As a safety guard, if there's any problematic character in the name for any reason, fall back to "p".
+                foreach (var c in parameterName)
+                {
+                    if (!char.IsLetterOrDigit(c) && c != '_')
+                    {
+                        parameterName = "p";
+                        break;
+                    }
+                }
+            }
+
             if (UseOldBehavior37152)
             {
                 // Uniquify the parameter name
@@ -2169,7 +2185,9 @@ public class ExpressionTreeFuncletizer : ExpressionVisitor
                 if (visited != expression)
                 {
                     parameterName = QueryFilterPrefix
-                        + (RemoveConvert(expression) is MemberExpression { Member.Name: var memberName } ? ("__" + memberName) : "__p");
+                        + (RemoveConvert(expression) is MemberExpression { Member.Name: var memberName }
+                            ? "__" + (UseOldBehavior38132 ? memberName : SanitizeCompilerGeneratedName(memberName))
+                            : "__p");
                     isContextAccessor = true;
 
                     // Context accessors (query filters accessing the context) never get constantized

--- a/test/EFCore.Specification.Tests/Query/AdHocQueryFiltersQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AdHocQueryFiltersQueryTestBase.cs
@@ -815,4 +815,39 @@ public abstract class AdHocQueryFiltersQueryTestBase(NonSharedFixture fixture)
     }
 
     #endregion
+
+    #region 38132
+
+    [ConditionalFact]
+    public virtual async Task Query_filter_with_pk_ctor_parameter()
+    {
+        var contextFactory = await InitializeAsync<Context38132>(
+            addServices: s =>
+            {
+                s.AddSingleton(typeof(Guid),
+                    new Guid("00000001-0000-0000-0000-000000000001"));
+                return s;
+            },
+            usePooling: false);
+        using var context = contextFactory.CreateContext();
+
+        var result = context.Set<Entity38132>().ToList();
+        Assert.Empty(result);
+    }
+
+    protected class Context38132(DbContextOptions options, Guid tenantId) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<Entity38132>()
+                .HasQueryFilter(e => e.TenantId == tenantId);
+    }
+
+    public class Entity38132
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public Guid TenantId { get; set; }
+    }
+
+    #endregion
 }

--- a/test/EFCore.Specification.Tests/Query/AdHocQueryFiltersQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AdHocQueryFiltersQueryTestBase.cs
@@ -819,7 +819,7 @@ public abstract class AdHocQueryFiltersQueryTestBase(NonSharedFixture fixture)
     #region 38132
 
     [ConditionalFact]
-    public virtual async Task Query_filter_with_pk_ctor_parameter()
+    public virtual async Task Query_filter_with_primary_constructor_parameter()
     {
         var contextFactory = await InitializeAsync<Context38132>(
             addServices: s =>

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocQueryFiltersQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocQueryFiltersQuerySqlServerTest.cs
@@ -446,9 +446,9 @@ ORDER BY [s].[Name]
 """);
     }
 
-    public override async Task Query_filter_with_pk_ctor_parameter()
+    public override async Task Query_filter_with_primary_constructor_parameter()
     {
-        await base.Query_filter_with_pk_ctor_parameter();
+        await base.Query_filter_with_primary_constructor_parameter();
 
         AssertSql(
             """

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocQueryFiltersQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocQueryFiltersQuerySqlServerTest.cs
@@ -445,4 +445,18 @@ WHERE [s].[IsDeleted] = 0
 ORDER BY [s].[Name]
 """);
     }
+
+    public override async Task Query_filter_with_pk_ctor_parameter()
+    {
+        await base.Query_filter_with_pk_ctor_parameter();
+
+        AssertSql(
+            """
+@ef_filter__tenantId='00000001-0000-0000-0000-000000000001'
+
+SELECT [e].[Id], [e].[Name], [e].[TenantId]
+FROM [Entity38132] AS [e]
+WHERE [e].[TenantId] = @ef_filter__tenantId
+""");
+    }
 }


### PR DESCRIPTION
Fixes #38132

**Description**
When a query filter references a primary constructor parameter (e.g. `tenantId`), the C# compiler stores it as a backing field with a compiler-generated name containing angle brackets (e.g. `<tenantId>P`). The query filter parameter naming code in `ExpressionTreeFuncletizer` used this raw `Member.Name` to build the SQL parameter name, producing names like `@ef_filter__<tenantId>P`. The angle brackets are not valid in SQL parameter names, causing query execution to fail. This was introduced by #37805, which replaced the old angle-bracket stripping logic with `SanitizeCompilerGeneratedName` but only applied it to the regular parameter evaluation path, not the query filter naming path.

**Customer impact**
Any query filter that captures a primary constructor parameter of the `DbContext` will fail at runtime with a `SqlException`:

```csharp
sealed class MyContext(string conn, Guid tenantId) : DbContext(...)
{
    protected override void OnModelCreating(ModelBuilder modelBuilder)
        => modelBuilder.Entity<Person>().HasQueryFilter(b => b.TenantId == tenantId);
}
```

The generated SQL contains `@ef_filter__<tenantId>P` which is invalid. There is no workaround other than downgrading to 10.0.5 or restructuring the context to avoid primary constructor parameters.

**How found**
User reported on 10.0.6. The issue clearly reproduces on 10.0.6 but not 10.0.5.

**Regression**
Yes. Introduced in 10.0.6 by #37805 (fix for #37465), which changed the parameter name sanitization logic but missed the query filter naming path.

**Testing**
1 new functional test added (`Query_filter_with_primary_constructor_parameter`) verifying that a query filter referencing a primary constructor parameter produces valid SQL with a sanitized parameter name.

**Risk**
Very low. The fix applies the existing `SanitizeCompilerGeneratedName` helper to the query filter parameter naming path where it was missing, and adds a general safety-net fallback (ported from `main`) that catches any remaining invalid characters. Quirk added (`Microsoft.EntityFrameworkCore.Issue38132`).