### PR TITLE
Route many-to-many loading through an injectable IManyToManyLoaderFactory (#38363)

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CSharpRuntimeModelCodeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpRuntimeModelCodeGenerator.cs
@@ -2826,6 +2826,23 @@ public class CSharpRuntimeModelCodeGenerator : ICompiledModelCodeGenerator
 
             SetNavigationBaseProperties(navigation, memberAccessReplacements, parameters);
 
+            if (parameters.ForNativeAot)
+            {
+                AddNamespace(navigation.TargetEntityType.ClrType, parameters.Namespaces);
+                AddNamespace(navigation.DeclaringEntityType.ClrType, parameters.Namespaces);
+                mainBuilder
+                    .Append(navigationVariable)
+                    .AppendLine(".SetManyToManyLoaderFactory(")
+                    .IncrementIndent()
+                    .Append("static (factory, navigation) => factory.Create<")
+                    .Append(_code.Reference(navigation.TargetEntityType.ClrType))
+                    .Append(", ")
+                    .Append(_code.Reference(navigation.DeclaringEntityType.ClrType))
+                    .AppendLine(">(navigation));")
+                    .DecrementIndent()
+                    .AppendLine();
+            }
+
             CreateAnnotations(navigation, _annotationCodeGenerator.Generate, parameters);
 
             mainBuilder

--- a/src/EFCore/ChangeTracking/CollectionEntry.cs
+++ b/src/EFCore/ChangeTracking/CollectionEntry.cs
@@ -337,7 +337,8 @@ public class CollectionEntry : NavigationEntry
     [field: AllowNull, MaybeNull]
     private ICollectionLoader TargetLoader
         => field ??= Metadata is IRuntimeSkipNavigation skipNavigation
-            ? skipNavigation.GetManyToManyLoader()
+            ? skipNavigation.GetManyToManyLoader(
+                InternalEntry.Context.GetDependencies().ManyToManyLoaderFactory)
             : new EntityFinderCollectionLoaderAdapter(
                 InternalEntry.StateManager.CreateEntityFinder(Metadata.TargetEntityType),
                 (INavigation)Metadata);

--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -218,6 +218,16 @@ public class DbContext :
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [EntityFrameworkInternal]
+    IManyToManyLoaderFactory IDbContextDependencies.ManyToManyLoaderFactory
+        => DbContextDependencies.ManyToManyLoaderFactory;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
     IAsyncQueryProvider IDbContextDependencies.QueryProvider
         => DbContextDependencies.QueryProvider;
 

--- a/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
+++ b/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
@@ -59,6 +59,7 @@ public class EntityFrameworkServicesBuilder
             { typeof(IDbSetInitializer), new ServiceCharacteristics(ServiceLifetime.Singleton) },
             { typeof(IDbSetSource), new ServiceCharacteristics(ServiceLifetime.Singleton) },
             { typeof(IEntityFinderSource), new ServiceCharacteristics(ServiceLifetime.Singleton) },
+            { typeof(IManyToManyLoaderFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
             { typeof(IStructuralTypeMaterializerSource), new ServiceCharacteristics(ServiceLifetime.Singleton) },
             { typeof(ITypeMappingSource), new ServiceCharacteristics(ServiceLifetime.Singleton) },
             { typeof(IModelCustomizer), new ServiceCharacteristics(ServiceLifetime.Singleton) },
@@ -239,6 +240,7 @@ public class EntityFrameworkServicesBuilder
         TryAdd<IDbSetInitializer, DbSetInitializer>();
         TryAdd<IDbSetSource, DbSetSource>();
         TryAdd<IEntityFinderSource, EntityFinderSource>();
+        TryAdd<IManyToManyLoaderFactory, ManyToManyLoaderFactory>();
         TryAdd<IStructuralTypeMaterializerSource, StructuralTypeMaterializerSource>();
         TryAdd<IProviderConventionSetBuilder, ProviderConventionSetBuilder>();
         TryAdd<IConventionSetBuilder, RuntimeConventionSetBuilder>();

--- a/src/EFCore/Internal/DbContextDependencies.cs
+++ b/src/EFCore/Internal/DbContextDependencies.cs
@@ -35,6 +35,7 @@ public sealed record DbContextDependencies : IDbContextDependencies
         IChangeDetector changeDetector,
         IDbSetSource setSource,
         IEntityFinderSource entityFinderSource,
+        IManyToManyLoaderFactory manyToManyLoaderFactory,
         IEntityGraphAttacher entityGraphAttacher,
         IAsyncQueryProvider queryProvider,
         IStateManager stateManager,
@@ -51,6 +52,7 @@ public sealed record DbContextDependencies : IDbContextDependencies
         UpdateLogger = updateLogger;
         InfrastructureLogger = infrastructureLogger;
         EntityFinderFactory = new EntityFinderFactory(entityFinderSource, stateManager, setSource, currentContext.Context);
+        ManyToManyLoaderFactory = manyToManyLoaderFactory;
     }
 
     /// <summary>
@@ -68,6 +70,14 @@ public sealed record DbContextDependencies : IDbContextDependencies
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public IEntityFinderFactory EntityFinderFactory { get; }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public IManyToManyLoaderFactory ManyToManyLoaderFactory { get; }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Internal/IDbContextDependencies.cs
+++ b/src/EFCore/Internal/IDbContextDependencies.cs
@@ -41,6 +41,14 @@ public interface IDbContextDependencies
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    IManyToManyLoaderFactory ManyToManyLoaderFactory { get; }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     IAsyncQueryProvider QueryProvider { get; }
 
     /// <summary>

--- a/src/EFCore/Internal/IManyToManyLoaderFactory.cs
+++ b/src/EFCore/Internal/IManyToManyLoaderFactory.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+/// <remarks>
+///     The service lifetime is <see cref="ServiceLifetime.Singleton" />. This means a single instance
+///     is used by many <see cref="DbContext" /> instances and the loaders it creates may be cached on the
+///     (singleton) model, so implementations and the loaders they return must be thread-safe and must not
+///     capture any scoped service or <see cref="DbContext" />.
+/// </remarks>
+public interface IManyToManyLoaderFactory
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    ICollectionLoader Create(ISkipNavigation skipNavigation);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    ICollectionLoader Create<TEntity, TSourceEntity>(ISkipNavigation skipNavigation)
+        where TEntity : class
+        where TSourceEntity : class;
+}

--- a/src/EFCore/Internal/ManyToManyLoaderFactory.cs
+++ b/src/EFCore/Internal/ManyToManyLoaderFactory.cs
@@ -11,38 +11,31 @@ namespace Microsoft.EntityFrameworkCore.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public class ManyToManyLoaderFactory
+public class ManyToManyLoaderFactory : IManyToManyLoaderFactory
 {
     private static readonly MethodInfo GenericCreate
         = typeof(ManyToManyLoaderFactory).GetTypeInfo().GetDeclaredMethod(nameof(CreateManyToMany))!;
 
-    private ManyToManyLoaderFactory()
-    {
-    }
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public static readonly ManyToManyLoaderFactory Instance = new();
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
+    /// <inheritdoc />
     public virtual ICollectionLoader Create(ISkipNavigation skipNavigation)
         => (ICollectionLoader)GenericCreate.MakeGenericMethod(
                 skipNavigation.TargetEntityType.ClrType,
                 skipNavigation.DeclaringEntityType.ClrType)
-            .Invoke(null, [skipNavigation])!;
+            .Invoke(this, [skipNavigation])!;
 
-    [UsedImplicitly]
-    private static ICollectionLoader CreateManyToMany<TEntity, TTargetEntity>(ISkipNavigation skipNavigation)
+    /// <inheritdoc />
+    public virtual ICollectionLoader Create<TEntity, TSourceEntity>(ISkipNavigation skipNavigation)
         where TEntity : class
-        where TTargetEntity : class
-        => new ManyToManyLoader<TEntity, TTargetEntity>(skipNavigation);
+        where TSourceEntity : class
+        => new ManyToManyLoader<TEntity, TSourceEntity>(skipNavigation);
+
+    // Invoked via reflection by the non-generic Create above (GenericCreate). It deliberately
+    // forwards to the virtual Create<,> so that a provider overriding Create<,> is still honored
+    // on the reflection path. Do not inline this into MakeGenericMethod against Create<,> directly:
+    // Create is overloaded, so GetDeclaredMethod(nameof(Create)) would be ambiguous.
+    [UsedImplicitly]
+    private ICollectionLoader CreateManyToMany<TEntity, TSourceEntity>(ISkipNavigation skipNavigation)
+        where TEntity : class
+        where TSourceEntity : class
+        => Create<TEntity, TSourceEntity>(skipNavigation);
 }

--- a/src/EFCore/Metadata/Internal/IRuntimeSkipNavigation.cs
+++ b/src/EFCore/Metadata/Internal/IRuntimeSkipNavigation.cs
@@ -19,5 +19,5 @@ public interface IRuntimeSkipNavigation : ISkipNavigation, IRuntimeNavigationBas
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    ICollectionLoader GetManyToManyLoader();
+    ICollectionLoader GetManyToManyLoader(IManyToManyLoaderFactory factory);
 }

