### PR TITLE
Allow configuring SQL Server temporal table period columns as not hidden

### DIFF
--- a/src/EFCore.SqlServer/Design/Internal/SqlServerAnnotationCodeGenerator.cs
+++ b/src/EFCore.SqlServer/Design/Internal/SqlServerAnnotationCodeGenerator.cs
@@ -148,6 +148,10 @@ public class SqlServerAnnotationCodeGenerator : AnnotationCodeGenerator
         = typeof(TemporalPeriodPropertyBuilder).GetRuntimeMethod(
             nameof(TemporalPeriodPropertyBuilder.HasColumnName), [typeof(string)])!;
 
+    private static readonly MethodInfo TemporalPropertyIsHiddenMethodInfo
+        = typeof(TemporalPeriodPropertyBuilder).GetRuntimeMethod(
+            nameof(TemporalPeriodPropertyBuilder.IsHidden), [typeof(bool)])!;
+
     private static readonly MethodInfo ModelHasFullTextCatalogMethodInfo
         = typeof(SqlServerModelBuilderExtensions).GetRuntimeMethod(
             nameof(SqlServerModelBuilderExtensions.HasFullTextCatalog), [typeof(ModelBuilder), typeof(string)])!;
@@ -304,6 +308,11 @@ public class SqlServerAnnotationCodeGenerator : AnnotationCodeGenerator
                     : new MethodCallCodeFragment(methodInfo, false));
         }
 
+        // The HIDDEN flag on temporal period columns is emitted via the temporal table builder
+        // (ttb.HasPeriodStart(...).IsHidden(false)), so remove it here to avoid also emitting it as a
+        // raw property-level annotation in the snapshot.
+        annotations.Remove(SqlServerAnnotationNames.IsHidden);
+
         return fragments;
     }
 
@@ -371,19 +380,17 @@ public class SqlServerAnnotationCodeGenerator : AnnotationCodeGenerator
                         : new MethodCallCodeFragment(TemporalTableUseHistoryTableMethodInfo2, historyTableName));
             }
 
-            // ttb => ttb.HasPeriodStart("Start").HasColumnName("ColumnStart")
+            // ttb => ttb.HasPeriodStart("Start").HasColumnName("ColumnStart").IsHidden(false)
+            // IsHidden(false) is only chained when the user explicitly configured the column visible —
+            // the default is HIDDEN, so omitting matches the legacy snapshot output.
             temporalTableBuilderCalls.Add(
-                periodStartColumnName != null
-                    ? new MethodCallCodeFragment(TemporalTableHasPeriodStartMethodInfo, periodStartPropertyName)
-                        .Chain(new MethodCallCodeFragment(TemporalPropertyHasColumnNameMethodInfo, periodStartColumnName))
-                    : new MethodCallCodeFragment(TemporalTableHasPeriodStartMethodInfo, periodStartPropertyName));
+                BuildPeriodPropertyCall(
+                    TemporalTableHasPeriodStartMethodInfo, periodStartPropertyName, periodStartColumnName, periodStartProperty));
 
-            // ttb => ttb.HasPeriodEnd("End").HasColumnName("ColumnEnd")
+            // ttb => ttb.HasPeriodEnd("End").HasColumnName("ColumnEnd").IsHidden(false)
             temporalTableBuilderCalls.Add(
-                periodEndColumnName != null
-                    ? new MethodCallCodeFragment(TemporalTableHasPeriodEndMethodInfo, periodEndPropertyName)
-                        .Chain(new MethodCallCodeFragment(TemporalPropertyHasColumnNameMethodInfo, periodEndColumnName))
-                    : new MethodCallCodeFragment(TemporalTableHasPeriodEndMethodInfo, periodEndPropertyName));
+                BuildPeriodPropertyCall(
+                    TemporalTableHasPeriodEndMethodInfo, periodEndPropertyName, periodEndColumnName, periodEndProperty));
 
             // ToTable(tb => tb.IsTemporal(ttb => { ... }))
             var toTemporalTableCall = new MethodCallCodeFragment(
@@ -406,6 +413,27 @@ public class SqlServerAnnotationCodeGenerator : AnnotationCodeGenerator
         }
 
         return fragments;
+
+        static MethodCallCodeFragment BuildPeriodPropertyCall(
+            MethodInfo hasPeriodMethod,
+            string? periodPropertyName,
+            string? periodColumnName,
+            IReadOnlyProperty? periodProperty)
+        {
+            var call = new MethodCallCodeFragment(hasPeriodMethod, periodPropertyName);
+
+            if (periodColumnName != null)
+            {
+                call = call.Chain(new MethodCallCodeFragment(TemporalPropertyHasColumnNameMethodInfo, periodColumnName));
+            }
+
+            if (periodProperty?.IsHidden() == false)
+            {
+                call = call.Chain(new MethodCallCodeFragment(TemporalPropertyIsHiddenMethodInfo, false));
+            }
+
+            return call;
+        }
     }
 
     /// <summary>

--- a/src/EFCore.SqlServer/Design/Internal/SqlServerCSharpRuntimeAnnotationCodeGenerator.cs
+++ b/src/EFCore.SqlServer/Design/Internal/SqlServerCSharpRuntimeAnnotationCodeGenerator.cs
@@ -68,6 +68,7 @@ public class SqlServerCSharpRuntimeAnnotationCodeGenerator : RelationalCSharpRun
             annotations.Remove(SqlServerAnnotationNames.IdentityIncrement);
             annotations.Remove(SqlServerAnnotationNames.IdentitySeed);
             annotations.Remove(SqlServerAnnotationNames.Sparse);
