### PR TITLE
Introduce CI redundancy groups

### DIFF
--- a/azure-pipelines-internal-tests.yml
+++ b/azure-pipelines-internal-tests.yml
@@ -97,6 +97,7 @@ extends:
       jobs:
       - template: /eng/common/templates-official/jobs/jobs.yml@self
         parameters:
+          continueOnError: true
           enableMicrobuild: true
           enablePublishBuildArtifacts: true
           enablePublishBuildAssets: false
@@ -129,14 +130,32 @@ extends:
               - script: "echo ##vso[build.addbuildtag]release-candidate"
                 condition: and(notin(variables['Build.Reason'], 'PullRequest'), eq(variables['IsFinalBuild'], 'true'))
                 displayName: 'Set CI tags'
-              - powershell: SqlLocalDB start
-                displayName: Start LocalDB
               - template: /eng/common/templates-official/steps/enable-internal-sources.yml
               - template: /eng/common/templates-official/steps/enable-internal-runtimes.yml
               - script: eng\common\cibuild.cmd -configuration $(_BuildConfig) -prepareMachine $(_InternalBuildArgs) $(_InternalRuntimeDownloadArgs)
                 env:
                   Test__Cosmos__DefaultConnection: $(_CosmosConnectionUrl)
+                  Test__SqlServer__DefaultConnection: "Data Source="
                 displayName: Build
+
+          - job: Windows_SqlServer
+            displayName: 'Windows SQL Server'
+            pool:
+              name: $(DncEngInternalBuildPool)
+              demands: ImageOverride -equals 1es-windows-2022
+              os: windows
+            timeoutInMinutes: 120
+            variables:
+              - skipComponentGovernanceDetection: true
+            steps:
+              - powershell: SqlLocalDB start
+                displayName: Start LocalDB
+              - template: /eng/common/templates-official/steps/enable-internal-sources.yml
+              - template: /eng/common/templates-official/steps/enable-internal-runtimes.yml
+              - script: eng\common\build.cmd -restore -build -test -ci -configuration $(_BuildConfig) -prepareMachine $(_InternalRuntimeDownloadArgs)
+                  /p:Projects="$(Build.SourcesDirectory)/test/EFCore.SqlServer.FunctionalTests/EFCore.SqlServer.FunctionalTests.csproj;$(Build.SourcesDirectory)/test/EFCore.SqlServer.HierarchyId.Tests/EFCore.SqlServer.HierarchyId.Tests.csproj;$(Build.SourcesDirectory)/test/EFCore.CrossStore.FunctionalTests/EFCore.CrossStore.FunctionalTests.csproj;$(Build.SourcesDirectory)/test/EFCore.OData.FunctionalTests/EFCore.OData.FunctionalTests.csproj;$(Build.SourcesDirectory)/test/EFCore.AspNet.SqlServer.FunctionalTests/EFCore.AspNet.SqlServer.FunctionalTests.csproj;$(Build.SourcesDirectory)/test/EFCore.VisualBasic.FunctionalTests/EFCore.VisualBasic.FunctionalTests.vbproj;$(Build.SourcesDirectory)/test/EFCore.FSharp.FunctionalTests/EFCore.FSharp.FunctionalTests.fsproj"
+                displayName: Test SQL Server
+
           - job: macOS
             pool:
               name: Azure Pipelines
@@ -174,6 +193,7 @@ extends:
               sdl:
                 binskim:
                   preReleaseVersion: ''
+
           - job: Linux_Cosmos
             displayName: 'Linux Cosmos'
             condition: notin(variables['Build.Reason'], 'PullRequest', 'Schedule')
@@ -218,6 +238,7 @@ extends:
               sdl:
                 binskim:
                   preReleaseVersion: ''
+
           - job: Helix_Windows
             displayName: 'Helix Windows'
             timeoutInMinutes: 180
@@ -231,6 +252,132 @@ extends:
                 value: $(_BuildConfig)
               - name: HelixTargetQueues
                 value: Windows.10.Amd64