--- a/src/EFCore/Metadata/Internal/SkipNavigation.cs
+++ b/src/EFCore/Metadata/Internal/SkipNavigation.cs
@@ -20,6 +20,7 @@ public class SkipNavigation : PropertyBase, IMutableSkipNavigation, IConventionS
 
     // Warning: Never access these fields directly as access needs to be thread-safe
     private bool _collectionAccessorInitialized;
+    private ICollectionLoader? _manyToManyLoader;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -373,21 +374,6 @@ public class SkipNavigation : PropertyBase, IMutableSkipNavigation, IConventionS
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    [field: AllowNull, MaybeNull]
-    public virtual ICollectionLoader ManyToManyLoader
-        => NonCapturingLazyInitializer.EnsureInitialized(
-            ref field, this, static navigation =>
-            {
-                navigation.EnsureReadOnly();
-                return ManyToManyLoaderFactory.Instance.Create(navigation);
-            });
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
     [DebuggerStepThrough]
     public override string ToString()
         => ((IReadOnlySkipNavigation)this).ToDebugString(MetadataDebugStringOptions.SingleLineDefault);
@@ -480,12 +466,12 @@ public class SkipNavigation : PropertyBase, IMutableSkipNavigation, IConventionS
     IClrCollectionAccessor? IPropertyBase.GetCollectionAccessor()
         => CollectionAccessor;
 
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    ICollectionLoader IRuntimeSkipNavigation.GetManyToManyLoader()
-        => ManyToManyLoader;
+    /// <inheritdoc />
+    ICollectionLoader IRuntimeSkipNavigation.GetManyToManyLoader(IManyToManyLoaderFactory factory)
+        => NonCapturingLazyInitializer.EnsureInitialized(
+            ref _manyToManyLoader, this, factory, static (navigation, factory) =>
+            {
+                navigation.EnsureReadOnly();
+                return factory.Create(navigation);
+            });
 }

