### PR TITLE
Hold detached entries weakly in the change tracker

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/EntityReferenceMap.cs
+++ b/src/EFCore/ChangeTracking/Internal/EntityReferenceMap.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
+
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 
 /// <summary>
@@ -12,7 +14,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 public class EntityReferenceMap
 {
     private readonly bool _hasSubMap;
-    private Dictionary<object, InternalEntityEntry>? _detachedReferenceMap;
+
+    // Detached entries are held weakly: an InternalEntityEntry can be created for an untracked entity
+    // (e.g. by DbContext.Entry) and cached so the same entry is returned for the same instance, but the
+    // context must not keep the entity alive once nothing else references it (issue #33557).
+    private ConditionalWeakTable<object, InternalEntityEntry>? _detachedReferenceMap;
     private Dictionary<object, InternalEntityEntry>? _unchangedReferenceMap;
     private Dictionary<object, InternalEntityEntry>? _addedReferenceMap;
     private Dictionary<object, InternalEntityEntry>? _modifiedReferenceMap;
@@ -68,8 +74,8 @@ public class EntityReferenceMap
                 switch (state)
                 {
                     case EntityState.Detached:
-                        _detachedReferenceMap ??= new Dictionary<object, InternalEntityEntry>(ReferenceEqualityComparer.Instance);
-                        _detachedReferenceMap[mapKey] = entry;
+                        _detachedReferenceMap ??= new ConditionalWeakTable<object, InternalEntityEntry>();
+                        _detachedReferenceMap.AddOrUpdate(mapKey, entry);
                         break;
                     case EntityState.Unchanged:
                         _unchangedReferenceMap ??=

--- a/test/EFCore.Tests/ChangeTracking/Internal/StateManagerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/StateManagerTest.cs
@@ -567,37 +567,14 @@ public class StateManagerTest
         public CompositeKeyOwned Owned { get; set; }
     }
 
-    private class DealContext : DbContext
+    private class WidgetContext : DbContext
     {
-        public DbSet<Deal> Deals { get; set; }
-        public DbSet<Transaction> Transactions { get; set; }
-        public DbSet<Flow> Flows { get; set; }
+        public DbSet<Widget> Widgets { get; set; }
 
         protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
-                .UseInMemoryDatabase(nameof(DealContext) + Guid.NewGuid())
+                .UseInMemoryDatabase(nameof(WidgetContext) + Guid.NewGuid())
                 .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider);
-    }
-
-    private class Deal
-    {
-        public int Id { get; set; }
-        public ICollection<Transaction> Transactions { get; set; } = new HashSet<Transaction>();
-    }
-
-    private class Transaction
-    {
-        public int Id { get; set; }
-        public int DealId { get; set; }
-        public Deal Deal { get; set; }
-        public ICollection<Flow> Flows { get; set; } = new HashSet<Flow>();
-    }
-
-    private class Flow
-    {
-        public int Id { get; set; }
-        public int TransactionId { get; set; }
-        public Transaction Transaction { get; set; }
     }
 
     [Fact]
