### PR TITLE
Decrement active contexts count after a pooled DbContext instance is torn-down

### DIFF
--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -65,6 +65,7 @@ public class DbContext :
     private List<IResettableService>? _cachedResettableServices;
     private bool _initializing;
     private bool _disposed;
+    private bool _leaseCleared;
 
     private readonly Guid _contextId = Guid.NewGuid();
     private int _leaseCount;
@@ -868,7 +869,15 @@ public class DbContext :
     /// </summary>
     [EntityFrameworkInternal]
     void IDbContextPoolable.ClearLease()
-        => _lease = DbContextLease.InactiveLease;
+    {
+        _lease = DbContextLease.InactiveLease;
+
+        // ClearLease is only called by the pool when a pooled instance is being torn down (it overflowed the pool or the
+        // pool is being disposed), as opposed to being returned to the pool for reuse. This flag lets the subsequent
+        // Dispose run the teardown that decrements the active DbContexts count even though the instance was already
+        // marked as disposed when it was returned to the pool.
+        _leaseCleared = true;
+    }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -896,11 +905,16 @@ public class DbContext :
 
     private void SetLeaseInternal(DbContextLease lease)
     {
+        // The configuration snapshot is null if the context was already fully torn down (e.g. it overflowed the pool and
+        // was disposed). Such a context cannot be resurrected via a new lease, so treat this as use of a disposed context.
+        if (_configurationSnapshot is null)
+        {
+            throw new ObjectDisposedException(GetType().ShortDisplayName(), CoreStrings.ContextDisposed);
+        }
+
         _lease = lease;
         _disposed = false;
         ++_leaseCount;
-
-        Check.DebugAssert(_configurationSnapshot != null, "configurationSnapshot is null");
 
         if (_changeTracker != null
             || _configurationSnapshot.HasChangeTrackerConfiguration)
@@ -1124,8 +1138,12 @@ public class DbContext :
                 _lease = DbContextLease.InactiveLease;
             }
         }