--- a/src/EFCore/Metadata/RuntimeSkipNavigation.cs
+++ b/src/EFCore/Metadata/RuntimeSkipNavigation.cs
@@ -24,6 +24,9 @@ public class RuntimeSkipNavigation : RuntimePropertyBase, IRuntimeSkipNavigation
     private IClrCollectionAccessor? _collectionAccessor;
     private bool _collectionAccessorInitialized;
     private ICollectionLoader? _manyToManyLoader;
+    // An optional compiled-model delegate that creates the loader, letting a compiled model carry the
+    // concrete generic types for native AOT. Null unless set during model build.
+    private Func<IManyToManyLoaderFactory, ISkipNavigation, ICollectionLoader>? _manyToManyLoaderDelegatedFactory;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -138,6 +141,17 @@ public class RuntimeSkipNavigation : RuntimePropertyBase, IRuntimeSkipNavigation
     }
 
     /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public virtual void SetManyToManyLoaderFactory(
+        Func<IManyToManyLoaderFactory, ISkipNavigation, ICollectionLoader> factory)
+        => _manyToManyLoaderDelegatedFactory = factory;
+
+    /// <summary>
     ///     Returns a string that represents the current object.
     /// </summary>
     /// <returns>A string that represents the current object.</returns>
@@ -204,10 +218,15 @@ public class RuntimeSkipNavigation : RuntimePropertyBase, IRuntimeSkipNavigation
                 : null);
 
     /// <inheritdoc />
-    ICollectionLoader IRuntimeSkipNavigation.GetManyToManyLoader()
+    ICollectionLoader IRuntimeSkipNavigation.GetManyToManyLoader(IManyToManyLoaderFactory factory)
         => NonCapturingLazyInitializer.EnsureInitialized(
-            ref _manyToManyLoader, this, static navigation =>
-                RuntimeFeature.IsDynamicCodeSupported
-                    ? ManyToManyLoaderFactory.Instance.Create(navigation)
-                    : throw new InvalidOperationException(CoreStrings.NativeAotNoCompiledModel));
+            ref _manyToManyLoader, this, factory, static (navigation, factory) =>
+            {
+                var generated = navigation._manyToManyLoaderDelegatedFactory;
+                return generated != null
+                    ? generated(factory, navigation)
+                    : RuntimeFeature.IsDynamicCodeSupported
+                        ? factory.Create(navigation)
+                        : throw new InvalidOperationException(CoreStrings.NativeAotNoCompiledModel);
+            });
 }

--- a/test/EFCore.Cosmos.FunctionalTests/Scaffolding/Baselines/BigModel/PrincipalBaseEntityType.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Scaffolding/Baselines/BigModel/PrincipalBaseEntityType.cs
@@ -919,6 +919,9 @@ public partial class PrincipalBaseEntityType
             (CompiledModelTestBase.PrincipalBase entity, ICollection<CompiledModelTestBase.PrincipalBase> collection) => PrincipalBaseUnsafeAccessors.Deriveds(entity) = ((ICollection<CompiledModelTestBase.PrincipalBase>)collection),
             ICollection<CompiledModelTestBase.PrincipalBase> (CompiledModelTestBase.PrincipalBase entity, Action<CompiledModelTestBase.PrincipalBase, ICollection<CompiledModelTestBase.PrincipalBase>> setter) => ClrCollectionAccessorFactory.CreateAndSetHashSet<CompiledModelTestBase.PrincipalBase, ICollection<CompiledModelTestBase.PrincipalBase>, CompiledModelTestBase.PrincipalBase>(entity, setter),
             ICollection<CompiledModelTestBase.PrincipalBase> () => ((ICollection<CompiledModelTestBase.PrincipalBase>)(((ICollection<CompiledModelTestBase.PrincipalBase>)(new HashSet<CompiledModelTestBase.PrincipalBase>(ReferenceEqualityComparer.Instance))))));
