### PR TITLE
Support file-scoped types as entity types

### DIFF
--- a/src/EFCore/Metadata/IReadOnlyTypeBase.cs
+++ b/src/EFCore/Metadata/IReadOnlyTypeBase.cs
@@ -90,11 +90,13 @@ public interface IReadOnlyTypeBase : IReadOnlyAnnotatable
             return StripFileScopedTypePrefixes(ClrType.ShortDisplayName());
         }
 
+        var clrTypeDisplayName = StripFileScopedTypePrefixes(ClrType.ShortDisplayName());
+
         var shortName = Name;
         var hashIndex = shortName.IndexOf("#", StringComparison.Ordinal);
         if (hashIndex == -1)
         {
-            return Name + " (" + ClrType.ShortDisplayName() + ")";
+            return Name + " (" + clrTypeDisplayName + ")";
         }
 
         var plusIndex = shortName.LastIndexOf("+", StringComparison.Ordinal);
@@ -116,7 +118,7 @@ public interface IReadOnlyTypeBase : IReadOnlyAnnotatable
         }
 
         return shortName == Name
-            ? shortName + " (" + ClrType.ShortDisplayName() + ")"
+            ? shortName + " (" + clrTypeDisplayName + ")"
             : shortName;
     }
 
@@ -176,7 +178,8 @@ public interface IReadOnlyTypeBase : IReadOnlyAnnotatable
     ///     types whose names begin with <c>&lt;</c> (async state machines <c>&lt;Method&gt;d__0</c>,
     ///     local function host classes <c>&lt;Method&gt;g__Local|0_0</c>, anonymous types
     ///     <c>&lt;&gt;f__AnonymousType</c>, closure display classes <c>&lt;&gt;c__DisplayClass</c>).
-    ///     Filenames cannot contain <c>&lt;</c> or <c>&gt;</c>, so the closing <c>&gt;</c> of a
+    ///     Roslyn's synthesized metadata pattern uses the literal <c>&lt;filename&gt;F&lt;hex&gt;__</c>
+    ///     shape; the filename portion does not contain <c>&lt;</c>, so the closing <c>&gt;</c> of a
     ///     sentinel is always the next <c>&gt;</c> after the opening <c>&lt;</c> with no
     ///     intervening <c>&lt;</c>.
     /// </remarks>

--- a/src/EFCore/Metadata/IReadOnlyTypeBase.cs
+++ b/src/EFCore/Metadata/IReadOnlyTypeBase.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata;
@@ -86,7 +87,7 @@ public interface IReadOnlyTypeBase : IReadOnlyAnnotatable
     {
         if (!HasSharedClrType)
         {
-            return ClrType.ShortDisplayName();
+            return StripFileScopedTypePrefixes(ClrType.ShortDisplayName());
         }
 
         var shortName = Name;
@@ -134,25 +135,13 @@ public interface IReadOnlyTypeBase : IReadOnlyAnnotatable
                 // Anonymous and closure types: <>f__AnonymousType0, <>c__DisplayClass0_0, ...
                 name = name[2..];
             }
-            else if (name.Length > 2 && name[0] == '<')
+            else
             {
                 // File-scoped types: Roslyn synthesizes the metadata name
                 // <FileName>F<hex>__UserTypeName for `file class` / `file record` declarations.
-                // The `>F` signature distinguishes file-scoped types from other compiler-generated
-                // types whose names also begin with `<` (async state machines `<Method>d__0`,
-                // local function host classes `<Method>g__Local|0_0`, etc.). For those the
-                // signature character following `>` is `d`, `g`, etc., never `F`.
-                var closeAngle = name.IndexOf('>', 1);
-                if (closeAngle != -1
-                    && closeAngle + 1 < name.Length
-                    && name[closeAngle + 1] == 'F')
-                {
-                    var separator = name.IndexOf("__", closeAngle + 1, StringComparison.Ordinal);
-                    if (separator != -1)
-                    {
-                        name = name[(separator + 2)..];
-                    }
-                }
+                // Strip these sentinels wherever they appear (top-level or nested in generic args),
+                // so e.g. List<<File>F1234__Inner> becomes List<Inner>.
+                name = StripFileScopedTypePrefixes(name);
             }
 
             var lessIndex = name.IndexOf('<', StringComparison.Ordinal);
