### PR TITLE
Translate string.Join/Concat with ordering on SQLite

### DIFF
--- a/src/EFCore.Sqlite.Core/Query/Internal/SqlExpressions/SqliteAggregateFunctionExpression.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqlExpressions/SqliteAggregateFunctionExpression.cs
@@ -1,0 +1,218 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class SqliteAggregateFunctionExpression : SqlExpression
+{
+    private static ConstructorInfo? _quotingConstructor;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqliteAggregateFunctionExpression(
+        string name,
+        IReadOnlyList<SqlExpression> arguments,
+        IReadOnlyList<OrderingExpression> orderings,
+        bool nullable,
+        IEnumerable<bool> argumentsPropagateNullability,
+        Type type,
+        RelationalTypeMapping? typeMapping)
+        : base(type, typeMapping)
+    {
+        Name = name;
+        Arguments = arguments.ToList();
+        Orderings = orderings;
+        IsNullable = nullable;
+        ArgumentsPropagateNullability = argumentsPropagateNullability.ToList();
+    }
+
+    /// <summary>
+    ///     The name of the aggregate SQL function, e.g. <c>group_concat</c>.
+    /// </summary>
+    public virtual string Name { get; }
+
+    /// <summary>
+    ///     The arguments passed to the aggregate function.
+    /// </summary>
+    public virtual IReadOnlyList<SqlExpression> Arguments { get; }
+
+    /// <summary>
+    ///     The orderings applied to the aggregated input, rendered inside the function call as
+    ///     <c>group_concat(value, separator ORDER BY ...)</c>.
+    /// </summary>
+    public virtual IReadOnlyList<OrderingExpression> Orderings { get; }
+
+    /// <summary>
+    ///     Whether the expression is nullable.
+    /// </summary>
+    public virtual bool IsNullable { get; }
+
+    /// <summary>
+    ///     For each argument, whether a <see langword="null" /> value propagates to a <see langword="null" /> result.
+    /// </summary>
+    public virtual IReadOnlyList<bool> ArgumentsPropagateNullability { get; }
+
+    /// <inheritdoc />
+    protected override Expression VisitChildren(ExpressionVisitor visitor)
+    {
+        SqlExpression[]? arguments = null;
+        for (var i = 0; i < Arguments.Count; i++)
+        {
+            var visitedArgument = (SqlExpression)visitor.Visit(Arguments[i]);
+            if (visitedArgument != Arguments[i] && arguments is null)
+            {
+                arguments = new SqlExpression[Arguments.Count];
+
+                for (var j = 0; j < i; j++)
+                {
+                    arguments[j] = Arguments[j];
+                }
+            }
+
+            if (arguments is not null)
+            {
+                arguments[i] = visitedArgument;
+            }
+        }
+
+        OrderingExpression[]? orderings = null;
+        for (var i = 0; i < Orderings.Count; i++)
+        {
+            var visitedOrdering = (OrderingExpression)visitor.Visit(Orderings[i]);
+            if (visitedOrdering != Orderings[i] && orderings is null)
+            {
+                orderings = new OrderingExpression[Orderings.Count];
+
+                for (var j = 0; j < i; j++)
+                {
+                    orderings[j] = Orderings[j];
+                }
+            }
+
+            if (orderings is not null)
+            {
+                orderings[i] = visitedOrdering;
+            }
+        }
+
+        return arguments is not null || orderings is not null
+            ? new SqliteAggregateFunctionExpression(
+                Name,
+                arguments ?? Arguments,
+                orderings ?? Orderings,
+                IsNullable,
+                ArgumentsPropagateNullability,
+                Type,
+                TypeMapping)
+            : this;
+    }
+
+    /// <summary>
+    ///     Applies the given type mapping, returning a new expression.
+    /// </summary>
+    public virtual SqliteAggregateFunctionExpression ApplyTypeMapping(RelationalTypeMapping? typeMapping)
+        => new(
+            Name,
+            Arguments,
+            Orderings,
+            IsNullable,
+            ArgumentsPropagateNullability,
+            Type,
+            typeMapping ?? TypeMapping);
+
+    /// <summary>
+    ///     Returns a new expression with the given arguments and orderings, or this instance if nothing changed.
+    /// </summary>
+    public virtual SqliteAggregateFunctionExpression Update(
+        IReadOnlyList<SqlExpression> arguments,
+        IReadOnlyList<OrderingExpression> orderings)
+        => (ReferenceEquals(arguments, Arguments) || arguments.SequenceEqual(Arguments))
+            && (ReferenceEquals(orderings, Orderings) || orderings.SequenceEqual(Orderings))
+                ? this
+                : new SqliteAggregateFunctionExpression(
+                    Name,
+                    arguments,
+                    orderings,
+                    IsNullable,
+                    ArgumentsPropagateNullability,
+                    Type,
+                    TypeMapping);
+
+    /// <inheritdoc />
+    public override Expression Quote()
+        => New(
+            _quotingConstructor ??= typeof(SqliteAggregateFunctionExpression).GetConstructor(
+            [
+                typeof(string), typeof(IReadOnlyList<SqlExpression>), typeof(IReadOnlyList<OrderingExpression>), typeof(bool),
+                typeof(IEnumerable<bool>), typeof(Type), typeof(RelationalTypeMapping)
+            ])!,
+            Constant(Name),
+            NewArrayInit(typeof(SqlExpression), initializers: Arguments.Select(a => a.Quote())),
+            NewArrayInit(typeof(OrderingExpression), Orderings.Select(o => o.Quote())),
+            Constant(IsNullable),
+            NewArrayInit(typeof(bool), initializers: ArgumentsPropagateNullability.Select(n => Constant(n))),
+            Constant(Type),
+            RelationalExpressionQuotingUtilities.QuoteTypeMapping(TypeMapping));
+
+    /// <inheritdoc />
+    protected override void Print(ExpressionPrinter expressionPrinter)
+    {
+        expressionPrinter.Append(Name);
+
+        expressionPrinter.Append("(");
+        expressionPrinter.VisitCollection(Arguments);
+
+        if (Orderings.Count > 0)
+        {
+            expressionPrinter.Append(" ORDER BY ");
+            expressionPrinter.VisitCollection(Orderings);
+        }
+
+        expressionPrinter.Append(")");
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+        => obj is SqliteAggregateFunctionExpression sqliteAggregateFunctionExpression && Equals(sqliteAggregateFunctionExpression);
+
+    private bool Equals(SqliteAggregateFunctionExpression? other)
+        => ReferenceEquals(this, other)
+            || other is not null
+            && base.Equals(other)
+            && Name == other.Name
+            && Arguments.SequenceEqual(other.Arguments)
+            && Orderings.SequenceEqual(other.Orderings);
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(base.GetHashCode());
+        hash.Add(Name);
+
+        for (var i = 0; i < Arguments.Count; i++)
+        {
+            hash.Add(Arguments[i]);
+        }
+
+        for (var i = 0; i < Orderings.Count; i++)
+        {
+            hash.Add(Orderings[i]);
+        }
+
+        return hash.ToHashCode();
+    }
+}

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteQuerySqlGenerator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteQuerySqlGenerator.cs
@@ -36,6 +36,10 @@ public class SqliteQuerySqlGenerator(QuerySqlGeneratorDependencies dependencies)
                 GenerateJsonEach(jsonEachExpression);
                 return extensionExpression;
 
