### PR TITLE
Fix NullReferenceException for SelectMany with inline array values

### DIFF
--- a/src/EFCore.Relational/Query/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/QuerySqlGenerator.cs
@@ -654,7 +654,7 @@ public class QuerySqlGenerator(QuerySqlGeneratorDependencies dependencies) : Exp
         if (sqlConstantExpression.TypeMapping is null)
         {
             throw new UnreachableException(
-                $"SqlConstantExpression with value '{sqlConstantExpression.Value}' has no type mapping. "
+                "SqlConstantExpression has no type mapping. "
                 + "Please file a bug report at https://github.com/dotnet/efcore.");
         }
 

--- a/src/EFCore.Relational/Query/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/QuerySqlGenerator.cs
@@ -651,8 +651,15 @@ public class QuerySqlGenerator(QuerySqlGeneratorDependencies dependencies) : Exp
     /// <param name="sqlConstantExpression">The <see cref="SqlConstantExpression" /> for which to generate SQL.</param>
     protected virtual Expression VisitSqlConstant(SqlConstantExpression sqlConstantExpression)
     {
+        if (sqlConstantExpression.TypeMapping is null)
+        {
+            throw new UnreachableException(
+                $"SqlConstantExpression with value '{sqlConstantExpression.Value}' has no type mapping. "
+                + "Please file a bug report at https://github.com/dotnet/efcore.");
+        }
+
         _relationalCommandBuilder
-            .Append(sqlConstantExpression.TypeMapping!.GenerateSqlLiteral(sqlConstantExpression.Value), sqlConstantExpression.IsSensitive);
+            .Append(sqlConstantExpression.TypeMapping.GenerateSqlLiteral(sqlConstantExpression.Value), sqlConstantExpression.IsSensitive);
 
         return sqlConstantExpression;
     }
@@ -663,6 +670,13 @@ public class QuerySqlGenerator(QuerySqlGeneratorDependencies dependencies) : Exp
     /// <param name="sqlParameterExpression">The <see cref="SqlParameterExpression" /> for which to generate SQL.</param>
     protected virtual Expression VisitSqlParameter(SqlParameterExpression sqlParameterExpression)
     {
+        if (sqlParameterExpression.TypeMapping is null)
+        {
+            throw new UnreachableException(
+                $"SqlParameterExpression '{sqlParameterExpression.Name}' has no type mapping. "
+                + "Please file a bug report at https://github.com/dotnet/efcore.");
+        }
+
         var name = sqlParameterExpression.Name;
 
         // Only add the parameter to the command the first time we see its (non-invariant) name, even though we may need to add its
@@ -672,7 +686,7 @@ public class QuerySqlGenerator(QuerySqlGeneratorDependencies dependencies) : Exp
             _relationalCommandBuilder.AddParameter(
                 sqlParameterExpression.InvariantName,
                 _sqlGenerationHelper.GenerateParameterName(name),
-                sqlParameterExpression.TypeMapping!,
+                sqlParameterExpression.TypeMapping,
                 sqlParameterExpression.IsNullable);
             _parameterNames.Add(name);
         }