+        skipNavigation.SetManyToManyLoaderFactory(
+            static (factory, navigation) => factory.Create<CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>>, CompiledModelTestBase.PrincipalBase>(navigation));
+
         return skipNavigation;
     }
 

--- a/test/EFCore.Cosmos.FunctionalTests/Scaffolding/Baselines/BigModel/PrincipalDerivedEntityType.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Scaffolding/Baselines/BigModel/PrincipalDerivedEntityType.cs
@@ -87,6 +87,9 @@ public partial class PrincipalDerivedEntityType
             (CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>> entity, ICollection<CompiledModelTestBase.PrincipalBase> collection) => PrincipalDerivedUnsafeAccessors<CompiledModelTestBase.DependentBase<byte?>>.Principals(entity) = ((ICollection<CompiledModelTestBase.PrincipalBase>)collection),
             ICollection<CompiledModelTestBase.PrincipalBase> (CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>> entity, Action<CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>>, ICollection<CompiledModelTestBase.PrincipalBase>> setter) => ClrCollectionAccessorFactory.CreateAndSetHashSet<CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>>, ICollection<CompiledModelTestBase.PrincipalBase>, CompiledModelTestBase.PrincipalBase>(entity, setter),
             ICollection<CompiledModelTestBase.PrincipalBase> () => ((ICollection<CompiledModelTestBase.PrincipalBase>)(((ICollection<CompiledModelTestBase.PrincipalBase>)(new HashSet<CompiledModelTestBase.PrincipalBase>(ReferenceEqualityComparer.Instance))))));
+        skipNavigation.SetManyToManyLoaderFactory(
+            static (factory, navigation) => factory.Create<CompiledModelTestBase.PrincipalBase, CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>>>(navigation));
+
         return skipNavigation;
     }
 

--- a/test/EFCore.InMemory.FunctionalTests/Scaffolding/Baselines/BigModel/PrincipalBaseEntityType.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Scaffolding/Baselines/BigModel/PrincipalBaseEntityType.cs
@@ -994,6 +994,9 @@ public partial class PrincipalBaseEntityType
             (CompiledModelTestBase.PrincipalBase entity, ICollection<CompiledModelTestBase.PrincipalBase> collection) => PrincipalBaseUnsafeAccessors.Deriveds(entity) = ((ICollection<CompiledModelTestBase.PrincipalBase>)collection),
             ICollection<CompiledModelTestBase.PrincipalBase> (CompiledModelTestBase.PrincipalBase entity, Action<CompiledModelTestBase.PrincipalBase, ICollection<CompiledModelTestBase.PrincipalBase>> setter) => ClrCollectionAccessorFactory.CreateAndSetHashSet<CompiledModelTestBase.PrincipalBase, ICollection<CompiledModelTestBase.PrincipalBase>, CompiledModelTestBase.PrincipalBase>(entity, setter),
             ICollection<CompiledModelTestBase.PrincipalBase> () => ((ICollection<CompiledModelTestBase.PrincipalBase>)(((ICollection<CompiledModelTestBase.PrincipalBase>)(new HashSet<CompiledModelTestBase.PrincipalBase>(ReferenceEqualityComparer.Instance))))));
+        skipNavigation.SetManyToManyLoaderFactory(
+            static (factory, navigation) => factory.Create<CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>>, CompiledModelTestBase.PrincipalBase>(navigation));
+
         return skipNavigation;
     }
 

--- a/test/EFCore.InMemory.FunctionalTests/Scaffolding/Baselines/BigModel/PrincipalDerivedEntityType.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Scaffolding/Baselines/BigModel/PrincipalDerivedEntityType.cs
@@ -87,6 +87,9 @@ public partial class PrincipalDerivedEntityType
             (CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>> entity, ICollection<CompiledModelTestBase.PrincipalBase> collection) => PrincipalDerivedUnsafeAccessors<CompiledModelTestBase.DependentBase<byte?>>.Principals(entity) = ((ICollection<CompiledModelTestBase.PrincipalBase>)collection),
             ICollection<CompiledModelTestBase.PrincipalBase> (CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>> entity, Action<CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>>, ICollection<CompiledModelTestBase.PrincipalBase>> setter) => ClrCollectionAccessorFactory.CreateAndSetHashSet<CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>>, ICollection<CompiledModelTestBase.PrincipalBase>, CompiledModelTestBase.PrincipalBase>(entity, setter),
             ICollection<CompiledModelTestBase.PrincipalBase> () => ((ICollection<CompiledModelTestBase.PrincipalBase>)(((ICollection<CompiledModelTestBase.PrincipalBase>)(new HashSet<CompiledModelTestBase.PrincipalBase>(ReferenceEqualityComparer.Instance))))));
