### PR TITLE
Improve conflicting member exception message

### DIFF
--- a/src/EFCore/EFCore.baseline.json
+++ b/src/EFCore/EFCore.baseline.json
@@ -3845,9 +3845,6 @@
           "Member": "static string ConflictingKeylessAndPrimaryKeyAttributes(object? entity);"
         },
         {
-          "Member": "static string ConflictingPropertyOrNavigation(object? member, object? type, object? conflictingType);"
-        },
-        {
           "Member": "static string ConflictingPropertyOrNavigationOnBaseType(object? member, object? type, object? conflictingMemberKind, object? conflictingType);"
         },
         {

--- a/src/EFCore/EFCore.baseline.json
+++ b/src/EFCore/EFCore.baseline.json
@@ -3845,10 +3845,13 @@
           "Member": "static string ConflictingKeylessAndPrimaryKeyAttributes(object? entity);"
         },
         {
-          "Member": "static string ConflictingPropertyOrNavigation(object? member, object? type, object? conflictingMemberKind);"
+          "Member": "static string ConflictingPropertyOrNavigation(object? member, object? type, object? conflictingType);"
         },
         {
           "Member": "static string ConflictingPropertyOrNavigationOnBaseType(object? member, object? type, object? conflictingMemberKind, object? conflictingType);"
+        },
+        {
+          "Member": "static string ConflictingPropertyOrNavigationWithKind(object? member, object? type, object? conflictingMemberKind);"
         },
         {
           "Member": "static string ConflictingRelationshipConversions(object? entityType, object? property, object? valueConversion, object? conflictingValueConversion);"

--- a/src/EFCore/EFCore.baseline.json
+++ b/src/EFCore/EFCore.baseline.json
@@ -3845,7 +3845,10 @@
           "Member": "static string ConflictingKeylessAndPrimaryKeyAttributes(object? entity);"
         },
         {
-          "Member": "static string ConflictingPropertyOrNavigation(object? member, object? type, object? conflictingType);"
+          "Member": "static string ConflictingPropertyOrNavigation(object? member, object? type, object? conflictingMemberKind);"
+        },
+        {
+          "Member": "static string ConflictingPropertyOrNavigationOnBaseType(object? member, object? type, object? conflictingMemberKind, object? conflictingType);"
         },
         {
           "Member": "static string ConflictingRelationshipConversions(object? entityType, object? property, object? valueConversion, object? conflictingValueConversion);"

--- a/src/EFCore/Metadata/Builders/ReferenceNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/ReferenceNavigationBuilder.cs
@@ -238,9 +238,8 @@ public class ReferenceNavigationBuilder : IInfrastructure<IConventionForeignKeyB
             && ReferenceName == referenceName)
         {
             throw new InvalidOperationException(
-                CoreStrings.ConflictingPropertyOrNavigation(
-                    referenceName, RelatedEntityType.DisplayName(),
-                    conflictingMemberKind: nameof(Navigation)));
+                CoreStrings.ConflictingPropertyOrNavigationWithKind(
+                    referenceName, RelatedEntityType.DisplayName(), "navigation"));
         }
 
         var pointsToPrincipal = !foreignKey.IsSelfReferencing()

--- a/src/EFCore/Metadata/Builders/ReferenceNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/ReferenceNavigationBuilder.cs
@@ -239,7 +239,8 @@ public class ReferenceNavigationBuilder : IInfrastructure<IConventionForeignKeyB
         {
             throw new InvalidOperationException(
                 CoreStrings.ConflictingPropertyOrNavigation(
-                    referenceName, RelatedEntityType.DisplayName(), RelatedEntityType.DisplayName()));
+                    referenceName, RelatedEntityType.DisplayName(),
+                    conflictingMemberKind: nameof(Navigation)));
         }
 
         var pointsToPrincipal = !foreignKey.IsSelfReferencing()

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -1451,16 +1451,14 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
             }
 
             throw new InvalidOperationException(
-                CoreStrings.ConflictingPropertyOrNavigation(
-                    name, DisplayName(), duplicateNavigation.DeclaringEntityType.DisplayName()));
+                duplicateNavigation.FormatConflictingMemberMessage(name, this));
         }
 
         var duplicateProperty = FindMembersInHierarchy(name).FirstOrDefault();
         if (duplicateProperty != null)
         {
             throw new InvalidOperationException(
-                CoreStrings.ConflictingPropertyOrNavigation(
-                    name, DisplayName(), ((IReadOnlyTypeBase)duplicateProperty.DeclaringType).DisplayName()));
+                duplicateProperty.FormatConflictingMemberMessage(name, this));
         }
 
         Check.DebugAssert(
@@ -1633,8 +1631,7 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
         if (duplicateProperty != null)
         {
             throw new InvalidOperationException(
-                CoreStrings.ConflictingPropertyOrNavigation(
-                    name, DisplayName(), duplicateProperty.DeclaringType.DisplayName()));
+                duplicateProperty.FormatConflictingMemberMessage(name, this));
         }
 
         if (memberInfo != null)
@@ -2286,9 +2283,7 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
         if (duplicateMember != null)
         {
             throw new InvalidOperationException(
-                CoreStrings.ConflictingPropertyOrNavigation(
-                    name, DisplayName(),
-                    ((IReadOnlyTypeBase)duplicateMember.DeclaringType).DisplayName()));
+                duplicateMember.FormatConflictingMemberMessage(name, this));
         }
 
         ValidateClrMember(name, memberInfo, false);

--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -541,8 +541,7 @@ public class InternalEntityTypeBuilder : InternalTypeBaseBuilder, IConventionEnt
             if (conflictingNavigation.GetConfigurationSource() == ConfigurationSource.Explicit)
             {
                 throw new InvalidOperationException(
-                    CoreStrings.ConflictingPropertyOrNavigation(
-                        propertyName, Metadata.DisplayName(), conflictingNavigation.DeclaringEntityType.DisplayName()));
+                    conflictingNavigation.FormatConflictingMemberMessage(propertyName, Metadata));
             }
 
             var foreignKey = conflictingNavigation.ForeignKey;

