### PR TITLE
Improve relational model integration in Query

### DIFF
--- a/src/EFCore.Relational/EFCore.Relational.baseline.json
+++ b/src/EFCore.Relational/EFCore.Relational.baseline.json
@@ -7323,6 +7323,9 @@
           "Member": "virtual Microsoft.EntityFrameworkCore.Query.JsonQueryExpression BindStructuralProperty(Microsoft.EntityFrameworkCore.Metadata.IPropertyBase structuralProperty);"
         },
         {
+          "Member": "virtual Microsoft.EntityFrameworkCore.Metadata.IRelationalJsonElement? FindJsonElement(Microsoft.EntityFrameworkCore.Metadata.IPropertyBase propertyBase);"
+        },
+        {
           "Member": "override bool Equals(object? obj);"
         },
         {

--- a/src/EFCore.Relational/EFCore.Relational.baseline.json
+++ b/src/EFCore.Relational/EFCore.Relational.baseline.json
@@ -7329,6 +7329,9 @@
           "Member": "override int GetHashCode();"
         },
         {
+          "Member": "virtual Microsoft.EntityFrameworkCore.Metadata.IRelationalJsonElement GetJsonElement(Microsoft.EntityFrameworkCore.Metadata.IPropertyBase propertyBase);"
+        },
+        {
           "Member": "virtual Microsoft.EntityFrameworkCore.Query.JsonQueryExpression MakeNullable();"
         },
         {
@@ -16520,6 +16523,9 @@
           "Member": "static string JsonCantNavigateToParentEntity(object? jsonEntity, object? parentEntity, object? navigation);"
         },
         {
+          "Member": "static string JsonElementMappingNotFound(object? structuralType, object? name, object? columnName);"
+        },
+        {
           "Member": "static string JsonEntityMappedToDifferentColumnThanOwner(object? jsonType, object? containingColumn, object? ownerType, object? ownerContainingColumn);"
         },
         {
@@ -16569,6 +16575,9 @@
         },
         {
           "Member": "static string JsonProjectingQueryableOperationNoTrackingWithIdentityResolution(object? asNoTrackingWithIdentityResolution);"
+        },
+        {
+          "Member": "static string JsonQueryExpressionWithoutUnderlyingColumn(object? structuralType);"
         },
         {
           "Member": "static string JsonRequiredEntityWithNullJson(object? entity);"

--- a/src/EFCore.Relational/Metadata/Internal/RelationalJsonElement.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalJsonElement.cs
@@ -85,13 +85,7 @@ public abstract class RelationalJsonElement : IRelationalJsonElement
     public virtual IReadOnlyList<IJsonElementMapping> PropertyMappings
         => _propertyMappings;
 
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    protected virtual RelationalTypeMapping? GetDefaultStoreTypeMapping()
+    private RelationalTypeMapping? GetDefaultStoreTypeMapping()
     {
         if (PropertyMappings.Select(m => m.Property).OfType<IProperty>().FirstOrDefault()?.GetTypeMapping() is RelationalTypeMapping mapping)
         {

--- a/src/EFCore.Relational/Metadata/Internal/RelationalTypeBaseExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalTypeBaseExtensions.cs
@@ -85,37 +85,49 @@ public static class RelationalTypeBaseExtensions
     }
 
     /// <summary>
-    ///     Returns the entity type's query mappings scoped to the tables actually being projected (when known via
-    ///     <paramref name="tableMap" />); falls back to all query mappings when no projected mapping qualifies. Used by
-    ///     query translation sites that need to pick the principal split-entity table for an entity reference.
+    ///     Returns the entity type's mappings to the tables actually being projected (as given by <paramref name="tableMap" />).
+    ///     Used by query translation sites that need to pick the principal split-entity table for an entity reference.
     /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The mappings are read straight off the projected tables, so this naturally returns the entity's default
+    ///         mapping for FromSql / table-valued-function queries (whose <paramref name="tableMap" /> contains the
+    ///         default table) and its real table/view mapping for ordinary queries, without re-applying the
+    ///         storage-priority logic used by <see cref="GetQueryMappings" />. When <paramref name="tableMap" /> is
+    ///         <see langword="null" /> (the projection is unknown) it falls back to all of the entity's query mappings.
+    ///     </para>
+    ///     <para>
+    ///         This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///         the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///         any release. You should only use it directly in your code with extreme caution and knowing that
+    ///         doing so can result in application failures when updating to a new Entity Framework Core release.
+    ///     </para>
+    /// </remarks>
     /// <param name="entityType">The entity type.</param>
     /// <param name="tableMap">The tables being projected from in the containing query, or <see langword="null" /> when unknown.</param>
-    /// <remarks>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </remarks>
     public static List<ITableMappingBase> GetProjectedQueryMappings(
         this IEntityType entityType,
         IReadOnlyDictionary<ITableBase, string>? tableMap)
     {
-        var allMappings = entityType.GetQueryMappings();
         if (tableMap is null)
         {
-            return [.. allMappings];
+            // The projection isn't known (no table map), so we can't scope to the projected tables; fall back to all of the
+            // entity's query mappings.
+            return [.. entityType.GetQueryMappings()];
         }
 
         var projected = new List<ITableMappingBase>();
-        foreach (var mapping in allMappings)
+        foreach (var table in tableMap.Keys)
         {
-            if (tableMap.ContainsKey(mapping.Table))
+            foreach (var mapping in table.EntityTypeMappings)
             {
-                projected.Add(mapping);
+                if (mapping.TypeBase == entityType)
+                {
+                    projected.Add(mapping);
+                }
             }
         }
 
-        return projected.Count > 0 ? projected : [.. allMappings];
+        return projected;
     }
 }

--- a/src/EFCore.Relational/Metadata/Internal/RelationalTypeBaseExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalTypeBaseExtensions.cs
@@ -14,16 +14,108 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal;
 public static class RelationalTypeBaseExtensions
 {
     /// <summary>
+    ///     Returns the storage mappings the type queries against, in priority order: default SQL query, default function,
+    ///     view, then table. The first non-empty set wins; an empty enumerable means the type has no
+    ///     real (non-default) storage and queries should fall back to default mappings.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Only the "default" function/SQL query mappings (those configured via <c>ToFunction</c>/<c>ToSqlQuery</c>
+    ///         on the entity) participate in the priority; additional <c>HasDbFunction</c>-style mappings remain
+    ///         invocation-only and never shadow the entity's view/table mapping for <c>Set&lt;T&gt;()</c> queries.
+    ///     </para>
+    ///     <para>
+    ///         This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///         the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///         any release. You should only use it directly in your code with extreme caution and knowing that
+    ///         doing so can result in application failures when updating to a new Entity Framework Core release.
+    ///     </para>
+    /// </remarks>
+    public static IEnumerable<ITableMappingBase> GetQueryMappings(this ITypeBase typeBase)
+    {
+        typeBase.Model.EnsureRelationalModel();
+        if (typeBase.FindRuntimeAnnotationValue(RelationalAnnotationNames.SqlQueryMappings) is List<SqlQueryMapping> sqlQueryMappings
+            && GetDefaults(sqlQueryMappings, static m => m.IsDefaultSqlQueryMapping) is { } defaultSqlQueryMappings)
+        {
+            return defaultSqlQueryMappings;
+        }
+
+        if (typeBase.FindRuntimeAnnotationValue(RelationalAnnotationNames.FunctionMappings) is List<FunctionMapping> functionMappings
+            && GetDefaults(functionMappings, static m => m.IsDefaultFunctionMapping) is { } defaultFunctionMappings)
+        {
+            return defaultFunctionMappings;
+        }
+
+        var viewMappings = typeBase.GetViewMappings();
+        return viewMappings.Any() ? viewMappings : typeBase.GetTableMappings();
+
+        static List<T>? GetDefaults<T>(List<T> mappings, Func<T, bool> isDefault)
+        {
+            var count = 0;
+            for (var i = 0; i < mappings.Count; i++)
+            {
+                if (isDefault(mappings[i]))
+                {
+                    count++;
+                }
+            }
+
+            if (count == 0)
+            {
+                return null;
+            }
+
+            if (count == mappings.Count)
+            {
+                return mappings;
+            }
+
+            var defaults = new List<T>(count);
+            for (var i = 0; i < mappings.Count; i++)
+            {
+                var mapping = mappings[i];
+                if (isDefault(mapping))
+                {
+                    defaults.Add(mapping);
+                }
+            }
+
+            return defaults;
+        }
+    }
+
+    /// <summary>
+    ///     Returns the entity type's query mappings scoped to the tables actually being projected (when known via
+    ///     <paramref name="tableMap" />); falls back to all query mappings when no projected mapping qualifies. Used by
+    ///     query translation sites that need to pick the principal split-entity table for an entity reference.
+    /// </summary>
+    /// <param name="entityType">The entity type.</param>
+    /// <param name="tableMap">The tables being projected from in the containing query, or <see langword="null" /> when unknown.</param>
+    /// <remarks>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public static IEnumerable<ITableMappingBase> GetViewOrTableMappings(this ITypeBase typeBase)
+    /// </remarks>
+    public static List<ITableMappingBase> GetProjectedQueryMappings(
+        this IEntityType entityType,
+        IReadOnlyDictionary<ITableBase, string>? tableMap)
     {
-        typeBase.Model.EnsureRelationalModel();
-        var viewMapping = typeBase.FindRuntimeAnnotationValue(RelationalAnnotationNames.ViewMappings);
-        var tableMapping = typeBase.FindRuntimeAnnotationValue(RelationalAnnotationNames.TableMappings);
-        return (IEnumerable<ITableMappingBase>?)(viewMapping ?? tableMapping) ?? [];
+        var allMappings = entityType.GetQueryMappings();
+        if (tableMap is null)
+        {
+            return [.. allMappings];
+        }
+
+        var projected = new List<ITableMappingBase>();
+        foreach (var mapping in allMappings)
+        {
+            if (tableMap.ContainsKey(mapping.Table))
+            {
+                projected.Add(mapping);
+            }
+        }
+
+        return projected.Count > 0 ? projected : [.. allMappings];
     }
 }

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -1210,6 +1210,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 jsonEntity, parentEntity, navigation);
 
         /// <summary>