+            case SqliteAggregateFunctionExpression aggregateFunctionExpression:
+                GenerateAggregateFunction(aggregateFunctionExpression);
+                return extensionExpression;
+
             default:
                 return base.VisitExtension(extensionExpression);
         }
@@ -172,6 +176,40 @@ public class SqliteQuerySqlGenerator(QuerySqlGeneratorDependencies dependencies)
 
         Sql.Append(" REGEXP ");
         Visit(regexpExpression.Pattern);
+    }
+
+    private void GenerateAggregateFunction(SqliteAggregateFunctionExpression aggregateFunctionExpression)
+    {
+        Sql.Append(aggregateFunctionExpression.Name).Append("(");
+
+        for (var i = 0; i < aggregateFunctionExpression.Arguments.Count; i++)
+        {
+            if (i > 0)
+            {
+                Sql.Append(", ");
+            }
+
+            Visit(aggregateFunctionExpression.Arguments[i]);
+        }
+
+        // Unlike SQL Server's "WITHIN GROUP (ORDER BY ...)", SQLite renders the ordering inside the function
+        // parentheses: group_concat(value, separator ORDER BY ...). Supported since SQLite 3.44.0.
+        if (aggregateFunctionExpression.Orderings.Count > 0)
+        {
+            Sql.Append(" ORDER BY ");
+
+            for (var i = 0; i < aggregateFunctionExpression.Orderings.Count; i++)
+            {
+                if (i > 0)
+                {
+                    Sql.Append(", ");
+                }
+
+                Visit(aggregateFunctionExpression.Orderings[i]);
+            }
+        }
+
+        Sql.Append(")");
     }
 
     /// <summary>

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlNullabilityProcessor.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlNullabilityProcessor.cs
@@ -41,6 +41,8 @@ public class SqliteSqlNullabilityProcessor : SqlNullabilityProcessor
         {
             GlobExpression globExpression => VisitGlob(globExpression, allowOptimizedExpansion, out nullable),
             RegexpExpression regexpExpression => VisitRegexp(regexpExpression, allowOptimizedExpansion, out nullable),
+            SqliteAggregateFunctionExpression aggregateFunctionExpression
+                => VisitAggregateFunction(aggregateFunctionExpression, allowOptimizedExpansion, out nullable),
             _ => base.VisitCustomSqlExpression(sqlExpression, allowOptimizedExpansion, out nullable)
         };
 