+            annotations.Remove(SqlServerAnnotationNames.IsHidden);
 
             if (!annotations.ContainsKey(SqlServerAnnotationNames.ValueGenerationStrategy))
             {
@@ -88,6 +89,7 @@ public class SqlServerCSharpRuntimeAnnotationCodeGenerator : RelationalCSharpRun
             annotations.Remove(SqlServerAnnotationNames.Sparse);
             annotations.Remove(SqlServerAnnotationNames.TemporalIsPeriodStartColumn);
             annotations.Remove(SqlServerAnnotationNames.TemporalIsPeriodEndColumn);
+            annotations.Remove(SqlServerAnnotationNames.IsHidden);
         }
 
         base.Generate(column, parameters);
@@ -187,6 +189,8 @@ public class SqlServerCSharpRuntimeAnnotationCodeGenerator : RelationalCSharpRun
             annotations.Remove(SqlServerAnnotationNames.TemporalHistoryTableSchema);
             annotations.Remove(SqlServerAnnotationNames.TemporalPeriodEndColumnName);
             annotations.Remove(SqlServerAnnotationNames.TemporalPeriodStartColumnName);
+            annotations.Remove(SqlServerAnnotationNames.TemporalPeriodStartHidden);
+            annotations.Remove(SqlServerAnnotationNames.TemporalPeriodEndHidden);
         }
 
         base.Generate(table, parameters);

--- a/src/EFCore.SqlServer/EFCore.SqlServer.baseline.json
+++ b/src/EFCore.SqlServer/EFCore.SqlServer.baseline.json
@@ -216,6 +216,9 @@
           "Member": "virtual Microsoft.EntityFrameworkCore.Metadata.Builders.OwnedNavigationTemporalPeriodPropertyBuilder HasPrecision(int precision);"
         },
         {
+          "Member": "virtual Microsoft.EntityFrameworkCore.Metadata.Builders.OwnedNavigationTemporalPeriodPropertyBuilder IsHidden(bool hidden = true);"
+        },
+        {
           "Member": "override string? ToString();"
         }
       ]