+        skipNavigation.SetManyToManyLoaderFactory(
+            static (factory, navigation) => factory.Create<CompiledModelTestBase.PrincipalBase, CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>>>(navigation));
+
         return skipNavigation;
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Scaffolding/Baselines/BigModel/PrincipalBaseEntityType.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Scaffolding/Baselines/BigModel/PrincipalBaseEntityType.cs
@@ -1061,6 +1061,9 @@ public partial class PrincipalBaseEntityType
             (CompiledModelTestBase.PrincipalBase entity, ICollection<CompiledModelTestBase.PrincipalBase> collection) => PrincipalBaseUnsafeAccessors.Deriveds(entity) = ((ICollection<CompiledModelTestBase.PrincipalBase>)collection),
             ICollection<CompiledModelTestBase.PrincipalBase> (CompiledModelTestBase.PrincipalBase entity, Action<CompiledModelTestBase.PrincipalBase, ICollection<CompiledModelTestBase.PrincipalBase>> setter) => ClrCollectionAccessorFactory.CreateAndSetHashSet<CompiledModelTestBase.PrincipalBase, ICollection<CompiledModelTestBase.PrincipalBase>, CompiledModelTestBase.PrincipalBase>(entity, setter),
             ICollection<CompiledModelTestBase.PrincipalBase> () => ((ICollection<CompiledModelTestBase.PrincipalBase>)(((ICollection<CompiledModelTestBase.PrincipalBase>)(new HashSet<CompiledModelTestBase.PrincipalBase>(ReferenceEqualityComparer.Instance))))));
+        skipNavigation.SetManyToManyLoaderFactory(
+            static (factory, navigation) => factory.Create<CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>>, CompiledModelTestBase.PrincipalBase>(navigation));
+
         return skipNavigation;
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Scaffolding/Baselines/BigModel/PrincipalDerivedEntityType.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Scaffolding/Baselines/BigModel/PrincipalDerivedEntityType.cs
@@ -100,6 +100,9 @@ public partial class PrincipalDerivedEntityType
             (CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>> entity, ICollection<CompiledModelTestBase.PrincipalBase> collection) => PrincipalDerivedUnsafeAccessors<CompiledModelTestBase.DependentBase<byte?>>.Principals(entity) = ((ICollection<CompiledModelTestBase.PrincipalBase>)collection),
             ICollection<CompiledModelTestBase.PrincipalBase> (CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>> entity, Action<CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>>, ICollection<CompiledModelTestBase.PrincipalBase>> setter) => ClrCollectionAccessorFactory.CreateAndSetHashSet<CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>>, ICollection<CompiledModelTestBase.PrincipalBase>, CompiledModelTestBase.PrincipalBase>(entity, setter),
             ICollection<CompiledModelTestBase.PrincipalBase> () => ((ICollection<CompiledModelTestBase.PrincipalBase>)(((ICollection<CompiledModelTestBase.PrincipalBase>)(new HashSet<CompiledModelTestBase.PrincipalBase>(ReferenceEqualityComparer.Instance))))));
+        skipNavigation.SetManyToManyLoaderFactory(
+            static (factory, navigation) => factory.Create<CompiledModelTestBase.PrincipalBase, CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>>>(navigation));
+
         return skipNavigation;
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Scaffolding/Baselines/BigModel_with_JSON_columns/PrincipalBaseEntityType.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Scaffolding/Baselines/BigModel_with_JSON_columns/PrincipalBaseEntityType.cs
@@ -1089,6 +1089,9 @@ public partial class PrincipalBaseEntityType
             (CompiledModelTestBase.PrincipalBase entity, ICollection<CompiledModelTestBase.PrincipalBase> collection) => PrincipalBaseUnsafeAccessors.Deriveds(entity) = ((ICollection<CompiledModelTestBase.PrincipalBase>)collection),
             ICollection<CompiledModelTestBase.PrincipalBase> (CompiledModelTestBase.PrincipalBase entity, Action<CompiledModelTestBase.PrincipalBase, ICollection<CompiledModelTestBase.PrincipalBase>> setter) => ClrCollectionAccessorFactory.CreateAndSetHashSet<CompiledModelTestBase.PrincipalBase, ICollection<CompiledModelTestBase.PrincipalBase>, CompiledModelTestBase.PrincipalBase>(entity, setter),
             ICollection<CompiledModelTestBase.PrincipalBase> () => ((ICollection<CompiledModelTestBase.PrincipalBase>)(((ICollection<CompiledModelTestBase.PrincipalBase>)(new HashSet<CompiledModelTestBase.PrincipalBase>(ReferenceEqualityComparer.Instance))))));
