### PR TITLE
Skip Cosmos vector/hybrid search tests on Linux emulator

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/Query/Translations/HybridSearchTranslationsCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/Translations/HybridSearchTranslationsCosmosTest.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Azure.Cosmos;
@@ -17,7 +17,6 @@ public class HybridSearchCosmosTest : IClassFixture<HybridSearchCosmosTest.Hybri
     protected HybridSearchFixture Fixture { get; }
 
     [ConditionalFact]
-    [CosmosCondition(CosmosCondition.IsNotLinuxEmulator)]
     public virtual async Task Rrf_with_FullTextScore_and_VectorDistance()
     {
         await using var context = CreateContext();
@@ -41,7 +40,6 @@ ORDER BY RANK RRF(FullTextScore(c["Description"], "beaver", "otter"), VectorDist
     }
 
     [ConditionalFact]
-    [CosmosCondition(CosmosCondition.IsNotLinuxEmulator)]
     public virtual async Task Rrf_with_FullTextScore_and_VectorDistance_with_weights()
     {
         await using var context = CreateContext();
@@ -131,28 +129,20 @@ ORDER BY RANK RRF(FullTextScore(c["Owned"]["AnotherDescription"], "beaver"), Vec
                 b.Property(x => x.Description).EnableFullTextSearch();
                 b.HasIndex(x => x.Description).IsFullTextIndex();
 
+                b.HasIndex(e => e.Bytes).IsVectorIndex(VectorIndexType.Flat);
+                b.HasIndex(e => e.SBytes).IsVectorIndex(VectorIndexType.Flat);
+                b.HasIndex(e => e.BytesArray).IsVectorIndex(VectorIndexType.Flat);
+                b.HasIndex(e => e.SinglesArray).IsVectorIndex(VectorIndexType.Flat);
+
+                b.Property(e => e.Bytes).IsVectorProperty(DistanceFunction.Cosine, 10);
+                b.Property(e => e.SBytes).IsVectorProperty(DistanceFunction.DotProduct, 10);
+                b.Property(e => e.BytesArray).IsVectorProperty(DistanceFunction.Cosine, 10);
                 b.Property(e => e.SinglesArray).IsVectorProperty(DistanceFunction.Cosine, 10);
-
-                if (!TestEnvironment.IsLinuxEmulator)
-                {
-                    b.HasIndex(e => e.SinglesArray).IsVectorIndex(VectorIndexType.DiskANN);
-                    b.HasIndex(e => e.Bytes).IsVectorIndex(VectorIndexType.DiskANN);
-                    b.HasIndex(e => e.SBytes).IsVectorIndex(VectorIndexType.DiskANN);
-                    b.HasIndex(e => e.BytesArray).IsVectorIndex(VectorIndexType.DiskANN);
-
-                    b.Property(e => e.Bytes).IsVectorProperty(DistanceFunction.Cosine, 10);
-                    b.Property(e => e.SBytes).IsVectorProperty(DistanceFunction.DotProduct, 10);
-                    b.Property(e => e.BytesArray).IsVectorProperty(DistanceFunction.Cosine, 10);
-                }
 
                 b.OwnsOne(
                     x => x.Owned, bb =>
                     {
-                        if (!TestEnvironment.IsLinuxEmulator)
-                        {
-                            bb.HasIndex(e => e.Singles).IsVectorIndex(VectorIndexType.DiskANN);
-                        }
-
+                        bb.HasIndex(e => e.Singles).IsVectorIndex(VectorIndexType.Flat);
                         bb.Property(e => e.Singles).IsVectorProperty(DistanceFunction.Cosine, 10);
 
                         bb.Property(x => x.AnotherDescription).EnableFullTextSearch();

--- a/test/EFCore.Cosmos.FunctionalTests/Query/Translations/HybridSearchTranslationsCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/Translations/HybridSearchTranslationsCosmosTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Azure.Cosmos;
@@ -17,6 +17,7 @@ public class HybridSearchCosmosTest : IClassFixture<HybridSearchCosmosTest.Hybri
     protected HybridSearchFixture Fixture { get; }
 
     [ConditionalFact]
+    [CosmosCondition(CosmosCondition.IsNotLinuxEmulator)]
     public virtual async Task Rrf_with_FullTextScore_and_VectorDistance()
     {
         await using var context = CreateContext();
@@ -40,6 +41,7 @@ ORDER BY RANK RRF(FullTextScore(c["Description"], "beaver", "otter"), VectorDist
     }
 
     [ConditionalFact]
+    [CosmosCondition(CosmosCondition.IsNotLinuxEmulator)]
     public virtual async Task Rrf_with_FullTextScore_and_VectorDistance_with_weights()
     {
         await using var context = CreateContext();
@@ -129,20 +131,28 @@ ORDER BY RANK RRF(FullTextScore(c["Owned"]["AnotherDescription"], "beaver"), Vec
                 b.Property(x => x.Description).EnableFullTextSearch();
                 b.HasIndex(x => x.Description).IsFullTextIndex();
 
-                b.HasIndex(e => e.Bytes).IsVectorIndex(VectorIndexType.Flat);
-                b.HasIndex(e => e.SBytes).IsVectorIndex(VectorIndexType.Flat);
-                b.HasIndex(e => e.BytesArray).IsVectorIndex(VectorIndexType.Flat);
-                b.HasIndex(e => e.SinglesArray).IsVectorIndex(VectorIndexType.Flat);
-
-                b.Property(e => e.Bytes).IsVectorProperty(DistanceFunction.Cosine, 10);
-                b.Property(e => e.SBytes).IsVectorProperty(DistanceFunction.DotProduct, 10);
-                b.Property(e => e.BytesArray).IsVectorProperty(DistanceFunction.Cosine, 10);
                 b.Property(e => e.SinglesArray).IsVectorProperty(DistanceFunction.Cosine, 10);
+
+                if (!TestEnvironment.IsLinuxEmulator)
+                {
+                    b.HasIndex(e => e.SinglesArray).IsVectorIndex(VectorIndexType.DiskANN);
+                    b.HasIndex(e => e.Bytes).IsVectorIndex(VectorIndexType.DiskANN);
+                    b.HasIndex(e => e.SBytes).IsVectorIndex(VectorIndexType.DiskANN);
+                    b.HasIndex(e => e.BytesArray).IsVectorIndex(VectorIndexType.DiskANN);
+
+                    b.Property(e => e.Bytes).IsVectorProperty(DistanceFunction.Cosine, 10);
+                    b.Property(e => e.SBytes).IsVectorProperty(DistanceFunction.DotProduct, 10);
+                    b.Property(e => e.BytesArray).IsVectorProperty(DistanceFunction.Cosine, 10);
+                }
 
                 b.OwnsOne(
                     x => x.Owned, bb =>
                     {
-                        bb.HasIndex(e => e.Singles).IsVectorIndex(VectorIndexType.Flat);
+                        if (!TestEnvironment.IsLinuxEmulator)
+                        {
+                            bb.HasIndex(e => e.Singles).IsVectorIndex(VectorIndexType.DiskANN);
+                        }
+
                         bb.Property(e => e.Singles).IsVectorProperty(DistanceFunction.Cosine, 10);
 
                         bb.Property(x => x.AnotherDescription).EnableFullTextSearch();

--- a/test/EFCore.Cosmos.FunctionalTests/Query/Translations/VectorSearchTranslationsCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/Translations/VectorSearchTranslationsCosmosTest.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Azure.Cosmos;
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore.Cosmos.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Query.Translations;
 
+[CosmosCondition(CosmosCondition.IsNotLinuxEmulator)]
 public class VectorSearchTranslationsCosmosTest : IClassFixture<VectorSearchTranslationsCosmosTest.VectorSearchFixture>
 {
     public VectorSearchTranslationsCosmosTest(VectorSearchFixture fixture, ITestOutputHelper testOutputHelper)
@@ -67,7 +68,6 @@ FROM root c
     }
 
     [ConditionalFact]
-    [CosmosCondition(CosmosCondition.IsNotLinuxEmulator)]
     public virtual async Task OrderBy_VectorDistance_bytes_memory()
     {
         await using var context = CreateContext();
@@ -90,7 +90,6 @@ ORDER BY VectorDistance(c["Bytes"], @p)
     }
 
     [ConditionalFact]
-    [CosmosCondition(CosmosCondition.IsNotLinuxEmulator)]
     public virtual async Task OrderBy_VectorDistance_bytes_array()
     {
         await using var context = CreateContext();
@@ -113,7 +112,6 @@ ORDER BY VectorDistance(c["BytesArray"], @p)
     }
 
     [ConditionalFact]
-    [CosmosCondition(CosmosCondition.IsNotLinuxEmulator)]
     public virtual async Task OrderBy_VectorDistance_sbyte()
     {
         await using var context = CreateContext();
@@ -258,7 +256,6 @@ FROM root c
     }
 
     [ConditionalFact]
-    [CosmosCondition(CosmosCondition.IsNotLinuxEmulator)]
     public virtual async Task RRF_with_two_Vector_distance_functions_in_OrderBy()
     {
         await using var context = CreateContext();
@@ -396,19 +393,15 @@ ORDER BY RANK RRF(VectorDistance(c["BytesArray"], @p), VectorDistance(c["Singles
                 b.HasKey(e => e.Id);
                 b.HasPartitionKey(e => e.Publisher);
 
+                b.HasIndex(e => e.Bytes).IsVectorIndex(VectorIndexType.Flat);
+                b.HasIndex(e => e.SBytes).IsVectorIndex(VectorIndexType.Flat);
+                b.HasIndex(e => e.BytesArray).IsVectorIndex(VectorIndexType.Flat);
+                b.HasIndex(e => e.SinglesArray).IsVectorIndex(VectorIndexType.Flat);
+
+                b.Property(e => e.Bytes).IsVectorProperty(DistanceFunction.Cosine, 10);
+                b.Property(e => e.SBytes).IsVectorProperty(DistanceFunction.DotProduct, 10);
+                b.Property(e => e.BytesArray).IsVectorProperty(DistanceFunction.Cosine, 10);
                 b.Property(e => e.SinglesArray).IsVectorProperty(DistanceFunction.Cosine, 10);
-
-                if (!TestEnvironment.IsLinuxEmulator)
-                {
-                    b.HasIndex(e => e.SinglesArray).IsVectorIndex(VectorIndexType.DiskANN);
-                    b.HasIndex(e => e.Bytes).IsVectorIndex(VectorIndexType.DiskANN);
-                    b.HasIndex(e => e.SBytes).IsVectorIndex(VectorIndexType.DiskANN);
-                    b.HasIndex(e => e.BytesArray).IsVectorIndex(VectorIndexType.DiskANN);
-
-                    b.Property(e => e.Bytes).IsVectorProperty(DistanceFunction.Cosine, 10);
-                    b.Property(e => e.SBytes).IsVectorProperty(DistanceFunction.DotProduct, 10);
-                    b.Property(e => e.BytesArray).IsVectorProperty(DistanceFunction.Cosine, 10);
-                }
 
                 b.OwnsOne(
                     x => x.OwnedReference, bb =>
@@ -416,11 +409,7 @@ ORDER BY RANK RRF(VectorDistance(c["BytesArray"], @p), VectorDistance(c["Singles
                         bb.OwnsOne(
                             x => x.NestedOwned, bbb =>
                             {
-                                if (!TestEnvironment.IsLinuxEmulator)
-                                {
-                                    bbb.HasIndex(x => x.NestedSingles).IsVectorIndex(VectorIndexType.DiskANN);
-                                }
-
+                                bbb.HasIndex(x => x.NestedSingles).IsVectorIndex(VectorIndexType.Flat);
                                 bbb.Property(x => x.NestedSingles).IsVectorProperty(DistanceFunction.Cosine, 10);
                             });
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/Translations/VectorSearchTranslationsCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/Translations/VectorSearchTranslationsCosmosTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Azure.Cosmos;
@@ -67,6 +67,7 @@ FROM root c
     }
 
     [ConditionalFact]
+    [CosmosCondition(CosmosCondition.IsNotLinuxEmulator)]
     public virtual async Task OrderBy_VectorDistance_bytes_memory()
     {
         await using var context = CreateContext();
@@ -89,6 +90,7 @@ ORDER BY VectorDistance(c["Bytes"], @p)
     }
 
     [ConditionalFact]
+    [CosmosCondition(CosmosCondition.IsNotLinuxEmulator)]
     public virtual async Task OrderBy_VectorDistance_bytes_array()
     {
         await using var context = CreateContext();
@@ -111,6 +113,7 @@ ORDER BY VectorDistance(c["BytesArray"], @p)
     }
 
     [ConditionalFact]
+    [CosmosCondition(CosmosCondition.IsNotLinuxEmulator)]
     public virtual async Task OrderBy_VectorDistance_sbyte()
     {
         await using var context = CreateContext();
@@ -255,6 +258,7 @@ FROM root c
     }
 
     [ConditionalFact]
+    [CosmosCondition(CosmosCondition.IsNotLinuxEmulator)]
     public virtual async Task RRF_with_two_Vector_distance_functions_in_OrderBy()
     {
         await using var context = CreateContext();
@@ -392,15 +396,19 @@ ORDER BY RANK RRF(VectorDistance(c["BytesArray"], @p), VectorDistance(c["Singles
                 b.HasKey(e => e.Id);
                 b.HasPartitionKey(e => e.Publisher);
 
-                b.HasIndex(e => e.Bytes).IsVectorIndex(VectorIndexType.Flat);
-                b.HasIndex(e => e.SBytes).IsVectorIndex(VectorIndexType.Flat);
-                b.HasIndex(e => e.BytesArray).IsVectorIndex(VectorIndexType.Flat);
-                b.HasIndex(e => e.SinglesArray).IsVectorIndex(VectorIndexType.Flat);
-
-                b.Property(e => e.Bytes).IsVectorProperty(DistanceFunction.Cosine, 10);
-                b.Property(e => e.SBytes).IsVectorProperty(DistanceFunction.DotProduct, 10);
-                b.Property(e => e.BytesArray).IsVectorProperty(DistanceFunction.Cosine, 10);
                 b.Property(e => e.SinglesArray).IsVectorProperty(DistanceFunction.Cosine, 10);
+
+                if (!TestEnvironment.IsLinuxEmulator)
+                {
+                    b.HasIndex(e => e.SinglesArray).IsVectorIndex(VectorIndexType.DiskANN);
+                    b.HasIndex(e => e.Bytes).IsVectorIndex(VectorIndexType.DiskANN);
+                    b.HasIndex(e => e.SBytes).IsVectorIndex(VectorIndexType.DiskANN);
+                    b.HasIndex(e => e.BytesArray).IsVectorIndex(VectorIndexType.DiskANN);
+
+                    b.Property(e => e.Bytes).IsVectorProperty(DistanceFunction.Cosine, 10);
+                    b.Property(e => e.SBytes).IsVectorProperty(DistanceFunction.DotProduct, 10);
+                    b.Property(e => e.BytesArray).IsVectorProperty(DistanceFunction.Cosine, 10);
+                }
 
                 b.OwnsOne(
                     x => x.OwnedReference, bb =>
@@ -408,7 +416,11 @@ ORDER BY RANK RRF(VectorDistance(c["BytesArray"], @p), VectorDistance(c["Singles
                         bb.OwnsOne(
                             x => x.NestedOwned, bbb =>
                             {
-                                bbb.HasIndex(x => x.NestedSingles).IsVectorIndex(VectorIndexType.Flat);
+                                if (!TestEnvironment.IsLinuxEmulator)
+                                {
+                                    bbb.HasIndex(x => x.NestedSingles).IsVectorIndex(VectorIndexType.DiskANN);
+                                }
+
                                 bbb.Property(x => x.NestedSingles).IsVectorProperty(DistanceFunction.Cosine, 10);
                             });
 


### PR DESCRIPTION
The Linux emulator doesn't currently support vector search: https://github.com/Azure/azure-cosmos-db-emulator-docker/issues/162. I'm not sure what/how exactly was passing before, but this PR disables these until support is properly added.
