### PR TITLE
Make the nullability marker survive GroupBy-element to-one subquery lowering

### DIFF
--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -191,7 +191,23 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor : Que
                 return new ShapedQueryExpression(groupClonedSelectExpression, groupRebuiltShaperExpression);
 
             case ShapedQueryExpression shapedQueryExpression:
-                var clonedSelectExpression = ((SelectExpression)shapedQueryExpression.QueryExpression).Clone();
+                var subquerySourceSelectExpression = (SelectExpression)shapedQueryExpression.QueryExpression;
+
+                // #22517/#30915: unlike the GroupByShaperExpression case above, this non-grouping subquery clone does NOT
+                // carry non-entity nullability markers across. It is safe today because a non-grouping subquery is bound to
+                // completion -- its markers created and consumed by the projection binder in the same window -- before it is
+                // embedded, so no live marker ever reaches this clone (verified: this case is never hit with a live marker
+                // across the whole #30915 suite, whereas the grouping sibling is). Clone() deliberately drops markers (see the
+                // _nonEntityNullabilityMarkers field comment), so if a future change ever routed a live marker here it would be
+                // silently stranded and the whole-object null gate would regress to a throw. Assert the invariant so that
+                // regression surfaces loudly in Debug; the fix would be to route through the same marker-aware remap the
+                // grouping case uses (SelectExpression.RemapGroupingElementShaper).
+                Check.DebugAssert(
+                    !subquerySourceSelectExpression.HasNonEntityNullabilityMarkers,
+                    "Non-grouping subquery clone carries a live non-entity nullability marker; it would be stranded by Clone(). "
+                    + "Route it through a marker-aware remap as the GroupByShaperExpression case does.");
+
+                var clonedSelectExpression = subquerySourceSelectExpression.Clone();
                 return new ShapedQueryExpression(
                     clonedSelectExpression,
                     new QueryExpressionReplacingExpressionVisitor(shapedQueryExpression.QueryExpression, clonedSelectExpression)

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -174,12 +174,21 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor : Que
 
             case GroupByShaperExpression groupByShaperExpression:
                 var groupShapedQueryExpression = groupByShaperExpression.GroupingEnumerable;
-                var groupClonedSelectExpression = ((SelectExpression)groupShapedQueryExpression.QueryExpression).Clone();
-                return new ShapedQueryExpression(
-                    groupClonedSelectExpression,
-                    new QueryExpressionReplacingExpressionVisitor(
-                            groupShapedQueryExpression.QueryExpression, groupClonedSelectExpression)
-                        .Visit(groupShapedQueryExpression.ShaperExpression));
+                var groupSourceSelectExpression = (SelectExpression)groupShapedQueryExpression.QueryExpression;
+                var groupClonedSelectExpression = groupSourceSelectExpression.Clone();
+
+                // #22517/#30915: this clone is (re)translating a grouping-element subquery (e.g.
+                // `els.Select(...).FirstOrDefault()`), so any non-entity nullability marker recorded on the source
+                // grouping SelectExpression must be carried over the same way ApplyGrouping does it -- otherwise the
+                // marker is stranded on groupSourceSelectExpression, which nothing consults once this clone is the
+                // one actually translated, and the whole-object null gate never fires for this subquery.
+                // RemapGroupingElementShaper rebuilds the shaper and owns that transfer (fail-safe; see its comments).
+                // Note: groupSourceSelectExpression here is the clone ApplyGrouping already populated -- this is the
+                // second hop of the propagation, not the origin, so the marker binding resolves against it.
+                var groupRebuiltShaperExpression = groupSourceSelectExpression.RemapGroupingElementShaper(
+                    groupClonedSelectExpression, groupShapedQueryExpression.ShaperExpression);
+
+                return new ShapedQueryExpression(groupClonedSelectExpression, groupRebuiltShaperExpression);
 
             case ShapedQueryExpression shapedQueryExpression:
                 var clonedSelectExpression = ((SelectExpression)shapedQueryExpression.QueryExpression).Clone();

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.Helper.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.Helper.cs
@@ -128,6 +128,202 @@ public sealed partial class SelectExpression
             => _tracker.Record(node, (MemberInitExpression)base.VisitMemberInit(node));
     }
 