+        skipNavigation.SetManyToManyLoaderFactory(
+            static (factory, navigation) => factory.Create<CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>>, CompiledModelTestBase.PrincipalBase>(navigation));
+
         return skipNavigation;
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Scaffolding/Baselines/BigModel_with_JSON_columns/PrincipalDerivedEntityType.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Scaffolding/Baselines/BigModel_with_JSON_columns/PrincipalDerivedEntityType.cs
@@ -87,6 +87,9 @@ public partial class PrincipalDerivedEntityType
             (CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>> entity, ICollection<CompiledModelTestBase.PrincipalBase> collection) => PrincipalDerivedUnsafeAccessors<CompiledModelTestBase.DependentBase<byte?>>.Principals(entity) = ((ICollection<CompiledModelTestBase.PrincipalBase>)collection),
             ICollection<CompiledModelTestBase.PrincipalBase> (CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>> entity, Action<CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>>, ICollection<CompiledModelTestBase.PrincipalBase>> setter) => ClrCollectionAccessorFactory.CreateAndSetHashSet<CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>>, ICollection<CompiledModelTestBase.PrincipalBase>, CompiledModelTestBase.PrincipalBase>(entity, setter),
             ICollection<CompiledModelTestBase.PrincipalBase> () => ((ICollection<CompiledModelTestBase.PrincipalBase>)(((ICollection<CompiledModelTestBase.PrincipalBase>)(new HashSet<CompiledModelTestBase.PrincipalBase>(ReferenceEqualityComparer.Instance))))));
+        skipNavigation.SetManyToManyLoaderFactory(
+            static (factory, navigation) => factory.Create<CompiledModelTestBase.PrincipalBase, CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>>>(navigation));
+
         return skipNavigation;
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Scaffolding/Baselines/BigModel/PrincipalBaseEntityType.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Scaffolding/Baselines/BigModel/PrincipalBaseEntityType.cs
@@ -981,6 +981,9 @@ public partial class PrincipalBaseEntityType
             (CompiledModelTestBase.PrincipalBase entity, ICollection<CompiledModelTestBase.PrincipalBase> collection) => PrincipalBaseUnsafeAccessors.Deriveds(entity) = ((ICollection<CompiledModelTestBase.PrincipalBase>)collection),
             ICollection<CompiledModelTestBase.PrincipalBase> (CompiledModelTestBase.PrincipalBase entity, Action<CompiledModelTestBase.PrincipalBase, ICollection<CompiledModelTestBase.PrincipalBase>> setter) => ClrCollectionAccessorFactory.CreateAndSetHashSet<CompiledModelTestBase.PrincipalBase, ICollection<CompiledModelTestBase.PrincipalBase>, CompiledModelTestBase.PrincipalBase>(entity, setter),
             ICollection<CompiledModelTestBase.PrincipalBase> () => ((ICollection<CompiledModelTestBase.PrincipalBase>)(((ICollection<CompiledModelTestBase.PrincipalBase>)(new HashSet<CompiledModelTestBase.PrincipalBase>(ReferenceEqualityComparer.Instance))))));
+        skipNavigation.SetManyToManyLoaderFactory(
+            static (factory, navigation) => factory.Create<CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>>, CompiledModelTestBase.PrincipalBase>(navigation));
+
         return skipNavigation;
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Scaffolding/Baselines/BigModel/PrincipalDerivedEntityType.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Scaffolding/Baselines/BigModel/PrincipalDerivedEntityType.cs
@@ -101,6 +101,9 @@ public partial class PrincipalDerivedEntityType
             (CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>> entity, ICollection<CompiledModelTestBase.PrincipalBase> collection) => PrincipalDerivedUnsafeAccessors<CompiledModelTestBase.DependentBase<byte?>>.Principals(entity) = ((ICollection<CompiledModelTestBase.PrincipalBase>)collection),
             ICollection<CompiledModelTestBase.PrincipalBase> (CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>> entity, Action<CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>>, ICollection<CompiledModelTestBase.PrincipalBase>> setter) => ClrCollectionAccessorFactory.CreateAndSetHashSet<CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>>, ICollection<CompiledModelTestBase.PrincipalBase>, CompiledModelTestBase.PrincipalBase>(entity, setter),
             ICollection<CompiledModelTestBase.PrincipalBase> () => ((ICollection<CompiledModelTestBase.PrincipalBase>)(((ICollection<CompiledModelTestBase.PrincipalBase>)(new HashSet<CompiledModelTestBase.PrincipalBase>(ReferenceEqualityComparer.Instance))))));
