### PR TITLE
Allow runtime constants in precompiled queries

### DIFF
--- a/src/EFCore.Design/Query/Internal/CSharpToLinqTranslator.cs
+++ b/src/EFCore.Design/Query/Internal/CSharpToLinqTranslator.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </remarks>
-public class CSharpToLinqTranslator : CSharpSyntaxVisitor<Expression>
+public class CSharpToLinqTranslator : CSharpSyntaxVisitor<Expression> // @TODO RuntimeConstantExpression?
 {
     private static readonly SymbolDisplayFormat QualifiedTypeNameSymbolDisplayFormat = new(
         typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces);

--- a/src/EFCore.Design/Query/Internal/CSharpToLinqTranslator.cs
+++ b/src/EFCore.Design/Query/Internal/CSharpToLinqTranslator.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </remarks>
-public class CSharpToLinqTranslator : CSharpSyntaxVisitor<Expression> // @TODO RuntimeConstantExpression?
+public class CSharpToLinqTranslator : CSharpSyntaxVisitor<Expression>
 {
     private static readonly SymbolDisplayFormat QualifiedTypeNameSymbolDisplayFormat = new(
         typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces);

--- a/src/EFCore.Design/Query/Internal/LinqToCSharpSyntaxTranslator.cs
+++ b/src/EFCore.Design/Query/Internal/LinqToCSharpSyntaxTranslator.cs
@@ -2752,15 +2752,17 @@ public class LinqToCSharpSyntaxTranslator(SyntaxGenerator syntaxGenerator) : Exp
 
         var parameterNames = _stack.Peek().VariableNames;
 
-        if (parameterNames.Contains(name) || _liftedState.VariableNames.Contains(name) || _constantReplacements?.Values.Contains(name) == true)
+        Func<string, bool> constantReplacementsContainsName =
+            _constantReplacements is BidirectionalDictionary<object, string> bidirectionalDictionary
+                ? bidirectionalDictionary.ContainsValue
+                : n => _constantReplacements?.Values.Contains(n) == true;
+
+        var baseName = name;
+        for (var j = isUnnamed ? _unnamedParameterCounter++ : 0;
+                parameterNames.Contains(name) || _liftedState.VariableNames.Contains(name) || constantReplacementsContainsName(name);
+                j++)
         {
-            var baseName = name;
-            for (var j = isUnnamed ? _unnamedParameterCounter++ : 0;
-                 parameterNames.Contains(name) || _liftedState.VariableNames.Contains(name) || _constantReplacements?.Values.Contains(name) == true;
-                 j++)
-            {
-                name = baseName + j;
-            }
+            name = baseName + j;
         }
 
         return name;

--- a/src/EFCore.Design/Query/Internal/LinqToCSharpSyntaxTranslator.cs
+++ b/src/EFCore.Design/Query/Internal/LinqToCSharpSyntaxTranslator.cs
@@ -2752,11 +2752,11 @@ public class LinqToCSharpSyntaxTranslator(SyntaxGenerator syntaxGenerator) : Exp
 
         var parameterNames = _stack.Peek().VariableNames;
 
-        if (parameterNames.Contains(name) || _liftedState.VariableNames.Contains(name))
+        if (parameterNames.Contains(name) || _liftedState.VariableNames.Contains(name) || _constantReplacements?.Values.Contains(name) == true)
         {
             var baseName = name;
             for (var j = isUnnamed ? _unnamedParameterCounter++ : 0;
-                 parameterNames.Contains(name) || _liftedState.VariableNames.Contains(name);
+                 parameterNames.Contains(name) || _liftedState.VariableNames.Contains(name) || _constantReplacements?.Values.Contains(name) == true;
                  j++)
             {
                 name = baseName + j;

--- a/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
+++ b/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.ExceptionServices;
 using System.Text.RegularExpressions;
+using System.Xml.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -260,7 +261,11 @@ public class PrecompiledQueryCodeGenerator : IPrecompiledQueryCodeGenerator
             _code.AppendLine("#endregion Unsafe accessors");
         }
 
-        GenerateRuntimeConstants(_code, _namespaces, _unsafeAccessors);
+        foreach (var (fieldName, constant) in _runtimeConstants.OrderBy(x => x.Key))
+        {
+            var syntax = _linqToCSharpTranslator.TranslateExpression(constant.InitializeExpression, constantReplacements: null, _namespaces, _unsafeAccessors);
+            _code.AppendLine($"private static readonly {constant.Type.FullName} {fieldName} = {syntax.NormalizeWhitespace().ToFullString()};");
+        }
 
         _code
             .DecrementIndent().AppendLine("}")
@@ -932,7 +937,6 @@ namespace System.Runtime.CompilerServices
         HashSet<MethodDeclarationSyntax> unsafeAccessors)
     {
         // We're going to generate the method which will create the query executor (Func<QueryContext, TResult>).
-        
         // Note that the we store the executor itself (and return it) as object, not as a typed Func<QueryContext, TResult>.
         // We can't strong-type it since it may return an anonymous type, which is unspeakable; so instead we cast down from object to
         // the real strongly-typed signature inside the interceptor, where the return value is represented as a generic type parameter
@@ -993,26 +997,6 @@ namespace System.Runtime.CompilerServices
             .AppendLine("}")
             .AppendLine()
             .AppendLine($"private static object Query{queryNum}_Executor;");
-    }
-
-    private void GenerateRuntimeConstants(IndentedStringBuilder code, HashSet<string> namespaces, HashSet<MethodDeclarationSyntax> unsafeAccessors)
-    {
-        if (_runtimeConstants.Count != 0)
-        {
-            code.AppendLine();
-
-            code.AppendLine("#region Runtime constants");
-
-            foreach (var (name, constant) in _runtimeConstants.OrderBy(x => x.Key))
-            {
-                var syntax = _linqToCSharpTranslator.TranslateExpression(constant.InitializeExpression, constantReplacements: null, namespaces, unsafeAccessors);
-                code.AppendLine($"private static readonly {constant.Type.FullName} {name} = {syntax.NormalizeWhitespace().ToFullString()};");
-            }
-
-            code.AppendLine("#endregion Runtime constants");
-
-            code.AppendLine();
-        }
     }
 
     /// <summary>

--- a/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
+++ b/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
@@ -29,6 +29,9 @@ public class PrecompiledQueryCodeGenerator : IPrecompiledQueryCodeGenerator
     private ExpressionTreeFuncletizer _funcletizer = null!;
     private RuntimeModelLinqToCSharpSyntaxTranslator _linqToCSharpTranslator = null!;
     private LiftableConstantProcessor _liftableConstantProcessor = null!;
+    private RuntimeConstantProcessor _runtimeConstantProcessor = null!;
+
+    private Dictionary<object, string> _constantReplacements = null!;
 
     private Symbols _symbols;
 
@@ -78,6 +81,8 @@ public class PrecompiledQueryCodeGenerator : IPrecompiledQueryCodeGenerator
         _linqToCSharpTranslator = new RuntimeModelLinqToCSharpSyntaxTranslator(_g);
         _memberAccessReplacements = memberAccessReplacements;
         _liftableConstantProcessor = new LiftableConstantProcessor(null!);
+        _constantReplacements = [];
+        _runtimeConstantProcessor = new RuntimeConstantProcessor(_constantReplacements);
         _queryCompiler = dbContext.GetService<IQueryCompiler>();
         _unsafeAccessors.Clear();
         var contextType = dbContext.GetType();
@@ -213,6 +218,7 @@ public class PrecompiledQueryCodeGenerator : IPrecompiledQueryCodeGenerator
                         cancellationToken);
 
                     GenerateQueryExecutor(_code, queryNum + 1, queryExecutor, _namespaces, _unsafeAccessors);
+
                 }
                 finally
                 {
@@ -250,6 +256,8 @@ public class PrecompiledQueryCodeGenerator : IPrecompiledQueryCodeGenerator
 
             _code.AppendLine("#endregion Unsafe accessors");
         }
+
+        GenerateRuntimeConstants(_code, _namespaces, _unsafeAccessors);
 
         _code
             .DecrementIndent().AppendLine("}")
