### PR TITLE
Add entry API overloads that work correctly with nullable value properties

### DIFF
--- a/src/EFCore/ChangeTracking/ComplexElementEntry`.cs
+++ b/src/EFCore/ChangeTracking/ComplexElementEntry`.cs
@@ -118,6 +118,28 @@ public class ComplexElementEntry<TEntity, TComplexProperty> : ComplexElementEntr
     ///     See <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see> for more information and
     ///     examples.
     /// </remarks>
+    /// <param name="propertyExpression">
+    ///     A lambda expression representing the property to access information and operations for.
+    /// </param>
+    /// <returns>An object that exposes change tracking information and operations for the given property.</returns>
+    public virtual ComplexPropertyEntry<TEntity, TNestedComplexProperty> ComplexProperty<TNestedComplexProperty>(
+        Expression<Func<TComplexProperty, TNestedComplexProperty?>> propertyExpression)
+        where TNestedComplexProperty : struct
+    {
+        Check.NotNull(propertyExpression, nameof(propertyExpression));
+
+        return new ComplexPropertyEntry<TEntity, TNestedComplexProperty>(
+            InternalEntry,
+            Metadata.ComplexType.GetComplexProperty(propertyExpression.GetMemberAccess().GetSimpleMemberName()));
+    }
+
+    /// <summary>
+    ///     Provides access to change tracking information and operations for a given complex type property of this complex type.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see> for more information and
+    ///     examples.
+    /// </remarks>
     /// <typeparam name="TElement">The element type.</typeparam>
     /// <param name="propertyExpression">
     ///     A lambda expression representing the property to access information and operations for.

--- a/src/EFCore/ChangeTracking/ComplexPropertyEntry`.cs
+++ b/src/EFCore/ChangeTracking/ComplexPropertyEntry`.cs
@@ -105,6 +105,28 @@ public class ComplexPropertyEntry<TEntity, TComplexProperty> : ComplexPropertyEn
     }
 
     /// <summary>
+    ///     Provides access to change tracking information and operations for a given nested complex type property of this complex type.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see> for more information and
+    ///     examples.
+    /// </remarks>
+    /// <param name="propertyExpression">
+    ///     A lambda expression representing the property to access information and operations for.
+    /// </param>
+    /// <returns>An object that exposes change tracking information and operations for the given property.</returns>
+    public virtual ComplexPropertyEntry<TEntity, TNestedComplexProperty> ComplexProperty<TNestedComplexProperty>(
+        Expression<Func<TComplexProperty, TNestedComplexProperty?>> propertyExpression)
+        where TNestedComplexProperty : struct
+    {
+        Check.NotNull(propertyExpression);
+
+        return new ComplexPropertyEntry<TEntity, TNestedComplexProperty>(
+            InternalEntry,
+            Metadata.ComplexType.GetComplexProperty(propertyExpression.GetMemberAccess().GetSimpleMemberName()));
+    }
+
+    /// <summary>
     ///     Provides access to change tracking information and operations for a given complex type property of this complex type.
     /// </summary>
     /// <remarks>

--- a/src/EFCore/ChangeTracking/EntityEntry`.cs
+++ b/src/EFCore/ChangeTracking/EntityEntry`.cs
@@ -90,6 +90,28 @@ public class EntityEntry<TEntity> : EntityEntry
     ///     See <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see> for more information and
     ///     examples.
     /// </remarks>
+    /// <param name="propertyExpression">
+    ///     A lambda expression representing the property to access information and operations for.
+    /// </param>
+    /// <returns>An object that exposes change tracking information and operations for the given property.</returns>
+    public virtual ComplexPropertyEntry<TEntity, TProperty> ComplexProperty<TProperty>(
+        Expression<Func<TEntity, TProperty?>> propertyExpression)
+        where TProperty : struct
+    {
+        Check.NotNull(propertyExpression);
+
+        return new ComplexPropertyEntry<TEntity, TProperty>(
+            InternalEntry,
+            Metadata.GetComplexProperty(propertyExpression.GetMemberAccess().GetSimpleMemberName()));
+    }
+
+    /// <summary>
+    ///     Provides access to change tracking information and operations for a given complex type property of this entity.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see> for more information and
+    ///     examples.
+    /// </remarks>
     /// <typeparam name="TElement">The element type.</typeparam>
     /// <param name="propertyExpression">
     ///     A lambda expression representing the property to access information and operations for.

