### PR TITLE
Improve handling of null values in JSON properties mapped to primitive collections

### DIFF
--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.ClientMethods.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.ClientMethods.cs
@@ -3,6 +3,7 @@
 
 using System.Collections;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.Internal;
@@ -78,6 +79,9 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
 
         private static readonly MethodInfo MaterializeJsonEntityCollectionMethodInfo
             = typeof(ShaperProcessingExpressionVisitor).GetTypeInfo().GetDeclaredMethod(nameof(MaterializeJsonEntityCollection))!;
+
+        private static readonly MethodInfo ReadPrimitiveCollectionFromJsonMethodInfo
+            = typeof(ShaperProcessingExpressionVisitor).GetTypeInfo().GetDeclaredMethod(nameof(ReadPrimitiveCollectionFromJson))!;
 
         private static readonly MethodInfo InverseCollectionFixupMethod
             = typeof(ShaperProcessingExpressionVisitor).GetTypeInfo().GetDeclaredMethod(nameof(InverseCollectionFixup))!;
@@ -954,6 +958,45 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             }
 
             dataReaderContext.HasNext = false;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public static object? ReadPrimitiveCollectionFromJson(
+            string? json,
+            JsonValueReaderWriter readerWriter,
+            bool nullable,
+            string propertyName)
+        {
+            if (json == null)
+            {
+                return null;
+            }
+
+            // Preserve the diagnostics of the converter path (JsonValueReaderWriter.FromJsonString), which rejects
+            // empty/whitespace JSON strings before tokenizing.
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                throw new InvalidOperationException(CoreStrings.EmptyJsonString);
+            }
+
+            // A primitive collection mapped to a column is read by parsing the JSON string with the collection's
+            // JsonValueReaderWriter (which doesn't handle the 'null' token). The stored value may be a JSON 'null'
+            // token (e.g. the literal string "null"), which must be materialized as null for an optional property,
+            // rather than letting the reader/writer throw. See issues #34881 and #38454.
+            var manager = new Utf8JsonReaderManager(new JsonReaderData(Encoding.UTF8.GetBytes(json)), null);
+            manager.MoveNext();
+
+            return manager.CurrentReader.TokenType == JsonTokenType.Null
+                ? nullable
+                    ? null
+                    : throw new InvalidOperationException(RelationalStrings.NullValueInRequiredJsonProperty(propertyName))
+                : readerWriter.FromJson(ref manager);
         }
 
         /// <summary>

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
@@ -10,6 +10,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Storage.Json;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using static System.Linq.Expressions.Expression;
 
 namespace Microsoft.EntityFrameworkCore.Query;
@@ -3000,7 +3001,66 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             var converter = typeMapping.Converter;
 
             var converterExpression = default(Expression);
-            if (converter != null)
+            var primitiveCollectionJsonHandled = false;
+
+            // #34881/#38454: A primitive collection mapped to a column uses CollectionToJsonStringConverter, which parses the
+            // provider JSON string via the collection's JsonValueReaderWriter. That reader/writer doesn't handle a JSON 'null'
+            // token, so we must peek the first token here and short-circuit to null (or throw for a required property) before
+            // invoking the converter, rather than letting the reader/writer throw a cryptic "Invalid token type: 'Null'".
+            if (property is IProperty { IsPrimitiveCollection: true } primitiveCollectionProperty
+                && converter is not null
+                && converter.GetType() is { IsGenericType: true } converterClrType
+                && converterClrType.GetGenericTypeDefinition() == typeof(CollectionToJsonStringConverter<>))
+            {
+                var liftableConstantParameter = Parameter(typeof(MaterializerLiftableConstantContext), "c");
+                var jsonReaderWriterExpression = _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
+                    primitiveCollectionProperty.GetJsonValueReaderWriter() ?? primitiveCollectionProperty.GetTypeMapping().JsonValueReaderWriter!,
+                    Lambda<Func<MaterializerLiftableConstantContext, object>>(
+                        Coalesce(
+                            Call(
+                                LiftableConstantExpressionHelpers.BuildMemberAccessForProperty(
+                                    primitiveCollectionProperty, liftableConstantParameter),
+                                PropertyGetJsonValueReaderWriterMethod),
+                            Property(
+                                Call(
+                                    LiftableConstantExpressionHelpers.BuildMemberAccessForProperty(
+                                        primitiveCollectionProperty, liftableConstantParameter),
+                                    PropertyGetTypeMappingMethod),
+                                nameof(CoreTypeMapping.JsonValueReaderWriter))),
+                        liftableConstantParameter),
+                    primitiveCollectionProperty.Name + "JsonReaderWriter",
+                    typeof(JsonValueReaderWriter));
+
+                if (valueExpression.Type != typeof(string))
+                {
+                    valueExpression = Convert(valueExpression, typeof(string));
+                }
+
+                Expression readExpression = Call(
+                    ReadPrimitiveCollectionFromJsonMethodInfo,
+                    valueExpression,
+                    jsonReaderWriterExpression,
+                    Constant(nullable),
+                    Constant(primitiveCollectionProperty.Name));
+
+                if (readExpression.Type != type)
+                {
+                    readExpression = Convert(readExpression, type);
+                }
+
+                if (nullable)
+                {
+                    // The column itself may be SQL NULL (DbNull), distinct from a JSON 'null' token in a non-null string.
+                    readExpression = Condition(
+                        Call(dbDataReader, IsDbNullMethod, indexExpression),
+                        Default(type),
+                        readExpression);
+                }
+
+                valueExpression = readExpression;
+                primitiveCollectionJsonHandled = true;
+            }
+            else if (converter != null)
             {
                 // if IProperty is available, we can reliably get the converter from the model and then incorporate FromProvider(Typed) delegate
                 // into the expression. This way we have consistent behavior between precompiled and normal queries (same code path)
@@ -3074,12 +3134,14 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                 }
             }
 
