### PR TITLE
Fold ValueTuple/Tuple member access through constructor-bound projections

### DIFF
--- a/src/EFCore/Query/ReplacingExpressionVisitor.cs
+++ b/src/EFCore/Query/ReplacingExpressionVisitor.cs
@@ -170,8 +170,9 @@ public class ReplacingExpressionVisitor : ExpressionVisitor
 
             // EF.Property<T>'s instance parameter is object, so a value-type entity expression (e.g. a ValueTuple)
             // arrives here boxed via a Convert node; unwrap it once up front for both checks below, same as the
-            // single unwrap VisitMember does. (A reference-type New -- anonymous type, Tuple -- never needs boxing,
-            // so it reaches here unwrapped either way; this only changes behavior for value types.)
+            // single unwrap VisitMember does. UnwrapTypeConversion also strips any redundant Convert/TypeAs on a
+            // reference-type expression, so this can newly expose a New/MemberInit that a boxing-only unwrap would
+            // have missed -- the effect isn't limited to value types.
             var unwrappedEntityExpression = newEntityExpression.UnwrapTypeConversion(out _);
 
             if (unwrappedEntityExpression is NewExpression newExpression)

--- a/src/EFCore/Query/ReplacingExpressionVisitor.cs
+++ b/src/EFCore/Query/ReplacingExpressionVisitor.cs
@@ -88,7 +88,8 @@ public class ReplacingExpressionVisitor : ExpressionVisitor
 
         if (innerExpression is NewExpression newExpression)
         {
-            var index = newExpression.Members?.IndexOf(memberExpression.Member);
+            var index = newExpression.Members?.IndexOf(memberExpression.Member)
+                ?? GetConstructorParameterIndex(newExpression, memberExpression.Member.Name);
             if (index >= 0)
             {
                 return newExpression.Arguments[index.Value];
@@ -106,23 +107,86 @@ public class ReplacingExpressionVisitor : ExpressionVisitor
         return memberExpression.Update(innerExpression);
     }
 
+    // The compiler only populates NewExpression.Members for anonymous types; it is always null for every other type
+    // (records, record structs, and ordinary classes/structs with a primary or explicit constructor), even when a
+    // constructor parameter and a read-only property share the same name (the common "positional" pattern). Without
+    // some fallback, a later member access on such a projected object (e.g. a join key selector referencing a member
+    // of a constructor-bound whole-object projection) can't be folded back to its underlying constructor argument,
+    // causing translation of the containing query to fail entirely.
+    //
+    // This fallback is intentionally restricted to System.ValueTuple<...> and System.Tuple<...>: these are the only
+    // non-anonymous types where the constructor-parameter-to-member correspondence is a guaranteed, closed contract
+    // rather than a mere convention -- their constructors and Item1..Item7/Rest members (fields on ValueTuple,
+    // properties on Tuple) are fixed, documented BCL behavior that no user code can intercept or override (unlike an
+    // ordinary class/record/struct, where a same-named property can legally be redeclared with a transforming
+    // initializer, e.g. "public string Name { get; } = name.Trim();", which is indistinguishable from a safe
+    // passthrough via reflection alone -- see the discussion that led to narrowing this from a general
+    // by-convention name match to this closed set). For every other type,
+    // this returns null and the member access is left unfolded, exactly as before this fallback existed: the
+    // containing query still fails to translate (loudly), rather than risking a silently-wrong fold.
+    private static int? GetConstructorParameterIndex(NewExpression newExpression, string memberName)
+    {
+        // NewExpression.Constructor is null for a value type's parameterless "new T()" (e.g. "() => new
+        // ValueTuple<int, int>()" compiles to exactly this), which -- like the anonymous-type case this fallback
+        // exists for -- also has null Members. IsValueTupleOrTuple would still be true here, so this null check
+        // must come first: there is no constructor to fold against, and Arguments is empty anyway.
+        if (newExpression.Constructor is null || !IsValueTupleOrTuple(newExpression.Type))
+        {
+            return null;
+        }
+
+        // ValueTuple/Tuple constructor parameters are always named "item1".."item7"/"rest", matching the
+        // corresponding "Item1".."Item7"/"Rest" member names up to case -- a fixed BCL contract, not a heuristic.
+        // Names are guaranteed unique here, so unlike a general by-convention match, no ambiguity is possible.
+        var parameters = newExpression.Constructor.GetParameters();
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            if (string.Equals(parameters[i].Name, memberName, StringComparison.OrdinalIgnoreCase))
+            {
+                return i;
+            }
+        }
+
+        return null;
+    }
+
+    private static readonly HashSet<Type> ValueTupleAndTupleOpenGenericTypes =
+    [
+        typeof(ValueTuple<>), typeof(ValueTuple<,>), typeof(ValueTuple<,,>), typeof(ValueTuple<,,,>),
+        typeof(ValueTuple<,,,,>), typeof(ValueTuple<,,,,,>), typeof(ValueTuple<,,,,,,>), typeof(ValueTuple<,,,,,,,>),
+        typeof(Tuple<>), typeof(Tuple<,>), typeof(Tuple<,,>), typeof(Tuple<,,,>),
+        typeof(Tuple<,,,,>), typeof(Tuple<,,,,,>), typeof(Tuple<,,,,,,>), typeof(Tuple<,,,,,,,>)
+    ];
+
+    private static bool IsValueTupleOrTuple(Type type)
+        => type.IsGenericType && ValueTupleAndTupleOpenGenericTypes.Contains(type.GetGenericTypeDefinition());
+
     /// <inheritdoc />
     protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
     {
         if (methodCallExpression.TryGetEFPropertyArguments(out var entityExpression, out var propertyName))
         {
             var newEntityExpression = Visit(entityExpression);
-            if (newEntityExpression is NewExpression newExpression)
+
+            // EF.Property<T>'s instance parameter is object, so a value-type entity expression (e.g. a ValueTuple)
+            // arrives here boxed via a Convert node; unwrap it once up front for both checks below, same as the
+            // single unwrap VisitMember does. (A reference-type New -- anonymous type, Tuple -- never needs boxing,
+            // so it reaches here unwrapped either way; this only changes behavior for value types.)
+            var unwrappedEntityExpression = newEntityExpression.UnwrapTypeConversion(out _);
+
+            if (unwrappedEntityExpression is NewExpression newExpression)
             {
-                var index = newExpression.Members?.Select(m => m.Name).IndexOf(propertyName);
+                var index = newExpression.Members?.Select(m => m.Name).IndexOf(propertyName)
+                    ?? GetConstructorParameterIndex(newExpression, propertyName);
                 if (index >= 0)
                 {
+                    // Discarding the outer Convert-to-object is safe: EF.Property<T>'s T is inferred from the call
+                    // site to match the property's/argument's own type, never the boxed instance's type.
                     return newExpression.Arguments[index.Value];
                 }
             }
 
-            var mayBeMemberInitExpression = newEntityExpression.UnwrapTypeConversion(out _);
-            if (mayBeMemberInitExpression is MemberInitExpression memberInitExpression
+            if (unwrappedEntityExpression is MemberInitExpression memberInitExpression
                 && memberInitExpression.Bindings.SingleOrDefault(mb => mb.Member.Name == propertyName) is MemberAssignment memberAssignment)
             {
                 return memberAssignment.Expression;

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
@@ -1174,7 +1174,7 @@ WHERE STARTSWITH(c["id"], "A")
     public override async Task Filtered_collection_projection_is_tracked(bool async)
     {
         // Cosmos client evaluation. Issue #17246.
-        await AssertTranslationFailed(() => base.Member_binding_after_ctor_arguments_fails_with_client_eval(async));
+        await AssertTranslationFailed(() => base.Filtered_collection_projection_is_tracked(async));
 
         AssertSql();
     }

--- a/test/EFCore.InMemory.FunctionalTests/Query/NorthwindGroupByQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/NorthwindGroupByQueryInMemoryTest.cs
@@ -73,6 +73,12 @@ public class NorthwindGroupByQueryInMemoryTest(NorthwindQueryInMemoryFixture<Noo
             () => base.Final_GroupBy_TagWith(async),
             InMemoryStrings.NonComposedGroupByNotSupported);
 
+    // The in-memory provider doesn't implement joining on a client-evaluated GroupBy result
+    // (InMemoryQueryExpression.AddJoin throws NotImplementedException); unrelated to the fold under test.
+    [Theory(Skip = "Issue#31209")]
+    public override Task GroupBy_ValueTuple_projection_joined_on_tuple_member(bool async)
+        => base.GroupBy_ValueTuple_projection_joined_on_tuple_member(async);
+
     [Theory(Skip = "Issue#31209")]
     public override Task GroupBy_Select_Anonymous_Type_With_Entire_Entity(bool async)
         => base.GroupBy_Select_Anonymous_Type_With_Entire_Entity(async);

--- a/test/EFCore.Relational.Specification.Tests/Query/AdHocMiscellaneousQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/AdHocMiscellaneousQueryRelationalTestBase.cs
@@ -411,7 +411,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         // ------------------------------------
         // COVERED (these tests assert correct results): direct whole-object projection of a left-joined
         //   non-entity, via both GroupJoin+DefaultIfEmpty and the LeftJoin operator -- including
-        //   member-init DTO, mutable struct / record struct (MemberInit-bound), nested anonymous wrapper,
+        //   member-init DTO, mutable struct / record struct (MemberInit-bound), constructor-bound
+        //   ValueTuple/Tuple (folded via the closed ValueTuple/Tuple contract), nested anonymous wrapper,
         //   client-side null-checks of the projection, Distinct and Take after the join, and projections
         //   with nullable/string members. The whole non-entity object correctly materializes as null (or,
         //   for a MemberInit-bound value type, a zeroed default(T) -- matching LINQ-to-Objects
@@ -424,11 +425,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         //   deliberately restricted to ValueTuple/Tuple -- see ValueTuple_whole_object_from_nullable_side --
         //   since only those BCL types have a closed, guaranteed constructor-to-property contract; an
         //   arbitrary named type's "matching name" convention can't be verified and could silently fold to
-        //   the wrong value for a transforming constructor); mutable struct whole-object (a MemberInit, not
-        //   constructor-bound, shape -- already translates via the unrelated, pre-existing MemberInit
-        //   member-fold, but still fails at MATERIALIZATION on a no-match row since the marker gate doesn't
-        //   yet cover value-type inners) and ValueTuple (now also translates, via the ValueTuple/Tuple fold,
-        //   but hits the same value-type materialization gap); GroupBy-after-join and a second join after
+        //   the wrong value for a transforming constructor); GroupBy-after-join and a second join after
         //   the DefaultIfEmpty (the shaper rebuild loses the marker); plain inner with no aggregate / no
         //   pushdown; Union and other set operations over the projection; and server-side OrderBy/Where
         //   null-checks against the whole non-entity projection.
@@ -1734,9 +1731,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             // ValueTuple is one of the two BCL types (with Tuple) where the constructor-parameter-to-property mapping
             // is a closed, guaranteed contract rather than a mere convention -- this fold does NOT generalize to
             // arbitrary constructor-bound types (see Dto_constructor_whole_object_LeftJoin /
-            // RecordStruct_whole_object_LeftJoin, which remain translation failures). It still fails at
-            // MATERIALIZATION on a no-match row here: the #30915 nullability-marker gate doesn't yet cover
-            // value-type inners -- a separate, deferred item on the #22517 follow-up list.
+            // RecordStruct_whole_object_LeftJoin, which remain translation failures). On a no-match row the
+            // value-type inner now correctly materializes as default(T) ((0, 0) here) -- matching LINQ-to-Objects
+            // DefaultIfEmpty semantics for a value-type sequence -- via the value-type default gate (#38555).
             var contextFactory = await InitializeNonSharedTest<Context30915>(seed: Seed30915);
             using var context = contextFactory.CreateDbContext();
 
@@ -1749,9 +1746,12 @@ namespace Microsoft.EntityFrameworkCore.Query
                         orderby s.PickupStatusId
                         select new { s.PickupStatusId, tuple = countInfo };
 
-            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => query.ToListAsync());
-            Assert.Contains("Nullable object must have a value", ex.Message);
-            // #30915 TODO: currently throws on base; flip to assert results once the value-type marker gate lands.
+            var result = await query.ToListAsync();
+
+            Assert.Equal(3, result.Count);
+            Assert.Equal((1, (1, 2)), (result[0].PickupStatusId, result[0].tuple));
+            Assert.Equal((2, (0, 0)), (result[1].PickupStatusId, result[1].tuple));
+            Assert.Equal((3, (3, 1)), (result[2].PickupStatusId, result[2].tuple));
         }
 
         [Fact]

--- a/test/EFCore.Relational.Specification.Tests/Query/AdHocMiscellaneousQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/AdHocMiscellaneousQueryRelationalTestBase.cs
@@ -419,8 +419,16 @@ namespace Microsoft.EntityFrameworkCore.Query
         //   no-match (a synthetic "marker" column is added inside the LEFT JOIN subquery so the shaper can
         //   distinguish a no-match row from a matched row whose members happen to be null).
         // DEFERRED (still failing, tracked as #30915 follow-ups; these tests assert the throw /
-        //   translation failure): constructor-bound DTO and positional record struct / ValueTuple (fail to
-        //   translate -- a distinct code path from MemberInit); GroupBy-after-join and a second join after
+        //   translation failure): constructor-bound (read-only) reference-type DTO and positional record
+        //   struct (fail to translate: ReplacingExpressionVisitor's constructor-parameter fold is
+        //   deliberately restricted to ValueTuple/Tuple -- see ValueTuple_whole_object_from_nullable_side --
+        //   since only those BCL types have a closed, guaranteed constructor-to-property contract; an
+        //   arbitrary named type's "matching name" convention can't be verified and could silently fold to
+        //   the wrong value for a transforming constructor); mutable struct whole-object (a MemberInit, not
+        //   constructor-bound, shape -- already translates via the unrelated, pre-existing MemberInit
+        //   member-fold, but still fails at MATERIALIZATION on a no-match row since the marker gate doesn't
+        //   yet cover value-type inners) and ValueTuple (now also translates, via the ValueTuple/Tuple fold,
+        //   but hits the same value-type materialization gap); GroupBy-after-join and a second join after
         //   the DefaultIfEmpty (the shaper rebuild loses the marker); plain inner with no aggregate / no
         //   pushdown; Union and other set operations over the projection; and server-side OrderBy/Where
         //   null-checks against the whole non-entity projection.
@@ -1721,10 +1729,14 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             // Pins that IsTransparentIdentifierType does NOT false-positive on a ValueTuple (it is not the
             // TransparentIdentifier<,> generic type) and that a ValueTuple constructed in a GroupBy projection is a
-            // value type so the marker gate never applies. Actual behavior: the constructor-bound ValueTuple
-            // projection fails to TRANSLATE (like the ctor-bound DTO in Dto_constructor_whole_object_LeftJoin / record struct in
-            // RecordStruct_whole_object_LeftJoin),
-            // rather than failing during materialization with "Nullable object must have a value".
+            // value type so the marker gate never applies. The constructor-bound ValueTuple projection now
+            // TRANSLATES: ReplacingExpressionVisitor folds c.Item1 back to its constructor argument, but ONLY because
+            // ValueTuple is one of the two BCL types (with Tuple) where the constructor-parameter-to-property mapping
+            // is a closed, guaranteed contract rather than a mere convention -- this fold does NOT generalize to
+            // arbitrary constructor-bound types (see Dto_constructor_whole_object_LeftJoin /
+            // RecordStruct_whole_object_LeftJoin, which remain translation failures). It still fails at
+            // MATERIALIZATION on a no-match row here: the #30915 nullability-marker gate doesn't yet cover
+            // value-type inners -- a separate, deferred item on the #22517 follow-up list.
             var contextFactory = await InitializeNonSharedTest<Context30915>(seed: Seed30915);
             using var context = contextFactory.CreateDbContext();
 
@@ -1738,9 +1750,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                         select new { s.PickupStatusId, tuple = countInfo };
 
             var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => query.ToListAsync());
-            Assert.Contains("could not be translated", ex.Message);
-            // #30915 TODO: value-type whole-object (ValueTuple) from the nullable side is a deferred gap; the
-            // constructor-bound ValueTuple GroupBy projection currently fails to translate.
+            Assert.Contains("Nullable object must have a value", ex.Message);
+            // #30915 TODO: currently throws on base; flip to assert results once the value-type marker gate lands.
         }
 
         [Fact]