@@ -769,9 +746,9 @@ public class StateManagerTest
     [Fact]
     public void Entry_for_untracked_shared_type_entity_does_not_keep_the_entity_alive()
     {
-        var model = BuildModel();
+        var model = BuildModelWithSharedType();
         var stateManager = CreateStateManager(model);
-        var entityType = model.FindEntityType("SharedEntityA")!;
+        var entityType = model.FindEntityType("SharedCategoryA")!;
 
         // Shared-type entities are cached in a per-type sub-map; that sub-map's detached cache must also
         // hold entries weakly so the entity can be collected once nothing else references it (issue #33557).
@@ -789,7 +766,7 @@ public class StateManagerTest
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static WeakReference CreateDetachedSharedTypeEntry(IStateManager stateManager, IEntityType entityType)
     {
-        var entity = new SharedEntity { Id = 1 };
+        var entity = new Category { Id = 1, PrincipalId = 777 };
         stateManager.GetOrCreateEntry(entity, entityType).SetEntityState(EntityState.Detached);
         return new WeakReference(entity);
     }
@@ -797,7 +774,7 @@ public class StateManagerTest
     [Fact]
     public void Detaching_a_tracked_graph_does_not_retain_references_to_detached_entities()
     {
-        using var context = new DealContext();
+        using var context = new WidgetContext();
 
         // Reproduces the issue's pattern: add a graph, then detach it by iterating and setting each
         // entity to Detached (detaching the principal cascade-detaches the dependents, so the later
@@ -815,35 +792,34 @@ public class StateManagerTest
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static WeakReference[] AddAndDetachGraph(DealContext context)
+    private static WeakReference[] AddAndDetachGraph(WidgetContext context)
     {
-        var deal = new Deal { Id = -3 };
-        var transaction = new Transaction { Id = -2, DealId = -3, Deal = deal };
-        var flow = new Flow { TransactionId = -2, Transaction = transaction };
-        transaction.Flows.Add(flow);
-        deal.Transactions.Add(transaction);
+        var root = new Widget { Id = -1 };
+        var child = new Widget { Id = -2, ParentWidget = root };
+        var grandChild = new Widget { Id = -3, ParentWidget = child };
+        root.ChildWidgets = [child];
+        child.ChildWidgets = [grandChild];
 
-        context.Add(flow);
+        context.Add(grandChild);
 
-        foreach (var entity in new object[] { deal, transaction, flow })
+        foreach (var entity in new object[] { root, child, grandChild })
         {
             context.Entry(entity).State = EntityState.Detached;
         }
 
-        return [new WeakReference(deal), new WeakReference(transaction), new WeakReference(flow)];
+        return [new WeakReference(root), new WeakReference(child), new WeakReference(grandChild)];
     }
 
     [Fact]
     public void Can_add_an_equivalent_graph_after_detaching_a_graph_with_the_same_keys()
     {
-        using var context = new DealContext();
+        using var context = new WidgetContext();
 
-        var first = new Flow { TransactionId = -2, Transaction = new Transaction { Id = -2, DealId = -3, Deal = new Deal { Id = -3 } } };
-        Connect(first);
+        var first = BuildWidgetGraph();
 
         // Capture the first graph's instances up front: detaching cascades through the graph and
         // nulls the navigations, so they can't be reached from 'first' afterwards.
-        var firstGraph = new object[] { first, first.Transaction!, first.Transaction!.Deal! };
+        var firstGraph = new object[] { first, first.ParentWidget!, first.ParentWidget!.ParentWidget! };
 
         context.Add(first);
         foreach (var entity in firstGraph)
@@ -851,8 +827,7 @@ public class StateManagerTest
             context.Entry(entity).State = EntityState.Detached;
         }
 
-        var second = new Flow { TransactionId = -2, Transaction = new Transaction { Id = -2, DealId = -3, Deal = new Deal { Id = -3 } } };
-        Connect(second);
+        var second = BuildWidgetGraph();
 
         // Must not throw an identity conflict and must not pull the detached first graph back in.
         context.Add(second);
@@ -864,16 +839,18 @@ public class StateManagerTest
 
         context.SaveChanges();
 
-        Assert.Equal(1, context.Set<Deal>().Count());
-        Assert.Equal(1, context.Set<Transaction>().Count());
-        Assert.Equal(1, context.Set<Flow>().Count());
+        Assert.Equal(3, context.Set<Widget>().Count());
 
-        static void Connect(Flow f)
+        // Builds a three-level chain (root -> child -> grandChild) with the same keys each time, and
+        // returns the leaf so adding it pulls in the whole graph via its to-principal navigations.
+        static Widget BuildWidgetGraph()
         {
-            f.TransactionId = f.Transaction!.Id;
-            f.Transaction.Flows.Add(f);
-            f.Transaction.DealId = f.Transaction.Deal!.Id;
-            f.Transaction.Deal.Transactions.Add(f.Transaction);
+            var root = new Widget { Id = -1 };
+            var child = new Widget { Id = -2, ParentWidget = root };
+            var grandChild = new Widget { Id = -3, ParentWidget = child };
+            root.ChildWidgets = [child];
+            child.ChildWidgets = [grandChild];
+            return grandChild;
         }
     }
 
@@ -1393,8 +1370,17 @@ public class StateManagerTest
 
         builder.Entity<Location>();
 
-        builder.SharedTypeEntity<SharedEntity>("SharedEntityA");
-        builder.SharedTypeEntity<SharedEntity>("SharedEntityB");
+        return builder.Model.FinalizeModel();
+    }
+
+    private static IModel BuildModelWithSharedType()
+    {
+        var builder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+
+        // Reuse Category as the CLR type for two shared-type entities so the model has a shared-type
+        // sub-map to exercise (Category is not used as a regular entity type in this model).
+        builder.SharedTypeEntity<Category>("SharedCategoryA");
+        builder.SharedTypeEntity<Category>("SharedCategoryB");
 
         return builder.Model.FinalizeModel();
     }

