### PR TITLE
Handle out-of-order split include rows during concurrent inserts

### DIFF
--- a/src/EFCore.Relational/DbQueryConcurrencyException.cs
+++ b/src/EFCore.Relational/DbQueryConcurrencyException.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.Serialization;
+
+namespace Microsoft.EntityFrameworkCore;
+
+/// <summary>
+///     An exception that is thrown when a query which loads related collections using
+///     <see cref="QuerySplittingBehavior.SplitQuery" /> cannot correlate the parent and child rows because the data was
+///     modified concurrently while the query was executing.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Split queries execute multiple SQL statements, and the results can become inconsistent when the underlying data is
+///         modified between those statements. When Entity Framework detects that it can no longer reliably correlate the parent
+///         and child rows, it throws this exception instead of returning incorrect results.
+///     </para>
+///     <para>
+///         The recommended way to handle this exception is to catch it and execute the query again, ideally within a
+///         serializable or snapshot transaction to prevent the concurrent modification from recurring.
+///     </para>
+///     <para>
+///         See <see href="https://aka.ms/efcore-docs-split-queries">Split queries</see> for more information and examples.
+///     </para>
+/// </remarks>
+[Serializable]
+public class DbQueryConcurrencyException : Exception
+{
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="DbQueryConcurrencyException" /> class.
+    /// </summary>
+    public DbQueryConcurrencyException()
+    {
+    }
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="DbQueryConcurrencyException" /> class.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    public DbQueryConcurrencyException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="DbQueryConcurrencyException" /> class.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
+    public DbQueryConcurrencyException(string message, Exception? innerException)
+        : base(message, innerException)
+    {
+    }
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="DbQueryConcurrencyException" /> class from a serialized form.
+    /// </summary>
+    /// <param name="info">The serialization info.</param>
+    /// <param name="context">The streaming context being used.</param>
+    [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+    protected DbQueryConcurrencyException(SerializationInfo info, StreamingContext context)
+        : base(info, context)
+    {
+    }
+}

--- a/src/EFCore.Relational/EFCore.Relational.baseline.json
+++ b/src/EFCore.Relational/EFCore.Relational.baseline.json
@@ -2296,6 +2296,24 @@
       ]
     },
     {
+      "Type": "class Microsoft.EntityFrameworkCore.DbQueryConcurrencyException : System.Exception",
+      "Methods": [
+        {
+          "Member": "DbQueryConcurrencyException();"
+        },
+        {
+          "Member": "DbQueryConcurrencyException(string message);"
+        },
+        {
+          "Member": "DbQueryConcurrencyException(string message, System.Exception? innerException);"
+        },
+        {
+          "Member": "DbQueryConcurrencyException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context);",
+          "Stage": "Obsolete"
+        }
+      ]
+    },
+    {
       "Type": "abstract class Microsoft.EntityFrameworkCore.Diagnostics.DbTransactionInterceptor : Microsoft.EntityFrameworkCore.Diagnostics.IDbTransactionInterceptor, Microsoft.EntityFrameworkCore.Diagnostics.IInterceptor",
       "Methods": [
         {
@@ -17191,6 +17209,9 @@
         },
         {
           "Member": "static string SetOperationsNotAllowedAfterClientEvaluation { get; }"
+        },
+        {
+          "Member": "static string SplitQueryConcurrentModification { get; }"
         },
         {
           "Member": "static string SplitQueryString { get; }"

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -1898,6 +1898,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 setOperationType);
 
         /// <summary>
+        ///     The results of a split query could not be correlated because the data was modified concurrently while the query was executing. Re-execute the query, or execute it within a serializable or snapshot transaction to prevent concurrent modifications.
+        /// </summary>
+        public static string SplitQueryConcurrentModification
+            => GetString("SplitQueryConcurrentModification");
+
+        /// <summary>
         ///     This LINQ query is being executed in split-query mode, and the SQL shown is for the first query to be executed. Additional queries may also be executed depending on the results of the first query.
         /// </summary>
         public static string SplitQueryString

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -1185,6 +1185,9 @@
   <data name="SetOperationsRequireAtLeastOneSideWithValidTypeMapping" xml:space="preserve">
     <value>A set operation '{setOperationType}' requires valid type mapping for at least one of its sides.</value>
   </data>
+  <data name="SplitQueryConcurrentModification" xml:space="preserve">
+    <value>The results of a split query could not be correlated because the data was modified concurrently while the query was executing. Re-execute the query, or execute it within a serializable or snapshot transaction to prevent concurrent modifications.</value>
+  </data>
   <data name="SplitQueryString" xml:space="preserve">
     <value>This LINQ query is being executed in split-query mode, and the SQL shown is for the first query to be executed. Additional queries may also be executed depending on the results of the first query.</value>
   </data>

--- a/src/EFCore.Relational/Query/Internal/GroupBySplitQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/GroupBySplitQueryingEnumerable.cs
@@ -309,6 +309,7 @@ public class GroupBySplitQueryingEnumerable<TKey, TElement>
                 }
                 else
                 {
+                    _resultCoordinator!.VerifyNoOrphanedChildRows();
                     Current = default!;
                 }
 
@@ -493,6 +494,7 @@ public class GroupBySplitQueryingEnumerable<TKey, TElement>
                 }
                 else
                 {
+                    _resultCoordinator!.VerifyNoOrphanedChildRows();
                     Current = default!;
                 }
 