-            if (valueExpression.Type != type)
+            if (!primitiveCollectionJsonHandled
+                && valueExpression.Type != type)
             {
                 valueExpression = Convert(valueExpression, type);
             }
 
-            if (nullable)
+            if (!primitiveCollectionJsonHandled
+                && nullable)
             {
                 Expression replaceExpression;
                 if (converter?.ConvertsNulls == true)
@@ -3275,6 +3337,31 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                             Utf8JsonReaderTokenTypeProperty),
                         Constant(JsonTokenType.Null)),
                     nullExpression,
+                    resultExpression);
+            }
+            else if (property.ClrType != typeof(string)
+                && property.ClrType.TryGetElementType(typeof(IEnumerable<>)) is not null)
+            {
+                // A required primitive collection nested in a JSON document can't be materialized from a JSON 'null'
+                // token. Throw a clear, property-named error instead of the cryptic reader/writer "Invalid token type".
+                if (resultExpression.Type != property.ClrType)
+                {
+                    resultExpression = Convert(resultExpression, property.ClrType);
+                }
+
+                resultExpression = Condition(
+                    Equal(
+                        Property(
+                            Field(
+                                jsonReaderManagerParameter,
+                                Utf8JsonReaderManagerCurrentReaderField),
+                            Utf8JsonReaderTokenTypeProperty),
+                        Constant(JsonTokenType.Null)),
+                    Throw(
+                        New(
+                            typeof(InvalidOperationException).GetConstructor([typeof(string)])!,
+                            Constant(RelationalStrings.NullValueInRequiredJsonProperty(property.Name))),
+                        property.ClrType),
                     resultExpression);
             }
 

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
@@ -3040,7 +3040,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                     ReadPrimitiveCollectionFromJsonMethodInfo,
                     valueExpression,
                     jsonReaderWriterExpression,
-                    Constant(nullable),
+                    Constant(primitiveCollectionProperty.IsNullable),
                     Constant(primitiveCollectionProperty.Name));
 
                 if (readExpression.Type != type)

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
@@ -3003,45 +3003,69 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             var converterExpression = default(Expression);
             var primitiveCollectionJsonHandled = false;
 