@@ -175,6 +164,63 @@ public interface IReadOnlyTypeBase : IReadOnlyAnnotatable
         }
 
         return Name[(hashIndex + 1)..];
+    }
+
+    /// <summary>
+    ///     Strips Roslyn's synthesized file-scoped type prefix (<c>&lt;FileName&gt;F&lt;hex&gt;__</c>)
+    ///     from a CLR display name, including occurrences nested inside generic argument lists.
+    ///     For example <c>List&lt;&lt;Program&gt;F1234__Inner&gt;</c> becomes <c>List&lt;Inner&gt;</c>.
+    /// </summary>
+    /// <remarks>
+    ///     The <c>&gt;F</c> signature distinguishes file-scoped types from other compiler-generated
+    ///     types whose names begin with <c>&lt;</c> (async state machines <c>&lt;Method&gt;d__0</c>,
+    ///     local function host classes <c>&lt;Method&gt;g__Local|0_0</c>, anonymous types
+    ///     <c>&lt;&gt;f__AnonymousType</c>, closure display classes <c>&lt;&gt;c__DisplayClass</c>).
+    ///     Filenames cannot contain <c>&lt;</c> or <c>&gt;</c>, so the closing <c>&gt;</c> of a
+    ///     sentinel is always the next <c>&gt;</c> after the opening <c>&lt;</c> with no
+    ///     intervening <c>&lt;</c>.
+    /// </remarks>
+    private static string StripFileScopedTypePrefixes(string name)
+    {
+        if (name.IndexOf('<', StringComparison.Ordinal) == -1)
+        {
+            return name;
+        }
+
+        StringBuilder? sb = null;
+        var i = 0;
+        while (i < name.Length)
+        {
+            if (name[i] == '<')
+            {
+                // Look for the immediately-following `>F<hex>__` sentinel:
+                //   - the next `>` must come without any nested `<` in between (filenames have neither)
+                //   - the char right after `>` must be `F`
+                //   - a `__` must follow (the prefix terminator)
+                var closeAngle = name.IndexOf('>', i + 1);
+                if (closeAngle != -1
+                    && closeAngle + 1 < name.Length
+                    && name[closeAngle + 1] == 'F')
+                {
+                    var nestedLt = name.IndexOf('<', i + 1, closeAngle - i - 1);
+                    if (nestedLt == -1)
+                    {
+                        var separator = name.IndexOf("__", closeAngle + 1, StringComparison.Ordinal);
+                        if (separator != -1)
+                        {
+                            sb ??= new StringBuilder(name.Length).Append(name, 0, i);
+                            i = separator + 2;
+                            continue;
+                        }
+                    }
+                }
+            }
+
+            sb?.Append(name[i]);
+            i++;
+        }
+
+        return sb?.ToString() ?? name;
     }
 
     /// <summary>

--- a/src/EFCore/Metadata/IReadOnlyTypeBase.cs
+++ b/src/EFCore/Metadata/IReadOnlyTypeBase.cs
@@ -131,16 +131,32 @@ public interface IReadOnlyTypeBase : IReadOnlyAnnotatable
             var name = ClrType.ShortDisplayName();
             if (name.StartsWith("<>", StringComparison.Ordinal))
             {
+                // Anonymous and closure types: <>f__AnonymousType0, <>c__DisplayClass0_0, ...
                 name = name[2..];
             }