--- a/src/EFCore.Relational/Query/Internal/SplitQueryResultCoordinator.cs
+++ b/src/EFCore.Relational/Query/Internal/SplitQueryResultCoordinator.cs
@@ -83,4 +83,26 @@ public sealed class SplitQueryResultCoordinator
 
         Collections[collectionId] = splitQueryCollectionContext;
     }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public void VerifyNoOrphanedChildRows()
+    {
+        foreach (var dataReaderContext in DataReaders)
+        {
+            // Split collection queries correlate child rows to parents by consuming, for each parent (in order), the leading child
+            // rows whose parent key matches. HasNext == true here means the split reader is parked on a child row that didn't match
+            // the last parent - and since every parent has now been processed, that row (and any after it) belongs to no parent in
+            // the parent query's results. This can only happen if the data was modified concurrently between the execution of the
+            // parent query and the child query, leaving orphan child rows that would otherwise be silently dropped (see #33826).
+            if (dataReaderContext?.HasNext == true)
+            {
+                throw new DbQueryConcurrencyException(RelationalStrings.SplitQueryConcurrentModification);
+            }
+        }
+    }
 }

--- a/src/EFCore.Relational/Query/Internal/SplitQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/SplitQueryingEnumerable.cs
@@ -230,6 +230,7 @@ public class SplitQueryingEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, I
                 }
                 else
                 {
+                    _resultCoordinator!.VerifyNoOrphanedChildRows();
                     Current = default!;
                 }
 
@@ -379,6 +380,7 @@ public class SplitQueryingEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, I
                 }
                 else
                 {
+                    _resultCoordinator!.VerifyNoOrphanedChildRows();
                     Current = default!;
                 }
 

--- a/test/EFCore.Relational.Specification.Tests/Query/AdHocQuerySplittingQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/AdHocQuerySplittingQueryTestBase.cs
@@ -363,6 +363,187 @@ public abstract class AdHocQuerySplittingQueryTestBase(NonSharedFixture fixture)
 
     #endregion
 
