### PR TITLE
Remove redundant MemberData on override test methods

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
@@ -303,7 +303,7 @@ WHERE (c["Terminator"] = "LeafA")
         AssertSql();
     }
 
-    [ConditionalTheory, MemberData(nameof(IsAsyncData))]
+    [ConditionalTheory]
     public override Task SelectMany_on_owned_collection(bool async)
         => CosmosTestHelpers.Instance.NoSyncTest(
             async, async a =>
@@ -319,7 +319,7 @@ WHERE c["Terminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA")
 """);
             });
 
-    [ConditionalTheory, MemberData(nameof(IsAsyncData))]
+    [ConditionalTheory]
     public override Task SelectMany_with_result_selector(bool async)
         => CosmosTestHelpers.Instance.NoSyncTest(
             async, async a =>
@@ -1124,7 +1124,7 @@ OFFSET 0 LIMIT @p
 """);
             });
 
-    [ConditionalTheory, MemberData(nameof(IsAsyncData))]
+    [ConditionalTheory]
     public override Task Client_method_take_loads_owned_navigations_variation_2(bool async)
         => CosmosTestHelpers.Instance.NoSyncTest(
             async, async a =>
@@ -1143,7 +1143,7 @@ OFFSET 0 LIMIT @p
 """);
             });
 
-    [ConditionalTheory, MemberData(nameof(IsAsyncData))]
+    [ConditionalTheory]
     public override Task Count_over_owned_collection(bool async)
         => CosmosTestHelpers.Instance.NoSyncTest(
             async, async a =>
@@ -1158,7 +1158,7 @@ WHERE (c["Terminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (ARRAY
 """);
             });
 
-    [ConditionalTheory, MemberData(nameof(IsAsyncData))]
+    [ConditionalTheory]
     public override Task Any_without_predicate_over_owned_collection(bool async)
         => CosmosTestHelpers.Instance.NoSyncTest(
             async, async a =>
@@ -1173,7 +1173,7 @@ WHERE (c["Terminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (ARRAY
 """);
             });
 
-    [ConditionalTheory, MemberData(nameof(IsAsyncData))]
+    [ConditionalTheory]
     public override Task Any_with_predicate_over_owned_collection(bool async)
         => CosmosTestHelpers.Instance.NoSyncTest(
             async, async a =>
@@ -1191,7 +1191,7 @@ WHERE (c["Terminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND EXISTS
 """);
             });
 
-    [ConditionalTheory, MemberData(nameof(IsAsyncData))]
+    [ConditionalTheory]
     public override Task Contains_over_owned_collection(bool async)
         => CosmosTestHelpers.Instance.NoSyncTest(
             async, async a =>
@@ -1209,7 +1209,7 @@ WHERE (c["Terminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND EXISTS
 """);
             });
 
-    [ConditionalTheory, MemberData(nameof(IsAsyncData))]
+    [ConditionalTheory]
     public override Task ElementAt_over_owned_collection(bool async)
         => CosmosTestHelpers.Instance.NoSyncTest(
             async, async a =>
@@ -1224,7 +1224,7 @@ WHERE (c["Terminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (c["Or
 """);
             });
 
-    [ConditionalTheory, MemberData(nameof(IsAsyncData))]
+    [ConditionalTheory]
     public override Task ElementAtOrDefault_over_owned_collection(bool async)
         => CosmosTestHelpers.Instance.NoSyncTest(
             async, async a =>
@@ -1239,7 +1239,7 @@ WHERE (c["Terminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND ((c["O
 """);
             });
 
-    [ConditionalTheory, MemberData(nameof(IsAsyncData))]
+    [ConditionalTheory]
     public override async Task OrderBy_ElementAt_over_owned_collection(bool async)
     {
         // Always throws for sync.
@@ -1261,7 +1261,7 @@ WHERE (c["Terminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (ARRAY
         }
     }
 
-    [ConditionalTheory, MemberData(nameof(IsAsyncData))]
+    [ConditionalTheory]
     public override Task Skip_Take_over_owned_collection(bool async)
         => CosmosTestHelpers.Instance.NoSyncTest(
             async, async a =>
@@ -1276,7 +1276,7 @@ WHERE (c["Terminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (ARRAY
 """);
             });
 