--- a/src/EFCore/EFCore.baseline.json
+++ b/src/EFCore/EFCore.baseline.json
@@ -1547,6 +1547,9 @@
           "Member": "virtual Microsoft.EntityFrameworkCore.ChangeTracking.ComplexPropertyEntry<TEntity, TNestedComplexProperty> ComplexProperty<TNestedComplexProperty>(System.Linq.Expressions.Expression<System.Func<TComplexProperty, TNestedComplexProperty>> propertyExpression);"
         },
         {
+          "Member": "virtual Microsoft.EntityFrameworkCore.ChangeTracking.ComplexPropertyEntry<TEntity, TNestedComplexProperty> ComplexProperty<TNestedComplexProperty>(System.Linq.Expressions.Expression<System.Func<TComplexProperty, TNestedComplexProperty?>> propertyExpression);"
+        },
+        {
           "Member": "virtual Microsoft.EntityFrameworkCore.ChangeTracking.ComplexPropertyEntry<TEntity, TNestedComplexProperty> ComplexProperty<TNestedComplexProperty>(Microsoft.EntityFrameworkCore.Metadata.IComplexProperty complexProperty);"
         },
         {

--- a/src/EFCore/Storage/IDatabaseCreator.cs
+++ b/src/EFCore/Storage/IDatabaseCreator.cs
@@ -32,7 +32,7 @@ public interface IDatabaseCreator
     ///         exist then the database is deleted.
     ///     </para>
     ///     <para>
-    ///         Warning: The entire database is deleted an no effort is made to remove just the database objects that are used by
+    ///         Warning: The entire database is deleted and no effort is made to remove just the database objects that are used by
     ///         the model for this context.
     ///     </para>
     /// </summary>
@@ -45,7 +45,7 @@ public interface IDatabaseCreator
     ///         exist then the database is deleted.
     ///     </para>
     ///     <para>
-    ///         Warning: The entire database is deleted an no effort is made to remove just the database objects that are used by
+    ///         Warning: The entire database is deleted and no effort is made to remove just the database objects that are used by
     ///         the model for this context.
     ///     </para>
     /// </summary>

--- a/test/EFCore.Specification.Tests/NonSharedModelTestBase.cs
+++ b/test/EFCore.Specification.Tests/NonSharedModelTestBase.cs
@@ -19,14 +19,14 @@ public abstract class NonSharedModelTestBase(NonSharedFixture fixture) : IAsyncL
     protected IServiceProvider NonSharedServiceProvider
         => _serviceProvider
             ?? throw new InvalidOperationException(
-                $"You must call `await {nameof(InitializeAsync)}(\"DatabaseName\");` at the beginning of the test.");
+                $"You must call `await {nameof(InitializeAsync)}<TContext>();` at the beginning of the test.");
 
     private TestStore? _testStore;
 
     protected TestStore NonSharedTestStore
         => _testStore
             ?? throw new InvalidOperationException(
-                $"You must call `await {nameof(InitializeAsync)}(\"DatabaseName\");` at the beginning of the test.");
+                $"You must call `await {nameof(InitializeAsync)}<TContext>();` at the beginning of the test.");
 
     private ListLoggerFactory? _listLoggerFactory;
 

--- a/test/EFCore.Specification.Tests/PropertyValuesTestBase.cs
+++ b/test/EFCore.Specification.Tests/PropertyValuesTestBase.cs
@@ -461,6 +461,7 @@ public abstract class PropertyValuesTestBase<TFixture>(TFixture fixture) : IClas
         building.Milk.Rating = changed.Milk.Rating;
         building.Milk.License = changed.Milk.License;
         building.Milk.Manufacturer = changed.Milk.Manufacturer;
+        building.OptionalMilk = changed.OptionalMilk;
 
         var entry = context.Entry(building);
         var values = await getPropertyValues(entry);