+    #region 33826
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public virtual async Task Split_include_collection_throws_for_orphan_child_rows_after_concurrent_insert(bool async)
+    {
+        var contextFactory = await InitializeNonSharedTest<Context33826>(
+            seed: c => c.SeedAsync(),
+            onConfiguring: o => SetQuerySplittingBehavior(o, QuerySplittingBehavior.SplitQuery),
+            createTestStore: CreateTestStore33826);
+
+        Context33826.ConcurrentContextFactory = contextFactory.CreateDbContext;
+        try
+        {
+            // A concurrent, unrelated Blog(15, 3) with a child is inserted while Blog(20, 1) is materialized. Because the parent
+            // query already returned its rows without Blog(15, 3), that blog's child appears in the split-include stream as an
+            // orphan row that correlates to no parent. Rather than silently dropping child collections (as before #33826), the
+            // materializer detects the leftover child rows once every parent has been processed and throws.
+            Context33826.InsertConcurrentEntity = true;
+            ClearLog();
+
+            using var context = contextFactory.CreateDbContext();
+            var query = context.Blogs
+                .Include(b => b.Posts)
+                .AsSplitQuery()
+                .OrderByDescending(b => b.Id)
+                .ThenByDescending(b => b.SecondId);
+
+            if (async)
+            {
+                await Assert.ThrowsAsync<DbQueryConcurrencyException>(() => query.ToListAsync());
+            }
+            else
+            {
+                Assert.Throws<DbQueryConcurrencyException>(() => query.ToList());
+            }
+        }
+        finally
+        {
+            Context33826.InsertConcurrentEntity = false;
+            Context33826.ConcurrentContextFactory = null;
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public virtual async Task Split_include_collection_not_dropped_when_other_parent_made_childless_concurrently(bool async)
+    {
+        var contextFactory = await InitializeNonSharedTest<Context33826>(
+            seed: c => c.SeedAsync(),
+            onConfiguring: o => SetQuerySplittingBehavior(o, QuerySplittingBehavior.SplitQuery),
+            createTestStore: CreateTestStore33826);
+
+        Context33826.ConcurrentContextFactory = contextFactory.CreateDbContext;
+        try
+        {
+            // While Blog(20, 1) is materialized, all children of Blog(10, 2) are deleted, making it childless in the child
+            // stream. Blog(20, 1) must still keep its children and Blog(10, 2) ends up with an empty collection - no exception.
+            Context33826.DeleteOtherParentsChildren = true;
+            ClearLog();
+
+            using var context = contextFactory.CreateDbContext();
+            var query = context.Blogs
+                .Include(b => b.Posts)
+                .AsSplitQuery()
+                .OrderByDescending(b => b.Id)
+                .ThenByDescending(b => b.SecondId);
+
+            var blogs = async
+                ? await query.ToListAsync()
+                : query.ToList();
+
+            var byKey = blogs.ToDictionary(b => (b.Id, b.SecondId));
+            Assert.Equal(["C", "D"], byKey[(20, 1)].Posts.OrderBy(p => p.Name).Select(p => p.Name));
+            Assert.Empty(byKey[(10, 2)].Posts);
+        }
+        finally
+        {
+            Context33826.DeleteOtherParentsChildren = false;
+            Context33826.ConcurrentContextFactory = null;
+        }
+    }
+
+    protected virtual TestStore CreateTestStore33826()
+    {
+        var testStore = (RelationalTestStore)CreateTestStore();
+        testStore.UseConnectionString = true;
+        return testStore;
+    }
+
+    protected class Context33826(DbContextOptions options) : DbContext(options)
+    {
+        public static Func<Context33826> ConcurrentContextFactory { get; set; }
+        public static bool InsertConcurrentEntity { get; set; }
+        public static bool DeleteOtherParentsChildren { get; set; }
+
+        public DbSet<Blog33826> Blogs { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Blog33826>(
+                b =>
+                {
+                    b.HasKey(e => new { e.Id, e.SecondId });
+                    b.Property(e => e.Id).ValueGeneratedNever();
+                    b.Property(e => e.SecondId).ValueGeneratedNever();
+                    b.HasMany(e => e.Posts).WithOne().HasForeignKey(e => new { e.BlogId, e.BlogSecondId });
+                });
+            modelBuilder.Entity<Post33826>(
+                p =>
+                {
+                    p.HasKey(e => new { e.Id, e.SecondId });
+                    p.Property(e => e.Id).ValueGeneratedNever();
+                    p.Property(e => e.SecondId).ValueGeneratedNever();
+                });
+        }
+
+        public Task SeedAsync()
+        {
+            Blogs.AddRange(
+                new Blog33826(10, 2, [new Post33826(1, 2, "A"), new Post33826(2, 2, "B")]),
+                new Blog33826(20, 1, [new Post33826(3, 1, "C"), new Post33826(4, 1, "D")]));
+
+            return SaveChangesAsync();
+        }
+    }
+
+    protected class Blog33826
+    {
+        public Blog33826(int id, int secondId, IEnumerable<Post33826> posts)
+        {
+            Id = id;
+            SecondId = secondId;
+            Posts = posts.ToList();
+        }
+
+        // EF materialization constructor - used to inject a concurrent modification at a deterministic point.
+        private Blog33826(int id, int secondId)
+        {
+            Id = id;
+            SecondId = secondId;
+
+            if (id == 20 && secondId == 1)
+            {
+                if (Context33826.InsertConcurrentEntity)
+                {
+                    Context33826.InsertConcurrentEntity = false;
+
+                    using var context = Context33826.ConcurrentContextFactory();
+                    context.Blogs.Add(new Blog33826(15, 3, [new Post33826(5, 3, "Concurrent")]));
+                    context.SaveChanges();
+                }
+
+                if (Context33826.DeleteOtherParentsChildren)
+                {
+                    Context33826.DeleteOtherParentsChildren = false;
+
+                    using var context = Context33826.ConcurrentContextFactory();
+                    context.Set<Post33826>().Where(p => p.BlogId == 10 && p.BlogSecondId == 2).ExecuteDelete();
+                }
+            }
+        }
+
+        public int Id { get; private init; }
+        public int SecondId { get; private init; }
+        public List<Post33826> Posts { get; private init; } = [];
+    }
+
+    protected class Post33826(int id, int secondId, string name)
+    {
+        public int Id { get; private init; } = id;
+        public int SecondId { get; private init; } = secondId;
+        public string Name { get; private init; } = name;
+        public int BlogId { get; private set; }
+        public int BlogSecondId { get; private set; }
+    }
+
+    #endregion
+
     #region 34728
 
     [Theory, InlineData(true), InlineData(false)]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocQuerySplittingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocQuerySplittingQuerySqlServerTest.cs
@@ -449,6 +449,15 @@ ORDER BY [p0].[Id]
     private void AssertContainsSql(params string[] expected)
         => TestSqlLoggerFactory.AssertBaseline(expected, assertOrder: false);
 
+    // The two split-include concurrency regression tests interleave concurrent writes (on a separate context that shares this
+    // fixture's SQL logger) with the split query, so the captured SQL is not deterministic. They assert behavior in the base
+    // class and are overridden here without a SQL baseline.
+    public override Task Split_include_collection_throws_for_orphan_child_rows_after_concurrent_insert(bool async)
+        => base.Split_include_collection_throws_for_orphan_child_rows_after_concurrent_insert(async);
+
+    public override Task Split_include_collection_not_dropped_when_other_parent_made_childless_concurrently(bool async)
+        => base.Split_include_collection_not_dropped_when_other_parent_made_childless_concurrently(async);
+
     [Fact]
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());

--- a/test/EFCore.Sqlite.FunctionalTests/Query/AdHocQuerySplittingQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/AdHocQuerySplittingQuerySqliteTest.cs
@@ -40,4 +40,13 @@ public class AdHocQuerySplittingQuerySqliteTest(NonSharedFixture fixture) : AdHo
 
         return optionsBuilder;
     }