@@ -2340,6 +2343,9 @@
           "Member": "static bool CanSetIdentityColumnSeed(this Microsoft.EntityFrameworkCore.Metadata.Builders.IConventionPropertyBuilder propertyBuilder, long? seed, in Microsoft.EntityFrameworkCore.Metadata.StoreObjectIdentifier storeObject, bool fromDataAnnotation = false);"
         },
         {
+          "Member": "static bool CanSetIsHidden(this Microsoft.EntityFrameworkCore.Metadata.Builders.IConventionPropertyBuilder propertyBuilder, bool? hidden, bool fromDataAnnotation = false);"
+        },
+        {
           "Member": "static bool CanSetIsSparse(this Microsoft.EntityFrameworkCore.Metadata.Builders.IConventionPropertyBuilder property, bool? sparse, bool fromDataAnnotation = false);"
         },
         {
@@ -2392,6 +2398,9 @@
         },
         {
           "Member": "static Microsoft.EntityFrameworkCore.Metadata.Builders.IConventionPropertyBuilder? HasValueGenerationStrategy(this Microsoft.EntityFrameworkCore.Metadata.Builders.IConventionPropertyBuilder propertyBuilder, Microsoft.EntityFrameworkCore.Metadata.SqlServerValueGenerationStrategy? valueGenerationStrategy, in Microsoft.EntityFrameworkCore.Metadata.StoreObjectIdentifier storeObject, bool fromDataAnnotation = false);"
+        },
+        {
+          "Member": "static Microsoft.EntityFrameworkCore.Metadata.Builders.IConventionPropertyBuilder? IsHidden(this Microsoft.EntityFrameworkCore.Metadata.Builders.IConventionPropertyBuilder propertyBuilder, bool? hidden, bool fromDataAnnotation = false);"
         },
         {
           "Member": "static Microsoft.EntityFrameworkCore.Metadata.Builders.PropertyBuilder IsSparse(this Microsoft.EntityFrameworkCore.Metadata.Builders.PropertyBuilder propertyBuilder, bool sparse = true);"
@@ -2516,6 +2525,9 @@
           "Member": "static Microsoft.EntityFrameworkCore.Metadata.ConfigurationSource? GetIdentitySeedConfigurationSource(this Microsoft.EntityFrameworkCore.Metadata.IConventionRelationalPropertyOverrides overrides);"
         },
         {
+          "Member": "static Microsoft.EntityFrameworkCore.Metadata.ConfigurationSource? GetIsHiddenConfigurationSource(this Microsoft.EntityFrameworkCore.Metadata.IConventionProperty property);"
+        },
+        {
           "Member": "static Microsoft.EntityFrameworkCore.Metadata.ConfigurationSource? GetIsSparseConfigurationSource(this Microsoft.EntityFrameworkCore.Metadata.IConventionProperty property);"
         },
         {
@@ -2556,6 +2568,9 @@
         },
         {
           "Member": "static bool IsCompatibleWithValueGeneration(Microsoft.EntityFrameworkCore.Metadata.IReadOnlyProperty property);"
+        },
+        {
+          "Member": "static bool IsHidden(this Microsoft.EntityFrameworkCore.Metadata.IReadOnlyProperty property);"
         },
         {
           "Member": "static bool? IsSparse(this Microsoft.EntityFrameworkCore.Metadata.IReadOnlyProperty property);"
@@ -2610,6 +2625,12 @@
         },
         {
           "Member": "static long? SetIdentitySeed(this Microsoft.EntityFrameworkCore.Metadata.IConventionRelationalPropertyOverrides overrides, long? seed, bool fromDataAnnotation = false);"
+        },
+        {
+          "Member": "static void SetIsHidden(this Microsoft.EntityFrameworkCore.Metadata.IMutableProperty property, bool? hidden);"
+        },
+        {
+          "Member": "static bool? SetIsHidden(this Microsoft.EntityFrameworkCore.Metadata.IConventionProperty property, bool? hidden, bool fromDataAnnotation = false);"
         },
         {
           "Member": "static void SetIsSparse(this Microsoft.EntityFrameworkCore.Metadata.IMutableProperty property, bool? sparse);"
@@ -3028,6 +3049,9 @@
         },
         {
           "Member": "virtual Microsoft.EntityFrameworkCore.Metadata.Builders.TemporalPeriodPropertyBuilder HasPrecision(int precision);"
+        },
+        {
+          "Member": "virtual Microsoft.EntityFrameworkCore.Metadata.Builders.TemporalPeriodPropertyBuilder IsHidden(bool hidden = true);"
         },
         {
           "Member": "override string? ToString();"

--- a/src/EFCore.SqlServer/Extensions/SqlServerPropertyBuilderExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerPropertyBuilderExtensions.cs
@@ -814,6 +814,52 @@ public static class SqlServerPropertyBuilderExtensions
         => property.CanSetAnnotation(SqlServerAnnotationNames.Sparse, sparse, fromDataAnnotation);
 
     /// <summary>
+    ///     Configures whether the property's column is defined with the SQL Server <c>HIDDEN</c> flag, which excludes the
+    ///     column from <c>SELECT *</c> results. This applies to generated columns such as temporal table period columns.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-temporal">Using SQL Server temporal tables with EF Core</see>
+    ///     for more information and examples.
+    /// </remarks>
+    /// <param name="propertyBuilder">The builder for the property being configured.</param>
+    /// <param name="hidden">A value indicating whether the property's column is hidden.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>The same builder instance if the configuration was applied, <see langword="null" /> otherwise.</returns>
+    public static IConventionPropertyBuilder? IsHidden(
+        this IConventionPropertyBuilder propertyBuilder,
+        bool? hidden,
+        bool fromDataAnnotation = false)
+    {
+        if (propertyBuilder.CanSetIsHidden(hidden, fromDataAnnotation))
+        {
+            propertyBuilder.Metadata.SetIsHidden(hidden, fromDataAnnotation);
+
+            return propertyBuilder;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    ///     Returns a value indicating whether the property's column can be configured with the SQL Server <c>HIDDEN</c> flag.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-temporal">Using SQL Server temporal tables with EF Core</see>
+    ///     for more information and examples.
+    /// </remarks>
+    /// <param name="propertyBuilder">The builder for the property being configured.</param>
+    /// <param name="hidden">A value indicating whether the property's column is hidden.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>
+    ///     <see langword="true" /> if the property's column can be configured with the <c>HIDDEN</c> flag.
+    /// </returns>
+    public static bool CanSetIsHidden(
+        this IConventionPropertyBuilder propertyBuilder,
+        bool? hidden,
+        bool fromDataAnnotation = false)
+        => propertyBuilder.CanSetAnnotation(SqlServerAnnotationNames.IsHidden, hidden, fromDataAnnotation);
+
+    /// <summary>
     ///     Configures the default value for the column that the property maps to when targeting SQL Server.
     /// </summary>
     /// <remarks>

--- a/src/EFCore.SqlServer/Extensions/SqlServerPropertyExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerPropertyExtensions.cs
@@ -1050,4 +1050,55 @@ public static class SqlServerPropertyExtensions
     /// <returns>The <see cref="ConfigurationSource" /> for whether the property's column is sparse.</returns>
     public static ConfigurationSource? GetIsSparseConfigurationSource(this IConventionProperty property)
         => property.FindAnnotation(SqlServerAnnotationNames.Sparse)?.GetConfigurationSource();
+
+    /// <summary>
+    ///     Returns a value indicating whether the property's column is defined with the SQL Server <c>HIDDEN</c> flag,
+    ///     which excludes the column from <c>SELECT *</c> results.
+    /// </summary>
+    /// <remarks>
+    ///     This applies to columns defined with <c>GENERATED ALWAYS AS</c>, including SQL Server temporal table
+    ///     period columns. The default for temporal period columns is <see langword="true" />; for other columns
+    ///     this annotation has no effect unless the column is generated.
+    /// </remarks>
+    /// <param name="property">The property.</param>
+    /// <returns>
+    ///     <see langword="true" /> if the property's column is hidden. Defaults to <see langword="true" /> when not
+    ///     explicitly configured, since temporal period columns are hidden by default.
+    /// </returns>
+    public static bool IsHidden(this IReadOnlyProperty property)
+        => (property is RuntimeProperty)
+            ? throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData)
+            : (bool?)property[SqlServerAnnotationNames.IsHidden] ?? true;
+
+    /// <summary>
+    ///     Sets a value indicating whether the property's column is defined with the SQL Server <c>HIDDEN</c> flag.
+    /// </summary>
+    /// <param name="property">The property.</param>
+    /// <param name="hidden">The value to set; <see langword="null" /> to remove the explicit configuration.</param>
+    public static void SetIsHidden(this IMutableProperty property, bool? hidden)
+        => property.SetOrRemoveAnnotation(SqlServerAnnotationNames.IsHidden, hidden);
+
+    /// <summary>
+    ///     Sets a value indicating whether the property's column is defined with the SQL Server <c>HIDDEN</c> flag.
+    /// </summary>
+    /// <param name="property">The property.</param>
+    /// <param name="hidden">The value to set; <see langword="null" /> to remove the explicit configuration.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>The configured value.</returns>
+    public static bool? SetIsHidden(
+        this IConventionProperty property,
+        bool? hidden,
+        bool fromDataAnnotation = false)
+        => (bool?)property.SetOrRemoveAnnotation(
+            SqlServerAnnotationNames.IsHidden,
+            hidden,
+            fromDataAnnotation)?.Value;
+
+    /// <summary>
+    ///     Returns the <see cref="ConfigurationSource" /> for whether the property's column is hidden.
+    /// </summary>
+    /// <param name="property">The property.</param>
+    /// <returns>The <see cref="ConfigurationSource" /> for whether the property's column is hidden.</returns>
+    public static ConfigurationSource? GetIsHiddenConfigurationSource(this IConventionProperty property)
+        => property.FindAnnotation(SqlServerAnnotationNames.IsHidden)?.GetConfigurationSource();
 }

--- a/src/EFCore.SqlServer/Metadata/Builders/OwnedNavigationTemporalPeriodPropertyBuilder.cs
+++ b/src/EFCore.SqlServer/Metadata/Builders/OwnedNavigationTemporalPeriodPropertyBuilder.cs
@@ -56,6 +56,29 @@ public class OwnedNavigationTemporalPeriodPropertyBuilder
         return this;
     }
 