-            // #34881/#38454: A primitive collection mapped to a column uses CollectionToJsonStringConverter, which parses the
-            // provider JSON string via the collection's JsonValueReaderWriter. That reader/writer doesn't handle a JSON 'null'
-            // token, so we must peek the first token here and short-circuit to null (or throw for a required property) before
-            // invoking the converter, rather than letting the reader/writer throw a cryptic "Invalid token type: 'Null'".
-            if (property is IProperty { IsPrimitiveCollection: true } primitiveCollectionProperty
-                && converter is not null
-                && converter.GetType() is { IsGenericType: true } converterClrType
-                && converterClrType.GetGenericTypeDefinition() == typeof(CollectionToJsonStringConverter<>))
+            // #34881/#38454: A primitive collection mapped to a column is stored as a JSON string and read via the collection's
+            // JsonValueReaderWriter. That reader/writer doesn't handle a JSON 'null' token, so we peek the first token here and
+            // short-circuit to null (or throw for a required property) before invoking the reader/writer, rather than letting it
+            // throw a cryptic "Invalid token type: 'Null'". This applies both when materializing an entity (the property is
+            // available) and when projecting the collection column directly (no property; a collection type mapping is
+            // identified by its ElementTypeMapping).
+            var jsonPrimitiveCollectionReaderWriter = converter is { ConvertsNulls: false }
+                ? property is IProperty { IsPrimitiveCollection: true } primitiveCollectionProperty
+                    ? primitiveCollectionProperty.GetJsonValueReaderWriter() ?? primitiveCollectionProperty.GetTypeMapping().JsonValueReaderWriter
+                    : property is null && typeMapping.ElementTypeMapping is not null
+                        ? typeMapping.JsonValueReaderWriter
+                        : null
+                : null;
+
+            if (jsonPrimitiveCollectionReaderWriter is not null)
             {
-                var liftableConstantParameter = Parameter(typeof(MaterializerLiftableConstantContext), "c");
-                var jsonReaderWriterExpression = _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
-                    primitiveCollectionProperty.GetJsonValueReaderWriter() ?? primitiveCollectionProperty.GetTypeMapping().JsonValueReaderWriter!,
-                    Lambda<Func<MaterializerLiftableConstantContext, object>>(
-                        Coalesce(
-                            Call(
-                                LiftableConstantExpressionHelpers.BuildMemberAccessForProperty(
-                                    primitiveCollectionProperty, liftableConstantParameter),
-                                PropertyGetJsonValueReaderWriterMethod),
-                            Property(
+                Expression jsonReaderWriterExpression;
+                if (property is IProperty jsonProperty)
+                {
+                    var liftableConstantParameter = Parameter(typeof(MaterializerLiftableConstantContext), "c");
+                    jsonReaderWriterExpression = _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
+                        jsonPrimitiveCollectionReaderWriter,
+                        Lambda<Func<MaterializerLiftableConstantContext, object>>(
+                            Coalesce(
                                 Call(
                                     LiftableConstantExpressionHelpers.BuildMemberAccessForProperty(
-                                        primitiveCollectionProperty, liftableConstantParameter),
-                                    PropertyGetTypeMappingMethod),
-                                nameof(CoreTypeMapping.JsonValueReaderWriter))),
-                        liftableConstantParameter),
-                    primitiveCollectionProperty.Name + "JsonReaderWriter",
-                    typeof(JsonValueReaderWriter));
+                                        jsonProperty, liftableConstantParameter),
+                                    PropertyGetJsonValueReaderWriterMethod),
+                                Property(
+                                    Call(
+                                        LiftableConstantExpressionHelpers.BuildMemberAccessForProperty(
+                                            jsonProperty, liftableConstantParameter),
+                                        PropertyGetTypeMappingMethod),
+                                    nameof(CoreTypeMapping.JsonValueReaderWriter))),
+                            liftableConstantParameter),
+                        jsonProperty.Name + "JsonReaderWriter",
+                        typeof(JsonValueReaderWriter));
+                }
+                else
+                {
+                    // No property is available (e.g. projecting the collection column directly), so we can't reference the
+                    // reader/writer via the property. Use its ConstructorExpression, which is a quotable expression tree that
+                    // reconstructs the reader/writer (the same mechanism CollectionToJsonStringConverter uses).
+                    jsonReaderWriterExpression = jsonPrimitiveCollectionReaderWriter.ConstructorExpression;
+                    if (jsonReaderWriterExpression.Type != typeof(JsonValueReaderWriter))
+                    {
+                        jsonReaderWriterExpression = Convert(jsonReaderWriterExpression, typeof(JsonValueReaderWriter));
+                    }
+                }
 
                 if (valueExpression.Type != typeof(string))
                 {
                     valueExpression = Convert(valueExpression, typeof(string));
                 }
 
+                // When there's no property this is a projection, which has no notion of "required", so a JSON 'null'
+                // token is always materialized as null rather than throwing.
                 Expression readExpression = Call(
                     ReadPrimitiveCollectionFromJsonMethodInfo,
                     valueExpression,
                     jsonReaderWriterExpression,
-                    Constant(primitiveCollectionProperty.IsNullable),
-                    Constant(primitiveCollectionProperty.Name));
+                    Constant((property as IProperty)?.IsNullable ?? true),
+                    Constant((property as IProperty)?.Name ?? string.Empty));
 
                 if (readExpression.Type != type)
                 {
@@ -3339,8 +3363,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                     nullExpression,
                     resultExpression);
             }
-            else if (property.ClrType != typeof(string)
-                && property.ClrType.TryGetElementType(typeof(IEnumerable<>)) is not null)
+            else if (property.GetElementType() is not null)
             {
                 // A required primitive collection nested in a JSON document can't be materialized from a JSON 'null'
                 // token. Throw a clear, property-named error instead of the cryptic reader/writer "Invalid token type".

--- a/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
@@ -678,14 +678,15 @@ public abstract class RelationalTypeMapping : CoreTypeMapping
     /// <returns>The default provider value.</returns>
     public virtual object? GetDefaultProviderValue()
     {
+        var providerType = (Converter?.ProviderClrType ?? ClrType).UnwrapNullableType();
+
+        // A primitive collection is serialized to a JSON string in its column, so its default value must be an empty JSON
+        // array rather than an empty string (which isn't valid JSON).
         if (ElementTypeMapping is not null
-            && Converter?.GetType() is { IsGenericType: true } converterType
-            && converterType.GetGenericTypeDefinition() == typeof(CollectionToJsonStringConverter<>))
+            && JsonValueReaderWriter != null)
         {
             return "[]";
         }
-
-        var providerType = (Converter?.ProviderClrType ?? ClrType).UnwrapNullableType();
 
         return providerType == typeof(string)
             ? string.Empty

--- a/test/EFCore.Relational.Specification.Tests/Query/PrecompiledQueryRelationalFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/PrecompiledQueryRelationalFixture.cs
@@ -7,6 +7,7 @@ using Blog = Microsoft.EntityFrameworkCore.Query.PrecompiledQueryRelationalTestB
 using Post = Microsoft.EntityFrameworkCore.Query.PrecompiledQueryRelationalTestBase.Post;
 using JsonRoot = Microsoft.EntityFrameworkCore.Query.PrecompiledQueryRelationalTestBase.JsonRoot;
 using JsonBranch = Microsoft.EntityFrameworkCore.Query.PrecompiledQueryRelationalTestBase.JsonBranch;
+using EntityWithPrimitiveCollection = Microsoft.EntityFrameworkCore.Query.PrecompiledQueryRelationalTestBase.EntityWithPrimitiveCollection;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
@@ -96,7 +97,17 @@ public abstract class PrecompiledQueryRelationalFixture
         };
 
         context.Posts.AddRange(post11, post12, post21, post22, post23);
