### PR TITLE
Strip no-op SQL CASTs

### DIFF
--- a/src/EFCore.Relational/Query/Internal/SqlExpressionSimplifyingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/SqlExpressionSimplifyingExpressionVisitor.cs
@@ -12,22 +12,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public class SqlExpressionSimplifyingExpressionVisitor : ExpressionVisitor
+public class SqlExpressionSimplifyingExpressionVisitor(
+    ISqlExpressionFactory _sqlExpressionFactory,
+    bool _useRelationalNulls) : ExpressionVisitor
 {
-    private readonly ISqlExpressionFactory _sqlExpressionFactory;
-    private readonly bool _useRelationalNulls;
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public SqlExpressionSimplifyingExpressionVisitor(ISqlExpressionFactory sqlExpressionFactory, bool useRelationalNulls)
-    {
-        _sqlExpressionFactory = sqlExpressionFactory;
-        _useRelationalNulls = useRelationalNulls;
-    }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -37,50 +25,51 @@ public class SqlExpressionSimplifyingExpressionVisitor : ExpressionVisitor
     /// </summary>
     protected override Expression VisitExtension(Expression extensionExpression)
     {
-        if (extensionExpression is ShapedQueryExpression shapedQueryExpression)
+        switch (extensionExpression)
         {
-            var newQueryExpression = Visit(shapedQueryExpression.QueryExpression);
-            var newShaperExpression = Visit(shapedQueryExpression.ShaperExpression);
-
-            return shapedQueryExpression.Update(newQueryExpression, newShaperExpression);
-        }
-
-        if (extensionExpression is SqlBinaryExpression sqlBinaryExpression)
-        {
-            return SimplifySqlBinary(sqlBinaryExpression);
-        }
-
-        if (extensionExpression is SqlFunctionExpression sqlFunctionExpression
-            && IsCoalesce(sqlFunctionExpression))
-        {
-            var arguments = new List<SqlExpression>();
-            foreach (var argument in sqlFunctionExpression.Arguments!)
+            case ShapedQueryExpression shapedQueryExpression:
             {
-                var newArgument = (SqlExpression)Visit(argument);
-                if (IsCoalesce(newArgument))
-                {
-                    arguments.AddRange(((SqlFunctionExpression)newArgument).Arguments!);
-                }
-                else
-                {
-                    arguments.Add(newArgument);
-                }
+                var newQueryExpression = Visit(shapedQueryExpression.QueryExpression);
+                var newShaperExpression = Visit(shapedQueryExpression.ShaperExpression);
+
+                return shapedQueryExpression.Update(newQueryExpression, newShaperExpression);
             }
 
-            var distinctArguments = arguments.Distinct().ToList();
+            case SqlBinaryExpression sqlBinaryExpression:
+                return SimplifySqlBinary(sqlBinaryExpression);
 
-            return distinctArguments.Count > 1
-                ? new SqlFunctionExpression(
-                    sqlFunctionExpression.Name,
-                    distinctArguments,
-                    sqlFunctionExpression.IsNullable,
-                    argumentsPropagateNullability: distinctArguments.Select(_ => false).ToArray(),
-                    sqlFunctionExpression.Type,
-                    sqlFunctionExpression.TypeMapping)
-                : distinctArguments[0];
+            case SqlFunctionExpression sqlFunctionExpression when IsCoalesce(sqlFunctionExpression):
+            {
+                var arguments = new List<SqlExpression>();
+                foreach (var argument in sqlFunctionExpression.Arguments!)
+                {
+                    var newArgument = (SqlExpression)Visit(argument);
+                    if (IsCoalesce(newArgument))
+                    {
+                        arguments.AddRange(((SqlFunctionExpression)newArgument).Arguments!);
+                    }
+                    else
+                    {
+                        arguments.Add(newArgument);
+                    }
+                }
+
+                var distinctArguments = arguments.Distinct().ToList();
+
+                return distinctArguments.Count > 1
+                    ? new SqlFunctionExpression(
+                        sqlFunctionExpression.Name,
+                        distinctArguments,
+                        sqlFunctionExpression.IsNullable,
+                        argumentsPropagateNullability: distinctArguments.Select(_ => false).ToArray(),
+                        sqlFunctionExpression.Type,
+                        sqlFunctionExpression.TypeMapping)
+                    : distinctArguments[0];
+            }
+
+            default:
+                return base.VisitExtension(extensionExpression);
         }
-
-        return base.VisitExtension(extensionExpression);
 
         static bool IsCoalesce(SqlExpression sqlExpression)
             => sqlExpression is SqlFunctionExpression { IsBuiltIn: true, Instance: null } sqlFunctionExpression

--- a/src/EFCore.Relational/Query/Internal/SqlExpressionSimplifyingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/SqlExpressionSimplifyingExpressionVisitor.cs
@@ -35,6 +35,20 @@ public class SqlExpressionSimplifyingExpressionVisitor(
                 return shapedQueryExpression.Update(newQueryExpression, newShaperExpression);
             }
 
+            // Strip no-op SQL CASTs: when the Convert's store type matches the operand's store type,
+            // the CAST would be a no-op in SQL (e.g. CAST(column AS nvarchar(max)) when column is already nvarchar(max)).
+            // This can occur in various situations, e.g. when a C# implicit conversion exists for a value-converted type
+            // (see #36247 for more context on why we don't refrain from creating the CAST node during translation).
+            // However, CASTs around constants are preserved: they serve to explicitly type the constant in SQL
+            // (e.g. CAST(100 AS int)), which is important for some queries.
+            case SqlUnaryExpression
+            {
+                OperatorType: ExpressionType.Convert,
+                Operand: not SqlConstantExpression and { TypeMapping.StoreType: var operandStoreType } operand,
+                TypeMapping.StoreType: var convertStoreType
+            } when convertStoreType == operandStoreType:
+                return Visit(operand);
+
             case SqlBinaryExpression sqlBinaryExpression:
                 return SimplifySqlBinary(sqlBinaryExpression);
 

--- a/src/EFCore.SqlServer/Query/Internal/Translators/SqlServerIsDateFunctionTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/Translators/SqlServerIsDateFunctionTranslator.cs
@@ -33,7 +33,7 @@ public class SqlServerIsDateFunctionTranslator(ISqlExpressionFactory sqlExpressi
                         [arguments[1]],
                         nullable: true,
                         argumentsPropagateNullability: Statics.TrueArrays[1],
-                        method.ReturnType),
+                        typeof(int)),
                     method.ReturnType)
                 : null;
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/AdHocMiscellaneousQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/AdHocMiscellaneousQueryRelationalTestBase.cs
@@ -349,6 +349,53 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         #endregion
+
+        #region 36247
+
+        [ConditionalTheory, MemberData(nameof(IsAsyncData))]
+        public virtual async Task Like_on_value_converted_string_column_does_not_produce_cast(bool async)
+        {
+            var contextFactory = await InitializeNonSharedTest<Context36247>(
+                seed: async ctx =>
+                {
+                    ctx.Users.AddRange(
+                        new Context36247.User { Name = new Context36247.FullName("Name1") },
+                        new Context36247.User { Name = new Context36247.FullName("Name2") });
+                    await ctx.SaveChangesAsync();
+                });
+            using var context = contextFactory.CreateDbContext();
+
+            var query = context.Users.Where(x => EF.Functions.Like(x.Name, "Name%"));
+
+            var result = async
+                ? await query.ToListAsync()
+                : [.. query];
+
+            Assert.Equal(2, result.Count);
+        }
+
+        protected class Context36247(DbContextOptions options) : DbContext(options)
+        {
+            public DbSet<User> Users { get; set; }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+                => modelBuilder.Entity<User>().Property(e => e.Name)
+                    .HasConversion(v => v.Value, v => new FullName(v));
+
+            public class User
+            {
+                public int Id { get; set; }
+                public FullName Name { get; set; }
+            }
+
+            public readonly record struct FullName(string Value)
+            {
+                public static implicit operator string(FullName fullName)
+                    => fullName.Value;
+            }
+        }
+
+        #endregion
     }
 }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocMiscellaneousQuerySqlServerTest.cs