+              - name: _HelixAccessToken
+                value: $(HelixApiAccessToken)
+            steps:
+              - task: NuGetCommand@2
+                displayName: 'Clear NuGet caches'
+                condition: succeeded()
+                inputs:
+                  command: custom
+                  arguments: 'locals all -clear'
+              - template: /eng/common/templates-official/steps/enable-internal-sources.yml
+              - template: /eng/common/templates-official/steps/enable-internal-runtimes.yml
+              - template: /eng/common/core-templates/steps/get-delegation-sas.yml
+                parameters:
+                  federatedServiceConnection: 'dotnetbuilds-internal-read'
+                  outputVariableName: 'dotnetbuilds-internal-container-read-token'
+                  expiryInHours: 3
+                  base64Encode: false
+                  storageAccount: dotnetbuilds
+                  container: internal
+                  permissions: rl
+              - script: restore.cmd -ci /p:configuration=$(_BuildConfig) $(_InternalRuntimeDownloadArgs)
+                displayName: Restore packages
+              - script: .dotnet\dotnet build eng\helix.proj /restore /t:Test /p:configuration=$(_BuildConfig) /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog $(_InternalRuntimeDownloadArgs)
+                displayName: Send tests to helix
+                env:
+                  HelixAccessToken: $(_HelixAccessToken)
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+                  DotNetBuildsInternalReadSasToken: $(dotnetbuilds-internal-container-read-token)
+
+          - job: Helix_Windows_SqlServer
+            displayName: 'Helix Windows SQL Server'
+            timeoutInMinutes: 180
+            pool:
+              name: $(DncEngInternalBuildPool)
+              demands: ImageOverride -equals 1es-windows-2022
+              os: windows
+            variables:
+              - skipComponentGovernanceDetection: true
+              - name: _HelixBuildConfig
+                value: $(_BuildConfig)
+              - name: HelixTargetQueues
+                value: Windows.11.Amd64.Client
+              - name: _HelixAccessToken
+                value: $(HelixApiAccessToken)
+            steps:
+              - task: NuGetCommand@2
+                displayName: 'Clear NuGet caches'
+                condition: succeeded()
+                inputs:
+                  command: custom
+                  arguments: 'locals all -clear'
+              - template: /eng/common/templates-official/steps/enable-internal-sources.yml
+              - template: /eng/common/templates-official/steps/enable-internal-runtimes.yml
+              - template: /eng/common/core-templates/steps/get-delegation-sas.yml
+                parameters:
+                  federatedServiceConnection: 'dotnetbuilds-internal-read'
+                  outputVariableName: 'dotnetbuilds-internal-container-read-token'
+                  expiryInHours: 3
+                  base64Encode: false
+                  storageAccount: dotnetbuilds
+                  container: internal
+                  permissions: rl
+              - script: restore.cmd -ci /p:configuration=$(_BuildConfig) $(_InternalRuntimeDownloadArgs)
+                displayName: Restore packages
+              - script: .dotnet\dotnet build eng\helix.proj /restore /t:Test /p:configuration=$(_BuildConfig) /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog $(_InternalRuntimeDownloadArgs)
+                displayName: Send tests to helix
+                env:
+                  HelixAccessToken: $(_HelixAccessToken)
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+                  DotNetBuildsInternalReadSasToken: $(dotnetbuilds-internal-container-read-token)
+
+          - job: Helix_Windows_Arm64
+            displayName: 'Helix Windows ARM64'
+            timeoutInMinutes: 180
+            pool:
+              name: $(DncEngInternalBuildPool)
+              demands: ImageOverride -equals 1es-windows-2022
+              os: windows
+            variables:
+              - skipComponentGovernanceDetection: true
+              - name: _HelixBuildConfig
+                value: $(_BuildConfig)
+              - name: HelixTargetQueues
+                value: Windows.11.Arm64
+              - name: _HelixAccessToken
+                value: $(HelixApiAccessToken)
+            steps:
+              - task: NuGetCommand@2
+                displayName: 'Clear NuGet caches'
+                condition: succeeded()
+                inputs:
+                  command: custom
+                  arguments: 'locals all -clear'
+              - template: /eng/common/templates-official/steps/enable-internal-sources.yml
+              - template: /eng/common/templates-official/steps/enable-internal-runtimes.yml
+              - template: /eng/common/core-templates/steps/get-delegation-sas.yml
+                parameters:
+                  federatedServiceConnection: 'dotnetbuilds-internal-read'
+                  outputVariableName: 'dotnetbuilds-internal-container-read-token'
+                  expiryInHours: 3
+                  base64Encode: false
+                  storageAccount: dotnetbuilds
+                  container: internal
+                  permissions: rl
+              - script: restore.cmd -ci /p:configuration=$(_BuildConfig) $(_InternalRuntimeDownloadArgs)
+                displayName: Restore packages
+              - script: .dotnet\dotnet build eng\helix.proj /restore /t:Test /p:configuration=$(_BuildConfig) /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog $(_InternalRuntimeDownloadArgs)
+                displayName: Send tests to helix
+                env:
+                  HelixAccessToken: $(_HelixAccessToken)
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+                  DotNetBuildsInternalReadSasToken: $(dotnetbuilds-internal-container-read-token)
+
+          - job: Helix_Windows_Cosmos
+            displayName: 'Helix Windows Cosmos'
+            timeoutInMinutes: 180
+            pool:
+              name: $(DncEngInternalBuildPool)
+              demands: ImageOverride -equals 1es-windows-2022
+              os: windows
+            variables:
+              - skipComponentGovernanceDetection: true
+              - name: _HelixBuildConfig
+                value: $(_BuildConfig)
+              - name: HelixTargetQueues
+                value: Windows.Server2025.Amd64
               - name: _HelixAccessToken
                 value: $(HelixApiAccessToken)
             steps:
@@ -470,3 +617,74 @@ extends:
                   HelixAccessToken: $(_HelixAccessToken)
                   SYSTEM_ACCESSTOKEN: $(System.AccessToken)
                   DotNetBuildsInternalReadSasToken: $(dotnetbuilds-internal-container-read-token)
+    - stage: validate
+      displayName: Validate
+      dependsOn: build
+      condition: always()
+      jobs:
+      - job: Validate_Job_Results
+        displayName: Validate Job Results
+        pool:
+          name: $(DncEngInternalBuildPool)
+          demands: ImageOverride -equals 1es-windows-2022
+          os: windows
+        variables:
+          WindowsResult: $[ stageDependencies.build.Windows.result ]
+          HelixWindowsResult: $[ stageDependencies.build.Helix_Windows.result ]
+          WindowsSqlServerResult: $[ stageDependencies.build.Windows_SqlServer.result ]
+          HelixWindowsSqlServerResult: $[ stageDependencies.build.Helix_Windows_SqlServer.result ]
+          HelixWindowsCosmosResult: $[ stageDependencies.build.Helix_Windows_Cosmos.result ]
+          LinuxResult: $[ stageDependencies.build.Linux.result ]
+          HelixUbuntuResult: $[ stageDependencies.build.Helix_Ubuntu.result ]
+          HelixUbuntuSqlServerResult: $[ stageDependencies.build.Helix_Ubuntu_SqlServer.result ]
+          MacOsResult: $[ stageDependencies.build.macOS.result ]
+          HelixMacOsX64Result: $[ stageDependencies.build.Helix_macOS_x64.result ]
+          HelixMacOsArm64Result: $[ stageDependencies.build.Helix_macOS_ARM64.result ]
+          HelixWindowsArm64Result: $[ stageDependencies.build.Helix_Windows_Arm64.result ]
+          LinuxCosmosResult: $[ stageDependencies.build.Linux_Cosmos.result ]
+          HelixUbuntuCosmosResult: $[ stageDependencies.build.Helix_Ubuntu_Cosmos.result ]
+        steps:
+          - pwsh: |
+              $groupResults = @{
+                  Windows = @("$(WindowsResult)", "$(HelixWindowsResult)")
+                  Linux = @("$(LinuxResult)", "$(HelixUbuntuResult)")
+                  MacOS = @("$(MacOsResult)", "$(HelixMacOsX64Result)")
+                  Arm64 = @("$(HelixWindowsArm64Result)", "$(HelixMacOsArm64Result)")
+                  Cosmos = @("$(HelixWindowsCosmosResult)", "$(LinuxCosmosResult)", "$(HelixUbuntuCosmosResult)")
+                  SqlServer = @("$(WindowsSqlServerResult)", "$(HelixWindowsSqlServerResult)", "$(HelixUbuntuSqlServerResult)")
+              }
+
+              $failedGroups = @()
+
+              foreach ($groupName in $groupResults.Keys)
+              {
+                  $results = $groupResults[$groupName]
+                  Write-Host "$groupName results: $($results -join ', ')"
+
+                  # Ignore jobs that were skipped (e.g. condition-gated)
+                  $ran = $results | Where-Object { $_ -ne 'Skipped' }
+                  if (-not $ran)
+                  {
+                      Write-Host "  -> all jobs skipped, treating group as successful"
+                      continue
+                  }
+
+                  # Only 'Succeeded' counts as success. 'SucceededWithIssues' is treated as failure
+                  # because the jobs run with continueOnError: true, which maps task failures to warnings.
+                  $hasSuccess = $ran | Where-Object { $_ -eq 'Succeeded' }
+                  if ($hasSuccess)
+                  {
+                      continue
+                  }
+
+                  $failedGroups += $groupName
+              }
+
+              if ($failedGroups.Count -gt 0)
+              {
+                  Write-Error "No jobs succeeded for group(s): $($failedGroups -join ', ')."
+                  exit 1
+              }
+
+              Write-Host 'Group validation passed.'
+            displayName: Evaluate grouped job outcomes