+        ///     No JSON element mapping was found for '{structuralType}.{name}' on column '{columnName}'.
+        /// </summary>
+        public static string JsonElementMappingNotFound(object? structuralType, object? name, object? columnName)
+            => string.Format(
+                GetString("JsonElementMappingNotFound", nameof(structuralType), nameof(name), nameof(columnName)),
+                structuralType, name, columnName);
+
+        /// <summary>
         ///     The database returned the empty string when a JSON object was expected.
         /// </summary>
         public static string JsonEmptyString
@@ -1380,6 +1388,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         public static string JsonPropertyNameShouldBeConfiguredOnNestedNavigation
             => GetString("JsonPropertyNameShouldBeConfiguredOnNestedNavigation");
+
+        /// <summary>
+        ///     The JSON query expression for '{structuralType}' has no underlying column.
+        /// </summary>
+        public static string JsonQueryExpressionWithoutUnderlyingColumn(object? structuralType)
+            => string.Format(
+                GetString("JsonQueryExpressionWithoutUnderlyingColumn", nameof(structuralType)),
+                structuralType);
 
         /// <summary>
         ///     Composing LINQ operators over collections inside JSON documents isn't supported or hasn't been implemented by your EF provider.

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -574,6 +574,9 @@
   <data name="JsonCantNavigateToParentEntity" xml:space="preserve">
     <value>Navigation from JSON-mapped entity '{jsonEntity}' to its parent entity '{parentEntity}' using navigation '{navigation}' is not supported. Entities mapped to JSON can only navigate to their children.</value>
   </data>
+  <data name="JsonElementMappingNotFound" xml:space="preserve">
+    <value>No JSON element mapping was found for '{structuralType}.{name}' on column '{columnName}'.</value>
+  </data>
   <data name="JsonEmptyString" xml:space="preserve">
     <value>The database returned the empty string when a JSON object was expected.</value>
   </data>
@@ -642,6 +645,9 @@
   </data>
   <data name="JsonPropertyNameShouldBeConfiguredOnNestedNavigation" xml:space="preserve">
     <value>The JSON property name should only be configured on nested owned navigations.</value>
+  </data>
+  <data name="JsonQueryExpressionWithoutUnderlyingColumn" xml:space="preserve">
+    <value>The JSON query expression for '{structuralType}' has no underlying column.</value>
   </data>
   <data name="JsonQueryLinqOperatorsNotSupported" xml:space="preserve">
     <value>Composing LINQ operators over collections inside JSON documents isn't supported or hasn't been implemented by your EF provider.</value>

--- a/src/EFCore.Relational/Query/Internal/JsonProjectionInfo.cs
+++ b/src/EFCore.Relational/Query/Internal/JsonProjectionInfo.cs
@@ -19,10 +19,12 @@ public readonly struct JsonProjectionInfo
     /// </summary>
     public JsonProjectionInfo(
         int jsonColumnIndex,
-        List<(IProperty?, int?, int?)> keyAccessInfo)
+        List<(IProperty?, int?, int?)> keyAccessInfo,
+        IColumnBase? jsonColumn = null)
     {
         JsonColumnIndex = jsonColumnIndex;
         KeyAccessInfo = keyAccessInfo;
+        JsonColumn = jsonColumn;
     }
 
     /// <summary>
@@ -52,4 +54,16 @@ public readonly struct JsonProjectionInfo
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </remarks>
     public List<(IProperty? KeyProperty, int? ConstantKeyValue, int? KeyProjectionIndex)> KeyAccessInfo { get; }
+
+    /// <summary>
+    ///     The relational-model column containing the JSON document, or null when this projection was built from
+    ///     a synthetic JSON expansion (OPENJSON / json_each) that has no underlying IColumnBase.
+    /// </summary>
+    /// <remarks>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </remarks>
+    public IColumnBase? JsonColumn { get; }
 }

--- a/src/EFCore.Relational/Query/JsonQueryExpression.cs
+++ b/src/EFCore.Relational/Query/JsonQueryExpression.cs
@@ -201,7 +201,7 @@ public class JsonQueryExpression : Expression, IPrintableExpression
             {
                 if (StructuralType is not IComplexType complexType)
                 {
-                    throw new UnreachableException("Navigation on complex JSON type");
+                    throw new UnreachableException("Non-root complex property on entity type");
                 }
 
                 Check.DebugAssert(KeyPropertyMap is null);
@@ -221,7 +221,7 @@ public class JsonQueryExpression : Expression, IPrintableExpression
             }
 
             default:
-                throw new UnreachableException();
+                throw new UnreachableException("Unexpected structural property type.");
         }
     }
 

--- a/src/EFCore.Relational/Query/JsonQueryExpression.cs
+++ b/src/EFCore.Relational/Query/JsonQueryExpression.cs
@@ -308,8 +308,7 @@ public class JsonQueryExpression : Expression, IPrintableExpression
     {
         var column = JsonColumn.Column
             ?? throw new InvalidOperationException(
-                RelationalStrings.JsonQueryExpressionWithoutUnderlyingColumn(propertyBase.DeclaringType.DisplayName()));
-
+                RelationalStrings.JsonQueryExpressionWithoutUnderlyingColumn(StructuralType.DisplayName()));
         return FindJsonElement(propertyBase)
             ?? throw new InvalidOperationException(
                 RelationalStrings.JsonElementMappingNotFound(propertyBase.DeclaringType.DisplayName(), propertyBase.Name, column.Name));

--- a/src/EFCore.Relational/Query/JsonQueryExpression.cs
+++ b/src/EFCore.Relational/Query/JsonQueryExpression.cs
@@ -310,16 +310,38 @@ public class JsonQueryExpression : Expression, IPrintableExpression
             ?? throw new InvalidOperationException(
                 RelationalStrings.JsonQueryExpressionWithoutUnderlyingColumn(propertyBase.DeclaringType.DisplayName()));
 
+        return FindJsonElement(propertyBase)
+            ?? throw new InvalidOperationException(
+                RelationalStrings.JsonElementMappingNotFound(propertyBase.DeclaringType.DisplayName(), propertyBase.Name, column.Name));
+    }
+
+    /// <summary>
+    ///     Finds the <see cref="IRelationalJsonElement" /> for the given property/navigation/complex property within the
+    ///     JSON column referenced by this expression by matching <see cref="JsonColumn" />'s underlying
+    ///     <see cref="ColumnExpression.Column" /> against <see cref="IRelationalJsonElement.ContainingColumn" />, or returns
+    ///     <see langword="null" /> if no such element exists (including when <see cref="JsonColumn" /> has no underlying
+    ///     <see cref="ColumnExpression.Column" />, e.g. for synthetic JSON expansions over OPENJSON / json_each, or for
+    ///     iterated properties such as shadow keys that have no JSON representation).
+    /// </summary>
+    /// <param name="propertyBase">The property, navigation or complex property to look up.</param>
+    /// <returns>The JSON element mapping for <paramref name="propertyBase" />, or <see langword="null" /> if not found.</returns>
+    public virtual IRelationalJsonElement? FindJsonElement(IPropertyBase propertyBase)
+    {
+        var containingColumn = JsonColumn.Column;
+        if (containingColumn is null)
+        {
+            return null;
+        }
+
         foreach (var mapping in propertyBase.GetJsonElementMappings())
         {
-            if (ReferenceEquals(mapping.Element.ContainingColumn, column))
+            if (ReferenceEquals(mapping.Element.ContainingColumn, containingColumn))
             {
                 return mapping.Element;
             }
         }
 
-        throw new InvalidOperationException(
-            RelationalStrings.JsonElementMappingNotFound(propertyBase.DeclaringType.DisplayName(), propertyBase.Name, column.Name));
+        return null;
     }
 
     /// <summary>

--- a/src/EFCore.Relational/Query/JsonQueryExpression.cs
+++ b/src/EFCore.Relational/Query/JsonQueryExpression.cs
@@ -137,11 +137,13 @@ public class JsonQueryExpression : Expression, IPrintableExpression
             return match;
         }
 
+        var element = GetJsonElement(property);
+
         return new JsonScalarExpression(
             JsonColumn,
-            [.. Path, new PathSegment(property.GetJsonPropertyName()!)],
+            [.. Path, new PathSegment(element.PropertyName!)],
             property.ClrType.UnwrapNullableType(),
-            property.FindRelationalTypeMapping()!,
+            element.StoreTypeMapping!,
             IsNullable || property.IsNullable);
     }
 
@@ -175,7 +177,7 @@ public class JsonQueryExpression : Expression, IPrintableExpression
 
                 var targetEntityType = navigation.TargetEntityType;
                 var newPath = Path.ToList();
-                newPath.Add(new PathSegment(targetEntityType.GetJsonPropertyName()!));
+                newPath.Add(new PathSegment(GetJsonElement(navigation).PropertyName!));
 
                 var newKeyPropertyMap = new Dictionary<IProperty, ColumnExpression>();
                 var targetPrimaryKeyProperties = targetEntityType.FindPrimaryKey()!.Properties.Take(KeyPropertyMap.Count);
@@ -206,7 +208,7 @@ public class JsonQueryExpression : Expression, IPrintableExpression
 
                 var targetComplexType = complexProperty.ComplexType;
                 var newPath = Path.ToList();
-                newPath.Add(new PathSegment(targetComplexType.GetJsonPropertyName()!));
+                newPath.Add(new PathSegment(GetJsonElement(complexProperty).PropertyName!));
 
                 return new JsonQueryExpression(
                     targetComplexType,
@@ -288,6 +290,36 @@ public class JsonQueryExpression : Expression, IPrintableExpression
         }
 
         return Update(jsonColumn, newKeyPropertyMap);