-
-            var lessIndex = name.IndexOf("<", StringComparison.Ordinal);
-            if (lessIndex == -1)
+            else if (name.Length > 2 && name[0] == '<')
             {
-                return name;
+                // File-scoped types: Roslyn synthesizes the metadata name
+                // <FileName>F<hex>__UserTypeName for `file class` / `file record` declarations.
+                // The `>F` signature distinguishes file-scoped types from other compiler-generated
+                // types whose names also begin with `<` (async state machines `<Method>d__0`,
+                // local function host classes `<Method>g__Local|0_0`, etc.). For those the
+                // signature character following `>` is `d`, `g`, etc., never `F`.
+                var closeAngle = name.IndexOf('>', 1);
+                if (closeAngle != -1
+                    && closeAngle + 1 < name.Length
+                    && name[closeAngle + 1] == 'F')
+                {
+                    var separator = name.IndexOf("__", closeAngle + 1, StringComparison.Ordinal);
+                    if (separator != -1)
+                    {
+                        name = name[(separator + 2)..];
+                    }
+                }
             }
 
-            return name[..lessIndex];
+            var lessIndex = name.IndexOf('<', StringComparison.Ordinal);
+            return lessIndex == -1 ? name : name[..lessIndex];
         }
 
         var hashIndex = Name.LastIndexOf("#", StringComparison.Ordinal);

--- a/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
@@ -3032,6 +3032,58 @@ public partial class EntityTypeTest
         Assert.Equal("__AnonymousType01Child", entityType.ShortName());
     }
 
+    [ConditionalTheory]
+    // file class MyEntity in Program.cs
+    [InlineData("<Program>F1234ABCD__MyEntity", "MyEntity")]
+    // file class declared in a file whose name itself contains "__"
+    [InlineData("<My__File>F1234ABCD__MyEntity", "MyEntity")]
+    // file class whose user-chosen name contains "__"
+    [InlineData("<Program>F1234ABCD__Foo__Bar", "Foo__Bar")]
+    // file class with generic type parameters
+    [InlineData("<Program>F1234ABCD__MyEntity<int>", "MyEntity")]
+    public void ShortName_on_file_scoped_type(string clrName, string expectedShortName)
+    {
+        var model = CreateModel();
+
+        var assemblyName = new AssemblyName("DynamicEntityClrTypeAssembly_FileScoped");
+        var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+        var moduleBuilder = assemblyBuilder.DefineDynamicModule("MyModule");
+        var typeBuilder = moduleBuilder.DefineType(clrName);
+        var type = typeBuilder.CreateType();
+
+        model.AddEntityType(type);
+
+        var entityType = model.FinalizeModel().FindEntityType(clrName);
+
+        Assert.Equal(expectedShortName, entityType.ShortName());
+    }
+
+    [ConditionalTheory]
+    // Regular type — no `<` prefix, no transformation
+    [InlineData("Foo", "Foo")]
+    // Type whose user-chosen name contains "__" but is not file-scoped — no `<` prefix, no transformation
+    [InlineData("Foo__Bar", "Foo__Bar")]
+    // Generic type — existing logic still strips generics from the tail
+    [InlineData("MyType<int>", "MyType")]
+    // Generic type whose name contains "__"
+    [InlineData("Foo__Bar<int>", "Foo__Bar")]
+    public void ShortName_unchanged_for_regular_types(string clrName, string expectedShortName)
+    {
+        var model = CreateModel();
+
+        var assemblyName = new AssemblyName("DynamicEntityClrTypeAssembly_Regular");
+        var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+        var moduleBuilder = assemblyBuilder.DefineDynamicModule("MyModule");
+        var typeBuilder = moduleBuilder.DefineType(clrName);
+        var type = typeBuilder.CreateType();
+
+        model.AddEntityType(type);
+
+        var entityType = model.FinalizeModel().FindEntityType(clrName);
+
+        Assert.Equal(expectedShortName, entityType.ShortName());
+    }
+
     private readonly IMutableModel _model = BuildModel();
 
     private IMutableEntityType DependentType

--- a/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
@@ -3141,20 +3141,38 @@ public partial class EntityTypeTest
     [InlineData("<MyMethod>g__Local|0_0", "<MyMethod>g__Local|0_0")]
     // Lowercase `f` — Roslyn anonymous-type marker, not file-scoped (`F` is uppercase). Untouched.
     [InlineData("<Program>f1234__NotFileScoped", "<Program>f1234__NotFileScoped")]