+    // #22517/#30915: all logic that reads or writes _nonEntityNullabilityMarkers is gathered here (the field itself
+    // lives with the other SelectExpression fields). The marker is transient build-time state that gates the whole-object
+    // projection of a non-entity from the nullable side of an outer join to null on no-match rows; see the
+    // _nonEntityNullabilityMarkers field comment for its lifecycle. AddJoin records/re-keys it, the grouping-element
+    // subquery lowering propagates it across a clone, and the projection binder consults it.
+    #region Non-entity nullability markers
+
+    // true when this SelectExpression currently carries any non-entity nullability marker. Used to assert the invariant
+    // that a non-grouping subquery clone never strands a live marker (Clone() deliberately drops markers).
+    internal bool HasNonEntityNullabilityMarkers
+        => _nonEntityNullabilityMarkers is { Count: > 0 };
+
+    // Rebuilds a grouping element's shaper against `clone` (a correlated-subquery clone of this SelectExpression) while
+    // carrying any recorded non-entity nullability marker across. Owns the whole protocol -- construct the remapper,
+    // propagate markers before visiting, visit, re-key after visiting -- so callers cannot get the ordering wrong.
+    // Internal infrastructure: only called within EFCore.Relational (ApplyGrouping and the grouping-element subquery
+    // translation in RelationalQueryableMethodTranslatingExpressionVisitor), so it is not part of the public surface.
+    internal Expression RemapGroupingElementShaper(SelectExpression clone, Expression shaperExpression)
+    {
+        var remapper = new GroupingElementShaperRemappingExpressionVisitor(this, clone);
+        PropagateNonEntityNullabilityMarkersTo(clone, remapper);
+        var rebuiltShaperExpression = remapper.Visit(shaperExpression);
+        clone.RekeyPropagatedNonEntityNullabilityMarkers(remapper);
+        return rebuiltShaperExpression;
+    }
+
+    private void PropagateNonEntityNullabilityMarkersTo(
+        SelectExpression clone,
+        GroupingElementShaperRemappingExpressionVisitor remapper)
+    {
+        // #22517/#30915: a grouping element's per-group correlated subquery is (re)bound against a clone of this
+        // SelectExpression -- once by ApplyGrouping (the clone captured in the RelationalGroupByShaperExpression's
+        // GroupingEnumerable), and again by RelationalQueryableMethodTranslatingExpressionVisitor when that clone is
+        // itself cloned to translate a grouping-element subquery (e.g. `els.Select(...).FirstOrDefault()`). Any
+        // non-entity nullability marker recorded on this SelectExpression (see _nonEntityNullabilityMarkers) needs
+        // to be propagated onto the clone -- with its marker binding rebound through the same visitor used to
+        // rebind the shaper's other ProjectionBindingExpressions -- otherwise the marker is stranded on an instance
+        // nothing consults after the clone is made, and the whole-object null gate never fires.
+        //
+        // This method only copies the entry onto the clone (still keyed by the original shaper node) with a rebound
+        // binding; re-keying onto the node the remapper rebuilds is done by the companion
+        // RekeyPropagatedNonEntityNullabilityMarkers, called after the shaper has been visited.
+        //
+        // Fail-safe: only propagate an entry whose marker binding is a ProjectionBindingExpression that actually
+        // resolves against this SelectExpression. If that check fails, skip the entry rather than copying a binding
+        // that would resolve incorrectly (or not at all) against the clone; the gate then simply does not fire for
+        // that entry and behavior degrades to the prior throw, never an incorrect result.
+        //
+        // This copies onto the clone and deliberately leaves this._nonEntityNullabilityMarkers intact (matching the
+        // AddJoin design): the source's stale keys are shaper nodes it no longer projects, so a lookup against the
+        // source cannot match them. Safe unless a future change re-visits the source's shaper against a rebuilt node.
+        if (_nonEntityNullabilityMarkers is null)
+        {
+            return;
+        }
+
+        foreach (var (oldNode, markerBinding) in _nonEntityNullabilityMarkers)
+        {
+            if (markerBinding is ProjectionBindingExpression { QueryExpression: var markerQuery }
+                && ReferenceEquals(markerQuery, this))
+            {
+                var reboundBinding = remapper.Visit(markerBinding);
+                (clone._nonEntityNullabilityMarkers ??=
+                    new Dictionary<Expression, Expression>(ReferenceEqualityComparer.Instance))[oldNode] = reboundBinding;
+            }
+        }
+    }
+
+    private void RekeyPropagatedNonEntityNullabilityMarkers(GroupingElementShaperRemappingExpressionVisitor remapper)
+    {
+        // Re-key any marker just propagated by PropagateNonEntityNullabilityMarkersTo (called on this
+        // SelectExpression, the target of the propagation) whose shaper node was itself rebuilt by the element
+        // remap -- this happens when the marker-bearing New/MemberInit node is nested inside the shaper root, e.g.
+        // as a constructor argument of an outer projection -- so TryGetNonEntityNullabilityMarker still finds it
+        // against its rebuilt identity.
+        //
+        // Unlike the AddJoin-branch re-key (see RekeyNonEntityNullabilityMarkersAfterOuterShaperRemap), this needs no
+        // binding-resolution guard: the marker binding stored on the clone was already validated and rebound by
+        // PropagateNonEntityNullabilityMarkersTo, so RemapNonEntityNullabilityMarker reuses it as-is. Do not add an
+        // AddJoin-style guard here -- it would be redundant, and its absence is intentional, not an oversight.
+        if (_nonEntityNullabilityMarkers is null)
+        {
+            return;
+        }
+
+        foreach (var oldNode in _nonEntityNullabilityMarkers.Keys.ToList())
+        {
+            if (remapper.RebuiltNodes.TryGetValue(oldNode, out var newNode))
+            {
+                RemapNonEntityNullabilityMarker(oldNode, newNode, _nonEntityNullabilityMarkers[oldNode]);
+            }
+        }
+    }
+
+    private void RekeyNonEntityNullabilityMarkersAfterOuterShaperRemap(
+        ProjectionMemberRemappingExpressionVisitor outerRemapper,
+        Dictionary<ProjectionMember, ProjectionMember> mapping)
+    {
+        // #30915: the outer remap in AddJoin rebuilds any New/MemberInit node whose projection bindings changed; a
+        // node previously recorded as a nullability-marker key is now a stale instance. Re-key each such marker
+        // onto its rebuilt node, re-binding the marker value through the same remap so it still resolves.
+        // Only the (outer client-eval == false) AddJoin branch is covered; the other AddJoin branches that remap the
+        // outer shaper are intentionally not re-keyed (no reachable repro). If one is ever hit with a live prior
+        // marker, the fail-safe holds: the gate simply does not fire and behavior falls back to the prior throw
+        // rather than producing an incorrect result. Tracked with the #30915 follow-ups.
+        if (_nonEntityNullabilityMarkers is null)
+        {
+            return;
+        }
+
+        foreach (var oldNode in _nonEntityNullabilityMarkers.Keys.ToList())
+        {
+            // Re-key only when the key node was rebuilt AND the marker binding still resolves through this
+            // remap. The marker column is not referenced by the shaper tree, so its projection member could in
+            // principle have been pruned from _projectionMapping while the key node survived; in that case
+            // skip the re-key rather than letting outerRemapper.Visit hit the throwing indexer
+            // (ProjectionMemberRemappingExpressionVisitor.VisitExtension). Skipping preserves the fail-safe:
+            // the gate does not fire and behavior degrades to the prior throw, never a KeyNotFoundException.
+            var existingMarkerBinding = _nonEntityNullabilityMarkers[oldNode];
+            if (outerRemapper.RebuiltNodes.TryGetValue(oldNode, out var newNode)
+                && existingMarkerBinding is ProjectionBindingExpression { ProjectionMember: { } markerMember }
+                && mapping.ContainsKey(markerMember))
+            {
+                var reboundBinding = outerRemapper.Visit(existingMarkerBinding);
+                RemapNonEntityNullabilityMarker(oldNode, newNode, reboundBinding);
+            }
+        }
+    }
+
+    private void TryRecordNonEntityNullabilityMarker(Expression innerShaper, Expression? markerBinding)
+    {
+        // #30915: record the finalized inner-shaper node (post remap and post entity-nullable marking) against its remapped
+        // marker binding, so the projection binder can later gate the whole inner object to null on no-match rows. Keyed on the
+        // node instance because the binder receives this exact New/MemberInit node (member-folds return arguments by reference;
+        // see ReplacingExpressionVisitor.VisitMember), and the inner shaper is left unwrapped so those folds keep working.
+        if (markerBinding is not null && innerShaper is NewExpression or MemberInitExpression)
+        {
+            (_nonEntityNullabilityMarkers ??= new Dictionary<Expression, Expression>(ReferenceEqualityComparer.Instance))[innerShaper] =
+                markerBinding;
+        }
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public bool TryGetNonEntityNullabilityMarker(Expression shaper, [NotNullWhen(true)] out Expression? markerBinding)
+    {
+        // #30915: looks up the nullability marker recorded for a non-entity inner shaper of an outer join (see
+        // _nonEntityNullabilityMarkers). The projection binder consults this when projecting the whole inner object, to gate it to
+        // null on no-match rows.
+        if (_nonEntityNullabilityMarkers is not null
+            && _nonEntityNullabilityMarkers.TryGetValue(shaper, out markerBinding))
+        {
+            return true;
+        }
+
+        markerBinding = null;
+        return false;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public void RemapNonEntityNullabilityMarker(Expression oldShaper, Expression newShaper, Expression newMarkerBinding)
+    {
+        // #30915: the recorded non-entity inner-shaper node is keyed by reference, and its marker binding is a projection binding
+        // valid only against the projection representation that existed when it was recorded. The TransparentIdentifier-rooted
+        // projection-binding pass (RelationalProjectionBindingExpressionVisitor) rebuilds the inner node into the final projection
+        // representation and rebinds its columns, leaving both the old node reference and the old marker binding stale. That pass
+        // calls this to re-key the recorded entry onto the rebuilt node with a freshly-rebound marker, so the *final* whole-object
+        // projection (a later pass over the same SelectExpression) still finds a valid node and marker binding to gate on.
+        if (_nonEntityNullabilityMarkers is not null
+            && _nonEntityNullabilityMarkers.ContainsKey(oldShaper))
+        {
+            _nonEntityNullabilityMarkers[newShaper] = newMarkerBinding;
+
+            // Guard the (not-currently-reachable) self-reference case: if the rebuilt node is reference-equal to the old node,
+            // the assignment above already updated the single entry in place; removing oldShaper would then delete it. Only drop
+            // the stale entry when the node identity actually changed.
+            if (!ReferenceEquals(oldShaper, newShaper))
+            {
+                _nonEntityNullabilityMarkers.Remove(oldShaper);
+            }
+        }
+    }
+
+    #endregion
+
     private sealed class ProjectionMemberToIndexConvertingExpressionVisitor(
         SelectExpression queryExpression,
         Dictionary<ProjectionMember, int> projectionMemberMappings)

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.Helper.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.Helper.cs
@@ -49,22 +49,42 @@ public sealed partial class SelectExpression
         }
     }
 