+    }
+
+    /// <summary>
+    ///     Finds the <see cref="IRelationalJsonElement" /> for the given property/navigation/complex property within the
+    ///     JSON column referenced by this expression by matching <see cref="JsonColumn" />'s underlying
+    ///     <see cref="ColumnExpression.Column" /> against <see cref="IRelationalJsonElement.ContainingColumn" />. This
+    ///     disambiguates entity-splitting, TPT and TPC scenarios where the same property has multiple JSON element
+    ///     mappings — one per concrete table.
+    ///     <see cref="IRelationalJsonElement.PropertyName" /> may be <see langword="null" /> for shadow keys that have
+    ///     no JSON representation; callers iterating over <see cref="ITypeBase.GetProperties" /> must handle that case
+    ///     and skip them.
+    /// </summary>
+    /// <param name="propertyBase">The property, navigation or complex property to look up.</param>
+    /// <returns>The JSON element mapping for <paramref name="propertyBase" />.</returns>
+    public virtual IRelationalJsonElement GetJsonElement(IPropertyBase propertyBase)
+    {
+        var column = JsonColumn.Column
+            ?? throw new InvalidOperationException(
+                RelationalStrings.JsonQueryExpressionWithoutUnderlyingColumn(propertyBase.DeclaringType.DisplayName()));
+
+        foreach (var mapping in propertyBase.GetJsonElementMappings())
+        {
+            if (ReferenceEquals(mapping.Element.ContainingColumn, column))
+            {
+                return mapping.Element;
+            }
+        }
+
+        throw new InvalidOperationException(
+            RelationalStrings.JsonElementMappingNotFound(propertyBase.DeclaringType.DisplayName(), propertyBase.Name, column.Name));
     }
 
     /// <summary>

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.CreateSelect.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.CreateSelect.cs
@@ -296,7 +296,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
                             {
                                 IProperty p => table.FindColumn(p),
                                 IComplexProperty p => p.ComplexType.GetContainerColumnName() is string columnName ? table.FindColumn(columnName) : null,
-                                _ => throw new UnreachableException()
+                                _ => throw new UnreachableException("Unexpected property type when building TPC union projection.")
                             };
 
                             Debug.Assert(column is not null, "Column not found for property " + property.Name);
@@ -439,7 +439,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
                 }
 
                 default:
-                    throw new UnreachableException();
+                    throw new UnreachableException("Unexpected mapping strategy.");
             }
 
             static ITableBase GetTableBaseFiltered(IEntityType entityType, Dictionary<ITableBase, string> existingTables)
@@ -733,7 +733,9 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
             // Find the containing column for the owned JSON entity type, and then the table in the table map that
             // contains that column.
             var targetEntityType = ownedJsonNavigation.TargetEntityType;
-            var containerColumnName = targetEntityType.GetContainerColumnName() ?? throw new UnreachableException();
+            var containerColumnName = targetEntityType.GetContainerColumnName()
+                ?? throw new UnreachableException(
+                    $"JSON-mapped entity type '{targetEntityType.DisplayName()}' without a container column name.");
             var (containerColumn, tableAlias) = tableMap
                 .Select(kvp => (Column: kvp.Key.FindColumn(containerColumnName), TableAlias: kvp.Value))
                 .SingleOrDefault(c => c.Column is not null);

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.CreateSelect.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.CreateSelect.cs
@@ -114,7 +114,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
                             _sqlExpressionFactory.Case(caseWhenClauses, elseResult: null));
 
                     var projection = new StructuralTypeProjectionExpression(
-                        entityType, propertyMap, complexPropertyMap, nullable: false, discriminatorExpression);
+                        entityType, propertyMap, complexPropertyMap, nullable: false, discriminatorExpression, tableMap);
 
                     return new SelectExpression(tables, projection, identifier, _sqlAliasManager);
                 }
@@ -128,7 +128,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
                     // (no UNION needed, no discriminator needed)
                     if (concreteEntityTypes is [var singleEntityType])
                     {
-                        var table = singleEntityType.GetViewOrTableMappings().Single().Table;
+                        var table = singleEntityType.GetQueryMappings().Single().Table;
                         var alias = _sqlAliasManager.GenerateTableAlias(table);
                         var tableExpression = new TableExpression(alias, table);
 
@@ -152,7 +152,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
 
                     foreach (var concreteEntityType in concreteEntityTypes)
                     {
-                        var table = concreteEntityType.GetViewOrTableMappings().Single().Table;
+                        var table = concreteEntityType.GetQueryMappings().Single().Table;
 
                         foreach (var currentType in concreteEntityType.GetAllBaseTypesInclusive())
                         {
@@ -232,7 +232,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
 
                                     var shaper = GenerateComplexJsonShaper(
                                         complexProperty,
-                                        containerColumn: null,
+                                        containerColumn,
                                         projectedColumnName,
                                         containerColumn.ProviderClrType,
                                         containerColumn.StoreTypeMapping,
@@ -272,7 +272,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
                     var discriminatorValues = new List<string>(concreteEntityTypes.Length);
                     foreach (var concreteEntityType in concreteEntityTypes)
                     {
-                        var table = concreteEntityType.GetViewOrTableMappings().Single().Table;
+                        var table = concreteEntityType.GetQueryMappings().Single().Table;
                         var tableAlias = _sqlAliasManager.GenerateTableAlias(table);
                         var tableExpression = new TableExpression(tableAlias, table);
 
@@ -303,12 +303,15 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
 
                             // Note that the projected name may differ from the column name on the entity's concrete table because of
                             // uniquification (i.e. two TPC entities in the same hierarchy have two properties mapped columns with the
-                            // same name)
+                            // same name).
+                            // The per-table IColumnBase flows through the inner projection so the outer union column carries a
+                            // model-column reference.
                             projections.Add(
                                 new ProjectionExpression(
                                     new ColumnExpression(
                                         column.Name,
                                         tableAlias,
+                                        column,
                                         column.ProviderClrType.UnwrapNullableType(),
                                         column.StoreTypeMapping,
                                         column.IsNullable),
@@ -338,9 +341,17 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
                     var tpcTablesExpression = new TpcTablesExpression(
                         tpcTableAlias, entityType, subSelectExpressions, discriminatorColumn, discriminatorValues);
 
+                    // Every concrete TPC table is projected through the union's outer alias.
+                    var tpcTableMap = new Dictionary<ITableBase, string>(concreteEntityTypes.Length);
+                    foreach (var concreteEntityType in concreteEntityTypes)
+                    {
+                        tpcTableMap[concreteEntityType.GetQueryMappings().Single().Table] = tpcTableAlias;
+                    }
+
                     return new SelectExpression(
                         [tpcTablesExpression],
-                        new StructuralTypeProjectionExpression(entityType, propertyMap, complexPropertyMap, nullable: false, discriminatorColumn),
+                        new StructuralTypeProjectionExpression(
+                            entityType, propertyMap, complexPropertyMap, nullable: false, discriminatorColumn, tpcTableMap),
                         identifier,
                         _sqlAliasManager);
                 }
@@ -357,7 +368,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
                             entityType, storeFunction, new TableValuedFunctionExpression(alias, (IStoreFunction)storeFunction, []));
                     }
 
-                    var mappings = entityType.GetViewOrTableMappings().ToList();
+                    var mappings = entityType.GetQueryMappings().ToList();
                     if (mappings is [{ Table: var singleTable }])
                     {
                         var alias = _sqlAliasManager.GenerateTableAlias(singleTable);
@@ -417,11 +428,11 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
                     var complexPropertyMap = new Dictionary<IComplexProperty, Expression>();
                     foreach (var complexProperty in entityType.GetComplexProperties())
                     {
-                        var table = complexProperty.ComplexType.GetViewOrTableMappings().Single().Table;
+                        var table = complexProperty.ComplexType.GetQueryMappings().Single().Table;
                         complexPropertyMap[complexProperty] = ProcessComplexProperty(complexProperty, table, tableMap[table], containerNullable: false);
                     }
 
-                    var projection = new StructuralTypeProjectionExpression(entityType, propertyMap, complexPropertyMap);
+                    var projection = new StructuralTypeProjectionExpression(entityType, propertyMap, complexPropertyMap, tableMap: tableMap);
                     AddJsonNavigationBindings(entityType, projection, propertyMap, tableMap);
 
                     return new SelectExpression(tables, projection, identifier, _sqlAliasManager);
@@ -432,7 +443,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
             }
 
             static ITableBase GetTableBaseFiltered(IEntityType entityType, Dictionary<ITableBase, string> existingTables)
-                => entityType.GetViewOrTableMappings().Single(m => !existingTables.ContainsKey(m.Table)).Table;
+                => entityType.GetQueryMappings().Single(m => !existingTables.ContainsKey(m.Table)).Table;
         }
     }
 
@@ -454,7 +465,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
         }
 
         var tableMap = new Dictionary<ITableBase, string> { [table] = alias };
-        var projection = new StructuralTypeProjectionExpression(entityType, propertyMap, complexPropertyMap);
+        var projection = new StructuralTypeProjectionExpression(entityType, propertyMap, complexPropertyMap, tableMap: tableMap);
         AddJsonNavigationBindings(entityType, projection, propertyMap, tableMap);
 
         var identifier = new List<(ColumnExpression Column, ValueComparer Comparer)>();
@@ -739,6 +750,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
             var column = new ColumnExpression(
                 containerColumnName,
                 tableAlias,
+                containerColumn,
                 containerColumnTypeMapping.ClrType,
                 containerColumnTypeMapping,
                 isNullable);
@@ -810,13 +822,15 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
                 continue;
             }
 
-            // Skip also properties with no JSON name (i.e. shadow keys containing the index in the collection, which don't actually exist
+            // Skip properties with no JSON name (i.e. shadow keys containing the index in the collection, which don't actually exist
             // in the JSON document and can't be bound to)
-            if (property.GetJsonPropertyName() is { } jsonPropertyName)
+            var element = jsonQueryExpression.GetJsonElement(property);
+            if (element.PropertyName is { } jsonPropertyName)
             {
                 propertyExpressions[property] = CreateColumnExpression(
-                    tableExpressionBase, jsonPropertyName, property.ClrType, property.GetRelationalTypeMapping(),
-                    /* jsonQueryExpression.IsNullable || */ property.IsNullable); // TODO:
+                    tableExpressionBase, jsonPropertyName, property.ClrType,
+                    element.StoreTypeMapping!,
+                    /* jsonQueryExpression.IsNullable || */ property.IsNullable); // TODO: Issue #28887
             }
         }
 
