### PR TITLE
Default a value-type non-entity left-join projection to default(T) on no-match

### DIFF
--- a/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
@@ -715,20 +715,18 @@ public class RelationalProjectionBindingExpressionVisitor : ExpressionVisitor
     // uses for every other projected sub-expression, so it survives to the reader as a readable nullable scalar projection.
     private Expression GateNonEntityOnNullabilityMarker(Expression visited, Expression markerBinding, Type objectType)
     {
-        // This skip conflates three cases:
-        //  1. Reference type (the case the fix targets): falls through below and is gated to null on a no-match row.
-        //  2. Non-nullable struct / record struct / ValueTuple: skipped here because Default(objectType) is a zeroed struct, not
-        //     null, so gating would be semantically wrong. On a no-match row the shaper still constructs the object from all-NULL
-        //     columns and throws "Nullable object must have a value" — identical to behavior on main; a pre-existing, deferred gap.
-        //     (As of #30915 the marker is no longer even recorded for value-type inners in SelectExpression.AddJoin, so for those
-        //     inners markerBinding is null and this method is not invoked; the IsValueType guard remains as defense in depth.)
-        //  3. Nullable<T>: would also be skipped here (passes IsValueType) and would therefore be semantically wrong (a no-match
-        //     should yield null), BUT it is unreachable: LINQ produces a Nullable<T> whole-object via a Convert node, not a New /
-        //     MemberInit node, so it never satisfies the SelectExpression.AddJoin recording condition and never reaches here.
-        //     Even if it somehow did, the skip falls back to base behavior (the throw), so there is no regression.
-        // Intermediate (TransparentIdentifier-rooted) projections are also suppressed: there the recorded object is composed
+        // Intermediate (TransparentIdentifier-rooted) projections are suppressed: there the recorded object is composed
         // further and must stay a bare New for downstream member-folding.
-        if (_rootIsTransparentIdentifier || objectType.IsValueType)
+        //
+        // For a value-type objectType (mutable struct / record struct projected via MemberInit), Expression.Default(objectType)
+        // is a zeroed struct rather than null -- which is exactly right here: it mirrors LINQ-to-Objects DefaultIfEmpty
+        // semantics for a value-type sequence (a no-match row yields default(T), not an exception). Constructor-bound structs
+        // (positional record structs, read-only DTOs, ValueTuple) ARE NewExpressions, so SelectExpression.AddJoin's recording
+        // condition still matches them and a markerBinding IS produced; they simply fail to TRANSLATE at a different, deferred
+        // point before the query ever reaches this gate (tracked separately), so the marker is injected but never consumed.
+        // Nullable<T> whole-object is unreachable here too: LINQ produces it via a Convert node, not a New/MemberInit node, so
+        // it never satisfies the SelectExpression.AddJoin recording condition that produces markerBinding.
+        if (_rootIsTransparentIdentifier)
         {
             return visited;
         }

--- a/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
@@ -715,17 +715,26 @@ public class RelationalProjectionBindingExpressionVisitor : ExpressionVisitor
     // uses for every other projected sub-expression, so it survives to the reader as a readable nullable scalar projection.
     private Expression GateNonEntityOnNullabilityMarker(Expression visited, Expression markerBinding, Type objectType)
     {
-        // Intermediate (TransparentIdentifier-rooted) projections are suppressed: there the recorded object is composed
-        // further and must stay a bare New for downstream member-folding.
+        // objectType is always the shaper node's own CLR type: the reference type for a reference-type New/MemberInit, or the
+        // (non-nullable) struct for a value-type MemberInit. It is never Nullable<T> here -- see the Nullable<T> note below.
         //
-        // For a value-type objectType (mutable struct / record struct projected via MemberInit), Expression.Default(objectType)
-        // is a zeroed struct rather than null -- which is exactly right here: it mirrors LINQ-to-Objects DefaultIfEmpty
-        // semantics for a value-type sequence (a no-match row yields default(T), not an exception). Constructor-bound structs
-        // (positional record structs, read-only DTOs, ValueTuple) ARE NewExpressions, so SelectExpression.AddJoin's recording
-        // condition still matches them and a markerBinding IS produced; they simply fail to TRANSLATE at a different, deferred
-        // point before the query ever reaches this gate (tracked separately), so the marker is injected but never consumed.
-        // Nullable<T> whole-object is unreachable here too: LINQ produces it via a Convert node, not a New/MemberInit node, so
-        // it never satisfies the SelectExpression.AddJoin recording condition that produces markerBinding.
+        // Reference type: Expression.Default(objectType) is null, gating the whole object to null on a no-match row (the #30915
+        // case). Value type (mutable struct / record struct projected via MemberInit): Expression.Default(objectType) is a zeroed
+        // struct rather than null -- which is exactly right, mirroring LINQ-to-Objects DefaultIfEmpty semantics for a value-type
+        // sequence (a no-match row yields default(T), not an exception). Both are gated here.
+        //
+        // Two shapes reach SelectExpression.AddJoin's New/MemberInit recording condition (so a markerBinding is produced) but are
+        // NOT meaningfully gated here:
+        //  - Constructor-bound structs (positional record structs, read-only DTOs, ValueTuple) are NewExpressions, so a marker is
+        //    injected, but they fail to TRANSLATE at an earlier, deferred point before the query ever reaches this gate (tracked
+        //    separately); the injected marker is simply never consumed.
+        //  - A user-visible Nullable<T> whole-object arrives as Convert(MemberInit, T?): the marker is recorded against the inner
+        //    MemberInit, so this gate DOES fire -- but with objectType = the underlying struct, producing a zeroed struct that the
+        //    outer Convert then lifts to a non-null T? (HasValue == true). That is correct: casting a real (if zeroed) struct to
+        //    Nullable<T> can never itself yield null, matching DefaultIfEmpty over a value-type sequence.
+        //
+        // Intermediate (TransparentIdentifier-rooted) projections are suppressed: there the recorded object is composed further
+        // and must stay a bare New for downstream member-folding.
         if (_rootIsTransparentIdentifier)
         {
             return visited;

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -2958,9 +2958,11 @@ public sealed partial class SelectExpression : TableExpressionBase
         // would be inlined into the combined SELECT and never become NULL. The standalone marker binding returned here is bound
         // against innerSelect; it is remapped alongside the inner shaper in each branch below so it stays valid, then recorded
         // against the finalized inner-shaper node (consumed later by the projection binder). We do NOT wrap the inner shaper.
-        // Also record for a value-type inner (mutable struct / record struct) shaped via MemberInit: the projection-binder gate
-        // (GateNonEntityOnNullabilityMarker) now defaults it to a zeroed struct on no-match, matching LINQ-to-Objects
-        // DefaultIfEmpty semantics for a value-type sequence.
+        // We record for ALL New/MemberInit inner shapers, reference-type and value-type alike (the condition does not inspect
+        // innerShaper.Type). Reference types are gated to null and value-type MemberInit shapes to a zeroed struct on a no-match
+        // row (see GateNonEntityOnNullabilityMarker). Constructor-bound value types (positional record structs, ValueTuple) are
+        // also NewExpressions and so match here, but they fail to translate at an earlier point, so their marker is injected yet
+        // never consumed -- harmless dead weight we do not bother to exclude, since detecting it would duplicate that later gate.
         var recordNullabilityMarker = innerNullable
             && innerShaper is NewExpression or MemberInitExpression;
         Expression? markerBinding = recordNullabilityMarker

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -2958,12 +2958,11 @@ public sealed partial class SelectExpression : TableExpressionBase
         // would be inlined into the combined SELECT and never become NULL. The standalone marker binding returned here is bound
         // against innerSelect; it is remapped alongside the inner shaper in each branch below so it stays valid, then recorded
         // against the finalized inner-shaper node (consumed later by the projection binder). We do NOT wrap the inner shaper.
-        // Restrict recording to reference-type inner shapers: the projection-binder gate (GateNonEntityOnNullabilityMarker) skips
-        // value types via objectType.IsValueType, so a value-type inner (struct / record struct / ValueTuple) would only get a dead
-        // marker column injected that is never consumed. Skipping it here is a functional no-op that avoids that dead weight.
+        // Also record for a value-type inner (mutable struct / record struct) shaped via MemberInit: the projection-binder gate
+        // (GateNonEntityOnNullabilityMarker) now defaults it to a zeroed struct on no-match, matching LINQ-to-Objects
+        // DefaultIfEmpty semantics for a value-type sequence.
         var recordNullabilityMarker = innerNullable
-            && innerShaper is NewExpression or MemberInitExpression
-            && !innerShaper.Type.IsValueType;
+            && innerShaper is NewExpression or MemberInitExpression;
         Expression? markerBinding = recordNullabilityMarker
             ? InjectNullabilityMarker(innerSelect)
             : null;

--- a/test/EFCore.Relational.Specification.Tests/Query/AdHocMiscellaneousQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/AdHocMiscellaneousQueryRelationalTestBase.cs
@@ -411,17 +411,19 @@ namespace Microsoft.EntityFrameworkCore.Query
         // ------------------------------------
         // COVERED (these tests assert correct results): direct whole-object projection of a left-joined
         //   non-entity, via both GroupJoin+DefaultIfEmpty and the LeftJoin operator -- including
-        //   member-init DTO, nested anonymous wrapper, client-side null-checks of the projection,
-        //   Distinct and Take after the join, and projections with nullable/string members. The whole
-        //   non-entity object correctly materializes as null on a no-match (a synthetic "marker" column
-        //   is added inside the LEFT JOIN subquery so the shaper can distinguish a no-match row from a
-        //   matched row whose members happen to be null).
+        //   member-init DTO, mutable struct / record struct (MemberInit-bound), nested anonymous wrapper,
+        //   client-side null-checks of the projection, Distinct and Take after the join, and projections
+        //   with nullable/string members. The whole non-entity object correctly materializes as null (or,
+        //   for a MemberInit-bound value type, a zeroed default(T) -- matching LINQ-to-Objects
+        //   DefaultIfEmpty semantics for a value-type sequence, which never yields a true null) on a
+        //   no-match (a synthetic "marker" column is added inside the LEFT JOIN subquery so the shaper can
+        //   distinguish a no-match row from a matched row whose members happen to be null).
         // DEFERRED (still failing, tracked as #30915 follow-ups; these tests assert the throw /
-        //   translation failure): constructor-bound DTO and positional record struct (fail to
-        //   translate); mutable struct whole-object (fails during materialization); GroupBy-after-join
-        //   and a second join after the DefaultIfEmpty (the shaper rebuild loses the marker); plain
-        //   inner with no aggregate / no pushdown; Union and other set operations over the projection;
-        //   and server-side OrderBy/Where null-checks against the whole non-entity projection.
+        //   translation failure): constructor-bound DTO and positional record struct / ValueTuple (fail to
+        //   translate -- a distinct code path from MemberInit); GroupBy-after-join and a second join after
+        //   the DefaultIfEmpty (the shaper rebuild loses the marker); plain inner with no aggregate / no
+        //   pushdown; Union and other set operations over the projection; and server-side OrderBy/Where
+        //   null-checks against the whole non-entity projection.
 
         #region Category A: whole non-entity object projected from the nullable side
 
@@ -633,9 +635,63 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .LeftJoin(categories, s => s.PickupStatusId, c => c.PickupStatusId, (s, countInfo) => new { s.PickupStatusId, countInfo })
                 .OrderBy(e => e.PickupStatusId);
 
-            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => query.ToListAsync());
-            Assert.Contains("Nullable object must have a value", ex.Message);
-            // #30915 TODO: currently throws on base; flip to assert results if/when fixed.
+            var result = await query.ToListAsync();
+
+            Assert.Equal(3, result.Count);
+
+            // status 1 -> matched, Count 2
+            Assert.Equal(1, result[0].PickupStatusId);
+            Assert.Equal(1, result[0].countInfo.PickupStatusId);
+            Assert.Equal(2, result[0].countInfo.Count);
+
+            // status 2 -> no match, whole struct defaults to zeroed fields (mirrors LINQ-to-Objects
+            // DefaultIfEmpty semantics for a value-type sequence: default(CountStruct30915))
+            Assert.Equal(2, result[1].PickupStatusId);
+            Assert.Equal(0, result[1].countInfo.PickupStatusId);
+            Assert.Equal(0, result[1].countInfo.Count);
+
+            // status 3 -> matched, Count 1
+            Assert.Equal(3, result[2].PickupStatusId);
+            Assert.Equal(3, result[2].countInfo.PickupStatusId);
+            Assert.Equal(1, result[2].countInfo.Count);
+        }
+
+        [Fact]
+        public virtual async Task Struct_whole_object_GroupJoin_DefaultIfEmpty()
+        {
+            // Same struct whole-object shape as Struct_whole_object_LeftJoin, but lowered via the classic
+            // GroupJoin + DefaultIfEmpty query syntax rather than the LeftJoin operator -- these go through
+            // different AddJoin call sites, so exercise both.
+            var contextFactory = await InitializeNonSharedTest<Context30915>(seed: Seed30915);
+            using var context = contextFactory.CreateDbContext();
+
+            var categories = context.Requests
+                .GroupBy(r => r.PickupStatusId, (k, els) => new Context30915.CountStruct30915 { PickupStatusId = k, Count = els.Count() });
+
+            var query = from s in context.Statuses
+                        join c in categories on s.PickupStatusId equals c.PickupStatusId into g
+                        from countInfo in g.DefaultIfEmpty()
+                        orderby s.PickupStatusId
+                        select new { s.PickupStatusId, countInfo };
+
+            var result = await query.ToListAsync();
+
+            Assert.Equal(3, result.Count);
+
+            // status 1 -> matched, Count 2
+            Assert.Equal(1, result[0].PickupStatusId);
+            Assert.Equal(1, result[0].countInfo.PickupStatusId);
+            Assert.Equal(2, result[0].countInfo.Count);
+
+            // status 2 -> no match, whole struct defaults to zeroed fields
+            Assert.Equal(2, result[1].PickupStatusId);
+            Assert.Equal(0, result[1].countInfo.PickupStatusId);
+            Assert.Equal(0, result[1].countInfo.Count);
+
+            // status 3 -> matched, Count 1
+            Assert.Equal(3, result[2].PickupStatusId);
+            Assert.Equal(3, result[2].countInfo.PickupStatusId);
+            Assert.Equal(1, result[2].countInfo.Count);
         }
 
         [Fact]
@@ -1095,6 +1151,47 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [Fact]
+        public virtual async Task Matched_struct_row_with_zero_aggregate_keeps_real_key()
+        {
+            // Struct analog of Matched_row_with_null_aggregate_keeps_object_non_null: a struct is gated
+            // SOLELY on the synthetic marker column, never on its own member values, so a matched group
+            // whose aggregate happens to equal the CLR default (0) must still surface the real matched key
+            // -- not the (0, 0) shape a genuine no-match would produce via Expression.Default(objectType).
+            // Status 4 matches (one request) but the filtered Count aggregate is 0.
+            var contextFactory = await InitializeNonSharedTest<Context30915>(seed: Seed30915MatchedZeroAggregate);
+            using var context = contextFactory.CreateDbContext();
+
+            var categories = context.Requests
+                .GroupBy(
+                    r => r.PickupStatusId,
+                    (k, els) => new Context30915.CountStruct30915 { PickupStatusId = k, Count = els.Count(x => x.Priority > 100) });
+
+            var query = context.Statuses
+                .LeftJoin(categories, s => s.PickupStatusId, c => c.PickupStatusId, (s, countInfo) => new { s.PickupStatusId, countInfo })
+                .OrderBy(e => e.PickupStatusId);
+
+            var result = await query.ToListAsync();
+
+            Assert.Equal(3, result.Count);
+
+            // status 1 -> matched, filtered Count = 1
+            Assert.Equal(1, result[0].PickupStatusId);
+            Assert.Equal(1, result[0].countInfo.PickupStatusId);
+            Assert.Equal(1, result[0].countInfo.Count);
+
+            // status 2 -> genuine no-match: default(CountStruct30915), i.e. (0, 0)
+            Assert.Equal(2, result[1].PickupStatusId);
+            Assert.Equal(0, result[1].countInfo.PickupStatusId);
+            Assert.Equal(0, result[1].countInfo.Count);
+
+            // status 4 -> MATCHED but filtered Count is 0: the struct MUST keep the real matched key (4),
+            // not the CLR-default key (0) a genuine no-match would produce.
+            Assert.Equal(4, result[2].PickupStatusId);
+            Assert.Equal(4, result[2].countInfo.PickupStatusId);
+            Assert.Equal(0, result[2].countInfo.Count);
+        }
+
+        [Fact]
         public virtual async Task Bare_whole_object_projection_is_null_on_no_match()
         {
             // The non-entity object is the ROOT of the projection (not nested in an anon wrapper).
@@ -1460,6 +1557,49 @@ namespace Microsoft.EntityFrameworkCore.Query
             Assert.Equal(1, result[2].countInfo.marker);
         }
 
+        [Fact]
+        public virtual async Task Struct_composed_user_marker_projection_into_subquery_self_heals()
+        {
+            // Struct analog of Composed_user_marker_projection_into_subquery_self_heals: this fix enables
+            // marker-column injection for value-type (MemberInit) inners too, so the same cosmetic
+            // duplicate-alias risk (a user struct member named "marker" colliding with the synthetic
+            // marker) now applies there as well. Pins that composing the projection into a subquery (forced
+            // via Distinct) still self-heals with no ambiguous-column error.
+            var contextFactory = await InitializeNonSharedTest<Context30915>(seed: Seed30915);
+            using var context = contextFactory.CreateDbContext();
+
+            var categories = context.Requests
+                .GroupBy(
+                    r => r.PickupStatusId,
+                    (k, els) => new Context30915.CountStructWithMarker30915 { pickupStatusId = k, marker = els.Count() });
+
+            var query =
+                (from s in context.Statuses
+                 join c in categories on s.PickupStatusId equals c.pickupStatusId into g
+                 from countInfo in g.DefaultIfEmpty()
+                 select new { s.PickupStatusId, countInfo })
+                .Distinct();
+
+            var result = await query.OrderBy(x => x.PickupStatusId).ToListAsync();
+
+            Assert.Equal(3, result.Count);
+
+            // status 1 -> matched, user marker = 2
+            Assert.Equal(1, result[0].PickupStatusId);
+            Assert.Equal(1, result[0].countInfo.pickupStatusId);
+            Assert.Equal(2, result[0].countInfo.marker);
+
+            // status 2 -> no match -> default(CountStructWithMarker30915), i.e. (0, 0)
+            Assert.Equal(2, result[1].PickupStatusId);
+            Assert.Equal(0, result[1].countInfo.pickupStatusId);
+            Assert.Equal(0, result[1].countInfo.marker);
+
+            // status 3 -> matched, user marker = 1
+            Assert.Equal(3, result[2].PickupStatusId);
+            Assert.Equal(3, result[2].countInfo.pickupStatusId);
+            Assert.Equal(1, result[2].countInfo.marker);
+        }
+
         #endregion
 
         #region Category F: hardening characterization (reachable structural edges of the marker mechanism)
@@ -1537,10 +1677,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         [Fact]
         public virtual async Task Nullable_struct_whole_object_from_nullable_side()
         {
-            // Pins the Nullable<T> case: project a CountStruct30915? whole-object from the nullable side.
-            // Per the gate doc, Nullable<T> arrives via a Convert node (not New/MemberInit), so the marker
-            // is never recorded and the gate never fires -- the shaper materializes from all-NULL columns
-            // on a no-match and throws, identical to the non-nullable struct case.
+            // Pins the Nullable<T> case: project a CountStruct30915? whole-object from the nullable side. The inner shaper
+            // (CountStruct30915 via MemberInit) is what the marker mechanism records against and gates; the Nullable<T> wrapping
+            // is a separate Convert applied afterward. A no-match row now gates the inner struct to default(CountStruct30915)
+            // (zeroed fields) and THEN wraps it in Nullable<T> -- which correctly produces HasValue=true, not null: casting a
+            // real (if zeroed) struct value to Nullable<T> can never itself yield null. This matches LINQ-to-Objects semantics
+            // for DefaultIfEmpty() over a value-type sequence, which likewise never produces a true null for a struct.
             var contextFactory = await InitializeNonSharedTest<Context30915>(seed: Seed30915);
             using var context = contextFactory.CreateDbContext();
 
@@ -1553,10 +1695,25 @@ namespace Microsoft.EntityFrameworkCore.Query
                     (s, countInfo) => new { s.PickupStatusId, countInfo = (Context30915.CountStruct30915?)countInfo })
                 .OrderBy(e => e.PickupStatusId);
 
-            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => query.ToListAsync());
-            Assert.Contains("Nullable object must have a value", ex.Message);
-            // #30915 TODO: Nullable<T> whole-object from the nullable side is a deferred gap (unreachable
-            // by the marker mechanism, which only records for New/MemberInit, not Convert).
+            var result = await query.ToListAsync();
+
+            Assert.Equal(3, result.Count);
+
+            Assert.Equal(1, result[0].PickupStatusId);
+            Assert.True(result[0].countInfo.HasValue);
+            Assert.Equal(1, result[0].countInfo!.Value.PickupStatusId);
+            Assert.Equal(2, result[0].countInfo!.Value.Count);
+
+            // status 2 -> no match; HasValue is true with zeroed fields (see comment above), not null.
+            Assert.Equal(2, result[1].PickupStatusId);
+            Assert.True(result[1].countInfo.HasValue);
+            Assert.Equal(0, result[1].countInfo!.Value.PickupStatusId);
+            Assert.Equal(0, result[1].countInfo!.Value.Count);
+
+            Assert.Equal(3, result[2].PickupStatusId);
+            Assert.True(result[2].countInfo.HasValue);
+            Assert.Equal(3, result[2].countInfo!.Value.PickupStatusId);
+            Assert.Equal(1, result[2].countInfo!.Value.Count);
         }
 
         [Fact]
