### PR TITLE
Skip ALTER COLUMN for computed columns when only CLR type changes

### DIFF
--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -294,7 +294,14 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
 
         var narrowed = false;
         var oldColumnSupported = IsOldColumnSupported(model);
-        if (oldColumnSupported)
+
+        // SQL Server can't ALTER COLUMN on a computed column when the expression is unchanged; see #33425.
+        var computedColumnIsNoOp = operation.ComputedColumnSql != null
+            && operation.OldColumn.ComputedColumnSql != null
+            && operation.ComputedColumnSql == operation.OldColumn.ComputedColumnSql
+            && operation.IsStored == operation.OldColumn.IsStored;
+
+        if (oldColumnSupported && !computedColumnIsNoOp)
         {
             if (IsIdentity(operation) != IsIdentity(operation.OldColumn))
             {
@@ -356,6 +363,11 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
             || operation.IsNullable != operation.OldColumn.IsNullable
             || operation.Collation != operation.OldColumn.Collation
             || HasDifferences(newAnnotations, oldAnnotations);
+
+        if (computedColumnIsNoOp)
+        {
+            alterStatementNeeded = false;
+        }
 
         var (oldDefaultValue, oldDefaultValueSql) = (operation.OldColumn.DefaultValue, operation.OldColumn.DefaultValueSql);
 

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsSqlServerTest.cs
@@ -829,6 +829,71 @@ EXEC(N'ALTER TABLE [People] ADD [IdPlusOne] AS [Id] + 1');
 """);
     }
 
+    [Fact]
+    public virtual async Task Alter_computed_column_clr_type_only_change_is_noop()
+    {
+        // Regression test for #33425: when only the CLR type of a property mapped to a computed
+        // column changes (the expression and IsStored are unchanged), SQL Server has nothing to
+        // alter — the column's type is derived from the expression. The migration must complete
+        // without emitting `ALTER TABLE ... ALTER COLUMN`, which would fail with
+        // "Cannot alter column ... because it is 'COMPUTED'".
+        await Test(
+            builder => builder.Entity(
+                "People", x =>
+                {
+                    x.Property<int>("Id");
+                    x.Property<int>("Calc").HasComputedColumnSql("[Id] * 2");
+                }),
+            builder => builder.Entity(
+                "People", x =>
+                {
+                    x.Property<int>("Id");
+                    x.Property<long>("Calc").HasComputedColumnSql("[Id] * 2");
+                }),
+            model =>
+            {
+                var table = Assert.Single(model.Tables);
+                var column = Assert.Single(table.Columns, c => c.Name == "Calc");
+                Assert.Equal("([Id]*(2))", column.ComputedColumnSql);
+            });
+
+        AssertSql();
+    }
+
+    [Fact]
+    public virtual async Task Alter_computed_column_clr_type_only_change_does_not_rebuild_indexes()
+    {
+        // Regression guard for #33425 / Copilot review: a CLR-type-only change on a computed
+        // column must be a TRUE no-op. The "narrowed" code path can otherwise treat the type
+        // change as a column-narrowing and drop+recreate every index on the column, even though
+        // no ALTER COLUMN is emitted. That's needlessly expensive on large tables. Verify no
+        // DROP/CREATE INDEX SQL appears.
+        await Test(
+            builder => builder.Entity(
+                "People", x =>
+                {
+                    x.Property<int>("Id");
+                    x.Property<int>("Calc").HasComputedColumnSql("[Id] * 2");
+                    x.HasIndex("Calc");
+                }),
+            builder => builder.Entity(
+                "People", x =>
+                {
+                    x.Property<int>("Id");
+                    x.Property<long>("Calc").HasComputedColumnSql("[Id] * 2");
+                    x.HasIndex("Calc");
+                }),
+            model =>
+            {
+                var table = Assert.Single(model.Tables);
+                var column = Assert.Single(table.Columns, c => c.Name == "Calc");
+                Assert.Equal("([Id]*(2))", column.ComputedColumnSql);
+                Assert.Single(table.Indexes);
+            });
+
+        AssertSql();
+    }
+
     public override async Task Add_column_with_required()
     {
         await base.Add_column_with_required();

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/SqlServerMigrationsSqlGeneratorTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/SqlServerMigrationsSqlGeneratorTest.cs
@@ -327,6 +327,73 @@ ALTER TABLE [People] ADD FOREIGN KEY ([SpouseId]) REFERENCES [People];
     }
 
     [Fact]
+    public virtual void AlterColumnOperation_computed_column_with_only_clr_type_change_is_noop()
+    {
+        // Regression test for #33425: when the CLR type of a property mapped to a computed column
+        // changes (e.g. int → long for a column with .HasComputedColumnSql("DATALENGTH(...)")) but
+        // the expression and IsStored are unchanged, no SQL should be emitted. SQL Server rejects
+        // ALTER COLUMN on computed columns with "Cannot alter column ... because it is 'COMPUTED'",
+        // and the underlying database column's type is derived from the expression — there is
+        // nothing to change.
+        Generate(
+            new AlterColumnOperation
+            {
+                Table = "Files",
+                Name = "FileSize",
+                ClrType = typeof(long),
+                ColumnType = "bigint",
+                IsNullable = false,
+                ComputedColumnSql = "DATALENGTH([FileContents])",
+                OldColumn = new AddColumnOperation
+                {
+                    ClrType = typeof(int),
+                    ColumnType = "int",
+                    IsNullable = false,
+                    ComputedColumnSql = "DATALENGTH([FileContents])"
+                }
+            });
+
+        AssertSql("");
+    }
+
+    [Fact]
+    public virtual void AlterColumnOperation_computed_column_with_changed_expression_drops_and_adds()
+    {
+        // Regression guard: when the computed column expression itself changes, SQL Server still
+        // cannot ALTER COLUMN — but a drop+add is required to apply the new expression. This path
+        // must remain intact.
+        Generate(
+            new AlterColumnOperation
+            {
+                Table = "Files",
+                Name = "FileSize",
+                ClrType = typeof(long),
+                ColumnType = "bigint",
+                IsNullable = false,
+                ComputedColumnSql = "LEN([FileContents])",
+                OldColumn = new AddColumnOperation
+                {
+                    ClrType = typeof(int),
+                    ColumnType = "int",
+                    IsNullable = false,
+                    ComputedColumnSql = "DATALENGTH([FileContents])"
+                }
+            });
+
+        AssertSql(
+            """
+DECLARE @var nvarchar(max);
+SELECT @var = QUOTENAME([d].[name])
+FROM [sys].[default_constraints] [d]
+INNER JOIN [sys].[columns] [c] ON [d].[parent_column_id] = [c].[column_id] AND [d].[parent_object_id] = [c].[object_id]
+WHERE ([d].[parent_object_id] = OBJECT_ID(N'[Files]') AND [c].[name] = N'FileSize');
+IF @var IS NOT NULL EXEC(N'ALTER TABLE [Files] DROP CONSTRAINT ' + @var + ';');
+ALTER TABLE [Files] DROP COLUMN [FileSize];
+ALTER TABLE [Files] ADD [FileSize] AS LEN([FileContents]);
+""");
+    }
+
+    [Fact]
     public virtual void AlterColumnOperation_with_identity_legacy()
     {
         Generate(


### PR DESCRIPTION
Migrations for properties mapped to a computed column failed at runtime when only the CLR type changed (e.g. `int` → `long` for a column with `.HasComputedColumnSql("DATALENGTH(...)")`). EF emitted `ALTER TABLE ... ALTER COLUMN`, which SQL Server rejected with:

> Cannot alter column 'FileSize' because it is 'COMPUTED'.

A computed column's store type is derived from the expression, so a CLR-type-only change is metadata on the EF side and requires no database-side change.

### Fix

In `SqlServerMigrationsSqlGenerator.Generate(AlterColumnOperation)`, detect the no-op case once and use it to short-circuit both the index drop/recreate path and the `ALTER COLUMN` emission:

```csharp
var narrowed = false;
var oldColumnSupported = IsOldColumnSupported(model);

// SQL Server can't ALTER COLUMN on a computed column when the expression is unchanged; see #33425.
var computedColumnIsNoOp = operation.ComputedColumnSql != null
    && operation.OldColumn.ComputedColumnSql != null
    && operation.ComputedColumnSql == operation.OldColumn.ComputedColumnSql
    && operation.IsStored == operation.OldColumn.IsStored;

if (oldColumnSupported && !computedColumnIsNoOp)
{
    // ... narrowed = ... (skipped when computed is unchanged)
}

// later
if (computedColumnIsNoOp)
{
    alterStatementNeeded = false;
}
```

The flag is computed once and gates two sites:
1. The `narrowed` block at the top — prevents `GetIndexesToRebuild` / `DropIndexes` / `CreateIndexes` from running for a column the DB won't see modified.
2. The `alterStatementNeeded` reset — suppresses the actual `ALTER COLUMN` SQL.

The provider-independent `MigrationsModelDiffer` is untouched — the constraint is SQL Server-specific (PostgreSQL/SQLite generated-column rules differ, MySQL allows `MODIFY COLUMN` on generated columns), so the suppression belongs in the SQL Server generator.

Comment changes via `sp_addextendedproperty` further down still run — this is intentional and covered by the existing `Alter_computed_column_add_comment` regression test.

### Behavior

| Scenario | Before | After |
|---|---|---|
| Computed column, CLR type changes, same expression | `ALTER COLUMN` → SQL Server rejects | No SQL emitted, no index rebuild |
| Computed column, expression changes | Drop+add path | Unchanged |
| Non-computed column, type changes | `ALTER COLUMN` | Unchanged |
| Computed column, comment changes | `sp_addextendedproperty` | Unchanged |

### Tests

Generator-level (`SqlServerMigrationsSqlGeneratorTest`):
- `AlterColumnOperation_computed_column_with_only_clr_type_change_is_noop` — asserts empty SQL for the bug case
- `AlterColumnOperation_computed_column_with_changed_expression_drops_and_adds` — guards the existing drop+add path

End-to-end (`MigrationsSqlServerTest`):
- `Alter_computed_column_clr_type_only_change_is_noop` — full migration against real SQL Server, zero SQL
- `Alter_computed_column_clr_type_only_change_does_not_rebuild_indexes` — same scenario with an index on the computed column, asserts no `DROP INDEX` / `CREATE INDEX` (would have caught the original Copilot-flagged regression)

CI matrix (SqlServer 2019/2022/2025) covers end-to-end execution.

Fixes #33425
