### PR TITLE
Add validation for Index included properties inside JSON-mapped types

### DIFF
--- a/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerModelValidator.cs
+++ b/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerModelValidator.cs
@@ -259,6 +259,20 @@ public class SqlServerModelValidator(
                         index.DeclaringEntityType.DisplayName()));
             }
 
+            foreach (var includeProperty in includeProperties)
+            {
+                var traversedComplexCollection = FindTraversedComplexCollection(index.DeclaringEntityType, includeProperty);
+                if (traversedComplexCollection != null)
+                {
+                    throw new InvalidOperationException(
+                        SqlServerStrings.IncludePropertyTraversesComplexCollection(
+                            includeProperty,
+                            index.DisplayName(),
+                            index.DeclaringEntityType.DisplayName(),
+                            traversedComplexCollection));
+                }
+            }
+
             var duplicateProperty = includeProperties
                 .GroupBy(i => i)
                 .Where(g => g.Count() > 1)
@@ -285,6 +299,32 @@ public class SqlServerModelValidator(
                         coveredProperty,
                         index.DisplayName()));
             }
+        }
+
+        // Returns the name of the first complex collection traversed by the given dotted include-property path, or
+        // <see langword="null" /> if the path does not traverse any complex collection. Properties nested inside a complex
+        // collection live in a JSON document and so cannot be included in a covering index.
+        static string? FindTraversedComplexCollection(IReadOnlyEntityType entityType, string propertyPath)
+        {
+            var segments = propertyPath.Split('.');
+            IReadOnlyTypeBase currentType = entityType;
+            for (var i = 0; i < segments.Length - 1; i++)
+            {
+                var complexProperty = currentType.FindComplexProperty(segments[i]);
+                if (complexProperty == null)
+                {
+                    return null;
+                }
+
+                if (complexProperty.IsCollection)
+                {
+                    return complexProperty.Name;
+                }
+
+                currentType = complexProperty.ComplexType;
+            }
+
+            return null;
         }
     }
 

--- a/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerModelValidator.cs
+++ b/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerModelValidator.cs
@@ -301,9 +301,9 @@ public class SqlServerModelValidator(
             }
         }
 
-        // Returns the name of the first complex collection traversed by the given dotted include-property path, or
-        // <see langword="null" /> if the path does not traverse any complex collection. Properties nested inside a complex
-        // collection live in a JSON document and so cannot be included in a covering index.
+        // Returns the name of the first complex collection traversed by the given dotted include-property path, or null if
+        // the path does not traverse any complex collection. Properties nested inside a complex collection live in a JSON
+        // document and so cannot be included in a covering index.
         static string? FindTraversedComplexCollection(IReadOnlyEntityType entityType, string propertyPath)
         {
             var segments = propertyPath.Split('.');

--- a/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerModelValidator.cs
+++ b/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerModelValidator.cs
@@ -247,7 +247,7 @@ public class SqlServerModelValidator(
         {
 #pragma warning disable EF1001 // Internal EF Core API usage.
             var notFound = includeProperties
-                .FirstOrDefault(i => RelationalModel.FindPropertyByPath(index.DeclaringEntityType, i) == null);
+                .FirstOrDefault(i => RelationalModel.FindPropertyBaseByPath(index.DeclaringEntityType, i) == null);
 #pragma warning restore EF1001 // Internal EF Core API usage.
 
             if (notFound != null)
@@ -261,15 +261,16 @@ public class SqlServerModelValidator(
 
             foreach (var includeProperty in includeProperties)
             {
-                var traversedComplexCollection = FindTraversedComplexCollection(index.DeclaringEntityType, includeProperty);
-                if (traversedComplexCollection != null)
+#pragma warning disable EF1001 // Internal EF Core API usage.
+                var propertyBase = RelationalModel.FindPropertyBaseByPath(index.DeclaringEntityType, includeProperty)!;
+#pragma warning restore EF1001 // Internal EF Core API usage.
+                if (propertyBase.DeclaringType.IsMappedToJson())
                 {
                     throw new InvalidOperationException(
-                        SqlServerStrings.IncludePropertyTraversesComplexCollection(
+                        SqlServerStrings.IncludePropertyInJsonMappedType(
                             includeProperty,
                             index.DisplayName(),
-                            index.DeclaringEntityType.DisplayName(),
-                            traversedComplexCollection));
+                            index.DeclaringEntityType.DisplayName()));
                 }
             }
 
@@ -299,32 +300,6 @@ public class SqlServerModelValidator(
                         coveredProperty,
                         index.DisplayName()));
             }
-        }
-
-        // Returns the name of the first complex collection traversed by the given dotted include-property path, or null if
-        // the path does not traverse any complex collection. Properties nested inside a complex collection live in a JSON
-        // document and so cannot be included in a covering index.
-        static string? FindTraversedComplexCollection(IReadOnlyEntityType entityType, string propertyPath)
-        {
-            var segments = propertyPath.Split('.');
-            IReadOnlyTypeBase currentType = entityType;
-            for (var i = 0; i < segments.Length - 1; i++)
-            {
-                var complexProperty = currentType.FindComplexProperty(segments[i]);
-                if (complexProperty == null)
-                {
-                    return null;
-                }
-
-                if (complexProperty.IsCollection)
-                {
-                    return complexProperty.Name;
-                }
-
-                currentType = complexProperty.ComplexType;
-            }
-
-            return null;
         }
     }
 