@@ -2211,7 +2211,7 @@ WHERE [f].[Taste] = CAST(1 AS tinyint)
 
         AssertSql(
             """
-SELECT CAST([f].[Taste] AS tinyint) AS [Bar]
+SELECT [f].[Taste] AS [Bar]
 FROM [Foods] AS [f]
 """);
     }
@@ -2668,6 +2668,18 @@ SELECT [d].[Id], CASE
 END AS [Foo]
 FROM [Data] AS [d]
 ORDER BY [d].[Id]
+""");
+    }
+
+    public override async Task Like_on_value_converted_string_column_does_not_produce_cast(bool async)
+    {
+        await base.Like_on_value_converted_string_column_does_not_produce_cast(async);
+
+        AssertSql(
+            """
+SELECT [u].[Id], [u].[Name]
+FROM [Users] AS [u]
+WHERE [u].[Name] LIKE N'Name%'
 """);
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -3546,7 +3546,7 @@ FROM [Weapons] AS [w]
             """
 SELECT [m].[CodeName]
 FROM [Missions] AS [m]
-WHERE CAST([m].[Difficulty] AS nvarchar(max)) LIKE N'%Med%'
+WHERE [m].[Difficulty] LIKE N'%Med%'
 """);
     }
 
@@ -7429,7 +7429,7 @@ WHERE @prm & [g].[Rank] = [g].[Rank]
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
-WHERE @prm & CAST([g].[Rank] AS int) = CAST([g].[Rank] AS int)
+WHERE @prm & [g].[Rank] = [g].[Rank]
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Inheritance/TPCGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Inheritance/TPCGearsOfWarQuerySqlServerTest.cs
@@ -4730,7 +4730,7 @@ FROM [Weapons] AS [w]
             """
 SELECT [m].[CodeName]
 FROM [Missions] AS [m]