--- a/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
@@ -1293,6 +1293,17 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
             e => e.Key);
 
     [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_ValueTuple_projection_joined_on_tuple_member(bool async)
+        // A GroupBy projecting a ValueTuple, then joined on a member of that tuple (t.Item1). The join key
+        // selector's member access is folded back to the tuple's constructor argument. Issue #22517.
+        => AssertQuery(
+            async,
+            ss => from t in ss.Set<Order>().GroupBy(o => o.CustomerID, (k, es) => new ValueTuple<string, int>(k, es.Count()))
+                  join c in ss.Set<Customer>() on t.Item1 equals c.CustomerID
+                  select new { c.CustomerID, Count = t.Item2 },
+            e => e.CustomerID);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task GroupBy_multi_navigation_members_Aggregate(bool async)
         => AssertQuery(
             async,

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocMiscellaneousQuerySqlServerTest.cs
@@ -3192,7 +3192,17 @@ ORDER BY [s].[PickupStatusId]
     {
         await base.ValueTuple_whole_object_from_nullable_side();
 
-        AssertSql();
+        AssertSql(
+            """
+SELECT [s].[PickupStatusId], [r0].[PickupStatusId], [r0].[c], [r0].[marker]
+FROM [Statuses] AS [s]
+LEFT JOIN (
+    SELECT [r].[PickupStatusId], COUNT(*) AS [c], 1 AS [marker]
+    FROM [Requests] AS [r]
+    GROUP BY [r].[PickupStatusId]
+) AS [r0] ON [s].[PickupStatusId] = [r0].[PickupStatusId]
+ORDER BY [s].[PickupStatusId]
+""");
     }
 
     public override async Task GroupBy_after_join_then_whole_object()

--- a/test/EFCore.Tests/Query/ReplacingExpressionVisitorTest.cs
+++ b/test/EFCore.Tests/Query/ReplacingExpressionVisitorTest.cs
@@ -1,0 +1,197 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public class ReplacingExpressionVisitorTest
+{
+    // A plain constructor-bound type deliberately NOT covered by the fold: the constructor-parameter-to-property
+    // correspondence for arbitrary named types is a convention, not a guarantee (see PositionalDto/TransformingDto
+    // below), so ReplacingExpressionVisitor intentionally leaves member access on these unfolded.
+    private class PositionalDto(int pickupStatusId, int count)
+    {
+        public int PickupStatusId { get; } = pickupStatusId;
+        public int Count { get; } = count;
+    }
+
+    // Demonstrates why the fold can't safely be generalized beyond ValueTuple/Tuple: this legal, unremarkable C#
+    // redeclares a positional-looking property with a transforming initializer. Via reflection it is
+    // indistinguishable from a genuine passthrough (both are compiler-generated auto-properties), so a name-based
+    // fold would silently return the wrong (untransformed) value here.
+    private class TransformingDto(int value)
+    {
+        public int Value { get; } = value + 1;
+    }
+
+    [Fact]
+    public void Member_access_on_ValueTuple_folds_to_constructor_argument()
+    {
+        var parameter = Expression.Parameter(typeof(int), "k");
+        var newExpression = Expression.New(
+            typeof(ValueTuple<int, int>).GetConstructors().Single(),
+            parameter, Expression.Constant(1));
+
+        var memberAccess = Expression.Field(newExpression, nameof(ValueTuple<int, int>.Item1));
+
+        var result = ReplacingExpressionVisitor.Replace(parameter, Expression.Constant(42), memberAccess);
+
+        Assert.Equal(Expression.Constant(42).ToString(), result.ToString());
+    }
+
+    [Fact]
+    public void Member_access_on_Tuple_folds_to_constructor_argument()
+    {
+        var parameter = Expression.Parameter(typeof(int), "k");
+        var newExpression = Expression.New(
+            typeof(Tuple<int, int>).GetConstructors().Single(),
+            parameter, Expression.Constant(1));
+
+        var memberAccess = Expression.Property(newExpression, nameof(Tuple<int, int>.Item1));
+
+        var result = ReplacingExpressionVisitor.Replace(parameter, Expression.Constant(42), memberAccess);
+
+        Assert.Equal(Expression.Constant(42).ToString(), result.ToString());
+    }
+
+    [Fact]
+    public void EFProperty_access_on_ValueTuple_folds_to_constructor_argument()
+    {
+        var parameter = Expression.Parameter(typeof(int), "k");
+        var newExpression = Expression.New(
+            typeof(ValueTuple<int, int>).GetConstructors().Single(),
+            parameter, Expression.Constant(1));
+
+        var efPropertyMethod = typeof(EF).GetMethod(nameof(EF.Property))!.MakeGenericMethod(typeof(int));
+        var efPropertyAccess = Expression.Call(
+            efPropertyMethod,
+            Expression.Convert(newExpression, typeof(object)),
+            Expression.Constant(nameof(ValueTuple<int, int>.Item1)));
+
+        var result = ReplacingExpressionVisitor.Replace(parameter, Expression.Constant(42), efPropertyAccess);
+
+        Assert.Equal(Expression.Constant(42).ToString(), result.ToString());
+    }
+
+    [Fact]
+    public void EFProperty_access_on_Tuple_folds_to_constructor_argument()
+    {
+        // Unlike ValueTuple, Tuple is a reference type: passing it where EF.Property<T> expects object needs no
+        // boxing Convert node, so this exercises the "already unwrapped" branch rather than the boxing-unwrap path
+        // the ValueTuple version above covers.
+        var parameter = Expression.Parameter(typeof(int), "k");
+        var newExpression = Expression.New(
+            typeof(Tuple<int, int>).GetConstructors().Single(),
+            parameter, Expression.Constant(1));
+
+        var efPropertyMethod = typeof(EF).GetMethod(nameof(EF.Property))!.MakeGenericMethod(typeof(int));
+        var efPropertyAccess = Expression.Call(
+            efPropertyMethod,
+            newExpression,
+            Expression.Constant(nameof(Tuple<int, int>.Item1)));
+
+        var result = ReplacingExpressionVisitor.Replace(parameter, Expression.Constant(42), efPropertyAccess);
+
+        Assert.Equal(Expression.Constant(42).ToString(), result.ToString());
+    }
+
+    [Fact]
+    public void Member_access_on_default_constructed_ValueTuple_does_not_throw()
+    {
+        // NewExpression.Constructor is null for a value type's parameterless "new T()" -- e.g. the C# compiler
+        // produces exactly this NewExpression shape for "() => new ValueTuple<int, int>()". Like the anonymous-type
+        // case, Members is also null here, so this must be checked before assuming a ValueTuple/Tuple always has a
+        // constructor to fold against (regression test for a null-Constructor dereference).
+        var newExpression = Expression.New(typeof(ValueTuple<int, int>));
+        Assert.Null(newExpression.Constructor);
+        Assert.Null(newExpression.Members);
+
+        var memberAccess = Expression.Field(newExpression, nameof(ValueTuple<int, int>.Item1));
+        var unrelatedOriginal = Expression.Parameter(typeof(int), "unused");
+        var visited = ReplacingExpressionVisitor.Replace(unrelatedOriginal, Expression.Constant(-1), memberAccess);
+
+        var resultMember = Assert.IsAssignableFrom<MemberExpression>(visited);
+        Assert.Equal(nameof(ValueTuple<int, int>.Item1), resultMember.Member.Name);
+    }
+
+    [Fact]
+    public void EFProperty_access_on_anonymous_type_under_conversion_folds_to_constructor_argument()
+    {
+        // Confirms the widened unwrap in the EF.Property path (added to support boxed ValueTuple instances) doesn't
+        // regress the pre-existing anonymous-type fold when an anonymous type instance happens to be wrapped in an
+        // (unnecessary, but legal) Convert-to-object node.
+        var parameter = Expression.Parameter(typeof(int), "k");
+
+        // Build an actual anonymous type via a lambda so NewExpression.Members is populated realistically.
+        Expression<Func<int, object>> anonFactory = k => new { Value = k };
+        var anonNew = (NewExpression)anonFactory.Body;
+        var boxedAnon = Expression.Convert(anonNew.Update([parameter]), typeof(object));
+
+        var efPropertyMethod = typeof(EF).GetMethod(nameof(EF.Property))!.MakeGenericMethod(typeof(int));
+        var efPropertyAccess = Expression.Call(efPropertyMethod, boxedAnon, Expression.Constant("Value"));
+
+        var result = ReplacingExpressionVisitor.Replace(parameter, Expression.Constant(42), efPropertyAccess);
+
+        Assert.Equal(Expression.Constant(42).ToString(), result.ToString());
+    }
+
+    [Fact]
+    public void Member_access_on_large_ValueTuple_including_Rest_folds_to_constructor_argument()
+    {
+        // Exercises the 8-arity ValueTuple (the "Rest"-nested form) to confirm the fixed item1..item7/rest
+        // parameter-name contract is honored uniformly, not just for the common small arities.
+        var parameters = Enumerable.Range(0, 7).Select(i => Expression.Parameter(typeof(int), $"p{i}")).ToArray();
+        var restParameter = Expression.Parameter(typeof(ValueTuple<int>), "rest");
+        var ctor = typeof(ValueTuple<int, int, int, int, int, int, int, ValueTuple<int>>).GetConstructors().Single();
+        var newExpression = Expression.New(
+            ctor, parameters[0], parameters[1], parameters[2], parameters[3], parameters[4], parameters[5],
+            parameters[6], restParameter);
+
+        var item7Access = Expression.Field(newExpression, "Item7");
+        var item7Result = ReplacingExpressionVisitor.Replace(parameters[6], Expression.Constant(42), item7Access);
+        Assert.Equal(Expression.Constant(42).ToString(), item7Result.ToString());
+
+        var restAccess = Expression.Field(newExpression, "Rest");
+        var restReplacement = Expression.New(typeof(ValueTuple<int>).GetConstructors().Single(), Expression.Constant(99));
+        var restResult = ReplacingExpressionVisitor.Replace(restParameter, restReplacement, restAccess);
+        Assert.Equal(restReplacement.ToString(), restResult.ToString());
+    }
+
+    [Fact]
+    public void Member_access_on_plain_constructor_bound_type_does_not_fold()
+    {
+        // The core assertion for the narrowed design: an ordinary (non-ValueTuple/Tuple) constructor-bound type
+        // must be left unfolded, even though its constructor parameter names conventionally match its property
+        // names -- because that correspondence isn't a guarantee for arbitrary user types (see TransformingDto).
+        var newExpression = Expression.New(
+            typeof(PositionalDto).GetConstructors().Single(),
+            Expression.Constant(1), Expression.Constant(2));
+
+        var memberAccess = Expression.Property(newExpression, nameof(PositionalDto.PickupStatusId));
+        var unrelatedOriginal = Expression.Parameter(typeof(int), "unused");
+        var visited = ReplacingExpressionVisitor.Replace(unrelatedOriginal, Expression.Constant(-1), memberAccess);
+
+        var resultMember = Assert.IsAssignableFrom<MemberExpression>(visited);
+        Assert.Equal(nameof(PositionalDto.PickupStatusId), resultMember.Member.Name);
+        Assert.Same(newExpression, resultMember.Expression);
+    }
+
+    [Fact]
+    public void Member_access_on_transforming_constructor_bound_type_does_not_fold_to_wrong_value()
+    {
+        // Concretely demonstrates the risk the narrowed design avoids: if this type WERE folded by name (as a
+        // general-purpose implementation might do), it would incorrectly return the raw constructor argument (41)
+        // instead of the real, transformed property value (42). Because it isn't ValueTuple/Tuple, it isn't folded
+        // at all, so this can't happen -- the member access is left in place and would be evaluated normally
+        // (or fail translation loudly), never silently returning the wrong data.
+        var newExpression = Expression.New(
+            typeof(TransformingDto).GetConstructors().Single(),
+            Expression.Constant(41));
+
+        var memberAccess = Expression.Property(newExpression, nameof(TransformingDto.Value));
+        var unrelatedOriginal = Expression.Parameter(typeof(int), "unused");
+        var visited = ReplacingExpressionVisitor.Replace(unrelatedOriginal, Expression.Constant(-1), memberAccess);
+
+        Assert.IsAssignableFrom<MemberExpression>(visited);
+        Assert.Equal(42, new TransformingDto(41).Value);
+    }
+}


### PR DESCRIPTION
Fixes translation failures when a later expression (e.g. a join key selector) accesses a member of a ValueTuple/Tuple projected earlier in the query. Restricted to these two BCL types since their constructor-to-member mapping is a closed, guaranteed contract; an earlier, broader design covering arbitrary constructor-bound types was scoped back after review because it could silently fold to the wrong value for a transforming constructor.

<details>
<summary>Full details</summary>

**Problem**

`ReplacingExpressionVisitor` folds a member access on a projected `NewExpression` back to its constructor argument using `NewExpression.Members`, which the C# compiler only populates for anonymous types. For every other type (including `ValueTuple`/`Tuple`), `Members` is null, so a query like a `GroupBy` producing a `ValueTuple` that's later joined on (`c.Item1`) failed to translate entirely.

**Fix**

- `GetConstructorParameterIndex` matches a member access to a constructor parameter by name, but only when the type is one of the 16 open generic `ValueTuple<...>`/`Tuple<...>` definitions (arities 1-8, including the `Rest`-nested 8-arity form). For every other type this returns null and the member access is left unfolded, same as before this fix existed.
- `VisitMethodCall`'s `EF.Property` path unwraps a boxing `Convert` node before checking for a `NewExpression`, since `EF.Property<T>`'s `object` parameter forces boxing for value-type instances (`ValueTuple`); this unwrap is now computed once and reused for the `MemberInit` check below it.
- Guards against `NewExpression.Constructor` being null, which happens for a value type's parameterless `new T()` (e.g. `new ValueTuple<int,int>()`) and would otherwise NRE.

**Why restricted to ValueTuple/Tuple**

Anonymous types, `ValueTuple`, and `Tuple` are the only types where the constructor-parameter-to-member correspondence can't be broken by user code: anonymous types are fully compiler-synthesized, and `ValueTuple`/`Tuple`'s constructors and `Item1..Item7`/`Rest` members are fixed BCL behavior. An ordinary class/record/struct's same-named property can legally be redeclared with a transforming initializer (e.g. `public string Name { get; } = name.Trim();`), which is indistinguishable from a safe passthrough via reflection alone -- a general by-convention name match risks silently returning the wrong value rather than failing loudly. This was verified empirically (a scratch repro showing identical `[CompilerGenerated]` metadata for both the safe and transforming cases) before narrowing the fix.

**Also fixed**

An unrelated, pre-existing copy-paste bug in
`NorthwindSelectQueryCosmosTest.Filtered_collection_projection_is_tracked`, which called the wrong base method.

**Tests**

New `ReplacingExpressionVisitorTest.cs` unit-tests the visitor directly: `ValueTuple`/`Tuple` member and `EF.Property` folding (including the 8-arity `Rest` case and the anonymous-type-under-Convert case), the null-`Constructor` regression, and two tests proving plain constructor-bound types are deliberately left unfolded.

</details>