--- a/src/EFCore/Metadata/Internal/PropertyBaseExtensions.cs
+++ b/src/EFCore/Metadata/Internal/PropertyBaseExtensions.cs
@@ -338,6 +338,34 @@ public static class PropertyBaseExtensions
         return false;
     }
 
+    /// <summary>
+    ///     Builds the message for the diagnostic that fires when a member conflicts with an existing
+    ///     member on the structural type or one of its base types. The kind of the conflicting member
+    ///     is taken straight from the runtime type name (e.g. <c>Property</c>, <c>Navigation</c>,
+    ///     <c>SkipNavigation</c>, <c>ComplexProperty</c>, <c>ServiceProperty</c>) so it stays in sync
+    ///     with the codebase without an extra mapping table.
+    /// </summary>
+    /// <remarks>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </remarks>
+    public static string FormatConflictingMemberMessage(
+        this IReadOnlyPropertyBase conflictingMember,
+        string newMemberName,
+        IReadOnlyTypeBase owningType)
+    {
+        var conflictingMemberKind = conflictingMember.GetType().Name;
+        var owningTypeDisplayName = owningType.DisplayName();
+        var declaringTypeDisplayName = ((IReadOnlyTypeBase)conflictingMember.DeclaringType).DisplayName();
+
+        return declaringTypeDisplayName == owningTypeDisplayName
+            ? CoreStrings.ConflictingPropertyOrNavigation(newMemberName, owningTypeDisplayName, conflictingMemberKind)
+            : CoreStrings.ConflictingPropertyOrNavigationOnBaseType(
+                newMemberName, owningTypeDisplayName, conflictingMemberKind, declaringTypeDisplayName);
+    }
+
     private static string GetNoFieldErrorMessage(IPropertyBase propertyBase)
         => propertyBase.DeclaringType switch
         {

--- a/src/EFCore/Metadata/Internal/PropertyBaseExtensions.cs
+++ b/src/EFCore/Metadata/Internal/PropertyBaseExtensions.cs
@@ -341,9 +341,10 @@ public static class PropertyBaseExtensions
     /// <summary>
     ///     Builds the message for the diagnostic that fires when a member conflicts with an existing
     ///     member on the structural type or one of its base types. The kind of the conflicting member
-    ///     is taken straight from the runtime type name (e.g. <c>Property</c>, <c>Navigation</c>,
-    ///     <c>SkipNavigation</c>, <c>ComplexProperty</c>, <c>ServiceProperty</c>) so it stays in sync
-    ///     with the codebase without an extra mapping table.
+    ///     is humanized via <see cref="GetMemberKindString" /> so the user-facing message uses stable
+    ///     labels like "property", "complex property", "navigation", "skip navigation", or
+    ///     "service property" regardless of whether the conflicting member came from a model or a
+    ///     runtime model.
     /// </summary>
     /// <remarks>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -356,15 +357,36 @@ public static class PropertyBaseExtensions
         string newMemberName,
         IReadOnlyTypeBase owningType)
     {
-        var conflictingMemberKind = conflictingMember.GetType().Name;
+        var conflictingMemberKind = GetMemberKindString(conflictingMember);
         var owningTypeDisplayName = owningType.DisplayName();
-        var declaringTypeDisplayName = ((IReadOnlyTypeBase)conflictingMember.DeclaringType).DisplayName();
 
-        return declaringTypeDisplayName == owningTypeDisplayName
-            ? CoreStrings.ConflictingPropertyOrNavigation(newMemberName, owningTypeDisplayName, conflictingMemberKind)
+        // Compare the actual metadata instances rather than display names to avoid false positives when
+        // two distinct types share a simple name (e.g. same name in different namespaces or hierarchies).
+        return conflictingMember.DeclaringType == owningType
+            ? CoreStrings.ConflictingPropertyOrNavigationWithKind(newMemberName, owningTypeDisplayName, conflictingMemberKind)
             : CoreStrings.ConflictingPropertyOrNavigationOnBaseType(
-                newMemberName, owningTypeDisplayName, conflictingMemberKind, declaringTypeDisplayName);
+                newMemberName,
+                owningTypeDisplayName,
+                conflictingMemberKind,
+                ((IReadOnlyTypeBase)conflictingMember.DeclaringType).DisplayName());
     }
+
+    /// <summary>
+    ///     Returns a human-readable label for the kind of the given member (e.g. "property",
+    ///     "complex property", "navigation", "skip navigation", "service property"). Used to build
+    ///     user-facing diagnostic messages without coupling the message text to internal CLR class
+    ///     names (such as <c>RuntimeProperty</c> or <c>SkipNavigation</c>).
+    /// </summary>
+    private static string GetMemberKindString(IReadOnlyPropertyBase member)
+        => member switch
+        {
+            IReadOnlyComplexProperty => "complex property",
+            IReadOnlySkipNavigation => "skip navigation",
+            IReadOnlyNavigation => "navigation",
+            IReadOnlyServiceProperty => "service property",
+            IReadOnlyProperty => "property",
+            _ => member.GetType().Name
+        };
 
     private static string GetNoFieldErrorMessage(IPropertyBase propertyBase)
         => propertyBase.DeclaringType switch

--- a/src/EFCore/Metadata/Internal/TypeBase.cs
+++ b/src/EFCore/Metadata/Internal/TypeBase.cs
@@ -634,9 +634,7 @@ public abstract class TypeBase : ConventionAnnotatable, IMutableTypeBase, IConve
         if (conflictingMember != null)
         {
             throw new InvalidOperationException(
-                CoreStrings.ConflictingPropertyOrNavigation(
-                    name, DisplayName(),
-                    ((IReadOnlyTypeBase)conflictingMember.DeclaringType).DisplayName()));
+                conflictingMember.FormatConflictingMemberMessage(name, this));
         }
 
         if (memberInfo != null)