@@ -830,9 +844,12 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
             var isNullable = jsonQueryExpression.IsNullable || complexProperty.IsNullable;
 
             var containerColumnExpression = new ColumnExpression(
-                complexType.GetJsonPropertyName()
-                ?? throw new UnreachableException($"No JSON property name for complex property {complexProperty.Name}"),
+                jsonQueryExpression.GetJsonElement(complexProperty).PropertyName
+                    ?? throw new UnreachableException($"No JSON property name for complex property {complexProperty.Name}"),
                 tableAlias,
+                // Nested container projects a sub-document of the same underlying JSON column, so preserve the model column
+                // for downstream FindJsonElement matching.
+                jsonColumn.Column,
                 jsonColumn.Type,
                 jsonColumn.TypeMapping,
                 isNullable);
@@ -860,7 +877,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
                              && n.ForeignKey.PrincipalToDependent == n))
             {
                 var targetEntityType = ownedJsonNavigation.TargetEntityType;
-                var jsonNavigationName = ownedJsonNavigation.TargetEntityType.GetJsonPropertyName();
+                var jsonNavigationName = jsonQueryExpression.GetJsonElement(ownedJsonNavigation).PropertyName;
                 Check.DebugAssert(jsonNavigationName is not null, "Invalid navigation found on JSON-mapped entity");
                 var isNullable = jsonQueryExpression.IsNullable
                     || !ownedJsonNavigation.ForeignKey.IsRequiredDependent
@@ -868,7 +885,9 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
 
                 // The TableExpressionBase represents a relational expansion of the JSON collection. We now need a ColumnExpression to represent
                 // the specific JSON property (projected as a relational column) which holds the JSON subtree for the target entity.
-                var column = new ColumnExpression(jsonNavigationName, tableAlias, jsonColumn.Type, jsonColumn.TypeMapping, isNullable);
+                // Pass the underlying model column through so FindJsonElement matches for properties of the nested entity.
+                var column = new ColumnExpression(
+                    jsonNavigationName, tableAlias, jsonColumn.Column, jsonColumn.Type, jsonColumn.TypeMapping, isNullable);
 
                 // need to remap key property map to use target entity key properties
                 var newKeyPropertyMap = new Dictionary<IProperty, ColumnExpression>();

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.CreateSelect.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.CreateSelect.cs
@@ -304,8 +304,8 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
                             // Note that the projected name may differ from the column name on the entity's concrete table because of
                             // uniquification (i.e. two TPC entities in the same hierarchy have two properties mapped columns with the
                             // same name).
-                            // The per-table IColumnBase flows through the inner projection so the outer union column carries a
-                            // model-column reference.
+                            // Each union arm's column references its own concrete table's model column; the outer union column
+                            // (created separately over the union alias) references no single model column and has a null Column.
                             projections.Add(
                                 new ProjectionExpression(
                                     new ColumnExpression(

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.ExecuteUpdate.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.ExecuteUpdate.cs
@@ -468,11 +468,11 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
                         {
                             // Find the container column in the relational model to get its type mapping
                             // Note that we assume exactly one column with the given name mapped to the entity (despite entity splitting).
-                            // See #38060 about improving this.
+                            // See #28520 about improving this.
                             var containerColumnName = complexType.GetContainerColumnName();
                             if (containerColumnName != null)
                             {
-                                targetColumnModel = complexType.ContainingEntityType.GetTableMappings()
+                                targetColumnModel = complexType.GetTableMappings()
                                     .Select(m => m.Table.FindColumn(containerColumnName))
                                     .SingleOrDefault(c => c is not null);
                             }

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -160,6 +160,8 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor : Que
                 && entityQueryRootExpression.EntityType.GetSqlQueryMappings().FirstOrDefault(m => m.IsDefaultSqlQueryMapping)?.SqlQuery is
                     { } sqlQuery:
             {
+                // TODO: Use the SqlQuery directly instead of the default mapping once hierarchy support is implemented.
+                // Issue #21660
                 var table = entityQueryRootExpression.EntityType.GetDefaultMappings().Single().Table;
                 var alias = _sqlAliasManager.GenerateTableAlias(table);
 

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
@@ -2555,15 +2555,18 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             }
         }
 
-        internal ParameterExpression GenerateJsonReader(int jsonColumnIndex, ITypeBase structuralType)
+        internal ParameterExpression GenerateJsonReader(int jsonColumnIndex, ITypeBase structuralType, IColumnBase? jsonColumn = null)
         {
             Check.DebugAssert(structuralType.IsMappedToJson());
 
-            var jsonColumnName = structuralType.GetContainerColumnName()!;
-            var jsonColumn = structuralType.ContainingEntityType.GetViewOrTableMappings()
-                .Select(m => m.Table.FindColumn(jsonColumnName))
-                .FirstOrDefault(c => c is not null)
-               ?? throw new UnreachableException($"Could not find JSON container column '{jsonColumnName}' for entity type '{structuralType.DisplayName()}'.");
+            if (jsonColumn is null)
+            {
+                var jsonColumnName = structuralType.GetContainerColumnName()!;
+                jsonColumn = structuralType.ContainingEntityType.GetQueryMappings()
+                    .Select(m => m.Table.FindColumn(jsonColumnName))
+                    .FirstOrDefault(c => c is not null)
+                    ?? throw new UnreachableException($"Could not find JSON container column '{jsonColumnName}' for entity type '{structuralType.DisplayName()}'.");
+            }
 
             var jsonColumnTypeMapping = jsonColumn.StoreTypeMapping;
 
@@ -2624,7 +2627,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             ITypeBase structuralType,
             bool isCollection)
         {
-            var jsonReaderDataVariable = GenerateJsonReader(jsonProjectionInfo.JsonColumnIndex, structuralType);
+            var jsonReaderDataVariable = GenerateJsonReader(jsonProjectionInfo.JsonColumnIndex, structuralType, jsonProjectionInfo.JsonColumn);
 
             // we should have keyAccessInfo for every PK property of the entity, unless we are generating shaper for the collection
             // in that case the final key property will be synthesized in the shaper code

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.StructuralEquality.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.StructuralEquality.cs
@@ -159,7 +159,9 @@ public partial class RelationalSqlTranslatingExpressionVisitor
                 if (nullComparedEntityType.GetRootType() == nullComparedEntityType
                     && nullComparedEntityType.GetMappingStrategy() != RelationalAnnotationNames.TpcMappingStrategy)
                 {
-                    var table = nullComparedEntityType.GetViewOrTableMappings().ToList() switch
+                    // Scope to actually-projected tables when known (entity-splitting).
+                    var tableMap = (nonNullEntityReference.Parameter?.ValueBufferExpression as StructuralTypeProjectionExpression)?.TableMap;
+                    var table = nullComparedEntityType.GetProjectedQueryMappings(tableMap) switch
                     {
                         [var singleMapping] => singleMapping.Table,
 

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -1291,8 +1291,9 @@ public partial class RelationalSqlTranslatingExpressionVisitor : ExpressionVisit
                     return propertyAccess;
                 }
 
-                var table = entityType.GetViewOrTableMappings().SingleOrDefault(e => e.IsSplitEntityTypePrincipal ?? true)?.Table
-                    ?? entityType.GetDefaultMappings().Single().Table;
+                // Scope to actually-projected tables when known (entity-splitting).
+                var table = entityType.GetProjectedQueryMappings(projection.TableMap)
+                    .Single(e => e.IsSplitEntityTypePrincipal ?? true).Table;
                 if (!table.IsOptional(entityType))
                 {
                     return propertyAccess;

--- a/src/EFCore.Relational/Query/RelationalStructuralTypeShaperExpression.cs
+++ b/src/EFCore.Relational/Query/RelationalStructuralTypeShaperExpression.cs
@@ -103,8 +103,9 @@ public class RelationalStructuralTypeShaperExpression : StructuralTypeShaperExpr
             return baseCondition;
         }
 
-        var table = entityType.GetViewOrTableMappings().SingleOrDefault(e => e.IsSplitEntityTypePrincipal ?? true)?.Table
-            ?? entityType.GetDefaultMappings().Single().Table;
+        var tableMap = (ValueBufferExpression as StructuralTypeProjectionExpression)?.TableMap;
+        var table = entityType.GetProjectedQueryMappings(tableMap)
+            .Single(e => e.IsSplitEntityTypePrincipal ?? true).Table;
         if (table.IsOptional(entityType))
         {
             // Optional dependent

--- a/src/EFCore.Relational/Query/SqlExpressions/ColumnExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/ColumnExpression.cs
@@ -88,7 +88,7 @@ public class ColumnExpression : SqlExpression
     /// </summary>
     /// <returns>A new expression which has <see cref="IsNullable" /> property set to true.</returns>
     public virtual ColumnExpression MakeNullable()
-        => IsNullable ? this : new ColumnExpression(Name, TableAlias, Type, TypeMapping, true);
+        => IsNullable ? this : new ColumnExpression(Name, TableAlias, Column, Type, TypeMapping, true);
 
     /// <summary>
     ///     Applies supplied type mapping to this expression.
@@ -96,7 +96,7 @@ public class ColumnExpression : SqlExpression
     /// <param name="typeMapping">A relational type mapping to apply.</param>
     /// <returns>A new expression which has supplied type mapping.</returns>
     public virtual SqlExpression ApplyTypeMapping(RelationalTypeMapping? typeMapping)
-        => new ColumnExpression(Name, TableAlias, Type, typeMapping, IsNullable);
+        => new ColumnExpression(Name, TableAlias, Column, Type, typeMapping, IsNullable);
 
     /// <inheritdoc />
     public override Expression Quote()

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.Helper.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.Helper.cs
@@ -360,7 +360,7 @@ public sealed partial class SelectExpression
                 }
 
                 case ColumnExpression column when _tableAliasMap.TryGetValue(column.TableAlias, out var newTableAlias):
-                    return new ColumnExpression(column.Name, newTableAlias, column.Type, column.TypeMapping, column.IsNullable);
+                    return new ColumnExpression(column.Name, newTableAlias, column.Column, column.Type, column.TypeMapping, column.IsNullable);
 
                 default:
                     return base.Visit(expression);

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -1286,10 +1286,13 @@ public sealed partial class SelectExpression : TableExpressionBase
                                         keyProjectionIndex != null ? projectionIndexMap[keyProjectionIndex.Value] : null));
                             }
 
+                            // The outer projection still references the same underlying JSON column; only the
+                            // index into the outer projection changes, so preserve JsonColumn for the shaper.
                             remappedConstant = Constant(
                                 new JsonProjectionInfo(
                                     projectionIndexMap[jsonProjectionInfo.JsonColumnIndex],
-                                    newKeyAccessInfo));
+                                    newKeyAccessInfo,
+                                    jsonProjectionInfo.JsonColumn));
                             break;
                         }
 