-WHERE CAST([m].[Difficulty] AS nvarchar(max)) LIKE N'%Med%'
+WHERE [m].[Difficulty] LIKE N'%Med%'
 """);
     }
 
@@ -9915,7 +9915,7 @@ FROM (
     SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOfBirthName], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o]
 ) AS [u]
-WHERE @prm & CAST([u].[Rank] AS int) = CAST([u].[Rank] AS int)
+WHERE @prm & [u].[Rank] = [u].[Rank]
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Inheritance/TPTGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Inheritance/TPTGearsOfWarQuerySqlServerTest.cs
@@ -4139,7 +4139,7 @@ FROM [Weapons] AS [w]
             """
 SELECT [m].[CodeName]
 FROM [Missions] AS [m]
-WHERE CAST([m].[Difficulty] AS nvarchar(max)) LIKE N'%Med%'
+WHERE [m].[Difficulty] LIKE N'%Med%'
 """);
     }
 
@@ -8377,7 +8377,7 @@ SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthNa
 END AS [Discriminator]
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId] = [o].[SquadId]
-WHERE @prm & CAST([g].[Rank] AS int) = CAST([g].[Rank] AS int)
+WHERE @prm & [g].[Rank] = [g].[Rank]
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSqlQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSqlQuerySqlServerTest.cs
@@ -50,11 +50,11 @@ WHERE [o].[OrderID] IN (
 
         AssertSql(
             """
-SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], CAST([s].[Value] AS int) AS [p]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [s].[Value] AS [p]
 FROM [Orders] AS [o]
 INNER JOIN (
     SELECT "ProductID" AS "Value" FROM "Products"
-) AS [s] ON [o].[OrderID] = CAST([s].[Value] AS int)
+) AS [s] ON [o].[OrderID] = [s].[Value]
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQueryOldSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQueryOldSqlServerTest.cs
@@ -449,7 +449,7 @@ SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT COUNT(*)
-    FROM (VALUES (CAST(@i AS int))) AS [v]([Value])
+    FROM (VALUES (@i)) AS [v]([Value])
     WHERE [v].[Value] > [p].[Id]) = 1
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServer160Test.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServer160Test.cs
@@ -415,7 +415,7 @@ SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT COUNT(*)
-    FROM (VALUES (CAST(@i AS int))) AS [v]([Value])
+    FROM (VALUES (@i)) AS [v]([Value])
     WHERE [v].[Value] > [p].[Id]) = 1
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerJsonTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerJsonTypeTest.cs
@@ -48,7 +48,7 @@ SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT COUNT(*)
-    FROM (VALUES (CAST(@i AS int))) AS [v]([Value])
+    FROM (VALUES (@i)) AS [v]([Value])
     WHERE [v].[Value] > [p].[Id]) = 1
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerTest.cs
@@ -443,7 +443,7 @@ SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT COUNT(*)
-    FROM (VALUES (CAST(@i AS int))) AS [v]([Value])
+    FROM (VALUES (@i)) AS [v]([Value])
     WHERE [v].[Value] > [p].[Id]) = 1
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
@@ -4239,7 +4239,7 @@ FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
             """
 SELECT [m].[CodeName]
 FROM [Missions] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [m]
-WHERE CAST([m].[Difficulty] AS nvarchar(max)) LIKE N'%Med%'
+WHERE [m].[Difficulty] LIKE N'%Med%'
 """);
     }
 