+        skipNavigation.SetManyToManyLoaderFactory(
+            static (factory, navigation) => factory.Create<CompiledModelTestBase.PrincipalBase, CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>>>(navigation));
+
         return skipNavigation;
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Scaffolding/Baselines/BigModel_with_JSON_columns/PrincipalBaseEntityType.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Scaffolding/Baselines/BigModel_with_JSON_columns/PrincipalBaseEntityType.cs
@@ -992,6 +992,9 @@ public partial class PrincipalBaseEntityType
             (CompiledModelTestBase.PrincipalBase entity, ICollection<CompiledModelTestBase.PrincipalBase> collection) => PrincipalBaseUnsafeAccessors.Deriveds(entity) = ((ICollection<CompiledModelTestBase.PrincipalBase>)collection),
             ICollection<CompiledModelTestBase.PrincipalBase> (CompiledModelTestBase.PrincipalBase entity, Action<CompiledModelTestBase.PrincipalBase, ICollection<CompiledModelTestBase.PrincipalBase>> setter) => ClrCollectionAccessorFactory.CreateAndSetHashSet<CompiledModelTestBase.PrincipalBase, ICollection<CompiledModelTestBase.PrincipalBase>, CompiledModelTestBase.PrincipalBase>(entity, setter),
             ICollection<CompiledModelTestBase.PrincipalBase> () => ((ICollection<CompiledModelTestBase.PrincipalBase>)(((ICollection<CompiledModelTestBase.PrincipalBase>)(new HashSet<CompiledModelTestBase.PrincipalBase>(ReferenceEqualityComparer.Instance))))));
+        skipNavigation.SetManyToManyLoaderFactory(
+            static (factory, navigation) => factory.Create<CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>>, CompiledModelTestBase.PrincipalBase>(navigation));
+
         return skipNavigation;
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Scaffolding/Baselines/BigModel_with_JSON_columns/PrincipalDerivedEntityType.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Scaffolding/Baselines/BigModel_with_JSON_columns/PrincipalDerivedEntityType.cs
@@ -88,6 +88,9 @@ public partial class PrincipalDerivedEntityType
             (CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>> entity, ICollection<CompiledModelTestBase.PrincipalBase> collection) => PrincipalDerivedUnsafeAccessors<CompiledModelTestBase.DependentBase<byte?>>.Principals(entity) = ((ICollection<CompiledModelTestBase.PrincipalBase>)collection),
             ICollection<CompiledModelTestBase.PrincipalBase> (CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>> entity, Action<CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>>, ICollection<CompiledModelTestBase.PrincipalBase>> setter) => ClrCollectionAccessorFactory.CreateAndSetHashSet<CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>>, ICollection<CompiledModelTestBase.PrincipalBase>, CompiledModelTestBase.PrincipalBase>(entity, setter),
             ICollection<CompiledModelTestBase.PrincipalBase> () => ((ICollection<CompiledModelTestBase.PrincipalBase>)(((ICollection<CompiledModelTestBase.PrincipalBase>)(new HashSet<CompiledModelTestBase.PrincipalBase>(ReferenceEqualityComparer.Instance))))));
+        skipNavigation.SetManyToManyLoaderFactory(
+            static (factory, navigation) => factory.Create<CompiledModelTestBase.PrincipalBase, CompiledModelTestBase.PrincipalDerived<CompiledModelTestBase.DependentBase<byte?>>>(navigation));
+
         return skipNavigation;
     }
 