-        else if (!_disposed)
+        else if (!_disposed || _leaseCleared)
         {
+            // Reset the flag before unsubscribing: unsubscribing can dispose injected service properties, which may
+            // re-enter Dispose on this context.
+            _leaseCleared = false;
+
             EntityFrameworkMetricsData.ReportDbContextDisposing();
 
             _dbContextDependencies?.InfrastructureLogger.ContextDisposed(this);

--- a/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
@@ -1500,6 +1500,26 @@ public class DbContextPoolingTest(NorthwindQuerySqlServerFixture<NoopModelCustom
         Assert.NotSame(context1, context2);
     }
 
+    [Theory, InlineData(false), InlineData(true)]
+    public async Task Setting_lease_on_fully_torn_down_context_throws(bool async)
+    {
+        var serviceProvider = BuildServiceProvider<PooledContext>();
+
+        var pool = serviceProvider.GetRequiredService<IDbContextPool<PooledContext>>();
+        var lease = new DbContextLease(pool, standalone: true);
+        var context = (PooledContext)lease.Context;
+        ((IDbContextPoolable)context).SetLease(lease);
+
+        // Fully tear the context down the same way the pool does for a context that overflows it: ClearLease followed by
+        // Dispose clears the captured configuration snapshot.
+        ((IDbContextPoolable)context).ClearLease();
+        await Dispose(context, async);
+
+        // A context that has been fully torn down cannot be resurrected via a new lease; it must throw rather than
+        // dereferencing the now-null configuration snapshot.
+        Assert.Throws<ObjectDisposedException>(() => ((IDbContextPoolable)context).SetLease(lease));
+    }
+
     [Theory, InlineData(false, false), InlineData(true, false), InlineData(false, true), InlineData(true, true)]
     public async Task Can_double_dispose_with_factory(bool async, bool withDependencyInjection)
     {

--- a/test/EFCore.Tests/Infrastructure/EntityFrameworkMetricsTest.cs
+++ b/test/EFCore.Tests/Infrastructure/EntityFrameworkMetricsTest.cs
@@ -52,6 +52,61 @@ public class EntityFrameworkMetricsTest
     }
 
     [Theory, InlineData(false), InlineData(true)]
+    public async Task Active_dbcontexts_is_decremented_when_pooled_context_is_torn_down(bool async)
+    {
+        var initial = EntityFrameworkMetricsData.GetActiveDbContexts();
+
+        // A pool size of 1 means the second returned context overflows the pool and is fully torn down.
+        using var serviceProvider = new ServiceCollection()
+            .AddPooledDbContextFactory<SomeDbContext>(ob => ob.UseInMemoryDatabase(nameof(EntityFrameworkMetricsTest)), poolSize: 1)
+            .BuildServiceProvider(validateScopes: true);
+
+        var factory = serviceProvider.GetRequiredService<IDbContextFactory<SomeDbContext>>();
+
+        var context1 = async ? await factory.CreateDbContextAsync() : factory.CreateDbContext();
+        var context2 = async ? await factory.CreateDbContextAsync() : factory.CreateDbContext();
+
+        Assert.Equal(initial + 2, EntityFrameworkMetricsData.GetActiveDbContexts());
+
+        // Returning the first context fills the single-slot pool; it stays counted while idle in the pool.
+        await Dispose(context1, async);
+        Assert.Equal(initial + 2, EntityFrameworkMetricsData.GetActiveDbContexts());
+
+        // Returning the second context overflows the pool, so it is fully torn down and the counter is decremented.
+        await Dispose(context2, async);
+        Assert.Equal(initial + 1, EntityFrameworkMetricsData.GetActiveDbContexts());
+    }
+
+    [Theory, InlineData(false), InlineData(true)]
+    public async Task Active_dbcontexts_is_decremented_when_scoped_pooled_context_is_torn_down(bool async)
+    {
+        var initial = EntityFrameworkMetricsData.GetActiveDbContexts();
+
+        // A pool size of 1 means the second released context overflows the pool and is fully torn down.
+        using var serviceProvider = new ServiceCollection()
+            .AddDbContextPool<SomeDbContext>(ob => ob.UseInMemoryDatabase(nameof(EntityFrameworkMetricsTest)), poolSize: 1)
+            .BuildServiceProvider(validateScopes: true);
+
+        var scope1 = serviceProvider.CreateScope();
+        _ = scope1.ServiceProvider.GetRequiredService<SomeDbContext>();
+
+        Assert.Equal(initial + 1, EntityFrameworkMetricsData.GetActiveDbContexts());
+
+        using (var scope2 = serviceProvider.CreateScope())
+        {
+            _ = scope2.ServiceProvider.GetRequiredService<SomeDbContext>();            
+        }
+
+        // Disposing the second scope releases its context, filling the single-slot pool; it stays counted while idle.
+        Assert.Equal(initial + 2, EntityFrameworkMetricsData.GetActiveDbContexts());
+
+        // Disposing the first scope releases a context that overflows the pool, so it is fully torn down and the
+        // counter is decremented.
+        await Dispose(scope1, async);
+        Assert.Equal(initial + 1, EntityFrameworkMetricsData.GetActiveDbContexts());
+    }
+
+    [Theory, InlineData(false), InlineData(true)]
     public async Task Validate_query_executed(bool async)
     {
         var initial = EntityFrameworkMetricsData.GetTotalQueriesExecuted();
@@ -272,8 +327,29 @@ public class EntityFrameworkMetricsTest
         }
     }
 
+    private static async Task Dispose(IDisposable disposable, bool async)
+    {
+        if (async)
+        {
+            await ((IAsyncDisposable)disposable).DisposeAsync();
+        }
+        else
+        {
+            disposable.Dispose();
+        }
+    }
+
     private class SomeDbContext : DbContext
     {
+        public SomeDbContext()
+        {
+        }
+
+        public SomeDbContext(DbContextOptions<SomeDbContext> options)
+            : base(options)
+        {
+        }
+
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
         public DbSet<Foo> Foos { get; set; }
 
@@ -281,8 +357,12 @@ public class EntityFrameworkMetricsTest
             => modelBuilder.Entity<Foo>().Property(e => e.Token).IsConcurrencyToken();
 
         protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            => optionsBuilder
-                .UseInMemoryDatabase(nameof(EntityFrameworkMetricsTest));
+        {
+            if (!optionsBuilder.IsConfigured)
+            {
+                optionsBuilder.UseInMemoryDatabase(nameof(EntityFrameworkMetricsTest));
+            }
+        }
     }
 
     private class Foo


### PR DESCRIPTION
Fixes #38538