@@ -480,6 +481,14 @@ public abstract class PropertyValuesTestBase<TFixture>(TFixture fixture) : IClas
         var milkManTagEntry = milkManufacturerEntry.ComplexProperty(e => e.Tag);
         var milkLicTogEntry = milkLicenseEntry.ComplexProperty(e => e.Tog);
         var milkLicTagEntry = milkLicenseEntry.ComplexProperty(e => e.Tag);
+
+        var optionalMilkEntry = entry.ComplexProperty(e => e.OptionalMilk);
+        var optionalMilkManufacturerEntry = optionalMilkEntry.ComplexProperty(e => e.Manufacturer);
+        var optionalMilkLicenseEntry = optionalMilkEntry.ComplexProperty(e => e.License);
+        var optionalMilkManTogEntry = optionalMilkManufacturerEntry.ComplexProperty(e => e.Tog);
+        var optionalMilkManTagEntry = optionalMilkManufacturerEntry.ComplexProperty(e => e.Tag);
+        var optionalMilkLicTogEntry = optionalMilkLicenseEntry.ComplexProperty(e => e.Tog);
+        var optionalMilkLicTagEntry = optionalMilkLicenseEntry.ComplexProperty(e => e.Tag);
 
         var expected = expectOriginalValues ? original : changed;
         Assert.Equal(expected.Culture.Rating, values[cultureEntry.Property(e => e.Rating).Metadata]);
@@ -503,6 +512,18 @@ public abstract class PropertyValuesTestBase<TFixture>(TFixture fixture) : IClas
         Assert.Equal(expected.Milk.License.Charge, values[milkLicenseEntry.Property(e => e.Charge).Metadata]);
         Assert.Equal(expected.Milk.License.Tog.Text, values[milkLicTogEntry.Property(e => e.Text).Metadata]);
         Assert.Equal(expected.Milk.License.Tag.Text, values[milkLicTagEntry.Property(e => e.Text).Metadata]);
+        Assert.Equal(expected.OptionalMilk!.Rating, values[optionalMilkEntry.Property(e => e.Rating).Metadata]);
+        Assert.Equal(expected.OptionalMilk!.Species, values[optionalMilkEntry.Property(e => e.Species).Metadata]);
+        Assert.Equal(expected.OptionalMilk!.Subspecies, values[optionalMilkEntry.Property(e => e.Subspecies).Metadata]);
+        Assert.Equal(expected.OptionalMilk!.Validation, values[optionalMilkEntry.Property(e => e.Validation).Metadata]);
+        Assert.Equal(expected.OptionalMilk!.Manufacturer.Name, values[optionalMilkManufacturerEntry.Property(e => e.Name).Metadata]);
+        Assert.Equal(expected.OptionalMilk!.Manufacturer.Rating, values[optionalMilkManufacturerEntry.Property(e => e.Rating).Metadata]);
+        Assert.Equal(expected.OptionalMilk!.Manufacturer.Tog.Text, values[optionalMilkManTogEntry.Property(e => e.Text).Metadata]);
+        Assert.Equal(expected.OptionalMilk!.Manufacturer.Tag.Text, values[optionalMilkManTagEntry.Property(e => e.Text).Metadata]);
+        Assert.Equal(expected.OptionalMilk!.License.Title, values[optionalMilkLicenseEntry.Property(e => e.Title).Metadata]);
+        Assert.Equal(expected.OptionalMilk!.License.Charge, values[optionalMilkLicenseEntry.Property(e => e.Charge).Metadata]);
+        Assert.Equal(expected.OptionalMilk!.License.Tog.Text, values[optionalMilkLicTogEntry.Property(e => e.Text).Metadata]);
+        Assert.Equal(expected.OptionalMilk!.License.Tag.Text, values[optionalMilkLicTagEntry.Property(e => e.Text).Metadata]);
 
         if (expectOriginalValues)
         {

--- a/test/EFCore.Tests/ChangeTracking/EntityEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/EntityEntryTest.cs
@@ -1124,7 +1124,11 @@ public class EntityEntryTest
 
         Assert.Equal("Culture", context.Entry(entity).ComplexProperty(e => e.Culture).Metadata.Name);
         Assert.Equal("Milk", context.Entry(entity).ComplexProperty(e => e.Milk).Metadata.Name);
-        Assert.Equal("OptionalCulture", context.Entry(entity).ComplexProperty(e => e.OptionalCulture).Metadata.Name);
+
+        var optionalCultureEntry = context.Entry(entity).ComplexProperty(e => e.OptionalCulture);
+        Assert.Equal("OptionalCulture", optionalCultureEntry.Metadata.Name);
+        Assert.Equal("License", optionalCultureEntry.ComplexProperty(e => e.License).Metadata.Name);
+        Assert.Equal("Manufacturer", optionalCultureEntry.ComplexProperty(e => e.Manufacturer).Metadata.Name);
     }
 
     [Fact]

