### PR TITLE
Fix funcletization of evaluatable lambda parameters

### DIFF
--- a/src/EFCore/Query/Internal/ExpressionTreeFuncletizer.cs
+++ b/src/EFCore/Query/Internal/ExpressionTreeFuncletizer.cs
@@ -1288,11 +1288,25 @@ public class ExpressionTreeFuncletizer : ExpressionVisitor
     /// </summary>
     protected override Expression VisitParameter(ParameterExpression parameterExpression)
     {
-        // ParameterExpressions are lambda parameters, which we cannot evaluate.
-        // However, _allowedParameters is a mechanism to allow evaluating Select(), see VisitMethodCall.
-        _state = _evaluatableParameters.Contains(parameterExpression)
-            ? State.CreateEvaluatable(typeof(ParameterExpression), containsCapturedVariable: false)
-            : State.NoEvaluatability;
+        // ParameterExpressions are lambda parameters, which are not evaluatable unless they are part of an evaluatable lambda;
+        // see the Enumerable.Select handling in VisitMethodCall. Even then, a parameter can only be evaluated as part of that
+        // larger lambda fragment, and never as an evaluatable root - see TryHandleNonEvaluatableAsRoot below.
+        if (_evaluatableParameters.Contains(parameterExpression))
+        {
+            var parameterExpression2 = parameterExpression;
+            _state = State.CreateEvaluatable(
+                typeof(ParameterExpression),
+                containsCapturedVariable: false,
+                notEvaluatableAsRootHandler: () =>
+                {
+                    _state = State.NoEvaluatability;
+                    return parameterExpression2;
+                });
+        }
+        else
+        {
+            _state = State.NoEvaluatability;
+        }
 
         return parameterExpression;
     }
@@ -1932,9 +1946,11 @@ public class ExpressionTreeFuncletizer : ExpressionVisitor
                 // different SQLs for each value.
                 || !_inLambda);
 
-        // We have some cases where a node is evaluatable, but only as part of a larger subtree, and should not be evaluated as a tree root.
-        // For these cases, the node's state has a notEvaluatableAsRootHandler lambda, which we can invoke to make evaluate the node's
-        // children (as needed), but not itself.
+        // Some nodes are evaluatable only as part of a larger subtree, and must not be evaluated as roots by themselves.
+        // For example, new[] { x, y } should generally be preserved as an inline list, and a ParameterExpression made
+        // evaluatable for an Enumerable.Select lambda is only bound inside that lambda. For these cases, the node's state
+        // has a notEvaluatableAsRootHandler lambda, which evaluates children as needed or otherwise preserves the node
+        // while setting the appropriate state, but does not evaluate the root itself.
         if (!forceEvaluation && TryHandleNonEvaluatableAsRoot(evaluatableRoot, state, evaluateAsParameter, out var result))
         {
             return result;
@@ -2039,6 +2055,9 @@ public class ExpressionTreeFuncletizer : ExpressionVisitor
                 // There are some cases of Convert nodes which we shouldn't evaluate when they're at the top of an evaluatable root (but can
                 // evaluate when they're part of a larger fragment).
                 case UnaryExpression unary when PreserveConvertNode(unary):
+                // Parameters made evaluatable for an Enumerable.Select lambda are only evaluatable inside that lambda, and attempting to
+                // evaluate them as roots produces an unbound parameter.
+                case ParameterExpression when state.NotEvaluatableAsRootHandler is not null:
                     result = state.NotEvaluatableAsRootHandler!();
                     return true;
 

--- a/src/EFCore/Query/Internal/ExpressionTreeFuncletizer.cs
+++ b/src/EFCore/Query/Internal/ExpressionTreeFuncletizer.cs
@@ -2057,7 +2057,7 @@ public class ExpressionTreeFuncletizer : ExpressionVisitor
                 case UnaryExpression unary when PreserveConvertNode(unary):
                 // Parameters made evaluatable for an Enumerable.Select lambda are only evaluatable inside that lambda, and attempting to
                 // evaluate them as roots produces an unbound parameter.
-                case ParameterExpression when state.NotEvaluatableAsRootHandler is not null:
+                case ParameterExpression:
                     result = state.NotEvaluatableAsRootHandler!();
                     return true;
 

--- a/src/EFCore/Query/Internal/ExpressionTreeFuncletizer.cs
+++ b/src/EFCore/Query/Internal/ExpressionTreeFuncletizer.cs
@@ -1293,14 +1293,14 @@ public class ExpressionTreeFuncletizer : ExpressionVisitor
         // larger lambda fragment, and never as an evaluatable root - see TryHandleNonEvaluatableAsRoot below.
         if (_evaluatableParameters.Contains(parameterExpression))
         {
-            var parameterExpression2 = parameterExpression;
+            var capturedParameterExpression = parameterExpression;
             _state = State.CreateEvaluatable(
                 typeof(ParameterExpression),
                 containsCapturedVariable: false,
                 notEvaluatableAsRootHandler: () =>
                 {
                     _state = State.NoEvaluatability;
-                    return parameterExpression2;
+                    return capturedParameterExpression;
                 });
         }
         else

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
@@ -1056,6 +1056,14 @@ WHERE STARTSWITH(c["id"], "A")
         AssertSql();
     }
 