-    [ConditionalTheory, MemberData(nameof(IsAsyncData))]
+    [ConditionalTheory]
     public override Task FirstOrDefault_over_owned_collection(bool async)
         => CosmosTestHelpers.Instance.NoSyncTest(
             async, async a =>
@@ -1294,7 +1294,7 @@ WHERE (c["Terminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (DateT
 """);
             });
 
-    [ConditionalTheory, MemberData(nameof(IsAsyncData))]
+    [ConditionalTheory]
     public override async Task Distinct_over_owned_collection(bool async)
     {
         // Always throws for sync.
@@ -1307,7 +1307,7 @@ WHERE (c["Terminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (DateT
         }
     }
 
-    [ConditionalTheory, MemberData(nameof(IsAsyncData))]
+    [ConditionalTheory]
     public override Task Union_over_owned_collection(bool async)
         => CosmosTestHelpers.Instance.NoSyncTest(
             async, async a =>

--- a/test/EFCore.Relational.Specification.Tests/Query/JsonQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/JsonQueryRelationalTestBase.cs
@@ -8,7 +8,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 public abstract class JsonQueryRelationalTestBase<TFixture>(TFixture fixture) : JsonQueryTestBase<TFixture>(fixture)
     where TFixture : JsonQueryRelationalFixture, new()
 {
-    [ConditionalTheory, MemberData(nameof(IsAsyncData))]
+    [ConditionalTheory]
     public override async Task Project_json_reference_in_tracking_query_fails(bool async)
     {
         var message =
@@ -17,7 +17,7 @@ public abstract class JsonQueryRelationalTestBase<TFixture>(TFixture fixture) : 
         Assert.Equal(CoreStrings.OwnedEntitiesCannotBeTrackedWithoutTheirOwner, message);
     }
 
-    [ConditionalTheory, MemberData(nameof(IsAsyncData))]
+    [ConditionalTheory]
     public override async Task Project_json_collection_in_tracking_query_fails(bool async)
     {
         var message =
@@ -27,7 +27,7 @@ public abstract class JsonQueryRelationalTestBase<TFixture>(TFixture fixture) : 
         Assert.Equal(CoreStrings.OwnedEntitiesCannotBeTrackedWithoutTheirOwner, message);
     }
 
-    [ConditionalTheory, MemberData(nameof(IsAsyncData))]
+    [ConditionalTheory]
     public override async Task Project_json_entity_in_tracking_query_fails_even_when_owner_is_present(bool async)
     {
         var message = (await Assert.ThrowsAsync<InvalidOperationException>(()

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqlServerTest.cs
@@ -1612,7 +1612,7 @@ WHERE [c].[CustomerID] LIKE N'F%'
 """);
     }
 
-    [ConditionalTheory, MemberData(nameof(IsAsyncData))]
+    [ConditionalTheory]
     public override async Task Update_with_two_inner_joins(bool async)
     {
         await base.Update_with_two_inner_joins(async);
@@ -1630,7 +1630,7 @@ WHERE [p].[Discontinued] = CAST(1 AS bit) AND [o0].[OrderDate] > '1990-01-01T00:
 """);
     }
 
-    [ConditionalTheory, MemberData(nameof(IsAsyncData))]
+    [ConditionalTheory]
     public override async Task Update_with_PK_pushdown_and_join_and_multiple_setters(bool async)
     {
         await base.Update_with_PK_pushdown_and_join_and_multiple_setters(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Update/StoreValueGenerationIdentitySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/StoreValueGenerationIdentitySqlServerTest.cs
@@ -387,7 +387,7 @@ WHERE [Id] = @p1;
 
     #region Different two operations
 
-    [ConditionalTheory, MemberData(nameof(IsAsyncData))]
+    [ConditionalTheory]
     public override async Task Delete_Add_with_same_entity_types(bool async)
     {
         await Test(EntityState.Deleted, EntityState.Added, GeneratedValues.Some, async, withSameEntityType: true);

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqliteTest.cs
@@ -1535,7 +1535,7 @@ WHERE "c"."CustomerID" LIKE 'F%'
 """);
     }
 
-    [ConditionalTheory, MemberData(nameof(IsAsyncData))]
+    [ConditionalTheory]
     public override async Task Update_with_PK_pushdown_and_join_and_multiple_setters(bool async)
     {
         await base.Update_with_PK_pushdown_and_join_and_multiple_setters(async);


### PR DESCRIPTION
When an override method re-declares `[MemberData(nameof(IsAsyncData))]` that already exists on the base `virtual` method, xUnit collects data attributes from the entire inheritance chain (`DataAttribute` has `AllowMultiple = true, Inherited = true`). This results in duplicate test data rows (`[false], [true], [false], [true]`), causing "Skipping test case with duplicate ID" warnings and skipped tests.

This removes the redundant `MemberData` from 21 override methods across 5 test files, leaving just `[ConditionalTheory]` on the override (the `MemberData` is inherited from the base).

**Affected files:**
- `OwnedQueryCosmosTest.cs` (14 cases)
- `JsonQueryRelationalTestBase.cs` (3 cases)
- `NorthwindBulkUpdatesSqlServerTest.cs` (2 cases)
- `StoreValueGenerationIdentitySqlServerTest.cs` (1 case)
- `NorthwindBulkUpdatesSqliteTest.cs` (1 case)