### PR TITLE
Cosmos: translate top-level Any() to LIMIT 1 instead of EXISTS

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitor.cs
@@ -428,12 +428,48 @@ public class CosmosQueryableMethodTranslatingExpressionVisitor : QueryableMethod
             subquery.ClearOrdering();
         }
 
-        var translation = _sqlExpressionFactory.Exists(subquery);
-        var selectExpression = new SelectExpression(translation);
+        // For subqueries, Cosmos supports EXISTS over correlated subqueries (e.g. within a WHERE clause).
+        if (_subquery)
+        {
+            var translation = _sqlExpressionFactory.Exists(subquery);
+            var selectExpression = new SelectExpression(translation);
 
-        return source.Update(
-            selectExpression,
-            Expression.Convert(new ProjectionBindingExpression(selectExpression, new ProjectionMember(), typeof(bool?)), typeof(bool)));
+            return source.Update(
+                selectExpression,
+                Expression.Convert(
+                    new ProjectionBindingExpression(selectExpression, new ProjectionMember(), typeof(bool?)), typeof(bool)));
+        }
+
+        // For top-level Any(), Cosmos doesn't support EXISTS over uncorrelated subqueries. Instead, we project a constant 'true'
+        // with LIMIT 1:
+        //   SELECT VALUE true FROM root c WHERE <predicate> OFFSET 0 LIMIT 1
+        // If at least one document matches, we get back 'true'; if no documents match, the result set is empty.
+        // We override the result cardinality to SingleOrDefault so that an empty result returns default(bool) = false
+        // (the caller sets ResultCardinality.Single which would throw on empty results).
+
+        // TODO: Subquery pushdown, #33968
+        if (subquery.IsDistinct)
+        {
+            return null;
+        }
+
+        subquery.ClearOrdering();
+
+        var topLevelTranslation = _sqlExpressionFactory.ApplyDefaultTypeMapping(_sqlExpressionFactory.Constant(true));
+        var projectionMapping = new Dictionary<ProjectionMember, Expression> { { new ProjectionMember(), topLevelTranslation } };
+        subquery.ReplaceProjectionMapping(projectionMapping);
+
+        if (!TryApplyLimit(subquery, TranslateExpression(Expression.Constant(1))!))
+        {
+            return null;
+        }
+
+        return source
+            .UpdateShaperExpression(
+                Expression.Convert(
+                    new ProjectionBindingExpression(source.QueryExpression, new ProjectionMember(), typeof(bool?)),
+                    typeof(bool)))
+            .UpdateResultCardinality(ResultCardinality.SingleOrDefault);
     }
 
     /// <summary>

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
@@ -2267,27 +2267,22 @@ WHERE NOT(false)
 """);
             });
 
-    public override async Task Contains_top_level(bool async)
-    {
-        // Always throws for sync.
-        if (async)
-        {
-            // Top-level Any(), see #33854.
-            var exception = await Assert.ThrowsAsync<CosmosException>(() => base.Contains_top_level(async));
+    public override Task Contains_top_level(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Contains_top_level(a);
 
-            Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
-
-            AssertSql(
-                """
+                AssertSql(
+                    """
 @p='ALFKI'
 
-SELECT VALUE EXISTS (
-    SELECT 1
-    FROM root c
-    WHERE (c["id"] = @p))
+SELECT VALUE true
+FROM root c
+WHERE (c["id"] = @p)
+OFFSET 0 LIMIT 1
 """);
-        }
-    }
+            });
 
     public override async Task Contains_with_local_tuple_array_closure(bool async)
     {
@@ -2519,28 +2514,22 @@ WHERE ARRAY_CONTAINS(@ids, c["id"])
 """);
             });
 
-    public override async Task Contains_over_entityType_with_null_should_rewrite_to_false(bool async)
-    {
-        // Always throws for sync.
-        if (async)
-        {
-            // Top-level Any(), see #33854.
-            var exception =
-                await Assert.ThrowsAsync<CosmosException>(() => base.Contains_over_entityType_with_null_should_rewrite_to_false(async));
+    public override Task Contains_over_entityType_with_null_should_rewrite_to_false(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Contains_over_entityType_with_null_should_rewrite_to_false(a);
 
-            Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
-
-            AssertSql(
-                """
+                AssertSql(
+                    """
 @entity_equality_p_OrderID=null
 
-SELECT VALUE EXISTS (
-    SELECT 1
-    FROM root c
-    WHERE (((c["$type"] = "Order") AND (c["CustomerID"] = "VINET")) AND (c["OrderID"] = @entity_equality_p_OrderID)))
+SELECT VALUE true
+FROM root c
+WHERE (((c["$type"] = "Order") AND (c["CustomerID"] = "VINET")) AND (c["OrderID"] = @entity_equality_p_OrderID))
+OFFSET 0 LIMIT 1
 """);
-        }
-    }
+            });
 
     public override async Task Contains_over_entityType_with_null_in_projection(bool async)
     {

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
@@ -801,43 +801,34 @@ OFFSET 0 LIMIT @p
         AssertSql();
     }
 