--- a/azure-pipelines-public.yml
+++ b/azure-pipelines-public.yml
@@ -40,6 +40,7 @@ stages:
   jobs:
     - template: eng/common/templates/jobs/jobs.yml
       parameters:
+        continueOnError: true
         enableMicrobuild: true
         enablePublishBuildArtifacts: true
         enablePublishBuildAssets: true
@@ -52,10 +53,10 @@ stages:
         jobs:
           - job: Windows
             enablePublishTestResults: true
+            timeoutInMinutes: 90
             pool:
               name: $(DncEngPublicBuildPool)
               demands: ImageOverride -equals 1es-windows-2022-open
-              timeoutInMinutes: 90
             variables:
               - _InternalBuildArgs: ''
               # Rely on task Arcade injects, not auto-injected build step.
@@ -74,13 +75,38 @@ stages:
               - script: "echo ##vso[build.addbuildtag]release-candidate"
                 condition: and(notin(variables['Build.Reason'], 'PullRequest'), eq(variables['IsFinalBuild'], 'true'))
                 displayName: 'Set CI tags'
-              - powershell: SqlLocalDB start
-                displayName: Start LocalDB
               - script: eng\common\cibuild.cmd -configuration $(_BuildConfig) -prepareMachine /bl:artifacts\log\$(_BuildConfig)\Build.binlog $(_InternalBuildArgs)
                   $(_InternalRuntimeDownloadArgs)
                 env:
                   Test__Cosmos__DefaultConnection: $(_CosmosConnectionUrl)
+                  Test__SqlServer__DefaultConnection: "Data Source="
                 name: Build
+              - task: PublishBuildArtifacts@1
+                displayName: Upload TestResults
+                condition: always()
+                continueOnError: true
+                inputs:
+                  pathtoPublish: artifacts/TestResults/$(_BuildConfig)/
+                  artifactName: $(Agent.Os)_$(Agent.JobName) TestResults
+                  artifactType: Container
+                  parallel: true
+
+          - job: Windows_SqlServer
+            displayName: 'Windows SQL Server'
+            enablePublishTestResults: true
+            timeoutInMinutes: 120
+            pool:
+              name: $(DncEngPublicBuildPool)
+              demands: ImageOverride -equals 1es-windows-2022-open
+            variables:
+              - skipComponentGovernanceDetection: true
+              - Codeql.SkipTaskAutoInjection: true
+            steps:
+              - powershell: SqlLocalDB start
+                displayName: Start LocalDB
+              - script: eng\common\build.cmd -restore -build -test -ci -configuration $(_BuildConfig) -prepareMachine $(_InternalRuntimeDownloadArgs)
+                  /p:Projects="$(Build.SourcesDirectory)/test/EFCore.SqlServer.FunctionalTests/EFCore.SqlServer.FunctionalTests.csproj;$(Build.SourcesDirectory)/test/EFCore.SqlServer.HierarchyId.Tests/EFCore.SqlServer.HierarchyId.Tests.csproj;$(Build.SourcesDirectory)/test/EFCore.CrossStore.FunctionalTests/EFCore.CrossStore.FunctionalTests.csproj;$(Build.SourcesDirectory)/test/EFCore.OData.FunctionalTests/EFCore.OData.FunctionalTests.csproj;$(Build.SourcesDirectory)/test/EFCore.AspNet.SqlServer.FunctionalTests/EFCore.AspNet.SqlServer.FunctionalTests.csproj;$(Build.SourcesDirectory)/test/EFCore.VisualBasic.FunctionalTests/EFCore.VisualBasic.FunctionalTests.vbproj;$(Build.SourcesDirectory)/test/EFCore.FSharp.FunctionalTests/EFCore.FSharp.FunctionalTests.fsproj"
+                displayName: Test SQL Server
               - task: PublishBuildArtifacts@1
                 displayName: Upload TestResults
                 condition: always()
@@ -153,6 +179,96 @@ stages:
                 value: $(_BuildConfig)
               - name: HelixTargetQueues
                 value: Windows.10.Amd64.Open