+    // #30915: shared state for a remapping visitor that needs to track which New/MemberInit shaper nodes it rebuilt
+    // (old instance → new instance). Callers re-key any _nonEntityNullabilityMarkers entry whose key was one of the
+    // rebuilt nodes, so a previously-recorded marker key does not go stale when a remap creates a fresh node instance.
+    // Composed into visitors (rather than shared via a base class) because they derive from different bases. Lazily
+    // allocated since most remaps rebuild nothing and most callers never read it.
+    private sealed class RebuiltNodeTracker
+    {
+        private static readonly IReadOnlyDictionary<Expression, Expression> Empty
+            = new Dictionary<Expression, Expression>(ReferenceEqualityComparer.Instance);
+
+        private Dictionary<Expression, Expression>? _nodes;
+
+        public IReadOnlyDictionary<Expression, Expression> Nodes
+            => _nodes ?? Empty;
+
+        public T Record<T>(T original, T visited)
+            where T : Expression
+        {
+            if (!ReferenceEquals(visited, original))
+            {
+                (_nodes ??= new Dictionary<Expression, Expression>(ReferenceEqualityComparer.Instance))[original] = visited;
+            }
+
+            return visited;
+        }
+    }
+
     private sealed class ProjectionMemberRemappingExpressionVisitor(
         SelectExpression queryExpression,
         Dictionary<ProjectionMember, ProjectionMember> projectionMemberMappings)
         : ExpressionVisitor
     {
-        // #30915: tracks New/MemberInit nodes rebuilt by this visitor (old instance → new instance). Used by the caller
-        // to re-key any _nonEntityNullabilityMarkers entries whose key was one of the rebuilt nodes, so that a previously-
-        // recorded marker key does not go stale when an outer-shaper remap creates a fresh node instance. Lazily
-        // allocated since most remaps rebuild nothing and most callers never read it.
-        private static readonly IReadOnlyDictionary<Expression, Expression> EmptyRebuiltNodes
-            = new Dictionary<Expression, Expression>(ReferenceEqualityComparer.Instance);
-
-        private Dictionary<Expression, Expression>? _rebuiltNodes;
+        private readonly RebuiltNodeTracker _tracker = new();
 
         public IReadOnlyDictionary<Expression, Expression> RebuiltNodes
-            => _rebuiltNodes ?? EmptyRebuiltNodes;
+            => _tracker.Nodes;
 
         protected override Expression VisitExtension(Expression expression)
         {
@@ -84,26 +104,28 @@ public sealed partial class SelectExpression
         }
 
         protected override Expression VisitNew(NewExpression node)
-        {
-            var visited = (NewExpression)base.VisitNew(node);
-            if (!ReferenceEquals(visited, node))
-            {
-                (_rebuiltNodes ??= new Dictionary<Expression, Expression>(ReferenceEqualityComparer.Instance))[node] = visited;
-            }
-
-            return visited;
-        }
+            => _tracker.Record(node, (NewExpression)base.VisitNew(node));
 
         protected override Expression VisitMemberInit(MemberInitExpression node)
-        {
-            var visited = (MemberInitExpression)base.VisitMemberInit(node);
-            if (!ReferenceEquals(visited, node))
-            {
-                (_rebuiltNodes ??= new Dictionary<Expression, Expression>(ReferenceEqualityComparer.Instance))[node] = visited;
-            }
+            => _tracker.Record(node, (MemberInitExpression)base.VisitMemberInit(node));
+    }
 
-            return visited;
-        }
+    // #22517/#30915: rebuilds a grouping element's shaper against a correlated-subquery clone, tracking any
+    // New/MemberInit nodes it rebuilds (old instance -> new instance) via RebuiltNodes. Used only through
+    // SelectExpression.RemapGroupingElementShaper, which owns the propagate/visit/re-key protocol.
+    private sealed class GroupingElementShaperRemappingExpressionVisitor(SelectExpression oldQuery, SelectExpression newQuery)
+        : QueryExpressionReplacingExpressionVisitor(oldQuery, newQuery)
+    {
+        private readonly RebuiltNodeTracker _tracker = new();
+
+        public IReadOnlyDictionary<Expression, Expression> RebuiltNodes
+            => _tracker.Nodes;
+
+        protected override Expression VisitNew(NewExpression node)
+            => _tracker.Record(node, (NewExpression)base.VisitNew(node));
+
+        protected override Expression VisitMemberInit(MemberInitExpression node)
+            => _tracker.Record(node, (MemberInitExpression)base.VisitMemberInit(node));
     }
 
     private sealed class ProjectionMemberToIndexConvertingExpressionVisitor(

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -1892,12 +1892,15 @@ public sealed partial class SelectExpression : TableExpressionBase
             }
         }
 
+        // #22517/#30915: the per-group correlated subquery shaper is bound against clonedSelectExpression, not
+        // against this SelectExpression, so any non-entity nullability marker recorded here must be carried over
+        // onto the clone; RemapGroupingElementShaper rebuilds the shaper and owns that transfer.
+        var rebuiltShaperExpression = RemapGroupingElementShaper(clonedSelectExpression, shaperExpression);
+
         return new RelationalGroupByShaperExpression(
             keySelector,
             shaperExpression,
-            new ShapedQueryExpression(
-                clonedSelectExpression,
-                new QueryExpressionReplacingExpressionVisitor(this, clonedSelectExpression).Visit(shaperExpression)));
+            new ShapedQueryExpression(clonedSelectExpression, rebuiltShaperExpression));
     }
 
     private static void PopulateGroupByTerms(
@@ -3187,6 +3190,95 @@ public sealed partial class SelectExpression : TableExpressionBase
 
         innerSelect._projectionMapping[NullabilityMarkerProjectionMember] = marker;
         return new ProjectionBindingExpression(innerSelect, NullabilityMarkerProjectionMember, typeof(int?));
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public Expression RemapGroupingElementShaper(SelectExpression clone, Expression shaperExpression)
+    {
+        // #22517/#30915: rebuilds a grouping element's shaper against `clone` (a correlated-subquery clone of this
+        // SelectExpression) while carrying any recorded non-entity nullability marker across. Owns the whole
+        // protocol -- construct the remapper, propagate markers before visiting, visit, re-key after visiting -- so
+        // callers cannot get the ordering wrong. Used by ApplyGrouping and by the grouping-element subquery
+        // translation in RelationalQueryableMethodTranslatingExpressionVisitor.
+        var remapper = new GroupingElementShaperRemappingExpressionVisitor(this, clone);
+        PropagateNonEntityNullabilityMarkersTo(clone, remapper);
+        var rebuiltShaperExpression = remapper.Visit(shaperExpression);
+        clone.RekeyPropagatedNonEntityNullabilityMarkers(remapper);
+        return rebuiltShaperExpression;
+    }
+
+    private void PropagateNonEntityNullabilityMarkersTo(
+        SelectExpression clone,
+        GroupingElementShaperRemappingExpressionVisitor remapper)
+    {
+        // #22517/#30915: a grouping element's per-group correlated subquery is (re)bound against a clone of this
+        // SelectExpression -- once by ApplyGrouping (the clone captured in the RelationalGroupByShaperExpression's
+        // GroupingEnumerable), and again by RelationalQueryableMethodTranslatingExpressionVisitor when that clone is
+        // itself cloned to translate a grouping-element subquery (e.g. `els.Select(...).FirstOrDefault()`). Any
+        // non-entity nullability marker recorded on this SelectExpression (see _nonEntityNullabilityMarkers) needs
+        // to be propagated onto the clone -- with its marker binding rebound through the same visitor used to
+        // rebind the shaper's other ProjectionBindingExpressions -- otherwise the marker is stranded on an instance
+        // nothing consults after the clone is made, and the whole-object null gate never fires.
+        //
+        // This method only copies the entry onto the clone (still keyed by the original shaper node) with a rebound
+        // binding; re-keying onto the node the remapper rebuilds is done by the companion
+        // RekeyPropagatedNonEntityNullabilityMarkers, called after the shaper has been visited.
+        //
+        // Fail-safe: only propagate an entry whose marker binding is a ProjectionBindingExpression that actually
+        // resolves against this SelectExpression. If that check fails, skip the entry rather than copying a binding
+        // that would resolve incorrectly (or not at all) against the clone; the gate then simply does not fire for
+        // that entry and behavior degrades to the prior throw, never an incorrect result.
+        //
+        // This copies onto the clone and deliberately leaves this._nonEntityNullabilityMarkers intact (matching the
+        // AddJoin design): the source's stale keys are shaper nodes it no longer projects, so a lookup against the
+        // source cannot match them. Safe unless a future change re-visits the source's shaper against a rebuilt node.
+        if (_nonEntityNullabilityMarkers is null)
+        {
+            return;
+        }
+
+        foreach (var (oldNode, markerBinding) in _nonEntityNullabilityMarkers)
+        {
+            if (markerBinding is ProjectionBindingExpression { QueryExpression: var markerQuery }
+                && ReferenceEquals(markerQuery, this))
+            {
+                var reboundBinding = remapper.Visit(markerBinding);
+                (clone._nonEntityNullabilityMarkers ??=
+                    new Dictionary<Expression, Expression>(ReferenceEqualityComparer.Instance))[oldNode] = reboundBinding;
+            }
+        }
+    }
+
+    private void RekeyPropagatedNonEntityNullabilityMarkers(GroupingElementShaperRemappingExpressionVisitor remapper)
+    {
+        // Re-key any marker just propagated by PropagateNonEntityNullabilityMarkersTo (called on this
+        // SelectExpression, the target of the propagation) whose shaper node was itself rebuilt by the element
+        // remap -- this happens when the marker-bearing New/MemberInit node is nested inside the shaper root, e.g.
+        // as a constructor argument of an outer projection -- so TryGetNonEntityNullabilityMarker still finds it
+        // against its rebuilt identity.
+        //
+        // Unlike the AddJoin-branch re-key (see the loop guarded by mapping.ContainsKey in AddJoin), this needs no
+        // binding-resolution guard: the marker binding stored on the clone was already validated and rebound by
+        // PropagateNonEntityNullabilityMarkersTo, so RemapNonEntityNullabilityMarker reuses it as-is. Do not add an
+        // AddJoin-style guard here -- it would be redundant, and its absence is intentional, not an oversight.
+        if (_nonEntityNullabilityMarkers is null)
+        {
+            return;
+        }
+
+        foreach (var oldNode in _nonEntityNullabilityMarkers.Keys.ToList())
+        {
+            if (remapper.RebuiltNodes.TryGetValue(oldNode, out var newNode))
+            {
+                RemapNonEntityNullabilityMarker(oldNode, newNode, _nonEntityNullabilityMarkers[oldNode]);
+            }
+        }
     }
 
     /// <summary>

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -3061,33 +3061,9 @@ public sealed partial class SelectExpression : TableExpressionBase
                 var outerRemapper = new ProjectionMemberRemappingExpressionVisitor(this, mapping);
                 outerShaper = outerRemapper.Visit(outerShaper);
 
-                // #30915: the outer remap above rebuilds any New/MemberInit node whose projection bindings changed; a
-                // node previously recorded as a nullability-marker key is now a stale instance. Re-key each such marker
-                // onto its rebuilt node, re-binding the marker value through the same remap so it still resolves.
-                // Only this (outer client-eval == false) branch is covered; the other AddJoin branches that remap the
-                // outer shaper are intentionally not re-keyed (no reachable repro). If one is ever hit with a live prior
-                // marker, the fail-safe holds: the gate simply does not fire and behavior falls back to the prior throw
-                // rather than producing an incorrect result. Tracked with the #30915 follow-ups.
-                if (_nonEntityNullabilityMarkers is not null)
-                {
-                    foreach (var oldNode in _nonEntityNullabilityMarkers.Keys.ToList())
-                    {
-                        // Re-key only when the key node was rebuilt AND the marker binding still resolves through this
-                        // remap. The marker column is not referenced by the shaper tree, so its projection member could in
-                        // principle have been pruned from _projectionMapping while the key node survived; in that case
-                        // skip the re-key rather than letting outerRemapper.Visit hit the throwing indexer
-                        // (ProjectionMemberRemappingExpressionVisitor.VisitExtension). Skipping preserves the fail-safe:
-                        // the gate does not fire and behavior degrades to the prior throw, never a KeyNotFoundException.
-                        var existingMarkerBinding = _nonEntityNullabilityMarkers[oldNode];
-                        if (outerRemapper.RebuiltNodes.TryGetValue(oldNode, out var newNode)
-                            && existingMarkerBinding is ProjectionBindingExpression { ProjectionMember: { } markerMember }
-                            && mapping.ContainsKey(markerMember))
-                        {
-                            var reboundBinding = outerRemapper.Visit(existingMarkerBinding);
-                            RemapNonEntityNullabilityMarker(oldNode, newNode, reboundBinding);
-                        }
-                    }
-                }
+                // #30915: the outer remap above may rebuild New/MemberInit nodes recorded as nullability-marker keys;
+                // re-key each such marker onto its rebuilt node. See the method for the full rationale and fail-safe.
+                RekeyNonEntityNullabilityMarkersAfterOuterShaperRemap(outerRemapper, mapping);
 
                 mapping.Clear();
 
@@ -3116,15 +3092,7 @@ public sealed partial class SelectExpression : TableExpressionBase
             innerShaper = new EntityShaperNullableMarkingExpressionVisitor().Visit(innerShaper);
         }
 