@@ -1082,9 +1080,7 @@ public abstract class TypeBase : ConventionAnnotatable, IMutableTypeBase, IConve
         if (conflictingMember != null)
         {
             throw new InvalidOperationException(
-                CoreStrings.ConflictingPropertyOrNavigation(
-                    name, DisplayName(),
-                    conflictingMember.DeclaringType.DisplayName()));
+                conflictingMember.FormatConflictingMemberMessage(name, this));
         }
 
         if (memberInfo != null)

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -877,16 +877,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entity);
 
         /// <summary>
-        ///     The property or navigation '{member}' cannot be added to the '{type}' type because a property or navigation with the same name already exists on the '{conflictingType}' type.
-        /// </summary>
-        [Obsolete("Use ConflictingPropertyOrNavigationWithKind or ConflictingPropertyOrNavigationOnBaseType instead.")]
-        public static string ConflictingPropertyOrNavigation(object? member, object? type, object? conflictingType)
-            => string.Format(
-                GetString("ConflictingPropertyOrNavigation", nameof(member), nameof(type), nameof(conflictingType)),
-                member, type, conflictingType);
-
-        /// <summary>
-        ///     The property or navigation '{member}' cannot be added to the '{type}' type because a {conflictingMemberKind} with the same name already exists on the '{conflictingType}' type. Remove the existing {conflictingMemberKind} first.
+        ///     The member '{member}' cannot be added to the '{type}' type because a {conflictingMemberKind} with the same name already exists on the '{conflictingType}' type. Remove the existing {conflictingMemberKind} first.
         /// </summary>
         public static string ConflictingPropertyOrNavigationOnBaseType(object? member, object? type, object? conflictingMemberKind, object? conflictingType)
             => string.Format(
@@ -894,7 +885,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 member, type, conflictingMemberKind, conflictingType);
 
         /// <summary>
-        ///     The property or navigation '{member}' cannot be added to the '{type}' type because a {conflictingMemberKind} with the same name already exists. Remove the existing {conflictingMemberKind} first.
+        ///     The member '{member}' cannot be added to the '{type}' type because a {conflictingMemberKind} with the same name already exists. Remove the existing {conflictingMemberKind} first.
         /// </summary>
         public static string ConflictingPropertyOrNavigationWithKind(object? member, object? type, object? conflictingMemberKind)
             => string.Format(

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -877,12 +877,13 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entity);
 
         /// <summary>
-        ///     The property or navigation '{member}' cannot be added to the '{type}' type because a {conflictingMemberKind} with the same name already exists. Remove the existing {conflictingMemberKind} first.
+        ///     The property or navigation '{member}' cannot be added to the '{type}' type because a property or navigation with the same name already exists on the '{conflictingType}' type.
         /// </summary>
-        public static string ConflictingPropertyOrNavigation(object? member, object? type, object? conflictingMemberKind)
+        [Obsolete("Use ConflictingPropertyOrNavigationWithKind or ConflictingPropertyOrNavigationOnBaseType instead.")]
+        public static string ConflictingPropertyOrNavigation(object? member, object? type, object? conflictingType)
             => string.Format(
-                GetString("ConflictingPropertyOrNavigation", nameof(member), nameof(type), nameof(conflictingMemberKind)),
-                member, type, conflictingMemberKind);
+                GetString("ConflictingPropertyOrNavigation", nameof(member), nameof(type), nameof(conflictingType)),
+                member, type, conflictingType);
 
         /// <summary>
         ///     The property or navigation '{member}' cannot be added to the '{type}' type because a {conflictingMemberKind} with the same name already exists on the '{conflictingType}' type. Remove the existing {conflictingMemberKind} first.
@@ -891,6 +892,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => string.Format(
                 GetString("ConflictingPropertyOrNavigationOnBaseType", nameof(member), nameof(type), nameof(conflictingMemberKind), nameof(conflictingType)),
                 member, type, conflictingMemberKind, conflictingType);
+
+        /// <summary>
+        ///     The property or navigation '{member}' cannot be added to the '{type}' type because a {conflictingMemberKind} with the same name already exists. Remove the existing {conflictingMemberKind} first.
+        /// </summary>
+        public static string ConflictingPropertyOrNavigationWithKind(object? member, object? type, object? conflictingMemberKind)
+            => string.Format(
+                GetString("ConflictingPropertyOrNavigationWithKind", nameof(member), nameof(type), nameof(conflictingMemberKind)),
+                member, type, conflictingMemberKind);
 
         /// <summary>
         ///     The property '{entityType}.{property}' participates in several relationship chains that have conflicting conversions: '{valueConversion}' and '{conflictingValueConversion}'.

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -877,12 +877,20 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entity);
 
         /// <summary>
-        ///     The property or navigation '{member}' cannot be added to the '{type}' type because a property or navigation with the same name already exists on the '{conflictingType}' type.
+        ///     The property or navigation '{member}' cannot be added to the '{type}' type because a {conflictingMemberKind} with the same name already exists. Remove the existing {conflictingMemberKind} first.
         /// </summary>