+
+        context.EntitiesWithPrimitiveCollection.AddRange(
+            new EntityWithPrimitiveCollection { Id = 1, Tags = ["a", "b"] },
+            new EntityWithPrimitiveCollection { Id = 2, Tags = ["x", "y"] });
         await context.SaveChangesAsync();
+
+        // Overwrite the second entity's collection column with the JSON 'null' token (as legacy/external data might),
+        // rather than a SQL NULL, so the materializer's null-token peek path is exercised under precompilation.
+        await context.Database.ExecuteSqlRawAsync(
+            TestStore.NormalizeDelimitersInRawString(
+                "UPDATE [EntitiesWithPrimitiveCollection] SET [Tags] = 'null' WHERE [Id] = 2"));
     }
 
     public abstract PrecompiledQueryTestHelpers PrecompiledQueryTestHelpers { get; }

--- a/test/EFCore.Relational.Specification.Tests/Query/PrecompiledQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/PrecompiledQueryRelationalTestBase.cs
@@ -1230,10 +1230,39 @@ var blogs2 = await context.Blogs.ToListAsync();
             interceptorCodeAsserter: code => Assert.Equal(
                 2, code.Split("private static extern ref int UnsafeAccessor_Microsoft_EntityFrameworkCore_Query_Blog_Id_Set").Length));
 
+    // #34881/#38454: A primitive collection mapped to a column is read via a JsonValueReaderWriter that is emitted as a
+    // liftable constant. This test makes sure that liftable constant is handled correctly under query precompilation,
+    // including the JSON 'null' token peek path (the second entity's column holds the literal 'null' token).
+    [Fact]
+    public virtual Task Materialize_entity_with_primitive_collection_mapped_to_column()
+        => Test(
+            """
+var entities = await context.EntitiesWithPrimitiveCollection.OrderBy(e => e.Id).ToListAsync();
+
+Assert.Equal(2, entities.Count);
+Assert.Equal(new[] { "a", "b" }, entities[0].Tags);
+Assert.Null(entities[1].Tags);
+""");
+
+    // Projecting the collection column directly reaches the materializer without an IProperty, so the JsonValueReaderWriter
+    // is emitted via its (quotable) ConstructorExpression rather than a property-based liftable constant. This makes sure
+    // that path is quotable under precompilation, including the JSON 'null' token peek.
+    [Fact]
+    public virtual Task Project_primitive_collection_mapped_to_column()
+        => Test(
+            """
+var tags = await context.EntitiesWithPrimitiveCollection.OrderBy(e => e.Id).Select(e => e.Tags).ToListAsync();
+
+Assert.Equal(2, tags.Count);
+Assert.Equal(new[] { "a", "b" }, tags[0]);
+Assert.Null(tags[1]);
+""");
+
     public class PrecompiledQueryContext(DbContextOptions options) : DbContext(options)
     {
         public DbSet<Blog> Blogs { get; set; } = null!;
         public DbSet<Post> Posts { get; set; } = null!;
+        public DbSet<EntityWithPrimitiveCollection> EntitiesWithPrimitiveCollection { get; set; } = null!;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -1247,6 +1276,7 @@ var blogs2 = await context.Blogs.ToListAsync();
                 });
             modelBuilder.Entity<Blog>().HasMany(x => x.Posts).WithOne(x => x.Blog).OnDelete(DeleteBehavior.Cascade);
             modelBuilder.Entity<Post>().Property(x => x.Id).ValueGeneratedNever();
+            modelBuilder.Entity<EntityWithPrimitiveCollection>().Property(x => x.Id).ValueGeneratedNever();
         }
     }
 
@@ -1335,6 +1365,16 @@ await using var context = new PrecompiledQueryContext(dbContextOptions);
         public string? Title { get; set; }
 
         public Blog? Blog { get; set; }
