### PR TITLE
Add DATA_COMPRESSION support for primary keys and unique constraints

### DIFF
--- a/src/EFCore.SqlServer/Design/Internal/SqlServerAnnotationCodeGenerator.cs
+++ b/src/EFCore.SqlServer/Design/Internal/SqlServerAnnotationCodeGenerator.cs
@@ -124,6 +124,10 @@ public class SqlServerAnnotationCodeGenerator : AnnotationCodeGenerator
         = typeof(SqlServerKeyBuilderExtensions).GetRuntimeMethod(
             nameof(SqlServerKeyBuilderExtensions.HasFillFactor), [typeof(KeyBuilder), typeof(int)])!;
 
+    private static readonly MethodInfo KeyUseDataCompressionMethodInfo
+        = typeof(SqlServerKeyBuilderExtensions).GetRuntimeMethod(
+            nameof(SqlServerKeyBuilderExtensions.UseDataCompression), [typeof(KeyBuilder), typeof(DataCompressionType)])!;
+
     private static readonly MethodInfo TableIsTemporalMethodInfo
         = typeof(SqlServerTableBuilderExtensions).GetRuntimeMethod(
             nameof(SqlServerTableBuilderExtensions.IsTemporal), [typeof(TableBuilder), typeof(bool)])!;
@@ -455,6 +459,8 @@ public class SqlServerAnnotationCodeGenerator : AnnotationCodeGenerator
                 : new MethodCallCodeFragment(KeyIsClusteredMethodInfo),
 
             SqlServerAnnotationNames.FillFactor => new MethodCallCodeFragment(KeyHasFillFactorMethodInfo, annotation.Value),
+
+            SqlServerAnnotationNames.DataCompression => new MethodCallCodeFragment(KeyUseDataCompressionMethodInfo, annotation.Value),
 
             _ => null
         };

--- a/src/EFCore.SqlServer/Design/Internal/SqlServerCSharpRuntimeAnnotationCodeGenerator.cs
+++ b/src/EFCore.SqlServer/Design/Internal/SqlServerCSharpRuntimeAnnotationCodeGenerator.cs
@@ -143,6 +143,7 @@ public class SqlServerCSharpRuntimeAnnotationCodeGenerator : RelationalCSharpRun
             var annotations = parameters.Annotations;
             annotations.Remove(SqlServerAnnotationNames.Clustered);
             annotations.Remove(SqlServerAnnotationNames.FillFactor);
+            annotations.Remove(SqlServerAnnotationNames.DataCompression);
         }
 
         base.Generate(key, parameters);
@@ -156,6 +157,7 @@ public class SqlServerCSharpRuntimeAnnotationCodeGenerator : RelationalCSharpRun
             var annotations = parameters.Annotations;
             annotations.Remove(SqlServerAnnotationNames.Clustered);
             annotations.Remove(SqlServerAnnotationNames.FillFactor);
+            annotations.Remove(SqlServerAnnotationNames.DataCompression);
         }
 
         base.Generate(uniqueConstraint, parameters);