@@ -1317,7 +1320,8 @@ public sealed partial class SelectExpression : TableExpressionBase
                                 newChildrenProjectionInfo.Add(
                                     (new JsonProjectionInfo(
                                             projectionIndexMap[childProjectionInfo.JsonProjectionInfo.JsonColumnIndex],
-                                            newKeyAccessInfo),
+                                            newKeyAccessInfo,
+                                            childProjectionInfo.JsonProjectionInfo.JsonColumn),
                                         childProjectionInfo.Navigation));
                             }
 
@@ -1508,7 +1512,7 @@ public sealed partial class SelectExpression : TableExpressionBase
                     throw new UnreachableException();
             }
 
-            return Constant(new JsonProjectionInfo(jsonColumnIndex, keyAccessInfo));
+            return Constant(new JsonProjectionInfo(jsonColumnIndex, keyAccessInfo, jsonQueryExpression.JsonColumn.Column));
         }
 
         static IReadOnlyList<IProperty> GetMappedKeyProperties(IKey key)
@@ -2453,7 +2457,8 @@ public sealed partial class SelectExpression : TableExpressionBase
                 }
 
                 var outerProjection = new StructuralTypeProjectionExpression(
-                    type, propertyExpressions, complexPropertyCache, nullable: false, discriminatorExpression);
+                    type, propertyExpressions, complexPropertyCache, nullable: false, discriminatorExpression,
+                    structuralProjection1.TableMap);
 
                 if (outerIdentifiers.Length > 0 && outerProjection is { StructuralType: IEntityType entityType })
                 {
@@ -2654,7 +2659,7 @@ public sealed partial class SelectExpression : TableExpressionBase
             var sourceTableForAnnotations = FindRootTableExpressionForColumn(selectExpression, identifyingColumn);
             var ownerType = navigation.DeclaringEntityType;
             var entityType = navigation.TargetEntityType;
-            var principalMappings = ownerType.GetViewOrTableMappings().Select(e => e.Table);
+            var principalMappings = ownerType.GetQueryMappings().Select(e => e.Table);
             var derivedType = ownerType.BaseType != null;
             var derivedTpt = derivedType && ownerType.GetMappingStrategy() == RelationalAnnotationNames.TptMappingStrategy;
             var parentNullable = identifyingColumn.IsNullable;
@@ -2665,11 +2670,11 @@ public sealed partial class SelectExpression : TableExpressionBase
                 || derivedType;
             if (derivedTpt)
             {
-                principalMappings = principalMappings.Except(ownerType.BaseType!.GetViewOrTableMappings().Select(e => e.Table));
+                principalMappings = principalMappings.Except(ownerType.BaseType!.GetQueryMappings().Select(e => e.Table));
             }
 
             var principalTables = principalMappings.ToList();
-            var dependentTables = entityType.GetViewOrTableMappings().Select(e => e.Table).ToList();
+            var dependentTables = entityType.GetQueryMappings().Select(e => e.Table).ToList();
             var baseTableIndex = selectExpression._tables.FindIndex(teb => ReferenceEquals(teb.UnwrapJoin(), tableExpressionBase));
             var dependentMainTable = dependentTables[0];
             var tableMap = new Dictionary<ITableBase, string>();
@@ -3952,7 +3957,8 @@ public sealed partial class SelectExpression : TableExpressionBase
             }
 
             var newEntityProjection = new StructuralTypeProjectionExpression(
-                projection.StructuralType, propertyExpressions, complexPropertyCache, nullable: false, discriminatorExpression);
+                projection.StructuralType, propertyExpressions, complexPropertyCache, nullable: false, discriminatorExpression,
+                projection.TableMap);
 
             if (projection.StructuralType is IEntityType entityType2)
             {
@@ -4242,7 +4248,14 @@ public sealed partial class SelectExpression : TableExpressionBase
         => new(
             subqueryProjection.Alias,
             tableAlias,
-            column: subqueryProjection.Expression is ColumnExpression { Column: { } column } ? column : null,
+            // Preserve the underlying model column through subquery boundaries so JsonQueryExpression.FindJsonElement keeps
+            // matching after lifts (e.g. LiftJsonQueryFromSubquery wraps the json column in a JsonScalarExpression).
+            column: subqueryProjection.Expression switch
+            {
+                ColumnExpression { Column: { } column } => column,
+                JsonScalarExpression { Json: ColumnExpression { Column: { } jsonColumn } } => jsonColumn,
+                _ => null
+            },
             subqueryProjection.Type,
             subqueryProjection.Expression.TypeMapping!,
             nullable: subqueryProjection.Expression switch

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -2423,7 +2423,9 @@ public sealed partial class SelectExpression : TableExpressionBase
                         select1._projection.Add(innerProjection);
                         select2._projection.Add(new ProjectionExpression(jsonScalar2, alias));
 
-                        var outerColumn = CreateColumnExpression(innerProjection, setOperationAlias);
+                        // The JsonColumn always represents the containing JSON column, so flow its model column through the set
+                        // operation even though the projection itself is a JsonScalarExpression (which has no model column of its own).
+                        var outerColumn = CreateColumnExpression(innerProjection, setOperationAlias, jsonQuery1.JsonColumn.Column);
                         if (jsonScalar1.IsNullable || jsonScalar2.IsNullable)
                         {
                             outerColumn = outerColumn.MakeNullable();
@@ -3993,7 +3995,10 @@ public sealed partial class SelectExpression : TableExpressionBase
                 jsonQueryExpression.JsonColumn.TypeMapping,
                 jsonQueryExpression.IsNullable);
 
-            var newJsonColumn = subquery.GenerateOuterColumn(subqueryAlias, jsonScalarExpression);
+            // The JsonColumn always represents the containing JSON column, so flow its model column through the pushdown even
+            // though the projection itself is a JsonScalarExpression (which has no model column of its own).
+            var newJsonColumn = subquery.GenerateOuterColumn(
+                subqueryAlias, jsonScalarExpression, column: jsonQueryExpression.JsonColumn.Column);
 
             Dictionary<IProperty, ColumnExpression>? newKeyPropertyMap = null;
 
@@ -4244,18 +4249,17 @@ public sealed partial class SelectExpression : TableExpressionBase
             column.PropertyMappings.First(m => m.Property == property).TypeMapping,
             nullable || column.IsNullable);
 
-    private static ColumnExpression CreateColumnExpression(ProjectionExpression subqueryProjection, string tableAlias)
+    private static ColumnExpression CreateColumnExpression(
+        ProjectionExpression subqueryProjection,
+        string tableAlias,
+        IColumnBase? column = null)
         => new(
             subqueryProjection.Alias,
             tableAlias,
-            // Preserve the underlying model column through subquery boundaries so JsonQueryExpression.FindJsonElement keeps
-            // matching after lifts (e.g. LiftJsonQueryFromSubquery wraps the json column in a JsonScalarExpression).
-            column: subqueryProjection.Expression switch
-            {
-                ColumnExpression { Column: { } column } => column,
-                JsonScalarExpression { Json: ColumnExpression { Column: { } jsonColumn } } => jsonColumn,
-                _ => null
-            },
+            // The referenced model column is the projected column's own model column, if any. JSON container columns are an
+            // exception: their JsonScalarExpression projection has no model column of its own, so callers lifting a JSON
+            // container (e.g. LiftJsonQueryFromSubquery) pass the containing column explicitly to preserve it across the subquery.
+            column: column ?? (subqueryProjection.Expression as ColumnExpression)?.Column,
             subqueryProjection.Type,
             subqueryProjection.Expression.TypeMapping!,
             nullable: subqueryProjection.Expression switch
@@ -4269,13 +4273,14 @@ public sealed partial class SelectExpression : TableExpressionBase
     private ColumnExpression GenerateOuterColumn(
         string tableAlias,
         SqlExpression projection,
-        string? columnAlias = null)
+        string? columnAlias = null,
+        IColumnBase? column = null)
     {
         // TODO: Add check if we can add projection in subquery to generate out column
         // Subquery having Distinct or GroupBy can block it.
         var index = AddToProjection(projection, columnAlias);
 
-        return CreateColumnExpression(_projection[index], tableAlias);
+        return CreateColumnExpression(_projection[index], tableAlias, column);
     }
 
     /// <inheritdoc />

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -371,7 +371,8 @@ public sealed partial class SelectExpression : TableExpressionBase
                                         continue;
 
                                     default:
-                                        throw new UnreachableException();
+                                        throw new UnreachableException(
+                                            "Unexpected complex property binding when processing identifiers for Distinct.");
                                 }
                             }
                         }
@@ -1360,7 +1361,7 @@ public sealed partial class SelectExpression : TableExpressionBase
                     StructuralTypeProjectionExpression p => AddStructuralTypeProjection(p),
                     JsonQueryExpression p => AddJsonProjection(p),
                     SqlExpression p => Constant(AddToProjection(p, projectionMember.Last?.Name)),
