### PR TITLE
Skip two failing tests and add SkipOnHelixCondition attribute

### DIFF
--- a/azure-pipelines-internal-tests.yml
+++ b/azure-pipelines-internal-tests.yml
@@ -623,7 +623,7 @@ extends:
       condition: always()
       jobs:
       - job: Validate_Job_Results
-        displayName: Validate Job Results
+        displayName: Job Results
         pool:
           name: $(DncEngInternalBuildPool)
           demands: ImageOverride -equals 1es-windows-2022

--- a/azure-pipelines-public.yml
+++ b/azure-pipelines-public.yml
@@ -442,7 +442,7 @@ stages:
   condition: always()
   jobs:
   - job: Validate_Job_Results
-    displayName: Validate Job Results
+    displayName: Job Results
     pool:
       name: $(DncEngPublicBuildPool)
       demands: ImageOverride -equals 1es-windows-2022-open

--- a/test/EFCore.Specification.Tests/TestUtilities/Xunit/SkipOnHelixConditionAttribute.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/Xunit/SkipOnHelixConditionAttribute.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
+
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly)]
+public sealed class SkipOnHelixConditionAttribute : Attribute, ITestCondition
+{
+    public ValueTask<bool> IsMetAsync()
+        => new(Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is null);
+
+    public string SkipReason { get; set; } = "Test does not run on Helix.";
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Geography/SqlServerGeographyCollectionTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Geography/SqlServerGeographyCollectionTypeTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using NetTopologySuite.Geometries;

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Geography/SqlServerGeographyCollectionTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Geography/SqlServerGeographyCollectionTypeTest.cs
@@ -1,7 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using NetTopologySuite.Geometries;
+
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Types.Geography;
 
@@ -175,15 +177,11 @@ FROM [JsonTypeEntity] AS [j]
         }
     }
 
+    // TODO: Currently failing on Helix only, see #36746
     [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    [SkipOnHelixCondition]
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
-        // TODO: Currently failing on Helix only, see #36746
-        if (Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null)
-        {
-            return;
-        }
-
         await base.ExecuteUpdate_within_json_to_nonjson_column();
 
         if (Fixture.UsingJsonType)

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Geography/SqlServerGeographyLineStringTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Geography/SqlServerGeographyLineStringTypeTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using NetTopologySuite.Geometries;

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Geography/SqlServerGeographyLineStringTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Geography/SqlServerGeographyLineStringTypeTest.cs
@@ -1,7 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using NetTopologySuite.Geometries;
+
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Types.Geography;
 
@@ -169,15 +171,11 @@ FROM [JsonTypeEntity] AS [j]
         }
     }
 
+    // TODO: Currently failing on Helix only, see #36746
     [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    [SkipOnHelixCondition]
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
-        // TODO: Currently failing on Helix only, see #36746
-        if (Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null)
-        {
-            return;
-        }
-
         await base.ExecuteUpdate_within_json_to_nonjson_column();
 
         if (Fixture.UsingJsonType)

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Geography/SqlServerGeographyMultiLineStringTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Geography/SqlServerGeographyMultiLineStringTypeTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using NetTopologySuite.Geometries;

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Geography/SqlServerGeographyMultiLineStringTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Geography/SqlServerGeographyMultiLineStringTypeTest.cs
@@ -1,7 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using NetTopologySuite.Geometries;
+
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Types.Geography;
 
@@ -173,15 +175,11 @@ FROM [JsonTypeEntity] AS [j]
         }
     }
 
+    // TODO: Currently failing on Helix only, see #36746
     [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    [SkipOnHelixCondition]
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
-        // TODO: Currently failing on Helix only, see #36746
-        if (Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null)
-        {
-            return;
-        }
-
         await base.ExecuteUpdate_within_json_to_nonjson_column();
 
         if (Fixture.UsingJsonType)

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Geography/SqlServerGeographyMultiPointTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Geography/SqlServerGeographyMultiPointTypeTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using NetTopologySuite.Geometries;

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Geography/SqlServerGeographyMultiPointTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Geography/SqlServerGeographyMultiPointTypeTest.cs
@@ -1,7 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using NetTopologySuite.Geometries;
+
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Types.Geography;
 
@@ -175,15 +177,11 @@ FROM [JsonTypeEntity] AS [j]
         }
     }
 