--- a/test/EFCore.Tests/ChangeTracking/ManyToManyLoaderTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/ManyToManyLoaderTest.cs
@@ -1,0 +1,110 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.EntityFrameworkCore.ChangeTracking;
+
+public class ManyToManyLoaderTest
+{
+    [Fact]
+    public void Provider_can_replace_many_to_many_loader_factory()
+    {
+        using var context = new ReplacedFactoryContext();
+
+        var left = new Left();
+        var right = new Right();
+        left.Rights.Add(right);
+        context.AddRange(left, right);
+        context.SaveChanges();
+        context.ChangeTracker.Clear();
+
+        var tracked = context.Set<Left>().Single();
+
+        // Accessing the collection loader must route through the replaced factory.
+        Assert.Throws<CustomLoaderSentinelException>(
+            () => context.Entry(tracked).Collection(e => e.Rights).Load());
+    }
+
+    [Fact]
+    public void Generated_loader_factory_delegate_routes_through_the_runtime_factory()
+    {
+        using var context = new DelegatePathContext();
+
+        var skipNavigation = (RuntimeSkipNavigation)context.Model
+            .FindEntityType(typeof(Left))!
+            .FindSkipNavigation(nameof(Left.Rights))!;
+
+        // Simulate what the compiled-model generator emits for native AOT: a static delegate
+        // that carries the concrete generic types but defers creation to the runtime factory.
+        skipNavigation.SetManyToManyLoaderFactory(
+            static (factory, navigation) => factory.Create<Right, Left>(navigation));
+
+        var loader = ((IRuntimeSkipNavigation)skipNavigation)
+            .GetManyToManyLoader(new CustomManyToManyLoaderFactory());
+
+        // The replaced factory governs creation even via the generated delegate.
+        Assert.IsType<CustomLoader>(loader);
+    }
+
+    private class ReplacedFactoryContext : DbContext
+    {
+        protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder
+                .UseInMemoryDatabase(nameof(ReplacedFactoryContext))
+                .ReplaceService<IManyToManyLoaderFactory, CustomManyToManyLoaderFactory>();
+
+        protected internal override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<Left>().HasMany(e => e.Rights).WithMany(e => e.Lefts);
+    }
+
+    private class DelegatePathContext : DbContext
+    {
+        protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseInMemoryDatabase(nameof(DelegatePathContext));
+
+        protected internal override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<Left>().HasMany(e => e.Rights).WithMany(e => e.Lefts);
+    }
+
+    private class CustomManyToManyLoaderFactory : IManyToManyLoaderFactory
+    {
+        public ICollectionLoader Create(ISkipNavigation skipNavigation)
+            => new CustomLoader();
+
+        public ICollectionLoader Create<TEntity, TSourceEntity>(ISkipNavigation skipNavigation)
+            where TEntity : class
+            where TSourceEntity : class
+            => new CustomLoader();
+    }
+
+    private class CustomLoader : ICollectionLoader
+    {
+        public void Load(InternalEntityEntry entry, LoadOptions options)
+            => throw new CustomLoaderSentinelException();
+
+        public Task LoadAsync(InternalEntityEntry entry, LoadOptions options, CancellationToken cancellationToken = default)
+            => throw new CustomLoaderSentinelException();
+
+        public IQueryable Query(InternalEntityEntry entry)
+            => throw new CustomLoaderSentinelException();
+    }
+
+    private sealed class CustomLoaderSentinelException : Exception { }
+
+    private class Left
+    {
+        public int Id { get; set; }
+        public List<Right> Rights { get; } = new();
+    }
+
+    private class Right
+    {
+        public int Id { get; set; }
+        public List<Left> Lefts { get; } = new();
+    }
+}


### PR DESCRIPTION
Fixes #38363.

- Adds IManyToManyLoaderFactory as a replaceable singleton service so providers can override how skip-navigation (many-to-many) collection loaders are created.
- Removes the static ManyToManyLoaderFactory.Instance; loaders are now resolved from DI via IDbContextDependencies.
- Loaders are cached per skip-navigation on the (singleton) model, so the factory and the loaders it returns must be thread-safe and capture no scoped state.
- Native AOT / compiled models emit a SetManyToManyLoaderFactory delegate carrying the concrete generic types, still routed through the runtime factory.
- Adds Create<TEntity, TSourceEntity>() for a reflection-free creation path; the reflection path now forwards to it so overrides are honored either way.

## Background

Many-to-many collection loaders for skip navigations were created by a static singleton, `ManyToManyLoaderFactory.Instance`, hard-wired into `SkipNavigation`/`RuntimeSkipNavigation`. Because creation was static there was no way for a provider to substitute its own loader, and the reflection-based generic dispatch (`MakeGenericMethod`) was not overridable and is unavailable to fully reflection-free native AOT.

## Change

Introduce `IManyToManyLoaderFactory` as a core service registered with a `Singleton` lifetime, implemented by `ManyToManyLoaderFactory`. The factory is exposed on `IDbContextDependencies` and consumed by `CollectionEntry` when building the target loader, replacing the static `Instance`. Providers can swap the implementation via `ReplaceService<IManyToManyLoaderFactory, ...>`.

`IRuntimeSkipNavigation.GetManyToManyLoader` now takes the factory as a parameter; both `SkipNavigation` and `RuntimeSkipNavigation` lazily create and cache the loader through it. A new
`Create<TEntity, TSourceEntity>()` overload provides a reflection-free creation path; the non-generic `Create` still uses `MakeGenericMethod` but now forwards to the virtual `Create<,>` (via the private `CreateManyToMany`) so a provider override is honored on both paths.

For native AOT, `CSharpRuntimeModelCodeGenerator` emits a `RuntimeSkipNavigation.SetManyToManyLoaderFactory(...)` call carrying a static delegate with the concrete generic type arguments. At runtime `GetManyToManyLoader` prefers that generated delegate (still invoking the injected factory) and otherwise falls back to the reflection path when dynamic code is supported, throwing `NativeAotNoCompiledModel` when it is not. Compiled-model `BigModel` baselines are regenerated accordingly.

## Tests

`ManyToManyLoaderReplacementTest`:
- `Provider_can_replace_many_to_many_loader_factory` — a context that replaces the service routes collection loading through the custom factory.
- `Generated_loader_factory_delegate_routes_through_the_runtime_factory` — the compiled-model delegate path still defers loader creation to the injected factory.