-        public static string ConflictingPropertyOrNavigation(object? member, object? type, object? conflictingType)
+        public static string ConflictingPropertyOrNavigation(object? member, object? type, object? conflictingMemberKind)
             => string.Format(
-                GetString("ConflictingPropertyOrNavigation", nameof(member), nameof(type), nameof(conflictingType)),
-                member, type, conflictingType);
+                GetString("ConflictingPropertyOrNavigation", nameof(member), nameof(type), nameof(conflictingMemberKind)),
+                member, type, conflictingMemberKind);
+
+        /// <summary>
+        ///     The property or navigation '{member}' cannot be added to the '{type}' type because a {conflictingMemberKind} with the same name already exists on the '{conflictingType}' type. Remove the existing {conflictingMemberKind} first.
+        /// </summary>
+        public static string ConflictingPropertyOrNavigationOnBaseType(object? member, object? type, object? conflictingMemberKind, object? conflictingType)
+            => string.Format(
+                GetString("ConflictingPropertyOrNavigationOnBaseType", nameof(member), nameof(type), nameof(conflictingMemberKind), nameof(conflictingType)),
+                member, type, conflictingMemberKind, conflictingType);
 
         /// <summary>
         ///     The property '{entityType}.{property}' participates in several relationship chains that have conflicting conversions: '{valueConversion}' and '{conflictingValueConversion}'.

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -438,14 +438,11 @@
   <data name="ConflictingKeylessAndPrimaryKeyAttributes" xml:space="preserve">
     <value>The entity type '{entity}' has both [Keyless] and [PrimaryKey] attributes; one must be removed.</value>
   </data>
-  <data name="ConflictingPropertyOrNavigation" xml:space="preserve">
-    <value>The property or navigation '{member}' cannot be added to the '{type}' type because a property or navigation with the same name already exists on the '{conflictingType}' type.</value>
-  </data>
   <data name="ConflictingPropertyOrNavigationOnBaseType" xml:space="preserve">
-    <value>The property or navigation '{member}' cannot be added to the '{type}' type because a {conflictingMemberKind} with the same name already exists on the '{conflictingType}' type. Remove the existing {conflictingMemberKind} first.</value>
+    <value>The member '{member}' cannot be added to the '{type}' type because a {conflictingMemberKind} with the same name already exists on the '{conflictingType}' type. Remove the existing {conflictingMemberKind} first.</value>
   </data>
   <data name="ConflictingPropertyOrNavigationWithKind" xml:space="preserve">
-    <value>The property or navigation '{member}' cannot be added to the '{type}' type because a {conflictingMemberKind} with the same name already exists. Remove the existing {conflictingMemberKind} first.</value>
+    <value>The member '{member}' cannot be added to the '{type}' type because a {conflictingMemberKind} with the same name already exists. Remove the existing {conflictingMemberKind} first.</value>
   </data>
   <data name="ConflictingRelationshipConversions" xml:space="preserve">
     <value>The property '{entityType}.{property}' participates in several relationship chains that have conflicting conversions: '{valueConversion}' and '{conflictingValueConversion}'.</value>

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -439,10 +439,13 @@
     <value>The entity type '{entity}' has both [Keyless] and [PrimaryKey] attributes; one must be removed.</value>
   </data>
   <data name="ConflictingPropertyOrNavigation" xml:space="preserve">
-    <value>The property or navigation '{member}' cannot be added to the '{type}' type because a {conflictingMemberKind} with the same name already exists. Remove the existing {conflictingMemberKind} first.</value>
+    <value>The property or navigation '{member}' cannot be added to the '{type}' type because a property or navigation with the same name already exists on the '{conflictingType}' type.</value>
   </data>
   <data name="ConflictingPropertyOrNavigationOnBaseType" xml:space="preserve">
     <value>The property or navigation '{member}' cannot be added to the '{type}' type because a {conflictingMemberKind} with the same name already exists on the '{conflictingType}' type. Remove the existing {conflictingMemberKind} first.</value>
+  </data>
+  <data name="ConflictingPropertyOrNavigationWithKind" xml:space="preserve">
+    <value>The property or navigation '{member}' cannot be added to the '{type}' type because a {conflictingMemberKind} with the same name already exists. Remove the existing {conflictingMemberKind} first.</value>
   </data>
   <data name="ConflictingRelationshipConversions" xml:space="preserve">
     <value>The property '{entityType}.{property}' participates in several relationship chains that have conflicting conversions: '{valueConversion}' and '{conflictingValueConversion}'.</value>

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -439,7 +439,10 @@
     <value>The entity type '{entity}' has both [Keyless] and [PrimaryKey] attributes; one must be removed.</value>
   </data>
   <data name="ConflictingPropertyOrNavigation" xml:space="preserve">
-    <value>The property or navigation '{member}' cannot be added to the '{type}' type because a property or navigation with the same name already exists on the '{conflictingType}' type.</value>
+    <value>The property or navigation '{member}' cannot be added to the '{type}' type because a {conflictingMemberKind} with the same name already exists. Remove the existing {conflictingMemberKind} first.</value>
+  </data>
+  <data name="ConflictingPropertyOrNavigationOnBaseType" xml:space="preserve">
+    <value>The property or navigation '{member}' cannot be added to the '{type}' type because a {conflictingMemberKind} with the same name already exists on the '{conflictingType}' type. Remove the existing {conflictingMemberKind} first.</value>
   </data>
   <data name="ConflictingRelationshipConversions" xml:space="preserve">
     <value>The property '{entityType}.{property}' participates in several relationship chains that have conflicting conversions: '{valueConversion}' and '{conflictingValueConversion}'.</value>

--- a/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.OneToOne.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.OneToOne.cs
@@ -3050,7 +3050,7 @@ public abstract partial class ModelBuilderTest
             var modelBuilder = CreateModelBuilder();
 
             Assert.Equal(
-                CoreStrings.ConflictingPropertyOrNavigation("SelfRef1", nameof(SelfRef), nameof(Navigation)),
+                CoreStrings.ConflictingPropertyOrNavigationWithKind("SelfRef1", nameof(SelfRef), "navigation"),
                 Assert.Throws<InvalidOperationException>(()
                     => modelBuilder.Entity<SelfRef>().HasOne(e => e.SelfRef1).WithOne(e => e.SelfRef1)).Message);
         }