+    // TODO: Currently failing on Helix only, see #36746
     [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    [SkipOnHelixCondition]
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
-        // TODO: Currently failing on Helix only, see #36746
-        if (Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null)
-        {
-            return;
-        }
-
         await base.ExecuteUpdate_within_json_to_nonjson_column();
 
         if (Fixture.UsingJsonType)

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Geography/SqlServerGeographyMultiPolygonTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Geography/SqlServerGeographyMultiPolygonTypeTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using NetTopologySuite.Geometries;

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Geography/SqlServerGeographyMultiPolygonTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Geography/SqlServerGeographyMultiPolygonTypeTest.cs
@@ -1,7 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using NetTopologySuite.Geometries;
+
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Types.Geography;
 
@@ -173,15 +175,11 @@ FROM [JsonTypeEntity] AS [j]
         }
     }
 
+    // TODO: Currently failing on Helix only, see #36746
     [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    [SkipOnHelixCondition]
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
-        // TODO: Currently failing on Helix only, see #36746
-        if (Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null)
-        {
-            return;
-        }
-
         await base.ExecuteUpdate_within_json_to_nonjson_column();
 
         if (Fixture.UsingJsonType)

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Geography/SqlServerGeographyPointTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Geography/SqlServerGeographyPointTypeTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using NetTopologySuite.Geometries;

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Geography/SqlServerGeographyPointTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Geography/SqlServerGeographyPointTypeTest.cs
@@ -1,7 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using NetTopologySuite.Geometries;
+
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Types.Geography;
 
@@ -167,15 +169,11 @@ FROM [JsonTypeEntity] AS [j]
         }
     }
 
+    // TODO: Currently failing on Helix only, see #36746
     [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    [SkipOnHelixCondition]
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
-        // TODO: Currently failing on Helix only, see #36746
-        if (Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null)
-        {
-            return;
-        }
-
         await base.ExecuteUpdate_within_json_to_nonjson_column();
 
         if (Fixture.UsingJsonType)

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Geography/SqlServerGeographyPolygonTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Geography/SqlServerGeographyPolygonTypeTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using NetTopologySuite.Geometries;

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Geography/SqlServerGeographyPolygonTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Geography/SqlServerGeographyPolygonTypeTest.cs
@@ -1,7 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using NetTopologySuite.Geometries;
+
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Types.Geography;
 
@@ -167,15 +169,11 @@ FROM [JsonTypeEntity] AS [j]
         }
     }
 
+    // TODO: Currently failing on Helix only, see #36746
     [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    [SkipOnHelixCondition]
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
-        // TODO: Currently failing on Helix only, see #36746
-        if (Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null)
-        {
-            return;
-        }
-
         await base.ExecuteUpdate_within_json_to_nonjson_column();
 
         if (Fixture.UsingJsonType)

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Geometry/SqlServerGeometryCollectionTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Geometry/SqlServerGeometryCollectionTypeTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using NetTopologySuite.Geometries;

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Geometry/SqlServerGeometryCollectionTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Geometry/SqlServerGeometryCollectionTypeTest.cs
@@ -1,7 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using NetTopologySuite.Geometries;
+
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Types.Geometry;
 
@@ -175,15 +177,11 @@ FROM [JsonTypeEntity] AS [j]
         }
     }
 
+    // TODO: Currently failing on Helix only, see #36746
     [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    [SkipOnHelixCondition]
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
-        // TODO: Currently failing on Helix only, see #36746
-        if (Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null)
-        {
-            return;
-        }
-
         await base.ExecuteUpdate_within_json_to_nonjson_column();
 
         if (Fixture.UsingJsonType)

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Geometry/SqlServerGeometryLineStringTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Geometry/SqlServerGeometryLineStringTypeTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using NetTopologySuite.Geometries;

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Geometry/SqlServerGeometryLineStringTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Geometry/SqlServerGeometryLineStringTypeTest.cs
@@ -1,7 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using NetTopologySuite.Geometries;
+
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Types.Geometry;
 
@@ -169,15 +171,11 @@ FROM [JsonTypeEntity] AS [j]
         }
     }
 