@@ -1637,6 +1794,23 @@ namespace Microsoft.EntityFrameworkCore.Query
             await context.SaveChangesAsync();
         }
 
+        // Provider-agnostic seed for the matched-zero-aggregate invariant (Matched_struct_row_with_zero_aggregate_keeps_real_key):
+        // status 4 MATCHES (one request) but the filtered Count(x => x.Priority > 100) aggregate is 0; status 2 is a genuine
+        // no-match.
+        private static async Task Seed30915MatchedZeroAggregate(Context30915 context)
+        {
+            context.Statuses.AddRange(
+                new Context30915.PickupStatus30915 { PickupStatusId = 1, Name = "HighPriority" },
+                new Context30915.PickupStatus30915 { PickupStatusId = 2, Name = "NoRequests" },
+                new Context30915.PickupStatus30915 { PickupStatusId = 4, Name = "ZeroFilteredCount" });
+
+            context.Requests.AddRange(
+                new Context30915.PickupRequest30915 { PickupStatusId = 1, Priority = 200 },
+                new Context30915.PickupRequest30915 { PickupStatusId = 4, Priority = 5 });
+
+            await context.SaveChangesAsync();
+        }
+
         protected class Context30915(DbContextOptions options) : DbContext(options)
         {
             public DbSet<PickupStatus30915> Statuses { get; set; }
@@ -1679,6 +1853,12 @@ namespace Microsoft.EntityFrameworkCore.Query
             {
                 public int PickupStatusId { get; set; }
                 public int Count { get; set; }
+            }
+
+            public struct CountStructWithMarker30915
+            {
+                public int pickupStatusId { get; set; }
+                public int marker { get; set; }
             }
 
             public record struct CountRecordStruct30915(int PickupStatusId, int Count);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocMiscellaneousQuerySqlServerTest.cs
@@ -3123,6 +3123,112 @@ ORDER BY [s0].[PickupStatusId]
 """);
     }
 
+    public override async Task Dto_constructor_whole_object_LeftJoin()
+    {
+        await base.Dto_constructor_whole_object_LeftJoin();
+
+        AssertSql();
+    }
+
+    public override async Task Struct_whole_object_LeftJoin()
+    {
+        await base.Struct_whole_object_LeftJoin();
+
+        AssertSql(
+            """
+SELECT [s].[PickupStatusId], [r0].[PickupStatusId], [r0].[Count], [r0].[marker]
+FROM [Statuses] AS [s]
+LEFT JOIN (
+    SELECT [r].[PickupStatusId], COUNT(*) AS [Count], 1 AS [marker]
+    FROM [Requests] AS [r]
+    GROUP BY [r].[PickupStatusId]
+) AS [r0] ON [s].[PickupStatusId] = [r0].[PickupStatusId]
+ORDER BY [s].[PickupStatusId]
+""");
+    }
+
+    public override async Task Struct_whole_object_GroupJoin_DefaultIfEmpty()
+    {
+        await base.Struct_whole_object_GroupJoin_DefaultIfEmpty();
+
+        AssertSql(
+            """
+SELECT [s].[PickupStatusId], [r0].[PickupStatusId], [r0].[Count], [r0].[marker]
+FROM [Statuses] AS [s]
+LEFT JOIN (
+    SELECT [r].[PickupStatusId], COUNT(*) AS [Count], 1 AS [marker]
+    FROM [Requests] AS [r]
+    GROUP BY [r].[PickupStatusId]
+) AS [r0] ON [s].[PickupStatusId] = [r0].[PickupStatusId]
+ORDER BY [s].[PickupStatusId]
+""");
+    }
+
+    public override async Task RecordStruct_whole_object_LeftJoin()
+    {
+        await base.RecordStruct_whole_object_LeftJoin();
+
+        AssertSql();
+    }
+
+    public override async Task Nullable_struct_whole_object_from_nullable_side()
+    {
+        await base.Nullable_struct_whole_object_from_nullable_side();
+
+        AssertSql(
+            """
+SELECT [s].[PickupStatusId], [r0].[PickupStatusId], [r0].[Count], [r0].[marker]
+FROM [Statuses] AS [s]
+LEFT JOIN (
+    SELECT [r].[PickupStatusId], COUNT(*) AS [Count], 1 AS [marker]
+    FROM [Requests] AS [r]
+    GROUP BY [r].[PickupStatusId]
+) AS [r0] ON [s].[PickupStatusId] = [r0].[PickupStatusId]
+ORDER BY [s].[PickupStatusId]
+""");
+    }
+
+    public override async Task ValueTuple_whole_object_from_nullable_side()
+    {
+        await base.ValueTuple_whole_object_from_nullable_side();
+
+        AssertSql();
+    }
+
+    public override async Task GroupBy_after_join_then_whole_object()
+    {
+        await base.GroupBy_after_join_then_whole_object();
+
+        AssertSql(
+            """
+SELECT [s1].[PickupStatusId], [s3].[pickupStatusId], [s3].[Count], [s3].[c]
+FROM (
+    SELECT [s].[PickupStatusId]
+    FROM [Statuses] AS [s]
+    LEFT JOIN (
+        SELECT [r].[PickupStatusId] AS [pickupStatusId]
+        FROM [Requests] AS [r]
+        GROUP BY [r].[PickupStatusId]
+    ) AS [r0] ON [s].[PickupStatusId] = [r0].[pickupStatusId]
+    GROUP BY [s].[PickupStatusId]
+) AS [s1]
+LEFT JOIN (
+    SELECT [s2].[pickupStatusId], [s2].[Count], [s2].[c], [s2].[PickupStatusId0]
+    FROM (
+        SELECT [r1].[pickupStatusId], [r1].[Count], 1 AS [c], [s0].[PickupStatusId] AS [PickupStatusId0], ROW_NUMBER() OVER(PARTITION BY [s0].[PickupStatusId] ORDER BY [s0].[PickupStatusId], [r1].[pickupStatusId]) AS [row]
+        FROM [Statuses] AS [s0]
+        LEFT JOIN (
+            SELECT [r2].[PickupStatusId] AS [pickupStatusId], COUNT(*) AS [Count]
+            FROM [Requests] AS [r2]
+            GROUP BY [r2].[PickupStatusId]
+        ) AS [r1] ON [s0].[PickupStatusId] = [r1].[pickupStatusId]
+    ) AS [s2]
+    WHERE [s2].[row] <= 1
+) AS [s3] ON [s1].[PickupStatusId] = [s3].[PickupStatusId0]
+ORDER BY [s1].[PickupStatusId]
+""");
+    }
+
     public override async Task Second_join_after_then_whole_object()
     {
         await base.Second_join_after_then_whole_object();
@@ -3138,6 +3244,83 @@ LEFT JOIN (
 ) AS [r0] ON [s].[PickupStatusId] = [r0].[pickupStatusId]
 INNER JOIN [Statuses] AS [s0] ON [s].[PickupStatusId] = [s0].[PickupStatusId]
 ORDER BY [s0].[PickupStatusId]
+""");
+    }
+
+    public override async Task Plain_inner_no_aggregate_LeftJoin_whole_object()
+    {
+        await base.Plain_inner_no_aggregate_LeftJoin_whole_object();
+
+        AssertSql(
+            """
+SELECT [s].[PickupStatusId], [r].[PickupStatusId], 1 AS [Count]
+FROM [Statuses] AS [s]
+LEFT JOIN [Requests] AS [r] ON [s].[PickupStatusId] = [r].[PickupStatusId]
+ORDER BY [s].[PickupStatusId]
+""");
+    }
+
+    public override async Task Union_of_two_leftjoin_nonentity()
+    {
+        await base.Union_of_two_leftjoin_nonentity();
+
+        AssertSql();
+    }
+
+    public override async Task OrderBy_member_of_nullable_projection()
+    {
+        await base.OrderBy_member_of_nullable_projection();
+
+        AssertSql();
+    }
+
+    public override async Task Where_nonentity_projection_not_null_serverside()
+    {
+        await base.Where_nonentity_projection_not_null_serverside();
+
+        AssertSql();
+    }
+
+    public override async Task Where_nonentity_projection_null_serverside()
+    {
+        await base.Where_nonentity_projection_null_serverside();
+
+        AssertSql();
+    }
+
+    public override async Task Matched_struct_row_with_zero_aggregate_keeps_real_key()
+    {
+        await base.Matched_struct_row_with_zero_aggregate_keeps_real_key();
+
+        AssertSql(
+            """
+SELECT [s].[PickupStatusId], [r0].[PickupStatusId], [r0].[Count], [r0].[marker]
+FROM [Statuses] AS [s]
+LEFT JOIN (
+    SELECT [r].[PickupStatusId], COUNT(CASE
+        WHEN [r].[Priority] > 100 THEN 1
+    END) AS [Count], 1 AS [marker]
+    FROM [Requests] AS [r]
+    GROUP BY [r].[PickupStatusId]
+) AS [r0] ON [s].[PickupStatusId] = [r0].[PickupStatusId]
+ORDER BY [s].[PickupStatusId]
+""");
+    }
+
+    public override async Task RightJoin_whole_object_outer_nullable()
+    {
+        await base.RightJoin_whole_object_outer_nullable();
+
+        AssertSql(
+            """
+SELECT [s].[PickupStatusId], [r0].[pickupStatusId], [r0].[Count]
+FROM (
+    SELECT [r].[PickupStatusId] AS [pickupStatusId], COUNT(*) AS [Count]
+    FROM [Requests] AS [r]
+    GROUP BY [r].[PickupStatusId]
+) AS [r0]
+RIGHT JOIN [Statuses] AS [s] ON [r0].[pickupStatusId] = [s].[PickupStatusId]
+ORDER BY [s].[PickupStatusId]
 """);
     }
 