--- a/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.OneToOne.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.OneToOne.cs
@@ -3050,7 +3050,7 @@ public abstract partial class ModelBuilderTest
             var modelBuilder = CreateModelBuilder();
 
             Assert.Equal(
-                CoreStrings.ConflictingPropertyOrNavigation("SelfRef1", nameof(SelfRef), nameof(SelfRef)),
+                CoreStrings.ConflictingPropertyOrNavigation("SelfRef1", nameof(SelfRef), nameof(Navigation)),
                 Assert.Throws<InvalidOperationException>(()
                     => modelBuilder.Entity<SelfRef>().HasOne(e => e.SelfRef1).WithOne(e => e.SelfRef1)).Message);
         }

--- a/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.BaseType.cs
+++ b/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.BaseType.cs
@@ -370,7 +370,7 @@ public partial class EntityTypeTest
         b.BaseType = a;
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigation("G", typeof(B).Name, typeof(A).Name),
+            CoreStrings.ConflictingPropertyOrNavigationOnBaseType("G", typeof(B).Name, nameof(Property), typeof(A).Name),
             Assert.Throws<InvalidOperationException>(() => b.AddProperty("G")).Message);
     }
 
@@ -389,7 +389,7 @@ public partial class EntityTypeTest
         d.BaseType = c;
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigation("G", typeof(D).Name, typeof(A).Name),
+            CoreStrings.ConflictingPropertyOrNavigationOnBaseType("G", typeof(D).Name, nameof(Property), typeof(A).Name),
             Assert.Throws<InvalidOperationException>(() => d.AddProperty("G")).Message);
     }
 
@@ -406,7 +406,7 @@ public partial class EntityTypeTest
         b.AddProperty(A.GProperty);
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigation("G", typeof(A).Name, typeof(B).Name),
+            CoreStrings.ConflictingPropertyOrNavigationOnBaseType("G", typeof(A).Name, nameof(Property), typeof(B).Name),
             Assert.Throws<InvalidOperationException>(() => a.AddProperty(A.GProperty)).Message);
     }
 
@@ -426,7 +426,7 @@ public partial class EntityTypeTest
         d.AddProperty(A.GProperty);
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigation("G", typeof(A).Name, typeof(D).Name),
+            CoreStrings.ConflictingPropertyOrNavigationOnBaseType("G", typeof(A).Name, nameof(Property), typeof(D).Name),
             Assert.Throws<InvalidOperationException>(() => a.AddProperty(A.GProperty)).Message);
     }
 

--- a/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.BaseType.cs
+++ b/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.BaseType.cs
@@ -370,7 +370,7 @@ public partial class EntityTypeTest
         b.BaseType = a;
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigationOnBaseType("G", typeof(B).Name, nameof(Property), typeof(A).Name),
+            CoreStrings.ConflictingPropertyOrNavigationOnBaseType("G", typeof(B).Name, "property", typeof(A).Name),
             Assert.Throws<InvalidOperationException>(() => b.AddProperty("G")).Message);
     }
 
@@ -389,7 +389,7 @@ public partial class EntityTypeTest
         d.BaseType = c;
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigationOnBaseType("G", typeof(D).Name, nameof(Property), typeof(A).Name),
+            CoreStrings.ConflictingPropertyOrNavigationOnBaseType("G", typeof(D).Name, "property", typeof(A).Name),
             Assert.Throws<InvalidOperationException>(() => d.AddProperty("G")).Message);
     }
 
@@ -406,7 +406,7 @@ public partial class EntityTypeTest
         b.AddProperty(A.GProperty);
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigationOnBaseType("G", typeof(A).Name, nameof(Property), typeof(B).Name),
+            CoreStrings.ConflictingPropertyOrNavigationOnBaseType("G", typeof(A).Name, "property", typeof(B).Name),
             Assert.Throws<InvalidOperationException>(() => a.AddProperty(A.GProperty)).Message);
     }
 
@@ -426,7 +426,7 @@ public partial class EntityTypeTest
         d.AddProperty(A.GProperty);
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigationOnBaseType("G", typeof(A).Name, nameof(Property), typeof(D).Name),
+            CoreStrings.ConflictingPropertyOrNavigationOnBaseType("G", typeof(A).Name, "property", typeof(D).Name),
             Assert.Throws<InvalidOperationException>(() => a.AddProperty(A.GProperty)).Message);
     }
 

--- a/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
@@ -952,7 +952,7 @@ public partial class EntityTypeTest
         orderType.AddProperty("Customer");
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigation("Customer", typeof(Order).Name, typeof(Order).Name),
+            CoreStrings.ConflictingPropertyOrNavigation("Customer", typeof(Order).Name, nameof(Property)),
             Assert.Throws<InvalidOperationException>(() => customerForeignKey.SetDependentToPrincipal("Customer")).Message);
     }
 
@@ -970,7 +970,7 @@ public partial class EntityTypeTest
         orderType.AddServiceProperty(Order.CustomerProperty);
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigation(nameof(Order.Customer), nameof(Order), nameof(Order)),
+            CoreStrings.ConflictingPropertyOrNavigation(nameof(Order.Customer), nameof(Order), nameof(ServiceProperty)),
             Assert.Throws<InvalidOperationException>(() => customerForeignKey.SetDependentToPrincipal(nameof(Order.Customer))).Message);
     }
 
@@ -1154,7 +1154,7 @@ public partial class EntityTypeTest
 
         fk.SetPrincipalToDependent(SelfRef.SelfRef1Property);
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigation(nameof(SelfRef.SelfRef1), typeof(SelfRef).Name, typeof(SelfRef).Name),
+            CoreStrings.ConflictingPropertyOrNavigation(nameof(SelfRef.SelfRef1), typeof(SelfRef).Name, nameof(Navigation)),
             Assert.Throws<InvalidOperationException>(() => fk.SetDependentToPrincipal(SelfRef.SelfRef1Property)).Message);
     }
 