@@ -5350,7 +5350,7 @@ FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
-WHERE @prm & CAST([g].[Rank] AS int) = CAST([g].[Rank] AS int)
+WHERE @prm & [g].[Rank] = [g].[Rank]
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Translations/Temporal/TimeOnlyTranslationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Translations/Temporal/TimeOnlyTranslationsSqlServerTest.cs
@@ -188,7 +188,7 @@ WHERE CAST([b].[DateTime] AS time) = '15:30:10'
             """
 SELECT [b].[Id], [b].[Bool], [b].[Byte], [b].[ByteArray], [b].[DateOnly], [b].[DateTime], [b].[DateTimeOffset], [b].[Decimal], [b].[Double], [b].[Enum], [b].[FlagsEnum], [b].[Float], [b].[Guid], [b].[Int], [b].[Long], [b].[Short], [b].[String], [b].[TimeOnly], [b].[TimeSpan]
 FROM [BasicTypesEntities] AS [b]
-WHERE CAST([b].[TimeSpan] AS time) < [b].[TimeOnly]
+WHERE [b].[TimeSpan] < [b].[TimeOnly]
 """);
     }
 
@@ -202,7 +202,7 @@ WHERE CAST([b].[TimeSpan] AS time) < [b].[TimeOnly]
 
 SELECT [b].[Id], [b].[Bool], [b].[Byte], [b].[ByteArray], [b].[DateOnly], [b].[DateTime], [b].[DateTimeOffset], [b].[Decimal], [b].[Double], [b].[Enum], [b].[FlagsEnum], [b].[Float], [b].[Guid], [b].[Int], [b].[Long], [b].[Short], [b].[String], [b].[TimeOnly], [b].[TimeSpan]
 FROM [BasicTypesEntities] AS [b]
-WHERE CAST([b].[TimeSpan] AS time) = @time
+WHERE [b].[TimeSpan] = @time
 """);
     }
 
@@ -214,7 +214,7 @@ WHERE CAST([b].[TimeSpan] AS time) = @time
             """
 SELECT [b].[Id], [b].[Bool], [b].[Byte], [b].[ByteArray], [b].[DateOnly], [b].[DateTime], [b].[DateTimeOffset], [b].[Decimal], [b].[Double], [b].[Enum], [b].[FlagsEnum], [b].[Float], [b].[Guid], [b].[Int], [b].[Long], [b].[Short], [b].[String], [b].[TimeOnly], [b].[TimeSpan]
 FROM [BasicTypesEntities] AS [b]