@@ -82,6 +84,67 @@ public class SqliteSqlNullabilityProcessor : SqlNullabilityProcessor
         nullable = matchNullable || patternNullable;
 
         return regexpExpression.Update(match, pattern);
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected virtual SqlExpression VisitAggregateFunction(
+        SqliteAggregateFunctionExpression aggregateFunctionExpression,
+        bool allowOptimizedExpansion,
+        out bool nullable)
+    {
+        nullable = aggregateFunctionExpression.IsNullable;
+
+        SqlExpression[]? arguments = null;
+        for (var i = 0; i < aggregateFunctionExpression.Arguments.Count; i++)
+        {
+            var visitedArgument = Visit(aggregateFunctionExpression.Arguments[i], out _);
+            if (visitedArgument != aggregateFunctionExpression.Arguments[i] && arguments is null)
+            {
+                arguments = new SqlExpression[aggregateFunctionExpression.Arguments.Count];
+
+                for (var j = 0; j < i; j++)
+                {
+                    arguments[j] = aggregateFunctionExpression.Arguments[j];
+                }
+            }
+
+            if (arguments is not null)
+            {
+                arguments[i] = visitedArgument;
+            }
+        }
+
+        OrderingExpression[]? orderings = null;
+        for (var i = 0; i < aggregateFunctionExpression.Orderings.Count; i++)
+        {
+            var ordering = aggregateFunctionExpression.Orderings[i];
+            var visitedOrdering = ordering.Update(Visit(ordering.Expression, out _));
+            if (visitedOrdering != aggregateFunctionExpression.Orderings[i] && orderings is null)
+            {
+                orderings = new OrderingExpression[aggregateFunctionExpression.Orderings.Count];
+
+                for (var j = 0; j < i; j++)
+                {
+                    orderings[j] = aggregateFunctionExpression.Orderings[j];
+                }
+            }
+
+            if (orderings is not null)
+            {
+                orderings[i] = visitedOrdering;
+            }
+        }
+
+        return arguments is not null || orderings is not null
+            ? aggregateFunctionExpression.Update(
+                arguments ?? aggregateFunctionExpression.Arguments,
+                orderings ?? aggregateFunctionExpression.Orderings)
+            : aggregateFunctionExpression;
     }
 
     /// <inheritdoc />

--- a/src/EFCore.Sqlite.Core/Query/Internal/Translators/SqliteStringAggregateMethodTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/Translators/SqliteStringAggregateMethodTranslator.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 
 // ReSharper disable once CheckNamespace