+    // TODO: Currently failing on Helix only, see #36746
     [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    [SkipOnHelixCondition]
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
-        // TODO: Currently failing on Helix only, see #36746
-        if (Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null)
-        {
-            return;
-        }
-
         await base.ExecuteUpdate_within_json_to_nonjson_column();
 
         if (Fixture.UsingJsonType)

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Geometry/SqlServerGeometryMultiLineStringTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Geometry/SqlServerGeometryMultiLineStringTypeTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using NetTopologySuite.Geometries;

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Geometry/SqlServerGeometryMultiLineStringTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Geometry/SqlServerGeometryMultiLineStringTypeTest.cs
@@ -1,7 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using NetTopologySuite.Geometries;
+
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Types.Geometry;
 
@@ -173,15 +175,11 @@ FROM [JsonTypeEntity] AS [j]
         }
     }
 
+    // TODO: Currently failing on Helix only, see #36746
     [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    [SkipOnHelixCondition]
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
-        // TODO: Currently failing on Helix only, see #36746
-        if (Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null)
-        {
-            return;
-        }
-
         await base.ExecuteUpdate_within_json_to_nonjson_column();
 
         if (Fixture.UsingJsonType)

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Geometry/SqlServerGeometryMultiPointTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Geometry/SqlServerGeometryMultiPointTypeTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using NetTopologySuite.Geometries;

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Geometry/SqlServerGeometryMultiPointTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Geometry/SqlServerGeometryMultiPointTypeTest.cs
@@ -1,7 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using NetTopologySuite.Geometries;
+
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Types.Geometry;
 
@@ -175,15 +177,11 @@ FROM [JsonTypeEntity] AS [j]
         }
     }
 
+    // TODO: Currently failing on Helix only, see #36746
     [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    [SkipOnHelixCondition]
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
-        // TODO: Currently failing on Helix only, see #36746
-        if (Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null)
-        {
-            return;
-        }
-
         await base.ExecuteUpdate_within_json_to_nonjson_column();
 
         if (Fixture.UsingJsonType)

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Geometry/SqlServerGeometryMultiPolygonTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Geometry/SqlServerGeometryMultiPolygonTypeTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using NetTopologySuite.Geometries;

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Geometry/SqlServerGeometryMultiPolygonTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Geometry/SqlServerGeometryMultiPolygonTypeTest.cs
@@ -1,7 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using NetTopologySuite.Geometries;
+
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Types.Geometry;
 
@@ -173,15 +175,11 @@ FROM [JsonTypeEntity] AS [j]
         }
     }
 
+    // TODO: Currently failing on Helix only, see #36746
     [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    [SkipOnHelixCondition]
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
-        // TODO: Currently failing on Helix only, see #36746
-        if (Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null)
-        {
-            return;
-        }
-
         await base.ExecuteUpdate_within_json_to_nonjson_column();
 
         if (Fixture.UsingJsonType)

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Geometry/SqlServerGeometryPointTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Geometry/SqlServerGeometryPointTypeTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using NetTopologySuite.Geometries;

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Geometry/SqlServerGeometryPointTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Geometry/SqlServerGeometryPointTypeTest.cs
@@ -1,7 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using NetTopologySuite.Geometries;
+
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Types.Geometry;
 
@@ -167,15 +169,11 @@ FROM [JsonTypeEntity] AS [j]
         }
     }
 
+    // TODO: Currently failing on Helix only, see #36746
     [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    [SkipOnHelixCondition]
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
-        // TODO: Currently failing on Helix only, see #36746
-        if (Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null)
-        {
-            return;
-        }
-
         await base.ExecuteUpdate_within_json_to_nonjson_column();
 
         if (Fixture.UsingJsonType)

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Geometry/SqlServerGeometryPolygonTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Geometry/SqlServerGeometryPolygonTypeTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using NetTopologySuite.Geometries;

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Geometry/SqlServerGeometryPolygonTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Geometry/SqlServerGeometryPolygonTypeTest.cs
@@ -1,7 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using NetTopologySuite.Geometries;
+
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Types.Geometry;
 
@@ -167,15 +169,11 @@ FROM [JsonTypeEntity] AS [j]
         }
     }
 
