### PR TITLE
Query: support composing over GroupBy + First per group (navigations and joins)

### DIFF
--- a/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
@@ -133,6 +133,14 @@ public class RelationalProjectionBindingExpressionVisitor : ExpressionVisitor
                         {
                             StructuralTypeProjectionExpression projection => AddClientProjection(projection, typeof(ValueBuffer)),
                             SqlExpression mappedSqlExpression => AddClientProjection(mappedSqlExpression, expression.Type.MakeNullable()),
+                            // A single-result subquery (e.g. the group element of GroupBy(k).Select(g => g.First()))
+                            // being composed over: lower it into the current select as a to-one join so the result
+                            // has a bindable shape, instead of failing.
+                            ShapedQueryExpression
+                                {
+                                    ResultCardinality: ResultCardinality.Single or ResultCardinality.SingleOrDefault
+                                } singleResultSubquery
+                                => _selectExpression.LowerSingleResultSubquery(singleResultSubquery, _clientProjections!),
                             _ => throw new InvalidOperationException(CoreStrings.TranslationFailed(projectionBindingExpression.Print()))
                         };
 

--- a/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
@@ -27,6 +27,7 @@ public class RelationalProjectionBindingExpressionVisitor : ExpressionVisitor
     private bool _rootIsTransparentIdentifier;
     private Dictionary<StructuralTypeProjectionExpression, ProjectionBindingExpression>? _projectionBindingCache;
     private List<Expression>? _clientProjections;
+    private Dictionary<object, Expression>? _loweredSingleResultSubqueries;
 
     private readonly Dictionary<ProjectionMember, Expression> _projectionMapping = new();
     private readonly Stack<ProjectionMember> _projectionMembers = new();
@@ -75,6 +76,7 @@ public class RelationalProjectionBindingExpressionVisitor : ExpressionVisitor
             _projectionBindingCache = new Dictionary<StructuralTypeProjectionExpression, ProjectionBindingExpression>();
             _projectionMapping.Clear();
             _clientProjections = [];
+            _loweredSingleResultSubqueries = null;
 
             result = Visit(expression);
 
@@ -140,7 +142,7 @@ public class RelationalProjectionBindingExpressionVisitor : ExpressionVisitor
                                 {
                                     ResultCardinality: ResultCardinality.Single or ResultCardinality.SingleOrDefault
                                 } singleResultSubquery
-                                => _selectExpression.LowerSingleResultSubquery(singleResultSubquery, _clientProjections!),
+                                => LowerSingleResultSubquery(projectionBindingExpression, singleResultSubquery),
                             _ => throw new InvalidOperationException(CoreStrings.TranslationFailed(projectionBindingExpression.Print()))
                         };
 
@@ -840,6 +842,24 @@ public class RelationalProjectionBindingExpressionVisitor : ExpressionVisitor
         }
 
         return new ProjectionBindingExpression(_selectExpression, existingIndex, type);