+              - name: _HelixAccessToken
+                value: ''
+            steps:
+              - task: NuGetCommand@2
+                displayName: 'Clear NuGet caches'
+                condition: succeeded()
+                inputs:
+                  command: custom
+                  arguments: 'locals all -clear'
+              - script: restore.cmd -ci /p:configuration=$(_BuildConfig) $(_InternalRuntimeDownloadArgs)
+                displayName: Restore packages
+              - script: .dotnet\dotnet build eng\helix.proj /restore /t:Test /p:configuration=$(_BuildConfig) /bl:artifacts/log/$(_BuildConfig)/SendToHelix.binlog $(_InternalRuntimeDownloadArgs)
+                displayName: Send tests to helix
+                env:
+                  HelixAccessToken: $(_HelixAccessToken)
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+
+          - job: Helix_Windows_SqlServer
+            displayName: 'Helix Windows SQL Server'
+            timeoutInMinutes: 180
+            pool:
+              name: $(DncEngPublicBuildPool)
+              demands: ImageOverride -equals 1es-windows-2022-open
+            variables:
+              - skipComponentGovernanceDetection: true
+              - Codeql.SkipTaskAutoInjection: true
+              - name: _HelixBuildConfig
+                value: $(_BuildConfig)
+              - name: HelixTargetQueues
+                value: Windows.11.Amd64.Client.Open
+              - name: _HelixAccessToken
+                value: ''
+            steps:
+              - task: NuGetCommand@2
+                displayName: 'Clear NuGet caches'
+                condition: succeeded()
+                inputs:
+                  command: custom
+                  arguments: 'locals all -clear'
+              - script: restore.cmd -ci /p:configuration=$(_BuildConfig) $(_InternalRuntimeDownloadArgs)
+                displayName: Restore packages
+              - script: .dotnet\dotnet build eng\helix.proj /restore /t:Test /p:configuration=$(_BuildConfig) /bl:artifacts/log/$(_BuildConfig)/SendToHelix.binlog $(_InternalRuntimeDownloadArgs)
+                displayName: Send tests to helix
+                env:
+                  HelixAccessToken: $(_HelixAccessToken)
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+
+          - job: Helix_Windows_Arm64
+            displayName: 'Helix Windows ARM64'
+            timeoutInMinutes: 180
+            pool:
+              name: $(DncEngPublicBuildPool)
+              demands: ImageOverride -equals 1es-windows-2022-open
+            variables:
+              - skipComponentGovernanceDetection: true
+              - Codeql.SkipTaskAutoInjection: true
+              - name: _HelixBuildConfig
+                value: $(_BuildConfig)
+              - name: HelixTargetQueues
+                value: Windows.11.Arm64.Open
+              - name: _HelixAccessToken
+                value: ''
+            steps:
+              - task: NuGetCommand@2
+                displayName: 'Clear NuGet caches'
+                condition: succeeded()
+                inputs:
+                  command: custom
+                  arguments: 'locals all -clear'
+              - script: restore.cmd -ci /p:configuration=$(_BuildConfig) $(_InternalRuntimeDownloadArgs)
+                displayName: Restore packages
+              - script: .dotnet\dotnet build eng\helix.proj /restore /t:Test /p:configuration=$(_BuildConfig) /bl:artifacts/log/$(_BuildConfig)/SendToHelix.binlog $(_InternalRuntimeDownloadArgs)
+                displayName: Send tests to helix
+                env:
+                  HelixAccessToken: $(_HelixAccessToken)
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+
+          - job: Helix_Windows_Cosmos
+            displayName: 'Helix Windows Cosmos'
+            timeoutInMinutes: 180
+            pool:
+              name: $(DncEngPublicBuildPool)
+              demands: ImageOverride -equals 1es-windows-2022-open
+            variables:
+              - skipComponentGovernanceDetection: true
+              - Codeql.SkipTaskAutoInjection: true
+              - name: _HelixBuildConfig
+                value: $(_BuildConfig)
+              - name: HelixTargetQueues
+                value: Windows.Server2025.Amd64.Open
               - name: _HelixAccessToken
                 value: ''
             steps:
@@ -320,3 +436,72 @@ stages:
                 env:
                   HelixAccessToken: $(_HelixAccessToken)
                   SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+- stage: validate
