### PR TITLE
Translate List<T>.Exists to Queryable.Any

### DIFF
--- a/src/EFCore/Query/Internal/QueryableMethodNormalizingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/QueryableMethodNormalizingExpressionVisitor.cs
@@ -178,6 +178,13 @@ public class QueryableMethodNormalizingExpressionVisitor : ExpressionVisitor
             visitedExpression = TryConvertCollectionContainsToQueryableContains(methodCallExpression);
         }
 
+        if (method.Name == nameof(List<>.Exists)
+            && method.DeclaringType is { IsGenericType: true } existsDeclaringType
+            && existsDeclaringType.GetGenericTypeDefinition() == typeof(List<>))
+        {
+            visitedExpression = TryConvertListExistsToQueryableAny(methodCallExpression);
+        }
+
         if (method.DeclaringType == typeof(EntityFrameworkQueryableExtensions)
             && method.Name is nameof(EntityFrameworkQueryableExtensions.Include)
                 or nameof(EntityFrameworkQueryableExtensions.ThenInclude)
@@ -504,6 +511,35 @@ public class QueryableMethodNormalizingExpressionVisitor : ExpressionVisitor
         }
 
         return methodCallExpression.Update(Visit(methodCallExpression.Object), arguments);
+    }
+
+    private Expression TryConvertListExistsToQueryableAny(MethodCallExpression methodCallExpression)
+    {
+        if (methodCallExpression.Object is MemberInitExpression or NewExpression)
+        {
+            return base.VisitMethodCall(methodCallExpression);
+        }
+
+        // List<T>.Exists takes a Predicate<T>; rewrite the lambda to Func<T, bool> so it matches
+        // Queryable.Any's Expression<Func<T, bool>> parameter.
+        if (methodCallExpression.Arguments[0] is not LambdaExpression predicateLambda)
+        {
+            return base.VisitMethodCall(methodCallExpression);
+        }
+
+        var sourceType = methodCallExpression.Method.DeclaringType!.GetGenericArguments()[0];
+        var rewrittenPredicate = Expression.Lambda(
+            typeof(Func<,>).MakeGenericType(sourceType, typeof(bool)),
+            predicateLambda.Body,
+            predicateLambda.Parameters);
+
+        return VisitMethodCall(
+            Expression.Call(
+                QueryableMethods.AnyWithPredicate.MakeGenericMethod(sourceType),
+                Expression.Call(
+                    QueryableMethods.AsQueryable.MakeGenericMethod(sourceType),
+                    methodCallExpression.Object!),
+                Expression.Quote(rewrittenPredicate)));
     }
 
     private Expression TryConvertCollectionContainsToQueryableContains(MethodCallExpression methodCallExpression)

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
@@ -1103,28 +1103,32 @@ SELECT VALUE EXISTS (
 
     public override async Task Where_Join_Exists(bool async)
     {
-        await base.Where_Join_Exists(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_Join_Exists(async));
 
         AssertSql();
     }
 
     public override async Task Where_Join_Exists_Inequality(bool async)
     {
-        await base.Where_Join_Exists_Inequality(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_Join_Exists_Inequality(async));
 
         AssertSql();
     }
 
     public override async Task Where_Join_Exists_Constant(bool async)
     {
-        await base.Where_Join_Exists_Constant(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_Join_Exists_Constant(async));
 
         AssertSql();
     }
 
     public override async Task Where_Join_Not_Exists(bool async)
     {
-        await base.Where_Join_Not_Exists(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_Join_Not_Exists(async));
 
         AssertSql();
     }

--- a/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
@@ -1942,33 +1942,31 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
 
     [ConditionalTheory, MemberData(nameof(IsAsyncData))]
     public virtual Task Where_Join_Exists(bool async)
-        // Translate List.Exists. Issue #17762.
-        => AssertTranslationFailed(() => AssertQuery(
+        => AssertQuery(
             async,
             ss => ss.Set<Customer>()
-                .Where(c => c.CustomerID == "ALFKI" && c.Orders.Exists(o => o.OrderDate == new DateTime(2008, 10, 24)))));
+                .Where(c => c.CustomerID == "ALFKI" && c.Orders.Exists(o => o.OrderDate == new DateTime(2008, 10, 24))),
+            assertEmpty: true);
 
     [ConditionalTheory, MemberData(nameof(IsAsyncData))]
     public virtual Task Where_Join_Exists_Inequality(bool async)
-        // Translate List.Exists. Issue #17762.
-        => AssertTranslationFailed(() => AssertQuery(
+        => AssertQuery(
             async,
             ss => ss.Set<Customer>()
-                .Where(c => c.CustomerID == "ALFKI" && c.Orders.Exists(o => o.OrderDate != new DateTime(2008, 10, 24)))));
+                .Where(c => c.CustomerID == "ALFKI" && c.Orders.Exists(o => o.OrderDate != new DateTime(2008, 10, 24))));
 
     [ConditionalTheory, MemberData(nameof(IsAsyncData))]
     public virtual Task Where_Join_Exists_Constant(bool async)
-        // Translate List.Exists. Issue #17762.
-        => AssertTranslationFailed(() => AssertQuery(
+        => AssertQuery(
             async,
-            ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI" && c.Orders.Exists(o => false))));
+            ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI" && c.Orders.Exists(o => false)),
+            assertEmpty: true);
 
     [ConditionalTheory, MemberData(nameof(IsAsyncData))]
     public virtual Task Where_Join_Not_Exists(bool async)
-        // Translate List.Exists. Issue #17762.
-        => AssertTranslationFailed(() => AssertQuery(
+        => AssertQuery(
             async,
-            ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI" && !c.Orders.Exists(o => false))));
+            ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI" && !c.Orders.Exists(o => false)));
 
     [ConditionalTheory, MemberData(nameof(IsAsyncData))]
     public virtual Task Multiple_joins_Where_Order_Any(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -1998,7 +1998,7 @@ WHERE [c].[CustomerID] = N'ALFKI' AND EXISTS (
             """
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = N'ALFKI' AND 0 = 1
+WHERE 0 = 1
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -1998,10 +1998,7 @@ WHERE [c].[CustomerID] = N'ALFKI' AND EXISTS (
             """
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = N'ALFKI' AND EXISTS (
-    SELECT 1
-    FROM [Orders] AS [o]
-    WHERE [c].[CustomerID] = [o].[CustomerID] AND 0 = 1)
+WHERE [c].[CustomerID] = N'ALFKI' AND 0 = 1
 """);
     }
 
@@ -2013,10 +2010,7 @@ WHERE [c].[CustomerID] = N'ALFKI' AND EXISTS (
             """
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = N'ALFKI' AND NOT EXISTS (
-    SELECT 1
-    FROM [Orders] AS [o]
-    WHERE [c].[CustomerID] = [o].[CustomerID] AND 0 = 1)
+WHERE [c].[CustomerID] = N'ALFKI'
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -1964,28 +1964,60 @@ WHERE [c].[CustomerID] LIKE N'A%' AND EXISTS (
     {
         await base.Where_Join_Exists(async);
 
-        AssertSql();
+        AssertSql(
+            """
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = N'ALFKI' AND EXISTS (
+    SELECT 1
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID] AND [o].[OrderDate] = '2008-10-24T00:00:00.000')
+""");
     }
 
     public override async Task Where_Join_Exists_Inequality(bool async)
     {
         await base.Where_Join_Exists_Inequality(async);
 
-        AssertSql();
+        AssertSql(
+            """
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = N'ALFKI' AND EXISTS (
+    SELECT 1
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID] AND ([o].[OrderDate] <> '2008-10-24T00:00:00.000' OR [o].[OrderDate] IS NULL))
+""");
     }
 
     public override async Task Where_Join_Exists_Constant(bool async)
     {
         await base.Where_Join_Exists_Constant(async);
 
-        AssertSql();
+        AssertSql(
+            """
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = N'ALFKI' AND EXISTS (
+    SELECT 1
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID] AND 0 = 1)
+""");
     }
 
     public override async Task Where_Join_Not_Exists(bool async)
     {
         await base.Where_Join_Not_Exists(async);
 
-        AssertSql();
+        AssertSql(
+            """
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = N'ALFKI' AND NOT EXISTS (
+    SELECT 1
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID] AND 0 = 1)
+""");
     }
 
     public override async Task Join_OrderBy_Count(bool async)


### PR DESCRIPTION
Rewrites `List<T>.Exists(predicate)` to `AsQueryable().Any(predicate)` in `QueryableMethodNormalizingExpressionVisitor`, mirroring the existing `ICollection<T>.Contains` conversion. The `Predicate<T>` lambda is rebuilt as `Func<T, bool>` so the resulting `Queryable.Any` call type-checks.

- New `TryConvertListExistsToQueryableAny` helper alongside `TryConvertCollectionContainsToQueryableContains`
- Detection branch gated to `List<T>` (other types like `Array.Exists` are out of scope)
- Bails out when the receiver is a literal (`new List<T>` / `new {...}`) or the predicate is a non-lambda delegate
- Flips four placeholder tests (`Where_Join_Exists`, `_Inequality`, `_Constant`, `Where_Join_Not_Exists`) tagged with `// Issue #17762` from `AssertTranslationFailed` to `AssertQuery`
- Populates SqlServer SQL baselines (EXISTS subquery + optimizer-simplified forms for constant-`false` predicates)
- Cosmos overrides wrapped in `AssertTranslationFailed` per Cosmos's existing `Issue #17246` pattern for navigation-collection `Any` translations

Fixes #17762