@@ -14,6 +15,10 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal;
 /// </summary>
 public class SqliteStringAggregateMethodTranslator(ISqlExpressionFactory sqlExpressionFactory) : IAggregateMethodCallTranslator
 {
+    // group_concat supports an in-function ORDER BY clause since SQLite 3.44.0.
+    private readonly bool _isOrderedAggregateSupported
+        = new Version(new SqliteConnection().ServerVersion) >= new Version(3, 44);
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -45,6 +50,15 @@ public class SqliteStringAggregateMethodTranslator(ISqlExpressionFactory sqlExpr
                 break;
             default:
                 return null;
+        }
+
+        // group_concat supports ORDER BY only since SQLite 3.44.0, and combining ORDER BY with DISTINCT is restricted
+        // (valid only when ordering by the distinct value itself). Refuse translation - falling back to client evaluation -
+        // for cases we cannot emit safely.
+        if (source.Orderings.Count > 0
+            && (!_isOrderedAggregateSupported || source.IsDistinct))
+        {
+            return null;
         }
 
         sqlExpression = sqlExpressionFactory.Coalesce(

--- a/src/EFCore.Sqlite.Core/Query/Internal/Translators/SqliteStringAggregateMethodTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/Translators/SqliteStringAggregateMethodTranslator.cs
@@ -47,13 +47,6 @@ public class SqliteStringAggregateMethodTranslator(ISqlExpressionFactory sqlExpr
                 return null;
         }
 
-        // SQLite does not support input ordering on aggregate methods. Since ordering matters very much for translating, if the user
-        // specified an ordering we refuse to translate (but to error than to ignore in this case).
-        if (source.Orderings.Count > 0)
-        {
-            return null;
-        }
-
         sqlExpression = sqlExpressionFactory.Coalesce(
             sqlExpression,
             sqlExpressionFactory.Constant(string.Empty, typeof(string)));
@@ -75,17 +68,33 @@ public class SqliteStringAggregateMethodTranslator(ISqlExpressionFactory sqlExpr
             sqlExpression = new DistinctExpression(sqlExpression);
         }
 
-        // group_concat returns null when there are no rows (or non-null values), but string.Join returns an empty string.
-        return sqlExpressionFactory.Coalesce(
-            sqlExpressionFactory.Function(
+        var functionArguments = new[]
+        {
+            sqlExpression,
+            sqlExpressionFactory.ApplyTypeMapping(separator, sqlExpression.TypeMapping)
+        };
+
+        // SQLite supports ORDER BY inside aggregate functions since 3.44.0: group_concat(value, separator ORDER BY ...).
+        // When the user specified an ordering we emit our custom expression that renders it; otherwise a plain function call.
+        SqlExpression aggregate = source.Orderings.Count == 0
+            ? sqlExpressionFactory.Function(
                 "group_concat",
-                [
-                    sqlExpression,
-                    sqlExpressionFactory.ApplyTypeMapping(separator, sqlExpression.TypeMapping)
-                ],
+                functionArguments,
                 nullable: true,
                 argumentsPropagateNullability: Statics.FalseArrays[2],
-                typeof(string)),
+                typeof(string))
+            : new SqliteAggregateFunctionExpression(
+                "group_concat",
+                functionArguments,
+                source.Orderings,
+                nullable: true,
+                argumentsPropagateNullability: Statics.FalseArrays[2],
+                typeof(string),
+                sqlExpression.TypeMapping);
+
+        // group_concat returns null when there are no rows (or non-null values), but string.Join returns an empty string.
+        return sqlExpressionFactory.Coalesce(
+            aggregate,
             sqlExpressionFactory.Constant(string.Empty, typeof(string)),
             sqlExpression.TypeMapping);
     }

--- a/src/EFCore.Sqlite.Core/Query/Internal/Translators/SqliteStringAggregateMethodTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/Translators/SqliteStringAggregateMethodTranslator.cs
@@ -52,11 +52,12 @@ public class SqliteStringAggregateMethodTranslator(ISqlExpressionFactory sqlExpr
                 return null;
         }
 
-        // group_concat supports ORDER BY only since SQLite 3.44.0, and combining ORDER BY with DISTINCT is restricted
-        // (valid only when ordering by the distinct value itself). Refuse translation - falling back to client evaluation -
-        // for cases we cannot emit safely.
-        if (source.Orderings.Count > 0
-            && (!_isOrderedAggregateSupported || source.IsDistinct))
+        // SQLite's group_concat() accepts only a single argument when DISTINCT is used, so it cannot be combined
+        // with the separator that string.Join/Concat always supply ("DISTINCT aggregates must have exactly one
+        // argument"). In-aggregate ORDER BY additionally requires SQLite 3.44.0. Fall back to client evaluation
+        // rather than emit SQL that fails at execution time.
+        if (source.IsDistinct
+            || (source.Orderings.Count > 0 && !_isOrderedAggregateSupported))
         {
             return null;
         }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Translations/StringTranslationsSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Translations/StringTranslationsSqliteTest.cs
@@ -1418,6 +1418,9 @@ GROUP BY "b"."Int"
 
     public override async Task Join_with_ordering()
     {
+        // group_concat with an ORDER BY clause requires SQLite 3.44.0.
+        Assert.SkipUnless(SqliteTestEnvironment.VersionAtLeast3_44, "Requires SQLite 3.44.0 for ORDER BY in aggregate functions.");
+
         await base.Join_with_ordering();
 
         AssertSql(

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Translations/StringTranslationsSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Translations/StringTranslationsSqliteTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.RegularExpressions;
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
 using Microsoft.EntityFrameworkCore.TestModels.BasicTypesModel;
 
 namespace Microsoft.EntityFrameworkCore.Query.Translations;
@@ -1433,6 +1434,22 @@ GROUP BY "b"."Int"
 
     public override Task Join_non_aggregate()
         => AssertTranslationFailed(() => base.Join_non_aggregate());
+
+    [Fact]
+    public virtual async Task Join_with_distinct()
+    {
+        // SQLite's group_concat() accepts only a single argument when DISTINCT is used, so it cannot be combined
+        // with the separator that string.Join always supplies ("DISTINCT aggregates must have exactly one argument").
+        // We therefore don't translate it; the query then falls back to APPLY, which SQLite does not support.
+        Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => AssertQuery(
+                    ss => ss.Set<BasicTypesEntity>()
+                        .GroupBy(c => c.Int)
+                        .Select(g => new { g.Key, Strings = string.Join("|", g.Select(e => e.String).Distinct()) }),
+                    elementSorter: x => x.Key))).Message);
+    }
 
     #endregion Join
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Translations/StringTranslationsSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Translations/StringTranslationsSqliteTest.cs
@@ -1418,19 +1418,13 @@ GROUP BY "b"."Int"
 
     public override async Task Join_with_ordering()
     {
-        // SQLite does not support input ordering on aggregate methods; the below does client evaluation.
         await base.Join_with_ordering();
 
         AssertSql(
             """
-SELECT "b1"."Int", "b0"."String", "b0"."Id"
-FROM (
-    SELECT "b"."Int"
-    FROM "BasicTypesEntities" AS "b"
-    GROUP BY "b"."Int"
-) AS "b1"
-LEFT JOIN "BasicTypesEntities" AS "b0" ON "b1"."Int" = "b0"."Int"
-ORDER BY "b1"."Int", "b0"."Id" DESC
+SELECT "b"."Int" AS "Key", COALESCE(group_concat("b"."String", '|' ORDER BY "b"."Id" DESC), '') AS "Strings"
+FROM "BasicTypesEntities" AS "b"
+GROUP BY "b"."Int"
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/TestUtilities/SqliteTestEnvironment.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/TestUtilities/SqliteTestEnvironment.cs
@@ -30,4 +30,10 @@ public static class SqliteTestEnvironment
     /// </summary>
     public static bool VersionAtLeast3_35
         => CurrentVersionLazy.Value is { } v && v >= new Version(3, 35, 0);
+
+    /// <summary>
+    ///     SQLite version >= 3.44.0 (required for ORDER BY inside aggregate functions, e.g. group_concat).
+    /// </summary>
+    public static bool VersionAtLeast3_44
+        => CurrentVersionLazy.Value is { } v && v >= new Version(3, 44, 0);
 }


### PR DESCRIPTION
Translates `string.Join`/`string.Concat` over an **ordered** grouping to SQLite's `group_concat` with an `ORDER BY` clause, supported since SQLite 3.44.0. Previously such queries fell back to client evaluation.

```sql
-- string.Join("|", g.OrderByDescending(e => e.Id).Select(e => e.String))
COALESCE(group_concat("b"."String", '|' ORDER BY "b"."Id" DESC), '')
```

### Changes
- Add `SqliteAggregateFunctionExpression` (carries the orderings), mirroring `SqlServerAggregateFunctionExpression`
- `SqliteStringAggregateMethodTranslator`: stop refusing translation when an ordering is present; emit the new expression (plain `group_concat` when there's no ordering — SQL unchanged)
- `SqliteQuerySqlGenerator`: render `group_concat(value, separator ORDER BY ...)`. Note SQLite places the ordering **inside** the parentheses, unlike SQL Server's `WITHIN GROUP`
- `SqliteSqlNullabilityProcessor`: handle the new expression
- Enable `Join_with_ordering` in `StringTranslationsSqliteTest`

### Notes
- Scope is `group_concat` (string aggregation); `ORDER BY` is meaningless for `Min`/`Max`.
- `group_concat(DISTINCT x ORDER BY y)` is restricted in SQLite (DISTINCT + ORDER BY only when ordering by the distinct column); no base test covers this combination.

Fixes #32201