+  displayName: Validate
+  dependsOn: build
+  condition: always()
+  jobs:
+  - job: Validate_Job_Results
+    displayName: Validate Job Results
+    pool:
+      name: $(DncEngPublicBuildPool)
+      demands: ImageOverride -equals 1es-windows-2022-open
+    variables:
+      WindowsResult: $[ stageDependencies.build.Windows.result ]
+      HelixWindowsResult: $[ stageDependencies.build.Helix_Windows.result ]
+      WindowsSqlServerResult: $[ stageDependencies.build.Windows_SqlServer.result ]
+      HelixWindowsSqlServerResult: $[ stageDependencies.build.Helix_Windows_SqlServer.result ]
+      HelixWindowsCosmosResult: $[ stageDependencies.build.Helix_Windows_Cosmos.result ]
+      LinuxResult: $[ stageDependencies.build.Linux.result ]
+      HelixUbuntuResult: $[ stageDependencies.build.Helix_Ubuntu.result ]
+      HelixUbuntuSqlServerResult: $[ stageDependencies.build.Helix_Ubuntu_SqlServer.result ]
+      MacOsResult: $[ stageDependencies.build.macOS.result ]
+      HelixMacOsX64Result: $[ stageDependencies.build.Helix_macOS_x64.result ]
+      HelixMacOsArm64Result: $[ stageDependencies.build.Helix_macOS_ARM64.result ]
+      HelixWindowsArm64Result: $[ stageDependencies.build.Helix_Windows_Arm64.result ]
+      HelixUbuntuCosmosResult: $[ stageDependencies.build.Helix_Ubuntu_Cosmos.result ]
+    steps:
+      - pwsh: |
+          $groupResults = @{
+              Windows = @("$(WindowsResult)", "$(HelixWindowsResult)")
+              Linux = @("$(LinuxResult)", "$(HelixUbuntuResult)")
+              MacOS = @("$(MacOsResult)", "$(HelixMacOsX64Result)")
+              Arm64 = @("$(HelixWindowsArm64Result)", "$(HelixMacOsArm64Result)")
+              Cosmos = @("$(HelixWindowsCosmosResult)", "$(HelixUbuntuCosmosResult)")
+              SqlServer = @("$(WindowsSqlServerResult)", "$(HelixWindowsSqlServerResult)", "$(HelixUbuntuSqlServerResult)")
+          }
+
+          $failedGroups = @()
+
+          foreach ($groupName in $groupResults.Keys)
+          {
+              $results = $groupResults[$groupName]
+              Write-Host "$groupName results: $($results -join ', ')"
+
+              # Ignore jobs that were skipped (e.g. condition-gated)
+              $ran = $results | Where-Object { $_ -ne 'Skipped' }
+              if (-not $ran)
+              {
+                  Write-Host "  -> all jobs skipped, treating group as successful"
+                  continue
+              }
+
+              # Only 'Succeeded' counts as success. 'SucceededWithIssues' is treated as failure
+              # because the jobs run with continueOnError: true, which maps task failures to warnings.
+              $hasSuccess = $ran | Where-Object { $_ -eq 'Succeeded' }
+              if ($hasSuccess)
+              {
+                  continue
+              }
+
+              $failedGroups += $groupName
+          }
+
+          if ($failedGroups.Count -gt 0)
+          {
+              Write-Error "No jobs succeeded for group(s): $($failedGroups -join ', ')."
+              exit 1
+          }
+
+          Write-Host 'Group validation passed.'
+        displayName: Evaluate grouped job outcomes

--- a/eng/helix.proj
+++ b/eng/helix.proj
@@ -18,7 +18,7 @@
 
   <PropertyGroup Condition = "'$(SYSTEM_ACCESSTOKEN)' == ''">
     <!-- Local build outside of Azure Pipeline -->
-    <HelixTargetQueues Condition = "'$(HelixTargetQueues)' == ''">Windows.10.Amd64.Open;OSX.15.Amd64.Open;OSX.15.ARM64.Open;Ubuntu.2204.Amd64.XL.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-sqlserver-amd64;Ubuntu.2204.Amd64.XL.Open;Ubuntu.2204.Amd64.Open</HelixTargetQueues>
+    <HelixTargetQueues Condition = "'$(HelixTargetQueues)' == ''">Windows.10.Amd64.Open;Windows.11.Amd64.Client.Open;Windows.11.Arm64.Open;Windows.Server2025.Amd64.Open;OSX.15.Amd64.Open;OSX.15.ARM64.Open;Ubuntu.2204.Amd64.XL.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-sqlserver-amd64;Ubuntu.2204.Amd64.XL.Open;Ubuntu.2204.Amd64.Open</HelixTargetQueues>
     <EnableAzurePipelinesReporter>false</EnableAzurePipelinesReporter>
     <HelixSource>efcore/localbuild/</HelixSource>
     <HelixBuild>t001</HelixBuild>
@@ -60,21 +60,36 @@
     </XUnitProject>
   </ItemGroup>
 