--- a/test/EFCore.Tests/ChangeTracking/Internal/StateManagerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/StateManagerTest.cs
@@ -733,6 +733,11 @@ public class StateManagerTest
         GC.Collect();
 
         Assert.False(reference.IsAlive);
+
+        // Keep the state manager (which owns the detached-entity cache) alive across the collection;
+        // otherwise the cache could be collected along with it and the entity would be released even
+        // with a strong cache, making this test pass without actually exercising the weak reference.
+        GC.KeepAlive(stateManager);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -741,6 +746,52 @@ public class StateManagerTest
         var category = new Category { Id = 1, PrincipalId = 777 };
         stateManager.GetOrCreateEntry(category).SetEntityState(EntityState.Detached);
         return new WeakReference(category);
+    }
+
+    [Fact]
+    public void Entry_for_untracked_entity_survives_collection_while_the_entity_is_referenced()
+    {
+        var stateManager = CreateStateManager(BuildModel());
+        var category = new Category { Id = 1, PrincipalId = 777 };
+
+        var entry = stateManager.GetOrCreateEntry(category);
+        entry.SetEntityState(EntityState.Detached);
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        // While the entity is still referenced, the weak cache must not drop the entry: the same entry
+        // must be returned so a subsequent Add/Attach acts on it (entry-stability contract, issue #33557).
+        Assert.Same(entry, stateManager.TryGetEntry(category));
+    }
+
+    [Fact]
+    public void Entry_for_untracked_shared_type_entity_does_not_keep_the_entity_alive()
+    {
+        var model = BuildModel();
+        var stateManager = CreateStateManager(model);
+        var entityType = model.FindEntityType("SharedEntityA")!;
+
+        // Shared-type entities are cached in a per-type sub-map; that sub-map's detached cache must also
+        // hold entries weakly so the entity can be collected once nothing else references it (issue #33557).
+        var reference = CreateDetachedSharedTypeEntry(stateManager, entityType);
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        Assert.False(reference.IsAlive);
+
+        GC.KeepAlive(stateManager);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference CreateDetachedSharedTypeEntry(IStateManager stateManager, IEntityType entityType)
+    {
+        var entity = new SharedEntity { Id = 1 };
+        stateManager.GetOrCreateEntry(entity, entityType).SetEntityState(EntityState.Detached);
+        return new WeakReference(entity);
     }
 
     [Fact]
@@ -1341,6 +1392,9 @@ public class StateManagerTest
         builder.Entity<Pin>(b => b.ComplexProperty(e => e.At));
 
         builder.Entity<Location>();
+
+        builder.SharedTypeEntity<SharedEntity>("SharedEntityA");
+        builder.SharedTypeEntity<SharedEntity>("SharedEntityB");
 
         return builder.Model.FinalizeModel();
     }

--- a/test/EFCore.Tests/ChangeTracking/Internal/StateManagerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/StateManagerTest.cs
@@ -6,6 +6,8 @@
 // ReSharper disable UnusedAutoPropertyAccessor.Local
 // ReSharper disable InconsistentNaming
 
+using System.Runtime.CompilerServices;
+
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 
 public class StateManagerTest
@@ -565,6 +567,39 @@ public class StateManagerTest
         public CompositeKeyOwned Owned { get; set; }
     }
 