+    // TODO: Currently failing on Helix only, see #36746
     [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    [SkipOnHelixCondition]
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
-        // TODO: Currently failing on Helix only, see #36746
-        if (Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null)
-        {
-            return;
-        }
-
         await base.ExecuteUpdate_within_json_to_nonjson_column();
 
         if (Fixture.UsingJsonType)

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Miscellaneous/SqlServerBoolTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Miscellaneous/SqlServerBoolTypeTest.cs
@@ -1,5 +1,7 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Types.Miscellaneous;
 
@@ -189,15 +191,11 @@ FROM [JsonTypeEntity] AS [j]
         }
     }
 
+    // TODO: Currently failing on Helix only, see #36746
     [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    [SkipOnHelixCondition]
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
-        // TODO: Currently failing on Helix only, see #36746
-        if (Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null)
-        {
-            return;
-        }
-
         await base.ExecuteUpdate_within_json_to_nonjson_column();
 
         if (Fixture.UsingJsonType)

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Miscellaneous/SqlServerBoolTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Miscellaneous/SqlServerBoolTypeTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Miscellaneous/SqlServerByteArrayTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Miscellaneous/SqlServerByteArrayTypeTest.cs
@@ -1,5 +1,7 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Types.Miscellaneous;
 
@@ -167,15 +169,11 @@ FROM [JsonTypeEntity] AS [j]
         }
     }
 
+    // TODO: Currently failing on Helix only, see #36746
     [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    [SkipOnHelixCondition]
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
-        // TODO: Currently failing on Helix only, see #36746
-        if (Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null)
-        {
-            return;
-        }
-
         await base.ExecuteUpdate_within_json_to_nonjson_column();
 
         if (Fixture.UsingJsonType)

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Miscellaneous/SqlServerByteArrayTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Miscellaneous/SqlServerByteArrayTypeTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Miscellaneous/SqlServerGuidTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Miscellaneous/SqlServerGuidTypeTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Miscellaneous/SqlServerGuidTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Miscellaneous/SqlServerGuidTypeTest.cs
@@ -1,5 +1,7 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Types.Miscellaneous;
 
@@ -177,15 +179,11 @@ FROM [JsonTypeEntity] AS [j]
         }
     }
 
+    // TODO: Currently failing on Helix only, see #36746
     [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    [SkipOnHelixCondition]
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
-        // TODO: Currently failing on Helix only, see #36746
-        if (Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null)
-        {
-            return;
-        }
-
         await base.ExecuteUpdate_within_json_to_nonjson_column();
 
         if (Fixture.UsingJsonType)

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Miscellaneous/SqlServerStringTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Miscellaneous/SqlServerStringTypeTest.cs
@@ -1,5 +1,7 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Types.Miscellaneous;
 
@@ -189,15 +191,11 @@ FROM [JsonTypeEntity] AS [j]
         }
     }
 
+    // TODO: Currently failing on Helix only, see #36746
     [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    [SkipOnHelixCondition]
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
-        // TODO: Currently failing on Helix only, see #36746
-        if (Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null)
-        {
-            return;
-        }
-
         await base.ExecuteUpdate_within_json_to_nonjson_column();
 
         if (Fixture.UsingJsonType)

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Miscellaneous/SqlServerStringTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Miscellaneous/SqlServerStringTypeTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Numeric/SqlServerByteTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Numeric/SqlServerByteTypeTest.cs
@@ -1,5 +1,7 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Types.Numeric;
 
@@ -189,15 +191,11 @@ FROM [JsonTypeEntity] AS [j]
         }
     }
 
+    // TODO: Currently failing on Helix only, see #36746
     [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    [SkipOnHelixCondition]
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
-        // TODO: Currently failing on Helix only, see #36746
-        if (Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null)
-        {
-            return;
-        }
-
         await base.ExecuteUpdate_within_json_to_nonjson_column();
 
         if (Fixture.UsingJsonType)

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Numeric/SqlServerByteTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Numeric/SqlServerByteTypeTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Numeric/SqlServerDecimalTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Numeric/SqlServerDecimalTypeTest.cs
@@ -1,5 +1,7 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Types.Numeric;
 
@@ -189,15 +191,11 @@ FROM [JsonTypeEntity] AS [j]
         }
     }
 
