### PR TITLE
Add wildcard (*) support to GetMigrations, ScriptMigration, and DropDatabase

### DIFF
--- a/src/EFCore.Design/Design/Internal/DbContextOperations.cs
+++ b/src/EFCore.Design/Design/Internal/DbContextOperations.cs
@@ -104,28 +104,27 @@ public class DbContextOperations
     {
         if (contextType == "*")
         {
-            var contexts = CreateAllContexts();
-
-            if (!contexts.Any())
+            var anyContext = false;
+            
+            foreach(var context in CreateAllContexts())
             {
-                throw new OperationException(DesignStrings.NoContext(_assembly.GetName().Name));
+                anyContext = true;
+                using (context)
+                {
+                    DropDatabase(context, connectionString);
+                }
             }
 
-            foreach(var item in contexts)
+            if (!anyContext)
             {
-                using (item)
-                {
-                    DropDatabaseContext(item, connectionString);
-                }
+                throw new OperationException(DesignStrings.NoContext(_assembly.GetName().Name));
             }
 
             return;
         }
 
-        using (var context = CreateContext(contextType))
-        {
-            DropDatabaseContext(context, connectionString);
-        }
+        using var context = CreateContext(contextType);
+         DropDatabaseContext(context, connectionString);
     }
 
     private void DropDatabaseContext(DbContext context, string? connectionString)