+    /// <summary>
+    ///     Configures whether the period column is defined with the SQL Server <c>HIDDEN</c> flag,
+    ///     which excludes it from <c>SELECT *</c> results.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The default is <see langword="true" /> for period columns, matching the behavior of EF Core releases
+    ///         prior to this option being introduced. Set to <see langword="false" /> to make the column visible.
+    ///     </para>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-temporal">Using SQL Server temporal tables with EF Core</see>
+    ///         for more information.
+    ///     </para>
+    /// </remarks>
+    /// <param name="hidden">A value indicating whether the column should be hidden.</param>
+    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    public virtual OwnedNavigationTemporalPeriodPropertyBuilder IsHidden(bool hidden = true)
+    {
+        ((IMutableProperty)_propertyBuilder.Metadata).SetIsHidden(hidden);
+
+        return this;
+    }
+
     #region Hidden System.Object members
 
     /// <summary>

--- a/src/EFCore.SqlServer/Metadata/Builders/TemporalPeriodPropertyBuilder.cs
+++ b/src/EFCore.SqlServer/Metadata/Builders/TemporalPeriodPropertyBuilder.cs
@@ -57,6 +57,29 @@ public class TemporalPeriodPropertyBuilder : IInfrastructure<PropertyBuilder>
         return this;
     }
 
+    /// <summary>
+    ///     Configures whether the period column is defined with the SQL Server <c>HIDDEN</c> flag,
+    ///     which excludes it from <c>SELECT *</c> results.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The default is <see langword="true" /> for period columns, matching the behavior of EF Core releases
+    ///         prior to this option being introduced. Set to <see langword="false" /> to make the column visible.
+    ///     </para>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-temporal">Using SQL Server temporal tables with EF Core</see>
+    ///         for more information.
+    ///     </para>
+    /// </remarks>
+    /// <param name="hidden">A value indicating whether the column should be hidden.</param>
+    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    public virtual TemporalPeriodPropertyBuilder IsHidden(bool hidden = true)
+    {
+        ((IMutableProperty)_propertyBuilder.Metadata).SetIsHidden(hidden);
+
+        return this;
+    }
+
     PropertyBuilder IInfrastructure<PropertyBuilder>.Instance
         => _propertyBuilder;
 

--- a/src/EFCore.SqlServer/Metadata/Internal/SqlServerAnnotationNames.cs
+++ b/src/EFCore.SqlServer/Metadata/Internal/SqlServerAnnotationNames.cs
@@ -305,6 +305,30 @@ public static class SqlServerAnnotationNames
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    public const string IsHidden = Prefix + "IsHidden";
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public const string TemporalPeriodStartHidden = Prefix + "TemporalPeriodStartHidden";
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public const string TemporalPeriodEndHidden = Prefix + "TemporalPeriodEndHidden";
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     public const string VectorIndexMetric = Prefix + "VectorIndexMetric";
 
     /// <summary>

--- a/src/EFCore.SqlServer/Metadata/Internal/SqlServerAnnotationProvider.cs
+++ b/src/EFCore.SqlServer/Metadata/Internal/SqlServerAnnotationProvider.cs
@@ -120,9 +120,10 @@ public class SqlServerAnnotationProvider(RelationalAnnotationProviderDependencie
             // see #26007
             var storeObjectIdentifier = StoreObjectIdentifier.Table(table.Name, table.Schema);
             var periodStartPropertyName = entityType.GetPeriodStartPropertyName();
+            IReadOnlyProperty? periodStartProperty = null;
             if (periodStartPropertyName != null)
             {
-                var periodStartProperty = entityType.FindProperty(periodStartPropertyName);
+                periodStartProperty = entityType.FindProperty(periodStartPropertyName);
                 var periodStartColumnName = periodStartProperty != null
                     ? periodStartProperty.GetColumnName(storeObjectIdentifier)
                     : periodStartPropertyName;
@@ -131,14 +132,28 @@ public class SqlServerAnnotationProvider(RelationalAnnotationProviderDependencie
             }
 
             var periodEndPropertyName = entityType.GetPeriodEndPropertyName();
+            IReadOnlyProperty? periodEndProperty = null;
             if (periodEndPropertyName != null)
             {
-                var periodEndProperty = entityType.FindProperty(periodEndPropertyName);
+                periodEndProperty = entityType.FindProperty(periodEndPropertyName);
                 var periodEndColumnName = periodEndProperty != null
                     ? periodEndProperty.GetColumnName(storeObjectIdentifier)
                     : periodEndPropertyName;
 
                 yield return new Annotation(SqlServerAnnotationNames.TemporalPeriodEndColumnName, periodEndColumnName);
+            }
+
+            // Emit the per-period-column hidden flags on the table operation so the migrations generator
+            // can read them in BuildTemporalInformationFromMigrationOperation. Only emit when the user
+            // explicitly configured the column visible (default is HIDDEN, omitted to keep table ops clean).
+            if (periodStartProperty?.IsHidden() == false)
+            {
+                yield return new Annotation(SqlServerAnnotationNames.TemporalPeriodStartHidden, false);
+            }
+
+            if (periodEndProperty?.IsHidden() == false)
+            {
+                yield return new Annotation(SqlServerAnnotationNames.TemporalPeriodEndHidden, false);
             }
         }
     }