--- a/src/EFCore.Relational/Query/RelationalTypeMappingPostprocessor.cs
+++ b/src/EFCore.Relational/Query/RelationalTypeMappingPostprocessor.cs
@@ -151,23 +151,15 @@ public class RelationalTypeMappingPostprocessor(
                     {
                         var value = rowValue.Values[j];
 
-                        if (value.TypeMapping is null)
+                        if (value.TypeMapping is null
+                            // Fall back to the default type mapping for the CLR type when no type mapping was inferred
+                            // from usage context (e.g. SelectMany where the value column isn't referenced).
+                            && (inferredTypeMappings[j]
+                                ?? RelationalDependencies.TypeMappingSource.FindMapping(
+                                    value.Type, QueryCompilationContext.Model))
+                            is { } resolvedTypeMapping)
                         {
-                            if (inferredTypeMappings[j] is { } inferredTypeMapping)
-                            {
-                                value = _sqlExpressionFactory.ApplyTypeMapping(value, inferredTypeMapping);
-                            }
-                            else
-                            {
-                                // No type mapping was inferred from usage context (e.g. SelectMany where the value column isn't
-                                // referenced). Fall back to the default type mapping for the CLR type.
-                                var defaultTypeMapping = RelationalDependencies.TypeMappingSource.FindMapping(
-                                    value.Type, QueryCompilationContext.Model);
-                                if (defaultTypeMapping is not null)
-                                {
-                                    value = _sqlExpressionFactory.ApplyTypeMapping(value, defaultTypeMapping);
-                                }
-                            }
+                            value = _sqlExpressionFactory.ApplyTypeMapping(value, resolvedTypeMapping);
                         }
 
                         // We currently add explicit conversions on the first row (but not to the _ord column), to ensure that the inferred

--- a/src/EFCore.Relational/Query/RelationalTypeMappingPostprocessor.cs
+++ b/src/EFCore.Relational/Query/RelationalTypeMappingPostprocessor.cs
@@ -151,10 +151,23 @@ public class RelationalTypeMappingPostprocessor(
                     {
                         var value = rowValue.Values[j];
 
-                        if (value.TypeMapping is null
-                            && inferredTypeMappings[j] is { } inferredTypeMapping)
+                        if (value.TypeMapping is null)
                         {
-                            value = _sqlExpressionFactory.ApplyTypeMapping(value, inferredTypeMapping);
+                            if (inferredTypeMappings[j] is { } inferredTypeMapping)
+                            {
+                                value = _sqlExpressionFactory.ApplyTypeMapping(value, inferredTypeMapping);
+                            }
+                            else
+                            {
+                                // No type mapping was inferred from usage context (e.g. SelectMany where the value column isn't
+                                // referenced). Fall back to the default type mapping for the CLR type.
+                                var defaultTypeMapping = RelationalDependencies.TypeMappingSource.FindMapping(
+                                    value.Type, QueryCompilationContext.Model);
+                                if (defaultTypeMapping is not null)
+                                {
+                                    value = _sqlExpressionFactory.ApplyTypeMapping(value, defaultTypeMapping);
+                                }
+                            }
                         }
 
                         // We currently add explicit conversions on the first row (but not to the _ord column), to ensure that the inferred

--- a/test/EFCore.Cosmos.FunctionalTests/Query/PrimitiveCollectionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/PrimitiveCollectionsQueryCosmosTest.cs
@@ -550,6 +550,13 @@ OFFSET 0 LIMIT 2
 """);
     }
 
+    public override async Task Inline_collection_SelectMany_with_unreferenced_collection_value()
+    {
+        await base.Inline_collection_SelectMany_with_unreferenced_collection_value();
+
+        AssertSql("PLACEHOLDER");
+    }
+
     // https://github.com/Azure/azure-cosmos-db-emulator-docker/issues/287 (Aggregates over subqueries return null result set)
     [CosmosCondition(CosmosCondition.IsNotLinuxEmulator)]
     public override async Task Parameter_collection_Count()

--- a/test/EFCore.Cosmos.FunctionalTests/Query/PrimitiveCollectionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/PrimitiveCollectionsQueryCosmosTest.cs
@@ -551,11 +551,8 @@ OFFSET 0 LIMIT 2
     }
 
     public override async Task Inline_collection_SelectMany_with_unreferenced_collection_value()
-    {
-        await base.Inline_collection_SelectMany_with_unreferenced_collection_value();
-
-        AssertSql("PLACEHOLDER");
-    }
+        => await Assert.ThrowsAsync<InvalidOperationException>(
+            () => base.Inline_collection_SelectMany_with_unreferenced_collection_value());
 
     // https://github.com/Azure/azure-cosmos-db-emulator-docker/issues/287 (Aggregates over subqueries return null result set)
     [CosmosCondition(CosmosCondition.IsNotLinuxEmulator)]

--- a/test/EFCore.Specification.Tests/Query/PrimitiveCollectionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/PrimitiveCollectionsQueryTestBase.cs
@@ -270,6 +270,11 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture>(TFixture fixtu
         Assert.Equal(2, result.Id);
     }
 
+    [ConditionalFact] // #38285
+    public virtual Task Inline_collection_SelectMany_with_unreferenced_collection_value()
+        => AssertQuery(
+            ss => ss.Set<PrimitiveCollectionsEntity>().SelectMany(e => new[] { "a", "b" }.Select(k => e)));
+
     [ConditionalFact]
     public virtual Task Parameter_collection_Count()
     {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQueryOldSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQueryOldSqlServerTest.cs
@@ -478,6 +478,18 @@ WHERE (
 """);
     }
 
+    public override async Task Inline_collection_SelectMany_with_unreferenced_collection_value()
+    {
+        await base.Inline_collection_SelectMany_with_unreferenced_collection_value();
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
+FROM [PrimitiveCollectionsEntity] AS [p]
+CROSS APPLY (VALUES (CAST(N'a' AS nvarchar(max))), (N'b')) AS [v]([Value])
+""");
+    }
+
     public override async Task Parameter_collection_Count()
     {
         await base.Parameter_collection_Count();

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerJsonTypeTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerJsonTypeTest.cs
@@ -655,6 +655,18 @@ WHERE (
 """);
     }
 
+    public override async Task Inline_collection_SelectMany_with_unreferenced_collection_value()
+    {
+        await base.Inline_collection_SelectMany_with_unreferenced_collection_value();
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
+FROM [PrimitiveCollectionsEntity] AS [p]
+CROSS APPLY (VALUES (CAST(N'a' AS nvarchar(max))), (N'b')) AS [v]([Value])
+""");
+    }
+
     public override async Task Parameter_collection_Count()
     {
         await base.Parameter_collection_Count();

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerTest.cs
@@ -721,6 +721,18 @@ WHERE (
 """);
     }
 