@@ -921,6 +929,8 @@ namespace System.Runtime.CompilerServices
         HashSet<MethodDeclarationSyntax> unsafeAccessors)
     {
         // We're going to generate the method which will create the query executor (Func<QueryContext, TResult>).
+        queryExecutor = _runtimeConstantProcessor.Process(queryExecutor);
+
         // Note that the we store the executor itself (and return it) as object, not as a typed Func<QueryContext, TResult>.
         // We can't strong-type it since it may return an anonymous type, which is unspeakable; so instead we cast down from object to
         // the real strongly-typed signature inside the interceptor, where the return value is represented as a generic type parameter
@@ -949,7 +959,7 @@ namespace System.Runtime.CompilerServices
         foreach (var liftedConstant in _liftableConstantProcessor.LiftedConstants)
         {
             var variableValueSyntax = _linqToCSharpTranslator.TranslateExpression(
-                liftedConstant.Expression, constantReplacements: null, _memberAccessReplacements, namespaces, unsafeAccessors);
+                liftedConstant.Expression, _constantReplacements, _memberAccessReplacements, namespaces, unsafeAccessors);
             // code.AppendLine($"{liftedConstant.Parameter.Type.Name} {liftedConstant.Parameter.Name} = {variableValueSyntax.NormalizeWhitespace().ToFullString()};");
             code.AppendLine($"var {liftedConstant.Parameter.Name} = {variableValueSyntax.NormalizeWhitespace().ToFullString()};");
         }
@@ -957,7 +967,7 @@ namespace System.Runtime.CompilerServices
         var queryExecutorSyntaxTree =
             (AnonymousFunctionExpressionSyntax)_linqToCSharpTranslator.TranslateExpression(
                 queryExecutorAfterLiftingExpression,
-                constantReplacements: null,
+                _constantReplacements,
                 _memberAccessReplacements,
                 namespaces,
                 unsafeAccessors);
@@ -968,6 +978,26 @@ namespace System.Runtime.CompilerServices
             .AppendLine("}")
             .AppendLine()
             .AppendLine($"private static object Query{queryNum}_Executor;");
+    }
+
+    private void GenerateRuntimeConstants(IndentedStringBuilder code, HashSet<string> namespaces, HashSet<MethodDeclarationSyntax> unsafeAccessors)
+    {
+        if (_runtimeConstantProcessor.RuntimeConstants.Any())
+        {
+            code.AppendLine();
+
+            code.AppendLine("#region Runtime constants");
+
+            foreach (var constant in _runtimeConstantProcessor.RuntimeConstants)
+            {
+                var syntax = _linqToCSharpTranslator.TranslateExpression(constant.Expression.InitializeExpression, constantReplacements: null, namespaces, unsafeAccessors);
+                code.AppendLine($"private static readonly {constant.Expression.Type.FullName} {constant.Name} = {syntax.NormalizeWhitespace().ToFullString()};");
+            }
+
+            code.AppendLine("#endregion Runtime constants");
+
+            code.AppendLine();
+        }
     }
 
     /// <summary>

--- a/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
+++ b/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
@@ -218,7 +218,6 @@ public class PrecompiledQueryCodeGenerator : IPrecompiledQueryCodeGenerator
                         cancellationToken);
 
                     GenerateQueryExecutor(_code, queryNum + 1, queryExecutor, _namespaces, _unsafeAccessors);