-        // #30915: record the finalized inner-shaper node (post remap and post entity-nullable marking) against its remapped
-        // marker binding, so the projection binder can later gate the whole inner object to null on no-match rows. Keyed on the
-        // node instance because the binder receives this exact New/MemberInit node (member-folds return arguments by reference;
-        // see ReplacingExpressionVisitor.VisitMember), and the inner shaper is left unwrapped so those folds keep working.
-        if (markerBinding is not null && innerShaper is NewExpression or MemberInitExpression)
-        {
-            (_nonEntityNullabilityMarkers ??= new Dictionary<Expression, Expression>(ReferenceEqualityComparer.Instance))[innerShaper] =
-                markerBinding;
-        }
+        TryRecordNonEntityNullabilityMarker(innerShaper, markerBinding);
 
         return New(
             transparentIdentifierType.GetTypeInfo().DeclaredConstructors.Single(),
@@ -3190,147 +3158,6 @@ public sealed partial class SelectExpression : TableExpressionBase
 
         innerSelect._projectionMapping[NullabilityMarkerProjectionMember] = marker;
         return new ProjectionBindingExpression(innerSelect, NullabilityMarkerProjectionMember, typeof(int?));
-    }
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    [EntityFrameworkInternal]
-    public Expression RemapGroupingElementShaper(SelectExpression clone, Expression shaperExpression)
-    {
-        // #22517/#30915: rebuilds a grouping element's shaper against `clone` (a correlated-subquery clone of this
-        // SelectExpression) while carrying any recorded non-entity nullability marker across. Owns the whole
-        // protocol -- construct the remapper, propagate markers before visiting, visit, re-key after visiting -- so
-        // callers cannot get the ordering wrong. Used by ApplyGrouping and by the grouping-element subquery
-        // translation in RelationalQueryableMethodTranslatingExpressionVisitor.
-        var remapper = new GroupingElementShaperRemappingExpressionVisitor(this, clone);
-        PropagateNonEntityNullabilityMarkersTo(clone, remapper);
-        var rebuiltShaperExpression = remapper.Visit(shaperExpression);
-        clone.RekeyPropagatedNonEntityNullabilityMarkers(remapper);
-        return rebuiltShaperExpression;
-    }
-
-    private void PropagateNonEntityNullabilityMarkersTo(
-        SelectExpression clone,
-        GroupingElementShaperRemappingExpressionVisitor remapper)
-    {
-        // #22517/#30915: a grouping element's per-group correlated subquery is (re)bound against a clone of this
-        // SelectExpression -- once by ApplyGrouping (the clone captured in the RelationalGroupByShaperExpression's
-        // GroupingEnumerable), and again by RelationalQueryableMethodTranslatingExpressionVisitor when that clone is
-        // itself cloned to translate a grouping-element subquery (e.g. `els.Select(...).FirstOrDefault()`). Any
-        // non-entity nullability marker recorded on this SelectExpression (see _nonEntityNullabilityMarkers) needs
-        // to be propagated onto the clone -- with its marker binding rebound through the same visitor used to
-        // rebind the shaper's other ProjectionBindingExpressions -- otherwise the marker is stranded on an instance
-        // nothing consults after the clone is made, and the whole-object null gate never fires.
-        //
-        // This method only copies the entry onto the clone (still keyed by the original shaper node) with a rebound
-        // binding; re-keying onto the node the remapper rebuilds is done by the companion
-        // RekeyPropagatedNonEntityNullabilityMarkers, called after the shaper has been visited.
-        //
-        // Fail-safe: only propagate an entry whose marker binding is a ProjectionBindingExpression that actually
-        // resolves against this SelectExpression. If that check fails, skip the entry rather than copying a binding
-        // that would resolve incorrectly (or not at all) against the clone; the gate then simply does not fire for
-        // that entry and behavior degrades to the prior throw, never an incorrect result.
-        //
-        // This copies onto the clone and deliberately leaves this._nonEntityNullabilityMarkers intact (matching the
-        // AddJoin design): the source's stale keys are shaper nodes it no longer projects, so a lookup against the
-        // source cannot match them. Safe unless a future change re-visits the source's shaper against a rebuilt node.
-        if (_nonEntityNullabilityMarkers is null)
-        {
-            return;
-        }
-
-        foreach (var (oldNode, markerBinding) in _nonEntityNullabilityMarkers)
-        {
-            if (markerBinding is ProjectionBindingExpression { QueryExpression: var markerQuery }
-                && ReferenceEquals(markerQuery, this))
-            {
-                var reboundBinding = remapper.Visit(markerBinding);
-                (clone._nonEntityNullabilityMarkers ??=
-                    new Dictionary<Expression, Expression>(ReferenceEqualityComparer.Instance))[oldNode] = reboundBinding;
-            }
-        }
-    }
-
-    private void RekeyPropagatedNonEntityNullabilityMarkers(GroupingElementShaperRemappingExpressionVisitor remapper)
-    {
-        // Re-key any marker just propagated by PropagateNonEntityNullabilityMarkersTo (called on this
-        // SelectExpression, the target of the propagation) whose shaper node was itself rebuilt by the element
-        // remap -- this happens when the marker-bearing New/MemberInit node is nested inside the shaper root, e.g.
-        // as a constructor argument of an outer projection -- so TryGetNonEntityNullabilityMarker still finds it
-        // against its rebuilt identity.
-        //
-        // Unlike the AddJoin-branch re-key (see the loop guarded by mapping.ContainsKey in AddJoin), this needs no
-        // binding-resolution guard: the marker binding stored on the clone was already validated and rebound by
-        // PropagateNonEntityNullabilityMarkersTo, so RemapNonEntityNullabilityMarker reuses it as-is. Do not add an
-        // AddJoin-style guard here -- it would be redundant, and its absence is intentional, not an oversight.
-        if (_nonEntityNullabilityMarkers is null)
-        {
-            return;
-        }
-
-        foreach (var oldNode in _nonEntityNullabilityMarkers.Keys.ToList())
-        {
-            if (remapper.RebuiltNodes.TryGetValue(oldNode, out var newNode))
-            {
-                RemapNonEntityNullabilityMarker(oldNode, newNode, _nonEntityNullabilityMarkers[oldNode]);
-            }
-        }
-    }
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    [EntityFrameworkInternal]
-    public bool TryGetNonEntityNullabilityMarker(Expression shaper, [NotNullWhen(true)] out Expression? markerBinding)
-    {
-        // #30915: looks up the nullability marker recorded for a non-entity inner shaper of an outer join (see
-        // _nonEntityNullabilityMarkers). The projection binder consults this when projecting the whole inner object, to gate it to
-        // null on no-match rows.
-        if (_nonEntityNullabilityMarkers is not null
-            && _nonEntityNullabilityMarkers.TryGetValue(shaper, out markerBinding))
-        {
-            return true;
-        }
-
-        markerBinding = null;
-        return false;
-    }
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    [EntityFrameworkInternal]
-    public void RemapNonEntityNullabilityMarker(Expression oldShaper, Expression newShaper, Expression newMarkerBinding)
-    {
-        // #30915: the recorded non-entity inner-shaper node is keyed by reference, and its marker binding is a projection binding
-        // valid only against the projection representation that existed when it was recorded. The TransparentIdentifier-rooted
-        // projection-binding pass (RelationalProjectionBindingExpressionVisitor) rebuilds the inner node into the final projection
-        // representation and rebinds its columns, leaving both the old node reference and the old marker binding stale. That pass
-        // calls this to re-key the recorded entry onto the rebuilt node with a freshly-rebound marker, so the *final* whole-object
-        // projection (a later pass over the same SelectExpression) still finds a valid node and marker binding to gate on.
-        if (_nonEntityNullabilityMarkers is not null
-            && _nonEntityNullabilityMarkers.ContainsKey(oldShaper))
-        {
-            _nonEntityNullabilityMarkers[newShaper] = newMarkerBinding;
-
-            // Guard the (not-currently-reachable) self-reference case: if the rebuilt node is reference-equal to the old node,
-            // the assignment above already updated the single entry in place; removing oldShaper would then delete it. Only drop
-            // the stale entry when the node identity actually changed.
-            if (!ReferenceEquals(oldShaper, newShaper))
-            {
-                _nonEntityNullabilityMarkers.Remove(oldShaper);
-            }
-        }
     }
 
     private void AddJoin(

--- a/test/EFCore.Relational.Specification.Tests/Query/AdHocMiscellaneousQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/AdHocMiscellaneousQueryRelationalTestBase.cs
@@ -418,15 +418,17 @@ namespace Microsoft.EntityFrameworkCore.Query
         //   for a MemberInit-bound value type, a zeroed default(T) -- matching LINQ-to-Objects
         //   DefaultIfEmpty semantics for a value-type sequence, which never yields a true null) on a
         //   no-match (a synthetic "marker" column is added inside the LEFT JOIN subquery so the shaper can
-        //   distinguish a no-match row from a matched row whose members happen to be null).
+        //   distinguish a no-match row from a matched row whose members happen to be null). A second join
+        //   after the DefaultIfEmpty, and GroupBy applied after the left join then reduced via a to-one
+        //   subquery / FirstOrDefault, also correctly materialize the whole non-entity object as null on a
+        //   no-match (the marker survives the shaper rebuild across the subsequent join / grouping).
         // DEFERRED (still failing, tracked as #30915 follow-ups; these tests assert the throw /
         //   translation failure): constructor-bound (read-only) reference-type DTO and positional record
         //   struct (fail to translate: ReplacingExpressionVisitor's constructor-parameter fold is
         //   deliberately restricted to ValueTuple/Tuple -- see ValueTuple_whole_object_from_nullable_side --
         //   since only those BCL types have a closed, guaranteed constructor-to-property contract; an
         //   arbitrary named type's "matching name" convention can't be verified and could silently fold to
-        //   the wrong value for a transforming constructor); GroupBy-after-join and a second join after
-        //   the DefaultIfEmpty (the shaper rebuild loses the marker); plain inner with no aggregate / no
+        //   the wrong value for a transforming constructor); plain inner with no aggregate / no
         //   pushdown; Union and other set operations over the projection; and server-side OrderBy/Where
         //   null-checks against the whole non-entity projection.
 
@@ -778,9 +780,143 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .GroupBy(e => e.s.PickupStatusId, (key, els) => new { key, anyInfo = els.Select(e => e.countInfo).FirstOrDefault() })
                 .OrderBy(e => e.key);
 
-            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => query.ToListAsync());
-            Assert.Contains("Nullable object must have a value", ex.Message);
-            // #30915 TODO: currently throws on base; flip to assert results if/when fixed.
+            var result = await query.ToListAsync();
+
+            Assert.Equal(3, result.Count);
+
+            // status 1 -> matched, Count 2
+            Assert.Equal(1, result[0].key);
+            Assert.NotNull(result[0].anyInfo);
+            Assert.Equal(1, result[0].anyInfo.pickupStatusId);
+            Assert.Equal(2, result[0].anyInfo.Count);
+
+            // status 2 -> no match on the left join; whole non-entity object is null after grouping
+            Assert.Equal(2, result[1].key);
+            Assert.Null(result[1].anyInfo);
+
+            // status 3 -> matched, Count 1
+            Assert.Equal(3, result[2].key);
+            Assert.NotNull(result[2].anyInfo);
+            Assert.Equal(3, result[2].anyInfo.pickupStatusId);
+            Assert.Equal(1, result[2].anyInfo.Count);
+        }
+
+        [Fact]
+        public virtual async Task GroupBy_after_join_then_whole_object_nested_in_wrapper()
+        {
+            var contextFactory = await InitializeNonSharedTest<Context30915>(seed: Seed30915);
+            using var context = contextFactory.CreateDbContext();
+
+            var categories = context.Requests
+                .GroupBy(r => r.PickupStatusId, (k, els) => new { pickupStatusId = k, Count = els.Count() });
+
+            var query = (from s in context.Statuses
+                         join c in categories on s.PickupStatusId equals c.pickupStatusId into g
+                         from countInfo in g.DefaultIfEmpty()
+                         select new { s, countInfo })
+                .GroupBy(
+                    e => e.s.PickupStatusId,
+                    (key, els) => new { key, wrapper = new { anyInfo = els.Select(e => e.countInfo).FirstOrDefault() } })
+                .OrderBy(e => e.key);
+
+            var result = await query.ToListAsync();
+
+            Assert.Equal(3, result.Count);
+
+            Assert.Equal(1, result[0].key);
+            Assert.NotNull(result[0].wrapper);
+            Assert.NotNull(result[0].wrapper.anyInfo);
+            Assert.Equal(2, result[0].wrapper.anyInfo.Count);
+
+            Assert.Equal(2, result[1].key);
+            Assert.NotNull(result[1].wrapper);
+            Assert.Null(result[1].wrapper.anyInfo);
+
+            Assert.Equal(3, result[2].key);
+            Assert.NotNull(result[2].wrapper);
+            Assert.NotNull(result[2].wrapper.anyInfo);
+            Assert.Equal(1, result[2].wrapper.anyInfo.Count);
+        }
+
+        [Fact]
+        public virtual async Task GroupBy_after_join_then_whole_object_dto_memberinit()
+        {
+            // Same GroupBy-after-join to-one lowering as GroupBy_after_join_then_whole_object, but the whole
+            // object is a MemberInit-bound DTO (CountDto30915) rather than an anonymous New -- this exercises
+            // the VisitMemberInit re-key path in GroupingElementShaperRemappingExpressionVisitor, which the
+            // anonymous-type tests never reach (they are New-only).
+            var contextFactory = await InitializeNonSharedTest<Context30915>(seed: Seed30915);
+            using var context = contextFactory.CreateDbContext();
+
+            var categories = context.Requests
+                .GroupBy(r => r.PickupStatusId, (k, els) => new Context30915.CountDto30915 { PickupStatusId = k, Count = els.Count() });
+
+            var query = (from s in context.Statuses
+                         join c in categories on s.PickupStatusId equals c.PickupStatusId into g
+                         from countInfo in g.DefaultIfEmpty()
+                         select new { s, countInfo })
+                .GroupBy(e => e.s.PickupStatusId, (key, els) => new { key, anyInfo = els.Select(e => e.countInfo).FirstOrDefault() })
+                .OrderBy(e => e.key);
+
+            var result = await query.ToListAsync();
+
+            Assert.Equal(3, result.Count);
+
+            // status 1 -> matched, Count 2
+            Assert.Equal(1, result[0].key);
+            Assert.NotNull(result[0].anyInfo);
+            Assert.Equal(1, result[0].anyInfo.PickupStatusId);
+            Assert.Equal(2, result[0].anyInfo.Count);
+
+            // status 2 -> no match on the left join; whole DTO object is null after grouping
+            Assert.Equal(2, result[1].key);
+            Assert.Null(result[1].anyInfo);
+
+            // status 3 -> matched, Count 1
+            Assert.Equal(3, result[2].key);
+            Assert.NotNull(result[2].anyInfo);
+            Assert.Equal(3, result[2].anyInfo.PickupStatusId);
+            Assert.Equal(1, result[2].anyInfo.Count);
+        }
+
+        [Fact]
+        public virtual async Task GroupBy_after_join_then_whole_object_struct()
+        {
+            // MemberInit-bound value type (CountStruct30915) reduced through the GroupBy-after-join to-one
+            // lowering. A value-type sequence's FirstOrDefault never yields a true null, so the no-match group
+            // yields default(CountStruct30915) (zeroed fields), mirroring LINQ-to-Objects DefaultIfEmpty
+            // semantics -- same as the direct Struct_whole_object_LeftJoin case.
+            var contextFactory = await InitializeNonSharedTest<Context30915>(seed: Seed30915);
+            using var context = contextFactory.CreateDbContext();
+
+            var categories = context.Requests
+                .GroupBy(r => r.PickupStatusId, (k, els) => new Context30915.CountStruct30915 { PickupStatusId = k, Count = els.Count() });
+
+            var query = (from s in context.Statuses
+                         join c in categories on s.PickupStatusId equals c.PickupStatusId into g
+                         from countInfo in g.DefaultIfEmpty()
+                         select new { s, countInfo })
+                .GroupBy(e => e.s.PickupStatusId, (key, els) => new { key, anyInfo = els.Select(e => e.countInfo).FirstOrDefault() })
+                .OrderBy(e => e.key);
+
+            var result = await query.ToListAsync();
+
+            Assert.Equal(3, result.Count);
+
+            // status 1 -> matched, Count 2
+            Assert.Equal(1, result[0].key);
+            Assert.Equal(1, result[0].anyInfo.PickupStatusId);
+            Assert.Equal(2, result[0].anyInfo.Count);
+
+            // status 2 -> no match; whole struct defaults to zeroed fields (value-type DefaultIfEmpty semantics)
+            Assert.Equal(2, result[1].key);
+            Assert.Equal(0, result[1].anyInfo.PickupStatusId);
+            Assert.Equal(0, result[1].anyInfo.Count);
+
+            // status 3 -> matched, Count 1
+            Assert.Equal(3, result[2].key);
+            Assert.Equal(3, result[2].anyInfo.PickupStatusId);
+            Assert.Equal(1, result[2].anyInfo.Count);
         }
 
         [Fact]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocMiscellaneousQuerySqlServerTest.cs