+    private class DealContext : DbContext
+    {
+        public DbSet<Deal> Deals { get; set; }
+        public DbSet<Transaction> Transactions { get; set; }
+        public DbSet<Flow> Flows { get; set; }
+
+        protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder
+                .UseInMemoryDatabase(nameof(DealContext) + Guid.NewGuid())
+                .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider);
+    }
+
+    private class Deal
+    {
+        public int Id { get; set; }
+        public ICollection<Transaction> Transactions { get; set; } = new HashSet<Transaction>();
+    }
+
+    private class Transaction
+    {
+        public int Id { get; set; }
+        public int DealId { get; set; }
+        public Deal Deal { get; set; }
+        public ICollection<Flow> Flows { get; set; } = new HashSet<Flow>();
+    }
+
+    private class Flow
+    {
+        public int Id { get; set; }
+        public int TransactionId { get; set; }
+        public Transaction Transaction { get; set; }
+    }
+
     [Fact]
     public void StartTracking_is_no_op_if_entity_is_already_tracked()
     {
@@ -667,6 +702,128 @@ public class StateManagerTest
 
         Assert.NotSame(entry, entry2);
         Assert.Equal(EntityState.Detached, entry.EntityState);
+    }
+
+    [Fact]
+    public void Entry_for_untracked_entity_is_cached_while_the_entity_is_referenced()
+    {
+        var stateManager = CreateStateManager(BuildModel());
+        var category = new Category { Id = 1, PrincipalId = 777 };
+
+        // GetOrCreateEntry (e.g. via ctx.Entry(category)) caches an entry for the untracked entity so
+        // that the same entry is returned and a subsequent Add/Attach acts on it. This must keep working
+        // as long as the entity is referenced.
+        var entry = stateManager.GetOrCreateEntry(category);
+        entry.SetEntityState(EntityState.Detached);
+
+        Assert.Same(entry, stateManager.TryGetEntry(category));
+    }
+
+    [Fact]
+    public void Entry_for_untracked_entity_does_not_keep_the_entity_alive()
+    {
+        var stateManager = CreateStateManager(BuildModel());
+
+        // The detached-entity cache must not prevent the entity from being collected once nothing else
+        // references it, even while the state manager (context) is still alive (issue #33557).
+        var reference = CreateDetachedEntry(stateManager);
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        Assert.False(reference.IsAlive);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference CreateDetachedEntry(IStateManager stateManager)
+    {
+        var category = new Category { Id = 1, PrincipalId = 777 };
+        stateManager.GetOrCreateEntry(category).SetEntityState(EntityState.Detached);
+        return new WeakReference(category);
+    }
+
+    [Fact]
+    public void Detaching_a_tracked_graph_does_not_retain_references_to_detached_entities()
+    {
+        using var context = new DealContext();
+
+        // Reproduces the issue's pattern: add a graph, then detach it by iterating and setting each
+        // entity to Detached (detaching the principal cascade-detaches the dependents, so the later
+        // iterations call ctx.Entry(...) on already-detached entities, caching detached entries).
+        // The context must not retain references to those entities once they are no longer referenced.
+        var references = AddAndDetachGraph(context);
+
+        Assert.Empty(context.ChangeTracker.Entries());
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        Assert.All(references, reference => Assert.False(reference.IsAlive));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference[] AddAndDetachGraph(DealContext context)
+    {
+        var deal = new Deal { Id = -3 };
+        var transaction = new Transaction { Id = -2, DealId = -3, Deal = deal };
+        var flow = new Flow { TransactionId = -2, Transaction = transaction };
+        transaction.Flows.Add(flow);
+        deal.Transactions.Add(transaction);
+
+        context.Add(flow);
+
+        foreach (var entity in new object[] { deal, transaction, flow })
+        {
+            context.Entry(entity).State = EntityState.Detached;
+        }
+
+        return [new WeakReference(deal), new WeakReference(transaction), new WeakReference(flow)];
+    }
+
+    [Fact]
+    public void Can_add_an_equivalent_graph_after_detaching_a_graph_with_the_same_keys()
+    {
+        using var context = new DealContext();
+
+        var first = new Flow { TransactionId = -2, Transaction = new Transaction { Id = -2, DealId = -3, Deal = new Deal { Id = -3 } } };
+        Connect(first);
+
+        // Capture the first graph's instances up front: detaching cascades through the graph and
+        // nulls the navigations, so they can't be reached from 'first' afterwards.
+        var firstGraph = new object[] { first, first.Transaction!, first.Transaction!.Deal! };
+
+        context.Add(first);
+        foreach (var entity in firstGraph)
+        {
+            context.Entry(entity).State = EntityState.Detached;
+        }
+
+        var second = new Flow { TransactionId = -2, Transaction = new Transaction { Id = -2, DealId = -3, Deal = new Deal { Id = -3 } } };
+        Connect(second);
+
+        // Must not throw an identity conflict and must not pull the detached first graph back in.
+        context.Add(second);
+
+        var entries = context.ChangeTracker.Entries().ToList();
+        Assert.Equal(3, entries.Count);
+        Assert.All(entries, e => Assert.Equal(EntityState.Added, e.State));
+        Assert.DoesNotContain(entries, e => firstGraph.Contains(e.Entity));
+
+        context.SaveChanges();
+
+        Assert.Equal(1, context.Set<Deal>().Count());
+        Assert.Equal(1, context.Set<Transaction>().Count());
+        Assert.Equal(1, context.Set<Flow>().Count());
+
+        static void Connect(Flow f)
+        {
+            f.TransactionId = f.Transaction!.Id;
+            f.Transaction.Flows.Add(f);
+            f.Transaction.DealId = f.Transaction.Deal!.Id;
+            f.Transaction.Deal.Transactions.Add(f.Transaction);
+        }
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #33557: A long-lived `DbContext` leaked entities that were detached via `ctx.Entry(x).State = Detached`.

- Root cause: _detachedReferenceMap held entities with references for the context's lifetime.
- Fix: make _detachedReferenceMap a ConditionalWeakTable
- The originally-reported InvalidOperationException is already fixed on main; the remaining defect was purely the leak.
- No API change, ~12 lines
- No measurable perf impact--see below--but does add some some extra memory pressure.

Full details from Claude

Background
----------
When ctx.Entry(entity) is called for an untracked entity, the StateManager creates an InternalEntityEntry in the Detached state and caches it in EntityReferenceMap._detachedReferenceMap so that subsequent calls for the same
instance return the same entry (and a later Add/Attach/Update acts on it).

That map was a Dictionary<object, InternalEntityEntry> keyed by the entity instance, so it held the entity with a strong reference until the entry transitioned to a tracked state or ChangeTracker.Clear()/dispose was called.
Detaching an entity (ctx.Entry(x).State = Detached) is a no-op state change that never transitions the entry out of the map, so the entity stayed rooted by the context. In the reported scenario the principal's detach cascade-detaches
the dependents, so the subsequent ctx.Entry(...) calls in the user's detach loop ran against already-detached entities, caching - and thus leaking - them.

Rejected approaches
-------------------
1. Evict the cached entry on the no-op SetEntityState(Detached).
   Breaks the entry-stability contract pinned by 15 existing tests
   (DbSetTest / DbContextTest / SharedTypeDbSetTest.Can_use_*_to_change_entity_state):
       var entry = ctx.Entry(e);   // caches entry https://github.com/dotnet/efcore/pull/1
       entry.State = Detached;     // no-op
       ctx.Add(e);                 // must transition entry https://github.com/dotnet/efcore/pull/1 -> Added
   Evicting https://github.com/dotnet/efcore/pull/1 makes Add create a new entry, so the caller's `entry` no longer reflects the Add.

2. Any other purely state/flag-based heuristic for "release on detach".
   Same problem. The ONLY thing that distinguishes the leak case (the user no longer references the entity) from the stability case (the user still holds  and reuses the entity) is whether the entity is still reachable. EF cannot
   know that from change-tracking state - only the GC does. That is precisely what a weak reference expresses, so weak references are required, not just one option among several.

Fix
---
Change _detachedReferenceMap to ConditionalWeakTable<object, InternalEntityEntry>.
CWT holds the key (entity) weakly via a DependentHandle, so:
- While the entity is referenced elsewhere, the cached entry is found and reused (entry-stability contract preserved).
- Once nothing else references the entity, the entity and its cached entry become collectable even though the context is still alive (leak fixed).

The change is contained to the field and the add site (AddOrUpdate); TryGetValue,Remove and the Clear (= null) paths are syntactically identical. Detached entries are never enumerated - GetCountForState / GetEntriesForState / GetNonDeletedEntities all exclude Detached - so no enumeration-based code is affected. CWT uses reference
equality, matching the previous ReferenceEqualityComparer.

Perf
----
Measured on the InMemory provider (Release, min of repeated runs), comparing this
change against main:
- Attach a 400k-entity graph (exercises detached-map add + transition-remove per
  node): ~416 ms (main) vs ~403-415 ms (this change).
- ctx.Entry() on 500k untracked entities (pure detached-map add): ~335 ms vs
  ~324-335 ms.
No measurable regression; the detached-map operations are a small fraction of the attach cost and CWT add/remove/lookup is comparable to Dictionary for this workload. Note: CWT allocates a GC-tracked DependentHandle per cached detached entry, so a workload creating millions of distinct untracked entities via ctx.Entry() without
tracking them would create more handles than the old Dictionary.

Tests
-----
Added to StateManagerTest:
- Entry_for_untracked_entity_is_cached_while_the_entity_is_referenced - the stability contract (same entry returned while the entity is referenced).
- Entry_for_untracked_entity_does_not_keep_the_entity_alive - GC/WeakReference test proving a cached detached entry no longer roots its entity.
- Detaching_a_tracked_graph_does_not_retain_references_to_detached_entities - GC/WeakReference test reproducing the issue's detach-loop pattern.
- Can_add_an_equivalent_graph_after_detaching_a_graph_with_the_same_keys - pins the already-fixed no-exception / no-save-detached behavior.