### PR TITLE
[Benchmarks] Reference SQLitePCLRaw.bundle_e_sqlite3 in EFCore.Sqlite.Benchmarks

### DIFF
--- a/benchmark/EFCore.Sqlite.Benchmarks/EFCore.Sqlite.Benchmarks.csproj
+++ b/benchmark/EFCore.Sqlite.Benchmarks/EFCore.Sqlite.Benchmarks.csproj
@@ -17,6 +17,16 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!--
+      Register the SQLitePCLRaw provider via the bundle's [ModuleInitializer].
+      Required since the SQLitePCLRaw 3.x bump (#36551): without this, every
+      benchmark throws "You need to call SQLitePCL.raw.SetProvider()" from
+      [GlobalSetup] and BenchmarkDotNet reports NA for every method.
+    -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="AdventureWorks2014.db">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
Fixes #38292. This was generated by AI, so if there is a different preferred approach, feel free to close.

Since the SQLitePCLRaw 3.x bump (#36551), every benchmark in
`EFCore.Sqlite.Benchmarks` throws on `[GlobalSetup]`:

```
System.Exception: You need to call SQLitePCL.raw.SetProvider().
If you are using a bundle package, this is done by calling
SQLitePCL.Batteries.Init().
   at SQLitePCL.raw.get_Provider()
   at SQLitePCL.raw.sqlite3_libversion()
   at Microsoft.Data.Sqlite.SqliteConnection.get_ServerVersion()
   at Microsoft.EntityFrameworkCore.Sqlite.Update.Internal
        .SqliteUpdateSqlGenerator..ctor(UpdateSqlGeneratorDependencies)
   ...
   at BenchmarkDotNet.Autogenerated.Runnable_0.GlobalSetup()
```

In SQLitePCLRaw 3.x the bundle packages register the provider via a
`[ModuleInitializer]`, so referencing `SQLitePCLRaw.bundle_e_sqlite3`
(the same package `EFCore.Sqlite.FunctionalTests` already uses) is
sufficient — no code change is needed. The version is already pinned in
the root `Directory.Packages.props` as
`SQLitePCLRaw.bundle_e_sqlite3 = $(SQLitePCLRawVersion)` (3.0.3).

This regression has been silently masking every EF Core measurement in
the `aspnet/Benchmarks` `benchmarks-ci-01` pipeline for ~122
consecutive builds since 2026-03-19. BenchmarkDotNet reports every
method as `NA` under "Benchmarks with issues" but exits with code 0,
and crank's `RunBenchmarkDotNet` only fails on agent-side errors, so
the AzDO task is marked succeeded. See the issue for the full
investigation.

### Verification

Reproduced locally with `crank` + `crank-agent --no-cleanup` on the
agent's net11.0 preview SDK. Funcletization scenario:

Before:
```
 Method            | Mean | Error | Op/s |
------------------ |-----:|------:|-----:|
 NewQueryInstance  |   NA |    NA |   NA |
 SameQueryInstance |   NA |    NA |   NA |
 ValueFromObject   |   NA |    NA |   NA |
```

After the one-line `<PackageReference>` add:
```
 Method            | Mean     | Error     | StdDev    | Op/s  | Gen0    | Gen1    | Allocated |
------------------ |---------:|----------:|----------:|------:|--------:|--------:|----------:|
 NewQueryInstance  | 5.443 ms | 1.7801 ms | 0.0976 ms | 183.7 | 54.6875 | 23.4375 |    1.4 MB |
 SameQueryInstance | 4.950 ms | 0.8875 ms | 0.0486 ms | 202.0 | 46.8750 | 23.4375 |   1.28 MB |
 ValueFromObject   | 5.474 ms | 0.8126 ms | 0.0445 ms | 182.7 | 54.6875 | 23.4375 |   1.44 MB |
```
