### PR TITLE
Add EF1004 analyzer for ToAsyncEnumerable on IQueryable

### DIFF
--- a/src/EFCore.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/EFCore.Analyzers/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,4 @@
+### New Rules
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+EF1004  | Usage    | Warning  | ToAsyncEnumerableOnQueryableDiagnosticAnalyzer

--- a/src/EFCore.Analyzers/Properties/AnalyzerStrings.Designer.cs
+++ b/src/EFCore.Analyzers/Properties/AnalyzerStrings.Designer.cs
@@ -124,6 +124,24 @@ namespace Microsoft.EntityFrameworkCore {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Avoid using &apos;ToAsyncEnumerable&apos; on an &apos;IQueryable&apos;..
+        /// </summary>
+        public static string ToAsyncEnumerableOnQueryableTitle {
+            get {
+                return ResourceManager.GetString("ToAsyncEnumerableOnQueryableTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Calling &apos;ToAsyncEnumerable&apos; on an &apos;IQueryable&apos; iterates the source synchronously. Use &apos;AsAsyncEnumerable&apos; instead to iterate the database query asynchronously, or suppress this warning if the &apos;IQueryable&apos; is not an EF Core query..
+        /// </summary>
+        public static string ToAsyncEnumerableOnQueryableMessageFormat {
+            get {
+                return ResourceManager.GetString("ToAsyncEnumerableOnQueryableMessageFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to DbSet properties on DbContext subclasses are automatically populated by the DbContext constructor..
         /// </summary>
         public static string UninitializedDbSetWarningSuppressionJustification {

--- a/src/EFCore.Analyzers/Properties/AnalyzerStrings.Designer.cs
+++ b/src/EFCore.Analyzers/Properties/AnalyzerStrings.Designer.cs
@@ -142,6 +142,15 @@ namespace Microsoft.EntityFrameworkCore {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Use &apos;AsAsyncEnumerable&apos; to iterate the query asynchronously..
+        /// </summary>
+        public static string ToAsyncEnumerableOnQueryableCodeActionTitle {
+            get {
+                return ResourceManager.GetString("ToAsyncEnumerableOnQueryableCodeActionTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to DbSet properties on DbContext subclasses are automatically populated by the DbContext constructor..
         /// </summary>
         public static string UninitializedDbSetWarningSuppressionJustification {

--- a/src/EFCore.Analyzers/Properties/AnalyzerStrings.resx
+++ b/src/EFCore.Analyzers/Properties/AnalyzerStrings.resx
@@ -48,4 +48,7 @@
   <data name="ToAsyncEnumerableOnQueryableMessageFormat" xml:space="preserve">
     <value>Calling 'ToAsyncEnumerable' on an 'IQueryable' iterates the source synchronously. Use 'AsAsyncEnumerable' instead to iterate the database query asynchronously, or suppress this warning if the 'IQueryable' is not an EF Core query.</value>
   </data>
+  <data name="ToAsyncEnumerableOnQueryableCodeActionTitle" xml:space="preserve">
+    <value>Use 'AsAsyncEnumerable' to iterate the query asynchronously</value>
+  </data>
 </root>

--- a/src/EFCore.Analyzers/Properties/AnalyzerStrings.resx
+++ b/src/EFCore.Analyzers/Properties/AnalyzerStrings.resx
@@ -42,4 +42,10 @@
   <data name="StringConcatenationUsageInRawQueriesMessageFormat" xml:space="preserve">
     <value>Method '{0}' inserts concatenated strings directly into the SQL, without any protection against SQL injection. Consider using '{1}' instead, which protects against SQL injection, or make sure that the value is sanitized and suppress the warning.</value>
   </data>
+  <data name="ToAsyncEnumerableOnQueryableTitle" xml:space="preserve">
+    <value>Avoid using 'ToAsyncEnumerable' on an 'IQueryable'.</value>
+  </data>
+  <data name="ToAsyncEnumerableOnQueryableMessageFormat" xml:space="preserve">
+    <value>Calling 'ToAsyncEnumerable' on an 'IQueryable' iterates the source synchronously. Use 'AsAsyncEnumerable' instead to iterate the database query asynchronously, or suppress this warning if the 'IQueryable' is not an EF Core query.</value>
+  </data>
 </root>

--- a/src/EFCore.Analyzers/ToAsyncEnumerableOnQueryableCodeFixProvider.cs
+++ b/src/EFCore.Analyzers/ToAsyncEnumerableOnQueryableCodeFixProvider.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.EntityFrameworkCore;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(ToAsyncEnumerableOnQueryableCodeFixProvider)), Shared]
+public sealed class ToAsyncEnumerableOnQueryableCodeFixProvider : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds
+        => [EFDiagnostics.ToAsyncEnumerableOnQueryable];
+
+    public override FixAllProvider GetFixAllProvider()
+        => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var document = context.Document;
+        var cancellationToken = context.CancellationToken;
+
+        // The analyzer reports a single diagnostic per location.
+        var diagnostic = context.Diagnostics.First();
+
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+        {
+            return;
+        }
+
+        if (root.FindNode(diagnostic.Location.SourceSpan) is not SimpleNameSyntax simpleName)
+        {
+            Debug.Fail("Analyzer reported diagnostic not on a SimpleNameSyntax. This should never happen");
+            return;
+        }
+
+        // Skip the static-call form `AsyncEnumerable.ToAsyncEnumerable<T>(q)`. Fixing it would require a
+        // structural rewrite to a different containing type (EntityFrameworkQueryableExtensions) or to
+        // the instance form, which is beyond a pure name swap. The analyzer still warns; the user can
+        // refactor manually.
+        if (simpleName.Parent is MemberAccessExpressionSyntax
+            {
+                Expression: IdentifierNameSyntax { Identifier.ValueText: "AsyncEnumerable" }
+            })
+        {
+            return;
+        }
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                AnalyzerStrings.ToAsyncEnumerableOnQueryableCodeActionTitle,
+                _ => Task.FromResult(document.WithSyntaxRoot(root.ReplaceNode(simpleName, GetReplacementName(simpleName)))),
+                nameof(ToAsyncEnumerableOnQueryableCodeFixProvider)),
+            diagnostic);
+    }
+
+    private static SimpleNameSyntax GetReplacementName(SimpleNameSyntax oldName)
+    {
+        // Preserve trivia (comments/whitespace) and any generic type arguments — only the identifier changes.
+        var newToken = SyntaxFactory.Identifier("AsAsyncEnumerable").WithTriviaFrom(oldName.Identifier);
+        return oldName.WithIdentifier(newToken);
+    }
+}

--- a/src/EFCore.Analyzers/ToAsyncEnumerableOnQueryableDiagnosticAnalyzer.cs
+++ b/src/EFCore.Analyzers/ToAsyncEnumerableOnQueryableDiagnosticAnalyzer.cs
@@ -59,28 +59,25 @@ public sealed class ToAsyncEnumerableOnQueryableDiagnosticAnalyzer : DiagnosticA
             return;
         }
 
-        // The source is exposed as Arguments[0].Value for an extension method invocation. Inspect the operation
-        // before any implicit IQueryable -> IEnumerable conversion: if the user wrote it as an IQueryable, warn.
-        // If they explicitly cast to IEnumerable first (e.g. ((IEnumerable<T>)q).ToAsyncEnumerable()), there is
-        // no implicit conversion to peel and the underlying IQueryable type is hidden — that's a deliberate opt-out.
+        // The source is exposed as Arguments[0].Value for an extension method invocation. Peel any
+        // chained implicit conversions to recover the user-written expression's type — a single C#
+        // expression can produce stacked IConversionOperation nodes in the Roslyn tree. An explicit
+        // cast to IEnumerable<T> (e.g. ((IEnumerable<T>)q).ToAsyncEnumerable()) shows up as
+        // IsImplicit: false, so the loop stops there and the underlying IQueryable type is hidden —
+        // a deliberate opt-out. Mirrors the WalkDownConversion(predicate) helper used across
+        // dotnet/roslyn-analyzers.
         if (invocation.Arguments.Length == 0)
         {
             return;
         }
 
         var sourceOperation = invocation.Arguments[0].Value;
-        ITypeSymbol? sourceType = null;
-
-        if (sourceOperation is IConversionOperation { IsImplicit: true } conversion)
+        while (sourceOperation is IConversionOperation { IsImplicit: true } conversion)
         {
-            sourceType = conversion.Operand.Type;
-        }
-        else
-        {
-            sourceType = sourceOperation.Type;
+            sourceOperation = conversion.Operand;
         }
 
-        if (sourceType is null || !ImplementsGenericIQueryable(sourceType))
+        if (sourceOperation.Type is not { } sourceType || !ImplementsGenericIQueryable(sourceType))
         {
             return;
         }

--- a/src/EFCore.Analyzers/ToAsyncEnumerableOnQueryableDiagnosticAnalyzer.cs
+++ b/src/EFCore.Analyzers/ToAsyncEnumerableOnQueryableDiagnosticAnalyzer.cs
@@ -1,0 +1,135 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Microsoft.EntityFrameworkCore;
+
+/// <summary>
+///     Reports calls to <c>System.Linq.AsyncEnumerable.ToAsyncEnumerable&lt;TSource&gt;(IEnumerable&lt;TSource&gt;)</c>
+///     whose source is an <c>IQueryable&lt;T&gt;</c>. The conversion forces the queryable to be enumerated synchronously,
+///     defeating the purpose of using <c>await foreach</c>. EF Core's <c>AsAsyncEnumerable&lt;T&gt;()</c> is the
+///     intended async-friendly alternative.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class ToAsyncEnumerableOnQueryableDiagnosticAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Descriptor
+        = new(
+            EFDiagnostics.ToAsyncEnumerableOnQueryable,
+            title: AnalyzerStrings.ToAsyncEnumerableOnQueryableTitle,
+            messageFormat: AnalyzerStrings.ToAsyncEnumerableOnQueryableMessageFormat,
+            category: "Usage",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+        => [Descriptor];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+        context.RegisterOperationAction(AnalyzeInvocation, OperationKind.Invocation);
+    }
+
+    private static void AnalyzeInvocation(OperationAnalysisContext context)
+    {
+        var invocation = (IInvocationOperation)context.Operation;
+        var targetMethod = invocation.TargetMethod;
+
+        if (targetMethod.Name != "ToAsyncEnumerable")
+        {
+            return;
+        }
+
+        // Only flag the System.Linq.AsyncEnumerable.ToAsyncEnumerable<TSource>(IEnumerable<TSource>) overload.
+        // Other libraries may define methods with the same name (e.g. on Channel<T>, IObservable<T>) — we don't
+        // want to false-positive on those.
+        var containingType = targetMethod.ContainingType;
+        if (containingType is null
+            || containingType.Name != "AsyncEnumerable"
+            || containingType.ContainingNamespace?.ToDisplayString() != "System.Linq")
+        {
+            return;
+        }
+
+        // The source is exposed as Arguments[0].Value for an extension method invocation. Inspect the operation
+        // before any implicit IQueryable -> IEnumerable conversion: if the user wrote it as an IQueryable, warn.
+        // If they explicitly cast to IEnumerable first (e.g. ((IEnumerable<T>)q).ToAsyncEnumerable()), there is
+        // no implicit conversion to peel and the underlying IQueryable type is hidden — that's a deliberate opt-out.
+        if (invocation.Arguments.Length == 0)
+        {
+            return;
+        }
+
+        var sourceOperation = invocation.Arguments[0].Value;
+        ITypeSymbol? sourceType = null;
+
+        if (sourceOperation is IConversionOperation { IsImplicit: true } conversion)
+        {
+            sourceType = conversion.Operand.Type;
+        }
+        else
+        {
+            sourceType = sourceOperation.Type;
+        }
+
+        if (sourceType is null || !ImplementsGenericIQueryable(sourceType))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(Descriptor, GetInvocationLocation(invocation)));
+    }
+
+    private static bool ImplementsGenericIQueryable(ITypeSymbol type)
+    {
+        if (IsGenericIQueryable(type))
+        {
+            return true;
+        }
+
+        foreach (var iface in type.AllInterfaces)
+        {
+            if (IsGenericIQueryable(iface))
+            {
+                return true;
+            }
+        }
+
+        return false;
+
+        static bool IsGenericIQueryable(ITypeSymbol candidate)
+            => candidate is INamedTypeSymbol { Name: "IQueryable", TypeArguments.Length: 1 } named
+                && named.ContainingNamespace?.ToDisplayString() == "System.Linq";
+    }
+
+    private static Location GetInvocationLocation(IInvocationOperation invocation)
+    {
+        if (invocation.Syntax is not InvocationExpressionSyntax invocationExpression)
+        {
+            return invocation.Syntax.GetLocation();
+        }
+
+        var targetNode = invocationExpression.Expression;
+
+        while (targetNode is MemberAccessExpressionSyntax memberAccess)
+        {
+            targetNode = memberAccess.Name;
+        }
+
+        // Generic name case (e.g. `AsyncEnumerable.ToAsyncEnumerable<T>(q)`): point at just the identifier.
+        if (targetNode is GenericNameSyntax genericName)
+        {
+            return genericName.Identifier.GetLocation();
+        }
+
+        return targetNode.GetLocation();
+    }
+}

--- a/src/Shared/EFDiagnostics.cs
+++ b/src/Shared/EFDiagnostics.cs
@@ -11,6 +11,7 @@ internal static class EFDiagnostics
     internal const string InternalUsage = "EF1001";
     internal const string InterpolatedStringUsageInRawQueries = "EF1002";
     internal const string StringConcatenationUsageInRawQueries = "EF1003";
+    internal const string ToAsyncEnumerableOnQueryable = "EF1004";
     internal const string SuppressUninitializedDbSetRule = "EFSPR1001";
 
     // Diagnostics for [Obsolete]

--- a/test/EFCore.Analyzers.Tests/ToAsyncEnumerableOnQueryableAnalyzerTests.cs
+++ b/test/EFCore.Analyzers.Tests/ToAsyncEnumerableOnQueryableAnalyzerTests.cs
@@ -1,0 +1,172 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Microsoft.EntityFrameworkCore;
+
+using Verify = CSharpAnalyzerVerifier<ToAsyncEnumerableOnQueryableDiagnosticAnalyzer>;
+
+public class ToAsyncEnumerableOnQueryableAnalyzerTests
+{
+    private const string MyDbContext =
+        """
+using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using System.Linq;
+
+class User
+{
+    public int Id { get; set; }
+}
+
+class MyDbContext : DbContext
+{
+    public DbSet<User> Users { get; init; }
+}
+""";
+
+    [Fact]
+    public Task DbSet_ToAsyncEnumerable_should_report()
+        => Verify.VerifyAnalyzerAsync(
+            $$"""
+{{MyDbContext}}
+
+class C
+{
+    void M(MyDbContext db)
+    {
+        _ = db.Users.{|#0:ToAsyncEnumerable|}();
+    }
+}
+""",
+            DiagnosticResult.CompilerWarning(EFDiagnostics.ToAsyncEnumerableOnQueryable).WithLocation(0));
+
+    [Fact]
+    public Task IQueryable_local_ToAsyncEnumerable_should_report()
+        => Verify.VerifyAnalyzerAsync(
+            $$"""
+{{MyDbContext}}
+
+class C
+{
+    void M(MyDbContext db)
+    {
+        IQueryable<User> q = db.Users.Where(u => u.Id > 0);
+        _ = q.{|#0:ToAsyncEnumerable|}();
+    }
+}
+""",
+            DiagnosticResult.CompilerWarning(EFDiagnostics.ToAsyncEnumerableOnQueryable).WithLocation(0));
+
+    [Fact]
+    public Task Chained_after_Where_should_report()
+        => Verify.VerifyAnalyzerAsync(
+            $$"""
+{{MyDbContext}}
+
+class C
+{
+    void M(MyDbContext db)
+    {
+        _ = db.Users.Where(u => u.Id > 0).Select(u => u.Id).{|#0:ToAsyncEnumerable|}();
+    }
+}
+""",
+            DiagnosticResult.CompilerWarning(EFDiagnostics.ToAsyncEnumerableOnQueryable).WithLocation(0));
+
+    [Fact]
+    public Task IEnumerable_local_should_not_report()
+        => Verify.VerifyAnalyzerAsync(
+            $$"""
+{{MyDbContext}}
+
+class C
+{
+    void M()
+    {
+        IEnumerable<User> users = new List<User>();
+        _ = users.ToAsyncEnumerable();
+    }
+}
+""");
+
+    [Fact]
+    public Task Explicit_cast_to_IEnumerable_should_not_report()
+        => Verify.VerifyAnalyzerAsync(
+            $$"""
+{{MyDbContext}}
+
+class C
+{
+    void M(MyDbContext db)
+    {
+        // Explicit cast to IEnumerable<T> opts out — caller knows they're forcing sync iteration.
+        _ = ((IEnumerable<User>)db.Users).ToAsyncEnumerable();
+    }
+}
+""");
+
+    [Fact]
+    public Task AsAsyncEnumerable_should_not_report()
+        => Verify.VerifyAnalyzerAsync(
+            $$"""
+{{MyDbContext}}
+
+class C
+{
+    void M(MyDbContext db)
+    {
+        _ = db.Users.AsAsyncEnumerable();
+    }
+}
+""");
+
+    [Fact]
+    public Task List_ToAsyncEnumerable_should_not_report()
+        => Verify.VerifyAnalyzerAsync(
+            $$"""
+{{MyDbContext}}
+
+class C
+{
+    void M()
+    {
+        var list = new List<User>();
+        _ = list.ToAsyncEnumerable();
+    }
+}
+""");
+
+    [Fact]
+    public Task Array_ToAsyncEnumerable_should_not_report()
+        => Verify.VerifyAnalyzerAsync(
+            $$"""
+{{MyDbContext}}
+
+class C
+{
+    void M()
+    {
+        var arr = new User[0];
+        _ = arr.ToAsyncEnumerable();
+    }
+}
+""");
+
+    [Fact]
+    public Task Static_call_form_should_report()
+        => Verify.VerifyAnalyzerAsync(
+            $$"""
+{{MyDbContext}}
+
+class C
+{
+    void M(MyDbContext db)
+    {
+        _ = AsyncEnumerable.{|#0:ToAsyncEnumerable|}<User>(db.Users);
+    }
+}
+""",
+            DiagnosticResult.CompilerWarning(EFDiagnostics.ToAsyncEnumerableOnQueryable).WithLocation(0));
+}

--- a/test/EFCore.Analyzers.Tests/ToAsyncEnumerableOnQueryableAnalyzerTests.cs
+++ b/test/EFCore.Analyzers.Tests/ToAsyncEnumerableOnQueryableAnalyzerTests.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis.Testing;
 
 namespace Microsoft.EntityFrameworkCore;
 
-using Verify = CSharpAnalyzerVerifier<ToAsyncEnumerableOnQueryableDiagnosticAnalyzer>;
+using Verify = CSharpCodeFixVerifier<ToAsyncEnumerableOnQueryableDiagnosticAnalyzer, ToAsyncEnumerableOnQueryableCodeFixProvider>;
 
 public class ToAsyncEnumerableOnQueryableAnalyzerTests
 {
@@ -169,4 +169,83 @@ class C
 }
 """,
             DiagnosticResult.CompilerWarning(EFDiagnostics.ToAsyncEnumerableOnQueryable).WithLocation(0));
+
+    // -- Code fix verification --
+
+    [Fact]
+    public Task CodeFix_DbSet_replaces_ToAsyncEnumerable_with_AsAsyncEnumerable()
+        => Verify.VerifyCodeFixAsync(
+            $$"""
+{{MyDbContext}}
+
+class C
+{
+    void M(MyDbContext db)
+    {
+        _ = db.Users.{|#0:ToAsyncEnumerable|}();
+    }
+}
+""",
+            $$"""
+{{MyDbContext}}
+
+class C
+{
+    void M(MyDbContext db)
+    {
+        _ = db.Users.AsAsyncEnumerable();
+    }
+}
+""",
+            DiagnosticResult.CompilerWarning(EFDiagnostics.ToAsyncEnumerableOnQueryable).WithLocation(0));
+
+    [Fact]
+    public Task CodeFix_chained_query_replaces_method_name_only()
+        => Verify.VerifyCodeFixAsync(
+            $$"""
+{{MyDbContext}}
+
+class C
+{
+    void M(MyDbContext db)
+    {
+        _ = db.Users.Where(u => u.Id > 0).Select(u => u.Id).{|#0:ToAsyncEnumerable|}();
+    }
+}
+""",
+            $$"""
+{{MyDbContext}}
+
+class C
+{
+    void M(MyDbContext db)
+    {
+        _ = db.Users.Where(u => u.Id > 0).Select(u => u.Id).AsAsyncEnumerable();
+    }
+}
+""",
+            DiagnosticResult.CompilerWarning(EFDiagnostics.ToAsyncEnumerableOnQueryable).WithLocation(0));
+
+    [Fact]
+    public async Task CodeFix_static_call_form_is_not_offered()
+    {
+        // The static-call form `AsyncEnumerable.ToAsyncEnumerable<T>(q)` would require a structural
+        // rewrite (different containing class). The analyzer warns but no automated fix is offered;
+        // VerifyCodeFixAsync with identical source/fixedSource asserts the fix does NOT change the code.
+        var source = $$"""
+{{MyDbContext}}
+
+class C
+{
+    void M(MyDbContext db)
+    {
+        _ = AsyncEnumerable.{|#0:ToAsyncEnumerable|}<User>(db.Users);
+    }
+}
+""";
+        await Verify.VerifyCodeFixAsync(
+            source,
+            source,
+            DiagnosticResult.CompilerWarning(EFDiagnostics.ToAsyncEnumerableOnQueryable).WithLocation(0));
+    }
 }


### PR DESCRIPTION
System.Linq.AsyncEnumerable.ToAsyncEnumerable<T>(IEnumerable<T>) wraps an IEnumerable in an IAsyncEnumerable but performs synchronous iteration. Calling it on an IQueryable<T> returned by EF Core forces the database query to be evaluated synchronously, defeating the purpose of `await foreach` and risking thread-pool starvation on hot paths. The intended async-friendly method is EF Core's AsAsyncEnumerable<T>.

Add a new EF1004 diagnostic that flags this pattern. Per maintainer guidance on #37670, treat all IQueryable<T> sources as EF queries on the assumption that the EF analyzer package being referenced implies EF use; mixed-provider apps can suppress per-call (#pragma, [SuppressMessage], .editorconfig) or opt out via an explicit cast to IEnumerable<T>.

Detection rules:
- Method symbol is exactly System.Linq.AsyncEnumerable.ToAsyncEnumerable (filters out same-named methods on Channel<T>, IObservable<T>, etc.).
- Source argument's pre-conversion type implements System.Linq.IQueryable<T>; explicit cast to IEnumerable<T> short-circuits.
- Reports at the method-name token, matching EF1002/EF1003 conventions.

Includes nine tests covering DbSet, IQueryable locals, chained LINQ, the static-call form, and negative cases (IEnumerable locals, List<T>, T[], explicit casts, AsAsyncEnumerable).

Fixes #37670