@@ -378,10 +393,21 @@ public class SqlServerAnnotationProvider(RelationalAnnotationProviderDependencie
             if (column.Name == periodStartColumnName)
             {
                 yield return new Annotation(SqlServerAnnotationNames.TemporalIsPeriodStartColumn, true);
+
+                // Period columns default to HIDDEN; only emit the annotation when explicitly visible.
+                if (periodStartProperty?.IsHidden() == false)
+                {
+                    yield return new Annotation(SqlServerAnnotationNames.IsHidden, false);
+                }
             }
             else if (column.Name == periodEndColumnName)
             {
                 yield return new Annotation(SqlServerAnnotationNames.TemporalIsPeriodEndColumn, true);
+
+                if (periodEndProperty?.IsHidden() == false)
+                {
+                    yield return new Annotation(SqlServerAnnotationNames.IsHidden, false);
+                }
             }
         }
     }

--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -1941,7 +1941,14 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
         {
             builder.Append(" GENERATED ALWAYS AS ROW ");
             builder.Append(isPeriodStartColumn ? "START" : "END");
-            builder.Append(" HIDDEN");
+
+            // Defaults to true to preserve backward compatibility - the period columns have always been hidden.
+            // Set to false via TemporalPeriodPropertyBuilder.IsHidden(false).
+            var hidden = operation[SqlServerAnnotationNames.IsHidden] as bool? ?? true;
+            if (hidden)
+            {
+                builder.Append(" HIDDEN");
+            }
         }
 
         builder.Append(operation.IsNullable ? " NULL" : " NOT NULL");
@@ -2947,6 +2954,19 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
                     {
                         // we create the temporal info based on the OLD table here - we want the initial state
                         var temporalTableInformation = BuildTemporalInformationFromMigrationOperation(schema, alterTableOperation.OldTable);
+
+                        // The period-column hidden flags reflect the user's intent for the NEW state of the table,
+                        // not the old state, so override them from the AlterTable operation itself when present.
+                        if (alterTableOperation[SqlServerAnnotationNames.TemporalPeriodStartHidden] is bool startHidden)
+                        {
+                            temporalTableInformation.PeriodStartHidden = startHidden;
+                        }
+
+                        if (alterTableOperation[SqlServerAnnotationNames.TemporalPeriodEndHidden] is bool endHidden)
+                        {
+                            temporalTableInformation.PeriodEndHidden = endHidden;
+                        }
+
                         temporalTableInformationMap[(tableName, rawSchema)] = temporalTableInformation;
                     }
 
@@ -3258,6 +3278,7 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
                     {
                         addColumnOperation.RemoveAnnotation(SqlServerAnnotationNames.TemporalIsPeriodStartColumn);
                         addColumnOperation.RemoveAnnotation(SqlServerAnnotationNames.TemporalIsPeriodEndColumn);
+                        addColumnOperation.RemoveAnnotation(SqlServerAnnotationNames.IsHidden);
 
                         // model differ adds default value, but for period end we need to replace it with the correct one -
                         // DateTime.MaxValue
@@ -3419,8 +3440,10 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
                     // generating ALTER COLUMN operations and could just muddy the waters
                     alterColumnOperation.RemoveAnnotation(SqlServerAnnotationNames.TemporalIsPeriodStartColumn);
                     alterColumnOperation.RemoveAnnotation(SqlServerAnnotationNames.TemporalIsPeriodEndColumn);
+                    alterColumnOperation.RemoveAnnotation(SqlServerAnnotationNames.IsHidden);
                     alterColumnOperation.OldColumn.RemoveAnnotation(SqlServerAnnotationNames.TemporalIsPeriodStartColumn);
                     alterColumnOperation.OldColumn.RemoveAnnotation(SqlServerAnnotationNames.TemporalIsPeriodEndColumn);
+                    alterColumnOperation.OldColumn.RemoveAnnotation(SqlServerAnnotationNames.IsHidden);
 
                     if (temporalInformation.IsTemporalTable)
                     {
@@ -3532,6 +3555,8 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
                 temporalInformation.Key.Schema,
                 temporalInformation.Value.PeriodStartColumnName!,
                 temporalInformation.Value.PeriodEndColumnName!,
+                temporalInformation.Value.PeriodStartHidden,
+                temporalInformation.Value.PeriodEndHidden,
                 temporalInformation.Value.SuppressTransaction);
         }
 
@@ -3557,13 +3582,19 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
             var periodStartColumnName = operation[SqlServerAnnotationNames.TemporalPeriodStartColumnName] as string;
             var periodEndColumnName = operation[SqlServerAnnotationNames.TemporalPeriodEndColumnName] as string;
 
+            // Period columns default to HIDDEN; the annotation is only present when explicitly configured visible.
+            var periodStartHidden = operation[SqlServerAnnotationNames.TemporalPeriodStartHidden] as bool? ?? true;
+            var periodEndHidden = operation[SqlServerAnnotationNames.TemporalPeriodEndHidden] as bool? ?? true;
+
             return new TemporalOperationInformation
             {
                 IsTemporalTable = isTemporalTable,
                 HistoryTableName = historyTableName,
                 HistoryTableSchema = historyTableSchema,
                 PeriodStartColumnName = periodStartColumnName,
-                PeriodEndColumnName = periodEndColumnName
+                PeriodEndColumnName = periodEndColumnName,
+                PeriodStartHidden = periodStartHidden,
+                PeriodEndHidden = periodEndHidden
             };
         }
 