-ORDER BY CAST([b].[TimeSpan] AS time)
+ORDER BY [b].[TimeSpan]
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
@@ -1770,7 +1770,7 @@ FROM "ObjectBackedDataTypes" AS "o"
 
         AssertSql(
             """
-SELECT CAST("b"."TestSignedByte" AS TEXT), CAST("b"."TestByte" AS TEXT), CAST("b"."TestInt16" AS TEXT), CAST("b"."TestUnsignedInt16" AS TEXT), CAST("b"."TestInt32" AS TEXT), CAST("b"."TestUnsignedInt32" AS TEXT), CAST("b"."TestInt64" AS TEXT), "b"."TestUnsignedInt64", CAST("b"."TestSingle" AS TEXT), CAST("b"."TestDouble" AS TEXT), CAST("b"."TestDecimal" AS TEXT), CAST("b"."TestCharacter" AS TEXT), CAST("b"."TestDateTime" AS TEXT), CAST("b"."TestDateTimeOffset" AS TEXT), CAST("b"."TestTimeSpan" AS TEXT), CAST("b"."TestDateOnly" AS TEXT), CAST("b"."TestTimeOnly" AS TEXT)
+SELECT CAST("b"."TestSignedByte" AS TEXT), CAST("b"."TestByte" AS TEXT), CAST("b"."TestInt16" AS TEXT), CAST("b"."TestUnsignedInt16" AS TEXT), CAST("b"."TestInt32" AS TEXT), CAST("b"."TestUnsignedInt32" AS TEXT), CAST("b"."TestInt64" AS TEXT), "b"."TestUnsignedInt64", CAST("b"."TestSingle" AS TEXT), CAST("b"."TestDouble" AS TEXT), "b"."TestDecimal", "b"."TestCharacter", "b"."TestDateTime", "b"."TestDateTimeOffset", "b"."TestTimeSpan", "b"."TestDateOnly", "b"."TestTimeOnly"
 FROM "BuiltInDataTypes" AS "b"
 WHERE "b"."Id" = 13
 """);

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqliteTest.cs
@@ -1069,7 +1069,7 @@ WHERE "o0"."OrderID" = "s"."OrderID"
 @p='1'
 
 UPDATE "Order Details" AS "o"
-SET "Quantity" = CAST(@p AS INTEGER)
+SET "Quantity" = @p
 FROM "Orders" AS "o0"
 LEFT JOIN "Customers" AS "c" ON "o0"."CustomerID" = "c"."CustomerID"
 WHERE "c"."City" = 'Seattle' AND "o"."OrderID" = "o0"."OrderID"
@@ -1546,7 +1546,7 @@ WHERE "c"."CustomerID" LIKE 'F%'
 @p2='10'
 
 UPDATE "Order Details" AS "o2"
-SET "Quantity" = CAST(@p AS INTEGER),
+SET "Quantity" = @p,
     "UnitPrice" = @p2
 FROM (
     SELECT "o1"."OrderID", "o1"."ProductID"

--- a/test/EFCore.Sqlite.FunctionalTests/Query/AdHocMiscellaneousQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/AdHocMiscellaneousQuerySqliteTest.cs
@@ -62,12 +62,12 @@ FROM "Prices" AS "p"
 """,
             //
             """
-SELECT CAST(AVG("p"."FloatColumn") AS REAL)
+SELECT AVG("p"."FloatColumn")
 FROM "Prices" AS "p"
 """,
             //
             """
-SELECT CAST(AVG("p"."NullableFloatColumn") AS REAL)
+SELECT AVG("p"."NullableFloatColumn")
 FROM "Prices" AS "p"
 """,
             //
@@ -158,6 +158,18 @@ SELECT "d"."Id", CASE
 END AS "Foo"
 FROM "Data" AS "d"
 ORDER BY "d"."Id"
+""");
+    }
+
+    public override async Task Like_on_value_converted_string_column_does_not_produce_cast(bool async)
+    {
+        await base.Like_on_value_converted_string_column_does_not_produce_cast(async);
+
+        AssertSql(
+            """
+SELECT "u"."Id", "u"."Name"
+FROM "Users" AS "u"
+WHERE "u"."Name" LIKE 'Name%'
 """);
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -2798,7 +2798,7 @@ FROM "Weapons" AS "w"
             """
 SELECT "m"."CodeName"
 FROM "Missions" AS "m"
-WHERE instr(CAST("m"."Difficulty" AS TEXT), 'Med') > 0
+WHERE instr("m"."Difficulty", 'Med') > 0
 """);
     }
 
@@ -4413,7 +4413,7 @@ WHERE substr("t"."Note", 0 + 1, "g"."SquadId") = "t"."GearNickName" OR (("t"."No
             """
 SELECT "l"."Name", "l"."Discriminator", "l"."LocustHordeId", "l"."ThreatLevel", "l"."ThreatLevelByte", "l"."ThreatLevelNullableByte", "l"."DefeatedByNickname", "l"."DefeatedBySquadId", "l"."HighCommandId"
 FROM "LocustLeaders" AS "l"
-WHERE CAST("l"."ThreatLevel" AS INTEGER) >= 5
+WHERE "l"."ThreatLevel" >= 5
 """);
     }
 