@@ -3205,40 +3205,6 @@ ORDER BY [s].[PickupStatusId]
 """);
     }
 
-    public override async Task GroupBy_after_join_then_whole_object()
-    {
-        await base.GroupBy_after_join_then_whole_object();
-
-        AssertSql(
-            """
-SELECT [s1].[PickupStatusId], [s3].[pickupStatusId], [s3].[Count], [s3].[c]
-FROM (
-    SELECT [s].[PickupStatusId]
-    FROM [Statuses] AS [s]
-    LEFT JOIN (
-        SELECT [r].[PickupStatusId] AS [pickupStatusId]
-        FROM [Requests] AS [r]
-        GROUP BY [r].[PickupStatusId]
-    ) AS [r0] ON [s].[PickupStatusId] = [r0].[pickupStatusId]
-    GROUP BY [s].[PickupStatusId]
-) AS [s1]
-LEFT JOIN (
-    SELECT [s2].[pickupStatusId], [s2].[Count], [s2].[c], [s2].[PickupStatusId0]
-    FROM (
-        SELECT [r1].[pickupStatusId], [r1].[Count], 1 AS [c], [s0].[PickupStatusId] AS [PickupStatusId0], ROW_NUMBER() OVER(PARTITION BY [s0].[PickupStatusId] ORDER BY [s0].[PickupStatusId], [r1].[pickupStatusId]) AS [row]
-        FROM [Statuses] AS [s0]
-        LEFT JOIN (
-            SELECT [r2].[PickupStatusId] AS [pickupStatusId], COUNT(*) AS [Count]
-            FROM [Requests] AS [r2]
-            GROUP BY [r2].[PickupStatusId]
-        ) AS [r1] ON [s0].[PickupStatusId] = [r1].[pickupStatusId]
-    ) AS [s2]
-    WHERE [s2].[row] <= 1
-) AS [s3] ON [s1].[PickupStatusId] = [s3].[PickupStatusId0]
-ORDER BY [s1].[PickupStatusId]
-""");
-    }
-
     public override async Task Second_join_after_then_whole_object()
     {
         await base.Second_join_after_then_whole_object();
@@ -3331,6 +3297,144 @@ FROM (
 ) AS [r0]
 RIGHT JOIN [Statuses] AS [s] ON [r0].[pickupStatusId] = [s].[PickupStatusId]
 ORDER BY [s].[PickupStatusId]
+""");
+    }
+
+    public override async Task GroupBy_after_join_then_whole_object()
+    {
+        await base.GroupBy_after_join_then_whole_object();
+
+        AssertSql(
+            """
+SELECT [s1].[PickupStatusId], [s3].[pickupStatusId], [s3].[Count], [s3].[marker], [s3].[c]
+FROM (
+    SELECT [s].[PickupStatusId]
+    FROM [Statuses] AS [s]
+    LEFT JOIN (
+        SELECT [r].[PickupStatusId] AS [pickupStatusId]
+        FROM [Requests] AS [r]
+        GROUP BY [r].[PickupStatusId]
+    ) AS [r0] ON [s].[PickupStatusId] = [r0].[pickupStatusId]
+    GROUP BY [s].[PickupStatusId]
+) AS [s1]
+LEFT JOIN (
+    SELECT [s2].[pickupStatusId], [s2].[Count], [s2].[marker], [s2].[c], [s2].[PickupStatusId0]
+    FROM (
+        SELECT [r1].[pickupStatusId], [r1].[Count], [r1].[marker], 1 AS [c], [s0].[PickupStatusId] AS [PickupStatusId0], ROW_NUMBER() OVER(PARTITION BY [s0].[PickupStatusId] ORDER BY [s0].[PickupStatusId], [r1].[pickupStatusId]) AS [row]
+        FROM [Statuses] AS [s0]
+        LEFT JOIN (
+            SELECT [r2].[PickupStatusId] AS [pickupStatusId], COUNT(*) AS [Count], 1 AS [marker]
+            FROM [Requests] AS [r2]
+            GROUP BY [r2].[PickupStatusId]
+        ) AS [r1] ON [s0].[PickupStatusId] = [r1].[pickupStatusId]
+    ) AS [s2]
+    WHERE [s2].[row] <= 1
+) AS [s3] ON [s1].[PickupStatusId] = [s3].[PickupStatusId0]
+ORDER BY [s1].[PickupStatusId]
+""");
+    }
+
+    public override async Task GroupBy_after_join_then_whole_object_nested_in_wrapper()
+    {
+        await base.GroupBy_after_join_then_whole_object_nested_in_wrapper();
+
+        // SQL is intentionally identical to the flat GroupBy_after_join_then_whole_object variant -- the wrapper is
+        // client-side-only nesting, so it changes no SQL. This test exists to exercise the nested-node rekey path.
+        AssertSql(
+            """
+SELECT [s1].[PickupStatusId], [s3].[pickupStatusId], [s3].[Count], [s3].[marker], [s3].[c]
+FROM (
+    SELECT [s].[PickupStatusId]
+    FROM [Statuses] AS [s]
+    LEFT JOIN (
+        SELECT [r].[PickupStatusId] AS [pickupStatusId]
+        FROM [Requests] AS [r]
+        GROUP BY [r].[PickupStatusId]
+    ) AS [r0] ON [s].[PickupStatusId] = [r0].[pickupStatusId]
+    GROUP BY [s].[PickupStatusId]
+) AS [s1]
+LEFT JOIN (
+    SELECT [s2].[pickupStatusId], [s2].[Count], [s2].[marker], [s2].[c], [s2].[PickupStatusId0]
+    FROM (
+        SELECT [r1].[pickupStatusId], [r1].[Count], [r1].[marker], 1 AS [c], [s0].[PickupStatusId] AS [PickupStatusId0], ROW_NUMBER() OVER(PARTITION BY [s0].[PickupStatusId] ORDER BY [s0].[PickupStatusId], [r1].[pickupStatusId]) AS [row]
+        FROM [Statuses] AS [s0]
+        LEFT JOIN (
+            SELECT [r2].[PickupStatusId] AS [pickupStatusId], COUNT(*) AS [Count], 1 AS [marker]
+            FROM [Requests] AS [r2]
+            GROUP BY [r2].[PickupStatusId]
+        ) AS [r1] ON [s0].[PickupStatusId] = [r1].[pickupStatusId]
+    ) AS [s2]
+    WHERE [s2].[row] <= 1
+) AS [s3] ON [s1].[PickupStatusId] = [s3].[PickupStatusId0]
+ORDER BY [s1].[PickupStatusId]
+""");
+    }
+
+    public override async Task GroupBy_after_join_then_whole_object_dto_memberinit()
+    {
+        await base.GroupBy_after_join_then_whole_object_dto_memberinit();
+
+        AssertSql(
+            """
+SELECT [s1].[PickupStatusId], [s3].[PickupStatusId], [s3].[Count], [s3].[marker], [s3].[c]
+FROM (
+    SELECT [s].[PickupStatusId]
+    FROM [Statuses] AS [s]
+    LEFT JOIN (
+        SELECT [r].[PickupStatusId]
+        FROM [Requests] AS [r]
+        GROUP BY [r].[PickupStatusId]
+    ) AS [r0] ON [s].[PickupStatusId] = [r0].[PickupStatusId]
+    GROUP BY [s].[PickupStatusId]
+) AS [s1]
+LEFT JOIN (
+    SELECT [s2].[PickupStatusId], [s2].[Count], [s2].[marker], [s2].[c], [s2].[PickupStatusId0]
+    FROM (
+        SELECT [r1].[PickupStatusId], [r1].[Count], [r1].[marker], 1 AS [c], [s0].[PickupStatusId] AS [PickupStatusId0], ROW_NUMBER() OVER(PARTITION BY [s0].[PickupStatusId] ORDER BY [s0].[PickupStatusId], [r1].[PickupStatusId]) AS [row]
+        FROM [Statuses] AS [s0]
+        LEFT JOIN (
+            SELECT [r2].[PickupStatusId], COUNT(*) AS [Count], 1 AS [marker]
+            FROM [Requests] AS [r2]
+            GROUP BY [r2].[PickupStatusId]
+        ) AS [r1] ON [s0].[PickupStatusId] = [r1].[PickupStatusId]
+    ) AS [s2]
+    WHERE [s2].[row] <= 1
+) AS [s3] ON [s1].[PickupStatusId] = [s3].[PickupStatusId0]
+ORDER BY [s1].[PickupStatusId]
+""");
+    }
+
+    public override async Task GroupBy_after_join_then_whole_object_struct()
+    {
+        await base.GroupBy_after_join_then_whole_object_struct();
+
+        AssertSql(
+            """
+SELECT [s1].[PickupStatusId], [s3].[PickupStatusId], [s3].[Count], [s3].[marker], [s3].[c]
+FROM (
+    SELECT [s].[PickupStatusId]
+    FROM [Statuses] AS [s]
+    LEFT JOIN (
+        SELECT [r].[PickupStatusId]
+        FROM [Requests] AS [r]
+        GROUP BY [r].[PickupStatusId]
+    ) AS [r0] ON [s].[PickupStatusId] = [r0].[PickupStatusId]
+    GROUP BY [s].[PickupStatusId]
+) AS [s1]
+LEFT JOIN (
+    SELECT [s2].[PickupStatusId], [s2].[Count], [s2].[marker], [s2].[c], [s2].[PickupStatusId0]
+    FROM (
+        SELECT [r1].[PickupStatusId], [r1].[Count], [r1].[marker], 1 AS [c], [s0].[PickupStatusId] AS [PickupStatusId0], ROW_NUMBER() OVER(PARTITION BY [s0].[PickupStatusId] ORDER BY [s0].[PickupStatusId], [r1].[PickupStatusId]) AS [row]
+        FROM [Statuses] AS [s0]
+        LEFT JOIN (
+            SELECT [r2].[PickupStatusId], COUNT(*) AS [Count], 1 AS [marker]
+            FROM [Requests] AS [r2]
+            GROUP BY [r2].[PickupStatusId]
+        ) AS [r1] ON [s0].[PickupStatusId] = [r1].[PickupStatusId]
+    ) AS [s2]
+    WHERE [s2].[row] <= 1
+) AS [s3] ON [s1].[PickupStatusId] = [s3].[PickupStatusId0]
+ORDER BY [s1].[PickupStatusId]
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/AdHocMiscellaneousQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/AdHocMiscellaneousQuerySqliteTest.cs
@@ -704,6 +704,144 @@ ORDER BY "s0"."PickupStatusId"
 """);
     }
 