-    // Has `>F` signature but no `__` separator — malformed, leave alone
-    [InlineData("<Program>F1234ABCD", "<Program>F1234ABCD")]
-    // `<` but no closing `>` — malformed, leave alone
-    [InlineData("<NoClose", "<NoClose")]
-    // Empty user portion after `__` — malformed Roslyn output, but ensure we don't crash;
-    // current behavior strips to empty (matches ShortName behavior; harmless edge case)
-    [InlineData("<Program>F1234ABCD__", "")]
-    // Length exactly 2 — guarded by `name.Length > 2`, falls through unchanged
-    [InlineData("<>", "<>")]
     public void DisplayName_unchanged_for_non_file_scoped_types(string clrName, string expectedDisplayName)
     {
         var model = CreateModel();
 
         var assemblyName = new AssemblyName("DynamicEntityClrTypeAssembly_DisplayRegular");
+        var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+        var moduleBuilder = assemblyBuilder.DefineDynamicModule("MyModule");
+        var typeBuilder = moduleBuilder.DefineType(clrName);
+        var type = typeBuilder.CreateType();
+
+        model.AddEntityType(type);
+
+        var entityType = model.FinalizeModel().FindEntityType(clrName);
+
+        Assert.Equal(expectedDisplayName, entityType.DisplayName());
+    }
+
+    [ConditionalTheory]
+    // Has `>F` signature but no `__` separator — file-scoped sentinel is incomplete, leave alone
+    [InlineData("<Program>F1234ABCD", "<Program>F1234ABCD")]
+    // `<` but no closing `>` — incomplete sentinel, leave alone
+    [InlineData("<NoClose", "<NoClose")]
+    // Empty user portion after `__` — malformed Roslyn output, but ensure we don't crash;
+    // current behavior strips to empty (matches ShortName behavior; harmless edge case)
+    [InlineData("<Program>F1234ABCD__", "")]
+    // Just `<>` — bounds check `closeAngle + 1 < name.Length` rejects this; no char follows the `>`.
+    [InlineData("<>", "<>")]
+    public void DisplayName_handles_malformed_or_incomplete_file_scoped_inputs_safely(string clrName, string expectedDisplayName)
+    {
+        var model = CreateModel();
+
+        var assemblyName = new AssemblyName("DynamicEntityClrTypeAssembly_DisplayMalformed");
         var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
         var moduleBuilder = assemblyBuilder.DefineDynamicModule("MyModule");
         var typeBuilder = moduleBuilder.DefineType(clrName);

--- a/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
@@ -3084,6 +3084,97 @@ public partial class EntityTypeTest
         Assert.Equal(expectedShortName, entityType.ShortName());
     }
 