--- a/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerModelValidator.cs
+++ b/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerModelValidator.cs
@@ -247,7 +247,13 @@ public class SqlServerModelValidator(
         {
 #pragma warning disable EF1001 // Internal EF Core API usage.
             var notFound = includeProperties
-                .FirstOrDefault(i => RelationalModel.FindPropertyBaseByPath(index.DeclaringEntityType, i) == null);
+                .FirstOrDefault(i =>
+                {
+                    var propertyBase = RelationalModel.FindPropertyBaseByPath(index.DeclaringEntityType, i);
+                    return propertyBase == null
+                        || (propertyBase is IComplexProperty complexProperty
+                            && !complexProperty.ComplexType.IsMappedToJson());
+                });
 #pragma warning restore EF1001 // Internal EF Core API usage.
 
             if (notFound != null)

--- a/src/EFCore.SqlServer/Metadata/Internal/SqlServerAnnotationProvider.cs
+++ b/src/EFCore.SqlServer/Metadata/Internal/SqlServerAnnotationProvider.cs
@@ -269,9 +269,15 @@ public class SqlServerAnnotationProvider(RelationalAnnotationProviderDependencie
         if (modelIndex.GetIncludeProperties(table) is { } includeProperties)
         {
 #pragma warning disable EF1001 // Internal EF Core API usage.
+            var storeObjectIdentifier = StoreObjectIdentifier.Table(table.Name, table.Schema);
             var includeColumns = includeProperties
-                .Select(p => RelationalModel.FindPropertyByPath(modelIndex.DeclaringEntityType, p)!
-                    .GetColumnName(StoreObjectIdentifier.Table(table.Name, table.Schema)))
+                .Select(p =>
+                {
+                    var propertyBase = RelationalModel.FindPropertyBaseByPath(modelIndex.DeclaringEntityType, p)!;
+                    return propertyBase is IReadOnlyProperty property
+                        ? property.GetColumnName(storeObjectIdentifier)
+                        : ((IReadOnlyComplexProperty)propertyBase).ComplexType.GetContainerColumnName();
+                })
                 .ToArray();
 #pragma warning restore EF1001 // Internal EF Core API usage.
 

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
@@ -238,6 +238,14 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
                 property, index, entityType);
 
         /// <summary>
+        ///     The include property '{property}' specified on the index {index} on entity type '{entityType}' traverses the complex collection '{complexCollection}'. Properties nested inside a complex collection are stored in a JSON document and cannot be included in an index.
+        /// </summary>
+        public static string IncludePropertyTraversesComplexCollection(object? property, object? index, object? entityType, object? complexCollection)
+            => string.Format(
+                GetString("IncludePropertyTraversesComplexCollection", nameof(property), nameof(index), nameof(entityType), nameof(complexCollection)),
+                property, index, entityType, complexCollection);
+
+        /// <summary>
         ///     Cannot use table '{table}' for entity type '{entityType}' since it is being used for entity type '{otherEntityType}' and entity type '{entityTypeWithSqlOutputClause}' is configured to use the SQL OUTPUT clause, but entity type '{entityTypeWithoutSqlOutputClause}' is not.
         /// </summary>
         public static string IncompatibleSqlOutputClauseMismatch(object? table, object? entityType, object? otherEntityType, object? entityTypeWithSqlOutputClause, object? entityTypeWithoutSqlOutputClause)

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
@@ -238,12 +238,12 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
                 property, index, entityType);
 
         /// <summary>
-        ///     The include property '{property}' specified on the index {index} on entity type '{entityType}' traverses the complex collection '{complexCollection}'. Properties nested inside a complex collection are stored in a JSON document and cannot be included in an index.
+        ///     The include property '{property}' specified on the index {index} on entity type '{entityType}' is contained within a JSON-mapped type. Properties contained within JSON-mapped types cannot be included in an index.
         /// </summary>
-        public static string IncludePropertyTraversesComplexCollection(object? property, object? index, object? entityType, object? complexCollection)
+        public static string IncludePropertyInJsonMappedType(object? property, object? index, object? entityType)
             => string.Format(
-                GetString("IncludePropertyTraversesComplexCollection", nameof(property), nameof(index), nameof(entityType), nameof(complexCollection)),
-                property, index, entityType, complexCollection);
+                GetString("IncludePropertyInJsonMappedType", nameof(property), nameof(index), nameof(entityType)),
+                property, index, entityType);
 
         /// <summary>
         ///     Cannot use table '{table}' for entity type '{entityType}' since it is being used for entity type '{otherEntityType}' and entity type '{entityTypeWithSqlOutputClause}' is configured to use the SQL OUTPUT clause, but entity type '{entityTypeWithoutSqlOutputClause}' is not.

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
@@ -201,8 +201,8 @@
   <data name="IncludePropertyNotFound" xml:space="preserve">
     <value>The include property '{property}' specified on the index {index} was not found on entity type '{entityType}'.</value>
   </data>
-  <data name="IncludePropertyTraversesComplexCollection" xml:space="preserve">
-    <value>The include property '{property}' specified on the index {index} on entity type '{entityType}' traverses the complex collection '{complexCollection}'. Properties nested inside a complex collection are stored in a JSON document and cannot be included in an index.</value>
+  <data name="IncludePropertyInJsonMappedType" xml:space="preserve">
+    <value>The include property '{property}' specified on the index {index} on entity type '{entityType}' is contained within a JSON-mapped type. Properties contained within JSON-mapped types cannot be included in an index.</value>
   </data>
   <data name="IncompatibleSqlOutputClauseMismatch" xml:space="preserve">
     <value>Cannot use table '{table}' for entity type '{entityType}' since it is being used for entity type '{otherEntityType}' and entity type '{entityTypeWithSqlOutputClause}' is configured to use the SQL OUTPUT clause, but entity type '{entityTypeWithoutSqlOutputClause}' is not.</value>

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
@@ -201,6 +201,9 @@
   <data name="IncludePropertyNotFound" xml:space="preserve">
     <value>The include property '{property}' specified on the index {index} was not found on entity type '{entityType}'.</value>
   </data>
+  <data name="IncludePropertyTraversesComplexCollection" xml:space="preserve">
+    <value>The include property '{property}' specified on the index {index} on entity type '{entityType}' traverses the complex collection '{complexCollection}'. Properties nested inside a complex collection are stored in a JSON document and cannot be included in an index.</value>
+  </data>
   <data name="IncompatibleSqlOutputClauseMismatch" xml:space="preserve">
     <value>Cannot use table '{table}' for entity type '{entityType}' since it is being used for entity type '{otherEntityType}' and entity type '{entityTypeWithSqlOutputClause}' is configured to use the SQL OUTPUT clause, but entity type '{entityTypeWithoutSqlOutputClause}' is not.</value>
   </data>

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsSqlServerTest.cs
@@ -2358,6 +2358,49 @@ CREATE INDEX [IX_People_Name] ON [People] ([Name]) INCLUDE ([FirstName], [LastNa
     }
 
     [Fact]
+    public virtual async Task Create_index_with_include_on_complex_property()
+    {
+        await Test(
+            builder => builder.Entity(
+                "People", e =>
+                {
+                    e.Property<int>("Id");
+                    e.HasKey("Id");
+                    e.Property<string>("Name");
+                    e.ComplexProperty<JsonIndexItem>(
+                        "Details", cb =>
+                        {
+                            cb.Property(i => i.Value);
+                            cb.Property(i => i.Other);
+                        });
+                }),
+            builder => { },
+            builder => builder.Entity("People").HasIndex("Name")
+                .IncludeProperties("Details.Value"),
+            model =>
+            {
+                var table = Assert.Single(model.Tables);
+                var index = Assert.Single(table.Indexes);
+                Assert.Equal(1, index.Columns.Count);
+                Assert.Contains(table.Columns.Single(c => c.Name == "Name"), index.Columns);
+            });
+
+        AssertSql(
+            """
+DECLARE @var nvarchar(max);
+SELECT @var = QUOTENAME(OBJECT_NAME([c].[default_object_id]))
+FROM [sys].[columns] [c]
+WHERE [c].[object_id] = OBJECT_ID(N'[People]') AND [c].[name] = N'Name';
+IF @var IS NOT NULL EXEC(N'ALTER TABLE [People] DROP CONSTRAINT ' + @var + ';');
+ALTER TABLE [People] ALTER COLUMN [Name] nvarchar(450) NULL;
+""",
+            //
+            """
+CREATE INDEX [IX_People_Name] ON [People] ([Name]) INCLUDE ([Details_Value]);
+""");
+    }
+
+    [Fact]
     public virtual async Task Create_index_with_include_and_filter()
     {
         await Test(

--- a/test/EFCore.SqlServer.Tests/Infrastructure/SqlServerModelValidatorTest.cs
+++ b/test/EFCore.SqlServer.Tests/Infrastructure/SqlServerModelValidatorTest.cs
@@ -602,10 +602,38 @@ public class SqlServerModelValidatorTest : RelationalModelValidatorTest
             modelBuilder);
     }
 
+    [Fact]
+    public void IncludeProperties_traversing_complex_collection_throws()
+    {
+        var modelBuilder = CreateConventionModelBuilder();
+        modelBuilder.Entity<EntityWithIncludedComplexCollection>(b =>
+        {
+            b.HasKey(e => e.Id);
+            b.ComplexCollection(e => e.Addresses, cb =>
+            {
+                cb.ToJson();
+                cb.Property(a => a.City).IsRequired();
+                cb.Property(a => a.Street).IsRequired();
+            });
+            b.HasIndex(e => e.Id).IncludeProperties("Addresses.City");
+        });
+
+        VerifyError(
+            SqlServerStrings.IncludePropertyTraversesComplexCollection(
+                "Addresses.City", "{'Id'}", nameof(EntityWithIncludedComplexCollection), "Addresses"),
+            modelBuilder);
+    }
+
     protected class EntityWithIncludedComplex
     {
         public int Id { get; set; }
         public required EntityWithIncludedComplexAddress Address { get; set; }
+    }
+
+    protected class EntityWithIncludedComplexCollection
+    {
+        public int Id { get; set; }
+        public required List<EntityWithIncludedComplexAddress> Addresses { get; set; }
     }
 
     protected class EntityWithIncludedComplexAddress

--- a/test/EFCore.SqlServer.Tests/Infrastructure/SqlServerModelValidatorTest.cs
+++ b/test/EFCore.SqlServer.Tests/Infrastructure/SqlServerModelValidatorTest.cs
@@ -603,6 +603,26 @@ public class SqlServerModelValidatorTest : RelationalModelValidatorTest
     }
 
     [Fact]
+    public void IncludeProperties_on_non_json_complex_property_throws()
+    {
+        var modelBuilder = CreateConventionModelBuilder();
+        modelBuilder.Entity<EntityWithIncludedComplex>(b =>
+        {
+            b.HasKey(e => e.Id);
+            b.ComplexProperty(e => e.Address, cb =>
+            {
+                cb.Property(a => a.City).IsRequired();
+                cb.Property(a => a.Street).IsRequired();
+            });
+            b.HasIndex(e => e.Id).IncludeProperties("Address");
+        });
+
+        VerifyError(
+            SqlServerStrings.IncludePropertyNotFound("Address", "{'Id'}", nameof(EntityWithIncludedComplex)),
+            modelBuilder);
+    }
+
+    [Fact]
     public void IncludeProperties_inside_json_complex_collection_throws()
     {
         var modelBuilder = CreateConventionModelBuilder();

--- a/test/EFCore.SqlServer.Tests/Infrastructure/SqlServerModelValidatorTest.cs
+++ b/test/EFCore.SqlServer.Tests/Infrastructure/SqlServerModelValidatorTest.cs
@@ -603,7 +603,7 @@ public class SqlServerModelValidatorTest : RelationalModelValidatorTest
     }
 
     [Fact]
-    public void IncludeProperties_traversing_complex_collection_throws()
+    public void IncludeProperties_inside_json_complex_collection_throws()
     {
         var modelBuilder = CreateConventionModelBuilder();
         modelBuilder.Entity<EntityWithIncludedComplexCollection>(b =>
@@ -619,9 +619,79 @@ public class SqlServerModelValidatorTest : RelationalModelValidatorTest
         });
 
         VerifyError(
-            SqlServerStrings.IncludePropertyTraversesComplexCollection(
-                "Addresses.City", "{'Id'}", nameof(EntityWithIncludedComplexCollection), "Addresses"),
+            SqlServerStrings.IncludePropertyInJsonMappedType(
+                "Addresses.City", "{'Id'}", nameof(EntityWithIncludedComplexCollection)),
             modelBuilder);
+    }
+
+    [Fact]
+    public void IncludeProperties_on_json_complex_collection_is_valid()
+    {
+        var modelBuilder = CreateConventionModelBuilder();
+        modelBuilder.Entity<EntityWithIncludedComplexCollection>(b =>
+        {
+            b.HasKey(e => e.Id);
+            b.ComplexCollection(e => e.Addresses, cb =>
+            {
+                cb.ToJson();
+                cb.Property(a => a.City).IsRequired();
+                cb.Property(a => a.Street).IsRequired();
+            });
+            b.HasIndex(e => e.Id).IncludeProperties("Addresses");
+        });
+
+        var model = Validate(modelBuilder);
+        var index = model.FindEntityType(typeof(EntityWithIncludedComplexCollection))!.GetIndexes().Single();
+        Assert.Equal(["Addresses"], index.GetIncludeProperties());
+    }
+
+    [Fact]
+    public void IncludeProperties_inside_json_complex_property_throws()
+    {
+        var modelBuilder = CreateConventionModelBuilder();
+        modelBuilder.Entity<EntityWithIncludedComplexJson>(b =>
+        {
+            b.HasKey(e => e.Id);
+            b.ComplexProperty(e => e.Address, cb =>
+            {
+                cb.ToJson();
+                cb.Property(a => a.City).IsRequired();
+                cb.Property(a => a.Street).IsRequired();
+            });
+            b.HasIndex(e => e.Id).IncludeProperties("Address.City");
+        });
+
+        VerifyError(
+            SqlServerStrings.IncludePropertyInJsonMappedType(
+                "Address.City", "{'Id'}", nameof(EntityWithIncludedComplexJson)),
+            modelBuilder);
+    }
+
+    [Fact]
+    public void IncludeProperties_on_json_complex_property_is_valid()
+    {
+        var modelBuilder = CreateConventionModelBuilder();
+        modelBuilder.Entity<EntityWithIncludedComplexJson>(b =>
+        {
+            b.HasKey(e => e.Id);
+            b.ComplexProperty(e => e.Address, cb =>
+            {
+                cb.ToJson();
+                cb.Property(a => a.City).IsRequired();
+                cb.Property(a => a.Street).IsRequired();
+            });
+            b.HasIndex(e => e.Id).IncludeProperties("Address");
+        });
+
+        var model = Validate(modelBuilder);
+        var index = model.FindEntityType(typeof(EntityWithIncludedComplexJson))!.GetIndexes().Single();
+        Assert.Equal(["Address"], index.GetIncludeProperties());
+    }
+
+    protected class EntityWithIncludedComplexJson
+    {
+        public int Id { get; set; }
+        public required EntityWithIncludedComplexAddress Address { get; set; }
     }
 
     protected class EntityWithIncludedComplex


### PR DESCRIPTION
Adds SQL Server-specific model validation to prevent configuring index `INCLUDE` properties that are nested inside a JSON-mapped type, and updates the annotation provider to correctly resolve JSON complex property paths to their container column names.

## Changes

- **`SqlServerModelValidator`**: Replace the "traverses a complex collection" check with a broader check on `propertyBase.DeclaringType.IsMappedToJson()`. This correctly rejects any include path whose target property lives inside a JSON-mapped type (collection or non-collection), while still allowing the JSON column itself to be included directly.
- **`SqlServerAnnotationProvider`**: Update include-column resolution to use `FindPropertyBaseByPath` and handle complex property paths by returning the JSON container column name via `ComplexType.GetContainerColumnName()`.
- **`SqlServerStrings`**: Replace `IncludePropertyTraversesComplexCollection` resource with `IncludePropertyInJsonMappedType` (3 parameters, no `complexCollection` argument).
- **Tests**: Update and expand model-validation tests to cover: nested property inside a JSON collection (throws), nested property inside a non-collection JSON complex type (throws), and including a JSON complex property/collection directly (valid).