+    public override async Task GroupBy_after_join_then_whole_object()
+    {
+        await base.GroupBy_after_join_then_whole_object();
+
+        AssertSql(
+            """
+SELECT "s1"."PickupStatusId", "s3"."pickupStatusId", "s3"."Count", "s3"."marker", "s3"."c"
+FROM (
+    SELECT "s"."PickupStatusId"
+    FROM "Statuses" AS "s"
+    LEFT JOIN (
+        SELECT "r"."PickupStatusId" AS "pickupStatusId"
+        FROM "Requests" AS "r"
+        GROUP BY "r"."PickupStatusId"
+    ) AS "r0" ON "s"."PickupStatusId" = "r0"."pickupStatusId"
+    GROUP BY "s"."PickupStatusId"
+) AS "s1"
+LEFT JOIN (
+    SELECT "s2"."pickupStatusId", "s2"."Count", "s2"."marker", "s2"."c", "s2"."PickupStatusId0"
+    FROM (
+        SELECT "r1"."pickupStatusId", "r1"."Count", "r1"."marker", 1 AS "c", "s0"."PickupStatusId" AS "PickupStatusId0", ROW_NUMBER() OVER(PARTITION BY "s0"."PickupStatusId" ORDER BY "s0"."PickupStatusId", "r1"."pickupStatusId") AS "row"
+        FROM "Statuses" AS "s0"
+        LEFT JOIN (
+            SELECT "r2"."PickupStatusId" AS "pickupStatusId", COUNT(*) AS "Count", 1 AS "marker"
+            FROM "Requests" AS "r2"
+            GROUP BY "r2"."PickupStatusId"
+        ) AS "r1" ON "s0"."PickupStatusId" = "r1"."pickupStatusId"
+    ) AS "s2"
+    WHERE "s2"."row" <= 1
+) AS "s3" ON "s1"."PickupStatusId" = "s3"."PickupStatusId0"
+ORDER BY "s1"."PickupStatusId"
+""");
+    }
+
+    public override async Task GroupBy_after_join_then_whole_object_nested_in_wrapper()
+    {
+        await base.GroupBy_after_join_then_whole_object_nested_in_wrapper();
+
+        // SQL is intentionally identical to the flat GroupBy_after_join_then_whole_object variant -- the wrapper is
+        // client-side-only nesting, so it changes no SQL. This test exists to exercise the nested-node rekey path.
+        AssertSql(
+            """
+SELECT "s1"."PickupStatusId", "s3"."pickupStatusId", "s3"."Count", "s3"."marker", "s3"."c"
+FROM (
+    SELECT "s"."PickupStatusId"
+    FROM "Statuses" AS "s"
+    LEFT JOIN (
+        SELECT "r"."PickupStatusId" AS "pickupStatusId"
+        FROM "Requests" AS "r"
+        GROUP BY "r"."PickupStatusId"
+    ) AS "r0" ON "s"."PickupStatusId" = "r0"."pickupStatusId"
+    GROUP BY "s"."PickupStatusId"
+) AS "s1"
+LEFT JOIN (
+    SELECT "s2"."pickupStatusId", "s2"."Count", "s2"."marker", "s2"."c", "s2"."PickupStatusId0"
+    FROM (
+        SELECT "r1"."pickupStatusId", "r1"."Count", "r1"."marker", 1 AS "c", "s0"."PickupStatusId" AS "PickupStatusId0", ROW_NUMBER() OVER(PARTITION BY "s0"."PickupStatusId" ORDER BY "s0"."PickupStatusId", "r1"."pickupStatusId") AS "row"
+        FROM "Statuses" AS "s0"
+        LEFT JOIN (
+            SELECT "r2"."PickupStatusId" AS "pickupStatusId", COUNT(*) AS "Count", 1 AS "marker"
+            FROM "Requests" AS "r2"
+            GROUP BY "r2"."PickupStatusId"
+        ) AS "r1" ON "s0"."PickupStatusId" = "r1"."pickupStatusId"
+    ) AS "s2"
+    WHERE "s2"."row" <= 1
+) AS "s3" ON "s1"."PickupStatusId" = "s3"."PickupStatusId0"
+ORDER BY "s1"."PickupStatusId"
+""");
+    }
+
+    public override async Task GroupBy_after_join_then_whole_object_dto_memberinit()
+    {
+        await base.GroupBy_after_join_then_whole_object_dto_memberinit();
+
+        AssertSql(
+            """
+SELECT "s1"."PickupStatusId", "s3"."PickupStatusId", "s3"."Count", "s3"."marker", "s3"."c"
+FROM (
+    SELECT "s"."PickupStatusId"
+    FROM "Statuses" AS "s"
+    LEFT JOIN (
+        SELECT "r"."PickupStatusId"
+        FROM "Requests" AS "r"
+        GROUP BY "r"."PickupStatusId"
+    ) AS "r0" ON "s"."PickupStatusId" = "r0"."PickupStatusId"
+    GROUP BY "s"."PickupStatusId"
+) AS "s1"
+LEFT JOIN (
+    SELECT "s2"."PickupStatusId", "s2"."Count", "s2"."marker", "s2"."c", "s2"."PickupStatusId0"
+    FROM (
+        SELECT "r1"."PickupStatusId", "r1"."Count", "r1"."marker", 1 AS "c", "s0"."PickupStatusId" AS "PickupStatusId0", ROW_NUMBER() OVER(PARTITION BY "s0"."PickupStatusId" ORDER BY "s0"."PickupStatusId", "r1"."PickupStatusId") AS "row"
+        FROM "Statuses" AS "s0"
+        LEFT JOIN (
+            SELECT "r2"."PickupStatusId", COUNT(*) AS "Count", 1 AS "marker"
+            FROM "Requests" AS "r2"
+            GROUP BY "r2"."PickupStatusId"
+        ) AS "r1" ON "s0"."PickupStatusId" = "r1"."PickupStatusId"
+    ) AS "s2"
+    WHERE "s2"."row" <= 1
+) AS "s3" ON "s1"."PickupStatusId" = "s3"."PickupStatusId0"
+ORDER BY "s1"."PickupStatusId"
+""");
+    }
+
+    public override async Task GroupBy_after_join_then_whole_object_struct()
+    {
+        await base.GroupBy_after_join_then_whole_object_struct();
+
+        AssertSql(
+            """
+SELECT "s1"."PickupStatusId", "s3"."PickupStatusId", "s3"."Count", "s3"."marker", "s3"."c"
+FROM (
+    SELECT "s"."PickupStatusId"
+    FROM "Statuses" AS "s"
+    LEFT JOIN (
+        SELECT "r"."PickupStatusId"
+        FROM "Requests" AS "r"
+        GROUP BY "r"."PickupStatusId"
+    ) AS "r0" ON "s"."PickupStatusId" = "r0"."PickupStatusId"
+    GROUP BY "s"."PickupStatusId"
+) AS "s1"
+LEFT JOIN (
+    SELECT "s2"."PickupStatusId", "s2"."Count", "s2"."marker", "s2"."c", "s2"."PickupStatusId0"
+    FROM (
+        SELECT "r1"."PickupStatusId", "r1"."Count", "r1"."marker", 1 AS "c", "s0"."PickupStatusId" AS "PickupStatusId0", ROW_NUMBER() OVER(PARTITION BY "s0"."PickupStatusId" ORDER BY "s0"."PickupStatusId", "r1"."PickupStatusId") AS "row"
+        FROM "Statuses" AS "s0"
+        LEFT JOIN (
+            SELECT "r2"."PickupStatusId", COUNT(*) AS "Count", 1 AS "marker"
+            FROM "Requests" AS "r2"
+            GROUP BY "r2"."PickupStatusId"
+        ) AS "r1" ON "s0"."PickupStatusId" = "r1"."PickupStatusId"
+    ) AS "s2"
+    WHERE "s2"."row" <= 1
+) AS "s3" ON "s1"."PickupStatusId" = "s3"."PickupStatusId0"
+ORDER BY "s1"."PickupStatusId"
+""");
+    }
+
     public override async Task Two_left_joined_nonentity_objects_second_marker_orphaned()
     {
         await base.Two_left_joined_nonentity_objects_second_marker_orphaned();


### PR DESCRIPTION
Fixes a #22517 sub-case (repro dup #28119): a whole non-entity object (anonymous type / DTO) projected from the nullable side of a LEFT JOIN / GroupJoin + DefaultIfEmpty, then grouped and reduced via a to-one subquery (e.g. `els.Select(e => e.countInfo).FirstOrDefault()`), threw `InvalidOperationException: "Nullable object must have a value"` on a no-match row instead of materializing the whole object as `null`.

## Background

Builds on #30915 (a synthesized marker column that materializes a left-joined non-entity projection as `null` on a no-match) and #38499 (marker survives a subsequent join). #30915 records the marker against the object's New/MemberInit shaper node in `SelectExpression._nonEntityNullabilityMarkers`; the projection binder gates the object to `null` when it finds the marker for that node.

## Root cause

The marker was lost on the grouping path at two points that clone the SelectExpression without carrying the marker dictionary (`Clone()` does not copy it):

1. `SelectExpression.ApplyGrouping` clones the SelectExpression for the grouping element source.
2. The `GroupBy(...).Select(element).FirstOrDefault()` lowering re-clones the grouping SelectExpression in `RelationalQueryableMethodTranslatingExpressionVisitor` (the `GroupByShaperExpression` case) as a `ROW_NUMBER`-based to-one join.

The marker column reached the generated SQL, but nothing in the shaper for the lowered path consulted it, so the whole-object null gate never fired.

## Fix

A single `SelectExpression.RemapGroupingElementShaper` entry point, called from both clone sites, rebuilds the grouping element's shaper against the clone and owns the whole marker-transfer protocol: propagate each recorded marker onto the clone (rebinding its `ProjectionBindingExpression` through the same remapper), visit the shaper, then re-key any marker whose node the visit rebuilt. Node tracking uses a marker-aware `GroupingElementShaperRemappingExpressionVisitor` that records old->new New/MemberInit nodes, mirroring the `RebuiltNodes` pattern from #38499.

The propagation is fail-safe: an entry is carried only when its marker binding resolves against the source SelectExpression; otherwise it is skipped, so behavior degrades to the prior throw rather than producing an incorrect result or a `KeyNotFoundException`.

## Tests

Flips the `GroupBy_after_join_then_whole_object` characterization test to assert correct results and adds anonymous-type (flat and nested-wrapper), MemberInit-DTO, and value-type struct variants -- covering both the New and MemberInit re-key paths -- each with SQLite and SQL Server SQL baselines showing the marker column threaded through the GROUP BY / ROW_NUMBER subquery and reading NULL on a no-match group. Also moves the (already-fixed by #38499) second-join case from DEFERRED to COVERED in the coverage-boundary notes.

<!--
Please check whether the PR fulfills these requirements
-->

- [ ] I've read the guidelines for [contributing](https://github.com/dotnet/efcore/blob/main/.github/CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [ ] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [ ] The code builds and tests pass locally (also verified by our automated build checks)
- [ ] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code follows the same patterns and style as existing code in this repo