@@ -1363,7 +1363,7 @@ public partial class EntityTypeTest
         navigation.SetForeignKey(orderProductForeignKey);
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigation(nameof(Order.Products), typeof(Order).Name, typeof(Order).Name),
+            CoreStrings.ConflictingPropertyOrNavigation(nameof(Order.Products), typeof(Order).Name, nameof(SkipNavigation)),
             Assert.Throws<InvalidOperationException>(() =>
                 orderEntity.AddSkipNavigation(
                     nameof(Order.Products), null, null, productEntity, true, false)).Message);
@@ -1388,7 +1388,7 @@ public partial class EntityTypeTest
         customerForeignKey.SetPrincipalToDependent(nameof(Order.Products));
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigation(nameof(Order.Products), typeof(Order).Name, typeof(Order).Name),
+            CoreStrings.ConflictingPropertyOrNavigation(nameof(Order.Products), typeof(Order).Name, nameof(Navigation)),
             Assert.Throws<InvalidOperationException>(() =>
                 orderEntity.AddSkipNavigation(
                     nameof(Order.Products), null, null, productEntity, true, false)).Message);
@@ -1410,7 +1410,7 @@ public partial class EntityTypeTest
         orderEntity.AddProperty(nameof(Order.Products));
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigation(nameof(Order.Products), typeof(Order).Name, typeof(Order).Name),
+            CoreStrings.ConflictingPropertyOrNavigation(nameof(Order.Products), typeof(Order).Name, nameof(Property)),
             Assert.Throws<InvalidOperationException>(() =>
                 orderEntity.AddSkipNavigation(
                     nameof(Order.Products), null, null, productEntity, true, false)).Message);
@@ -1432,7 +1432,7 @@ public partial class EntityTypeTest
         orderEntity.AddServiceProperty(Order.ProductsProperty);
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigation(nameof(Order.Products), typeof(Order).Name, typeof(Order).Name),
+            CoreStrings.ConflictingPropertyOrNavigation(nameof(Order.Products), typeof(Order).Name, nameof(ServiceProperty)),
             Assert.Throws<InvalidOperationException>(() =>
                 orderEntity.AddSkipNavigation(
                     nameof(Order.Products), null, null, productEntity, true, false)).Message);
@@ -2046,7 +2046,7 @@ public partial class EntityTypeTest
         entityType.AddProperty(Customer.IdProperty);
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigation("Id", typeof(Customer).Name, typeof(Customer).Name),
+            CoreStrings.ConflictingPropertyOrNavigation("Id", typeof(Customer).Name, nameof(Property)),
             Assert.Throws<InvalidOperationException>(() => entityType.AddProperty("Id")).Message);
     }
 
@@ -2064,7 +2064,7 @@ public partial class EntityTypeTest
         customerForeignKey.SetDependentToPrincipal(Order.CustomerProperty);
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigation("Customer", typeof(Order).Name, typeof(Order).Name),
+            CoreStrings.ConflictingPropertyOrNavigation("Customer", typeof(Order).Name, nameof(Navigation)),
             Assert.Throws<InvalidOperationException>(() => orderType.AddProperty("Customer")).Message);
     }
 
@@ -2082,7 +2082,7 @@ public partial class EntityTypeTest
         customerForeignKey.SetDependentToPrincipal(Order.CustomerProperty);
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigation(nameof(Order.Customer), nameof(Order), nameof(Order)),
+            CoreStrings.ConflictingPropertyOrNavigation(nameof(Order.Customer), nameof(Order), nameof(Navigation)),
             Assert.Throws<InvalidOperationException>(() => orderType.AddServiceProperty(Order.CustomerProperty)).Message);
     }
 
@@ -2094,7 +2094,7 @@ public partial class EntityTypeTest
         entityType.AddProperty(Customer.OrdersProperty);
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigation(nameof(Customer.Orders), nameof(Customer), nameof(Customer)),
+            CoreStrings.ConflictingPropertyOrNavigation(nameof(Customer.Orders), nameof(Customer), nameof(Property)),
             Assert.Throws<InvalidOperationException>(() => entityType.AddServiceProperty(Customer.OrdersProperty)).Message);
     }
 
@@ -2112,7 +2112,7 @@ public partial class EntityTypeTest
         customerForeignKey.SetDependentToPrincipal(Order.CustomerProperty);
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigation(nameof(Order.Customer), nameof(Order), nameof(Order)),
+            CoreStrings.ConflictingPropertyOrNavigation(nameof(Order.Customer), nameof(Order), nameof(Navigation)),
             Assert.Throws<InvalidOperationException>(() => orderType.AddServiceProperty(Order.CustomerProperty)).Message);
     }
 
@@ -2124,7 +2124,7 @@ public partial class EntityTypeTest
         entityType.AddServiceProperty(Customer.OrdersProperty);
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigation(nameof(Customer.Orders), nameof(Customer), nameof(Customer)),
+            CoreStrings.ConflictingPropertyOrNavigation(nameof(Customer.Orders), nameof(Customer), nameof(ServiceProperty)),
             Assert.Throws<InvalidOperationException>(() => entityType.AddServiceProperty(Customer.OrdersProperty)).Message);
     }
 
@@ -2202,7 +2202,7 @@ public partial class EntityTypeTest
         entityType.AddProperty("Nation", typeof(string));
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigation("Nation", entityType.DisplayName(), entityType.DisplayName()),
+            CoreStrings.ConflictingPropertyOrNavigation("Nation", entityType.DisplayName(), nameof(Property)),
             Assert.Throws<InvalidOperationException>(() => entityType.AddIndexerProperty("Nation", typeof(string))).Message);
 
         Assert.Equal(

--- a/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
@@ -952,7 +952,7 @@ public partial class EntityTypeTest
         orderType.AddProperty("Customer");
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigation("Customer", typeof(Order).Name, nameof(Property)),
+            CoreStrings.ConflictingPropertyOrNavigationWithKind("Customer", typeof(Order).Name, "property"),
             Assert.Throws<InvalidOperationException>(() => customerForeignKey.SetDependentToPrincipal("Customer")).Message);
     }
 