--- a/src/EFCore.SqlServer/EFCore.SqlServer.baseline.json
+++ b/src/EFCore.SqlServer/EFCore.SqlServer.baseline.json
@@ -1752,6 +1752,9 @@
       "Type": "static class Microsoft.EntityFrameworkCore.SqlServerKeyBuilderExtensions",
       "Methods": [
         {
+          "Member": "static bool CanSetDataCompression(this Microsoft.EntityFrameworkCore.Metadata.Builders.IConventionKeyBuilder keyBuilder, Microsoft.EntityFrameworkCore.DataCompressionType? dataCompressionType, bool fromDataAnnotation = false);"
+        },
+        {
           "Member": "static bool CanSetFillFactor(this Microsoft.EntityFrameworkCore.Metadata.Builders.IConventionKeyBuilder keyBuilder, int? fillFactor, bool fromDataAnnotation = false);"
         },
         {
@@ -1774,12 +1777,30 @@
         },
         {
           "Member": "static Microsoft.EntityFrameworkCore.Metadata.Builders.IConventionKeyBuilder? IsClustered(this Microsoft.EntityFrameworkCore.Metadata.Builders.IConventionKeyBuilder keyBuilder, bool? clustered, bool fromDataAnnotation = false);"
+        },
+        {
+          "Member": "static Microsoft.EntityFrameworkCore.Metadata.Builders.KeyBuilder UseDataCompression(this Microsoft.EntityFrameworkCore.Metadata.Builders.KeyBuilder keyBuilder, Microsoft.EntityFrameworkCore.DataCompressionType dataCompressionType);"
+        },
+        {
+          "Member": "static Microsoft.EntityFrameworkCore.Metadata.Builders.KeyBuilder<TEntity> UseDataCompression<TEntity>(this Microsoft.EntityFrameworkCore.Metadata.Builders.KeyBuilder<TEntity> keyBuilder, Microsoft.EntityFrameworkCore.DataCompressionType dataCompressionType);"
+        },
+        {
+          "Member": "static Microsoft.EntityFrameworkCore.Metadata.Builders.IConventionKeyBuilder? UseDataCompression(this Microsoft.EntityFrameworkCore.Metadata.Builders.IConventionKeyBuilder keyBuilder, Microsoft.EntityFrameworkCore.DataCompressionType? dataCompressionType, bool fromDataAnnotation = false);"
         }
       ]
     },
     {
       "Type": "static class Microsoft.EntityFrameworkCore.SqlServerKeyExtensions",
       "Methods": [
+        {
+          "Member": "static Microsoft.EntityFrameworkCore.DataCompressionType? GetDataCompression(this Microsoft.EntityFrameworkCore.Metadata.IReadOnlyKey key);"
+        },
+        {
+          "Member": "static Microsoft.EntityFrameworkCore.DataCompressionType? GetDataCompression(this Microsoft.EntityFrameworkCore.Metadata.IReadOnlyKey key, in Microsoft.EntityFrameworkCore.Metadata.StoreObjectIdentifier storeObject);"
+        },
+        {
+          "Member": "static Microsoft.EntityFrameworkCore.Metadata.ConfigurationSource? GetDataCompressionConfigurationSource(this Microsoft.EntityFrameworkCore.Metadata.IConventionKey key);"
+        },
         {
           "Member": "static int? GetFillFactor(this Microsoft.EntityFrameworkCore.Metadata.IReadOnlyKey key);"
         },
@@ -1797,6 +1818,12 @@
         },
         {
           "Member": "static bool? IsClustered(this Microsoft.EntityFrameworkCore.Metadata.IReadOnlyKey key, in Microsoft.EntityFrameworkCore.Metadata.StoreObjectIdentifier storeObject);"
+        },
+        {
+          "Member": "static void SetDataCompression(this Microsoft.EntityFrameworkCore.Metadata.IMutableKey key, Microsoft.EntityFrameworkCore.DataCompressionType? dataCompression);"
+        },
+        {
+          "Member": "static Microsoft.EntityFrameworkCore.DataCompressionType? SetDataCompression(this Microsoft.EntityFrameworkCore.Metadata.IConventionKey key, Microsoft.EntityFrameworkCore.DataCompressionType? dataCompression, bool fromDataAnnotation = false);"
         },
         {
           "Member": "static void SetFillFactor(this Microsoft.EntityFrameworkCore.Metadata.IMutableKey key, int? fillFactor);"

--- a/src/EFCore.SqlServer/Extensions/SqlServerKeyBuilderExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerKeyBuilderExtensions.cs
@@ -178,4 +178,86 @@ public static class SqlServerKeyBuilderExtensions
         int? fillFactor,
         bool fromDataAnnotation = false)
         => keyBuilder.CanSetAnnotation(SqlServerAnnotationNames.FillFactor, fillFactor, fromDataAnnotation);
+
+    /// <summary>
+    ///     Configures whether the key is created with data compression option when targeting SQL Server.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see>, and
+    ///     <see href="https://aka.ms/efcore-docs-sqlserver">Accessing SQL Server and Azure SQL databases with EF Core</see>
+    ///     for more information and examples.
+    /// </remarks>
+    /// <param name="keyBuilder">The builder for the key being configured.</param>
+    /// <param name="dataCompressionType">A value indicating the data compression option to be used.</param>
+    /// <returns>A builder to further configure the key.</returns>
+    public static KeyBuilder UseDataCompression(this KeyBuilder keyBuilder, DataCompressionType dataCompressionType)
+    {
+        keyBuilder.Metadata.SetDataCompression(dataCompressionType);
+
+        return keyBuilder;
+    }
+
+    /// <summary>
+    ///     Configures whether the key is created with data compression option when targeting SQL Server.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see>, and
+    ///     <see href="https://aka.ms/efcore-docs-sqlserver">Accessing SQL Server and Azure SQL databases with EF Core</see>
+    ///     for more information and examples.
+    /// </remarks>
+    /// <param name="keyBuilder">The builder for the key being configured.</param>
+    /// <param name="dataCompressionType">A value indicating the data compression option to be used.</param>
+    /// <returns>A builder to further configure the key.</returns>
+    public static KeyBuilder<TEntity> UseDataCompression<TEntity>(
+        this KeyBuilder<TEntity> keyBuilder,
+        DataCompressionType dataCompressionType)
+        => (KeyBuilder<TEntity>)UseDataCompression((KeyBuilder)keyBuilder, dataCompressionType);
+
+    /// <summary>
+    ///     Configures whether the key is created with data compression option when targeting SQL Server.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see>, and
+    ///     <see href="https://aka.ms/efcore-docs-sqlserver">Accessing SQL Server and Azure SQL databases with EF Core</see>
+    ///     for more information and examples.
+    /// </remarks>
+    /// <param name="keyBuilder">The builder for the key being configured.</param>
+    /// <param name="dataCompressionType">A value indicating the data compression option to be used.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>
+    ///     The same builder instance if the configuration was applied,
+    ///     <see langword="null" /> otherwise.
+    /// </returns>
+    public static IConventionKeyBuilder? UseDataCompression(
+        this IConventionKeyBuilder keyBuilder,
+        DataCompressionType? dataCompressionType,
+        bool fromDataAnnotation = false)
+    {
+        if (keyBuilder.CanSetDataCompression(dataCompressionType, fromDataAnnotation))
+        {
+            keyBuilder.Metadata.SetDataCompression(dataCompressionType, fromDataAnnotation);
+
+            return keyBuilder;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    ///     Returns a value indicating whether the key can be configured with data compression option when targeting SQL Server.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see>, and
+    ///     <see href="https://aka.ms/efcore-docs-sqlserver">Accessing SQL Server and Azure SQL databases with EF Core</see>
+    ///     for more information and examples.
+    /// </remarks>
+    /// <param name="keyBuilder">The builder for the key being configured.</param>
+    /// <param name="dataCompressionType">A value indicating the data compression option to be used.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns><see langword="true" /> if the key can be configured with data compression option when targeting SQL Server.</returns>
+    public static bool CanSetDataCompression(
+        this IConventionKeyBuilder keyBuilder,
+        DataCompressionType? dataCompressionType,
+        bool fromDataAnnotation = false)
+        => keyBuilder.CanSetAnnotation(SqlServerAnnotationNames.DataCompression, dataCompressionType, fromDataAnnotation);
 }

--- a/src/EFCore.SqlServer/Extensions/SqlServerKeyExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerKeyExtensions.cs
@@ -163,4 +163,71 @@ public static class SqlServerKeyExtensions
     /// <returns>The <see cref="ConfigurationSource" /> for whether the key uses the fill factor.</returns>
     public static ConfigurationSource? GetFillFactorConfigurationSource(this IConventionKey key)
         => key.FindAnnotation(SqlServerAnnotationNames.FillFactor)?.GetConfigurationSource();
+
+    /// <summary>
+    ///     Returns the data compression that the key uses.
+    /// </summary>
+    /// <param name="key">The key.</param>
+    /// <returns>The data compression that the key uses.</returns>
+    public static DataCompressionType? GetDataCompression(this IReadOnlyKey key)
+        => (key is RuntimeKey)
+            ? throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData)
+            : (DataCompressionType?)key[SqlServerAnnotationNames.DataCompression];
+
+    /// <summary>
+    ///     Returns the data compression that the key uses.
+    /// </summary>
+    /// <param name="key">The key.</param>
+    /// <param name="storeObject">The identifier of the store object.</param>
+    /// <returns>The data compression that the key uses.</returns>
+    public static DataCompressionType? GetDataCompression(this IReadOnlyKey key, in StoreObjectIdentifier storeObject)
+    {
+        if (key is RuntimeKey)
+        {
+            throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData);
+        }
+
+        var annotation = key.FindAnnotation(SqlServerAnnotationNames.DataCompression);
+        if (annotation != null)
+        {
+            return (DataCompressionType?)annotation.Value;
+        }
+
+        var sharedTableRootKey = key.FindSharedObjectRootKey(storeObject);
+        return sharedTableRootKey?.GetDataCompression(storeObject);
+    }
+
+    /// <summary>
+    ///     Sets a value indicating the data compression the key uses.
+    /// </summary>
+    /// <param name="key">The key.</param>
+    /// <param name="dataCompression">The value to set.</param>
+    public static void SetDataCompression(this IMutableKey key, DataCompressionType? dataCompression)
+        => key.SetAnnotation(
+            SqlServerAnnotationNames.DataCompression,
+            dataCompression);
+
+    /// <summary>
+    ///     Sets a value indicating the data compression the key uses.
+    /// </summary>
+    /// <param name="key">The key.</param>
+    /// <param name="dataCompression">The value to set.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>The configured value.</returns>
+    public static DataCompressionType? SetDataCompression(
+        this IConventionKey key,
+        DataCompressionType? dataCompression,
+        bool fromDataAnnotation = false)
+        => (DataCompressionType?)key.SetAnnotation(
+            SqlServerAnnotationNames.DataCompression,
+            dataCompression,
+            fromDataAnnotation)?.Value;
+
+    /// <summary>
+    ///     Returns the <see cref="ConfigurationSource" /> for the data compression the key uses.
+    /// </summary>
+    /// <param name="key">The key.</param>
+    /// <returns>The <see cref="ConfigurationSource" /> for the data compression the key uses.</returns>
+    public static ConfigurationSource? GetDataCompressionConfigurationSource(this IConventionKey key)
+        => key.FindAnnotation(SqlServerAnnotationNames.DataCompression)?.GetConfigurationSource();
 }

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerRuntimeModelConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerRuntimeModelConvention.cs
@@ -117,6 +117,7 @@ public class SqlServerRuntimeModelConvention : RelationalRuntimeModelConvention
         {
             annotations.Remove(SqlServerAnnotationNames.Clustered);
             annotations.Remove(SqlServerAnnotationNames.FillFactor);
+            annotations.Remove(SqlServerAnnotationNames.DataCompression);
         }
     }
 