--- a/test/EFCore.Tests/ChangeTracking/EntityEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/EntityEntryTest.cs
@@ -956,6 +956,7 @@ public class EntityEntryTest
                 "Nonkey",
                 "Culture",
                 "Milk",
+                "OptionalCulture",
                 "Garcia"
             ],
             context.Attach(CreateChunky()).Members.Select(e => e.Metadata.Name).ToList());
@@ -1123,6 +1124,7 @@ public class EntityEntryTest
 
         Assert.Equal("Culture", context.Entry(entity).ComplexProperty(e => e.Culture).Metadata.Name);
         Assert.Equal("Milk", context.Entry(entity).ComplexProperty(e => e.Milk).Metadata.Name);
+        Assert.Equal("OptionalCulture", context.Entry(entity).ComplexProperty(e => e.OptionalCulture).Metadata.Name);
     }
 
     [Fact]
@@ -1305,7 +1307,7 @@ public class EntityEntryTest
     {
         using var context = new FreezerContext();
         Assert.Equal(
-            ["Culture", "Milk"],
+            ["Culture", "Milk", "OptionalCulture"],
             context.Attach(CreateChunky()).ComplexProperties.Select(e => e.Metadata.Name).ToList());
 
         Assert.Equal(
@@ -1543,6 +1545,7 @@ public class EntityEntryTest
         public Cherry? Garcia { get; set; }
 
         public Culture Culture { get; set; }
+        public Culture? OptionalCulture { get; set; }
         public Milk Milk { get; set; } = null!;
     }
 
@@ -1787,6 +1790,23 @@ public class EntityEntryTest
 
                 b.ComplexProperty(
                     e => e.Milk, b =>
+                    {
+                        b.ComplexProperty(
+                            e => e.License, b =>
+                            {
+                                b.ComplexProperty(e => e.Tag);
+                                b.ComplexProperty(e => e.Tog);
+                            });
+                        b.ComplexProperty(
+                            e => e.Manufacturer, b =>
+                            {
+                                b.ComplexProperty(e => e.Tag);
+                                b.ComplexProperty(e => e.Tog);
+                            });
+                    });
+
+                b.ComplexProperty(
+                    e => e.OptionalCulture, b =>
                     {
                         b.ComplexProperty(
                             e => e.License, b =>


### PR DESCRIPTION
This pull request introduces new overloads for the `ComplexProperty` API in EF Core's change tracking system to support nullable value type complex properties, and updates tests and documentation accordingly. It also includes minor documentation fixes and test improvements for better coverage of optional complex properties.

API enhancements for complex property tracking:

* Added new overloads of `ComplexProperty` methods in `EntityEntry`, `ComplexPropertyEntry`, and `ComplexElementEntry` classes to support nullable value type (`struct?`) complex properties, enabling change tracking for optional nested complex properties. [[1]](diffhunk://#diff-cd0a81560c1c78c76a7969a2d24e103e8b5986b9c744c0ef6318a8df8e7cba5fR86-R107) [[2]](diffhunk://#diff-cc6ff18202fa5a8bc8a542e20d0ca8c7c61dc25493950926f76244b89336231aR107-R128) [[3]](diffhunk://#diff-1e4810e0d2d22786b78d279ba67a39a85d93f883a82e4906e175c6b460847075R114-R135)