+    }
+
+    public class EntityWithPrimitiveCollection
+    {
+        public int Id { get; set; }
+
+        // Mapped to a column as a JSON string via the primitive-collection convention (CollectionToJsonStringConverter).
+        // An array (rather than List<T>) is used so entity materialization assigns the collection directly instead of
+        // going through the PopulateList optimization (which is unrelated to the JSON null-token handling under test).
+        public string[]? Tags { get; set; }
     }
 
     public static readonly IEnumerable<object[]> IsAsyncData = [[false], [true]];

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocJsonQuerySqlServerTestBase.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocJsonQuerySqlServerTestBase.cs
@@ -473,6 +473,268 @@ VALUES(
 """);
     }
 
+    #region PrimitiveCollectionInColumn
+
+    [Fact]
+    public virtual async Task Materialize_json_null_primitive_collection_mapped_to_column_is_null()
+    {
+        var contextFactory = await InitializeNonSharedTest<ContextPrimitiveCollectionInColumn>(
+            onModelCreating: OnModelCreatingPrimitiveCollectionInColumn,
+            onConfiguring: b => b.ConfigureWarnings(ConfigureWarnings),
+            seed: SeedPrimitiveCollectionInColumn);
+
+        using var context = contextFactory.CreateDbContext();
+
+        // The primitive collection is mapped to its own column via CollectionToJsonStringConverter (which does NOT
+        // handle the JSON 'null' token). Legacy/external data may store the JSON 'null' token (the literal string
+        // "null", which Utf8JsonReader tokenizes as JsonTokenType.Null) rather than a SQL NULL. The materializer peeks
+        // the first token and short-circuits to null instead of letting JsonCollectionOfReferencesReaderWriter throw
+        // "Invalid token type: 'Null'". See issues #34881 and #38454.
+        var result = await context.Set<ContextPrimitiveCollectionInColumn.MyEntity>()
+            .Where(x => x.Id < 4).OrderBy(x => x.Id).ToListAsync();
+
+        Assert.Equal(3, result.Count);
+        Assert.Equal(["a", "b"], result[0].Tags);
+        Assert.Null(result[1].Tags); // JSON 'null' token
+        Assert.Null(result[2].Tags); // SQL NULL
+    }
+
+    [Fact]
+    public virtual async Task Materialize_empty_json_primitive_collection_mapped_to_column_throws()
+    {
+        var contextFactory = await InitializeNonSharedTest<ContextPrimitiveCollectionInColumn>(
+            onModelCreating: OnModelCreatingPrimitiveCollectionInColumn,
+            onConfiguring: b => b.ConfigureWarnings(ConfigureWarnings),
+            seed: SeedPrimitiveCollectionInColumn);
+
+        using var context = contextFactory.CreateDbContext();
+
+        // An empty/whitespace JSON string in the column isn't valid JSON; the diagnostics here match the converter
+        // path (JsonValueReaderWriter.FromJsonString), which rejects it with CoreStrings.EmptyJsonString.
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => context.Set<ContextPrimitiveCollectionInColumn.MyEntity>().Where(x => x.Id == 4).ToListAsync());
+
+        Assert.Equal(CoreStrings.EmptyJsonString, exception.Message);
+    }
+
+    protected virtual async Task SeedPrimitiveCollectionInColumn(DbContext ctx)
+    {
+        // primitive collection column contains a JSON array
+        await ctx.Database.ExecuteSqlAsync(
+            $$"""
+INSERT INTO [Entities] ([Id], [Tags])
+VALUES(1, N'["a","b"]')
+""");
+
+        // primitive collection column contains a JSON null token (the literal string "null", not a SQL NULL)
+        await ctx.Database.ExecuteSqlAsync(
+            $$"""
+INSERT INTO [Entities] ([Id], [Tags])
+VALUES(2, N'null')
+""");
+
+        // primitive collection column is SQL NULL
+        await ctx.Database.ExecuteSqlAsync(
+            $$"""
+INSERT INTO [Entities] ([Id], [Tags])
+VALUES(3, NULL)
+""");
+
+        // primitive collection column contains an empty (invalid) JSON string
+        await ctx.Database.ExecuteSqlAsync(
+            $$"""
+INSERT INTO [Entities] ([Id], [Tags])
+VALUES(4, N'')
+""");
+    }
+
+    protected virtual void OnModelCreatingPrimitiveCollectionInColumn(ModelBuilder modelBuilder)
+        => modelBuilder.Entity<ContextPrimitiveCollectionInColumn.MyEntity>(b =>
+        {
+            b.ToTable("Entities");
+            b.Property(x => x.Id).ValueGeneratedNever();
+            b.PrimitiveCollection(x => x.Tags);
+        });
+
+    protected class ContextPrimitiveCollectionInColumn(DbContextOptions options) : DbContext(options)
+    {
+        public class MyEntity
+        {
+            public int Id { get; set; }
+
+            // IList<string> matches the legacy mapping reported in #34881.
+            public IList<string> Tags { get; set; }
+        }
+    }
+
+    #endregion
+
+    #region JsonPropertyWithConverters
+
+    [Fact]
+    public virtual async Task Materialize_json_null_property_with_converters()
+    {
+        var contextFactory = await InitializeNonSharedTest<ContextJsonPropertyWithConverters>(
+            onModelCreating: OnModelCreatingJsonPropertyWithConverters,
+            onConfiguring: b => b.ConfigureWarnings(ConfigureWarnings),
+            seed: SeedJsonPropertyWithConverters);
+
+        using var context = contextFactory.CreateDbContext();
+        var result = await context.Set<ContextJsonPropertyWithConverters.MyEntity>().SingleAsync(x => x.Id == 1);
+
+        Assert.Equal("e1", result.Reference.Name);
+
+        // Both properties have a JSON 'null' token value. The streaming JSON shaper's null guard
+        // (CreateReadJsonPropertyValueExpression) routes the null based on the converter's ConvertsNulls flag:
+        //  - ConvertsNulls == true  -> ConvertFromProvider(default) maps DB null to the "FROM_DB_NULL" sentinel.
+        //  - ConvertsNulls == false -> returns default(string) (null) without invoking the converter.
+        Assert.Equal("FROM_DB_NULL", result.Reference.ConvertedHandlingNulls);
+        Assert.Null(result.Reference.ConvertedNotHandlingNulls);
+    }
+
+    protected virtual async Task SeedJsonPropertyWithConverters(DbContext ctx)
+        => await ctx.Database.ExecuteSqlAsync(
+            $$"""
+INSERT INTO [Entities] ([Id], [Reference])
+VALUES(1, '{"Name":"e1","ConvertedHandlingNulls":null,"ConvertedNotHandlingNulls":null}')
+""");
+
+    protected virtual void OnModelCreatingJsonPropertyWithConverters(ModelBuilder modelBuilder)
+        => modelBuilder.Entity<ContextJsonPropertyWithConverters.MyEntity>(b =>
+        {
+            b.ToTable("Entities");
+            b.Property(x => x.Id).ValueGeneratedNever();
+            b.OwnsOne(x => x.Reference, b =>
+            {
+                b.ToJson().HasColumnType(JsonColumnType);
+                b.Property(x => x.ConvertedHandlingNulls).HasConversion(
+                    new ValueConverter<string, string>(
+                        v => v,
+                        v => v ?? "FROM_DB_NULL",
+                        convertsNulls: true));
+                b.Property(x => x.ConvertedNotHandlingNulls).HasConversion(
+                    new ValueConverter<string, string>(
+                        v => v,
+                        v => "FROM_CONVERTER:" + v,
+                        convertsNulls: false));
+            });
+        });
+
+    protected class ContextJsonPropertyWithConverters(DbContextOptions options) : DbContext(options)
+    {
+        public class MyEntity
+        {
+            public int Id { get; set; }
+            public MyJsonEntity Reference { get; set; }
+        }
+
+        public class MyJsonEntity
+        {
+            public string Name { get; set; }
+            public string ConvertedHandlingNulls { get; set; }
+            public string ConvertedNotHandlingNulls { get; set; }
+        }
+    }
+
+    #endregion
+
+    #region PrimitiveCollectionInJson
+
+    [Fact]
+    public virtual async Task Materialize_json_null_optional_primitive_collection_in_json_is_null()
+    {
+        var contextFactory = await InitializeNonSharedTest<ContextPrimitiveCollectionInJson>(
+            onModelCreating: OnModelCreatingPrimitiveCollectionInJson,
+            onConfiguring: b => b.ConfigureWarnings(ConfigureWarnings),
+            seed: SeedPrimitiveCollectionInJson);
+
+        using var context = contextFactory.CreateDbContext();
+        var result = await context.Set<ContextPrimitiveCollectionInJson.MyEntity>()
+            .Where(x => x.Id < 3).OrderBy(x => x.Id).ToListAsync();
+
+        Assert.Equal(2, result.Count);
+
+        // Id == 1: JSON has "NullableStrings": null -> materialized as null.
+        Assert.Null(result[0].Reference.NullableStrings);
+        Assert.Equal(["a", "b"], result[0].Reference.RequiredStrings);
+
+        // Id == 2: JSON has "NullableStrings": ["x", "y"].
+        Assert.Equal(["x", "y"], result[1].Reference.NullableStrings);
+        Assert.Equal(["c", "d"], result[1].Reference.RequiredStrings);
+    }
+
+    [Fact]
+    public virtual async Task Materialize_json_null_required_primitive_collection_in_json_throws()
+    {
+        var contextFactory = await InitializeNonSharedTest<ContextPrimitiveCollectionInJson>(
+            onModelCreating: OnModelCreatingPrimitiveCollectionInJson,
+            onConfiguring: b => b.ConfigureWarnings(ConfigureWarnings),
+            seed: SeedPrimitiveCollectionInJson);
+
+        using var context = contextFactory.CreateDbContext();
+
+        // A required primitive collection nested in a JSON document whose value is a 'null' token yields a clear,
+        // property-named error rather than the cryptic reader/writer "Invalid token type: 'Null'".
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => context.Set<ContextPrimitiveCollectionInJson.MyEntity>().Where(x => x.Id == 3).ToListAsync());
+
+        Assert.Equal(RelationalStrings.NullValueInRequiredJsonProperty("RequiredStrings"), exception.Message);
+    }
+
+    protected virtual async Task SeedPrimitiveCollectionInJson(DbContext ctx)
+    {
+        // optional collection is JSON null
+        await ctx.Database.ExecuteSqlAsync(
+            $$"""
+INSERT INTO [Entities] ([Id], [Reference])
+VALUES(1, '{"NullableStrings":null,"RequiredStrings":["a","b"]}')
+""");
+
+        // optional collection has a value
+        await ctx.Database.ExecuteSqlAsync(
+            $$"""
+INSERT INTO [Entities] ([Id], [Reference])
+VALUES(2, '{"NullableStrings":["x","y"],"RequiredStrings":["c","d"]}')
+""");
+
+        // required collection is JSON null (materialization throws)
+        await ctx.Database.ExecuteSqlAsync(
+            $$"""
+INSERT INTO [Entities] ([Id], [Reference])
+VALUES(3, '{"NullableStrings":["x","y"],"RequiredStrings":null}')
+""");
+    }
+
+    protected virtual void OnModelCreatingPrimitiveCollectionInJson(ModelBuilder modelBuilder)
+        => modelBuilder.Entity<ContextPrimitiveCollectionInJson.MyEntity>(b =>
+        {
+            b.ToTable("Entities");
+            b.Property(x => x.Id).ValueGeneratedNever();
+            b.OwnsOne(x => x.Reference, b =>
+            {
+                b.ToJson().HasColumnType(JsonColumnType);
+                b.Property(x => x.NullableStrings).IsRequired(false);
+                b.Property(x => x.RequiredStrings).IsRequired();
+            });
+        });
+
+    protected class ContextPrimitiveCollectionInJson(DbContextOptions options) : DbContext(options)
+    {
+        public class MyEntity
+        {
+            public int Id { get; set; }
+            public MyJsonEntity Reference { get; set; }
+        }
+
+        public class MyJsonEntity
+        {
+            public List<string> NullableStrings { get; set; }
+            public List<string> RequiredStrings { get; set; }
+        }
+    }
+
+    #endregion
+
     #region EnumLegacyValues
 
     [Theory, MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocJsonQuerySqlServerTestBase.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocJsonQuerySqlServerTestBase.cs
@@ -517,34 +517,59 @@ VALUES(
         Assert.Equal(CoreStrings.EmptyJsonString, exception.Message);
     }
 
+    [Fact]
+    public virtual async Task Materialize_json_null_required_primitive_collection_mapped_to_column_throws()
+    {
+        var contextFactory = await InitializeNonSharedTest<ContextPrimitiveCollectionInColumn>(
+            onModelCreating: OnModelCreatingPrimitiveCollectionInColumn,
+            onConfiguring: b => b.ConfigureWarnings(ConfigureWarnings),
+            seed: SeedPrimitiveCollectionInColumn);
+
+        using var context = contextFactory.CreateDbContext();
+
+        // The required primitive collection column holds the JSON 'null' token. Since the property is required, the
+        // materializer throws a clear, property-named error rather than silently materializing null. See #34881.
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => context.Set<ContextPrimitiveCollectionInColumn.MyEntity>().Where(x => x.Id == 5).ToListAsync());
+
+        Assert.Equal(RelationalStrings.NullValueInRequiredJsonProperty("RequiredTags"), exception.Message);
+    }
+
     protected virtual async Task SeedPrimitiveCollectionInColumn(DbContext ctx)
     {
         // primitive collection column contains a JSON array
         await ctx.Database.ExecuteSqlAsync(
             $$"""
-INSERT INTO [Entities] ([Id], [Tags])
-VALUES(1, N'["a","b"]')
+INSERT INTO [Entities] ([Id], [Tags], [RequiredTags])
+VALUES(1, N'["a","b"]', N'[]')
 """);
 
         // primitive collection column contains a JSON null token (the literal string "null", not a SQL NULL)
         await ctx.Database.ExecuteSqlAsync(
             $$"""
-INSERT INTO [Entities] ([Id], [Tags])
-VALUES(2, N'null')
+INSERT INTO [Entities] ([Id], [Tags], [RequiredTags])
+VALUES(2, N'null', N'[]')
 """);
 
         // primitive collection column is SQL NULL
         await ctx.Database.ExecuteSqlAsync(
             $$"""
-INSERT INTO [Entities] ([Id], [Tags])
-VALUES(3, NULL)
+INSERT INTO [Entities] ([Id], [Tags], [RequiredTags])
+VALUES(3, NULL, N'[]')
 """);
 
         // primitive collection column contains an empty (invalid) JSON string
         await ctx.Database.ExecuteSqlAsync(
             $$"""
-INSERT INTO [Entities] ([Id], [Tags])
-VALUES(4, N'')
+INSERT INTO [Entities] ([Id], [Tags], [RequiredTags])
+VALUES(4, N'', N'[]')
+""");
+
+        // required primitive collection column contains a JSON null token
+        await ctx.Database.ExecuteSqlAsync(
+            $$"""
+INSERT INTO [Entities] ([Id], [Tags], [RequiredTags])
+VALUES(5, N'["a","b"]', N'null')
 """);
     }
 
@@ -554,6 +579,7 @@ VALUES(4, N'')
             b.ToTable("Entities");
             b.Property(x => x.Id).ValueGeneratedNever();
             b.PrimitiveCollection(x => x.Tags);
+            b.PrimitiveCollection(x => x.RequiredTags).IsRequired();
         });
 
     protected class ContextPrimitiveCollectionInColumn(DbContextOptions options) : DbContext(options)
@@ -564,6 +590,8 @@ VALUES(4, N'')
 
             // IList<string> matches the legacy mapping reported in #34881.
             public IList<string> Tags { get; set; }
+
+            public IList<string> RequiredTags { get; set; }
         }
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocJsonQuerySqlServerTestBase.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocJsonQuerySqlServerTestBase.cs
@@ -535,6 +535,27 @@ VALUES(
         Assert.Equal(RelationalStrings.NullValueInRequiredJsonProperty("RequiredTags"), exception.Message);
     }
 
+    [Fact]
+    public virtual async Task Project_json_null_primitive_collection_mapped_to_column_is_null()
+    {
+        var contextFactory = await InitializeNonSharedTest<ContextPrimitiveCollectionInColumn>(
+            onModelCreating: OnModelCreatingPrimitiveCollectionInColumn,
+            onConfiguring: b => b.ConfigureWarnings(ConfigureWarnings),
+            seed: SeedPrimitiveCollectionInColumn);
+
+        using var context = contextFactory.CreateDbContext();
+
+        // Projecting the collection column directly reaches the materializer without an IProperty. The JSON 'null'
+        // token (and SQL NULL) must still be materialized as null rather than throwing "Invalid token type: 'Null'".
+        var tags = await context.Set<ContextPrimitiveCollectionInColumn.MyEntity>()
+            .Where(x => x.Id < 4).OrderBy(x => x.Id).Select(x => x.Tags).ToListAsync();
+
+        Assert.Equal(3, tags.Count);
+        Assert.Equal(["a", "b"], tags[0]);
+        Assert.Null(tags[1]); // JSON 'null' token
+        Assert.Null(tags[2]); // SQL NULL
+    }
+
     protected virtual async Task SeedPrimitiveCollectionInColumn(DbContext ctx)
     {
         // primitive collection column contains a JSON array
@@ -741,8 +762,8 @@ VALUES(3, '{"NullableStrings":["x","y"],"RequiredStrings":null}')
             b.OwnsOne(x => x.Reference, b =>
             {
                 b.ToJson().HasColumnType(JsonColumnType);
-                b.Property(x => x.NullableStrings).IsRequired(false);
-                b.Property(x => x.RequiredStrings).IsRequired();
+                b.PrimitiveCollection(x => x.NullableStrings).IsRequired(false);
+                b.PrimitiveCollection(x => x.RequiredStrings).IsRequired();
             });
         });
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrecompiledQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrecompiledQuerySqlServerTest.cs
@@ -2187,6 +2187,30 @@ FROM [Blogs] AS [b]
 """);
     }
 