+    [ConditionalTheory]
+    // file class MyEntity in Program.cs
+    [InlineData("<Program>F1234ABCD__MyEntity", "MyEntity")]
+    // file class declared in a file whose name itself contains "__"
+    [InlineData("<My__File>F1234ABCD__MyEntity", "MyEntity")]
+    // file class whose user-chosen name contains "__"
+    [InlineData("<Program>F1234ABCD__Foo__Bar", "Foo__Bar")]
+    // file class with single generic type parameter — DisplayName preserves generics (unlike ShortName)
+    [InlineData("<Program>F1234ABCD__MyEntity<int>", "MyEntity<int>")]
+    // file class with nested generics
+    [InlineData("<Program>F1234ABCD__Wrapper<List<int>>", "Wrapper<List<int>>")]
+    // file class used as a generic argument inside another type — sentinel must be stripped from the inner position too
+    [InlineData("List<<Program>F1234ABCD__MyFileClass>", "List<MyFileClass>")]
+    // generic of generic, with a file-scoped type at the inner-inner position
+    [InlineData("List<List<<Program>F1234ABCD__Inner>>", "List<List<Inner>>")]
+    // short hex digest (Roslyn varies digest length)
+    [InlineData("<Program>F12__Foo", "Foo")]
+    // long hex digest
+    [InlineData("<Program>FABCDEF1234567890__Foo", "Foo")]
+    // file class whose user-chosen name starts with an underscore
+    [InlineData("<Program>F1234ABCD___Underscored", "_Underscored")]
+    public void DisplayName_on_file_scoped_type(string clrName, string expectedDisplayName)
+    {
+        var model = CreateModel();
+
+        var assemblyName = new AssemblyName("DynamicEntityClrTypeAssembly_FileScopedDisplay");
+        var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+        var moduleBuilder = assemblyBuilder.DefineDynamicModule("MyModule");
+        var typeBuilder = moduleBuilder.DefineType(clrName);
+        var type = typeBuilder.CreateType();
+
+        model.AddEntityType(type);
+
+        var entityType = model.FinalizeModel().FindEntityType(clrName);
+
+        Assert.Equal(expectedDisplayName, entityType.DisplayName());
+    }
+
+    [ConditionalTheory]
+    // Regular type — no `<` prefix, no transformation
+    [InlineData("Foo", "Foo")]
+    // Type whose user-chosen name contains "__" but is not file-scoped
+    [InlineData("Foo__Bar", "Foo__Bar")]
+    // Generic type — DisplayName preserves generics (unlike ShortName)
+    [InlineData("MyType<int>", "MyType<int>")]
+    // Generic type whose name contains "__"
+    [InlineData("Foo__Bar<int>", "Foo__Bar<int>")]
+    // Anonymous-style synthesized name (`<>`) — not file-scoped, untouched by file-scoped branch
+    [InlineData("<>__AnonymousType01Child", "<>__AnonymousType01Child")]
+    // Closure display class — `<>c` prefix, not `>F`, untouched
+    [InlineData("<>c__DisplayClass0_0", "<>c__DisplayClass0_0")]
+    // Async state machine — `>d` signature, not `>F`, untouched
+    [InlineData("<MyMethod>d__0", "<MyMethod>d__0")]
+    // Local function — `>g` signature, not `>F`, untouched
+    [InlineData("<MyMethod>g__Local|0_0", "<MyMethod>g__Local|0_0")]
+    // Lowercase `f` — Roslyn anonymous-type marker, not file-scoped (`F` is uppercase). Untouched.
+    [InlineData("<Program>f1234__NotFileScoped", "<Program>f1234__NotFileScoped")]
+    // Has `>F` signature but no `__` separator — malformed, leave alone
+    [InlineData("<Program>F1234ABCD", "<Program>F1234ABCD")]
+    // `<` but no closing `>` — malformed, leave alone
+    [InlineData("<NoClose", "<NoClose")]
+    // Empty user portion after `__` — malformed Roslyn output, but ensure we don't crash;
+    // current behavior strips to empty (matches ShortName behavior; harmless edge case)
+    [InlineData("<Program>F1234ABCD__", "")]
+    // Length exactly 2 — guarded by `name.Length > 2`, falls through unchanged
+    [InlineData("<>", "<>")]
+    public void DisplayName_unchanged_for_non_file_scoped_types(string clrName, string expectedDisplayName)
+    {
+        var model = CreateModel();
+
+        var assemblyName = new AssemblyName("DynamicEntityClrTypeAssembly_DisplayRegular");
+        var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+        var moduleBuilder = assemblyBuilder.DefineDynamicModule("MyModule");
+        var typeBuilder = moduleBuilder.DefineType(clrName);
+        var type = typeBuilder.CreateType();
+
+        model.AddEntityType(type);
+
+        var entityType = model.FinalizeModel().FindEntityType(clrName);
+
+        Assert.Equal(expectedDisplayName, entityType.DisplayName());
+    }
+
+    [ConditionalFact]
+    public void DisplayName_unchanged_for_well_known_types()
+    {
+        Assert.Equal("EntityTypeTest", CreateModel().AddEntityType(typeof(EntityTypeTest)).DisplayName());
+        Assert.Equal("Customer", CreateModel().AddEntityType(typeof(Customer)).DisplayName());
+        Assert.Equal("List<Customer>", CreateModel().AddEntityType(typeof(List<Customer>)).DisplayName());
+    }
+
     private readonly IMutableModel _model = BuildModel();
 
     private IMutableEntityType DependentType


### PR DESCRIPTION
Fixes #32323.