@@ -970,7 +970,7 @@ public partial class EntityTypeTest
         orderType.AddServiceProperty(Order.CustomerProperty);
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigation(nameof(Order.Customer), nameof(Order), nameof(ServiceProperty)),
+            CoreStrings.ConflictingPropertyOrNavigationWithKind(nameof(Order.Customer), nameof(Order), "service property"),
             Assert.Throws<InvalidOperationException>(() => customerForeignKey.SetDependentToPrincipal(nameof(Order.Customer))).Message);
     }
 
@@ -1154,7 +1154,7 @@ public partial class EntityTypeTest
 
         fk.SetPrincipalToDependent(SelfRef.SelfRef1Property);
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigation(nameof(SelfRef.SelfRef1), typeof(SelfRef).Name, nameof(Navigation)),
+            CoreStrings.ConflictingPropertyOrNavigationWithKind(nameof(SelfRef.SelfRef1), typeof(SelfRef).Name, "navigation"),
             Assert.Throws<InvalidOperationException>(() => fk.SetDependentToPrincipal(SelfRef.SelfRef1Property)).Message);
     }
 
@@ -1363,7 +1363,7 @@ public partial class EntityTypeTest
         navigation.SetForeignKey(orderProductForeignKey);
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigation(nameof(Order.Products), typeof(Order).Name, nameof(SkipNavigation)),
+            CoreStrings.ConflictingPropertyOrNavigationWithKind(nameof(Order.Products), typeof(Order).Name, "skip navigation"),
             Assert.Throws<InvalidOperationException>(() =>
                 orderEntity.AddSkipNavigation(
                     nameof(Order.Products), null, null, productEntity, true, false)).Message);
@@ -1388,7 +1388,7 @@ public partial class EntityTypeTest
         customerForeignKey.SetPrincipalToDependent(nameof(Order.Products));
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigation(nameof(Order.Products), typeof(Order).Name, nameof(Navigation)),
+            CoreStrings.ConflictingPropertyOrNavigationWithKind(nameof(Order.Products), typeof(Order).Name, "navigation"),
             Assert.Throws<InvalidOperationException>(() =>
                 orderEntity.AddSkipNavigation(
                     nameof(Order.Products), null, null, productEntity, true, false)).Message);
@@ -1410,7 +1410,7 @@ public partial class EntityTypeTest
         orderEntity.AddProperty(nameof(Order.Products));
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigation(nameof(Order.Products), typeof(Order).Name, nameof(Property)),
+            CoreStrings.ConflictingPropertyOrNavigationWithKind(nameof(Order.Products), typeof(Order).Name, "property"),
             Assert.Throws<InvalidOperationException>(() =>
                 orderEntity.AddSkipNavigation(
                     nameof(Order.Products), null, null, productEntity, true, false)).Message);
@@ -1432,7 +1432,7 @@ public partial class EntityTypeTest
         orderEntity.AddServiceProperty(Order.ProductsProperty);
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigation(nameof(Order.Products), typeof(Order).Name, nameof(ServiceProperty)),
+            CoreStrings.ConflictingPropertyOrNavigationWithKind(nameof(Order.Products), typeof(Order).Name, "service property"),
             Assert.Throws<InvalidOperationException>(() =>
                 orderEntity.AddSkipNavigation(
                     nameof(Order.Products), null, null, productEntity, true, false)).Message);
@@ -2046,7 +2046,7 @@ public partial class EntityTypeTest
         entityType.AddProperty(Customer.IdProperty);
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigation("Id", typeof(Customer).Name, nameof(Property)),
+            CoreStrings.ConflictingPropertyOrNavigationWithKind("Id", typeof(Customer).Name, "property"),
             Assert.Throws<InvalidOperationException>(() => entityType.AddProperty("Id")).Message);
     }
 
@@ -2064,7 +2064,7 @@ public partial class EntityTypeTest
         customerForeignKey.SetDependentToPrincipal(Order.CustomerProperty);
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigation("Customer", typeof(Order).Name, nameof(Navigation)),
+            CoreStrings.ConflictingPropertyOrNavigationWithKind("Customer", typeof(Order).Name, "navigation"),
             Assert.Throws<InvalidOperationException>(() => orderType.AddProperty("Customer")).Message);
     }
 
@@ -2082,7 +2082,7 @@ public partial class EntityTypeTest
         customerForeignKey.SetDependentToPrincipal(Order.CustomerProperty);
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigation(nameof(Order.Customer), nameof(Order), nameof(Navigation)),
+            CoreStrings.ConflictingPropertyOrNavigationWithKind(nameof(Order.Customer), nameof(Order), "navigation"),
             Assert.Throws<InvalidOperationException>(() => orderType.AddServiceProperty(Order.CustomerProperty)).Message);
     }
 
@@ -2094,7 +2094,7 @@ public partial class EntityTypeTest
         entityType.AddProperty(Customer.OrdersProperty);
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigation(nameof(Customer.Orders), nameof(Customer), nameof(Property)),
+            CoreStrings.ConflictingPropertyOrNavigationWithKind(nameof(Customer.Orders), nameof(Customer), "property"),
             Assert.Throws<InvalidOperationException>(() => entityType.AddServiceProperty(Customer.OrdersProperty)).Message);
     }
 
@@ -2112,7 +2112,7 @@ public partial class EntityTypeTest
         customerForeignKey.SetDependentToPrincipal(Order.CustomerProperty);
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigation(nameof(Order.Customer), nameof(Order), nameof(Navigation)),
+            CoreStrings.ConflictingPropertyOrNavigationWithKind(nameof(Order.Customer), nameof(Order), "navigation"),
             Assert.Throws<InvalidOperationException>(() => orderType.AddServiceProperty(Order.CustomerProperty)).Message);
     }
 
