### PR TITLE
[Test] Simplify SQL Server feature checks to use only compatibility level

### DIFF
--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestEnvironment.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestEnvironment.cs
@@ -139,7 +139,7 @@ public static class TestEnvironment
 
             try
             {
-                _supportsHiddenColumns = ((GetProductMajorVersion() >= 13 && GetEngineEdition() != 6) || IsAzureSql) && GetCompatibilityLevel() >= 130;
+                _supportsHiddenColumns = GetEngineEdition() != 6 && GetCompatibilityLevel() >= 130;
             }
             catch (PlatformNotSupportedException)
             {
@@ -448,8 +448,7 @@ public static class TestEnvironment
 
             try
             {
-                _isVectorTypeSupported = ((!IsLocalDb && GetProductMajorVersion() >= 17) || IsAzureSql)
-                    && GetCompatibilityLevel() >= 170;
+                _isVectorTypeSupported = !IsLocalDb && GetCompatibilityLevel() >= 170;
             }
             catch (PlatformNotSupportedException)
             {
@@ -523,7 +522,7 @@ public static class TestEnvironment
         sqlConnection.Open();
 
         using var command = new SqlCommand(
-            "SELECT compatibility_level FROM sys.databases WHERE [name] = 'master';", sqlConnection);
+            "SELECT compatibility_level FROM sys.databases WHERE [name] = 'model';", sqlConnection);
         _compatibilityLevel = (byte)command.ExecuteScalar();
 
         return _compatibilityLevel.Value;

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestEnvironment.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestEnvironment.cs
@@ -259,7 +259,7 @@ public static class TestEnvironment
 
             try
             {
-                _supportsTemporalTablesCascadeDelete = (GetProductMajorVersion() >= 14 || IsAzureSql) && GetCompatibilityLevel() >= 140;
+                _supportsTemporalTablesCascadeDelete = GetCompatibilityLevel() >= 140;
             }
             catch (PlatformNotSupportedException)
             {
@@ -286,7 +286,7 @@ public static class TestEnvironment
 
             try
             {
-                _supportsUtf8 = (GetProductMajorVersion() >= 15 || IsAzureSql) && GetCompatibilityLevel() >= 150;
+                _supportsUtf8 = GetCompatibilityLevel() >= 150;
             }
             catch (PlatformNotSupportedException)
             {
@@ -313,7 +313,7 @@ public static class TestEnvironment
 
             try
             {
-                _supportsJsonPathExpressions = (GetProductMajorVersion() >= 14 || IsAzureSql) && GetCompatibilityLevel() >= 140;
+                _supportsJsonPathExpressions = GetCompatibilityLevel() >= 140;
             }
             catch (PlatformNotSupportedException)
             {
@@ -340,7 +340,7 @@ public static class TestEnvironment
 
             try
             {
-                _supportsFunctions2017 = (GetProductMajorVersion() >= 14 || IsAzureSql) && GetCompatibilityLevel() >= 140;
+                _supportsFunctions2017 = GetCompatibilityLevel() >= 140;
             }
             catch (PlatformNotSupportedException)
             {
@@ -367,7 +367,7 @@ public static class TestEnvironment
 
             try
             {
-                _supportsFunctions2019 = (GetProductMajorVersion() >= 15 || IsAzureSql) && GetCompatibilityLevel() >= 150;
+                _supportsFunctions2019 = GetCompatibilityLevel() >= 150;
             }
             catch (PlatformNotSupportedException)
             {
@@ -394,7 +394,7 @@ public static class TestEnvironment
 
             try
             {
-                _supportsFunctions2022 = (GetProductMajorVersion() >= 16 || IsAzureSql) && GetCompatibilityLevel() >= 160;
+                _supportsFunctions2022 = GetCompatibilityLevel() >= 160;
             }
             catch (PlatformNotSupportedException)
             {
@@ -421,7 +421,7 @@ public static class TestEnvironment
 
             try
             {
-                _isJsonTypeSupported = (GetProductMajorVersion() >= 17 || IsAzureSql) && GetCompatibilityLevel() >= 170;
+                _isJsonTypeSupported = GetCompatibilityLevel() >= 170;
             }
             catch (PlatformNotSupportedException)
             {
@@ -464,7 +464,11 @@ public static class TestEnvironment
         => GetProductMajorVersion();
 
     public static DbContextOptionsBuilder SetCompatibilityLevelFromEnvironment(DbContextOptionsBuilder builder)
-        => builder.UseSqlServerCompatibilityLevel(SqlServerMajorVersion * 10);
+    {
+        builder.UseSqlServerCompatibilityLevel(GetCompatibilityLevel());
+
+        return builder;
+    }
 
     public static string? ElasticPoolName { get; } = Config["ElasticPoolName"];
 


### PR DESCRIPTION
Remove SQL Server version and Azure checks from feature detection in TestEnvironment. Feature support is now determined solely by compatibility level, streamlining logic and reducing complexity. Update SetCompatibilityLevelFromEnvironment to use GetCompatibilityLevel() directly.

Also, FYI: Vector is supported on LocalDB provided the latest CU is installed: see https://erikej.github.io/sqlserver/localdb/2026/03/13/localdb-sqlserver-2025.html

Notice that the compatibility level is read from the master database, and tests usually run against a user database.

<!--
Please check whether the PR fulfills these requirements
-->

- [x] I've read the guidelines for [contributing](https://github.com/dotnet/efcore/blob/main/.github/CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [ ] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [ ] The code builds and tests pass locally (also verified by our automated build checks)
- [ ] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