+    public override async Task SelectMany_over_inline_array_projecting_range_variable_and_outer(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.SelectMany_over_inline_array_projecting_range_variable_and_outer(async));
+
+        AssertSql();
+    }
+
     public override async Task SelectMany_correlated_with_outer_2(bool async)
     {
         // Cosmos client evaluation. Issue #17246.

--- a/test/EFCore.InMemory.FunctionalTests/Query/NorthwindSelectQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/NorthwindSelectQueryInMemoryTest.cs
@@ -11,4 +11,7 @@ public class NorthwindSelectQueryInMemoryTest(NorthwindQueryInMemoryFixture<Noop
         => Assert.ThrowsAsync<NotImplementedException>(() => base
             .SelectMany_with_collection_being_correlated_subquery_which_references_non_mapped_properties_from_inner_and_outer_entity(
                 async));
+
+    public override Task SelectMany_over_inline_array_projecting_range_variable_and_outer(bool async)
+        => AssertTranslationFailed(() => base.SelectMany_over_inline_array_projecting_range_variable_and_outer(async));
 }

--- a/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
@@ -1204,6 +1204,15 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
             ss => ss.Set<Customer>().SelectMany(c => c.Orders.Select(o => o.CustomerID)));
 
     [ConditionalTheory, MemberData(nameof(IsAsyncData))]
+    public virtual Task SelectMany_over_inline_array_projecting_range_variable_and_outer(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Customer>()
+                .Where(c => c.CustomerID == "ALFKI")
+                .SelectMany(c => new[] { "a", "b" }.Select(k => new { k, c })),
+            elementSorter: e => e.k);
+
+    [ConditionalTheory, MemberData(nameof(IsAsyncData))]
     public virtual Task SelectMany_correlated_with_outer_1(bool async)
         => AssertQuery(
             async,

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
@@ -1230,6 +1230,19 @@ INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 """);
     }
 
+    public override async Task SelectMany_over_inline_array_projecting_range_variable_and_outer(bool async)
+    {
+        await base.SelectMany_over_inline_array_projecting_range_variable_and_outer(async);
+
+        AssertSql(
+            """
+SELECT [v].[Value] AS [k], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+CROSS APPLY (VALUES (CAST(N'a' AS nvarchar(max))), (N'b')) AS [v]([Value])
+WHERE [c].[CustomerID] = N'ALFKI'
+""");
+    }
+
     public override async Task SelectMany_correlated_with_outer_1(bool async)
     {
         await base.SelectMany_correlated_with_outer_1(async);

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindSelectQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindSelectQuerySqliteTest.cs
@@ -168,6 +168,12 @@ FROM "Orders" AS "o"
             SqliteStrings.ApplyNotSupported,
             (await Assert.ThrowsAsync<InvalidOperationException>(() => base.SelectMany_correlated_with_outer_1(async))).Message);
 
+    public override async Task SelectMany_over_inline_array_projecting_range_variable_and_outer(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.SelectMany_over_inline_array_projecting_range_variable_and_outer(async))).Message);
+
     public override async Task SelectMany_correlated_with_outer_2(bool async)
         => Assert.Equal(
             SqliteStrings.ApplyNotSupported,


### PR DESCRIPTION
Fixes #38287.

Prevents `ParameterExpression`s that are made evaluatable for LINQ-to-Objects `Enumerable.Select` lambdas from being evaluated as independent roots, where they are unbound. The parameter remains evaluatable only as part of the larger lambda fragment via `NotEvaluatableAsRootHandler`.

Adds shared Northwind query coverage for `SelectMany` over an inline array projecting both the range variable and the outer entity, with SQL Server baseline and SQLite/Cosmos provider overrides.

Validation:
- `dotnet test .\test\EFCore.SqlServer.FunctionalTests\EFCore.SqlServer.FunctionalTests.csproj --filter "FullyQualifiedName~NorthwindSelectQuerySqlServerTest.SelectMany_over_inline_array_projecting_range_variable_and_outer" --no-restore`
- `dotnet test .\test\EFCore.Sqlite.FunctionalTests\EFCore.Sqlite.FunctionalTests.csproj --filter "FullyQualifiedName~NorthwindSelectQuerySqliteTest.SelectMany_over_inline_array_projecting_range_variable_and_outer" --no-restore`
- `dotnet test .\test\EFCore.Cosmos.FunctionalTests\EFCore.Cosmos.FunctionalTests.csproj --filter "FullyQualifiedName~NorthwindSelectQueryCosmosTest.SelectMany_over_inline_array_projecting_range_variable_and_outer" --no-restore`
- `dotnet test .\test\EFCore.SqlServer.FunctionalTests\EFCore.SqlServer.FunctionalTests.csproj --filter "FullyQualifiedName~Microsoft.EntityFrameworkCore.Query" --no-restore -- xUnit.MaxParallelThreads=1`