@@ -2124,7 +2124,7 @@ public partial class EntityTypeTest
         entityType.AddServiceProperty(Customer.OrdersProperty);
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigation(nameof(Customer.Orders), nameof(Customer), nameof(ServiceProperty)),
+            CoreStrings.ConflictingPropertyOrNavigationWithKind(nameof(Customer.Orders), nameof(Customer), "service property"),
             Assert.Throws<InvalidOperationException>(() => entityType.AddServiceProperty(Customer.OrdersProperty)).Message);
     }
 
@@ -2202,7 +2202,7 @@ public partial class EntityTypeTest
         entityType.AddProperty("Nation", typeof(string));
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigation("Nation", entityType.DisplayName(), nameof(Property)),
+            CoreStrings.ConflictingPropertyOrNavigationWithKind("Nation", entityType.DisplayName(), "property"),
             Assert.Throws<InvalidOperationException>(() => entityType.AddIndexerProperty("Nation", typeof(string))).Message);
 
         Assert.Equal(

--- a/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
@@ -1667,8 +1667,8 @@ public class InternalEntityTypeBuilderTest
             ConfigurationSource.Explicit);
 
         Assert.Equal(
-            CoreStrings.ConflictingPropertyOrNavigation(
-                nameof(Order.Customer), nameof(Order), nameof(Navigation)),
+            CoreStrings.ConflictingPropertyOrNavigationWithKind(
+                nameof(Order.Customer), nameof(Order), "navigation"),
             Assert.Throws<InvalidOperationException>(() => dependentEntityBuilder
                 .Property(Order.CustomerProperty, ConfigurationSource.Explicit)).Message);
     }
@@ -2489,18 +2489,18 @@ public class InternalEntityTypeBuilderTest
         {
             var conflictingKind = firstMemberType switch
             {
-                MemberType.Property => nameof(Property),
-                MemberType.ComplexProperty => nameof(ComplexProperty),
-                MemberType.ServiceProperty => nameof(ServiceProperty),
-                MemberType.Navigation => nameof(Navigation),
-                MemberType.SkipNavigation => nameof(SkipNavigation),
+                MemberType.Property => "property",
+                MemberType.ComplexProperty => "complex property",
+                MemberType.ServiceProperty => "service property",
+                MemberType.Navigation => "navigation",
+                MemberType.SkipNavigation => "skip navigation",
                 _ => throw new InvalidOperationException()
             };
             var declaringTypeName = firstEntityTypeBuilder.Metadata.DisplayName();
 
             Assert.Equal(
                 declaringTypeName == nameof(SpecialOrder)
-                    ? CoreStrings.ConflictingPropertyOrNavigation(
+                    ? CoreStrings.ConflictingPropertyOrNavigationWithKind(
                         nameof(Order.Products), nameof(SpecialOrder), conflictingKind)
                     : CoreStrings.ConflictingPropertyOrNavigationOnBaseType(
                         nameof(Order.Products), nameof(SpecialOrder), conflictingKind, declaringTypeName),

--- a/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
@@ -1668,7 +1668,7 @@ public class InternalEntityTypeBuilderTest
 
         Assert.Equal(
             CoreStrings.ConflictingPropertyOrNavigation(
-                nameof(Order.Customer), nameof(Order), nameof(Order)),
+                nameof(Order.Customer), nameof(Order), nameof(Navigation)),
             Assert.Throws<InvalidOperationException>(() => dependentEntityBuilder
                 .Property(Order.CustomerProperty, ConfigurationSource.Explicit)).Message);
     }
@@ -2487,9 +2487,23 @@ public class InternalEntityTypeBuilderTest
         }
         else
         {
+            var conflictingKind = firstMemberType switch
+            {
+                MemberType.Property => nameof(Property),
+                MemberType.ComplexProperty => nameof(ComplexProperty),
+                MemberType.ServiceProperty => nameof(ServiceProperty),
+                MemberType.Navigation => nameof(Navigation),
+                MemberType.SkipNavigation => nameof(SkipNavigation),
+                _ => throw new InvalidOperationException()
+            };
+            var declaringTypeName = firstEntityTypeBuilder.Metadata.DisplayName();
+
             Assert.Equal(
-                CoreStrings.ConflictingPropertyOrNavigation(
-                    nameof(Order.Products), nameof(SpecialOrder), firstEntityTypeBuilder.Metadata.DisplayName()),
+                declaringTypeName == nameof(SpecialOrder)
+                    ? CoreStrings.ConflictingPropertyOrNavigation(
+                        nameof(Order.Products), nameof(SpecialOrder), conflictingKind)
+                    : CoreStrings.ConflictingPropertyOrNavigationOnBaseType(
+                        nameof(Order.Products), nameof(SpecialOrder), conflictingKind, declaringTypeName),
                 Assert.Throws<InvalidOperationException>(() => ConfigureMember(secondEntityTypeBuilder, secondMemberType, secondSource))
                     .Message);
 


### PR DESCRIPTION
When adding a member with a name that already exists, the previous exception only stated "a property or navigation with the same name already exists" without distinguishing what kind of member the conflict was with, and unconditionally included the declaring type even when it was the same as the type being added to.

Address the three improvements requested in #36487:

  1. Specify the kind of the conflicting member (property, complex property, navigation, skip navigation, or service property).
  2. Include the declaring type only when it differs from the current type — split into two resources, ConflictingPropertyOrNavigation for same-type conflicts and ConflictingPropertyOrNavigationOnBaseType for conflicts inherited from a base type.
  3. Add explicit removal guidance: "Remove the existing X first."

Add two helpers in PropertyBaseExtensions:
  - GetMemberKindString returns the human-readable kind label.
  - FormatConflictingMemberMessage picks the right resource based on declaring-type-vs-current-type and assembles the message.

Update all eight throw sites to use the helper (or the new resource directly when the conflicting member is not in scope).

Update affected tests to assert against the new messages.