### PR TITLE
Translate TimeOnly.Hour/Minute/Second on SQLite

### DIFF
--- a/src/EFCore.Sqlite.Core/Query/Internal/Translators/SqliteTimeOnlyMemberTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/Translators/SqliteTimeOnlyMemberTranslator.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+// ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal;
 
 /// <summary>
@@ -9,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public class SqliteMemberTranslatorProvider : RelationalMemberTranslatorProvider
+public class SqliteTimeOnlyMemberTranslator(SqliteSqlExpressionFactory sqlExpressionFactory) : IMemberTranslator
 {
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -17,17 +20,32 @@ public class SqliteMemberTranslatorProvider : RelationalMemberTranslatorProvider
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public SqliteMemberTranslatorProvider(RelationalMemberTranslatorProviderDependencies dependencies)
-        : base(dependencies)
+    public virtual SqlExpression? Translate(
+        SqlExpression? instance,
+        MemberInfo member,
+        Type returnType,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
     {
-        var sqlExpressionFactory = (SqliteSqlExpressionFactory)dependencies.SqlExpressionFactory;
+        if (member.DeclaringType != typeof(TimeOnly) || instance is null)
+        {
+            return null;
+        }
 
-        AddTranslators(
-        [
-            new SqliteDateTimeMemberTranslator(sqlExpressionFactory),
-            new SqliteStringLengthTranslator(sqlExpressionFactory),
-            new SqliteDateOnlyMemberTranslator(sqlExpressionFactory),
-            new SqliteTimeOnlyMemberTranslator(sqlExpressionFactory)
-        ]);
+        return member.Name switch
+        {
+            nameof(TimeOnly.Hour) => DatePart("%H"),
+            nameof(TimeOnly.Minute) => DatePart("%M"),
+            nameof(TimeOnly.Second) => DatePart("%S"),
+
+            _ => null
+        };
+
+        SqlExpression DatePart(string datePart)
+            => sqlExpressionFactory.Convert(
+                sqlExpressionFactory.Strftime(
+                    typeof(string),
+                    datePart,
+                    instance),
+                returnType);
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Translations/Temporal/TimeOnlyTranslationsSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Translations/Temporal/TimeOnlyTranslationsSqliteTest.cs
@@ -14,26 +14,38 @@ public class TimeOnlyTranslationsSqliteTest : TimeOnlyTranslationsTestBase<Basic
 
     public override async Task Hour()
     {
-        // TimeSpan. Issue #18844.
-        await AssertTranslationFailed(() => base.Hour());
+        await base.Hour();
 
-        AssertSql();
+        AssertSql(
+            """
+SELECT "b"."Id", "b"."Bool", "b"."Byte", "b"."ByteArray", "b"."DateOnly", "b"."DateTime", "b"."DateTimeOffset", "b"."Decimal", "b"."Double", "b"."Enum", "b"."FlagsEnum", "b"."Float", "b"."Guid", "b"."Int", "b"."Long", "b"."Short", "b"."String", "b"."TimeOnly", "b"."TimeSpan"
+FROM "BasicTypesEntities" AS "b"
+WHERE CAST(strftime('%H', "b"."TimeOnly") AS INTEGER) = 15
+""");
     }
 
     public override async Task Minute()
     {
-        // TimeSpan. Issue #18844.
-        await AssertTranslationFailed(() => base.Minute());
+        await base.Minute();
 
-        AssertSql();
+        AssertSql(
+            """
+SELECT "b"."Id", "b"."Bool", "b"."Byte", "b"."ByteArray", "b"."DateOnly", "b"."DateTime", "b"."DateTimeOffset", "b"."Decimal", "b"."Double", "b"."Enum", "b"."FlagsEnum", "b"."Float", "b"."Guid", "b"."Int", "b"."Long", "b"."Short", "b"."String", "b"."TimeOnly", "b"."TimeSpan"
+FROM "BasicTypesEntities" AS "b"
+WHERE CAST(strftime('%M', "b"."TimeOnly") AS INTEGER) = 30
+""");
     }
 
     public override async Task Second()
     {
-        // TimeSpan. Issue #18844.
-        await AssertTranslationFailed(() => base.Second());
+        await base.Second();
 
-        AssertSql();
+        AssertSql(
+            """
+SELECT "b"."Id", "b"."Bool", "b"."Byte", "b"."ByteArray", "b"."DateOnly", "b"."DateTime", "b"."DateTimeOffset", "b"."Decimal", "b"."Double", "b"."Enum", "b"."FlagsEnum", "b"."Float", "b"."Guid", "b"."Int", "b"."Long", "b"."Short", "b"."String", "b"."TimeOnly", "b"."TimeSpan"
+FROM "BasicTypesEntities" AS "b"
+WHERE CAST(strftime('%S', "b"."TimeOnly") AS INTEGER) = 10
+""");
     }
 
     public override async Task Millisecond()


### PR DESCRIPTION
Adds SQLite translation for `TimeOnly.Hour`, `TimeOnly.Minute`, and `TimeOnly.Second`, which previously threw *"could not be translated"*.

Since `TimeOnly` is stored as TEXT (`"HH:MM:SS[.fffffff]"`), these map cleanly to `strftime`, mirroring the existing `SqliteDateOnlyMemberTranslator`:

```sql
-- b.TimeOnly.Hour == 15
WHERE CAST(strftime('%H', "b"."TimeOnly") AS INTEGER) = 15
```

This enables the corresponding base tests (`Hour`, `Minute`, `Second`) in `TimeOnlyTranslationsSqliteTest`.

I kept the PR focused on the three integer members that translate without precision concerns. The remaining pieces split naturally into follow-ups:

- Sub-second members (`Millisecond`/`Microsecond`/`Nanosecond`) — need `strftime('%f')` sub-second parsing
- `AddHours`/`AddMinutes` — time modifiers with 24h wrap-around
- `Add(TimeSpan)`/`Subtract`/`FromTimeSpan` — depend on TimeSpan support (#18844)

Part of #25103