@@ -6514,7 +6514,7 @@ FROM "Gears" AS "g"
 
 SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank"
 FROM "Gears" AS "g"
-WHERE @prm & CAST("g"."Rank" AS INTEGER) = CAST("g"."Rank" AS INTEGER)
+WHERE @prm & "g"."Rank" = "g"."Rank"
 """);
     }
 
@@ -7481,7 +7481,7 @@ ORDER BY "f"."Id", "g0"."Nickname"
             """
 SELECT "l"."Name", "l"."Discriminator", "l"."LocustHordeId", "l"."ThreatLevel", "l"."ThreatLevelByte", "l"."ThreatLevelNullableByte", "l"."DefeatedByNickname", "l"."DefeatedBySquadId", "l"."HighCommandId"
 FROM "LocustLeaders" AS "l"
-WHERE CAST("l"."ThreatLevel" AS INTEGER) <= 5 + CAST("l"."ThreatLevel" AS INTEGER)
+WHERE "l"."ThreatLevel" <= 5 + "l"."ThreatLevel"
 """);
     }
 
@@ -8260,7 +8260,7 @@ INNER JOIN "Squads" AS "s" ON "g"."SquadId" = "s"."Id"
 
         AssertSql(
             """
-SELECT 'HasSoulPatch ' || CAST("g"."HasSoulPatch" AS TEXT) || ' HasSoulPatch' AS "HasSoulPatch", 'Rank ' || CAST("g"."Rank" AS TEXT) || ' Rank' AS "Rank", 'SquadId ' || CAST("g"."SquadId" AS TEXT) || ' SquadId' AS "SquadId", 'Rating ' || COALESCE(CAST("m"."Rating" AS TEXT), '') || ' Rating' AS "Rating", 'Timeline ' || CAST("m"."Timeline" AS TEXT) || ' Timeline' AS "Timeline"
+SELECT 'HasSoulPatch ' || CAST("g"."HasSoulPatch" AS TEXT) || ' HasSoulPatch' AS "HasSoulPatch", 'Rank ' || CAST("g"."Rank" AS TEXT) || ' Rank' AS "Rank", 'SquadId ' || CAST("g"."SquadId" AS TEXT) || ' SquadId' AS "SquadId", 'Rating ' || COALESCE(CAST("m"."Rating" AS TEXT), '') || ' Rating' AS "Rating", 'Timeline ' || "m"."Timeline" || ' Timeline' AS "Timeline"
 FROM "Gears" AS "g"
 CROSS JOIN "Missions" AS "m"
 ORDER BY "g"."Nickname", "m"."Id"
@@ -8847,7 +8847,7 @@ ORDER BY "g"."SquadId", "g"."Nickname"
 
         AssertSql(
             """
-SELECT "g"."FullName", CAST("l0"."ThreatLevel" AS INTEGER) AS "ThreatLevel"
+SELECT "g"."FullName", "l0"."ThreatLevel"
 FROM "Gears" AS "g"
 LEFT JOIN (
     SELECT "l"."ThreatLevel", "l"."DefeatedByNickname"

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindSelectQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindSelectQuerySqliteTest.cs
@@ -125,7 +125,7 @@ FROM "Orders" AS "o"
 
         AssertSql(
             """
-SELECT CAST(CAST(strftime('%w', "o"."OrderDate") AS INTEGER) AS INTEGER)
+SELECT CAST(strftime('%w', "o"."OrderDate") AS INTEGER)
 FROM "Orders" AS "o"
 """);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/PrimitiveCollectionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/PrimitiveCollectionsQuerySqliteTest.cs
@@ -426,7 +426,7 @@ SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE (
     SELECT COUNT(*)
-    FROM (SELECT CAST(@i AS INTEGER) AS "Value") AS "v"
+    FROM (SELECT @i AS "Value") AS "v"
     WHERE "v"."Value" > "p"."Id") = 1
 """);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Translations/EnumTranslationsSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Translations/EnumTranslationsSqliteTest.cs