+    // TODO: Currently failing on Helix only, see #36746
     [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    [SkipOnHelixCondition]
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
-        // TODO: Currently failing on Helix only, see #36746
-        if (Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null)
-        {
-            return;
-        }
-
         await base.ExecuteUpdate_within_json_to_nonjson_column();
 
         if (Fixture.UsingJsonType)

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Numeric/SqlServerDecimalTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Numeric/SqlServerDecimalTypeTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Numeric/SqlServerDoubleTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Numeric/SqlServerDoubleTypeTest.cs
@@ -1,5 +1,7 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Types.Numeric;
 
@@ -189,15 +191,11 @@ FROM [JsonTypeEntity] AS [j]
         }
     }
 
+    // TODO: Currently failing on Helix only, see #36746
     [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    [SkipOnHelixCondition]
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
-        // TODO: Currently failing on Helix only, see #36746
-        if (Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null)
-        {
-            return;
-        }
-
         await base.ExecuteUpdate_within_json_to_nonjson_column();
 
         if (Fixture.UsingJsonType)

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Numeric/SqlServerDoubleTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Numeric/SqlServerDoubleTypeTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Numeric/SqlServerFloatTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Numeric/SqlServerFloatTypeTest.cs
@@ -1,5 +1,7 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Types.Numeric;
 
@@ -189,15 +191,11 @@ FROM [JsonTypeEntity] AS [j]
         }
     }
 
+    // TODO: Currently failing on Helix only, see #36746
     [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    [SkipOnHelixCondition]
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
-        // TODO: Currently failing on Helix only, see #36746
-        if (Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null)
-        {
-            return;
-        }
-
         await base.ExecuteUpdate_within_json_to_nonjson_column();
 
         if (Fixture.UsingJsonType)

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Numeric/SqlServerFloatTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Numeric/SqlServerFloatTypeTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Numeric/SqlServerIntTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Numeric/SqlServerIntTypeTest.cs
@@ -1,5 +1,7 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Types.Numeric;
 
@@ -189,15 +191,11 @@ FROM [JsonTypeEntity] AS [j]
         }
     }
 
+    // TODO: Currently failing on Helix only, see #36746
     [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    [SkipOnHelixCondition]
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
-        // TODO: Currently failing on Helix only, see #36746
-        if (Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null)
-        {
-            return;
-        }
-
         await base.ExecuteUpdate_within_json_to_nonjson_column();
 
         if (Fixture.UsingJsonType)

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Numeric/SqlServerIntTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Numeric/SqlServerIntTypeTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Numeric/SqlServerLongTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Numeric/SqlServerLongTypeTest.cs
@@ -1,5 +1,7 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Types.Numeric;
 
@@ -189,15 +191,11 @@ FROM [JsonTypeEntity] AS [j]
         }
     }
 
+    // TODO: Currently failing on Helix only, see #36746
     [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    [SkipOnHelixCondition]
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
-        // TODO: Currently failing on Helix only, see #36746
-        if (Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null)
-        {
-            return;
-        }
-
         await base.ExecuteUpdate_within_json_to_nonjson_column();
 
         if (Fixture.UsingJsonType)

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Numeric/SqlServerLongTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Numeric/SqlServerLongTypeTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Numeric/SqlServerShortTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Numeric/SqlServerShortTypeTest.cs
@@ -1,5 +1,7 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Types.Numeric;
 
@@ -189,15 +191,11 @@ FROM [JsonTypeEntity] AS [j]
         }
     }
 