+    public override async Task Materialize_entity_with_primitive_collection_mapped_to_column()
+    {
+        await base.Materialize_entity_with_primitive_collection_mapped_to_column();
+
+        AssertSql(
+            """
+SELECT [e].[Id], [e].[Tags]
+FROM [EntitiesWithPrimitiveCollection] AS [e]
+ORDER BY [e].[Id]
+""");
+    }
+
+    public override async Task Project_primitive_collection_mapped_to_column()
+    {
+        await base.Project_primitive_collection_mapped_to_column();
+
+        AssertSql(
+            """
+SELECT [e].[Tags]
+FROM [EntitiesWithPrimitiveCollection] AS [e]
+ORDER BY [e].[Id]
+""");
+    }
+
     [Fact]
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());


### PR DESCRIPTION
Fixes https://github.com/dotnet/efcore/issues/38454

Changes materialization behavior when JSON contains the `null` token for primitive collections (both when mapped to a dedicated column and when nested inside a JSON document), aiming to return `null` for optional properties and throw a clearer, property-named exception for required ones.

**Changes:**
- Add a shaper-side fast path for primitive collections mapped to columns to detect JSON `null` before invoking `CollectionToJsonStringConverter<>`.
- Improve error reporting for **required** primitive collections nested in JSON by throwing `RelationalStrings.NullValueInRequiredJsonProperty(...)` instead of a reader/writer token-type exception.
- Add functional tests covering nullable/required primitive collections and converter `ConvertsNulls` behavior.