-                    _ => throw new UnreachableException()
+                    _ => throw new UnreachableException("Unexpected expression type in projection mapping.")
                 };
             }
 
@@ -1455,7 +1456,8 @@ public sealed partial class SelectExpression : TableExpressionBase
                             break;
 
                         default:
-                            throw new UnreachableException();
+                            throw new UnreachableException(
+                                "Unexpected complex property binding when building structural type projection.");
                     }
                 }
             }
@@ -1509,7 +1511,7 @@ public sealed partial class SelectExpression : TableExpressionBase
                     break;
 
                 default:
-                    throw new UnreachableException();
+                    throw new UnreachableException("Unexpected structural type when building JSON projection.");
             }
 
             return Constant(new JsonProjectionInfo(jsonColumnIndex, keyAccessInfo, jsonQueryExpression.JsonColumn.Column));
@@ -2395,7 +2397,8 @@ public sealed partial class SelectExpression : TableExpressionBase
                             continue;
 
                         default:
-                            throw new UnreachableException();
+                            throw new UnreachableException(
+                                "Unexpected complex property binding in set operation over structural types.");
                     }
 
                     void ProcessJson(JsonQueryExpression jsonQuery1, JsonQueryExpression jsonQuery2)
@@ -3387,7 +3390,7 @@ public sealed partial class SelectExpression : TableExpressionBase
                             ExpressionType.GreaterThan => ExpressionType.LessThan,
                             ExpressionType.GreaterThanOrEqual => ExpressionType.LessThanOrEqual,
 
-                            _ => throw new UnreachableException()
+                            _ => throw new UnreachableException($"Unexpected operator type '{sqlBinaryExpression.OperatorType}'.")
                         };
 
                         return new SqlBinaryExpression(
@@ -3946,7 +3949,8 @@ public sealed partial class SelectExpression : TableExpressionBase
                         continue;
 
                     default:
-                        throw new UnreachableException();
+                        throw new UnreachableException(
+                            "Unexpected complex property binding when lifting structural projection from subquery.");
                 }
             }
 
@@ -4226,7 +4230,7 @@ public sealed partial class SelectExpression : TableExpressionBase
             IEntityType entityType => entityType.GetAllBaseTypes().Concat(entityType.GetDerivedTypesInclusive())
                 .SelectMany(t => t.GetDeclaredComplexProperties()),
             IComplexType complexType => complexType.GetDeclaredComplexProperties(),
-            _ => throw new UnreachableException()
+            _ => throw new UnreachableException("Unexpected structural type.")
         };
 
     private static ColumnExpression CreateColumnExpression(

--- a/src/EFCore.Relational/Query/StructuralTypeProjectionExpression.cs
+++ b/src/EFCore.Relational/Query/StructuralTypeProjectionExpression.cs
@@ -32,14 +32,16 @@ public class StructuralTypeProjectionExpression : Expression
         IReadOnlyDictionary<IProperty, ColumnExpression> propertyExpressionMap,
         IReadOnlyDictionary<IComplexProperty, Expression> complexPropertyMap,
         bool nullable = false,
-        SqlExpression? discriminatorExpression = null)
+        SqlExpression? discriminatorExpression = null,
+        IReadOnlyDictionary<ITableBase, string>? tableMap = null)
         : this(
             type,
             propertyExpressionMap,
             ownedNavigationMap: [],
             complexPropertyMap,
             nullable,
-            discriminatorExpression)
+            discriminatorExpression,
+            tableMap)
     {
     }
 
@@ -49,7 +51,8 @@ public class StructuralTypeProjectionExpression : Expression
         Dictionary<INavigation, StructuralTypeShaperExpression> ownedNavigationMap,
         IReadOnlyDictionary<IComplexProperty, Expression> complexPropertyMap,
         bool nullable,
-        SqlExpression? discriminatorExpression = null)
+        SqlExpression? discriminatorExpression = null,
+        IReadOnlyDictionary<ITableBase, string>? tableMap = null)
     {
         StructuralType = type;
         _propertyExpressionMap = propertyExpressionMap;
@@ -57,6 +60,7 @@ public class StructuralTypeProjectionExpression : Expression
         _complexPropertyMap = complexPropertyMap;
         IsNullable = nullable;
         DiscriminatorExpression = discriminatorExpression;
+        TableMap = tableMap;
     }
 
     /// <summary>
@@ -77,6 +81,20 @@ public class StructuralTypeProjectionExpression : Expression
     ///     A <see cref="SqlExpression" /> to generate discriminator for entity type.
     /// </summary>
     public virtual SqlExpression? DiscriminatorExpression { get; }
+
+    /// <summary>
+    ///     The tables being projected from, mapping each <see cref="ITableBase" /> to its alias in the containing
+    ///     <see cref="SelectExpression" />. <see langword="null" /> when the projection wasn't constructed with this
+    ///     information; consumers should fall back to model-wide accessors in that case.
+    /// </summary>
+    /// <remarks>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </remarks>
+    [EntityFrameworkInternal]
+    public virtual IReadOnlyDictionary<ITableBase, string>? TableMap { get; }
 
     /// <summary>
     ///     The <see cref="ExpressionType" /> of the <see cref="Expression" />.
@@ -136,7 +154,7 @@ public class StructuralTypeProjectionExpression : Expression
         return changed
             ? new StructuralTypeProjectionExpression(
                 StructuralType, propertyExpressionMap, ownedNavigationMap, complexPropertyMap, IsNullable,
-                discriminatorExpression)
+                discriminatorExpression, TableMap)
             : this;
     }
 
@@ -192,7 +210,8 @@ public class StructuralTypeProjectionExpression : Expression
             ownedNavigationMap,
             complexPropertyMap,
             nullable: true,
-            discriminatorExpression);
+            discriminatorExpression,
+            TableMap);
     }
 
     /// <summary>
@@ -260,7 +279,7 @@ public class StructuralTypeProjectionExpression : Expression
 
         return new StructuralTypeProjectionExpression(
             derivedType, propertyExpressionMap, ownedNavigationMap, complexPropertyMap, IsNullable,
-            discriminatorExpression);
+            discriminatorExpression, TableMap);
     }
 
     /// <summary>

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
@@ -525,8 +525,7 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
         // (for owned JSON entities)
         foreach (var property in structuralType.GetPropertiesInHierarchy())
         {
-            var element = jsonQueryExpression.GetJsonElement(property);
-            if (element.PropertyName is { } jsonPropertyName)
+            if (jsonQueryExpression.FindJsonElement(property) is { PropertyName: { } jsonPropertyName } element)
             {
                 var typeMapping = element.StoreTypeMapping!;
                 columnInfos.Add(
@@ -540,15 +539,6 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
             }
         }
 
-        // Prefer the JsonQueryExpression's column (chosen at CreateSelect time) over re-resolving via the model,
-        // which is ambiguous under entity-splitting / TPT + JSON; fall back for synthetic JSON columns over OPENJSON.
-#pragma warning disable EF1001 // Internal EF Core API usage.
-        var containerColumn = jsonQueryExpression.JsonColumn.Column
-            ?? structuralType.ContainingEntityType.GetQueryMappings()
-                .Select(m => m.Table.FindColumn(structuralType.GetContainerColumnName()!))
-                .First(c => c is not null)!;
-#pragma warning restore EF1001
-
         var nestedJsonPropertyNames = jsonQueryExpression.StructuralType switch
         {
             IEntityType entityType
@@ -556,13 +546,12 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
                     .Where(n => n.ForeignKey.IsOwnership
                         && n.TargetEntityType.IsMappedToJson()
                         && n.ForeignKey.PrincipalToDependent == n)
-                    .Select(n => jsonQueryExpression.GetJsonElement(n).PropertyName
-                        ?? throw new UnreachableException("JSON-mapped navigation without a JSON property name.")),
+                    .Select(n => n.TargetEntityType.GetJsonPropertyName()                    
+                    ?? throw new UnreachableException("JSON-mapped navigation without a JSON property name.")),
 
             IComplexType complexType
-                => complexType.GetComplexProperties()
-                    .Select(p => jsonQueryExpression.GetJsonElement(p).PropertyName
-                        ?? throw new UnreachableException("JSON-mapped complex property without a JSON property name.")),
+                => complexType.GetComplexProperties().Select(p => p.ComplexType.GetJsonPropertyName()
+                    ?? throw new UnreachableException("JSON-mapped complex property without a JSON property name.")),
 
             _ => throw new UnreachableException("Unexpected structural type when transforming JSON query to table.")
         };
@@ -573,7 +562,7 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
                 new SqlServerOpenJsonExpression.ColumnInfo
                 {
                     Name = jsonPropertyName,
-                    TypeMapping = containerColumn.StoreTypeMapping,
+                    TypeMapping = jsonQueryExpression.JsonColumn.TypeMapping!,
                     Path = [new PathSegment(jsonPropertyName)],
                     AsJson = true
                 });

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
@@ -203,7 +203,7 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
         {
             nameof(SqlServerQueryableExtensions.FreeTextTable) => "FREETEXTTABLE",
             nameof(SqlServerQueryableExtensions.ContainsTable) => "CONTAINSTABLE",
-            _ => throw new UnreachableException()
+            _ => throw new UnreachableException($"Unexpected full-text method '{method.Name}'.")
         };
 
         var (columnsExpression, searchText, languageTerm, topN) = methodCallExpression.Arguments switch
@@ -217,7 +217,7 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
             // Use an empty array to signal "*" (all columns)
             [_, var s, var l, var t] => ((Expression)Expression.NewArrayInit(typeof(ColumnExpression)), s, l, t),
 
