### PR TITLE
Better error when using EF.Constant/Parameter with compiled queries or query filters

### DIFF
--- a/src/EFCore/EFCore.baseline.json
+++ b/src/EFCore/EFCore.baseline.json
@@ -3971,6 +3971,9 @@
           "Member": "static string DuplicateTrigger(object? trigger, object? entityType, object? conflictingEntityType);"
         },
         {
+          "Member": "static string EFMethodNotSupportedInCompiledQueries(object? methodName);"
+        },
+        {
           "Member": "static string EFMethodWithNonEvaluatableArgument(object? methodName);"
         },
         {

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -1229,6 +1229,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => GetString("EFConstantNotSupportedInPrecompiledQueries");
 
         /// <summary>
+        ///     '{methodName}' is not supported when using compiled queries or query filters.
+        /// </summary>
+        public static string EFMethodNotSupportedInCompiledQueries(object? methodName)
+            => string.Format(
+                GetString("EFMethodNotSupportedInCompiledQueries", nameof(methodName)),
+                methodName);
+
+        /// <summary>
         ///     The '{methodName}' method may only be used with an argument that can be evaluated client-side and does not contain any reference to database-side entities.
         /// </summary>
         public static string EFMethodWithNonEvaluatableArgument(object? methodName)

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -576,6 +576,9 @@
   <data name="EFConstantNotSupportedInPrecompiledQueries" xml:space="preserve">
     <value>The 'EF.Constant&lt;T&gt;' method is not supported when using precompiled queries.</value>
   </data>
+  <data name="EFMethodNotSupportedInCompiledQueries" xml:space="preserve">
+    <value>'{methodName}' is not supported when using compiled queries or query filters.</value>
+  </data>
   <data name="EFMethodWithNonEvaluatableArgument" xml:space="preserve">
     <value>The '{methodName}' method may only be used with an argument that can be evaluated client-side and does not contain any reference to database-side entities.</value>
   </data>

--- a/src/EFCore/Query/Internal/ExpressionTreeFuncletizer.cs
+++ b/src/EFCore/Query/Internal/ExpressionTreeFuncletizer.cs
@@ -934,6 +934,11 @@ public class ExpressionTreeFuncletizer : ExpressionVisitor
                         throw new InvalidOperationException(CoreStrings.EFConstantNotSupportedInPrecompiledQueries);
                     }
 
+                    if (!_parameterize)
+                    {
+                        throw new InvalidOperationException(CoreStrings.EFMethodNotSupportedInCompiledQueries("EF.Constant<T>"));
+                    }
+
                     var argument = Visit(methodCall.Arguments[0], out var argumentState);
 
                     if (!argumentState.IsEvaluatable)
@@ -1118,6 +1123,11 @@ public class ExpressionTreeFuncletizer : ExpressionVisitor
 
         Expression HandleParameter(MethodCallExpression methodCall, string methodName)
         {
+            if (!_parameterize)
+            {
+                throw new InvalidOperationException(CoreStrings.EFMethodNotSupportedInCompiledQueries(methodName));
+            }
+
             var argument = Visit(methodCall.Arguments[0], out var argumentState);
 
             if (!argumentState.IsEvaluatable)

--- a/test/EFCore.Specification.Tests/Query/AdHocQueryFiltersQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AdHocQueryFiltersQueryTestBase.cs
@@ -850,4 +850,52 @@ public abstract class AdHocQueryFiltersQueryTestBase(NonSharedFixture fixture)
     }
 
     #endregion
