### PR TITLE
Allow all warnings in dev build

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -57,7 +57,8 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(DeveloperBuild)' == 'true'">
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);CS1591;SA1636</WarningsNotAsErrors>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <WarningsAsErrors></WarningsAsErrors>
   </PropertyGroup>
 
   <!-- HACK: Work around #15093 -->


### PR DESCRIPTION
This is a small change to make developer builds not treat any warnings as errors