@@ -3659,7 +3690,14 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
                 });
         }
 
-        void EnablePeriod(string table, string? schema, string periodStartColumnName, string periodEndColumnName, bool suppressTransaction)
+        void EnablePeriod(
+            string table,
+            string? schema,
+            string periodStartColumnName,
+            string periodEndColumnName,
+            bool periodStartHidden,
+            bool periodEndHidden,
+            bool suppressTransaction)
         {
             var addPeriodSql = new StringBuilder()
                 .Append("ALTER TABLE ")
@@ -3683,31 +3721,39 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
             operations.Add(
                 new SqlOperation { Sql = addPeriodSql, SuppressTransaction = suppressTransaction });
 
-            operations.Add(
-                new SqlOperation
-                {
-                    Sql = new StringBuilder()
-                        .Append("ALTER TABLE ")
-                        .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(table, schema))
-                        .Append(" ALTER COLUMN ")
-                        .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(periodStartColumnName))
-                        .Append(" ADD HIDDEN")
-                        .ToString(),
-                    SuppressTransaction = suppressTransaction
-                });
+            // Period columns are HIDDEN by default. Skip the `ADD HIDDEN` ALTER when the column was
+            // configured visible via TemporalPeriodPropertyBuilder.IsHidden(false).
+            if (periodStartHidden)
+            {
+                operations.Add(
+                    new SqlOperation
+                    {
+                        Sql = new StringBuilder()
+                            .Append("ALTER TABLE ")
+                            .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(table, schema))
+                            .Append(" ALTER COLUMN ")
+                            .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(periodStartColumnName))
+                            .Append(" ADD HIDDEN")
+                            .ToString(),
+                        SuppressTransaction = suppressTransaction
+                    });
+            }
 
-            operations.Add(
-                new SqlOperation
-                {
-                    Sql = new StringBuilder()
-                        .Append("ALTER TABLE ")
-                        .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(table, schema))
-                        .Append(" ALTER COLUMN ")
-                        .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(periodEndColumnName))
-                        .Append(" ADD HIDDEN")
-                        .ToString(),
-                    SuppressTransaction = suppressTransaction
-                });
+            if (periodEndHidden)
+            {
+                operations.Add(
+                    new SqlOperation
+                    {
+                        Sql = new StringBuilder()
+                            .Append("ALTER TABLE ")
+                            .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(table, schema))
+                            .Append(" ALTER COLUMN ")
+                            .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(periodEndColumnName))
+                            .Append(" ADD HIDDEN")
+                            .ToString(),
+                        SuppressTransaction = suppressTransaction
+                    });
+            }
         }
 
         void DecompressTable(string tableName, string? schema, bool suppressTransaction)
@@ -3789,5 +3835,11 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
         public bool ShouldEnableVersioning { get; set; }
         public bool ShouldEnablePeriod { get; set; }
         public bool SuppressTransaction { get; set; }
+
+        // Period columns default to HIDDEN. When converting an existing table to temporal, these flags
+        // capture the user-configured visibility from the period column annotations so EnablePeriod can
+        // conditionally emit `ALTER COLUMN ... ADD HIDDEN`.
+        public bool PeriodStartHidden { get; set; } = true;
+        public bool PeriodEndHidden { get; set; } = true;
     }
 }

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.ModelSnapshot.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.ModelSnapshot.cs
@@ -3611,6 +3611,67 @@ partial class Snapshot : ModelSnapshot
                     a => a.Name == SqlServerAnnotationNames.TemporalPeriodEndPropertyName && a.Value as string == "PeriodEnd");
             });
 
+    [Fact]
+    public virtual void Temporal_table_with_visible_period_columns_is_stored_in_snapshot()
+        => Test(
+            builder => builder.Entity<EntityWithStringProperty>().ToTable(tb => tb.IsTemporal(ttb =>
+            {
+                ttb.UseHistoryTable("HistoryTable");
+                ttb.HasPeriodStart("Start").HasColumnName("PeriodStart").IsHidden(false);
+                ttb.HasPeriodEnd("End").HasColumnName("PeriodEnd").IsHidden(false);
+            })),
+            AddBoilerPlate(
+                GetHeading()
+                + """
+        modelBuilder.Entity("Microsoft.EntityFrameworkCore.Migrations.Design.CSharpMigrationsGeneratorTest+EntityWithStringProperty", b =>
+            {
+                var id = b.Property<int>("Id")
+                    .ValueGeneratedOnAdd()
+                    .HasColumnType("int");
+
+                SqlServerPropertyBuilderExtensions.UseIdentityColumn(id);
+
+                b.Property<DateTime>("End")
+                    .ValueGeneratedOnAddOrUpdate()
+                    .HasColumnType("datetime2")
+                    .HasColumnName("PeriodEnd");
+
+                b.Property<string>("Name")
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<DateTime>("Start")
+                    .ValueGeneratedOnAddOrUpdate()
+                    .HasColumnType("datetime2")
+                    .HasColumnName("PeriodStart");
+
+                b.HasKey("Id");
+
+                b.ToTable("EntityWithStringProperty", "DefaultSchema");
+
+                b.ToTable(tb => tb.IsTemporal(ttb =>
+                        {
+                            ttb.UseHistoryTable("HistoryTable");
+                            ttb
+                                .HasPeriodStart("Start")
+                                .HasColumnName("PeriodStart")
+                                .IsHidden(false);
+                            ttb
+                                .HasPeriodEnd("End")
+                                .HasColumnName("PeriodEnd")
+                                .IsHidden(false);
+                        }));
+            });
+""", usingSystem: true),
+            o =>
+            {
+                var temporalEntity = o.FindEntityType(
+                    "Microsoft.EntityFrameworkCore.Migrations.Design.CSharpMigrationsGeneratorTest+EntityWithStringProperty");
+
+                Assert.True(temporalEntity.IsTemporal());
+                Assert.False(temporalEntity.GetProperty("Start").IsHidden());
+                Assert.False(temporalEntity.GetProperty("End").IsHidden());
+            });
+
     #endregion
 
     #region Owned types

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsSqlServerTest.TemporalTables.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsSqlServerTest.TemporalTables.cs
@@ -61,6 +61,106 @@ EXEC(N'CREATE TABLE [Customer] (
     }
 
     [Fact]