+
+    #region 38151
+
+    [ConditionalFact]
+    public virtual async Task Query_filter_with_EF_Constant_throws()
+    {
+        var contextFactory = await InitializeNonSharedTest<Context38151_Constant>();
+        using var context = contextFactory.CreateDbContext();
+
+        var message = Assert.Throws<InvalidOperationException>(() => context.Set<Entity38151>().ToList()).Message;
+        Assert.Equal(CoreStrings.EFMethodNotSupportedInCompiledQueries("EF.Constant<T>"), message);
+    }
+
+    protected class Context38151_Constant(DbContextOptions options) : DbContext(options)
+    {
+        public int TenantId { get; set; } = 1;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<Entity38151>()
+                .HasQueryFilter(e => e.TenantId == EF.Constant(TenantId));
+    }
+
+    [ConditionalFact]
+    public virtual async Task Query_filter_with_EF_Parameter_throws()
+    {
+        var contextFactory = await InitializeNonSharedTest<Context38151_Parameter>();
+        using var context = contextFactory.CreateDbContext();
+
+        var message = Assert.Throws<InvalidOperationException>(() => context.Set<Entity38151>().ToList()).Message;
+        Assert.Equal(CoreStrings.EFMethodNotSupportedInCompiledQueries("EF.Parameter<T>"), message);
+    }
+
+    protected class Context38151_Parameter(DbContextOptions options) : DbContext(options)
+    {
+        public int TenantId { get; set; } = 1;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<Entity38151>()
+                .HasQueryFilter(e => e.TenantId == EF.Parameter(TenantId));
+    }
+
+    public class Entity38151
+    {
+        public int Id { get; set; }
+        public int TenantId { get; set; }
+    }
+
+    #endregion
 }

--- a/test/EFCore.Specification.Tests/Query/NorthwindCompiledQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindCompiledQueryTestBase.cs
@@ -801,6 +801,32 @@ public abstract class NorthwindCompiledQueryTestBase<TFixture>(TFixture fixture)
                 "CHOPS", "CONSH", default));
     }
 
+    [ConditionalFact]
+    public virtual void Compiled_query_with_EF_Constant_throws()
+    {
+        var query = EF.CompileQuery(
+            (NorthwindContext context) => context.Customers.Where(c => c.CustomerID == EF.Constant("ALFKI")));
+
+        using var context = CreateContext();
+
+        var message = Assert.Throws<InvalidOperationException>(() => query(context).ToList()).Message;
+        Assert.Equal(CoreStrings.EFMethodNotSupportedInCompiledQueries("EF.Constant<T>"), message);
+    }
+
+    [ConditionalFact]
+    public virtual void Compiled_query_with_EF_Parameter_throws()
+    {
+        var customerID = "ALFKI";
+
+        var query = EF.CompileQuery(
+            (NorthwindContext context) => context.Customers.Where(c => c.CustomerID == EF.Parameter(customerID)));
+
+        using var context = CreateContext();
+
+        var message = Assert.Throws<InvalidOperationException>(() => query(context).ToList()).Message;
+        Assert.Equal(CoreStrings.EFMethodNotSupportedInCompiledQueries("EF.Parameter<T>"), message);
+    }
+
     protected async Task<int> CountAsync<T>(IAsyncEnumerable<T> source)
     {
         var count = 0;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindCompiledQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindCompiledQuerySqlServerTest.cs
@@ -759,6 +759,12 @@ ORDER BY [c].[CustomerID]
 """);
     }
 
+    public override void Compiled_query_with_EF_Constant_throws()
+        => base.Compiled_query_with_EF_Constant_throws();
+
+    public override void Compiled_query_with_EF_Parameter_throws()
+        => base.Compiled_query_with_EF_Parameter_throws();
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }


### PR DESCRIPTION
When `EF.Constant()`, `EF.Parameter()`, or `EF.MultipleParameters()` are used inside compiled queries or query filters, a cryptic `InvalidCastException` was thrown:

```
System.InvalidCastException: Unable to cast object of type 'System.Linq.Expressions.ConstantExpression'
  to type 'Microsoft.EntityFrameworkCore.Query.QueryParameterExpression'.
```

This now throws a clear `InvalidOperationException` with the message:
> '{methodName}' is not supported when using compiled queries or query filters.

The check is placed in `ExpressionTreeFuncletizer` where the `parameterize` flag is known to be `false` for compiled queries and query filters — the two contexts where these methods aren't supported.

### Changes
- **`ExpressionTreeFuncletizer.cs`** — Added `!_parameterize` checks in `EF.Constant` and `HandleParameter` (used by `EF.Parameter` and `MultipleParameters`) handlers
- **`CoreStrings.resx` / `.Designer.cs`** — New `EFMethodNotSupportedInCompiledQueries` resource string
- **Tests** — 4 new tests: 2 for compiled queries (`NorthwindCompiledQueryTestBase`) + 2 for query filters (`AdHocQueryFiltersQueryTestBase`)

Closes #38151