@@ -138,13 +138,13 @@ WHERE "b"."FlagsEnum" & 8 = 8
             """
 SELECT "b"."Id", "b"."Bool", "b"."Byte", "b"."ByteArray", "b"."DateOnly", "b"."DateTime", "b"."DateTimeOffset", "b"."Decimal", "b"."Double", "b"."Enum", "b"."FlagsEnum", "b"."Float", "b"."Guid", "b"."Int", "b"."Long", "b"."Short", "b"."String", "b"."TimeOnly", "b"."TimeSpan"
 FROM "BasicTypesEntities" AS "b"
-WHERE CAST("b"."FlagsEnum" AS INTEGER) & 8 = 8
+WHERE "b"."FlagsEnum" & 8 = 8
 """,
             //
             """
 SELECT "b"."Id", "b"."Bool", "b"."Byte", "b"."ByteArray", "b"."DateOnly", "b"."DateTime", "b"."DateTimeOffset", "b"."Decimal", "b"."Double", "b"."Enum", "b"."FlagsEnum", "b"."Float", "b"."Guid", "b"."Int", "b"."Long", "b"."Short", "b"."String", "b"."TimeOnly", "b"."TimeSpan"
 FROM "BasicTypesEntities" AS "b"
-WHERE CAST("b"."FlagsEnum" AS INTEGER) & 8 = 8
+WHERE "b"."FlagsEnum" & 8 = 8
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Translations/GuidTranslationsSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Translations/GuidTranslationsSqliteTest.cs
@@ -44,7 +44,7 @@ WHERE "b"."Guid" = @p
 
         AssertSql(
             """
-SELECT CAST("b"."Guid" AS TEXT)
+SELECT "b"."Guid"
 FROM "BasicTypesEntities" AS "b"
 """);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Translations/MathTranslationsSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Translations/MathTranslationsSqliteTest.cs
@@ -47,7 +47,7 @@ WHERE abs("b"."Double") = 9.5
             """
 SELECT "b"."Id", "b"."Bool", "b"."Byte", "b"."ByteArray", "b"."DateOnly", "b"."DateTime", "b"."DateTimeOffset", "b"."Decimal", "b"."Double", "b"."Enum", "b"."FlagsEnum", "b"."Float", "b"."Guid", "b"."Int", "b"."Long", "b"."Short", "b"."String", "b"."TimeOnly", "b"."TimeSpan"
 FROM "BasicTypesEntities" AS "b"
-WHERE CAST(abs("b"."Float") AS REAL) = 9.5
+WHERE abs("b"."Float") = 9.5
 """);
     }
 
@@ -186,7 +186,7 @@ WHERE round("b"."Double", 1) = 255.09999999999999
             """
 SELECT "b"."Id", "b"."Bool", "b"."Byte", "b"."ByteArray", "b"."DateOnly", "b"."DateTime", "b"."DateTimeOffset", "b"."Decimal", "b"."Double", "b"."Enum", "b"."FlagsEnum", "b"."Float", "b"."Guid", "b"."Int", "b"."Long", "b"."Short", "b"."String", "b"."TimeOnly", "b"."TimeSpan"
 FROM "BasicTypesEntities" AS "b"
-WHERE round(CAST("b"."Float" AS REAL), 1) = 255.09999999999999
+WHERE round("b"."Float", 1) = 255.09999999999999
 """);
     }
 
@@ -609,7 +609,7 @@ WHERE "b"."Double" >= -1.0 AND "b"."Double" <= 1.0 AND asin("b"."Double") > -1.7
             """
 SELECT "b"."Id", "b"."Bool", "b"."Byte", "b"."ByteArray", "b"."DateOnly", "b"."DateTime", "b"."DateTimeOffset", "b"."Decimal", "b"."Double", "b"."Enum", "b"."FlagsEnum", "b"."Float", "b"."Guid", "b"."Int", "b"."Long", "b"."Short", "b"."String", "b"."TimeOnly", "b"."TimeSpan"
 FROM "BasicTypesEntities" AS "b"
