### PR TITLE
EF1003: Detect explicit string.Format/string.Concat in raw SQL APIs

### DIFF
--- a/src/EFCore.Analyzers/StringsUsageInRawQueriesDiagnosticAnalyzer.cs
+++ b/src/EFCore.Analyzers/StringsUsageInRawQueriesDiagnosticAnalyzer.cs
@@ -208,6 +208,15 @@ public sealed class StringsUsageInRawQueriesDiagnosticAnalyzer : DiagnosticAnaly
     {
         foreach (var argument in invocation.Arguments)
         {
+            // The IFormatProvider argument of the string.Format(IFormatProvider, ...) overloads
+            // (e.g. CultureInfo.InvariantCulture) never contributes to the SQL text and is never a
+            // compile-time constant — skip it so a fully-constant format call isn't flagged. See #37915.
+            if (argument.Parameter?.Type is
+                { Name: "IFormatProvider", ContainingNamespace: { Name: "System", ContainingNamespace.IsGlobalNamespace: true } })
+            {
+                continue;
+            }
+
             var value = Unwrap(argument.Value);
 
             // Implicit params arrays — inspect each element rather than the array itself.

--- a/src/EFCore.Analyzers/StringsUsageInRawQueriesDiagnosticAnalyzer.cs
+++ b/src/EFCore.Analyzers/StringsUsageInRawQueriesDiagnosticAnalyzer.cs
@@ -186,8 +186,64 @@ public sealed class StringsUsageInRawQueriesDiagnosticAnalyzer : DiagnosticAnaly
             } concatenation when AnalyzeConcatenation(concatenation)
                 => StringConcatenationDescriptor,
 
+            // ...an explicit call to string.Format(...) or string.Concat(...)
+            IInvocationOperation argInvocation
+                => AnalyzeStringMethodInvocation(argInvocation),
+
             _ => null,
         };
+
+    private static DiagnosticDescriptor? AnalyzeStringMethodInvocation(IInvocationOperation invocation)
+    {
+        if (invocation.TargetMethod.ContainingType.SpecialType != SpecialType.System_String
+            || invocation.TargetMethod.Name is not (nameof(string.Format) or nameof(string.Concat)))
+        {
+            return null;
+        }
+
+        return HasNonConstantArgument(invocation) ? StringConcatenationDescriptor : null;
+    }
+
+    private static bool HasNonConstantArgument(IInvocationOperation invocation)
+    {
+        foreach (var argument in invocation.Arguments)
+        {
+            var value = Unwrap(argument.Value);
+
+            // Implicit params arrays — inspect each element rather than the array itself.
+            if (argument.ArgumentKind == ArgumentKind.ParamArray
+                && value is IArrayCreationOperation { Initializer.ElementValues: var elements })
+            {
+                foreach (var element in elements)
+                {
+                    if (!Unwrap(element).ConstantValue.HasValue)
+                    {
+                        return true;
+                    }
+                }
+
+                continue;
+            }
+
+            if (!value.ConstantValue.HasValue)
+            {
+                return true;
+            }
+        }
+
+        return false;
+
+        // Strip implicit conversions (e.g. boxing to object) so we see the original constant.
+        static IOperation Unwrap(IOperation operation)
+        {
+            while (operation is IConversionOperation { IsImplicit: true } conversion)
+            {
+                operation = conversion.Operand;
+            }
+
+            return operation;
+        }
+    }
 
     private static bool AnalyzeInterpolatedString(IInterpolatedStringOperation interpolatedString)
     {

--- a/test/EFCore.Analyzers.Tests/StringConcatenationInRawQueriesAnalyzerTests.cs
+++ b/test/EFCore.Analyzers.Tests/StringConcatenationInRawQueriesAnalyzerTests.cs
@@ -182,6 +182,39 @@ class C
 """);
 
     [Theory]
+    [MemberData(nameof(DoNotReportData))]
+    public Task Constant_string_format_with_format_provider_do_not_report(string call)
+        => Verify.VerifyAnalyzerAsync(
+            $$"""
+{{MyDbContext}}
+
+class C
+{
+    void M(MyDbContext db)
+    {
+        db.{{call}}(string.Format(System.Globalization.CultureInfo.InvariantCulture, "FooBar WHERE Id = {0}", "1"));
+    }
+}
+""");
+
+    [Theory]
+    [MemberData(nameof(ShouldReportData))]
+    public Task String_format_with_format_provider_and_argument_should_report(string call)
+        => Verify.VerifyAnalyzerAsync(
+            $$"""
+{{MyDbContext}}
+
+class C
+{
+    void M(MyDbContext db, string id)
+    {
+        db.{{call}}(string.Format(System.Globalization.CultureInfo.InvariantCulture, "FooBar WHERE Id = {0}", id));
+    }
+}
+""",
+            DiagnosticResult.CompilerWarning(EFDiagnostics.StringConcatenationUsageInRawQueries).WithLocation(0));
+
+    [Theory]
     [MemberData(nameof(ShouldReportData))]
     public Task String_format_with_argument_should_report(string call)
         => Verify.VerifyAnalyzerAsync(

--- a/test/EFCore.Analyzers.Tests/StringConcatenationInRawQueriesAnalyzerTests.cs
+++ b/test/EFCore.Analyzers.Tests/StringConcatenationInRawQueriesAnalyzerTests.cs
@@ -164,4 +164,108 @@ class C
 }
 """,
             DiagnosticResult.CompilerWarning(EFDiagnostics.StringConcatenationUsageInRawQueries).WithLocation(0));
