### PR TITLE
Make DateTime.Parse translation tests culture-invariant

### DIFF
--- a/test/EFCore.Specification.Tests/Query/Translations/Temporal/DateTimeTranslationsTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Translations/Temporal/DateTimeTranslationsTestBase.cs
@@ -88,12 +88,12 @@ public abstract class DateTimeTranslationsTestBase<TFixture>(TFixture fixture) :
 
     [Fact]
     public virtual Task Parse_with_constant()
-        => AssertQuery(ss => ss.Set<BasicTypesEntity>().Where(o => o.DateTime == DateTime.Parse("5/4/1998 15:30:10 PM")));
+        => AssertQuery(ss => ss.Set<BasicTypesEntity>().Where(o => o.DateTime == DateTime.Parse("1998-05-04T15:30:10")));
 
     [Fact]
     public virtual Task Parse_with_parameter()
     {
-        var date = "5/4/1998 15:30:10 PM";
+        var date = "1998-05-04T15:30:10";
 
         return AssertQuery(ss => ss.Set<BasicTypesEntity>().Where(o => o.DateTime == DateTime.Parse(date)));
     }


### PR DESCRIPTION
They fail locally for me against the Cosmos emulator on Mac, which has GB-en settings. (So sane date ordering. :-) )