--- a/src/EFCore.SqlServer/Metadata/Internal/SqlServerAnnotationProvider.cs
+++ b/src/EFCore.SqlServer/Metadata/Internal/SqlServerAnnotationProvider.cs
@@ -175,6 +175,11 @@ public class SqlServerAnnotationProvider(RelationalAnnotationProviderDependencie
         {
             yield return new Annotation(SqlServerAnnotationNames.FillFactor, fillFactor);
         }
+
+        if (key.GetDataCompression() is { } dataCompression)
+        {
+            yield return new Annotation(SqlServerAnnotationNames.DataCompression, dataCompression);
+        }
     }
 
     /// <summary>

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsSqlServerTest.cs
@@ -390,6 +390,44 @@ CREATE TABLE [People] (
 """);
     }
 
+    [Fact]
+    public virtual async Task Create_table_with_data_compression()
+    {
+        await Test(
+            _ => { },
+            builder =>
+            {
+                builder.Entity("People").Property<int>("TheKey");
+                builder.Entity("People").Property<Guid>("TheAlternateKey");
+                builder.Entity("People").HasKey("TheKey").UseDataCompression(DataCompressionType.Page);
+                builder.Entity("People").HasAlternateKey("TheAlternateKey").UseDataCompression(DataCompressionType.Row);
+            },
+            model =>
+            {
+                var table = Assert.Single(model.Tables);
+
+                // DATA_COMPRESSION is not currently reverse-engineered, so it round-trips as null on the
+                // scaffolded model (same as the index case); the generated SQL below is the real assertion.
+                var primaryKey = table.PrimaryKey;
+                Assert.NotNull(primaryKey);
+                Assert.Null(primaryKey[SqlServerAnnotationNames.DataCompression]);
+
+                var uniqueConstraint = table.UniqueConstraints.FirstOrDefault();
+                Assert.NotNull(uniqueConstraint);
+                Assert.Null(uniqueConstraint[SqlServerAnnotationNames.DataCompression]);
+            });
+
+        AssertSql(
+            """
+CREATE TABLE [People] (
+    [TheKey] int NOT NULL IDENTITY,
+    [TheAlternateKey] uniqueidentifier NOT NULL,
+    CONSTRAINT [PK_People] PRIMARY KEY ([TheKey]) WITH (DATA_COMPRESSION = PAGE),
+    CONSTRAINT [AK_People_TheAlternateKey] UNIQUE ([TheAlternateKey]) WITH (DATA_COMPRESSION = ROW)
+);
+""");
+    }
+
     public override async Task Drop_table()
     {
         await base.Drop_table();

--- a/test/EFCore.SqlServer.Tests/Metadata/SqlServerBuilderExtensionsTest.cs
+++ b/test/EFCore.SqlServer.Tests/Metadata/SqlServerBuilderExtensionsTest.cs
@@ -158,6 +158,36 @@ public class SqlServerBuilderExtensionsTest
     }
 
     [Fact]
+    public void Can_set_key_with_data_compression()
+    {
+        var modelBuilder = CreateConventionModelBuilder();
+
+        modelBuilder
+            .Entity<Customer>()
+            .HasKey(e => e.Id)
+            .UseDataCompression(DataCompressionType.Page);
+
+        var key = modelBuilder.Model.FindEntityType(typeof(Customer)).FindPrimaryKey();
+
+        Assert.Equal(DataCompressionType.Page, key.GetDataCompression());
+    }
+
+    [Fact]
+    public void Can_set_key_with_data_compression_non_generic()
+    {
+        var modelBuilder = CreateConventionModelBuilder();
+
+        modelBuilder
+            .Entity(typeof(Customer))
+            .HasKey("Id")
+            .UseDataCompression(DataCompressionType.Row);
+
+        var key = modelBuilder.Model.FindEntityType(typeof(Customer)).FindPrimaryKey();
+
+        Assert.Equal(DataCompressionType.Row, key.GetDataCompression());
+    }
+
+    [Fact]
     public void Can_set_index_include()
     {
         var modelBuilder = CreateConventionModelBuilder();


### PR DESCRIPTION
SQL Server `PRIMARY KEY` / `UNIQUE` constraints accept `WITH (DATA_COMPRESSION = ...)`, just like indexes do (#30408 added it for indexes). This adds first-class support for configuring it on keys, mirroring the existing index `DATA_COMPRESSION` and key `FILLFACTOR` support.

```csharp
modelBuilder.Entity<Blog>().HasKey(b => b.Id).UseDataCompression(DataCompressionType.Page);
modelBuilder.Entity<Blog>().HasAlternateKey(b => b.Code).UseDataCompression(DataCompressionType.Row);
```

produces:

```sql
CONSTRAINT [PK_Blog] PRIMARY KEY ([Id]) WITH (DATA_COMPRESSION = PAGE)
CONSTRAINT [AK_Blog_Code] UNIQUE ([Code]) WITH (DATA_COMPRESSION = ROW)
```

`SqlServerAnnotationProvider.For(IUniqueConstraint)` attaches the annotation; the base generator's `PrimaryKeyConstraint`/`UniqueConstraint` already call the shared `IndexOptions`, which already emits `DATA_COMPRESSION`, so the migrations generator itself is unchanged. As with the index case, `DATA_COMPRESSION` is not reverse-engineered.

Fixes #33145