@@ -3196,6 +3379,26 @@ LEFT JOIN (
     GROUP BY [r].[PickupStatusId]
 ) AS [r0] ON [s].[PickupStatusId] = [r0].[pickupStatusId]
 INNER JOIN [Statuses] AS [s0] ON [s].[PickupStatusId] = [s0].[PickupStatusId]
+ORDER BY [s0].[PickupStatusId]
+""");
+    }
+
+    public override async Task Struct_composed_user_marker_projection_into_subquery_self_heals()
+    {
+        await base.Struct_composed_user_marker_projection_into_subquery_self_heals();
+
+        AssertSql(
+            """
+SELECT [s0].[PickupStatusId], [s0].[pickupStatusId0] AS [pickupStatusId], [s0].[marker], [s0].[marker0] AS [marker]
+FROM (
+    SELECT DISTINCT [s].[PickupStatusId], [r0].[pickupStatusId] AS [pickupStatusId0], [r0].[marker], [r0].[marker0]
+    FROM [Statuses] AS [s]
+    LEFT JOIN (
+        SELECT [r].[PickupStatusId] AS [pickupStatusId], COUNT(*) AS [marker], 1 AS [marker0]
+        FROM [Requests] AS [r]
+        GROUP BY [r].[PickupStatusId]
+    ) AS [r0] ON [s].[PickupStatusId] = [r0].[pickupStatusId]
+) AS [s0]
 ORDER BY [s0].[PickupStatusId]
 """);
     }


### PR DESCRIPTION
Extends the #30915 nullability-marker mechanism (previously reference-type only) to MemberInit-bound struct/record struct whole-object projections from the nullable side of an outer join. 

Previously the marker was only recorded for reference-type inners, so a no-match row still materialized the struct from all-NULL columns and threw "Nullable object must have a value". Gating to default(T) instead matches LINQ-to-Objects DefaultIfEmpty semantics for a value-type sequence, which never produces a true null for a struct.

As a side effect, this also fixes the adjacent Nullable<T>-wrapped-struct case, since it shares the same underlying MemberInit shaper: a no-match row now correctly yields HasValue == true with zeroed fields rather than throwing, since casting a real (if zeroed) struct to Nullable<T> can never itself produce null.

Part of the #22517 follow-up work tracked after #30915/#38479.