-  <!-- Start LocalDb instance for test projects which uses SqlServer on Windows -->
-  <ItemGroup Condition = "'$(HelixTargetQueue.StartsWith(`Windows`))'">
-    <XUnitProject Update="$(SqlServerTests)">
+  <ItemGroup Condition = "'$(HelixTargetQueue.StartsWith(`Windows.10.Amd64`))'">
+    <XUnitProject Remove="$(CosmosTests)"/>
+    <XUnitProject Remove="$(SqlServerTests)"/>
+    <XUnitProject Update="@(XUnitProject)">
+      <PreCommands>$(PreCommands); set "Test__SqlServer__DefaultConnection=Data Source="</PreCommands>
+    </XUnitProject>
+  </ItemGroup>
+
+  <ItemGroup Condition = "'$(HelixTargetQueue.StartsWith(`Windows.11.Arm64`))'">
+    <XUnitProject Remove="$(SqlServerTests)"/>
+    <XUnitProject Remove="$(CosmosTests)"/>
+    <XUnitProject Update="@(XUnitProject)">
+      <PreCommands>$(PreCommands); set "Test__SqlServer__DefaultConnection=Data Source="</PreCommands>
+    </XUnitProject>
+  </ItemGroup>
+
+  <ItemGroup Condition = "'$(HelixTargetQueue.StartsWith(`Windows.11.Amd64.Client`))'">
+    <XUnitProject Remove="$(RepoRoot)/test/**/*.csproj"/>
+    <XUnitProject Remove="$(RepoRoot)/test/**/*.fsproj"/>
+    <XUnitProject Include="$(SqlServerTests)">
       <PreCommands>$(PreCommands); SqlLocalDB start</PreCommands>
     </XUnitProject>
   </ItemGroup>
 
-  <ItemGroup Condition = "'$(HelixTargetQueue.StartsWith(`Windows.11`))'">
-    <XUnitProject Remove="$(CosmosTests)"/>
-  </ItemGroup>
-
   <ItemGroup Condition = "'$(HelixTargetQueue.StartsWith(`Windows.Server2025.Amd64`))'">
-    <XUnitProject Update="$(CosmosTests)">
-      <PreCommands>$(PreCommands); set Test__Cosmos__SkipConnectionCheck=true</PreCommands>
-    </XUnitProject>
+    <XUnitProject Remove="$(RepoRoot)/test/**/*.csproj"/>
+    <XUnitProject Remove="$(RepoRoot)/test/**/*.fsproj"/>
+    <XUnitProject Include="$(CosmosTests)">
+      <PreCommands>$(PreCommands); call %HELIX_CORRELATION_PAYLOAD%\testing\WaitCosmosEmulator.cmd; set Test__Cosmos__DefaultConnection=https://localhost:8081; set Test__Cosmos__SkipConnectionCheck=true</PreCommands>
+     </XUnitProject>
   </ItemGroup>
 
   <!-- Start SqlServer instance for test projects which uses SqlServer on docker. Only run SqlServer tests. -->

--- a/eng/testing/WaitCosmosEmulator.cmd
+++ b/eng/testing/WaitCosmosEmulator.cmd
@@ -1,0 +1,24 @@
+@echo off
+setlocal enabledelayedexpansion
+
+set RETRIES=0
+set MAX_RETRIES=60
+
+:check
+if !RETRIES! geq %MAX_RETRIES% (
+    echo ERROR: Cosmos DB Emulator did not start after %MAX_RETRIES% attempts.
+    exit /b 1
+)
+
+for /f %%a in ('curl -k -s -o nul -w "%%{http_code}" https://localhost:8081/ 2^>nul') do set HTTP_CODE=%%a
+
+if "!HTTP_CODE!"=="401" (
+    echo Cosmos DB Emulator is running ^(HTTP 401 received^).
+    timeout /t 2 >nul
+    exit /b 0
+)
+
+set /a RETRIES+=1
+echo Attempt !RETRIES!/%MAX_RETRIES%: Waiting for Cosmos DB Emulator ^(got HTTP !HTTP_CODE!^)...
+timeout /t 5 >nul
+goto :check

--- a/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
@@ -250,6 +250,14 @@ public class CosmosTestStore : TestStore
     }
 
     public override async Task CleanAsync(DbContext context, bool createTables = true)
+        => await new TestCosmosExecutionStrategy().ExecuteAsync(
+            (context, createTables), async (state, ct) =>
+            {
+                await CleanAsyncImpl(state.context, state.createTables).ConfigureAwait(false);
+                return true;
+            }, default);
+
+    private async Task CleanAsyncImpl(DbContext context, bool createTables)
     {
         var created = await EnsureCreatedAsync(context).ConfigureAwait(false);
         try

--- a/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
@@ -249,13 +249,13 @@ public class CosmosTestStore : TestStore
         return _armClient.GetCosmosDBAccountResource(databaseAccountIdentifier).GetAsync(cancellationToken);
     }
 