+    public virtual async Task Create_temporal_table_with_period_columns_not_hidden()
+    {
+        await Test(
+            builder => { },
+            builder => builder.Entity(
+                "Customer", e =>
+                {
+                    e.Property<int>("Id").ValueGeneratedOnAdd();
+                    e.Property<string>("Name");
+                    e.Property<DateTime>("SystemTimeStart").ValueGeneratedOnAddOrUpdate();
+                    e.Property<DateTime>("SystemTimeEnd").ValueGeneratedOnAddOrUpdate();
+                    e.HasKey("Id");
+
+                    e.ToTable(tb => tb.IsTemporal(ttb =>
+                    {
+                        ttb.HasPeriodStart("SystemTimeStart").IsHidden(false);
+                        ttb.HasPeriodEnd("SystemTimeEnd").IsHidden(false);
+                    }));
+                }),
+            model =>
+            {
+                var table = Assert.Single(model.Tables);
+                Assert.Equal("Customer", table.Name);
+                Assert.Equal(true, table[SqlServerAnnotationNames.IsTemporal]);
+                Assert.Equal("SystemTimeStart", table[SqlServerAnnotationNames.TemporalPeriodStartPropertyName]);
+                Assert.Equal("SystemTimeEnd", table[SqlServerAnnotationNames.TemporalPeriodEndPropertyName]);
+
+                Assert.Collection(
+                    table.Columns,
+                    c => Assert.Equal("Id", c.Name),
+                    c => Assert.Equal("Name", c.Name));
+            });
+
+        AssertSql(
+            """
+DECLARE @historyTableSchema nvarchar(max) = QUOTENAME(SCHEMA_NAME())
+EXEC(N'CREATE TABLE [Customer] (
+    [Id] int NOT NULL IDENTITY,
+    [Name] nvarchar(max) NULL,
+    [SystemTimeEnd] datetime2 GENERATED ALWAYS AS ROW END NOT NULL,
+    [SystemTimeStart] datetime2 GENERATED ALWAYS AS ROW START NOT NULL,
+    CONSTRAINT [PK_Customer] PRIMARY KEY ([Id]),
+    PERIOD FOR SYSTEM_TIME([SystemTimeStart], [SystemTimeEnd])
+) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = ' + @historyTableSchema + N'.[CustomerHistory]))');
+""");
+    }
+
+    [Fact]
+    public virtual async Task Convert_normal_table_to_temporal_with_visible_period_columns()
+    {
+        await Test(
+            builder => builder.Entity(
+                "Customer", e =>
+                {
+                    e.Property<int>("Id").ValueGeneratedOnAdd();
+                    e.Property<string>("Name");
+                    e.HasKey("Id");
+                }),
+            builder => builder.Entity(
+                "Customer", e =>
+                {
+                    e.Property<int>("Id").ValueGeneratedOnAdd();
+                    e.Property<string>("Name");
+                    e.Property<DateTime>("PeriodStart").ValueGeneratedOnAddOrUpdate();
+                    e.Property<DateTime>("PeriodEnd").ValueGeneratedOnAddOrUpdate();
+                    e.HasKey("Id");
+                    e.ToTable(tb => tb.IsTemporal(ttb =>
+                    {
+                        ttb.HasPeriodStart("PeriodStart").IsHidden(false);
+                        ttb.HasPeriodEnd("PeriodEnd").IsHidden(false);
+                    }));
+                }),
+            model =>
+            {
+                var table = Assert.Single(model.Tables);
+                Assert.Equal(true, table[SqlServerAnnotationNames.IsTemporal]);
+            });
+
+        // The convert-to-temporal path should NOT emit `ALTER COLUMN ... ADD HIDDEN` operations
+        // when the user has configured the period columns visible.
+        AssertSql(
+            """
+ALTER TABLE [Customer] ADD [PeriodEnd] datetime2 NOT NULL DEFAULT '9999-12-31T23:59:59.9999999';
+""",
+            //
+            """
+ALTER TABLE [Customer] ADD [PeriodStart] datetime2 NOT NULL DEFAULT '0001-01-01T00:00:00.0000000';
+""",
+            //
+            """
+ALTER TABLE [Customer] ADD PERIOD FOR SYSTEM_TIME ([PeriodStart], [PeriodEnd])
+""",
+            //
+            """
+DECLARE @historyTableSchema nvarchar(max) = QUOTENAME(SCHEMA_NAME())
+EXEC(N'ALTER TABLE [Customer] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = ' + @historyTableSchema + '.[CustomerHistory]))')
+""");
+    }
+
+    [Fact]
     public virtual async Task Create_temporal_table_custom_column_mappings_and_default_history_table()
     {
         await Test(

--- a/test/EFCore.SqlServer.FunctionalTests/ModelBuilding/SqlServerModelBuilderTestBase.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ModelBuilding/SqlServerModelBuilderTestBase.cs
@@ -1368,6 +1368,58 @@ public class SqlServerModelBuilderTestBase : RelationalModelBuilderTest
         }
 
         [Fact]
+        public virtual void Temporal_table_period_columns_hidden_by_default()
+        {
+            var modelBuilder = CreateModelBuilder();
+            var model = modelBuilder.Model;
+
+            modelBuilder.Entity<Customer>().ToTable(tb => tb.IsTemporal());
+            modelBuilder.FinalizeModel();
+
+            var entity = model.FindEntityType(typeof(Customer))!;
+            Assert.True(entity.IsTemporal());
+            Assert.True(entity.GetProperty(entity.GetPeriodStartPropertyName()!).IsHidden());
+            Assert.True(entity.GetProperty(entity.GetPeriodEndPropertyName()!).IsHidden());
+        }
+
+        [Fact]
+        public virtual void Temporal_table_period_columns_can_be_made_visible_per_column()
+        {
+            var modelBuilder = CreateModelBuilder();
+            var model = modelBuilder.Model;
+
+            modelBuilder.Entity<Customer>().ToTable(tb => tb.IsTemporal(ttb =>
+            {
+                ttb.HasPeriodStart("PeriodStart").IsHidden(false);
+                ttb.HasPeriodEnd("PeriodEnd").IsHidden(false);
+            }));
+            modelBuilder.FinalizeModel();
+
+            var entity = model.FindEntityType(typeof(Customer))!;
+            Assert.True(entity.IsTemporal());
+            Assert.False(entity.GetProperty("PeriodStart").IsHidden());
+            Assert.False(entity.GetProperty("PeriodEnd").IsHidden());
+        }
+
+        [Fact]
+        public virtual void Temporal_table_period_column_can_be_made_visible_per_column()
+        {
+            var modelBuilder = CreateModelBuilder();
+            var model = modelBuilder.Model;
+
+            modelBuilder.Entity<Customer>().ToTable(tb => tb.IsTemporal(ttb =>
+            {
+                ttb.HasPeriodStart("PeriodStart").IsHidden(false);
+                ttb.HasPeriodEnd("PeriodEnd");
+            }));
+            modelBuilder.FinalizeModel();
+
+            var entity = model.FindEntityType(typeof(Customer))!;
+            Assert.False(entity.GetProperty("PeriodStart").IsHidden());
+            Assert.True(entity.GetProperty("PeriodEnd").IsHidden());
+        }
+
+        [Fact]
         public virtual void Temporal_table_default_settings()
         {
             var modelBuilder = CreateModelBuilder();
@@ -2424,6 +2476,9 @@ public class SqlServerModelBuilderTestBase : RelationalModelBuilderTest
 
         public TestTemporalPeriodPropertyBuilder HasColumnName(string name)
             => new(TemporalPeriodPropertyBuilder.HasColumnName(name));
+
+        public TestTemporalPeriodPropertyBuilder IsHidden(bool hidden = true)
+            => new(TemporalPeriodPropertyBuilder.IsHidden(hidden));
     }
 
     public class TestOwnedNavigationTemporalPeriodPropertyBuilder(
@@ -2433,6 +2488,9 @@ public class SqlServerModelBuilderTestBase : RelationalModelBuilderTest
 
         public TestOwnedNavigationTemporalPeriodPropertyBuilder HasColumnName(string name)
             => new(TemporalPeriodPropertyBuilder.HasColumnName(name));
+
+        public TestOwnedNavigationTemporalPeriodPropertyBuilder IsHidden(bool hidden = true)
+            => new(TemporalPeriodPropertyBuilder.IsHidden(hidden));
     }
 
 #pragma warning disable EF9105 // Vector indexes are experimental


### PR DESCRIPTION
Adds `TemporalPeriodPropertyBuilder.IsHidden(bool hidden = true)` to opt individual SQL Server temporal table period columns out of the `HIDDEN` flag. Default remains `HIDDEN` to preserve backward compatibility. Each period column is independently configurable.

Per @roji's review feedback, `IsHidden` is exposed as a **general SQL Server property facet** (mirroring `IsSparse`), not a temporal-specific flag — forward-compatible with future non-temporal `HIDDEN` scenarios.

- New annotation `SqlServerAnnotationNames.IsHidden` (property + column level)
- New annotations `SqlServerAnnotationNames.TemporalPeriodStartHidden` / `TemporalPeriodEndHidden` (table level, lifted by `SqlServerAnnotationProvider` for the migrations differ)
- Property extensions `IsHidden` / `SetIsHidden` (mutable + convention) / `GetIsHiddenConfigurationSource` on `SqlServerPropertyExtensions` (mirrors `IsSparse` pattern)
- `IsHidden(bool hidden = true)` method added to `TemporalPeriodPropertyBuilder` and `OwnedNavigationTemporalPeriodPropertyBuilder`
- Annotation propagated through `SqlServerAnnotationProvider` (per-period-column) and `SqlServerMigrationsSqlGenerator` — conditional `HIDDEN` SQL emit in both `ColumnDefinition` (CREATE TABLE path) and `EnablePeriod` (ALTER TABLE convert-to-temporal path)
- Snapshot fluent-API generation chains `.IsHidden(false)` per period property; runtime annotation strip in `SqlServerCSharpRuntimeAnnotationCodeGenerator`
- 2 migrations functional tests in `MigrationsSqlServerTest.TemporalTables` (`Create_temporal_table_with_period_columns_not_hidden`, `Convert_normal_table_to_temporal_with_visible_period_columns`) verified against real SQL Server in CI matrix (2019/2022/2025); 3 model-builder tests in `SqlServerModelBuilderTestBase`; baseline.json entries updated for new public surface

Fixes #36608