+    }
+
+    private Expression LowerSingleResultSubquery(
+        ProjectionBindingExpression projectionBindingExpression,
+        ShapedQueryExpression singleResultSubquery)
+    {
+        // The lowering mutates the select expression (pushdown + to-one join), so it must run
+        // once per projection slot — a second reference to the same slot reuses the shaper
+        // produced by the first, instead of adding a duplicate join.
+        _loweredSingleResultSubqueries ??= new Dictionary<object, Expression>();
+        var key = projectionBindingExpression.Index is int index ? index : (object)projectionBindingExpression.ProjectionMember!;
+        if (!_loweredSingleResultSubqueries.TryGetValue(key, out var loweredShaper))
+        {
+            loweredShaper = _selectExpression.LowerSingleResultSubquery(singleResultSubquery, _clientProjections!);
+            _loweredSingleResultSubqueries[key] = loweredShaper;
+        }
+
+        return loweredShaper;
     }
 
     /// <summary>

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -871,74 +871,18 @@ public sealed partial class SelectExpression : TableExpressionBase
                         ResultCardinality: ResultCardinality.Single or ResultCardinality.SingleOrDefault
                     } shapedQueryExpression:
                     {
-                        var innerSelectExpression = (SelectExpression)shapedQueryExpression.QueryExpression;
-                        var innerShaperExpression = shapedQueryExpression.ShaperExpression;
-                        if (innerSelectExpression._clientProjections.Count == 0)
-                        {
-                            var mapping = innerSelectExpression.ConvertProjectionMappingToClientProjections(
-                                innerSelectExpression._projectionMapping);
-                            innerShaperExpression =
-                                new ProjectionMemberToIndexConvertingExpressionVisitor(innerSelectExpression, mapping)
-                                    .Visit(innerShaperExpression);
-                        }
-
-                        var innerExpression = RemoveConvert(innerShaperExpression);
-                        if (innerExpression is not (StructuralTypeShaperExpression or IncludeExpression))
-                        {
-                            var sentinelExpression = innerSelectExpression.Limit!;
-                            var sentinelNullableType = sentinelExpression.Type.MakeNullable();
-                            innerSelectExpression._clientProjections.Add(sentinelExpression);
-                            innerSelectExpression._aliasForClientProjections.Add(null);
-                            var dummyProjection = new ProjectionBindingExpression(
-                                innerSelectExpression, innerSelectExpression._clientProjections.Count - 1, sentinelNullableType);
-
-                            var defaultResult = shapedQueryExpression.ResultCardinality == ResultCardinality.SingleOrDefault
-                                ? (Expression)Default(innerShaperExpression.Type)
-                                : Block(
-                                    Throw(
-                                        New(
-                                            typeof(InvalidOperationException).GetConstructors()
-                                                .Single(ci =>
-                                                {
-                                                    var parameters = ci.GetParameters();
-                                                    return parameters.Length == 1
-                                                        && parameters[0].ParameterType == typeof(string);
-                                                }),
-                                            Constant(CoreStrings.SequenceContainsNoElements))),
-                                    Default(innerShaperExpression.Type));
-
-                            innerShaperExpression = Condition(
-                                Equal(dummyProjection, Default(sentinelNullableType)),
-                                defaultResult,
-                                innerShaperExpression);
-                        }
-
-                        // Single-result (to-one) joins never increase result cardinality, so the outer entity's
-                        // identifiers are already sufficient to uniquely identify rows. We don't need to add the
-                        // inner's identifiers to our own; doing so would cause unnecessary reference table JOINs,
-                        // ORDER BY columns, and projections in split collection queries (#29182).
-                        AddJoin(JoinType.OuterApply, ref innerSelectExpression, out _, isToOneJoin: true, isPrunableJoin: true);
-                        var offset = _clientProjections.Count;
-                        var count = innerSelectExpression._clientProjections.Count;
-
-                        _clientProjections.AddRange(
-                            innerSelectExpression._clientProjections.Select(e => MakeNullable(e, nullable: true)));
-
-                        _aliasForClientProjections.AddRange(innerSelectExpression._aliasForClientProjections);
-                        innerShaperExpression = new ProjectionIndexRemappingExpressionVisitor(
-                                innerSelectExpression,
-                                this,
-                                Enumerable.Range(offset, count).ToArray())
-                            .Visit(innerShaperExpression);
-                        innerShaperExpression = entityShaperNullableMarkingExpressionVisitor!.Visit(innerShaperExpression);
+                        var innerShaperExpression = LowerSingleResultSubqueryCore(
+                            shapedQueryExpression,
+                            (projection, alias) =>
+                            {
+                                _clientProjections.Add(projection);
+                                _aliasForClientProjections.Add(alias);
+                                return _clientProjections.Count - 1;
+                            },
+                            entityShaperNullableMarkingExpressionVisitor!);
                         clientProjectionIndexMap.Add(innerShaperExpression);
                         remappingRequired = true;
                         break;
-
-                        static Expression RemoveConvert(Expression expression)
-                            => expression is UnaryExpression { NodeType: ExpressionType.Convert } unaryExpression
-                                ? RemoveConvert(unaryExpression.Operand)
-                                : expression;
                     }
 
                     case ShapedQueryExpression { ResultCardinality: ResultCardinality.Enumerable } shapedQueryExpression:
@@ -3905,6 +3849,126 @@ public sealed partial class SelectExpression : TableExpressionBase
     /// </summary>
     public void PushdownIntoSubquery()
         => PushdownIntoSubqueryInternal();
+
+    // Lowers a single-result subquery held as a client projection (e.g. the group element of
+    // GroupBy(k).Select(g => g.First())) into this SelectExpression as a prunable to-one OUTER APPLY —
+    // the same lowering ApplyProjection defers to the end of translation, but on demand, so that the
+    // result can still be composed over (joined, re-projected) instead of failing with
+    // "ProjectionBindingExpression could not be translated". The inner projections are appended to
+    // `clientProjectionList` (the projection binder's working list, which replaces this
+    // SelectExpression's projections once the binder completes) and the remapped inner shaper is returned.
+    // Internal infrastructure: only called from RelationalProjectionBindingExpressionVisitor.
+    internal Expression LowerSingleResultSubquery(
+        ShapedQueryExpression shapedQueryExpression,
+        List<Expression> clientProjectionList)
+    {
+        // A join is about to be added; contain any shape-altering state first, as ApplyProjection does.
+        // Any expressions the projection binder has already collected reference the pre-pushdown
+        // tables, so they must be remapped alongside this SelectExpression's own state.
+        if (Limit != null
+            || Offset != null
+            || IsDistinct
+            || GroupBy.Count > 0)
+        {
+            var remappingVisitor = PushdownIntoSubqueryInternal();
+            for (var i = 0; i < clientProjectionList.Count; i++)
+            {
+                clientProjectionList[i] = remappingVisitor.Visit(clientProjectionList[i]);
+            }
+        }
+
+        return LowerSingleResultSubqueryCore(
+            shapedQueryExpression,
+            (projection, _) =>
+            {
+                var existingIndex = clientProjectionList.FindIndex(e => e.Equals(projection));
+                if (existingIndex == -1)
+                {
+                    clientProjectionList.Add(projection);
+                    existingIndex = clientProjectionList.Count - 1;
+                }
+
+                return existingIndex;
+            },
+            new EntityShaperNullableMarkingExpressionVisitor());
+    }
+
+    // Shared core of the single-result (to-one) subquery lowering, used both by ApplyProjection
+    // (deferred, at the end of translation) and by the projection binder through
+    // LowerSingleResultSubquery (on demand, when the single result is composed over).
+    // `addProjection` places one lowered projection (with its alias) into the caller's projection
+    // list and returns its index there.
+    private Expression LowerSingleResultSubqueryCore(
+        ShapedQueryExpression shapedQueryExpression,
+        Func<Expression, string?, int> addProjection,
+        EntityShaperNullableMarkingExpressionVisitor entityShaperNullableMarkingExpressionVisitor)
+    {
+        var innerSelectExpression = (SelectExpression)shapedQueryExpression.QueryExpression;
+        var innerShaperExpression = shapedQueryExpression.ShaperExpression;
+        if (innerSelectExpression._clientProjections.Count == 0)
+        {
+            var mapping = innerSelectExpression.ConvertProjectionMappingToClientProjections(
+                innerSelectExpression._projectionMapping);
+            innerShaperExpression =
+                new ProjectionMemberToIndexConvertingExpressionVisitor(innerSelectExpression, mapping)
+                    .Visit(innerShaperExpression);
+        }
+
+        var innerExpression = RemoveConvert(innerShaperExpression);
+        if (innerExpression is not (StructuralTypeShaperExpression or IncludeExpression))
+        {
+            var sentinelExpression = innerSelectExpression.Limit!;
+            var sentinelNullableType = sentinelExpression.Type.MakeNullable();
+            innerSelectExpression._clientProjections.Add(sentinelExpression);
+            innerSelectExpression._aliasForClientProjections.Add(null);
+            var dummyProjection = new ProjectionBindingExpression(
+                innerSelectExpression, innerSelectExpression._clientProjections.Count - 1, sentinelNullableType);
+
+            var defaultResult = shapedQueryExpression.ResultCardinality == ResultCardinality.SingleOrDefault
+                ? (Expression)Default(innerShaperExpression.Type)
+                : Block(
+                    Throw(
+                        New(
+                            typeof(InvalidOperationException).GetConstructors()
+                                .Single(ci =>
+                                {
+                                    var parameters = ci.GetParameters();
+                                    return parameters.Length == 1
+                                        && parameters[0].ParameterType == typeof(string);
+                                }),
+                            Constant(CoreStrings.SequenceContainsNoElements))),
+                    Default(innerShaperExpression.Type));
+
+            innerShaperExpression = Condition(
+                Equal(dummyProjection, Default(sentinelNullableType)),
+                defaultResult,
+                innerShaperExpression);
+        }
+
+        // Single-result (to-one) joins never increase result cardinality, so the outer entity's
+        // identifiers are already sufficient to uniquely identify rows. We don't need to add the
+        // inner's identifiers to our own; doing so would cause unnecessary reference table JOINs,
+        // ORDER BY columns, and projections in split collection queries (#29182).
+        AddJoin(JoinType.OuterApply, ref innerSelectExpression, out _, isToOneJoin: true, isPrunableJoin: true);
+
+        var indexMap = new int[innerSelectExpression._clientProjections.Count];
+        for (var i = 0; i < innerSelectExpression._clientProjections.Count; i++)
+        {
+            indexMap[i] = addProjection(
+                MakeNullable(innerSelectExpression._clientProjections[i], nullable: true),
+                innerSelectExpression._aliasForClientProjections[i]);
+        }
+
+        innerShaperExpression = new ProjectionIndexRemappingExpressionVisitor(innerSelectExpression, this, indexMap)
+            .Visit(innerShaperExpression);
+
+        return entityShaperNullableMarkingExpressionVisitor.Visit(innerShaperExpression);
+
+        static Expression RemoveConvert(Expression expression)
+            => expression is UnaryExpression { NodeType: ExpressionType.Convert } unaryExpression
+                ? RemoveConvert(unaryExpression.Operand)
+                : expression;
+    }
 
     /// <summary>
     ///     Pushes down the <see cref="SelectExpression" /> into a subquery.

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
@@ -1689,6 +1689,12 @@ public partial class NavigationExpandingExpressionVisitor : ExpressionVisitor
         selectorBody = Visit(selectorBody);
         selectorBody =
             new PendingSelectorExpandingExpressionVisitor(this, _extensibilityHelper, applyIncludes: true).Visit(selectorBody);