+    // TODO: Currently failing on Helix only, see #36746
     [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    [SkipOnHelixCondition]
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
-        // TODO: Currently failing on Helix only, see #36746
-        if (Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null)
-        {
-            return;
-        }
-
         await base.ExecuteUpdate_within_json_to_nonjson_column();
 
         if (Fixture.UsingJsonType)

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Numeric/SqlServerShortTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Numeric/SqlServerShortTypeTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Temporal/SqlServerDateOnlyTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Temporal/SqlServerDateOnlyTypeTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Temporal/SqlServerDateOnlyTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Temporal/SqlServerDateOnlyTypeTest.cs
@@ -1,5 +1,7 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Types.Temporal;
 
@@ -189,15 +191,11 @@ FROM [JsonTypeEntity] AS [j]
         }
     }
 
+    // TODO: Currently failing on Helix only, see #36746
     [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    [SkipOnHelixCondition]
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
-        // TODO: Currently failing on Helix only, see #36746
-        if (Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null)
-        {
-            return;
-        }
-
         await base.ExecuteUpdate_within_json_to_nonjson_column();
 
         if (Fixture.UsingJsonType)

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Temporal/SqlServerDateTime2TypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Temporal/SqlServerDateTime2TypeTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Temporal/SqlServerDateTime2TypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Temporal/SqlServerDateTime2TypeTest.cs
@@ -1,5 +1,7 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Types.Temporal;
 
@@ -189,15 +191,11 @@ FROM [JsonTypeEntity] AS [j]
         }
     }
 
+    // TODO: Currently failing on Helix only, see #36746
     [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    [SkipOnHelixCondition]
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
-        // TODO: Currently failing on Helix only, see #36746
-        if (Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null)
-        {
-            return;
-        }
-
         await base.ExecuteUpdate_within_json_to_nonjson_column();
 
         if (Fixture.UsingJsonType)

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Temporal/SqlServerDateTimeOffsetTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Temporal/SqlServerDateTimeOffsetTypeTest.cs
@@ -1,5 +1,7 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Types.Temporal;
 
@@ -191,15 +193,11 @@ FROM [JsonTypeEntity] AS [j]
         }
     }
 
+    // TODO: Currently failing on Helix only, see #36746
     [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    [SkipOnHelixCondition]
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
-        // TODO: Currently failing on Helix only, see #36746
-        if (Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null)
-        {
-            return;
-        }
-
         await base.ExecuteUpdate_within_json_to_nonjson_column();
 
         if (Fixture.UsingJsonType)

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Temporal/SqlServerDateTimeOffsetTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Temporal/SqlServerDateTimeOffsetTypeTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Temporal/SqlServerDateTimeTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Temporal/SqlServerDateTimeTypeTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Temporal/SqlServerDateTimeTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Temporal/SqlServerDateTimeTypeTest.cs
@@ -1,5 +1,7 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Types.Temporal;
 
@@ -175,15 +177,11 @@ FROM [JsonTypeEntity] AS [j]
         }
     }
 
+    // TODO: Currently failing on Helix only, see #36746
     [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    [SkipOnHelixCondition]
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
-        // TODO: Currently failing on Helix only, see #36746
-        if (Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null)
-        {
-            return;
-        }
-
         await base.ExecuteUpdate_within_json_to_nonjson_column();
 
         if (Fixture.UsingJsonType)

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Temporal/SqlServerTimeOnlyTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Temporal/SqlServerTimeOnlyTypeTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Temporal/SqlServerTimeOnlyTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Temporal/SqlServerTimeOnlyTypeTest.cs
@@ -1,5 +1,7 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Types.Temporal;
 
@@ -189,15 +191,11 @@ FROM [JsonTypeEntity] AS [j]
         }
     }
 
+    // TODO: Currently failing on Helix only, see #36746
     [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    [SkipOnHelixCondition]
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
-        // TODO: Currently failing on Helix only, see #36746
-        if (Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null)
-        {
-            return;
-        }
-
         await base.ExecuteUpdate_within_json_to_nonjson_column();
 
         if (Fixture.UsingJsonType)

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Temporal/SqlServerTimeSpanTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Temporal/SqlServerTimeSpanTypeTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;

--- a/test/EFCore.SqlServer.FunctionalTests/Types/Temporal/SqlServerTimeSpanTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Types/Temporal/SqlServerTimeSpanTypeTest.cs
@@ -1,5 +1,7 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Types.Temporal;
 
@@ -189,15 +191,11 @@ FROM [JsonTypeEntity] AS [j]
         }
     }
 
