### PR TITLE
Render TVP type name correctly in ToQueryString for SQL Server

### DIFF
--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQueryStringFactory.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQueryStringFactory.cs
@@ -51,8 +51,18 @@ public class SqlServerQueryStringFactory : IRelationalQueryStringFactory
                 .Append("DECLARE ")
                 .Append(parameter.ParameterName)
                 .Append(' ')
-                .Append(typeName)
-                .Append(" = ");
+                .Append(typeName);
+
+            // Table-valued parameters (TVPs) cannot be initialized inline in SQL, and rendering their rows
+            // would be expensive — and counter-productive for IEnumerable<SqlDataRecord> values. Emit only
+            // the DECLARE so the result remains pasteable into SSMS for plan analysis. See #33849.
+            if (parameter is SqlParameter { SqlDbType: SqlDbType.Structured })
+            {
+                builder.AppendLine(";");
+                continue;
+            }
+
+            builder.Append(" = ");
 
             if (parameter.Value == DBNull.Value || parameter.Value is null)
             {
@@ -177,7 +187,7 @@ internal static class TypeNameBuilder
                 SqlDbType.SmallDateTime => builder.Append("smalldatetime"),
                 SqlDbType.SmallInt => builder.Append("smallint"),
                 SqlDbType.SmallMoney => builder.Append("smallmoney"),
-                SqlDbType.Structured => builder.Append("structured"),
+                SqlDbType.Structured => builder.Append(sqlParameter.TypeName),
                 SqlDbType.Text => builder.Append("text"),
                 SqlDbType.Time => builder.Append("time").AppendScale(parameter),
                 SqlDbType.Timestamp => builder.Append("rowversion"),

--- a/test/EFCore.SqlServer.Tests/Query/SqlServerQueryStringFactoryTest.cs
+++ b/test/EFCore.SqlServer.Tests/Query/SqlServerQueryStringFactoryTest.cs
@@ -1,0 +1,83 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Data;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore.SqlServer.Infrastructure.Internal;
+using Microsoft.EntityFrameworkCore.SqlServer.Query.Internal;
+using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public class SqlServerQueryStringFactoryTest
+{
+    [ConditionalFact]
+    public void Returns_command_text_unchanged_when_no_parameters()
+    {
+        var factory = CreateFactory();
+        using var command = new SqlCommand("SELECT 1");
+
+        Assert.Equal("SELECT 1", factory.Create(command));
+    }
+
+    [ConditionalFact]
+    public void Renders_DECLARE_with_value_for_simple_int_parameter()
+    {
+        var factory = CreateFactory();
+        using var command = new SqlCommand("SELECT @p0");
+        command.Parameters.Add(new SqlParameter("@p0", SqlDbType.Int) { Value = 42 });
+
+        var result = factory.Create(command);
+
+        Assert.Contains("DECLARE @p0 int = 42;", result);
+        Assert.EndsWith("SELECT @p0", result);
+    }
+
+    [ConditionalFact]
+    public void Renders_DECLARE_with_TypeName_and_no_value_for_structured_parameter()
+    {
+        var factory = CreateFactory();
+        using var command = new SqlCommand("SELECT * FROM @data");
+        command.Parameters.Add(
+            new SqlParameter("@data", SqlDbType.Structured) { TypeName = "dbo.IntList", Value = new DataTable() });
+
+        var result = factory.Create(command);
+
+        // The DECLARE must use the actual TVP type name, not the literal "structured", and must NOT
+        // attempt to assign a value since TVPs cannot be initialized inline in T-SQL. See #33849.
+        Assert.Contains("DECLARE @data dbo.IntList;", result);
+        Assert.DoesNotContain("structured", result);
+        Assert.DoesNotContain("DECLARE @data dbo.IntList = ", result);
+        Assert.EndsWith("SELECT * FROM @data", result);
+    }
+
+    [ConditionalFact]
+    public void Renders_structured_parameter_alongside_other_parameters()
+    {
+        var factory = CreateFactory();
+        using var command = new SqlCommand("SELECT * FROM @data WHERE [Region] = @region");
+        command.Parameters.Add(
+            new SqlParameter("@data", SqlDbType.Structured) { TypeName = "dbo.IntList", Value = new DataTable() });
+        command.Parameters.Add(new SqlParameter("@region", SqlDbType.NVarChar, 32) { Value = "EMEA" });
+
+        var result = factory.Create(command);
+
+        Assert.Contains("DECLARE @data dbo.IntList;", result);
+        Assert.Contains("DECLARE @region nvarchar(32) = N'EMEA';", result);
+        Assert.EndsWith("SELECT * FROM @data WHERE [Region] = @region", result);
+    }
+
+    private static SqlServerQueryStringFactory CreateFactory()
+    {
+        var optionsBuilder = new DbContextOptionsBuilder();
+        optionsBuilder.UseSqlServer();
+        var singletonOptions = new SqlServerSingletonOptions();
+        singletonOptions.Initialize(optionsBuilder.Options);
+
+        return new SqlServerQueryStringFactory(
+            new SqlServerTypeMappingSource(
+                TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
+                TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>(),
+                singletonOptions));
+    }
+}

--- a/test/EFCore.SqlServer.Tests/Query/SqlServerQueryStringFactoryTest.cs
+++ b/test/EFCore.SqlServer.Tests/Query/SqlServerQueryStringFactoryTest.cs
@@ -11,7 +11,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 public class SqlServerQueryStringFactoryTest
 {
-    [ConditionalFact]
+    [Fact]
     public void Returns_command_text_unchanged_when_no_parameters()
     {
         var factory = CreateFactory();
@@ -20,7 +20,7 @@ public class SqlServerQueryStringFactoryTest
         Assert.Equal("SELECT 1", factory.Create(command));
     }
 
-    [ConditionalFact]
+    [Fact]
     public void Renders_DECLARE_with_value_for_simple_int_parameter()
     {
         var factory = CreateFactory();
@@ -33,7 +33,7 @@ public class SqlServerQueryStringFactoryTest
         Assert.EndsWith("SELECT @p0", result);
     }
 
-    [ConditionalFact]
+    [Fact]
     public void Renders_DECLARE_with_TypeName_and_no_value_for_structured_parameter()
     {
         var factory = CreateFactory();
@@ -46,12 +46,12 @@ public class SqlServerQueryStringFactoryTest
         // The DECLARE must use the actual TVP type name, not the literal "structured", and must NOT
         // attempt to assign a value since TVPs cannot be initialized inline in T-SQL. See #33849.
         Assert.Contains("DECLARE @data dbo.IntList;", result);
-        Assert.DoesNotContain("structured", result);
+        Assert.DoesNotContain("DECLARE @data structured", result);
         Assert.DoesNotContain("DECLARE @data dbo.IntList = ", result);
         Assert.EndsWith("SELECT * FROM @data", result);
     }
 
-    [ConditionalFact]
+    [Fact]
     public void Renders_structured_parameter_alongside_other_parameters()
     {
         var factory = CreateFactory();


### PR DESCRIPTION
When a `SqlParameter` has `SqlDbType.Structured` (table-valued parameter), `SqlServerQueryStringFactory` previously emitted invalid T-SQL of the form:

```sql
DECLARE @data structured = ;
```

— both the literal `"structured"` instead of the actual TVP type name, and a trailing `= ;` that cannot be valid since TVPs cannot be initialized inline in T-SQL.

This change:

- Uses `sqlParameter.TypeName` for structured parameters so the actual TVP type appears in the `DECLARE`
- Skips the `= <value>` segment for TVPs since they cannot be initialized inline; the `DECLARE` alone keeps `ToQueryString()` output pasteable into SSMS for plan analysis

Other parameter rendering is unchanged.

**Before:**
```sql
DECLARE @data structured = ;

SELECT * FROM @data WHERE [Region] = @region
```

**After:**
```sql
DECLARE @data dbo.IntList;
DECLARE @region nvarchar(32) = N'EMEA';

SELECT * FROM @data WHERE [Region] = @region
```

Tests added in `SqlServerQueryStringFactoryTest`:
- `Returns_command_text_unchanged_when_no_parameters`
- `Renders_DECLARE_with_value_for_simple_int_parameter` (regression guard)
- `Renders_DECLARE_with_TypeName_and_no_value_for_structured_parameter`
- `Renders_structured_parameter_alongside_other_parameters`

The fix shape was suggested by the issue reporter and the direction was confirmed by @roji in the issue thread.

Fixes #33849