### PR TITLE
Fix OriginalValues.ToObject for added complex collections

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/OriginalPropertyValues.cs
+++ b/src/EFCore/ChangeTracking/Internal/OriginalPropertyValues.cs
@@ -71,7 +71,9 @@ public class OriginalPropertyValues : EntryPropertyValues
 
             // The stored original collection contains references to the current CLR elements
             // (see SnapshotComplexCollection), so we must reconstruct each element from the
-            // per-entry original value snapshots to get true original values.
+            // per-entry original value snapshots to get true original values. For added entries,
+            // original values fall back to current values, so elements do not have original ordinals.
+            var useCurrentValues = entry.EntityState == EntityState.Added;
             var reconstructed = (IList)((IRuntimePropertyBase)complexProperty).GetIndexedCollectionAccessor()
                 .Create(originalCollection.Count);
             for (var i = 0; i < originalCollection.Count; i++)
@@ -83,14 +85,21 @@ public class OriginalPropertyValues : EntryPropertyValues
                     continue;
                 }
 
-                var complexEntry = entry.GetComplexCollectionOriginalEntry(complexProperty, i);
-                if (!complexEntry.HasOriginalValuesSnapshot)
+                var complexEntry = useCurrentValues
+                    ? entry.GetComplexCollectionEntry(complexProperty, i)
+                    : entry.GetComplexCollectionOriginalEntry(complexProperty, i);
+                if (!useCurrentValues
+                    && !complexEntry.HasOriginalValuesSnapshot)
                 {
                     complexEntry.EnsureOriginalValues();
                     SetValuesFromInstance(complexEntry, (IRuntimeTypeBase)complexProperty.ComplexType, element, skipChangeDetection: true);
                 }
 
-                reconstructed.Add(new OriginalPropertyValues(complexEntry).Clone().ToObject());
+                PropertyValues propertyValues = useCurrentValues
+                    ? new CurrentPropertyValues(complexEntry)
+                    : new OriginalPropertyValues(complexEntry);
+
+                reconstructed.Add(propertyValues.Clone().ToObject());
             }
 
             return reconstructed;

--- a/test/EFCore.Tests/ChangeTracking/Internal/PropertyValuesTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/PropertyValuesTest.cs
@@ -197,6 +197,53 @@ public class PropertyValuesTest
         Assert.Equal("505", result.Errors[2].InnerError!.InnerError!.Code);
     }
 
+    [Fact]
+    public void OriginalValues_ToObject_with_complex_collection_for_added_entity()
+    {
+        var job = new Job
+        {
+            Id = 1,
+            Name = "Added Job",
+            Errors =
+            [
+                new RootJobError
+                {
+                    Code = "500",
+                    Message = "Server Error",
+                    InnerErrors =
+                    [
+                        new JobError { Code = "501", Message = "Not Implemented" }
+                    ]
+                }
+            ]
+        };
+
+        var stateManager = CreateStateManager(BuildJobModel);
+        var internalEntry = stateManager.GetOrCreateEntry(job);
+        internalEntry.SetEntityState(EntityState.Added);
+        var entry = new EntityEntry<Job>(internalEntry);
+
+        var result = (Job)entry.OriginalValues.ToObject();
+
+        Assert.NotSame(job, result);
+        Assert.Equal("Added Job", result.Name);
+        Assert.Single(result.Errors);
+
+        var error = result.Errors[0];
+        Assert.NotSame(job.Errors[0], error);
+        Assert.Equal("500", error.Code);
+        Assert.Equal("Server Error", error.Message);
+        Assert.Single(error.InnerErrors);
+        Assert.NotSame(job.Errors[0].InnerErrors[0], error.InnerErrors[0]);
+        Assert.Equal("501", error.InnerErrors[0].Code);
+
+        error.Code = "Changed";
+        error.InnerErrors[0].Code = "Changed";
+
+        Assert.Equal("500", job.Errors[0].Code);
+        Assert.Equal("501", job.Errors[0].InnerErrors[0].Code);
+    }
+
     [Theory]
     [ClassData(typeof(DataGenerator<bool?, SetValues?>))]
     public void ToObject_with_null_complex_property_in_complex_collection_in_complex_collection(


### PR DESCRIPTION
Fixes #38486

### Problem

`OriginalValues.ToObject()` can throw for an entity in the `Added` state when the entity contains a complex collection. Scalar original values already fall back to current values for added entries, but complex collection reconstruction was still trying to read element entries by original ordinal.

For added entities, complex collection elements do not have usable original ordinals. Calling `GetComplexCollectionOriginalEntry(...)` therefore throws before `ToObject()` can materialize the value graph.

### Change

This updates `OriginalPropertyValues` so complex collection reconstruction uses current complex collection entries when the containing entry is in the `Added` state. For non-added entries, the existing original-entry reconstruction path is preserved so modified and unchanged entities continue to reconstruct from original snapshots.

The added-state branch also avoids creating per-element original snapshots, since the result is materialized through `CurrentPropertyValues` and those snapshots would not be read.

### Tests

Adds a regression test for `OriginalValues.ToObject()` on an added entity with:

- a complex collection
- a nested complex collection inside one of the collection elements
- assertions that the returned object graph is cloned rather than sharing the tracked complex element instances

Validation:

- `dotnet build test/EFCore.Tests/EFCore.Tests.csproj --no-restore`
- `dotnet artifacts/bin/EFCore.Tests/Debug/net11.0/Microsoft.EntityFrameworkCore.Tests.dll --filter-method Microsoft.EntityFrameworkCore.ChangeTracking.Internal.PropertyValuesTest.OriginalValues_ToObject_with_complex_collection_for_added_entity --no-progress --no-ansi`
- `dotnet artifacts/bin/EFCore.Tests/Debug/net11.0/Microsoft.EntityFrameworkCore.Tests.dll --filter-class Microsoft.EntityFrameworkCore.ChangeTracking.Internal.PropertyValuesTest --no-progress --no-ansi`