-    public override async Task Any_simple(bool async)
-    {
-        // Always throws for sync.
-        if (async)
-        {
-            // Top-level Any(), see #33854.
-            var exception = await Assert.ThrowsAsync<CosmosException>(() => base.Any_simple(async));
+    public override Task Any_simple(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Any_simple(a);
 
-            Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
-
-            AssertSql(
-                """
-SELECT VALUE EXISTS (
-    SELECT 1
-    FROM root c)
+                AssertSql(
+                    """
+SELECT VALUE true
+FROM root c
+OFFSET 0 LIMIT 1
 """);
-        }
-    }
+            });
 
-    public override async Task Any_predicate(bool async)
-    {
-        // Always throws for sync.
-        if (async)
-        {
-            // Top-level Any(), see #33854.
-            var exception = await Assert.ThrowsAsync<CosmosException>(() => base.Any_predicate(async));
+    public override Task Any_predicate(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.Any_predicate(a);
 
-            Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
-            AssertSql(
-                """
-SELECT VALUE EXISTS (
-    SELECT 1
-    FROM root c
-    WHERE STARTSWITH(c["ContactName"], "A"))
+                AssertSql(
+                    """
+SELECT VALUE true
+FROM root c
+WHERE STARTSWITH(c["ContactName"], "A")
+OFFSET 0 LIMIT 1
 """);
-        }
-    }
+            });
 
     public override async Task Any_nested_negated(bool async)
     {
@@ -1295,26 +1286,10 @@ SELECT VALUE EXISTS (
 
     public override async Task Skip_Take_Any(bool async)
     {
-        // Always throws for sync.
-        if (async)
-        {
-            // Top-level Any(), see #33854.
-            var exception = await Assert.ThrowsAsync<CosmosException>(() => base.Skip_Take_Any(async));
+        // TODO: Subquery pushdown, #33968
+        await AssertTranslationFailed(() => base.Skip_Take_Any(async));
 
-            Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
-
-            AssertSql(
-                """
-@p='5'
-@p1='10'
-
-SELECT VALUE EXISTS (
-    SELECT 1
-    FROM root c
-    ORDER BY c["ContactName"]
-    OFFSET @p LIMIT @p1)
-""");
-        }
+        AssertSql();
     }
 
     public override async Task Skip_Take_All(bool async)
@@ -1506,24 +1481,19 @@ ORDER BY c["Country"], c["City"]
         }
     }
 
-    public override async Task OrderBy_ThenBy_Any(bool async)
-    {
-        // Always throws for sync.
-        if (async)
-        {
-            // Top-level Any(), see #33854.
-            var exception = await Assert.ThrowsAsync<CosmosException>(() => base.OrderBy_ThenBy_Any(async));
+    public override Task OrderBy_ThenBy_Any(bool async)
+        => Fixture.NoSyncTest(
+            async, async a =>
+            {
+                await base.OrderBy_ThenBy_Any(a);
 
-            Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
-
-            AssertSql(
-                """
-SELECT VALUE EXISTS (
-    SELECT 1
-    FROM root c)
+                AssertSql(
+                    """
+SELECT VALUE true
+FROM root c
+OFFSET 0 LIMIT 1
 """);
-        }
-    }
+            });
 
     public override async Task OrderBy_correlated_subquery1(bool async)
     {


### PR DESCRIPTION
Cosmos doesn't support EXISTS with uncorrelated subqueries, so top-level `Any()` (e.g. `db.Customers.AnyAsync()`) was generating invalid SQL that Cosmos rejects with HTTP 400:

```sql
SELECT VALUE EXISTS (
    SELECT 1
    FROM root c)
```

This translates `Any()` by projecting a constant `true` with `LIMIT 1` instead:

```sql
SELECT VALUE true
FROM root c
OFFSET 0 LIMIT 1
```

If at least one document matches, we get back `true`; if no documents match, the result set is empty and `SingleOrDefault` returns `default(bool)` = `false`.

Fixes #33854