### PR TITLE
Exclude __EFMigrationsLock from SQLite scaffolding

### DIFF
--- a/src/EFCore.Sqlite.Core/Migrations/Internal/SqliteHistoryRepository.cs
+++ b/src/EFCore.Sqlite.Core/Migrations/Internal/SqliteHistoryRepository.cs
@@ -36,9 +36,17 @@ public class SqliteHistoryRepository : HistoryRepository
         => CreateExistsSql(TableName);
 
     /// <summary>
-    ///     The name of the table that will serve as a database-wide lock for migrations.
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected virtual string LockTableName { get; } = "__EFMigrationsLock";
+    public const string DefaultLockTableName = "__EFMigrationsLock";
+
+     /// <summary>
+    ///     The default name for the migrations lock table.
+    /// </summary>
+    protected virtual string LockTableName { get; } = DefaultLockTableName;
 
     private string CreateExistsSql(string tableName)
     {

--- a/src/EFCore.Sqlite.Core/Migrations/Internal/SqliteHistoryRepository.cs
+++ b/src/EFCore.Sqlite.Core/Migrations/Internal/SqliteHistoryRepository.cs
@@ -44,7 +44,7 @@ public class SqliteHistoryRepository : HistoryRepository
     public const string DefaultLockTableName = "__EFMigrationsLock";
 
      /// <summary>
-    ///     The default name for the migrations lock table.
+    ///     The name for the migrations lock table.
     /// </summary>
     protected virtual string LockTableName { get; } = DefaultLockTableName;
 

--- a/src/EFCore.Sqlite.Core/Scaffolding/Internal/SqliteDatabaseModelFactory.cs
+++ b/src/EFCore.Sqlite.Core/Scaffolding/Internal/SqliteDatabaseModelFactory.cs
@@ -8,6 +8,7 @@ using System.Text.RegularExpressions;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
 using Microsoft.EntityFrameworkCore.Sqlite.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Migrations.Internal;
 using static SQLitePCL.raw;
 
 namespace Microsoft.EntityFrameworkCore.Sqlite.Scaffolding.Internal;
@@ -259,7 +260,7 @@ WHERE "name" = 'geometry_columns' AND "type" = 'table'
 SELECT "name", "type"
 FROM "sqlite_master"
 WHERE "type" IN ('table', 'view') AND instr("name", 'sqlite_') <> 1 AND "name" NOT IN (
-'{HistoryRepository.DefaultTableName}',
+'{HistoryRepository.DefaultTableName}', '{SqliteHistoryRepository.DefaultLockTableName}',
 'ElementaryGeometries', 'geometry_columns', 'geometry_columns_auth',
 'geometry_columns_field_infos', 'geometry_columns_statistics', 'geometry_columns_time',
 'spatial_ref_sys', 'spatial_ref_sys_aux', 'SpatialIndex', 'spatialite_history',

--- a/test/EFCore.Sqlite.FunctionalTests/Scaffolding/SqliteDatabaseModelFactoryTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Scaffolding/SqliteDatabaseModelFactoryTest.cs
@@ -1539,6 +1539,23 @@ CREATE TABLE DependentTable (
 DROP TABLE DependentTable;
 DROP TABLE PrincipalTable;");
 
+    [ConditionalFact]
+    public void EF_internal_tables_are_not_scaffolded()
+        => Test(
+            @"
+CREATE TABLE ""__EFMigrationsLock"" ( ""Id"" INTEGER NOT NULL PRIMARY KEY, ""Timestamp"" TEXT NOT NULL );
+CREATE TABLE ""MyTable"" ( ""Id"" INTEGER NOT NULL PRIMARY KEY );",
+            [],
+            [],
+            dbModel =>
+            {
+                var table = Assert.Single(dbModel.Tables);
+                Assert.Equal("MyTable", table.Name);
+            },
+        @"
+DROP TABLE ""__EFMigrationsLock"";
+DROP TABLE ""MyTable"";");
+
     #endregion
 
     public class SqliteDatabaseModelFixture : SharedStoreFixtureBase<PoolableDbContext>

--- a/test/EFCore.Sqlite.FunctionalTests/Scaffolding/SqliteDatabaseModelFactoryTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Scaffolding/SqliteDatabaseModelFactoryTest.cs
@@ -333,6 +333,25 @@ DROP TABLE PrincipalTable;");
                     DROP TABLE MinimalFKTest1;
                 ");
 
+    [ConditionalFact]
+    public void EF_internal_tables_are_not_scaffolded()
+        => Test(
+            @"
+CREATE TABLE ""__EFMigrationsLock"" ( ""Id"" INTEGER NOT NULL PRIMARY KEY, ""Timestamp"" TEXT NOT NULL );
+CREATE TABLE ""MyTable"" ( ""Id"" INTEGER NOT NULL PRIMARY KEY );",
+                [],
+                [],
+                dbModel =>
+                {
+                    var table = Assert.Single(dbModel.Tables);
+                    Assert.Equal("MyTable", table.Name);
+                },
+                @"
+                    DROP TABLE ""__EFMigrationsLock"";
+                    DROP TABLE ""MyTable"";
+                ");
+    
+
     #endregion
 
     #region ColumnFacets
@@ -1538,23 +1557,6 @@ CREATE TABLE DependentTable (
             @"
 DROP TABLE DependentTable;
 DROP TABLE PrincipalTable;");
-
-    [ConditionalFact]
-    public void EF_internal_tables_are_not_scaffolded()
-        => Test(
-            @"
-CREATE TABLE ""__EFMigrationsLock"" ( ""Id"" INTEGER NOT NULL PRIMARY KEY, ""Timestamp"" TEXT NOT NULL );
-CREATE TABLE ""MyTable"" ( ""Id"" INTEGER NOT NULL PRIMARY KEY );",
-            [],
-            [],
-            dbModel =>
-            {
-                var table = Assert.Single(dbModel.Tables);
-                Assert.Equal("MyTable", table.Name);
-            },
-        @"
-DROP TABLE ""__EFMigrationsLock"";
-DROP TABLE ""MyTable"";");
 
     #endregion
 


### PR DESCRIPTION
## Summary

Fixes #38148

When scaffolding a SQLite database that has had EF migrations applied, the `__EFMigrationsLock` table was incorrectly included in the scaffolded model. This table is EF-internal and should be excluded just like `__EFMigrationsHistory`.

## Root Cause

`SqliteDatabaseModelFactory.GetTables` explicitly excluded `__EFMigrationsHistory` via `HistoryRepository.DefaultTableName`, but did not exclude `__EFMigrationsLock`, which is created by `SqliteHistoryRepository` to implement distributed locking during migrations on SQLite.

## Changes

- Added `DefaultLockTableName` public const to `SqliteHistoryRepository` to avoid hardcoding the table name in multiple places.
- Added `__EFMigrationsLock` to the exclusion list in `SqliteDatabaseModelFactory.GetTables`.
- Added a test in `SqliteDatabaseModelFactoryTest` to verify that EF-internal tables are not scaffolded.

<!--
Please check whether the PR fulfills these requirements
-->

- [x] I've read the guidelines for [contributing](https://github.com/dotnet/efcore/blob/main/.github/CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [x] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