-
                 }
                 finally
                 {

--- a/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
+++ b/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
@@ -32,8 +32,8 @@ public class PrecompiledQueryCodeGenerator : IPrecompiledQueryCodeGenerator
     private LiftableConstantProcessor _liftableConstantProcessor = null!;
     private RuntimeConstantProcessor _runtimeConstantProcessor = null!;
 
-    private BidirectionalDictionary<string, RuntimeConstantExpression> _runtimeConstants = null!;
-    private Dictionary<object, string> _constantReplacements = null!;
+    private Dictionary<string, RuntimeConstantExpression> _runtimeConstants = null!;
+    private BidirectionalDictionary<object, string> _constantReplacements = null!;
 
     private Symbols _symbols;
 

--- a/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
+++ b/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.ExceptionServices;
+using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -31,6 +33,7 @@ public class PrecompiledQueryCodeGenerator : IPrecompiledQueryCodeGenerator
     private LiftableConstantProcessor _liftableConstantProcessor = null!;
     private RuntimeConstantProcessor _runtimeConstantProcessor = null!;
 
+    private Dictionary<string, RuntimeConstantExpression> _runtimeConstants = null!;
     private Dictionary<object, string> _constantReplacements = null!;
 
     private Symbols _symbols;
@@ -82,7 +85,8 @@ public class PrecompiledQueryCodeGenerator : IPrecompiledQueryCodeGenerator
         _memberAccessReplacements = memberAccessReplacements;
         _liftableConstantProcessor = new LiftableConstantProcessor(null!);
         _constantReplacements = [];
-        _runtimeConstantProcessor = new RuntimeConstantProcessor(_constantReplacements);
+        _runtimeConstants = [];
+        _runtimeConstantProcessor = new RuntimeConstantProcessor();
         _queryCompiler = dbContext.GetService<IQueryCompiler>();
         _unsafeAccessors.Clear();
         var contextType = dbContext.GetType();
@@ -928,8 +932,7 @@ namespace System.Runtime.CompilerServices
         HashSet<MethodDeclarationSyntax> unsafeAccessors)
     {
         // We're going to generate the method which will create the query executor (Func<QueryContext, TResult>).
-        queryExecutor = _runtimeConstantProcessor.Process(queryExecutor);
-
+        
         // Note that the we store the executor itself (and return it) as object, not as a typed Func<QueryContext, TResult>.
         // We can't strong-type it since it may return an anonymous type, which is unspeakable; so instead we cast down from object to
         // the real strongly-typed signature inside the interceptor, where the return value is represented as a generic type parameter
@@ -945,7 +948,20 @@ namespace System.Runtime.CompilerServices
             .AppendLine("    dbContext.GetService<RelationalShapedQueryCompilingExpressionVisitorDependencies>(),")
             .AppendLine("    dbContext.GetService<RelationalCommandBuilderDependencies>());");
 
-        HashSet<string> variableNames = ["relationalModel", "relationalTypeMappingSource", "materializerLiftableConstantContext"];
+        queryExecutor = _runtimeConstantProcessor.Process(queryExecutor, _runtimeConstants.Values);
+        foreach (var runtimeConstant in _runtimeConstantProcessor.RuntimeConstants)
+        {
+            var name = SanitizeIdentifierName(runtimeConstant.Name);
+            var baseName = name;
+            for (var j = 0; _runtimeConstants.ContainsKey(name); j++)
+            {
+                name = baseName + j;
+            }
+            _runtimeConstants.Add(name, runtimeConstant);
+            _constantReplacements.Add(runtimeConstant.Value, name);
+        }
+
+        HashSet<string> variableNames = [.. _constantReplacements.Values, "relationalModel", "relationalTypeMappingSource", "materializerLiftableConstantContext"];
 
         var materializerLiftableConstantContext =
             Expression.Parameter(typeof(RelationalMaterializerLiftableConstantContext), "materializerLiftableConstantContext");
@@ -981,16 +997,16 @@ namespace System.Runtime.CompilerServices
 
     private void GenerateRuntimeConstants(IndentedStringBuilder code, HashSet<string> namespaces, HashSet<MethodDeclarationSyntax> unsafeAccessors)
     {
-        if (_runtimeConstantProcessor.RuntimeConstants.Any())
+        if (_runtimeConstants.Count != 0)
         {
             code.AppendLine();
 
             code.AppendLine("#region Runtime constants");
 
-            foreach (var constant in _runtimeConstantProcessor.RuntimeConstants)
+            foreach (var (name, constant) in _runtimeConstants)
             {
-                var syntax = _linqToCSharpTranslator.TranslateExpression(constant.Expression.InitializeExpression, constantReplacements: null, namespaces, unsafeAccessors);
-                code.AppendLine($"private static readonly {constant.Expression.Type.FullName} {constant.Name} = {syntax.NormalizeWhitespace().ToFullString()};");
+                var syntax = _linqToCSharpTranslator.TranslateExpression(constant.InitializeExpression, constantReplacements: null, namespaces, unsafeAccessors);
+                code.AppendLine($"private static readonly {constant.Type.FullName} {name} = {syntax.NormalizeWhitespace().ToFullString()};");
             }
 
             code.AppendLine("#endregion Runtime constants");
@@ -1250,6 +1266,36 @@ namespace System.Runtime.CompilerServices
         // so setters were added in reverse order. Reverse to restore source code order.
         var settersArray = settersBuilder.BuildSettersExpression();
         return Expression.NewArrayInit(settersArray.Type.GetElementType()!, settersArray.Expressions.Reverse());
+    }
+
+    [return: NotNullIfNotNull(nameof(name))]
+    private static string? SanitizeIdentifierName(string? name)
+    {
+        if (name == null)
+        {
+            return null;
+        }
+
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return "_";
+        }
+
+        var replaced = name
+            .Select(c => SyntaxFacts.IsIdentifierPartCharacter(c) ? c : '_')
+            .ToArray();
+
+        var result = Regex.Replace(new string(replaced), "(_)+", "_");
+
+        if (!SyntaxFacts.IsIdentifierStartCharacter(result[0]))
+        {
+            result = "_" + result;
+
+        }
+
+        Debug.Assert(SyntaxFacts.IsValidIdentifier(result));
+
+        return result;
     }
 
     /// <summary>

--- a/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
+++ b/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
@@ -952,8 +952,8 @@ namespace System.Runtime.CompilerServices
             .AppendLine("    dbContext.GetService<RelationalShapedQueryCompilingExpressionVisitorDependencies>(),")
             .AppendLine("    dbContext.GetService<RelationalCommandBuilderDependencies>());");
 
-        queryExecutor = _runtimeConstantProcessor.Process(queryExecutor, _runtimeConstants.Values);
-        foreach (var runtimeConstant in _runtimeConstantProcessor.RuntimeConstants)
+        queryExecutor = _runtimeConstantProcessor.Process(queryExecutor);
+        foreach (var runtimeConstant in _runtimeConstantProcessor.LastProcessFoundRuntimeConstants)
         {
             var name = SanitizeIdentifierName(runtimeConstant.Name);
             var baseName = name;

--- a/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
+++ b/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
@@ -1003,7 +1003,7 @@ namespace System.Runtime.CompilerServices
 
             code.AppendLine("#region Runtime constants");
 
-            foreach (var (name, constant) in _runtimeConstants)
+            foreach (var (name, constant) in _runtimeConstants.OrderBy(x => x.Key))
             {
                 var syntax = _linqToCSharpTranslator.TranslateExpression(constant.InitializeExpression, constantReplacements: null, namespaces, unsafeAccessors);
                 code.AppendLine($"private static readonly {constant.Type.FullName} {name} = {syntax.NormalizeWhitespace().ToFullString()};");

--- a/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
+++ b/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
@@ -261,8 +261,10 @@ public class PrecompiledQueryCodeGenerator : IPrecompiledQueryCodeGenerator
 
         foreach (var (fieldName, constant) in _runtimeConstants.OrderBy(x => x.Key))
         {
+            var typeSymbol = GetTypeSymbol(semanticModel.Compilation, constant.Type);
+
             var syntax = _linqToCSharpTranslator.TranslateExpression(constant.InitializeExpression, constantReplacements: null, _namespaces, _unsafeAccessors);
-            _code.AppendLine($"private static readonly {constant.Type.FullName} {fieldName} = {syntax.NormalizeWhitespace().ToFullString()};");
+            _code.AppendLine($"private static readonly {typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)} {fieldName} = {syntax.NormalizeWhitespace().ToFullString()};");
         }
 
         _code
@@ -1248,6 +1250,38 @@ namespace System.Runtime.CompilerServices
         // so setters were added in reverse order. Reverse to restore source code order.
         var settersArray = settersBuilder.BuildSettersExpression();
         return Expression.NewArrayInit(settersArray.Type.GetElementType()!, settersArray.Expressions.Reverse());
+    }
+
+    private static ITypeSymbol GetTypeSymbol(Compilation compilation, Type type)
+    {
+        if (type.IsByRef || type.IsPointer || type.IsGenericParameter)
+        {
+            throw new NotSupportedException($"Unsupported type: {type}");
+        }
+
+        if (type.IsArray)
+        {
+            var elementSymbol = GetTypeSymbol(compilation, type.GetElementType()!);
+            return compilation.CreateArrayTypeSymbol(elementSymbol, type.GetArrayRank());
+        }
+
+        if (type.IsGenericType && !type.IsGenericTypeDefinition)
+        {
+            var genericDefinition = (INamedTypeSymbol)GetTypeSymbol(
+                compilation,
+                type.GetGenericTypeDefinition());
+
+            var typeArguments = type
+                .GetGenericArguments()
+                .Select(t => GetTypeSymbol(compilation, t))
+                .ToArray();
+
+            return genericDefinition.Construct(typeArguments);
+        }
+
+        return type.FullName is null || compilation.GetTypeByMetadataName(type.FullName) is not { } typeSymbol
+            ? throw new InvalidOperationException($"Couldn't find type symbol for: {type}")
+            : typeSymbol;
     }
 
     [return: NotNullIfNotNull(nameof(name))]

--- a/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
+++ b/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
@@ -1254,7 +1254,7 @@ namespace System.Runtime.CompilerServices
 
     private static ITypeSymbol GetTypeSymbol(Compilation compilation, Type type)
     {
-        if (type.IsByRef || type.IsPointer || type.IsGenericParameter)
+        if (type.IsByRef || type.IsPointer || type.IsGenericParameter || type.IsByRefLike)
         {
             throw new NotSupportedException($"Unsupported type: {type}");
         }
@@ -1300,7 +1300,7 @@ namespace System.Runtime.CompilerServices
         var result = new string(
             [.. name.Select(c => SyntaxFacts.IsIdentifierPartCharacter(c) ? c : '_')]);
 
-        if (!SyntaxFacts.IsIdentifierStartCharacter(result[0]))
+        if (!SyntaxFacts.IsValidIdentifier(result))
         {
             result = "_" + result;
         }

--- a/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
+++ b/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
@@ -34,7 +34,7 @@ public class PrecompiledQueryCodeGenerator : IPrecompiledQueryCodeGenerator
     private LiftableConstantProcessor _liftableConstantProcessor = null!;
     private RuntimeConstantProcessor _runtimeConstantProcessor = null!;
 
-    private Dictionary<string, RuntimeConstantExpression> _runtimeConstants = null!;
+    private BidirectionalDictionary<string, RuntimeConstantExpression> _runtimeConstants = null!;
     private Dictionary<object, string> _constantReplacements = null!;
 
     private Symbols _symbols;

--- a/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
+++ b/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
@@ -4,9 +4,6 @@
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.ExceptionServices;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Xml.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
+++ b/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.ExceptionServices;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using Microsoft.CodeAnalysis;
@@ -1265,16 +1266,12 @@ namespace System.Runtime.CompilerServices
             return "_";
         }
 
-        var replaced = name
-            .Select(c => SyntaxFacts.IsIdentifierPartCharacter(c) ? c : '_')
-            .ToArray();
-
-        var result = Regex.Replace(new string(replaced), "(_)+", "_");
+        var result = new string(
+            [.. name.Select(c => SyntaxFacts.IsIdentifierPartCharacter(c) ? c : '_')]);
 
         if (!SyntaxFacts.IsIdentifierStartCharacter(result[0]))
         {
             result = "_" + result;
-
         }
 
         Debug.Assert(SyntaxFacts.IsValidIdentifier(result));

--- a/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
+++ b/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
@@ -32,8 +32,8 @@ public class PrecompiledQueryCodeGenerator : IPrecompiledQueryCodeGenerator
     private LiftableConstantProcessor _liftableConstantProcessor = null!;
     private RuntimeConstantProcessor _runtimeConstantProcessor = null!;
 
-    private Dictionary<string, RuntimeConstantExpression> _runtimeConstants = null!;
-    private BidirectionalDictionary<object, string> _constantReplacements = null!;
+    private readonly Dictionary<string, RuntimeConstantExpression> _runtimeConstants = [];
+    private readonly BidirectionalDictionary<object, string> _constantReplacements = [];
 
     private Symbols _symbols;
 
@@ -83,8 +83,8 @@ public class PrecompiledQueryCodeGenerator : IPrecompiledQueryCodeGenerator
         _linqToCSharpTranslator = new RuntimeModelLinqToCSharpSyntaxTranslator(_g);
         _memberAccessReplacements = memberAccessReplacements;
         _liftableConstantProcessor = new LiftableConstantProcessor(null!);
-        _constantReplacements = [];
-        _runtimeConstants = [];
+        _constantReplacements.Clear();
+        _runtimeConstants.Clear();
         _runtimeConstantProcessor = new RuntimeConstantProcessor();
         _queryCompiler = dbContext.GetService<IQueryCompiler>();
         _unsafeAccessors.Clear();

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
@@ -83,6 +83,12 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
         private static readonly MethodInfo Utf8JsonReaderValueTextEqualsMethod
             = typeof(Utf8JsonReader).GetMethod(nameof(Utf8JsonReader.ValueTextEquals), [typeof(ReadOnlySpan<byte>)])!;
 
+        private static readonly PropertyInfo EncodingUtf8Property
+            = typeof(Encoding).GetProperty(nameof(Encoding.UTF8))!;
+
+        private static readonly MethodInfo Utf8GetBytesMethod
+            = typeof(Encoding).GetMethod(nameof(Encoding.GetBytes), [typeof(string)])!;
+
         private static readonly MethodInfo ByteArrayAsSpanMethod = typeof(MemoryExtensions).GetMethods()
             .Where(x => x.Name == nameof(MemoryExtensions.AsSpan) && x.GetGenericArguments().Count() == 1)
             .Select(x => new { x, prms = x.GetParameters() })
@@ -2136,7 +2142,12 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                     {
                         var property = valueBufferTryReadValueMethodToProcess.Arguments[2].GetConstantValue<IProperty>();
                         var jsonPropertyName = property.GetJsonPropertyName()!;
-                        var jsonPropertyNameBytes = Encoding.UTF8.GetBytes(jsonPropertyName);
+                        var jsonPropertyNameBytes = new RuntimeConstantExpression(
+                            jsonPropertyName + "Bytes",
+                            Call(
+                                Property(null, EncodingUtf8Property),
+                                Utf8GetBytesMethod,
+                                Constant(jsonPropertyName)));
                         testExpressions.Add(
                             Call(
                                 Field(
@@ -2146,7 +2157,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                                 Convert(
                                     Call(
                                         ByteArrayAsSpanMethod,
-                                        Constant(jsonPropertyNameBytes)),
+                                        jsonPropertyNameBytes),
                                     typeof(ReadOnlySpan<>).MakeGenericType(typeof(byte)))));
 
                         var propertyVariable = Variable(valueBufferTryReadValueMethodToProcess.Type);
@@ -2173,7 +2184,12 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                     foreach (var innerShaperMapElement in innerShapersMap)
                     {
                         var innerShaperMapElementKey = innerShaperMapElement.Key;
-                        var jsonPropertyNameBytes = Encoding.UTF8.GetBytes(innerShaperMapElementKey);
+                        var jsonPropertyNameBytes = new RuntimeConstantExpression(
+                            innerShaperMapElementKey + "Bytes",
+                            Call(
+                                Property(null, EncodingUtf8Property),
+                                Utf8GetBytesMethod,
+                                Constant(innerShaperMapElementKey)));
                         testExpressions.Add(
                             Call(
                                 Field(
@@ -2183,7 +2199,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                                 Convert(
                                     Call(
                                         ByteArrayAsSpanMethod,
-                                        Constant(jsonPropertyNameBytes)),
+                                        jsonPropertyNameBytes),
                                     typeof(ReadOnlySpan<>).MakeGenericType(typeof(byte)))));
 
                         var propertyVariable = Variable(innerShaperMapElement.Value.Type);

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
@@ -2205,7 +2205,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                         var propertyVariable = Variable(innerShaperMapElement.Value.Type);
                         finalBlockVariables.Add(propertyVariable);
 
-                        _navigationVariableMap[innerShaperMapElement.Key] = propertyVariable;
+                        _navigationVariableMap[innerShaperMapElementKey] = propertyVariable;
 
                         var moveNext = Call(managerVariable, Utf8JsonReaderManagerMoveNextMethod);
                         var captureState = Call(managerVariable, Utf8JsonReaderManagerCaptureStateMethod);

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
@@ -83,12 +83,6 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
         private static readonly MethodInfo Utf8JsonReaderValueTextEqualsMethod
             = typeof(Utf8JsonReader).GetMethod(nameof(Utf8JsonReader.ValueTextEquals), [typeof(ReadOnlySpan<byte>)])!;
 
-        private static readonly PropertyInfo EncodingUtf8Property
-            = typeof(Encoding).GetProperty(nameof(Encoding.UTF8))!;
-
-        private static readonly MethodInfo Utf8GetBytesMethod
-            = typeof(Encoding).GetMethod(nameof(Encoding.GetBytes), [typeof(string)])!;
-
         private static readonly MethodInfo ByteArrayAsSpanMethod = typeof(MemoryExtensions).GetMethods()
             .Where(x => x.Name == nameof(MemoryExtensions.AsSpan) && x.GetGenericArguments().Count() == 1)
             .Select(x => new { x, prms = x.GetParameters() })
@@ -2142,6 +2136,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                     {
                         var property = valueBufferTryReadValueMethodToProcess.Arguments[2].GetConstantValue<IProperty>();
                         var jsonPropertyName = property.GetJsonPropertyName()!;
+                        var jsonPropertyNameBytes = Encoding.UTF8.GetBytes(jsonPropertyName);
                         testExpressions.Add(
                             Call(
                                 Field(
@@ -2151,10 +2146,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                                 Convert(
                                     Call(
                                         ByteArrayAsSpanMethod,
-                                        Call(
-                                            Property(null, EncodingUtf8Property),
-                                            Utf8GetBytesMethod,
-                                            Constant(jsonPropertyName))),
+                                        Constant(jsonPropertyNameBytes)),
                                     typeof(ReadOnlySpan<>).MakeGenericType(typeof(byte)))));
 
                         var propertyVariable = Variable(valueBufferTryReadValueMethodToProcess.Type);
@@ -2181,6 +2173,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                     foreach (var innerShaperMapElement in innerShapersMap)
                     {
                         var innerShaperMapElementKey = innerShaperMapElement.Key;
+                        var jsonPropertyNameBytes = Encoding.UTF8.GetBytes(innerShaperMapElementKey);
                         testExpressions.Add(
                             Call(
                                 Field(
@@ -2190,10 +2183,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                                 Convert(
                                     Call(
                                         ByteArrayAsSpanMethod,
-                                        Call(
-                                            Property(null, EncodingUtf8Property),
-                                            Utf8GetBytesMethod,
-                                            Constant(innerShaperMapElementKey))),
+                                        Constant(jsonPropertyNameBytes)),
                                     typeof(ReadOnlySpan<>).MakeGenericType(typeof(byte)))));
 
                         var propertyVariable = Variable(innerShaperMapElement.Value.Type);

--- a/src/EFCore/EFCore.baseline.json
+++ b/src/EFCore/EFCore.baseline.json
@@ -22464,7 +22464,7 @@
           "Stage": "Experimental"
         },
         {
-          "Member": "virtual System.Linq.Expressions.Expression Process(System.Linq.Expressions.Expression expression, System.Collections.Generic.IEnumerable<Microsoft.EntityFrameworkCore.Query.RuntimeConstantExpression>? preexistingRuntimeConstants);",
+          "Member": "virtual System.Linq.Expressions.Expression Process(System.Linq.Expressions.Expression expression);",
           "Stage": "Experimental"
         },
         {
@@ -22474,7 +22474,7 @@
       ],
       "Properties": [
         {
-          "Member": "virtual System.Collections.Generic.IReadOnlyList<Microsoft.EntityFrameworkCore.Query.RuntimeConstantExpression> RuntimeConstants { get; }",
+          "Member": "virtual System.Collections.Generic.IReadOnlyList<Microsoft.EntityFrameworkCore.Query.RuntimeConstantExpression> LastProcessFoundRuntimeConstants { get; }",
           "Stage": "Experimental"
         }
       ]

--- a/src/EFCore/EFCore.baseline.json
+++ b/src/EFCore/EFCore.baseline.json
@@ -22404,6 +22404,82 @@
       ]
     },
     {
+      "Type": "class Microsoft.EntityFrameworkCore.Query.RuntimeConstantExpression : System.Linq.Expressions.Expression, Microsoft.EntityFrameworkCore.Query.IPrintableExpression",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "RuntimeConstantExpression(string name, System.Linq.Expressions.Expression initializeExpression);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "void Print(Microsoft.EntityFrameworkCore.Query.ExpressionPrinter expressionPrinter);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "override System.Linq.Expressions.Expression Reduce();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "virtual Microsoft.EntityFrameworkCore.Query.RuntimeConstantExpression Update(System.Linq.Expressions.Expression initializeExpression);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "override System.Linq.Expressions.Expression VisitChildren(System.Linq.Expressions.ExpressionVisitor visitor);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "override bool CanReduce { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "virtual System.Linq.Expressions.Expression InitializeExpression { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "virtual string Name { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "override System.Linq.Expressions.ExpressionType NodeType { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "override System.Type Type { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "virtual object Value { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.EntityFrameworkCore.Query.RuntimeConstantProcessor : System.Linq.Expressions.ExpressionVisitor",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "RuntimeConstantProcessor();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "virtual System.Linq.Expressions.Expression Process(System.Linq.Expressions.Expression expression, System.Collections.Generic.IEnumerable<Microsoft.EntityFrameworkCore.Query.RuntimeConstantExpression>? preexistingRuntimeConstants);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "override System.Linq.Expressions.Expression VisitExtension(System.Linq.Expressions.Expression node);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "virtual System.Collections.Generic.IReadOnlyList<Microsoft.EntityFrameworkCore.Query.RuntimeConstantExpression> RuntimeConstants { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
       "Type": "class Microsoft.EntityFrameworkCore.Metadata.RuntimeElementType : Microsoft.EntityFrameworkCore.Infrastructure.RuntimeAnnotatableBase, Microsoft.EntityFrameworkCore.Metadata.IElementType, Microsoft.EntityFrameworkCore.Metadata.IReadOnlyElementType, Microsoft.EntityFrameworkCore.Infrastructure.IReadOnlyAnnotatable, Microsoft.EntityFrameworkCore.Infrastructure.IAnnotatable",
       "Methods": [
         {

--- a/src/EFCore/Query/RuntimeConstantExpression.cs
+++ b/src/EFCore/Query/RuntimeConstantExpression.cs
@@ -31,7 +31,7 @@ public class RuntimeConstantExpression : Expression, IPrintableExpression
     public RuntimeConstantExpression(string name, Expression initializeExpression)
     {
         name = name.Trim();
-        ArgumentException.ThrowIfNullOrWhiteSpace(nameof(name), name);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name, nameof(name));
 
         var type = initializeExpression.Type;
         Value = Lambda<Func<object>>(Convert(initializeExpression, typeof(object))).Compile()();

--- a/src/EFCore/Query/RuntimeConstantExpression.cs
+++ b/src/EFCore/Query/RuntimeConstantExpression.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.EntityFrameworkCore.Query;
 
 /// <summary>
-///     A node containing an expression expressing the retreival of a value which doesn't change across executions of the query.
+///     A node containing an expression expressing the retrieval of a value which doesn't change across executions of the query.
 /// </summary>
 /// <remarks>
 ///     <para>

--- a/src/EFCore/Query/RuntimeConstantExpression.cs
+++ b/src/EFCore/Query/RuntimeConstantExpression.cs
@@ -30,12 +30,15 @@ public class RuntimeConstantExpression : Expression, IPrintableExpression
     /// </summary>
     public RuntimeConstantExpression(string name, Expression initializeExpression)
     {
+        name = name.Trim();
+        ArgumentException.ThrowIfNullOrWhiteSpace(nameof(name), name);
+
         var type = initializeExpression.Type;
-        Value = Lambda<Func<object>>(Convert(initializeExpression, typeof(object)), null).Compile()();
+        Value = Lambda<Func<object>>(Convert(initializeExpression, typeof(object))).Compile()();
         _constantExpression = Constant(Value, type);
 
         InitializeExpression = initializeExpression;
-        Name = char.ToUpper(name[0]) + name[1..];
+        Name = char.ToUpperInvariant(name[0]) + name[1..];
         Type = type;
     }
 

--- a/src/EFCore/Query/RuntimeConstantExpression.cs
+++ b/src/EFCore/Query/RuntimeConstantExpression.cs
@@ -1,0 +1,114 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+/// <summary>
+///     A node containing an expression expressing the retreival of a value which doesn't change across executions of the query.
+/// </summary>
+/// <remarks>
+///     <para>
+///         When the expression tree is compiled, the value will be retrieved from the expression, and a
+///         <see cref="ConstantExpression" /> expression can directly reference the result.
+///     </para>
+///     <para>
+///         When the expression tree is translated to source code instead (in query pre-compilation), the expression can be rendered out
+///         separately, to be assigned to a private static readonly field, and this node is replaced by a reference to that field.
+///     </para>
+/// </remarks>
+[DebuggerDisplay("{Microsoft.EntityFrameworkCore.Query.ExpressionPrinter.Print(this), nq}"),
+ Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+public class RuntimeConstantExpression : Expression, IPrintableExpression
+{
+    private readonly ConstantExpression _constantExpression;
+
+    /// <summary>
+    ///     This is an experimental API used by the Entity Framework Core feature and it is not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public RuntimeConstantExpression(string name, Expression initializeExpression)
+    {
+        var type = initializeExpression.Type;
+        Value = Lambda<Func<object>>(Convert(initializeExpression, typeof(object)), null).Compile()();
+        _constantExpression = Constant(Value, type);
+
+        InitializeExpression = initializeExpression;
+        Name = name;
+        Type = type;
+    }
+
+    /// <summary>
+    ///     This is an experimental API used by the Entity Framework Core feature and it is not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual Expression InitializeExpression { get; }
+
+    /// <summary>
+    ///     This is an experimental API used by the Entity Framework Core feature and it is not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual object Value { get; }
+
+    /// <summary>
+    ///     This is an experimental API used by the Entity Framework Core feature and it is not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual string Name { get; }
+
+    /// <inheritdoc />
+    public override Type Type { get; }
+
+    /// <inheritdoc />
+    public override ExpressionType NodeType
+        => ExpressionType.Extension;
+
+    /// <inheritdoc />
+    public override bool CanReduce
+        => true;
+
+    /// <inheritdoc />
+    public override Expression Reduce()
+        => _constantExpression;
+
+    /// <inheritdoc />
+    protected override Expression VisitChildren(ExpressionVisitor visitor)
+    {
+        var initializeExpression = visitor.Visit(InitializeExpression);
+
+        return Update(initializeExpression);
+    }
+
+    /// <summary>
+    ///     This is an experimental API used by the Entity Framework Core feature and it is not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual RuntimeConstantExpression Update(Expression initializeExpression)
+        => initializeExpression != InitializeExpression
+            ? new RuntimeConstantExpression(Name, initializeExpression)
+            : this;
+
+    /// <summary>
+    ///     This is an experimental API used by the Entity Framework Core feature and it is not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public void Print(ExpressionPrinter expressionPrinter)
+    {
+        expressionPrinter.Append("[RUNTIME Constant: ");
+        expressionPrinter.Visit(InitializeExpression);
+        expressionPrinter.Append(" | Storage: ");
+        expressionPrinter.Append(Name);
+        expressionPrinter.Append("]");
+    }
+}

--- a/src/EFCore/Query/RuntimeConstantExpression.cs
+++ b/src/EFCore/Query/RuntimeConstantExpression.cs
@@ -35,7 +35,7 @@ public class RuntimeConstantExpression : Expression, IPrintableExpression
         _constantExpression = Constant(Value, type);
 
         InitializeExpression = initializeExpression;
-        Name = name;
+        Name = char.ToUpper(name[0]) + name[1..];
         Type = type;
     }
 

--- a/src/EFCore/Query/RuntimeConstantProcessor.cs
+++ b/src/EFCore/Query/RuntimeConstantProcessor.cs
@@ -44,8 +44,13 @@ public class RuntimeConstantProcessor : ExpressionVisitor
     {
         if (node is RuntimeConstantExpression runtimeConstant)
         {
+            if (runtimeConstant.Value is null)
+            {
+                return Expression.Constant(null, runtimeConstant.Type);
+            }
+
             var existing = _preexistingRuntimeConstants.Concat(_foundRuntimeConstants)
-                .FirstOrDefault(x => x.Value == runtimeConstant.Value ||
+                .FirstOrDefault(x => runtimeConstant.Value.Equals(x.Value) ||
                     ExpressionEqualityComparer.Instance.Equals(
                         x.InitializeExpression,
                         runtimeConstant.InitializeExpression));

--- a/src/EFCore/Query/RuntimeConstantProcessor.cs
+++ b/src/EFCore/Query/RuntimeConstantProcessor.cs
@@ -10,9 +10,10 @@ namespace Microsoft.EntityFrameworkCore.Query;
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
 [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
-public class RuntimeConstantProcessor(Dictionary<object, string> constantReplacements) : ExpressionVisitor
+public class RuntimeConstantProcessor : ExpressionVisitor
 {
-    private readonly List<(string Name, RuntimeConstantExpression Expression)> _runtimeConstants = [];
+    private IEnumerable<RuntimeConstantExpression> _preexistingRuntimeConstants = null!;
+    private readonly List<RuntimeConstantExpression> _foundRuntimeConstants = [];
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -20,7 +21,15 @@ public class RuntimeConstantProcessor(Dictionary<object, string> constantReplace
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual Expression Process(Expression expression) => Visit(expression);
+    public virtual Expression Process(Expression expression, IEnumerable<RuntimeConstantExpression>? preexistingRuntimeConstants)
+    {
+        _preexistingRuntimeConstants = preexistingRuntimeConstants ?? [];
+        _foundRuntimeConstants.Clear();
+
+        var result = Visit(expression);
+
+        return result;
+    }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -28,15 +37,14 @@ public class RuntimeConstantProcessor(Dictionary<object, string> constantReplace
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual IReadOnlyList<(string Name, RuntimeConstantExpression Expression)> RuntimeConstants => _runtimeConstants;
+    public virtual IReadOnlyList<RuntimeConstantExpression> RuntimeConstants => _foundRuntimeConstants;
 
     /// <inheritdoc/>
     protected override Expression VisitExtension(Expression node)
     {
         if (node is RuntimeConstantExpression runtimeConstant)
         {
-            var existing = _runtimeConstants
-                .Select(x => x.Expression)
+            var existing = _preexistingRuntimeConstants.Concat(_foundRuntimeConstants)
                 .FirstOrDefault(x => x.Value == runtimeConstant.Value ||
                     ExpressionEqualityComparer.Instance.Equals(
                         x.InitializeExpression,
@@ -44,10 +52,7 @@ public class RuntimeConstantProcessor(Dictionary<object, string> constantReplace
 
             if (existing is null)
             {
-                var fieldName = UniquifyName(runtimeConstant.Name);
-
-                _runtimeConstants.Add((fieldName, runtimeConstant));
-                constantReplacements.Add(runtimeConstant.Value, fieldName);
+                _foundRuntimeConstants.Add(runtimeConstant);
             }
             else
             {
@@ -58,16 +63,5 @@ public class RuntimeConstantProcessor(Dictionary<object, string> constantReplace
         }
 
         return base.VisitExtension(node);
-    }
-
-    private string UniquifyName(string baseName)
-    {
-        var name = baseName;
-        var i = 0;
-        while (_runtimeConstants.Any(c => c.Name == name))
-        {
-            name = baseName + i++;
-        }
-        return name;
     }
 }

--- a/src/EFCore/Query/RuntimeConstantProcessor.cs
+++ b/src/EFCore/Query/RuntimeConstantProcessor.cs
@@ -28,7 +28,7 @@ public class RuntimeConstantProcessor(Dictionary<object, string> constantReplace
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public IReadOnlyList<(string Name, RuntimeConstantExpression Expression)> RuntimeConstants => _runtimeConstants;
+    public virtual IReadOnlyList<(string Name, RuntimeConstantExpression Expression)> RuntimeConstants => _runtimeConstants;
 
     /// <inheritdoc/>
     protected override Expression VisitExtension(Expression node)

--- a/src/EFCore/Query/RuntimeConstantProcessor.cs
+++ b/src/EFCore/Query/RuntimeConstantProcessor.cs
@@ -14,6 +14,10 @@ public class RuntimeConstantProcessor : ExpressionVisitor
 {
     private IEnumerable<RuntimeConstantExpression> _preexistingRuntimeConstants = null!;
     private readonly List<RuntimeConstantExpression> _foundRuntimeConstants = [];
+    private readonly Dictionary<Expression, RuntimeConstantExpression> _runtimeConstantsByExpression =
+        new(ExpressionEqualityComparer.Instance);
+    private readonly Dictionary<object, RuntimeConstantExpression> _runtimeConstantsByValue = [];
+    private bool _runtimeConstantLookupsInitialized;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -25,6 +29,9 @@ public class RuntimeConstantProcessor : ExpressionVisitor
     {
         _preexistingRuntimeConstants = preexistingRuntimeConstants ?? [];
         _foundRuntimeConstants.Clear();
+        _runtimeConstantsByExpression.Clear();
+        _runtimeConstantsByValue.Clear();
+        _runtimeConstantLookupsInitialized = false;
 
         var result = Visit(expression);
 
@@ -49,24 +56,40 @@ public class RuntimeConstantProcessor : ExpressionVisitor
                 return Expression.Constant(null, runtimeConstant.Type);
             }
 
-            var existing = _preexistingRuntimeConstants.Concat(_foundRuntimeConstants)
-                .FirstOrDefault(x => runtimeConstant.Value.Equals(x.Value) ||
-                    ExpressionEqualityComparer.Instance.Equals(
-                        x.InitializeExpression,
-                        runtimeConstant.InitializeExpression));
-
-            if (existing is null)
+            if (!_runtimeConstantLookupsInitialized)
             {
-                _foundRuntimeConstants.Add(runtimeConstant);
+                foreach (var preexistingRuntimeConstant in _preexistingRuntimeConstants)
+                {
+                    AddRuntimeConstantLookup(preexistingRuntimeConstant);
+                }
+
+                _runtimeConstantLookupsInitialized = true;
+            }
+
+            if (_runtimeConstantsByValue.TryGetValue(runtimeConstant.Value, out var existing)
+             || _runtimeConstantsByExpression.TryGetValue(runtimeConstant.InitializeExpression, out existing))
+            {
+                runtimeConstant = existing;
             }
             else
             {
-                runtimeConstant = existing;
+                AddRuntimeConstantLookup(runtimeConstant);
+                _foundRuntimeConstants.Add(runtimeConstant);
             }
 
             return Expression.Constant(runtimeConstant.Value, runtimeConstant.Type);
         }
 
         return base.VisitExtension(node);
+    }
+
+    private void AddRuntimeConstantLookup(RuntimeConstantExpression runtimeConstant)
+    {
+        _runtimeConstantsByExpression.TryAdd(runtimeConstant.InitializeExpression, runtimeConstant);
+
+        if (runtimeConstant.Value is not null)
+        {
+            _runtimeConstantsByValue.TryAdd(runtimeConstant.Value, runtimeConstant);
+        }
     }
 }

--- a/src/EFCore/Query/RuntimeConstantProcessor.cs
+++ b/src/EFCore/Query/RuntimeConstantProcessor.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+/// <summary>
+///     This is an experimental API used by the Entity Framework Core feature and it is not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+[Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
+public class RuntimeConstantProcessor(Dictionary<object, string> constantReplacements) : ExpressionVisitor
+{
+    private readonly List<(string Name, RuntimeConstantExpression Expression)> _runtimeConstants = [];
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual Expression Process(Expression expression) => Visit(expression);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public IReadOnlyList<(string Name, RuntimeConstantExpression Expression)> RuntimeConstants => _runtimeConstants;
+
+    /// <inheritdoc/>
+    protected override Expression VisitExtension(Expression node)
+    {
+        if (node is RuntimeConstantExpression runtimeConstant)
+        {
+            var existing = _runtimeConstants
+                .Select(x => x.Expression)
+                .FirstOrDefault(x => ExpressionEqualityComparer.Instance.Equals(
+                    x.InitializeExpression,
+                    runtimeConstant.InitializeExpression));
+
+            if (existing is null)
+            {
+                var fieldName = UniquifyName(runtimeConstant.Name);
+
+                _runtimeConstants.Add((fieldName, runtimeConstant));
+                constantReplacements.Add(runtimeConstant.Value, fieldName);
+            }
+            else
+            {
+                runtimeConstant = existing;
+            }
+
+            return Expression.Constant(runtimeConstant.Value, runtimeConstant.Type);
+        }
+
+        return base.VisitExtension(node);
+    }
+
+    private string UniquifyName(string baseName)
+    {
+        var name = baseName;
+        var i = 0;
+        while (_runtimeConstants.Any(c => c.Name == name))
+        {
+            name = baseName + i++;
+        }
+        return name;
+    }
+}

--- a/src/EFCore/Query/RuntimeConstantProcessor.cs
+++ b/src/EFCore/Query/RuntimeConstantProcessor.cs
@@ -12,12 +12,10 @@ namespace Microsoft.EntityFrameworkCore.Query;
 [Experimental(EFDiagnostics.PrecompiledQueryExperimental)]
 public class RuntimeConstantProcessor : ExpressionVisitor
 {
-    private IEnumerable<RuntimeConstantExpression> _preexistingRuntimeConstants = null!;
     private readonly List<RuntimeConstantExpression> _foundRuntimeConstants = [];
     private readonly Dictionary<Expression, RuntimeConstantExpression> _runtimeConstantsByExpression =
         new(ExpressionEqualityComparer.Instance);
     private readonly Dictionary<object, RuntimeConstantExpression> _runtimeConstantsByValue = [];
-    private bool _runtimeConstantLookupsInitialized;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -25,13 +23,9 @@ public class RuntimeConstantProcessor : ExpressionVisitor
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual Expression Process(Expression expression, IEnumerable<RuntimeConstantExpression>? preexistingRuntimeConstants)
+    public virtual Expression Process(Expression expression)
     {
-        _preexistingRuntimeConstants = preexistingRuntimeConstants ?? [];
         _foundRuntimeConstants.Clear();
-        _runtimeConstantsByExpression.Clear();
-        _runtimeConstantsByValue.Clear();
-        _runtimeConstantLookupsInitialized = false;
 
         var result = Visit(expression);
 
@@ -44,7 +38,7 @@ public class RuntimeConstantProcessor : ExpressionVisitor
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual IReadOnlyList<RuntimeConstantExpression> RuntimeConstants => _foundRuntimeConstants;
+    public virtual IReadOnlyList<RuntimeConstantExpression> LastProcessFoundRuntimeConstants => _foundRuntimeConstants;
 
     /// <inheritdoc/>
     protected override Expression VisitExtension(Expression node)
@@ -56,16 +50,6 @@ public class RuntimeConstantProcessor : ExpressionVisitor
                 return Expression.Constant(null, runtimeConstant.Type);
             }
 
-            if (!_runtimeConstantLookupsInitialized)
-            {
-                foreach (var preexistingRuntimeConstant in _preexistingRuntimeConstants)
-                {
-                    AddRuntimeConstantLookup(preexistingRuntimeConstant);
-                }
-
-                _runtimeConstantLookupsInitialized = true;
-            }
-
             if (_runtimeConstantsByValue.TryGetValue(runtimeConstant.Value, out var existing)
              || _runtimeConstantsByExpression.TryGetValue(runtimeConstant.InitializeExpression, out existing))
             {
@@ -73,7 +57,8 @@ public class RuntimeConstantProcessor : ExpressionVisitor
             }
             else
             {
-                AddRuntimeConstantLookup(runtimeConstant);
+                _runtimeConstantsByExpression.TryAdd(runtimeConstant.InitializeExpression, runtimeConstant);
+                _runtimeConstantsByValue.TryAdd(runtimeConstant.Value, runtimeConstant);
                 _foundRuntimeConstants.Add(runtimeConstant);
             }
 
@@ -81,15 +66,5 @@ public class RuntimeConstantProcessor : ExpressionVisitor
         }
 
         return base.VisitExtension(node);
-    }
-
-    private void AddRuntimeConstantLookup(RuntimeConstantExpression runtimeConstant)
-    {
-        _runtimeConstantsByExpression.TryAdd(runtimeConstant.InitializeExpression, runtimeConstant);
-
-        if (runtimeConstant.Value is not null)
-        {
-            _runtimeConstantsByValue.TryAdd(runtimeConstant.Value, runtimeConstant);
-        }
     }
 }

--- a/src/EFCore/Query/RuntimeConstantProcessor.cs
+++ b/src/EFCore/Query/RuntimeConstantProcessor.cs
@@ -37,9 +37,10 @@ public class RuntimeConstantProcessor(Dictionary<object, string> constantReplace
         {
             var existing = _runtimeConstants
                 .Select(x => x.Expression)
-                .FirstOrDefault(x => ExpressionEqualityComparer.Instance.Equals(
-                    x.InitializeExpression,
-                    runtimeConstant.InitializeExpression));
+                .FirstOrDefault(x => x.Value == runtimeConstant.Value ||
+                    ExpressionEqualityComparer.Instance.Equals(
+                        x.InitializeExpression,
+                        runtimeConstant.InitializeExpression));
 
             if (existing is null)
             {

--- a/test/EFCore.Design.Tests/Query/LinqToCSharpSyntaxTranslatorTest.cs
+++ b/test/EFCore.Design.Tests/Query/LinqToCSharpSyntaxTranslatorTest.cs
@@ -1049,6 +1049,25 @@ else
     }
 
     [Fact]
+    public void Variable_with_same_name_as_constant_replacement_gets_renamed()
+    {
+        var i = Parameter(typeof(int), "i");
+
+        AssertStatement(
+            Block(
+                variables: [i],
+                Assign(i, Constant(8)),
+                Call(ReturnsIntWithParamMethod, i)),
+            """
+{
+    var i0 = i;
+    LinqToCSharpSyntaxTranslatorTest.ReturnsIntWithParam(i0);
+}
+""",
+            new Dictionary<object, string> { { 8, "i" } });
+    }
+
+    [Fact]
     public void Variable_with_same_name_in_lambda_does_not_get_renamed()
     {
         var i1 = Parameter(typeof(int), "i");

--- a/test/EFCore.Relational.Specification.Tests/Query/AdHocPrecompiledQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/AdHocPrecompiledQueryRelationalTestBase.cs
@@ -358,8 +358,8 @@ var books = await context.Entities.ToListAsync();
             options,
             interceptorCodeAsserter: (code) =>
             {
-                Assert.Contains("private static readonly System.Byte[] _1_NOT_VALID_Bytes = ", code);
-                Assert.Contains("private static readonly System.Byte[] _1_NOT_VALID_Bytes0 = ", code);
+                Assert.Contains("_1_NOT_VALID_Bytes = ", code);
+                Assert.Contains("_1_NOT_VALID_Bytes0 = ", code);
             });
     }
 

--- a/test/EFCore.Relational.Specification.Tests/Query/AdHocPrecompiledQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/AdHocPrecompiledQueryRelationalTestBase.cs
@@ -341,6 +341,56 @@ var books = await context.Books.ToListAsync();
         }
     }
 
+    #region Invalid runtime constant name
+
+    [Fact]
+    public virtual async Task Invalid_identifier_json_property_name()
+    {
+        var contextFactory = await InitializeNonSharedTest<InvalidNameContext>();
+        var options = contextFactory.GetOptions();
+
+        await Test(
+            """
+await using var context = new AdHocPrecompiledQueryRelationalTestBase.InvalidNameContext(dbContextOptions);
+var books = await context.Entities.ToListAsync();
+""",
+            typeof(InvalidNameContext),
+            options,
+            interceptorCodeAsserter: (code) =>
+            {
+                Assert.Contains("private static readonly System.Byte[] _1_NOT_VALID_Bytes = ", code);
+                Assert.Contains("private static readonly System.Byte[] _1_NOT_VALID_Bytes0 = ", code);
+            });
+    }
+
+    public class InvalidNameContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<InvalidNameEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<InvalidNameEntity>().ComplexProperty(x => x.Nested, b =>
+            {
+                b.ToJson();
+                b.Property(x => x.Name).HasJsonPropertyName("1!NOT VALID;");
+                b.Property(x => x.Name2).HasJsonPropertyName("1-NOT VALID!");
+            });
+    }
+
+    public class InvalidNameEntity
+    {
+        public Guid Id { get; set; } = Guid.NewGuid();
+
+        public InvalidNameNestedEntity Nested { get; set; } = new();
+    }
+
+    public class InvalidNameNestedEntity
+    {
+        public string Name { get; set; } = "";
+        public string Name2 { get; set; } = "";
+    }
+
+    #endregion
+
     protected TestSqlLoggerFactory TestSqlLoggerFactory
         => (TestSqlLoggerFactory)ListLoggerFactory;
 

--- a/test/EFCore.Relational.Specification.Tests/Query/PrecompiledQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/PrecompiledQueryRelationalTestBase.cs
@@ -60,6 +60,21 @@ Assert.Equal(new DateTime(2002, 2, 2), blog2.Json[1].Inner.Date);
 """);
 
     [Fact]
+    public virtual Task Json_entity_shaper_uses_runtime_constant_bytes()
+        => Test(
+            """
+await context.Blogs.ToListAsync();
+""",
+            interceptorCodeAsserter: code =>
+            {
+                // Asserts that we are not embedding the result of Encoding.UTF8.GetBytes("Number") directly into the code, but instead referencing a generated static field, which will be initialized at runtime.
+                Assert.DoesNotMatch(@"(?<!private static readonly System\.Byte\[\] NumberBytes = )Encoding\.UTF8\.GetBytes\(""Number""\)", code);
+                Assert.Contains("CurrentReader.ValueTextEquals(((ReadOnlySpan<byte>)(NumberBytes.AsSpan<byte>())))", code);
+
+                Assert.Contains("private static readonly System.Byte[] NumberBytes = Encoding.UTF8.GetBytes(\"Number\");", code);
+            });
+
+    [Fact]
     public virtual Task Conditional_no_evaluatable()
         => Test(
             """

--- a/test/EFCore.Relational.Specification.Tests/Query/PrecompiledQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/PrecompiledQueryRelationalTestBase.cs
@@ -203,8 +203,8 @@ _ = await context.Blogs.Select(b => new[] { b.Id, b.Id + i }).ToListAsync();
 
     [Fact]
     public virtual Task RuntimeConstantExpression()
-    => Test(
-        """
+        => Test(
+            """
 await context.Blogs.ToListAsync();
 """,
         interceptorCodeAsserter: code =>

--- a/test/EFCore.Relational.Specification.Tests/Query/PrecompiledQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/PrecompiledQueryRelationalTestBase.cs
@@ -3,6 +3,7 @@
 
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.Internal;
@@ -58,21 +59,6 @@ Assert.Equal(2, blog2.Json[1].Number);
 Assert.Equal("Two", blog2.Json[1].Text);
 Assert.Equal(new DateTime(2002, 2, 2), blog2.Json[1].Inner.Date);
 """);
-
-    [Fact]
-    public virtual Task Json_entity_shaper_uses_runtime_constant_bytes()
-        => Test(
-            """
-await context.Blogs.ToListAsync();
-""",
-            interceptorCodeAsserter: code =>
-            {
-                // Asserts that we are not embedding the result of Encoding.UTF8.GetBytes("Number") directly into the code, but instead referencing a generated static field, which will be initialized at runtime.
-                Assert.DoesNotMatch(@"(?<!private static readonly System\.Byte\[\] NumberBytes = )Encoding\.UTF8\.GetBytes\(""Number""\)", code);
-                Assert.Contains("CurrentReader.ValueTextEquals(((ReadOnlySpan<byte>)(NumberBytes.AsSpan<byte>())))", code);
-
-                Assert.Contains("private static readonly System.Byte[] NumberBytes = Encoding.UTF8.GetBytes(\"Number\");", code);
-            });
 
     [Fact]
     public virtual Task Conditional_no_evaluatable()
@@ -214,6 +200,18 @@ _ = await context.Blogs.Select(b => new[] { b.Id, b.Id + i }).ToListAsync();
     [Fact]
     public virtual Task Unary()
         => Test("_ = await context.Blogs.Where(b => (short)b.Id == (short)8).ToListAsync();");
+
+    [Fact]
+    public virtual Task RuntimeConstantExpression()
+    => Test(
+        """
+await context.Blogs.ToListAsync();
+""",
+        interceptorCodeAsserter: code =>
+        {
+            Assert.Matches(@"\bprivate\s+static\s+readonly\b(?=[^;]*\bNumberBytes\b)[^;=]*\bNumberBytes\s*=\s*[^;]+;", code); // Expected a private static readonly field named NumberBytes with an initializer.
+            Assert.True(Regex.Matches(code, @"\bNumberBytes\b").Count > 1, "Expected at least 1 reference to NumberBytes excluding the initializer.");
+        });
 
     #endregion Expression types
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocPrecompiledQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocPrecompiledQuerySqlServerTest.cs
@@ -119,6 +119,17 @@ FROM [Books] AS [b]
 """);
     }
 
+    public override async Task Invalid_identifier_json_property_name()
+    {
+        await base.Invalid_identifier_json_property_name();
+
+        AssertSql(
+            """
+SELECT [e].[Id], [e].[Nested]
+FROM [Entities] AS [e]
+""");
+    }
+
     [Fact]
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrecompiledQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrecompiledQuerySqlServerTest.cs
@@ -30,17 +30,6 @@ WHERE [b].[Id] > @id
 """);
     }
 
-    public override async Task Json_entity_shaper_uses_runtime_constant_bytes()
-    {
-        await base.Json_entity_shaper_uses_runtime_constant_bytes();
-
-        AssertSql(
-            """
-SELECT [b].[Id], [b].[Name], [b].[Json]
-FROM [Blogs] AS [b]
-""");
-    }
-
     public override async Task Conditional_no_evaluatable()
     {
         await base.Conditional_no_evaluatable();
@@ -278,6 +267,17 @@ WHERE CAST([b].[Id] AS smallint) = CAST(8 AS smallint)
         await Test("""_ = context.Blogs.Where(b => EF.Functions.Collate(b.Name, "German_PhoneBook_CI_AS") == "foo").ToList();""");
 
         AssertSql();
+    }
+
+    public override async Task RuntimeConstantExpression()
+    {
+        await base.RuntimeConstantExpression();
+
+        AssertSql(
+            """
+SELECT [b].[Id], [b].[Name], [b].[Json]
+FROM [Blogs] AS [b]
+""");
     }
 
     #endregion Expression types

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrecompiledQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrecompiledQuerySqlServerTest.cs
@@ -12,7 +12,7 @@ public class PrecompiledQuerySqlServerTest(
         IClassFixture<PrecompiledQuerySqlServerTest.PrecompiledQuerySqlServerFixture>
 {
     protected override bool AlwaysPrintGeneratedSources
-        => true;
+        => false;
 
     #region Expression types
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrecompiledQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrecompiledQuerySqlServerTest.cs
@@ -12,7 +12,7 @@ public class PrecompiledQuerySqlServerTest(
         IClassFixture<PrecompiledQuerySqlServerTest.PrecompiledQuerySqlServerFixture>
 {
     protected override bool AlwaysPrintGeneratedSources
-        => false;
+        => true;
 
     #region Expression types
 
@@ -27,6 +27,17 @@ public class PrecompiledQuerySqlServerTest(
 SELECT [b].[Id], [b].[Name], [b].[Json]
 FROM [Blogs] AS [b]
 WHERE [b].[Id] > @id
+""");
+    }
+
+    public override async Task Json_entity_shaper_uses_runtime_constant_bytes()
+    {
+        await base.Json_entity_shaper_uses_runtime_constant_bytes();
+
+        AssertSql(
+            """
+SELECT [b].[Id], [b].[Name], [b].[Json]
+FROM [Blogs] AS [b]
 """);
     }
 


### PR DESCRIPTION
Adds support for storing values which don't change across executions of the query in precompiled queries as a private static readonly field. Also allowing non-precompiled queries to use a ConstantExpression directly for these values.
Improves performance by moving GetBytes call to query compile time instead of shaper runtime. 