-    public override async Task CleanAsync(DbContext context, bool createTables = true)
-        => await new TestCosmosExecutionStrategy().ExecuteAsync(
-            (context, createTables), async (state, ct) =>
+    public override Task CleanAsync(DbContext context, bool createTables = true)
+        => new TestCosmosExecutionStrategy().ExecuteAsync(
+            (context, createTables), async (_, state, ct) =>
             {
                 await CleanAsyncImpl(state.context, state.createTables).ConfigureAwait(false);
                 return true;
-            }, default);
+            }, null, default);
 
     private async Task CleanAsyncImpl(DbContext context, bool createTables)
     {

--- a/test/EFCore.FSharp.FunctionalTests/NorthwindQueryFSharpTest.fs
+++ b/test/EFCore.FSharp.FunctionalTests/NorthwindQueryFSharpTest.fs
@@ -9,6 +9,7 @@ open Microsoft.EntityFrameworkCore.TestModels.Northwind
 open Microsoft.EntityFrameworkCore.TestUtilities
 open global.Xunit
 
+[<SqlServerConfiguredCondition>]
 type NorthwindQueryFSharpTest(fixture) as self =
     inherit QueryTestBase<NorthwindFSharpQuerySqlServerFixture<NoopModelCustomizer>>(fixture)
 

--- a/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
@@ -392,7 +392,7 @@ public class DbContextPoolingTest(NorthwindQuerySqlServerFixture<NoopModelCustom
         }
     }
 
-    [Fact, SqlServerConfiguredCondition]
+    [ConditionalFact, SqlServerConfiguredCondition]
     public async Task Parameterless_pooled_factory_should_use_ConfigureDbContext_options()
     {
         var services = new ServiceCollection();
@@ -409,7 +409,7 @@ public class DbContextPoolingTest(NorthwindQuerySqlServerFixture<NoopModelCustom
         Assert.Equal("Microsoft.EntityFrameworkCore.SqlServer", db.Database.ProviderName);
     }
 
-    [Fact, SqlServerConfiguredCondition]
+    [ConditionalFact, SqlServerConfiguredCondition]
     public async Task Parameterless_pooled_factory_with_custom_pool_size_should_still_resolve()
     {
         var services = new ServiceCollection();

--- a/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
@@ -392,7 +392,7 @@ public class DbContextPoolingTest(NorthwindQuerySqlServerFixture<NoopModelCustom
         }
     }
 
-    [Fact]
+    [Fact, SqlServerConfiguredCondition]
     public async Task Parameterless_pooled_factory_should_use_ConfigureDbContext_options()
     {
         var services = new ServiceCollection();
@@ -409,7 +409,7 @@ public class DbContextPoolingTest(NorthwindQuerySqlServerFixture<NoopModelCustom
         Assert.Equal("Microsoft.EntityFrameworkCore.SqlServer", db.Database.ProviderName);
     }
 
-    [Fact]
+    [Fact, SqlServerConfiguredCondition]
     public async Task Parameterless_pooled_factory_with_custom_pool_size_should_still_resolve()
     {
         var services = new ServiceCollection();

--- a/test/EFCore.VisualBasic.FunctionalTests/NorthwindQueryVisualBasicTest.vb
+++ b/test/EFCore.VisualBasic.FunctionalTests/NorthwindQueryVisualBasicTest.vb
@@ -6,6 +6,7 @@ Imports Microsoft.EntityFrameworkCore.TestModels.Northwind
 Imports Microsoft.EntityFrameworkCore.TestUtilities
 Imports Xunit
 
+<SqlServerConfiguredCondition>
 Partial Public Class NorthwindQueryVisualBasicTest
     Inherits QueryTestBase(Of NorthwindVBQuerySqlServerFixture(Of NoopModelCustomizer))
 


### PR DESCRIPTION
- Added `continueOnError: true` to all major jobs in both `azure-pipelines-internal-tests.yml` and `azure-pipelines-public.yml`, allowing the pipeline to continue running even if individual jobs fail. 
- Introduced a new `Validate_Job_Results` job in both pipeline files that runs after all test jobs, collecting the results for each group and failing the pipeline only if all jobs in a group fail. 
 - Added more Helix queues
   - Windows.11.Amd64.Client - only SQL Server tests
   - Windows.Server2025.Amd64 - only Cosmos tests on the emulator
   - Windows.11.Arm64 - All other tests
 - The job groups are defined as follows:
   - **Windows**: {Windows, Helix_Windows}
   - **Linux**: {Linux, Helix_Ubuntu}
   - **macOS**: {macOS, macOS x64}
   - **Arm64**: {Helix Windows Arm64, Helix macOS ARM64}
   - **SQL Server**: {Windows SqlServer, Helix Windows SqlServer, Helix Ubuntu SqlServer}
   - **Cosmos** : {Linux_Cosmos, Helix Windows Cosmos, Helix Ubuntu Cosmos}