+
+        // Snapshot the structure of the selector result before reducing, so that entity references
+        // survive and navigations accessed on the elements afterwards can still be expanded
+        // (e.g. GroupBy(k).Select(g => g.First()).OrderBy(e => e.Navigation.Member)).
+        var newStructure = SnapshotSelectorStructure(selectorBody);
+
         selectorBody = Reduce(selectorBody);
         selector = Expression.Lambda(selectorBody, groupBySource.CurrentParameter);
 
@@ -1697,11 +1703,19 @@ public partial class NavigationExpandingExpressionVisitor : ExpressionVisitor
             groupBySource.Source,
             Expression.Quote(selector));
 
-        var navigationTree = new NavigationTreeExpression(Expression.Default(selector.ReturnType));
+        var navigationTree = new NavigationTreeExpression(newStructure);
         var parameterName = GetParameterName("e");
 
         return new NavigationExpansionExpression(newSource, navigationTree, navigationTree, parameterName);
     }
+
+    private static Expression SnapshotSelectorStructure(Expression expression)
+        => expression is NavigationExpansionExpression { CardinalityReducingGenericMethodInfo: not null } navigationExpansion
+            // A cardinality-reduced subquery yields its pending selector's shape as the element
+            // (e.g. the group element entity for g.OrderBy(...).First()), so entity references
+            // survive and navigations can still be expanded on the result.
+            ? SnapshotExpression(navigationExpansion.PendingSelector)
+            : SnapshotExpression(expression);
 
     /// <summary>
     ///     Rewrites GroupBy(k).Select(g => ...aggregates...) so reference navigations used in aggregate

