### PR TITLE
fix #34001: NULL handling in search condition CASE/WHEN

### DIFF
--- a/src/EFCore.SqlServer/Query/Internal/SearchConditionConverter.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SearchConditionConverter.cs
@@ -76,15 +76,17 @@ public class SearchConditionConverter(ISqlExpressionFactory sqlExpressionFactory
                 : sqlExpressionFactory.Equal(sqlExpression, sqlExpressionFactory.Constant(true)),
 
             // A search condition expression in non-search condition context - wrap in CASE/WHEN to convert to bit:
-            // e.g. SELECT a LIKE b => SELECT CASE WHEN a LIKE b THEN 1 ELSE 0 END
-            // TODO: NULL is not handled properly here, see #34001
+            // e.g. SELECT a LIKE b => SELECT CASE WHEN a LIKE b THEN 1 WHEN NOT (a LIKE b) THEN 0 ELSE NULL END
             (false, true) => sqlExpressionFactory.Case(
                 [
                     new CaseWhenClause(
                         SimplifyNegatedBinary(sqlExpression),
-                        sqlExpressionFactory.ApplyDefaultTypeMapping(sqlExpressionFactory.Constant(true)))
+                        sqlExpressionFactory.ApplyDefaultTypeMapping(sqlExpressionFactory.Constant(true))),
+                    new CaseWhenClause(
+                        SimplifyNegatedBinary(sqlExpressionFactory.Not(sqlExpression)),
+                        sqlExpressionFactory.ApplyDefaultTypeMapping(sqlExpressionFactory.Constant(false)))
                 ],
-                sqlExpressionFactory.Constant(false)),
+                sqlExpressionFactory.Constant(null, sqlExpression.Type, sqlExpression.TypeMapping)),
 
             // All other cases (e.g. WHERE a LIKE b, SELECT b.SomebitColumn) - no need to do anything.
             _ => sqlExpression


### PR DESCRIPTION
fixes #34001 bug issue

<!--
Please check whether the PR fulfills these requirements
-->

- [x] I've read the guidelines for [contributing](https://github.com/dotnet/efcore/blob/main/.github/CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [ ] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

Description
---

The SqlServer ``SearchConditionConverter`` previously forced a binary translation ``CASE WHEN <condition> THEN 1 ELSE 0 END``. This caused UNKNOWN evaluations when NULL was involved in the original expression to erroneously fall back to 0 false.

My local test
---

```csharp
using System;
using System.Linq;
using Microsoft.EntityFrameworkCore;

class Program
{
    static void Main()
    {
        using var db = new TestContext();
        var query = db.Entities
            .Select(e => EF.Functions.Like(e.NullableString, "a"));

        Console.WriteLine("Generated SQL for SELECT LIKE:");
        Console.WriteLine("-------");
        Console.WriteLine(query.ToQueryString());
        Console.WriteLine("-------");
        
        var query2 = db.Entities
            .Select(e => e.NullableInt > 0);

        Console.WriteLine("Generated SQL for SELECT > 0:");
        Console.WriteLine("-------");
        Console.WriteLine(query2.ToQueryString());
        Console.WriteLine("-------");
        
        var query3 = db.Entities
            .Select(e => (bool?)(e.NullableInt > 0));

        Console.WriteLine("Generated SQL for SELECT (bool?)(> 0):");
        Console.WriteLine("-------");
        Console.WriteLine(query3.ToQueryString());
        Console.WriteLine("-------");
    }
}

public class TestEntity
{
    public int Id { get; set; }
    public string? NullableString { get; set; }
    public int? NullableInt { get; set; }
}

public class TestContext : DbContext
{
    public DbSet<TestEntity> Entities { get; set; }
    protected override void OnConfiguring(DbContextOptionsBuilder options)
    {
        options.UseSqlServer("Server=unreachable;Database=dummy;Integrated Security=True;", o => o.UseRelationalNulls(true));
    }
    protected override void OnModelCreating(ModelBuilder modelBuilder)
    {
        modelBuilder.Entity<TestEntity>().HasNoKey();
    }
}

```

---

Log test
```sql
Generated SQL for SELECT LIKE:
-------
SELECT CASE
    WHEN [e].[NullableString] LIKE N'a' THEN CAST(1 AS bit)
    WHEN [e].[NullableString] NOT LIKE N'a' THEN CAST(0 AS bit)
END
FROM [Entities] AS [e]
-------
Generated SQL for SELECT > 0:
-------
SELECT CASE
    WHEN [e].[NullableInt] > 0 THEN CAST(1 AS bit)
    ELSE CAST(0 AS bit)
END
FROM [Entities] AS [e]
-------
Generated SQL for SELECT (bool?)(> 0):
-------
SELECT CASE
    WHEN [e].[NullableInt] > 0 THEN CAST(1 AS bit)
    ELSE CAST(0 AS bit)
END
FROM [Entities] AS [e]
-------
```