-            _ => throw new UnreachableException()
+            _ => throw new UnreachableException("Unexpected argument shape for full-text table function.")
         };
 
         if (TranslateExpression(searchText) is not { } translatedSearchText
@@ -556,13 +556,15 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
                     .Where(n => n.ForeignKey.IsOwnership
                         && n.TargetEntityType.IsMappedToJson()
                         && n.ForeignKey.PrincipalToDependent == n)
-                    .Select(n => jsonQueryExpression.GetJsonElement(n).PropertyName ?? throw new UnreachableException()),
+                    .Select(n => jsonQueryExpression.GetJsonElement(n).PropertyName
+                        ?? throw new UnreachableException("JSON-mapped navigation without a JSON property name.")),
 
             IComplexType complexType
                 => complexType.GetComplexProperties()
-                    .Select(p => jsonQueryExpression.GetJsonElement(p).PropertyName ?? throw new UnreachableException()),
+                    .Select(p => jsonQueryExpression.GetJsonElement(p).PropertyName
+                        ?? throw new UnreachableException("JSON-mapped complex property without a JSON property name.")),
 
-            _ => throw new UnreachableException()
+            _ => throw new UnreachableException("Unexpected structural type when transforming JSON query to table.")
         };
 
         foreach (var jsonPropertyName in nestedJsonPropertyNames)
@@ -1014,7 +1016,7 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
             JsonScalarExpression { TypeMapping.ElementTypeMapping: not null } j => ((ColumnExpression)j.Json, j.Path, false),
             JsonQueryExpression j => (j.JsonColumn, j.Path, false),
 
-            _ => throw new UnreachableException(),
+            _ => throw new UnreachableException("Unexpected target expression for JSON partial update setter."),
         };
 
         // SQL Server 2025 introduced the modify method (https://learn.microsoft.com/sql/t-sql/data-types/json-data-type#modify-method),

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
@@ -525,27 +525,28 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
         // (for owned JSON entities)
         foreach (var property in structuralType.GetPropertiesInHierarchy())
         {
-            if (property.GetJsonPropertyName() is { } jsonPropertyName)
+            var element = jsonQueryExpression.GetJsonElement(property);
+            if (element.PropertyName is { } jsonPropertyName)
             {
+                var typeMapping = element.StoreTypeMapping!;
                 columnInfos.Add(
                     new SqlServerOpenJsonExpression.ColumnInfo
                     {
                         Name = jsonPropertyName,
-                        TypeMapping = property.GetRelationalTypeMapping(),
+                        TypeMapping = typeMapping,
                         Path = [new PathSegment(jsonPropertyName)],
-                        AsJson = property.GetRelationalTypeMapping().ElementTypeMapping is not null
+                        AsJson = typeMapping.ElementTypeMapping is not null
                     });
             }
         }
 
-        // Find the container column in the relational model to get its type mapping.
-        // Note that we assume exactly one column with the given name mapped to the entity (despite entity splitting).
-        // See #38060 about improving this.
-        var containerColumnName = structuralType.GetContainerColumnName()!;
+        // Prefer the JsonQueryExpression's column (chosen at CreateSelect time) over re-resolving via the model,
+        // which is ambiguous under entity-splitting / TPT + JSON; fall back for synthetic JSON columns over OPENJSON.
 #pragma warning disable EF1001 // Internal EF Core API usage.
-        var containerColumn = structuralType.ContainingEntityType.GetViewOrTableMappings()
-            .Select(m => m.Table.FindColumn(containerColumnName))
-            .First(c => c is not null)!;
+        var containerColumn = jsonQueryExpression.JsonColumn.Column
+            ?? structuralType.ContainingEntityType.GetQueryMappings()
+                .Select(m => m.Table.FindColumn(structuralType.GetContainerColumnName()!))
+                .First(c => c is not null)!;
 #pragma warning restore EF1001
 
         var nestedJsonPropertyNames = jsonQueryExpression.StructuralType switch
@@ -555,10 +556,11 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
                     .Where(n => n.ForeignKey.IsOwnership
                         && n.TargetEntityType.IsMappedToJson()
                         && n.ForeignKey.PrincipalToDependent == n)
-                    .Select(n => n.TargetEntityType.GetJsonPropertyName() ?? throw new UnreachableException()),
+                    .Select(n => jsonQueryExpression.GetJsonElement(n).PropertyName ?? throw new UnreachableException()),
 
             IComplexType complexType
-                => complexType.GetComplexProperties().Select(p => p.ComplexType.GetJsonPropertyName() ?? throw new UnreachableException()),
+                => complexType.GetComplexProperties()
+                    .Select(p => jsonQueryExpression.GetJsonElement(p).PropertyName ?? throw new UnreachableException()),
 
             _ => throw new UnreachableException()
         };