--- a/test/EFCore.InMemory.FunctionalTests/Query/NorthwindGroupByQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/NorthwindGroupByQueryInMemoryTest.cs
@@ -114,4 +114,20 @@ public class NorthwindGroupByQueryInMemoryTest(NorthwindQueryInMemoryFixture<Noo
     [Theory(Skip = "Issue#31209")]
     public override Task GroupBy_Select_Entire_Entity_composite_key_Select(bool async)
         => base.GroupBy_Select_Entire_Entity_composite_key_Select(async);
+
+    [Theory(Skip = "Issue#31209")]
+    public override Task GroupBy_Select_Entire_Entity_OrderBy_navigation(bool async)
+        => base.GroupBy_Select_Entire_Entity_OrderBy_navigation(async);
+
+    [Theory(Skip = "Issue#31209")]
+    public override Task GroupBy_Select_Entire_Entity_Select_navigation_member(bool async)
+        => base.GroupBy_Select_Entire_Entity_Select_navigation_member(async);
+
+    [Theory(Skip = "Issue#31209")]
+    public override Task GroupBy_Select_Entire_Entity_Where_navigation(bool async)
+        => base.GroupBy_Select_Entire_Entity_Where_navigation(async);
+
+    [Theory(Skip = "Issue#31209")]
+    public override Task GroupBy_Select_Entire_Entity_Join(bool async)
+        => base.GroupBy_Select_Entire_Entity_Join(async);
 }

--- a/test/EFCore.InMemory.FunctionalTests/Query/NorthwindGroupByQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/NorthwindGroupByQueryInMemoryTest.cs
@@ -128,6 +128,10 @@ public class NorthwindGroupByQueryInMemoryTest(NorthwindQueryInMemoryFixture<Noo
         => base.GroupBy_Select_Entire_Entity_Where_navigation(async);
 
     [Theory(Skip = "Issue#31209")]
+    public override Task GroupBy_Select_Entire_Entity_Select_referenced_twice(bool async)
+        => base.GroupBy_Select_Entire_Entity_Select_referenced_twice(async);
+
+    [Theory(Skip = "Issue#31209")]
     public override Task GroupBy_Select_Entire_Entity_Join(bool async)
         => base.GroupBy_Select_Entire_Entity_Join(async);
 }