+
+    // SQLite uses a per-connection snapshot within a transaction, so a concurrent modification made on a separate connection
+    // is not visible to the split query's child statements (which run on the same connection). The concurrent-modification
+    // scenario from #33826 therefore cannot be reproduced on SQLite; it is covered by the SQL Server tests.
+    public override Task Split_include_collection_throws_for_orphan_child_rows_after_concurrent_insert(bool async)
+        => Task.CompletedTask;
+
+    public override Task Split_include_collection_not_dropped_when_other_parent_made_childless_concurrently(bool async)
+        => Task.CompletedTask;
 }


### PR DESCRIPTION
Fixes #33826 

## Problem

When a query uses `AsSplitQuery()` with collection `Include`s, EF executes one SQL statement per collection level. Between those statements the database can change. Issue #33826 showed that a completely **unrelated** concurrent insert could make EF **silently drop the child collections of untouched parents**:

```csharp
var blogs = await db.Blogs
    .Include(b => b.Posts)
    .AsSplitQuery()
    .OrderByDescending(b => b.Id)
    .ToListAsync();
// Blog 1's posts come back empty — even though Blog 1 and its posts were never modified —
// simply because an unrelated Blog 2 was inserted between the two split queries.
```

### Root cause

The parent query and each child query both carry the *same* `ORDER BY <parent key>`, so a parent's child rows arrive as a contiguous, correctly-ordered **block**. The old stitching loop streamed child rows and treated **the first row whose parent key didn't match the current parent as the boundary of the next parent** — then stopped. When a concurrent insert put an unrelated child row in the stream (e.g. an out-of-order/orphan parent key), that row was misread as "the current parent has no more children," so the remaining real children were abandoned and the whole collection was lost. The bug is purely in **client-side correlation** — the correct rows were fetched from the database and then thrown away.

## Why this approach

I considered several designs; the key constraints (from reviewing the earlier attempt in this PR and the issue discussion) were:

1. **No client-side ordering comparison.** The obvious fix — "if the non-matching row sorts *after* the current parent it's the next parent, otherwise skip it as an orphan" — requires comparing key *magnitudes* on the client. That's wrong because .NET ordering doesn't always match the database's ordering (GUIDs on SQL Server, culture/collation-sensitive strings, etc.). Any magnitude comparison risks new, subtler correctness bugs. **We must rely only on key *equality*, which EF already trusts.**

2. **Avoid buffering the whole result set.** The previous iteration of this PR (https://github.com/dotnet/efcore/pull/38590) fell back to buffering every child row into a dictionary whenever ordering wasn't "trusted," which defeats the streaming purpose of split queries and regressed memory for ordinary queries.

3. **Fail loudly rather than silently corrupt.** Where a scenario genuinely can't be disambiguated, throwing is far better than returning wrong data.

The chosen design satisfies all three by keeping track of the orphans and throwing a retriable exception:

> The results of a split query could not be correlated because the data was modified concurrently while the query was executing. Re-execute the query, or execute it within a serializable or snapshot transaction to prevent concurrent modifications.
## Changes

- **New public API**: `DbQueryConcurrencyException` (relational).
- **End-of-stream check**: `SplitQueryResultCoordinator.VerifyNoOrphanedChildRows()` (called when the outer enumerator completes) throws if a buffered "childless" block was never claimed.
- **Tests**: `#33826` regression tests in `AdHocQuerySplittingQueryTestBase` covering a concurrent unrelated insert and a concurrent parent-made-childless, sync + async (SQL Server; no-ops on SQLite, whose per-connection snapshot can't reproduce cross-statement visibility).