+    // TODO: Currently failing on Helix only, see #36746
     [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    [SkipOnHelixCondition]
     public override async Task ExecuteUpdate_within_json_to_nonjson_column()
     {
-        // TODO: Currently failing on Helix only, see #36746
-        if (Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null)
-        {
-            return;
-        }
-
         await base.ExecuteUpdate_within_json_to_nonjson_column();
 
         if (Fixture.UsingJsonType)

--- a/test/dotnet-ef.Tests/ProjectTest.cs
+++ b/test/dotnet-ef.Tests/ProjectTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.DotNet.Cli.CommandLine;
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Tools;
 
@@ -69,7 +70,8 @@ public sealed class ProjectTest(ITestOutputHelper output)
         Assert.Null(RootCommand.ResolveOption(primary, alias, configValue: null));
     }
 
-    [Fact]
+    [ConditionalFact]
+    [SkipOnHelixCondition]
     public void Csproj_metadata_can_be_extracted()
     {
         var capturedOutput = WithCapturedOutput(() =>
@@ -113,7 +115,8 @@ public sealed class ProjectTest(ITestOutputHelper output)
         Assert.DoesNotContain(Reporter.ErrorPrefix, capturedOutput);
     }
 
-    [Fact]
+    [ConditionalFact]
+    [SkipOnHelixCondition]
     public void File_based_app_can_be_built()
     {
         var capturedOutput = WithCapturedOutput(() =>

--- a/test/dotnet-ef.Tests/ProjectTest.cs
+++ b/test/dotnet-ef.Tests/ProjectTest.cs
@@ -71,7 +71,7 @@ public sealed class ProjectTest(ITestOutputHelper output)
     }
 
     [ConditionalFact]
-    [SkipOnHelixCondition]
+    [SkipOnCiCondition]
     public void Csproj_metadata_can_be_extracted()
     {
         var capturedOutput = WithCapturedOutput(() =>
@@ -116,7 +116,7 @@ public sealed class ProjectTest(ITestOutputHelper output)
     }
 
     [ConditionalFact]
-    [SkipOnHelixCondition]
+    [SkipOnCiCondition]
     public void File_based_app_can_be_built()
     {
         var capturedOutput = WithCapturedOutput(() =>

--- a/test/dotnet-ef.Tests/dotnet-ef.Tests.csproj
+++ b/test/dotnet-ef.Tests/dotnet-ef.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>

--- a/test/dotnet-ef.Tests/dotnet-ef.Tests.csproj
+++ b/test/dotnet-ef.Tests/dotnet-ef.Tests.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\dotnet-ef\dotnet-ef.csproj" />
+    <ProjectReference Include="..\EFCore.Specification.Tests\EFCore.Specification.Tests.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Several `dotnet-ef` tests (`Csproj_metadata_can_be_extracted`, `File_based_app_can_be_built`) fail on AzDo agents because they shell out to `dotnet restore`/`dotnet build` which requires a full SDK that is not installed there. Similarly, 31 SqlServer type tests had inline `HELIX_WORKITEM_ROOT` environment variable checks to early-return on Helix.

This PR introduces a reusable `[SkipOnHelixCondition]` attribute in the `ConditionalFact` test infrastructure and replaces all ad-hoc Helix skip logic with it.

### Changes

- **New `SkipOnHelixConditionAttribute`** in `EFCore.Specification.Tests` -- an `ITestCondition` that checks `HELIX_WORKITEM_ROOT`, usable on any `[ConditionalFact]`/`[ConditionalTheory]` test
- **`dotnet-ef.Tests`** -- added project reference to `EFCore.Specification.Tests` to get access to `ConditionalFact` and the new attribute; marked both SDK-dependent tests with `[SkipOnCICondition]`
- **31 SqlServer type test files** -- replaced inline `if (Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null) { return; }` blocks with `[SkipOnHelixCondition]`, keeping the `// TODO` comments referencing #36746
- **Pipeline rename** -- `Validate Job Results` -> `Job Results` in both `azure-pipelines-public.yml` and `azure-pipelines-internal-tests.yml`