--- a/src/EFCore.Design/Design/Internal/DbContextOperations.cs
+++ b/src/EFCore.Design/Design/Internal/DbContextOperations.cs
@@ -106,12 +106,12 @@ public class DbContextOperations
         {
             var anyContext = false;
             
-            foreach(var context in CreateAllContexts())
+            foreach(var contextItem in CreateAllContexts())
             {
                 anyContext = true;
-                using (context)
+                using (contextItem)
                 {
-                    DropDatabase(context, connectionString);
+                    DropDatabaseContext(contextItem, connectionString);
                 }
             }
 

--- a/src/EFCore.Design/Design/Internal/DbContextOperations.cs
+++ b/src/EFCore.Design/Design/Internal/DbContextOperations.cs
@@ -104,12 +104,33 @@ public class DbContextOperations
     {
         if (contextType == "*")
         {
-            throw new OperationException(DesignStrings.WildcardNotSupported);
+            var contexts = CreateAllContexts();
+
+            if (!contexts.Any())
+            {
+                throw new OperationException(DesignStrings.NoContext(_assembly.GetName().Name));
+            }
+
+            foreach(var item in contexts)
+            {
+                using (item)
+                {
+                    DropDatabaseContext(item, connectionString);
+                }
+            }
+
+            return;
         }
 
-        using var context = CreateContext(contextType);
+        using (var context = CreateContext(contextType))
+        {
+            DropDatabaseContext(context, connectionString);
+        }
+    }
 
-        if (connectionString != null)
+    private void DropDatabaseContext(DbContext context, string? connectionString)
+    {
+        if (connectionString is not null)
         {
             context.Database.SetConnectionString(connectionString);
         }

--- a/src/EFCore.Design/Design/Internal/MigrationsOperations.cs
+++ b/src/EFCore.Design/Design/Internal/MigrationsOperations.cs
@@ -155,31 +155,28 @@ public class MigrationsOperations
     {
         if (contextType == "*")
         {
-            var contexts = _contextOperations.CreateAllContexts();
-
-            if (!contexts.Any())
-            {
-                throw new OperationException(DesignStrings.NoContext(_assembly.GetName().Name));
-            }
-
+            var anyContext = false;
             var contextsList = new List<MigrationInfo>();
-            foreach(var item in contexts)
+
+            foreach(var context in _contextOperations.CreateAllContexts())
             {
-                using (item)
+                anyContext = true;
+                using (context)
                 {
-                    var migrationInfo = GetMigrationsContext(item, connectionString, noConnect);
-                    contextsList.AddRange(migrationInfo);
+                    contextsList.AddRange(GetMigrationsContext(context, connectionString, noConnect));
                 }
             }
 
-            return contextsList;
+            if (!anyContext)
+            {
+                throw new OperationException(DesignStrings.NoContext(_assembly.GetName().Name));
+            }
         }
 
-        using (var context = _contextOperations.CreateContext(contextType))
-        {
+        using var context = _contextOperations.CreateContext(contextType);
+         {
             return GetMigrationsContext(context, connectionString, noConnect);
-        }
-        
+         }
     }
 
     private IEnumerable<MigrationInfo> GetMigrationsContext(DbContext context, string? connectionString, bool noConnect)
@@ -234,30 +231,30 @@ public class MigrationsOperations
     {
         if (contextType == "*")
         {
-            var contexts = _contextOperations.CreateAllContexts();
-
-            if (!contexts.Any())
-            {
-                throw new OperationException(DesignStrings.NoContext(_assembly.GetName().Name));
-            }
-
+            var anyContext = false;
             var stringBuilder = new StringBuilder();
-            foreach (var item in contexts)
+
+            foreach(var context in _contextOperations.CreateAllContexts())
             {
-                using (item)
+                anyContext = true;
+                using (context)
                 {
-                    var script = ScriptMigrationContext(fromMigration, toMigration, options, item);
-                    stringBuilder.Append(script);
+                    stringBuilder.Append(ScriptMigrationContext(fromMigration, toMigration, options, context));
                 }
             }
 
-            return stringBuilder.ToString();
+            if (!anyContext)
+             {
+                 throw new OperationException(DesignStrings.NoContext(_assembly.GetName().Name));
+             }
+
+             return stringBuilder;
         }
 
-        using (var context = _contextOperations.CreateContext(contextType))
-        {
+        using var context = _contextOperations.CreateContext(contextType);
+         {
             return ScriptMigrationContext(fromMigration, toMigration, options, context);
-        }
+         }
     }
 
     private string ScriptMigrationContext(string? fromMigration, string? toMigration, MigrationsSqlGenerationOptions options, DbContext context)

--- a/src/EFCore.Design/Design/Internal/MigrationsOperations.cs
+++ b/src/EFCore.Design/Design/Internal/MigrationsOperations.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Text;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Migrations.Design;
 using Microsoft.EntityFrameworkCore.Migrations.Design.Internal;
@@ -154,12 +155,36 @@ public class MigrationsOperations
     {
         if (contextType == "*")
         {
-            throw new OperationException(DesignStrings.WildcardNotSupported);
+            var contexts = _contextOperations.CreateAllContexts();
+
+            if (!contexts.Any())
+            {
+                throw new OperationException(DesignStrings.NoContext(_assembly.GetName().Name));
+            }
+
+            var contextsList = new List<MigrationInfo>();
+            foreach(var item in contexts)
+            {
+                using (item)
+                {
+                    var migrationInfo = GetMigrationsContext(item, connectionString, noConnect);
+                    contextsList.AddRange(migrationInfo);
+                }
+            }
+
+            return contextsList;
         }
 
-        using var context = _contextOperations.CreateContext(contextType);
+        using (var context = _contextOperations.CreateContext(contextType))
+        {
+            return GetMigrationsContext(context, connectionString, noConnect);
+        }
+        
+    }
 
-        if (connectionString != null)
+    private IEnumerable<MigrationInfo> GetMigrationsContext(DbContext context, string? connectionString, bool noConnect)
+    {
+        if (connectionString is not null)
         {
             context.Database.SetConnectionString(connectionString);
         }
@@ -209,10 +234,34 @@ public class MigrationsOperations
     {
         if (contextType == "*")
         {
-            throw new OperationException(DesignStrings.WildcardNotSupported);
+            var contexts = _contextOperations.CreateAllContexts();
+
+            if (!contexts.Any())
+            {
+                throw new OperationException(DesignStrings.NoContext(_assembly.GetName().Name));
+            }
+
+            var stringBuilder = new StringBuilder();
+            foreach (var item in contexts)
+            {
+                using (item)
+                {
+                    var script = ScriptMigrationContext(fromMigration, toMigration, options, item);
+                    stringBuilder.Append(script);
+                }
+            }
+
+            return stringBuilder.ToString();
         }
 
-        using var context = _contextOperations.CreateContext(contextType);
+        using (var context = _contextOperations.CreateContext(contextType))
+        {
+            return ScriptMigrationContext(fromMigration, toMigration, options, context);
+        }
+    }
+
+    private string ScriptMigrationContext(string? fromMigration, string? toMigration, MigrationsSqlGenerationOptions options, DbContext context)
+    {
         var services = _servicesBuilder.Build(context);
         EnsureServices(services);
 

--- a/src/EFCore.Design/Design/Internal/MigrationsOperations.cs
+++ b/src/EFCore.Design/Design/Internal/MigrationsOperations.cs
@@ -158,12 +158,12 @@ public class MigrationsOperations
             var anyContext = false;
             var contextsList = new List<MigrationInfo>();
 
-            foreach(var context in _contextOperations.CreateAllContexts())
+            foreach(var contextItem in _contextOperations.CreateAllContexts())
             {
                 anyContext = true;
-                using (context)
+                using (contextItem)
                 {
-                    contextsList.AddRange(GetMigrationsContext(context, connectionString, noConnect));
+                    contextsList.AddRange(GetMigrationsContext(contextItem, connectionString, noConnect));
                 }
             }
 
@@ -234,12 +234,12 @@ public class MigrationsOperations
             var anyContext = false;
             var stringBuilder = new StringBuilder();
 
-            foreach(var context in _contextOperations.CreateAllContexts())
+            foreach(var contextItem in _contextOperations.CreateAllContexts())
             {
                 anyContext = true;
-                using (context)
+                using (contextItem)
                 {
-                    stringBuilder.Append(ScriptMigrationContext(fromMigration, toMigration, options, context));
+                    stringBuilder.Append(ScriptMigrationContext(fromMigration, toMigration, options, contextItem));
                 }
             }
 
@@ -248,7 +248,7 @@ public class MigrationsOperations
                  throw new OperationException(DesignStrings.NoContext(_assembly.GetName().Name));
              }
 
-             return stringBuilder;
+             return stringBuilder.ToString();
         }
 
         using var context = _contextOperations.CreateContext(contextType);


### PR DESCRIPTION
Implements wildcard (*) support for contextType in three methods of MigrationsOperations, following the same pattern established in the previous wildcard implementation.

Changes:
- GetMigrations: iterates all contexts and aggregates MigrationInfo results
- ScriptMigration: iterates all contexts and concatenates generated scripts
- DropDatabase: iterates all contexts and drops each database

Not implemented:
- RemoveMigration: wildcard not applicable — the command only supports unapplied migrations, making a wildcard operation semantically ambiguous
- GetContextInfo: current signature returns a single ContextInfo object. Supporting wildcard would require changing the return type to IEnumerable<ContextInfo>, which is a breaking change. Happy to implement if the team decides on the preferred approach. Same for AddMigrations.

Tested manually.