+    public override async Task Inline_collection_SelectMany_with_unreferenced_collection_value()
+    {
+        await base.Inline_collection_SelectMany_with_unreferenced_collection_value();
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[NullableWrappedId], [p].[NullableWrappedIdWithNullableComparer], [p].[String], [p].[Strings], [p].[WrappedId]
+FROM [PrimitiveCollectionsEntity] AS [p]
+CROSS APPLY (VALUES (CAST(N'a' AS nvarchar(max))), (N'b')) AS [v]([Value])
+""");
+    }
+
     public override async Task Parameter_collection_Count()
     {
         await base.Parameter_collection_Count();

--- a/test/EFCore.Sqlite.FunctionalTests/Query/PrimitiveCollectionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/PrimitiveCollectionsQuerySqliteTest.cs
@@ -2053,6 +2053,12 @@ WHERE (
             SqliteStrings.ApplyNotSupported,
             (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Column_collection_SelectMany())).Message);
 
+    public override async Task Inline_collection_SelectMany_with_unreferenced_collection_value()
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Inline_collection_SelectMany_with_unreferenced_collection_value())).Message);
+
     public override async Task Column_collection_SelectMany_with_filter()
         => Assert.Equal(
             SqliteStrings.ApplyNotSupported,


### PR DESCRIPTION
Fixes #38285

When using `SelectMany` with an inline array where the collection values are unreferenced (e.g. `e => new[] { "a", "b" }.Select(k => e)`), the values in the `ValuesExpression` had no type mapping inferred from usage context. The postprocessor then wrapped them in a `Convert` expression with null `TypeMapping`, causing a `NullReferenceException` in `QuerySqlGenerator.VisitSqlConstant`.

**Fix:** In `ApplyTypeMappingsOnValuesExpression`, when no type mapping is inferred from usage context, fall back to the default type mapping for the value's CLR type.

**Generated SQL (SQL Server):**
```sql
SELECT [p].[Id], ...
FROM [PrimitiveCollectionsEntity] AS [p]
CROSS APPLY (VALUES (CAST(N'a' AS nvarchar(max))), (N'b')) AS [v]([Value])
```