### PR TITLE
Translate Any() over byte array

### DIFF
--- a/src/EFCore.SqlServer/Query/Internal/Translators/SqlServerByteArrayMethodTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/Translators/SqlServerByteArrayMethodTranslator.cs
@@ -59,6 +59,17 @@ public class SqlServerByteArrayMethodTranslator(ISqlExpressionFactory sqlExpress
                             argumentsPropagateNullability: Statics.TrueArrays[3],
                             typeof(byte[])),
                         method.ReturnType);
+
+                // Any without a predicate
+                case nameof(Enumerable.Any) when arguments is [var source] && source.Type == typeof(byte[]):
+                    return sqlExpressionFactory.GreaterThan(
+                        sqlExpressionFactory.Function(
+                            "DATALENGTH",
+                            [source],
+                            nullable: true,
+                            argumentsPropagateNullability: Statics.TrueArrays[1],
+                            typeof(int)),
+                        sqlExpressionFactory.Constant(0));
             }
         }
 

--- a/src/EFCore.Sqlite.Core/Query/Internal/Translators/SqliteByteArrayMethodTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/Translators/SqliteByteArrayMethodTranslator.cs
@@ -51,6 +51,22 @@ public class SqliteByteArrayMethodTranslator(ISqlExpressionFactory sqlExpression
                 sqlExpressionFactory.Constant(0));
         }
 
+        if (method.IsGenericMethod
+            && method.DeclaringType == typeof(Enumerable)
+            && method.Name == nameof(Enumerable.Any)
+            && arguments is [var anySource]
+            && anySource.Type == typeof(byte[]))
+        {
+            return sqlExpressionFactory.GreaterThan(
+                sqlExpressionFactory.Function(
+                    "length",
+                    [anySource],
+                    nullable: true,
+                    argumentsPropagateNullability: Statics.TrueArrays[1],
+                    typeof(int)),
+                sqlExpressionFactory.Constant(0));
+        }
+
         return null;
     }
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/Translations/ByteArrayTranslationsCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/Translations/ByteArrayTranslationsCosmosTest.cs
@@ -30,6 +30,9 @@ public class ByteArrayTranslationsCosmosTest : ByteArrayTranslationsTestBase<Bas
     public override Task Contains_with_column()
         => AssertTranslationFailed(() => base.Contains_with_column());
 
+    public override Task Any()
+        => AssertTranslationFailed(() => base.Any());
+
     public override Task SequenceEqual()
         => AssertTranslationFailed(() => base.SequenceEqual());
 

--- a/test/EFCore.Specification.Tests/Query/Translations/ByteArrayTranslationsTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Translations/ByteArrayTranslationsTestBase.cs
@@ -37,6 +37,10 @@ public abstract class ByteArrayTranslationsTestBase<TFixture>(TFixture fixture) 
         => AssertQuery(ss => ss.Set<BasicTypesEntity>().Where(s => s.ByteArray.Contains(s.Byte)));
 
     [ConditionalFact]
+    public virtual Task Any()
+        => AssertQuery(ss => ss.Set<BasicTypesEntity>().Where(e => e.ByteArray.Any()));
+
+    [ConditionalFact]
     public virtual Task SequenceEqual()
     {
         var byteArrayParam = new byte[] { 0xDE, 0xAD, 0xBE, 0xEF };

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Translations/ByteArrayTranslationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Translations/ByteArrayTranslationsSqlServerTest.cs
@@ -86,6 +86,18 @@ WHERE CHARINDEX(CAST([b].[Byte] AS varbinary(max)), [b].[ByteArray]) > 0
 """);
     }
 
+    public override async Task Any()
+    {
+        await base.Any();
+
+        AssertSql(
+            """
+SELECT [b].[Id], [b].[Bool], [b].[Byte], [b].[ByteArray], [b].[DateOnly], [b].[DateTime], [b].[DateTimeOffset], [b].[Decimal], [b].[Double], [b].[Enum], [b].[FlagsEnum], [b].[Float], [b].[Guid], [b].[Int], [b].[Long], [b].[Short], [b].[String], [b].[TimeOnly], [b].[TimeSpan]
+FROM [BasicTypesEntities] AS [b]
+WHERE DATALENGTH([b].[ByteArray]) > 0
+""");
+    }
+
     public override async Task SequenceEqual()
     {
         await base.SequenceEqual();

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Translations/ByteArrayTranslationsSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Translations/ByteArrayTranslationsSqliteTest.cs
@@ -70,6 +70,18 @@ WHERE instr("b"."ByteArray", char("b"."Byte")) > 0
 """);
     }
 
+    public override async Task Any()
+    {
+        await base.Any();
+
+        AssertSql(
+            """
+SELECT "b"."Id", "b"."Bool", "b"."Byte", "b"."ByteArray", "b"."DateOnly", "b"."DateTime", "b"."DateTimeOffset", "b"."Decimal", "b"."Double", "b"."Enum", "b"."FlagsEnum", "b"."Float", "b"."Guid", "b"."Int", "b"."Long", "b"."Short", "b"."String", "b"."TimeOnly", "b"."TimeSpan"
+FROM "BasicTypesEntities" AS "b"
+WHERE length("b"."ByteArray") > 0
+""");
+    }
+
     public override async Task SequenceEqual()
     {
         await base.SequenceEqual();


### PR DESCRIPTION
Adds translation of `Enumerable.Any()` on `byte[]` to `DATALENGTH(col) > 0` (SQL Server) and `length(col) > 0` (SQLite). Cosmos keeps `AssertTranslationFailed` since it doesn't support byte array operations.

The base test is added to `ByteArrayTranslationsTestBase` with provider-specific SQL assertions.

Ported from npgsql/efcore.pg#3817.

Fixes #38167