--- a/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
@@ -2124,6 +2124,14 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
                 .Where(o => o.Customer.City == "London"));
 
     [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_Select_Entire_Entity_Select_referenced_twice(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>().GroupBy(o => o.CustomerID)
+                .Select(g => g.OrderBy(o => o.OrderID).First())
+                .Select(o => new { First = o, Second = o }));
+
+    [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task GroupBy_Select_Entire_Entity_Join(bool async) // #28125
         => AssertQuery(
             async,

--- a/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
@@ -2096,6 +2096,46 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
                 .Select(p => p.OrderID));
 
     [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_Select_Entire_Entity_OrderBy_navigation(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>().GroupBy(o => o.CustomerID)
+                .Select(g => g.OrderBy(o => o.OrderID).First())
+                .OrderBy(o => o.Customer.City)
+                .ThenBy(o => o.OrderID)
+                // Identity projection: the ordering by City is collation-sensitive, so the order
+                // itself is not asserted across providers.
+                .Select(o => o));
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_Select_Entire_Entity_Select_navigation_member(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>().GroupBy(o => o.CustomerID)
+                .Select(g => g.OrderBy(o => o.OrderID).First())
+                .Select(o => new { o.OrderID, o.Customer.City }));
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_Select_Entire_Entity_Where_navigation(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>().GroupBy(o => o.CustomerID)
+                .Select(g => g.OrderBy(o => o.OrderID).First())
+                .Where(o => o.Customer.City == "London"));
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_Select_Entire_Entity_Join(bool async) // #28125
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>().GroupBy(o => o.CustomerID)
+                .Select(g => g.OrderBy(o => o.OrderID).First())
+                .Join(
+                    ss.Set<Customer>(),
+                    o => o.CustomerID,
+                    c => c.CustomerID,
+                    (o, c) => new { o.OrderID, c.City }));
+
+    [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task GroupBy_aggregate_join_with_group_result(bool async)
         => AssertQuery(
             async,

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -3417,6 +3417,29 @@ WHERE [c].[City] = N'London'
 """);
     }
 
+    public override async Task GroupBy_Select_Entire_Entity_Select_referenced_twice(bool async)
+    {
+        await base.GroupBy_Select_Entire_Entity_Select_referenced_twice(async);
+
+        AssertSql(
+            """
+SELECT [o3].[OrderID], [o3].[CustomerID], [o3].[EmployeeID], [o3].[OrderDate]
+FROM (
+    SELECT [o].[CustomerID]
+    FROM [Orders] AS [o]
+    GROUP BY [o].[CustomerID]
+) AS [o1]
+LEFT JOIN (
+    SELECT [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate]
+    FROM (
+        SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], ROW_NUMBER() OVER(PARTITION BY [o0].[CustomerID] ORDER BY [o0].[OrderID]) AS [row]
+        FROM [Orders] AS [o0]
+    ) AS [o2]
+    WHERE [o2].[row] <= 1
+) AS [o3] ON [o1].[CustomerID] = [o3].[CustomerID]
+""");
+    }
+
     public override async Task GroupBy_Select_Entire_Entity_Join(bool async)
     {
         await base.GroupBy_Select_Entire_Entity_Join(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -3331,6 +3331,120 @@ GROUP BY [o].[CustomerID], [o].[EmployeeID]
 """);
     }
 
+    public override async Task GroupBy_Select_Entire_Entity_OrderBy_navigation(bool async)
+    {
+        await base.GroupBy_Select_Entire_Entity_OrderBy_navigation(async);
+
+        AssertSql(
+            """
+SELECT [o4].[OrderID], [o4].[CustomerID], [o4].[EmployeeID], [o4].[OrderDate]
+FROM (
+    SELECT [o].[CustomerID]
+    FROM [Orders] AS [o]
+    GROUP BY [o].[CustomerID]
+) AS [o2]
+LEFT JOIN [Customers] AS [c] ON (
+    SELECT TOP(1) [o1].[CustomerID]
+    FROM [Orders] AS [o1]
+    WHERE [o2].[CustomerID] = [o1].[CustomerID] OR ([o2].[CustomerID] IS NULL AND [o1].[CustomerID] IS NULL)
+    ORDER BY [o1].[OrderID]) = [c].[CustomerID]
+LEFT JOIN (
+    SELECT [o3].[OrderID], [o3].[CustomerID], [o3].[EmployeeID], [o3].[OrderDate]
+    FROM (
+        SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], ROW_NUMBER() OVER(PARTITION BY [o0].[CustomerID] ORDER BY [o0].[OrderID]) AS [row]
+        FROM [Orders] AS [o0]
+    ) AS [o3]
+    WHERE [o3].[row] <= 1
+) AS [o4] ON [o2].[CustomerID] = [o4].[CustomerID]
+ORDER BY [c].[City], [o4].[OrderID]
+""");
+    }
+
+    public override async Task GroupBy_Select_Entire_Entity_Select_navigation_member(bool async)
+    {
+        await base.GroupBy_Select_Entire_Entity_Select_navigation_member(async);
+
+        AssertSql(
+            """
+SELECT [o4].[OrderID], [c].[City]
+FROM (
+    SELECT [o].[CustomerID]
+    FROM [Orders] AS [o]
+    GROUP BY [o].[CustomerID]
+) AS [o2]
+LEFT JOIN [Customers] AS [c] ON (
+    SELECT TOP(1) [o1].[CustomerID]
+    FROM [Orders] AS [o1]
+    WHERE [o2].[CustomerID] = [o1].[CustomerID] OR ([o2].[CustomerID] IS NULL AND [o1].[CustomerID] IS NULL)
+    ORDER BY [o1].[OrderID]) = [c].[CustomerID]
+LEFT JOIN (
+    SELECT [o3].[OrderID], [o3].[CustomerID]
+    FROM (
+        SELECT [o0].[OrderID], [o0].[CustomerID], ROW_NUMBER() OVER(PARTITION BY [o0].[CustomerID] ORDER BY [o0].[OrderID]) AS [row]
+        FROM [Orders] AS [o0]
+    ) AS [o3]
+    WHERE [o3].[row] <= 1
+) AS [o4] ON [o2].[CustomerID] = [o4].[CustomerID]
+""");
+    }
+
+    public override async Task GroupBy_Select_Entire_Entity_Where_navigation(bool async)
+    {
+        await base.GroupBy_Select_Entire_Entity_Where_navigation(async);
+
+        AssertSql(
+            """
+SELECT [o4].[OrderID], [o4].[CustomerID], [o4].[EmployeeID], [o4].[OrderDate]
+FROM (
+    SELECT [o].[CustomerID]
+    FROM [Orders] AS [o]
+    GROUP BY [o].[CustomerID]
+) AS [o2]
+LEFT JOIN [Customers] AS [c] ON (
+    SELECT TOP(1) [o1].[CustomerID]
+    FROM [Orders] AS [o1]
+    WHERE [o2].[CustomerID] = [o1].[CustomerID] OR ([o2].[CustomerID] IS NULL AND [o1].[CustomerID] IS NULL)
+    ORDER BY [o1].[OrderID]) = [c].[CustomerID]
+LEFT JOIN (
+    SELECT [o3].[OrderID], [o3].[CustomerID], [o3].[EmployeeID], [o3].[OrderDate]
+    FROM (
+        SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], ROW_NUMBER() OVER(PARTITION BY [o0].[CustomerID] ORDER BY [o0].[OrderID]) AS [row]
+        FROM [Orders] AS [o0]
+    ) AS [o3]
+    WHERE [o3].[row] <= 1
+) AS [o4] ON [o2].[CustomerID] = [o4].[CustomerID]
+WHERE [c].[City] = N'London'
+""");
+    }
+
+    public override async Task GroupBy_Select_Entire_Entity_Join(bool async)
+    {
+        await base.GroupBy_Select_Entire_Entity_Join(async);
+
+        AssertSql(
+            """
+SELECT [o4].[OrderID], [c].[City]
+FROM (
+    SELECT [o].[CustomerID]
+    FROM [Orders] AS [o]
+    GROUP BY [o].[CustomerID]
+) AS [o2]
+INNER JOIN [Customers] AS [c] ON (
+    SELECT TOP(1) [o1].[CustomerID]
+    FROM [Orders] AS [o1]
+    WHERE [o2].[CustomerID] = [o1].[CustomerID] OR ([o2].[CustomerID] IS NULL AND [o1].[CustomerID] IS NULL)
+    ORDER BY [o1].[OrderID]) = [c].[CustomerID]
+LEFT JOIN (
+    SELECT [o3].[OrderID], [o3].[CustomerID]
+    FROM (
+        SELECT [o0].[OrderID], [o0].[CustomerID], ROW_NUMBER() OVER(PARTITION BY [o0].[CustomerID] ORDER BY [o0].[OrderID]) AS [row]
+        FROM [Orders] AS [o0]
+    ) AS [o3]
+    WHERE [o3].[row] <= 1
+) AS [o4] ON [o2].[CustomerID] = [o4].[CustomerID]
+""");
+    }
+
     public override async Task GroupBy_Select_Entire_Entity_Order(bool async)
     {
         await base.GroupBy_Select_Entire_Entity_Order(async);


### PR DESCRIPTION
Fixes #38686
Fixes #28125

## Summary

Composing over the entity produced by a top-1-per-group query failed in two independent layers:

```csharp
ctx.TimeSheets
    .GroupBy(t => t.OrderId)
    .Select(g => g.OrderBy(x => x.Id).First())
    .OrderBy(t => t.Order.Number)   // ← "Translation of member 'Order' ... failed" (misleading: it IS mapped)
```

1. **Navigation expansion** built the result tree from `Expression.Default`, so the group element entity lost its entity reference and no navigation on it could be expanded (#20291 territory).
2. Even with the navigation expanded (or with a **manual join**, no navigations involved — #28125), the relational projection binder had no handling for a client projection slot holding a single-result subquery; its lowering only ran at the end of translation in `ApplyProjection` — "we don't allow this terms to compose (yet!)".

## Implementation

- `NavigationExpandingExpressionVisitor.ProcessSelect(GroupBy…)` now snapshots the selector structure before reducing (same mechanism `ProcessDistinct` uses for its pending selector), so a cardinality-reduced group element keeps its entity reference and later navigation accesses expand into regular joins over the grouped query.
- The single-result to-one lowering is extracted from `ApplyProjection` into a shared core (`LowerSingleResultSubqueryCore`, parameterized on the projection sink — behavior-identical for the existing deferred path) and the projection binder now invokes it **on demand** when a composed query binds a single-result slot: pushdown if needed (remapping the binder's already-collected projections with the pushdown's remapping visitor), prunable to-one `OUTER APPLY`, shaper remap. Since the lowering mutates the select expression, the binder memoizes the lowered shaper per projection slot (same idiom as its existing `_projectionBindingCache`), so a projection referencing the slot more than once reuses the single join.

Scalar member access after the per-group `First()` already worked (#26748 fixed the second-projection case; `OrderBy` by scalar translates as a correlated scalar subquery). This PR adds the missing entity-level composition. Known follow-up: the join key over the group element still binds as a correlated scalar subquery in the `ON` clause instead of reusing the lowered join's column — correct but suboptimal (the duplication described in #20291).

All currently-failing shapes throw today, so no existing SQL baselines change.

Aware of #37859/#32957 (moving navigation expansion into translation, 12.0): the navigation-expansion piece is a targeted fix for the 11 pipeline; the on-demand lowering lives on the translation side, aligned with that direction, and the new tests pin the behavior for the rewrite.

## Testing

- New specification tests following the `GroupBy_Select_Entire_Entity` family: navigation `OrderBy`/`Where`/projection over the group element, a manual `Join` over it (#28125), and a projection referencing the group element twice (whose baseline pins the single-join shape). Results-verified baselines on SQL Server; skipped on InMemory like the rest of the family (#31209).
- Full local runs: `EFCore.SqlServer.FunctionalTests` (50,818), `EFCore.Sqlite.FunctionalTests` (38,375), `EFCore.InMemory.FunctionalTests` (28,230) — remaining failures are environment-only (Full-Text Search, memory-optimized, SqlAzure, PrimitiveCollections BCL-preview artifact); InMemory fully clean.