+
+    [Theory]
+    [MemberData(nameof(DoNotReportData))]
+    public Task Constant_string_format_do_not_report(string call)
+        => Verify.VerifyAnalyzerAsync(
+            $$"""
+{{MyDbContext}}
+
+class C
+{
+    void M(MyDbContext db)
+    {
+        db.{{call}}(string.Format("FooBar WHERE Id = {0}", "1"));
+    }
+}
+""");
+
+    [Theory]
+    [MemberData(nameof(ShouldReportData))]
+    public Task String_format_with_argument_should_report(string call)
+        => Verify.VerifyAnalyzerAsync(
+            $$"""
+{{MyDbContext}}
+
+class C
+{
+    void M(MyDbContext db, string id)
+    {
+        db.{{call}}(string.Format("FooBar WHERE Id = {0}", id));
+    }
+}
+""",
+            DiagnosticResult.CompilerWarning(EFDiagnostics.StringConcatenationUsageInRawQueries).WithLocation(0));
+
+    [Theory]
+    [MemberData(nameof(ShouldReportData))]
+    public Task String_format_with_method_call_should_report(string call)
+        => Verify.VerifyAnalyzerAsync(
+            $$"""
+{{MyDbContext}}
+
+class C
+{
+    void M(MyDbContext db)
+    {
+        db.{{call}}(string.Format("FooBar WHERE Id = {0}", GetId()));
+    }
+
+    string GetId() => "1";
+}
+""",
+            DiagnosticResult.CompilerWarning(EFDiagnostics.StringConcatenationUsageInRawQueries).WithLocation(0));
+
+    [Theory]
+    [MemberData(nameof(DoNotReportData))]
+    public Task Constant_string_concat_do_not_report(string call)
+        => Verify.VerifyAnalyzerAsync(
+            $$"""
+{{MyDbContext}}
+
+class C
+{
+    void M(MyDbContext db)
+    {
+        db.{{call}}(string.Concat("FooBar", " WHERE Id = ", "1"));
+    }
+}
+""");
+
+    [Theory]
+    [MemberData(nameof(ShouldReportData))]
+    public Task String_concat_with_argument_should_report(string call)
+        => Verify.VerifyAnalyzerAsync(
+            $$"""
+{{MyDbContext}}
+
+class C
+{
+    void M(MyDbContext db, string id)
+    {
+        db.{{call}}(string.Concat("FooBar WHERE Id = ", id));
+    }
+}
+""",
+            DiagnosticResult.CompilerWarning(EFDiagnostics.StringConcatenationUsageInRawQueries).WithLocation(0));
+
+    [Theory]
+    [MemberData(nameof(ShouldReportData))]
+    public Task String_concat_with_method_call_should_report(string call)
+        => Verify.VerifyAnalyzerAsync(
+            $$"""
+{{MyDbContext}}
+
+class C
+{
+    void M(MyDbContext db)
+    {
+        db.{{call}}(string.Concat("FooBar WHERE Id = ", GetId()));
+    }
+
+    string GetId() => "1";
+}
+""",
+            DiagnosticResult.CompilerWarning(EFDiagnostics.StringConcatenationUsageInRawQueries).WithLocation(0));
 }


### PR DESCRIPTION
Fixes #37915.

## Problem

EF1003 (`StringConcatenationUsageInRawQueries`) currently warns when a raw SQL API receives a string built with the `+` operator, and EF1002 covers interpolated strings. Equivalent dynamic-string patterns built with explicit method calls were silently allowed:

```csharp
db.Database.ExecuteSqlRaw(string.Format("UPDATE T SET X = {0}", userInput));
db.Users.FromSqlRaw(string.Concat("SELECT * FROM T WHERE Id = ", userInput));
```

These have the same SQL-injection profile as the `+` form but produced no diagnostic.

## Fix

Extend `StringsUsageInRawQueriesDiagnosticAnalyzer.AnalyzeInvocation` with a third pattern: when the SQL argument is itself an `IInvocationOperation` of `string.Format` or `string.Concat`, walk its arguments and report EF1003 if at least one of them is non-constant.

Per the issue title (`EF1003: Also detect ...`), both `string.Format` and `string.Concat` map to EF1003. Happy to split `string.Format` onto EF1002 if reviewers prefer the semantic split.

Implementation notes:

* Implicit conversions (notably the `string` → `object` boxing in `string.Format(string, object)` overloads) are unwrapped via a small helper so a fully constant call like `string.Format("X = {0}", "1")` is correctly recognized as constant and does **not** warn.
* `params object?[]` arrays are inspected element-by-element rather than tested as a whole.
* No new diagnostic IDs, no new resource strings, no new release notes — this is a pure rule extension on EF1003.

## Verification

* `EFCore.Analyzers` builds clean (`netstandard2.0`).
* `test/EFCore.Analyzers.Tests` — full suite passes locally: **114/114** (was 90; +24 new theory cases across the four target methods × six new scenarios).

New test scenarios cover:

* `string.Format(constFormat, constArg)` — does **not** report
* `string.Format(constFormat, parameter)` — reports EF1003
* `string.Format(constFormat, GetId())` — reports EF1003
* `string.Concat(const, const, const)` — does **not** report
* `string.Concat(const, parameter)` — reports EF1003
* `string.Concat(const, GetId())` — reports EF1003

Each scenario is parameterized over `FromSqlRaw`, `ExecuteSqlRaw`, `ExecuteSqlRawAsync`, and `SqlQueryRaw<T>`.