### PR TITLE
Enable unsafe PR checkout in API review workflow

### DIFF
--- a/.github/workflows/api-review-baselines.yml
+++ b/.github/workflows/api-review-baselines.yml
@@ -117,6 +117,7 @@ jobs:
         with:
           ref: ${{ steps.detect.outputs.target_sha }}
           fetch-depth: 1
+          allow-unsafe-pr-checkout: true
 
       - name: Restore repo-local .NET SDK
         if: steps.detect.outputs.has_baselines == 'true'


### PR DESCRIPTION
This is safe as the action only runs for merged PRs