--- a/src/EFCore.SqlServer/Update/Internal/SqlServerModificationCommand.cs
+++ b/src/EFCore.SqlServer/Update/Internal/SqlServerModificationCommand.cs
@@ -43,7 +43,7 @@ public class SqlServerModificationCommand : ModificationCommand
     /// </summary>
     protected override void ProcessSinglePropertyJsonUpdate(ref ColumnModificationParameters parameters)
     {
-        // TODO: Move more of this logic to the type mapping. Issue #34432
+        // TODO: Move more of this logic to the type mapping. Issue #38036
         var property = parameters.Property!;
         var mapping = property.GetRelationalTypeMapping();
         var propertyProviderClrType = (mapping.Converter?.ProviderClrType ?? property.ClrType).UnwrapNullableType();

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryableMethodTranslatingExpressionVisitor.cs
@@ -467,8 +467,7 @@ public class SqliteQueryableMethodTranslatingExpressionVisitor : RelationalQuery
         // We're only interested in properties which actually exist in the JSON, filter out uninteresting synthetic keys
         foreach (var property in structuralType.GetPropertiesInHierarchy())
         {
-            var element = jsonQueryExpression.GetJsonElement(property);
-            if (element.PropertyName is { } jsonPropertyName)
+            if (jsonQueryExpression.FindJsonElement(property) is { PropertyName: { } jsonPropertyName } element)
             {
                 // HACK: currently the only way to project multiple values from a SelectExpression is to simulate a Select out to an anonymous
                 // type; this requires the MethodInfos of the anonymous type properties, from which the projection alias gets taken.

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryableMethodTranslatingExpressionVisitor.cs
@@ -467,7 +467,8 @@ public class SqliteQueryableMethodTranslatingExpressionVisitor : RelationalQuery
         // We're only interested in properties which actually exist in the JSON, filter out uninteresting synthetic keys
         foreach (var property in structuralType.GetPropertiesInHierarchy())
         {
-            if (property.GetJsonPropertyName() is { } jsonPropertyName)
+            var element = jsonQueryExpression.GetJsonElement(property);
+            if (element.PropertyName is { } jsonPropertyName)
             {
                 // HACK: currently the only way to project multiple values from a SelectExpression is to simulate a Select out to an anonymous
                 // type; this requires the MethodInfos of the anonymous type properties, from which the projection alias gets taken.
@@ -476,9 +477,9 @@ public class SqliteQueryableMethodTranslatingExpressionVisitor : RelationalQuery
 
                 propertyJsonScalarExpression[projectionMember] = new JsonScalarExpression(
                     jsonColumn,
-                    [new PathSegment(property.GetJsonPropertyName()!)],
+                    [new PathSegment(jsonPropertyName)],
                     property.ClrType.UnwrapNullableType(),
-                    property.GetRelationalTypeMapping(),
+                    element.StoreTypeMapping!,
                     property.IsNullable);
             }
         }
@@ -490,7 +491,7 @@ public class SqliteQueryableMethodTranslatingExpressionVisitor : RelationalQuery
                              && n.TargetEntityType.IsMappedToJson()
                              && n.ForeignKey.PrincipalToDependent == n))
             {
-                var jsonNavigationName = navigation.TargetEntityType.GetJsonPropertyName();
+                var jsonNavigationName = jsonQueryExpression.GetJsonElement(navigation).PropertyName;
                 Check.DebugAssert(jsonNavigationName is not null, "Invalid navigation found on JSON-mapped entity");
 
                 var projectionMember = new ProjectionMember().Append(new FakeMemberInfo(jsonNavigationName));
@@ -506,7 +507,7 @@ public class SqliteQueryableMethodTranslatingExpressionVisitor : RelationalQuery
 
         foreach (var complexProperty in structuralType.GetComplexProperties())
         {
-            var jsonNavigationName = complexProperty.ComplexType.GetJsonPropertyName();
+            var jsonNavigationName = jsonQueryExpression.GetJsonElement(complexProperty).PropertyName;
             Check.DebugAssert(jsonNavigationName is not null, "Invalid complex property found on JSON-mapped structural type");
 
             var projectionMember = new ProjectionMember().Append(new FakeMemberInfo(jsonNavigationName));

--- a/test/EFCore.Relational.Specification.Tests/Query/Associations/OwnedJson/OwnedJsonStructuralEqualityRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/Associations/OwnedJson/OwnedJsonStructuralEqualityRelationalTestBase.cs
@@ -33,7 +33,7 @@ public abstract class OwnedJsonStructuralEqualityRelationalTestBase<TFixture> : 
     public override async Task Contains_with_parameter()
     {
         // No backing field could be found for property 'RootEntity.RequiredRelated#RelatedType.NestedCollection#NestedType.RelatedTypeRootEntityId' and the property does not have a getter.
-        await Assert.ThrowsAsync<KeyNotFoundException>(base.Contains_with_parameter);
+        await Assert.ThrowsAsync<InvalidOperationException>(base.Contains_with_parameter);
 
         AssertSql();
     }
@@ -41,7 +41,7 @@ public abstract class OwnedJsonStructuralEqualityRelationalTestBase<TFixture> : 
     public override async Task Contains_with_operators_composed_on_the_collection()
     {
         // No backing field could be found for property 'RootEntity.RequiredRelated#RelatedType.NestedCollection#NestedType.RelatedTypeRootEntityId' and the property does not have a getter.
-        await Assert.ThrowsAsync<KeyNotFoundException>(base.Contains_with_operators_composed_on_the_collection);
+        await Assert.ThrowsAsync<InvalidOperationException>(base.Contains_with_operators_composed_on_the_collection);
 
         AssertSql();
     }
@@ -49,7 +49,7 @@ public abstract class OwnedJsonStructuralEqualityRelationalTestBase<TFixture> : 
     public override async Task Contains_with_nested_and_composed_operators()
     {
         // No backing field could be found for property 'RootEntity.RequiredRelated#RelatedType.NestedCollection#NestedType.RelatedTypeRootEntityId' and the property does not have a getter.
-        await Assert.ThrowsAsync<KeyNotFoundException>(base.Contains_with_nested_and_composed_operators);
+        await Assert.ThrowsAsync<InvalidOperationException>(base.Contains_with_nested_and_composed_operators);
 
         AssertSql();
     }

--- a/test/EFCore.Relational.Specification.Tests/Query/EntitySplittingQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/EntitySplittingQueryTestBase.cs
@@ -2255,7 +2255,53 @@ public abstract class EntitySplittingQueryTestBase : NonSharedModelTestBase, ICl
             entryCount: 5);
     }
 
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual async Task FromSql_on_split_entity_with_renamed_columns_uses_default_mappings(bool async)
+    {
+        await InitializeContextFactoryAsync(mb =>
+        {
+            mb.Entity<EntityOne>().SplitToTable(
+                "SplitEntityOnePart",
+                tb =>
+                {
+                    // Configure column names on the split table that differ from the default (logical) column names.
+                    // This makes the table mappings diverge from the default mappings, which is what FromSql must use.
+                    tb.Property(e => e.IntValue3).HasColumnName("CustomIntValue3");
+                    tb.Property(e => e.StringValue3).HasColumnName("CustomStringValue3");
+                    tb.Property(e => e.IntValue4);
+                    tb.Property(e => e.StringValue4);
+                });
+        });
+
+        using var context = CreateContext();
+
+        // The raw SQL exposes the split-table columns under their default (logical) names. If FromSql incorrectly used
+        // the table mappings (CustomIntValue3/CustomStringValue3) rather than the default mappings, the composed query
+        // would reference columns that don't exist in the raw SQL's result.
+        var sql = NormalizeDelimitersInRawString(
+            @"SELECT [m].*, [s].[CustomStringValue3] AS [StringValue3], [s].[StringValue4], [s].[CustomIntValue3] AS [IntValue3], [s].[IntValue4]
+              FROM [EntityOne] AS [m]
+              INNER JOIN [SplitEntityOnePart] AS [s] ON [m].[Id] = [s].[Id]");
+
+        var query = context.Set<EntityOne>().FromSqlRaw(sql).OrderBy(e => e.Id);
+
+        var actual = async
+            ? await query.ToListAsync()
+            : query.ToList();
+
+        var expected = GetExpectedData().Set<EntityOne>().OrderBy(e => e.Id).ToList();
+
+        Assert.Equal(expected.Count, actual.Count);
+        for (var i = 0; i < expected.Count; i++)
+        {
+            AssertEqual(expected[i], actual[i]);
+        }
+    }
+
     #region TestHelpers
+
+    protected string NormalizeDelimitersInRawString(string sql)
+        => ((RelationalTestStore)NonSharedTestStore).NormalizeDelimitersInRawString(sql);
 
     protected async Task AssertQuery<TResult>(
         bool async,

--- a/test/EFCore.Relational.Tests/Metadata/Conventions/Internal/TableValuedDbFunctionConventionTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/Conventions/Internal/TableValuedDbFunctionConventionTest.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 
@@ -23,7 +22,7 @@ public class TableValuedDbFunctionConventionTest
         var entityType = model.FindEntityType(typeof(KeylessEntity));
 
         Assert.Null(entityType.FindPrimaryKey());
-        Assert.Equal("KeylessEntity", entityType.GetViewOrTableMappings().Single().Table.Name);
+        Assert.Equal("KeylessEntity", entityType.GetTableMappings().Single().Table.Name);
     }
 
     [Fact]
@@ -41,7 +40,7 @@ public class TableValuedDbFunctionConventionTest
         var entityType = model.FindEntityType(typeof(TestEntity));
 
         Assert.Equal(nameof(TestEntity.Name), entityType.FindPrimaryKey().Properties.Single().Name);
-        Assert.Equal("TestTable", entityType.GetViewOrTableMappings().Single().Table.Name);
+        Assert.Equal("TestTable", entityType.GetTableMappings().Single().Table.Name);
     }
 
     [Fact]

--- a/test/EFCore.Relational.Tests/Metadata/RelationalModelTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/RelationalModelTest.cs
@@ -324,7 +324,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         {
             var orderType = model.Model.FindEntityType(typeof(Order))!;
             var orderMapping = orderType.GetViewMappings().Single();
-            Assert.Equal(orderType.GetViewMappings(), orderType.GetViewOrTableMappings());
+            Assert.Equal(orderType.GetViewMappings(), orderType.GetQueryMappings());
             Assert.Null(orderMapping.IncludesDerivedTypes);
             Assert.Equal(
                 [nameof(Order.Id), nameof(Order.AlternateId), nameof(Order.CustomerId), nameof(Order.OrderDate)],
@@ -3253,6 +3253,66 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
             Assert.True(defaultMapping1.Table.Columns.Single().IsNullable);
             Assert.False(defaultMapping2.Table.Columns.Single().IsNullable);
+        }
+
+        [Fact]
+        public void GetQueryMappings_returns_in_priority_order_sql_query_function_view_table()
+        {
+            var modelBuilder = CreateConventionModelBuilder();
+            modelBuilder.Entity<Order>(cb =>
+            {
+                cb.Ignore(c => c.Customer);
+                cb.Ignore(c => c.Details);
+                cb.Ignore(c => c.DateDetails);
+                cb.Ignore(c => c.Addresses);
+                cb.HasNoKey();
+            });
+
+            var sqlQueryOnly = (IEntityType)modelBuilder.Model.AddEntityType(typeof(NameSpace1.SameEntityType));
+            modelBuilder.Entity(sqlQueryOnly.ClrType).HasNoKey().ToSqlQuery("SELECT 1 AS Id");
+
+            // Table + view: view wins (table mappings are not returned).
+            var viewAndTable = modelBuilder.Entity<NameSpace2.SameEntityType>(b => b.HasNoKey().ToView("V").ToTable("T"));
+
+            // Function + view + table: function wins.
+            modelBuilder.Ignore<Tag>();
+            modelBuilder.Entity<Customer>(b =>
+            {
+                b.Ignore(c => c.Orders);
+                b.HasNoKey();
+                b.ToFunction("GetCustomers");
+                b.ToView("CustomersView");
+                b.ToTable("Customers");
+            });
+
+            // Table-only.
+            modelBuilder.Entity<Order>(b => b.ToTable("Orders"));
+
+            var model = Finalize(modelBuilder);
+
+            // Table-only -> table mappings.
+            var orderType = model.Model.FindEntityType(typeof(Order));
+            var orderMappings = orderType.GetQueryMappings().ToList();
+            Assert.Single(orderMappings);
+            Assert.IsAssignableFrom<ITableMapping>(orderMappings[0]);
+
+            // SqlQuery-only -> SQL query mappings.
+            var sqlQueryEntity = model.Model.FindEntityType(typeof(NameSpace1.SameEntityType));
+            var sqlQueryMappings = sqlQueryEntity.GetQueryMappings().ToList();
+            Assert.Single(sqlQueryMappings);
+            Assert.IsAssignableFrom<ISqlQueryMapping>(sqlQueryMappings[0]);
+
+            // Table + view -> view mappings win (lower-priority table mappings are not returned).
+            var viewAndTableEntity = model.Model.FindEntityType(typeof(NameSpace2.SameEntityType));
+            var viewAndTableMappings = viewAndTableEntity.GetQueryMappings().ToList();
+            Assert.Single(viewAndTableMappings);
+            Assert.IsAssignableFrom<IViewMapping>(viewAndTableMappings[0]);
+
+            // Function + view + table -> function mappings win (lower-priority view/table mappings are not returned).
+            var customerType = model.Model.FindEntityType(typeof(Customer));
+            var customerMappings = customerType.GetQueryMappings().ToList();
+            Assert.Single(customerMappings);
+            Assert.IsAssignableFrom<IFunctionMapping>(customerMappings[0]);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #38060
Fixes #35466
Fixes #32853

The query pipeline previously fell back to model‑wide accessors (`GetJsonPropertyName`, container‑column‑by‑name scans) at translation time, which produced wrong/ambiguous results under entity splitting, TPT, and JSON‑on‑view scenarios. This change threads the actual table set and JSON element metadata through the existing relational query expressions and consolidates priority logic in one place.

## Changes

- **New `GetQueryMappings()` internal helper** (RelationalTypeBaseExtensions) returns storage mappings in priority order — *default* SQL query → *default* function → view → table — and replaces all `GetViewOrTableMappings()` call sites in the query pipeline. Casts directly to the concrete `List<TMapping>` runtime type and filters in place to avoid LINQ allocations.
- **`StructuralTypeProjectionExpression.TableMap`** (optional `IReadOnlyDictionary<ITableBase, string>`) — threaded through TPT, single‑table, entity‑splitting and TPC `CreateSelect` branches, preserved across `MakeNullable`, `UpdateEntityType`, `VisitChildren`, set‑op merge, and subquery lift. `BindProperty`, `TryRewriteEntityEquality`, and `GenerateMaterializationCondition` now scope their principal‑split‑table lookup to the actually‑projected tables.
- **`JsonQueryExpression.FindJsonElement(IPropertyBase)`** — returns the `IRelationalJsonElement` whose containing column matches `JsonColumn` when available, otherwise the first element from the property's mappings. `BindProperty`/`BindStructuralProperty` and the OPENJSON/json_each translators in `RelationalQueryableMethodTranslatingExpressionVisitor`, `SqlServer`, and `Sqlite` now use this instead of model‑wide `GetJsonPropertyName()`.
- **`JsonProjectionInfo.JsonColumn`** + **`ColumnExpression.Column` preservation** in `MakeNullable`/`ApplyTypeMapping` — the shaper now uses the column resolved at CreateSelect time, falling back to a model scan only when there's no underlying `IColumnBase` (synthetic JSON columns over OPENJSON/json_each).
