### PR TITLE
Don't reject JSON entities reached only through Include under AsNoTrackingWithIdentityResolution

### DIFF
--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
@@ -3613,6 +3613,10 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                     _insideInclude = true;
                     Visit(includeExpression.NavigationExpression);
                     _insideInclude = insideInclude;
+                    // Visit EntityExpression explicitly here, rather than falling through to base.VisitExtension,
+                    // so we avoid re-visiting NavigationExpression a second time with _insideInclude incorrectly reset to false.
+                    Visit(includeExpression.EntityExpression);
+                    return extensionExpression;
                 }
 
                 if (extensionExpression is StructuralTypeShaperExpression
@@ -3625,7 +3629,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                     switch (entityProjection)
                     {
                         case QueryableJsonProjectionInfo:
-                        case JsonProjectionInfo when _insideCollection:
+                        case JsonProjectionInfo when _insideCollection && !_insideInclude:
                             throw new InvalidOperationException(
                                 RelationalStrings.JsonProjectingQueryableOperationNoTrackingWithIdentityResolution(
                                     nameof(QueryTrackingBehavior.NoTrackingWithIdentityResolution)));
@@ -3664,7 +3668,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                     switch (collectionProjection)
                     {
                         case QueryableJsonProjectionInfo:
-                        case JsonProjectionInfo when _insideCollection:
+                        case JsonProjectionInfo when _insideCollection && !_insideInclude:
                             throw new InvalidOperationException(
                                 RelationalStrings.JsonProjectingQueryableOperationNoTrackingWithIdentityResolution(
                                     nameof(QueryTrackingBehavior.NoTrackingWithIdentityResolution)));

--- a/test/EFCore.Cosmos.FunctionalTests/Query/JsonQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/JsonQueryCosmosTest.cs
@@ -276,6 +276,30 @@ WHERE (c["$type"] = "CustomNaming")
             message);
     }
 
+    public override async Task Entity_including_collection_with_json_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        var message = (await Assert.ThrowsAsync<InvalidOperationException>(
+            () => base.Entity_including_collection_with_json_AsNoTrackingWithIdentityResolution(async))).Message;
+
+        Assert.Equal(
+            CosmosStrings.NonEmbeddedIncludeNotSupported(
+                "Navigation: EntityBasic.JsonEntityBasics (List<JsonEntityBasic>) Collection ToDependent JsonEntityBasic"),
+            message);
+    }
+
+    public override async Task Entity_including_collection_with_json_and_separate_json_projection_AsNoTrackingWithIdentityResolution(
+        bool async)
+    {
+        var message = (await Assert.ThrowsAsync<InvalidOperationException>(
+            () => base.Entity_including_collection_with_json_and_separate_json_projection_AsNoTrackingWithIdentityResolution(async)))
+            .Message;
+
+        Assert.Equal(
+            CosmosStrings.NonEmbeddedIncludeNotSupported(
+                "Navigation: EntityBasic.JsonEntityBasics (List<JsonEntityBasic>) Collection ToDependent JsonEntityBasic"),
+            message);
+    }
+
     [Theory(Skip = "issue #17313")]
     public override Task Group_by_FirstOrDefault_on_json_scalar(bool async)
         => base.Group_by_FirstOrDefault_on_json_scalar(async);

--- a/test/EFCore.Specification.Tests/Query/JsonQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/JsonQueryTestBase.cs
@@ -1617,6 +1617,40 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
                 new ExpectedInclude<EntityBasic>(x => x.JsonEntityBasics)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task Entity_including_collection_with_json_AsNoTrackingWithIdentityResolution(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<EntityBasic>().Include(e => e.JsonEntityBasics).AsNoTrackingWithIdentityResolution(),
+            elementAsserter: (e, a) => AssertInclude(
+                e, a,
+                new ExpectedInclude<EntityBasic>(x => x.JsonEntityBasics)));
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task Entity_including_collection_with_json_and_separate_json_projection_AsNoTrackingWithIdentityResolution(
+        bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<EntityBasic>()
+                .Include(e => e.JsonEntityBasics)
+                .Select(e => new
+                {
+                    e,
+                    First = ss.Set<JsonEntityBasic>()
+                        .OrderBy(x => x.Id)
+                        .Select(x => x.OwnedReferenceRoot)
+                        .FirstOrDefault()
+                })
+                .AsNoTrackingWithIdentityResolution(),
+            elementSorter: e => e.e.Id,
+            elementAsserter: (e, a) =>
+            {
+                AssertInclude(
+                    e.e, a.e,
+                    new ExpectedInclude<EntityBasic>(x => x.JsonEntityBasics));
+                AssertEqual(e.First, a.First);
+            });
+
+    [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_with_include_on_entity_collection_and_reference(bool async)
         => AssertQuery(
             async,

--- a/test/EFCore.SqlServer.FunctionalTests/Query/JsonQueryJsonTypeSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/JsonQueryJsonTypeSqlServerTest.cs
@@ -2332,6 +2332,19 @@ ORDER BY [e].[Id]
 """);
     }
 
+    public override async Task Entity_including_collection_with_json_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        await base.Entity_including_collection_with_json_AsNoTrackingWithIdentityResolution(async);
+
+        AssertSql(
+            """
+SELECT [e].[Id], [e].[Name], [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
+FROM [EntitiesBasic] AS [e]
+LEFT JOIN [JsonEntitiesBasic] AS [j] ON [e].[Id] = [j].[EntityBasicId]
+ORDER BY [e].[Id]
+""");
+    }
+
     public override async Task Json_with_include_on_entity_collection_and_reference(bool async)
     {
         await base.Json_with_include_on_entity_collection_and_reference(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
@@ -2297,6 +2297,19 @@ ORDER BY [e].[Id]
 """);
     }
 
+    public override async Task Entity_including_collection_with_json_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        await base.Entity_including_collection_with_json_AsNoTrackingWithIdentityResolution(async);
+
+        AssertSql(
+            """
+SELECT [e].[Id], [e].[Name], [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
+FROM [EntitiesBasic] AS [e]
+LEFT JOIN [JsonEntitiesBasic] AS [j] ON [e].[Id] = [j].[EntityBasicId]
+ORDER BY [e].[Id]
+""");
+    }
+
     public override async Task Json_with_include_on_entity_collection_and_reference(bool async)
     {
         await base.Json_with_include_on_entity_collection_and_reference(async);

--- a/test/EFCore.Sqlite.FunctionalTests/Query/JsonQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/JsonQuerySqliteTest.cs
@@ -457,6 +457,15 @@ FROM "JsonEntitiesCustomNaming" AS "j"
     public override Task Json_projection_using_queryable_methods_on_top_of_JSON_collection_AsNoTrackingWithIdentityResolution(bool async)
         => Task.CompletedTask;
 
+    // The uncorrelated FirstOrDefault subquery translates via APPLY, which SQLite doesn't support.
+    public override async Task
+        Entity_including_collection_with_json_and_separate_json_projection_AsNoTrackingWithIdentityResolution(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(()
+                => base.Entity_including_collection_with_json_and_separate_json_projection_AsNoTrackingWithIdentityResolution(async)))
+            .Message);
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }


### PR DESCRIPTION
Fixes #35468.

Include on a collection navigation whose target has JSON-mapped (.ToJson()) owned data threw InvalidOperationException under AsNoTrackingWithIdentityResolution, because Include can't cause the JSON-ordering corruption the check guards against. Narrowed the guard to exempt Include-only paths, fixed a fallout bug where doing so skipped revalidating part of the shaper tree, and added regression tests.

<details>
<summary>Full explanation</summary>

Combining `.Include()` on a relational collection navigation with `.AsNoTrackingWithIdentityResolution()` incorrectly threw:

    InvalidOperationException: Projecting queryable operations on JSON
    collection is not supported for 'NoTrackingWithIdentityResolution'.

whenever the included entity carried JSON-mapped (`.ToJson()`) owned data. This was a regression from EF Core 8 to 9/10.

`JsonCorrectOrderOfEntitiesForChangeTrackerValidator` throws to prevent JSON entities from landing in the change tracker out of order when a JSON collection is reordered/filtered by an arbitrary LINQ operator. But `Include` cannot filter or reorder owned/JSON navigations, so JSON entities reached purely through `Include` can never trigger that corruption and are always safe. The validator's guard didn't account for this: `case JsonProjectionInfo when _insideCollection` threw unconditionally as soon as a JSON entity was nested inside any collection shaper, even when it was also inside an `Include`.

The fix narrows both throwing guards to `JsonProjectionInfo when _insideCollection && !_insideInclude`, so Include-reached JSON entities/collections fall through to the existing `_includedJsonEntityTypes` tracking instead of throwing. `QueryableJsonProjectionInfo` (an explicit LINQ operator applied directly to a JSON collection) still throws unconditionally in all cases, since that shape cannot occur through `Include` and remains genuinely unsafe.

Suppressing the throw exposed a second issue: `IncludeExpression` handling used to fall through to `base.VisitExtension`, which visits both `EntityExpression` and `NavigationExpression` - redundantly revisiting `NavigationExpression` a second time with `_insideInclude` reset to false, which would re-trigger the very exception being fixed. The fix now visits `NavigationExpression` once (with `_insideInclude` true) and explicitly visits `EntityExpression` before returning, so every JSON-bearing node in the shaper tree - including chained `.Include(a).Include(b)` chains - is visited exactly once with the correct `_insideInclude` state.

Test coverage added:
- `Entity_including_collection_with_json_AsNoTrackingWithIdentityResolution`: reproduces the reported bug shape (Include on a relational collection navigation whose target carries JSON data).
- `Entity_including_collection_with_json_and_separate_json_projection_AsNoTrackingWithIdentityResolution`: combines Include of a JSON-bearing collection with a separate, non-Include projection of the same JSON entity type in the same query, exercising the `_includedJsonEntityTypes` / `_projectedKeyAccessInfos` dedup path in `Validate()`.
- Cosmos overrides documenting that Cosmos already rejects this Include for an unrelated, pre-existing reason (`CosmosStrings.NonEmbeddedIncludeNotSupported`), confirming this fix doesn't touch Cosmos behavior.

Verified no regression: all ~80 existing `*_AsNoTrackingWithIdentityResolution` tests that don't use Include continue to throw as before (the genuinely-unsafe cases this validator protects), the full `JsonQuerySqlServerTest` and `JsonQueryCosmosTest` suites are green, and the exact repro from the issue (SQLite, `OwnsOne(...).ToJson()` on a collection element) no longer throws.
