### PR TITLE
Use ShortName() for liftable constant variable name seeds

### DIFF
--- a/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
@@ -574,7 +574,7 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
                                             ? liftableConstantFactory.CreateLiftableConstant(
                                                 typeBase,
                                                 LiftableConstantExpressionHelpers.BuildMemberAccessLambdaForStructuralType(typeBase),
-                                                typeBase.Name + "EntityType",
+                                                typeBase.ShortName() + "EntityType",
                                                 typeof(IEntityType))
                                             : Constant(typeBase),
                                         supportsPrecompiledQuery
@@ -588,7 +588,7 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
                                                             EntityTypeFindPrimaryKeyMethod),
                                                         nameof(IKey.Properties)),
                                                     resolverPrm),
-                                                typeBase.Name + "PrimaryKeyProperties",
+                                                typeBase.ShortName() + "PrimaryKeyProperties",
                                                 typeof(IReadOnlyList<IProperty>))
                                             : Constant(primaryKey.Properties),
                                         keyValuesVariable))));

--- a/test/EFCore.Relational.Specification.Tests/Query/AdHocPrecompiledQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/AdHocPrecompiledQueryRelationalTestBase.cs
@@ -131,6 +131,35 @@ Assert.Equal(10, e.PrivateAutoPropertyExposer);
             });
     }
 
+    [ConditionalFact]
+    public virtual async Task NoTracking_query_with_namespaced_entity_generates_valid_identifiers()
+    {
+        // Regression test for #37972: entity types whose Name is namespace-qualified
+        // (e.g. "Microsoft.EntityFrameworkCore.Query.JsonEntity") were used directly as the
+        // variable-name seed when generating the no-tracking identity-resolution shaper, producing
+        // invalid C# identifiers like `microsoft.EntityFrameworkCore.Query.JsonEntityPrimaryKeyProperties`.
+        // The fix is to use IReadOnlyTypeBase.ShortName() instead of .Name. This test guards
+        // against the regression by exercising the same path: the generated interceptor source
+        // would fail to compile if the variable name contains dots.
+        var contextFactory = await InitializeNonSharedTest<JsonContext>();
+        var options = contextFactory.GetOptions();
+
+        await Test(
+            """
+await using var context = new AdHocPrecompiledQueryRelationalTestBase.JsonContext(dbContextOptions);
+await context.Database.BeginTransactionAsync();
+
+_ = context.JsonEntities.AsNoTracking().ToList();
+""",
+            typeof(JsonContext),
+            options,
+            interceptorCodeAsserter: code =>
+            {
+                Assert.Contains("jsonEntityPrimaryKeyProperties", code);
+                Assert.DoesNotContain("Microsoft.EntityFrameworkCore.Query.JsonEntityPrimaryKeyProperties", code);
+            });
+    }
+
     public class NonPublicContext(DbContextOptions options) : DbContext(options)
     {
         public DbSet<NonPublicEntity> NonPublicEntities { get; set; } = null!;


### PR DESCRIPTION
The no-tracking identity-resolution shaper construction in ShapedQueryCompilingExpressionVisitor was passing IReadOnlyTypeBase.Name (namespace-qualified, e.g. "Microsoft.EntityFrameworkCore.Query.JsonEntity") as the variable-name seed when creating liftable constants for the entity type and its primary key properties. The precompiled-query code generator emits these seeds directly as C# variable identifiers, so the embedded dots produced invalid C# (e.g. `var microsoft.EntityFrameworkCore.Query.JsonEntityPrimaryKeyProperties = ...`), breaking compilation of the generated *.EFInterceptors.cs files for any no-tracking query whose entity type lives in a non-empty namespace.

Switch to ShortName() to match the existing convention used elsewhere in the same file (lines 238/243) and the rest of the precompiled-query codegen surface. Collisions across entity types sharing the same simple name in different namespaces are handled by LiftableConstantProcessor's existing uniquification step (suffixes 0, 1, ... appended on duplicate).

Add a regression test exercising AsNoTracking() against an entity in a multi-segment namespace; without the fix the generated source fails to compile with CS1003/CS1002.