-WHERE "b"."Float" >= -1 AND "b"."Float" <= 1 AND CAST(asin("b"."Float") AS REAL) > -1.7976931348623157E+308
+WHERE "b"."Float" >= -1 AND "b"."Float" <= 1 AND asin("b"."Float") > -1.7976931348623157E+308
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Translations/Operators/BitwiseOperatorTranslationsSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Translations/Operators/BitwiseOperatorTranslationsSqliteTest.cs
@@ -20,11 +20,11 @@ public class BitwiseOperatorTranslationsSqliteTest : BitwiseOperatorTranslations
             """
 SELECT "b"."Id", "b"."Bool", "b"."Byte", "b"."ByteArray", "b"."DateOnly", "b"."DateTime", "b"."DateTimeOffset", "b"."Decimal", "b"."Double", "b"."Enum", "b"."FlagsEnum", "b"."Float", "b"."Guid", "b"."Int", "b"."Long", "b"."Short", "b"."String", "b"."TimeOnly", "b"."TimeSpan"
 FROM "BasicTypesEntities" AS "b"
-WHERE CAST("b"."Int" AS INTEGER) | "b"."Long" = 7
+WHERE "b"."Int" | "b"."Long" = 7
 """,
             //
             """
-SELECT CAST("b"."Int" AS INTEGER) | "b"."Long"
+SELECT "b"."Int" | "b"."Long"
 FROM "BasicTypesEntities" AS "b"
 """);
     }
@@ -54,7 +54,7 @@ FROM "BasicTypesEntities" AS "b"
             """
 SELECT "b"."Id", "b"."Bool", "b"."Byte", "b"."ByteArray", "b"."DateOnly", "b"."DateTime", "b"."DateTimeOffset", "b"."Decimal", "b"."Double", "b"."Enum", "b"."FlagsEnum", "b"."Float", "b"."Guid", "b"."Int", "b"."Long", "b"."Short", "b"."String", "b"."TimeOnly", "b"."TimeSpan"
 FROM "BasicTypesEntities" AS "b"
-WHERE CAST("b"."Int" | "b"."Short" AS INTEGER) | "b"."Long" = 7
+WHERE "b"."Int" | "b"."Short" | "b"."Long" = 7
 """);
     }
 


### PR DESCRIPTION
**REVIEW 2ND COMMIT ONLY, THE 1ST IS PURE CLEANUP**

Fixes #36247

When a value-converted type has an implicit conversion operator to its provider type (e.g. `FullName -> string`), the C# compiler inserts a Convert node that gets translated to an unnecessary `CAST(column AS nvarchar(max))` even though the column already stores `nvarchar(max)`. This produces suboptimal SQL, e.g.:

```sql
-- Before
SELECT ... WHERE CAST([u].[Name] AS nvarchar(max)) LIKE N'Name%'

-- After
SELECT ... WHERE [u].[Name] LIKE N'Name%'
```

## Approach

The fix adds a post-processing step in `SqlExpressionSimplifyingExpressionVisitor` that strips `SqlUnaryExpression(Convert)` nodes where the Convert's store type matches the operand's store type — i.e. the CAST would be a no-op in SQL. This also catches other same-store-type no-op CASTs (e.g. `CAST(AVG(float_column) AS REAL)` on SQLite where both `float` and `double` map to `REAL`).

## Alternative considered: fixing type inference in `ApplyTypeMapping`

We also explored fixing this earlier in the pipeline, by eliminating the Convert node during translation (in `VisitUnary`) and fixing type inference centrally in `SqlExpressionFactory.ApplyTypeMapping`. The idea was: when an inferred `RelationalTypeMapping` has a value converter whose model CLR type doesn't match the target expression's CLR type, the converter is inapplicable — so resolve a mapping for the expression's own CLR type instead.

This would avoid the unnecessary CAST node entirely (rather than creating it and stripping it in post-processing), and is arguably more principled. However, it requires constructing a new type mapping that preserves all the facets and provider-specific state of the original (store type, size, precision, scale, unicode, fixed-length, plus any custom state in provider subclasses). `RelationalTypeMapping.Clone` can't clear a converter (null means "keep existing"), and `FindMapping(clrType, storeType)` may not reproduce custom provider state. Since type mappings can be arbitrary provider-defined subclasses with arbitrary state, there's a risk of losing information. We chose not to go with this approach for now, as the post-processing approach is safe and correct.