## Problem

`file class` / `file record` declarations crash EF Core with `IndexOutOfRangeException` when used as entity types:

```csharp
file class MyEntity { public int Id { get; set; } }

class MyContext : DbContext
{
    protected override void OnModelCreating(ModelBuilder mb)
        => mb.Entity<MyEntity>().HasNoKey();
}

await context.Set<MyEntity>().ToListAsync();
// → IndexOutOfRangeException at NavigationExpandingExpressionVisitor.CreateNavigationExpansionExpression
```

The same problem reproduces via `DbContext.Database.SqlQuery<MyEntity>` (per @TwentyFourMinutes' comment on the issue).

## Root cause

The C# compiler synthesizes the metadata name for a file-scoped type as `<FileName>F<hex>__UserTypeName`. `IReadOnlyTypeBase.ShortName` uses `IndexOf("<")` to strip generic type arguments from the short display name. For file-scoped types the leading `<` of the synthesized prefix is at index `0`, so `name[..0]` produces an empty string and downstream consumers — for example `NavigationExpandingExpressionVisitor.CreateNavigationExpansionExpression` at `entityType.ShortName()[0].ToString().ToLowerInvariant()` — crash on the indexer.

## Fix

Detect the synthesized file-scoped prefix specifically and skip past `__` to expose the user-visible type name. The detection uses the `<...>F` signature, which distinguishes file-scoped types from other compiler-generated types whose names also begin with `<`:

| Synthesized name | Signature character after `>` | Touched by this PR? |
|---|---|---|
| `<>f__AnonymousType0` (anonymous) | n/a (`<>` prefix, handled by existing branch) | no |
| `<File>F<hex>__Type` (file-scoped) | `F` | **yes — extracts `Type`** |
| `<Method>d__0` (async state machine) | `d` | no |
| `<Method>g__Local\|0_0` (local function) | `g` | no |

The `__` separator is searched starting **after** the closing `>`, so file names containing `__` are not misparsed. Once located, only the first `__` after the prefix is consumed, so user type names containing `__` are preserved.

If any check in the new branch fails (e.g. no `>`, signature is not `F`, no `__` follows), `name` is left unchanged and falls through to the existing generic-stripping logic. The fix is a strict refinement, not a replacement.

## Tests

Added under `EntityTypeTest.ShortName_…`:

**Positive — file-scoped synthesized names produce user-visible short names:**
- `<Program>F1234ABCD__MyEntity` → `MyEntity`
- `<My__File>F1234ABCD__MyEntity` → `MyEntity` *(filename contains `__`)*
- `<Program>F1234ABCD__Foo__Bar` → `Foo__Bar` *(user name contains `__`)*
- `<Program>F1234ABCD__MyEntity<int>` → `MyEntity` *(file-scoped + generic)*

**Negative — regular types are not touched by the new branch:**
- `Foo` → `Foo`
- `Foo__Bar` → `Foo__Bar` *(`__` alone is not a trigger)*
- `MyType<int>` → `MyType` *(existing generic strip)*
- `Foo__Bar<int>` → `Foo__Bar` *(combination)*

The three pre-existing `ShortName_on_compiler_generated_typeN` tests covering `<>`-prefixed anonymous types continue to pass unchanged.

## Verification

- `dotnet build src/EFCore/EFCore.csproj` — clean, 0 warnings
- `dotnet test test/EFCore.Tests/EFCore.Tests.csproj` — **6,804 / 6,804 pass** (was 6,800; +4 new theory rows)
- `dotnet test test/EFCore.InMemory.FunctionalTests/...` — **27,592 / 27,592 pass** (full query pipeline confirmed unaffected)

## What's intentionally not in this PR

The symptom site at `NavigationExpandingExpressionVisitor.CreateNavigationExpansionExpression` and the similar pattern at line 857 (`methodCallExpression.Method.Name[0].ToString().ToLowerInvariant()`) could also crash for synthesized method names, but those are out of scope here. This PR fixes the source — every consumer of `ShortName()` benefits without further changes. Happy to follow up on the method-name path in a separate PR if desired.