### PR TITLE
Fix typos and improve documentation clarity across various files

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -201,7 +201,7 @@ public void MoveClients(string oldOwner, string newOwner)
 	
 ### Security Note: Migration APIs not designed for untrusted input
 
-The migrations APIs are designed to accept trusted values that are compiled into your application as part of migration code files. Most of the values are appropriately escaped, but if you are accepting untrusted input you should ensure appropriate validation is performed. There are some APIs (such as the `Sql(string)` method and the `defaultValueSql` parameter) that are pass-thru in nature and do not perform and validation or escaping. 
+The migrations APIs are designed to accept trusted values that are compiled into your application as part of migration code files. Most of the values are appropriately escaped, but if you are accepting untrusted input you should ensure appropriate validation is performed. There are some APIs (such as the `Sql(string)` method and the `defaultValueSql` parameter) that are pass-thru in nature and do not perform any validation or escaping. 
 
 **Guidance:** The migrations APIs are not designed to accept input from an untrusted source. If input from an untrusted source (e.g. the end user of an application) is passed to the migrations APIs then it should be validated to protect against SQL injection attacks.
 

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
@@ -696,7 +696,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
             => GetString("WithPartitionKeyAlreadyCalled");
 
         /// <summary>
-        ///     'WithPartitionKey' can only be called on a entity query root. See https://aka.ms/efdocs-cosmos-partition-keys for more information.
+        ///     'WithPartitionKey' can only be called on an entity query root. See https://aka.ms/efdocs-cosmos-partition-keys for more information.
         /// </summary>
         public static string WithPartitionKeyBadNode
             => GetString("WithPartitionKeyBadNode");

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.resx
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.resx
@@ -437,7 +437,7 @@
     <value>'WithPartitionKey' can only be called once in a query. See https://aka.ms/efdocs-cosmos-partition-keys for more information.</value>
   </data>
   <data name="WithPartitionKeyBadNode" xml:space="preserve">
-    <value>'WithPartitionKey' can only be called on a entity query root. See https://aka.ms/efdocs-cosmos-partition-keys for more information.</value>
+    <value>'WithPartitionKey' can only be called on an entity query root. See https://aka.ms/efdocs-cosmos-partition-keys for more information.</value>
   </data>
   <data name="WithPartitionKeyNotConstantOrParameter" xml:space="preserve">
     <value>'WithPartitionKey' only accepts simple constant or parameter arguments. See https://aka.ms/efdocs-cosmos-partition-keys for more information.</value>

--- a/src/EFCore.Design/Properties/DesignStrings.Designer.cs
+++ b/src/EFCore.Design/Properties/DesignStrings.Designer.cs
@@ -403,7 +403,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 foreignKeyName, existingForeignKey);
 
         /// <summary>
-        ///     The namespace '{migrationsNamespace}' contains migrations for a different DbContext. This can result in conflicting migration names. It's recommend to put migrations for different DbContext classes into different namespaces.
+        ///     The namespace '{migrationsNamespace}' contains migrations for a different DbContext. This can result in conflicting migration names. It's recommended to put migrations for different DbContext classes into different namespaces.
         /// </summary>
         public static string ForeignMigrations(object? migrationsNamespace)
             => string.Format(

--- a/src/EFCore.Design/Properties/DesignStrings.resx
+++ b/src/EFCore.Design/Properties/DesignStrings.resx
@@ -272,7 +272,7 @@ Consider changing your target project to the DbContext project by using the Pack
     <value>Could not scaffold the foreign key '{foreignKeyName}'. Foreign key '{existingForeignKey}' is defined on same columns targeting same key on principal table.</value>
   </data>
   <data name="ForeignMigrations" xml:space="preserve">
-    <value>The namespace '{migrationsNamespace}' contains migrations for a different DbContext. This can result in conflicting migration names. It's recommend to put migrations for different DbContext classes into different namespaces.</value>
+    <value>The namespace '{migrationsNamespace}' contains migrations for a different DbContext. This can result in conflicting migration names. It's recommended to put migrations for different DbContext classes into different namespaces.</value>
   </data>
   <data name="FoundContextFactory" xml:space="preserve">
     <value>Found IDesignTimeDbContextFactory implementation '{factory}'.</value>

--- a/src/EFCore.InMemory/Metadata/Conventions/InMemoryConventionSetBuilder.cs
+++ b/src/EFCore.InMemory/Metadata/Conventions/InMemoryConventionSetBuilder.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions;
 
 /// <summary>
-///     A builder for building conventions for th in-memory provider.
+///     A builder for building conventions for the in-memory provider.
 /// </summary>
 /// <remarks>
 ///     <para>

--- a/src/EFCore.Relational/Diagnostics/IndexWithPropertyEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/IndexWithPropertyEventData.cs
@@ -13,7 +13,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics;
 public class IndexWithPropertyEventData : EventData
 {
     /// <summary>
-    ///     Constructs the event payload for indexes with a invalid property.
+    ///     Constructs the event payload for indexes with an invalid property.
     /// </summary>
     /// <param name="eventDefinition">The event definition.</param>
     /// <param name="messageGenerator">A delegate that generates a log message for this event.</param>

--- a/src/EFCore.Relational/Diagnostics/RelationalEventId.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalEventId.cs
@@ -208,7 +208,7 @@ public static class RelationalEventId
     public static readonly EventId ConnectionDisposed = MakeConnectionId(Id.ConnectionDisposed);
 
     /// <summary>
-    ///     A error occurred while opening or using a database connection.
+    ///     An error occurred while opening or using a database connection.
     /// </summary>
     /// <remarks>
     ///     <para>

--- a/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
@@ -467,7 +467,7 @@ public class RelationalModelValidator(
     }
 
     /// <summary>
-    ///     Validates the stored procedures for a entity type.
+    ///     Validates the stored procedures for an entity type.
     /// </summary>
     /// <param name="entityType">The entity type to validate.</param>
     /// <param name="logger">The logger to use.</param>

--- a/src/EFCore.Relational/Infrastructure/RelationalOptionsExtension.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalOptionsExtension.cs
@@ -435,7 +435,7 @@ public abstract class RelationalOptionsExtension : IDbContextOptionsExtension
     ///     Adds the services required to make the selected options work. This is used when there
     ///     is no external <see cref="IServiceProvider" /> and EF is maintaining its own service
     ///     provider internally. This allows database providers (and other extensions) to register their
-    ///     required services when EF is creating an service provider.
+    ///     required services when EF is creating a service provider.
     /// </summary>
     /// <param name="services">The collection to add services to.</param>
     public abstract void ApplyServices(IServiceCollection services);

--- a/src/EFCore.Relational/Metadata/IMutableDbFunction.cs
+++ b/src/EFCore.Relational/Metadata/IMutableDbFunction.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 namespace Microsoft.EntityFrameworkCore.Metadata;
 
 /// <summary>
-///     Represents a relational database function in an model in
+///     Represents a relational database function in a model in
 ///     the form that can be mutated while the model is being built.
 /// </summary>
 /// <remarks>

--- a/src/EFCore.Relational/Migrations/IMigrationCommandExecutor.cs
+++ b/src/EFCore.Relational/Migrations/IMigrationCommandExecutor.cs
@@ -37,7 +37,7 @@ public interface IMigrationCommandExecutor
     /// <param name="connection">The connection to use.</param>
     /// <param name="executionState">The state of the current migration execution.</param>
     /// <param name="commitTransaction">
-    ///     Indicates whether the transaction started by this call should be commited.
+    ///     Indicates whether the transaction started by this call should be committed.
     ///     If <see langword="false" />, the transaction will be made available in <paramref name="executionState" />.
     /// </param>
     /// <param name="isolationLevel">The isolation level for the transaction.</param>
@@ -68,7 +68,7 @@ public interface IMigrationCommandExecutor
     /// <param name="connection">The connection to use.</param>
     /// <param name="executionState">The state of the current migration execution.</param>
     /// <param name="commitTransaction">
-    ///     Indicates whether the transaction started by this call should be commited.
+    ///     Indicates whether the transaction started by this call should be committed.
     ///     If <see langword="false" />, the transaction will be made available in <paramref name="executionState" />.
     /// </param>
     /// <param name="isolationLevel">The isolation level for the transaction.</param>

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.ExecuteDelete.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.ExecuteDelete.cs
@@ -161,7 +161,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor
     }
 
     /// <summary>
-    ///     Checks weather the current select expression can be used as-is for executing a delete operation, or whether it must be pushed
+    ///     Checks whether the current select expression can be used as-is for executing a delete operation, or whether it must be pushed
     ///     down into a subquery.
     /// </summary>
     /// <remarks>

--- a/src/EFCore.Relational/Storage/RelationalGeometryTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/RelationalGeometryTypeMapping.cs
@@ -136,7 +136,7 @@ public abstract class RelationalGeometryTypeMapping<TGeometry, TProvider> : Rela
     }
 
     /// <summary>
-    ///     Creates a an expression tree that can be used to generate code for the literal value.
+    ///     Creates an expression tree that can be used to generate code for the literal value.
     ///     Currently, only very basic expressions such as constructor calls and factory methods taking
     ///     simple constants are supported.
     /// </summary>

--- a/src/EFCore.SqlServer/DataCompressionType.cs
+++ b/src/EFCore.SqlServer/DataCompressionType.cs
@@ -6,7 +6,7 @@
 namespace Microsoft.EntityFrameworkCore;
 
 /// <summary>
-///     Indicates type of data compression used on a index.
+///     Indicates type of data compression used on an index.
 /// </summary>
 /// <remarks>
 ///     See <see href="https://docs.microsoft.com/sql/relational-databases/data-compression">Data Compression</see> for more information on

--- a/src/EFCore.SqlServer/Extensions/SqlServerDbContextOptionsBuilderExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerDbContextOptionsBuilderExtensions.cs
@@ -240,7 +240,7 @@ public static class SqlServerDbContextOptionsExtensions
             (DbContextOptionsBuilder)optionsBuilder, connection, contextOwnsConnection, sqlServerOptionsAction);
 
     /// <summary>
-    ///     Configures the context to connect to a Azure SQL database, but without initially setting any
+    ///     Configures the context to connect to an Azure SQL database, but without initially setting any
     ///     <see cref="DbConnection" /> or connection string.
     /// </summary>
     /// <remarks>
@@ -270,7 +270,7 @@ public static class SqlServerDbContextOptionsExtensions
     }
 
     /// <summary>
-    ///     Configures the context to connect to a Azure SQL database.
+    ///     Configures the context to connect to an Azure SQL database.
     /// </summary>
     /// <remarks>
     ///     See <see href="https://aka.ms/efcore-docs-dbcontext-options">Using DbContextOptions</see>, and
@@ -296,7 +296,7 @@ public static class SqlServerDbContextOptionsExtensions
 
     // Note: Decision made to use DbConnection not SqlConnection: Issue #772
     /// <summary>
-    ///     Configures the context to connect to a Azure SQL database.
+    ///     Configures the context to connect to an Azure SQL database.
     /// </summary>
     /// <remarks>
     ///     See <see href="https://aka.ms/efcore-docs-dbcontext-options">Using DbContextOptions</see>, and
@@ -320,7 +320,7 @@ public static class SqlServerDbContextOptionsExtensions
 
     // Note: Decision made to use DbConnection not SqlConnection: Issue #772
     /// <summary>
-    ///     Configures the context to connect to a Azure SQL database.
+    ///     Configures the context to connect to an Azure SQL database.
     /// </summary>
     /// <remarks>
     ///     See <see href="https://aka.ms/efcore-docs-dbcontext-options">Using DbContextOptions</see>, and
@@ -357,7 +357,7 @@ public static class SqlServerDbContextOptionsExtensions
     }
 
     /// <summary>
-    ///     Configures the context to connect to a Azure SQL database, but without initially setting any
+    ///     Configures the context to connect to an Azure SQL database, but without initially setting any
     ///     <see cref="DbConnection" /> or connection string.
     /// </summary>
     /// <remarks>
@@ -383,7 +383,7 @@ public static class SqlServerDbContextOptionsExtensions
             (DbContextOptionsBuilder)optionsBuilder, azureSqlOptionsAction);
 
     /// <summary>
-    ///     Configures the context to connect to a Azure SQL database.
+    ///     Configures the context to connect to an Azure SQL database.
     /// </summary>
     /// <remarks>
     ///     See <see href="https://aka.ms/efcore-docs-dbcontext-options">Using DbContextOptions</see>, and
@@ -405,7 +405,7 @@ public static class SqlServerDbContextOptionsExtensions
 
     // Note: Decision made to use DbConnection not SqlConnection: Issue #772
     /// <summary>
-    ///     Configures the context to connect to a Azure SQL database.
+    ///     Configures the context to connect to an Azure SQL database.
     /// </summary>
     /// <remarks>
     ///     See <see href="https://aka.ms/efcore-docs-dbcontext-options">Using DbContextOptions</see>, and
@@ -432,7 +432,7 @@ public static class SqlServerDbContextOptionsExtensions
 
     // Note: Decision made to use DbConnection not SqlConnection: Issue #772
     /// <summary>
-    ///     Configures the context to connect to a Azure SQL database.
+    ///     Configures the context to connect to an Azure SQL database.
     /// </summary>
     /// <remarks>
     ///     See <see href="https://aka.ms/efcore-docs-dbcontext-options">Using DbContextOptions</see>, and
@@ -463,7 +463,7 @@ public static class SqlServerDbContextOptionsExtensions
             (DbContextOptionsBuilder)optionsBuilder, connection, contextOwnsConnection, azureSqlOptionsAction);
 
     /// <summary>
-    ///     Configures the context to connect to a Azure Synapse database, but without initially setting any
+    ///     Configures the context to connect to an Azure Synapse database, but without initially setting any
     ///     <see cref="DbConnection" /> or connection string.
     /// </summary>
     /// <remarks>
@@ -493,7 +493,7 @@ public static class SqlServerDbContextOptionsExtensions
     }
 
     /// <summary>
-    ///     Configures the context to connect to a Azure Synapse database.
+    ///     Configures the context to connect to an Azure Synapse database.
     /// </summary>
     /// <remarks>
     ///     See <see href="https://aka.ms/efcore-docs-dbcontext-options">Using DbContextOptions</see>, and
@@ -519,7 +519,7 @@ public static class SqlServerDbContextOptionsExtensions
 
     // Note: Decision made to use DbConnection not SqlConnection: Issue #772
     /// <summary>
-    ///     Configures the context to connect to a Azure Synapse database.
+    ///     Configures the context to connect to an Azure Synapse database.
     /// </summary>
     /// <remarks>
     ///     See <see href="https://aka.ms/efcore-docs-dbcontext-options">Using DbContextOptions</see>, and
@@ -543,7 +543,7 @@ public static class SqlServerDbContextOptionsExtensions
 
     // Note: Decision made to use DbConnection not SqlConnection: Issue #772
     /// <summary>
-    ///     Configures the context to connect to a Azure Synapse database.
+    ///     Configures the context to connect to an Azure Synapse database.
     /// </summary>
     /// <remarks>
     ///     See <see href="https://aka.ms/efcore-docs-dbcontext-options">Using DbContextOptions</see>, and
@@ -580,7 +580,7 @@ public static class SqlServerDbContextOptionsExtensions
     }
 
     /// <summary>
-    ///     Configures the context to connect to a Azure Synapse database, but without initially setting any
+    ///     Configures the context to connect to an Azure Synapse database, but without initially setting any
     ///     <see cref="DbConnection" /> or connection string.
     /// </summary>
     /// <remarks>
@@ -606,7 +606,7 @@ public static class SqlServerDbContextOptionsExtensions
             (DbContextOptionsBuilder)optionsBuilder, azureSynapseOptionsAction);
 
     /// <summary>
-    ///     Configures the context to connect to a Azure Synapse database.
+    ///     Configures the context to connect to an Azure Synapse database.
     /// </summary>
     /// <remarks>
     ///     See <see href="https://aka.ms/efcore-docs-dbcontext-options">Using DbContextOptions</see>, and
@@ -628,7 +628,7 @@ public static class SqlServerDbContextOptionsExtensions
 
     // Note: Decision made to use DbConnection not SqlConnection: Issue #772
     /// <summary>
-    ///     Configures the context to connect to a Azure Synapse database.
+    ///     Configures the context to connect to an Azure Synapse database.
     /// </summary>
     /// <remarks>
     ///     See <see href="https://aka.ms/efcore-docs-dbcontext-options">Using DbContextOptions</see>, and
@@ -655,7 +655,7 @@ public static class SqlServerDbContextOptionsExtensions
 
     // Note: Decision made to use DbConnection not SqlConnection: Issue #772
     /// <summary>
-    ///     Configures the context to connect to a Azure Synapse database.
+    ///     Configures the context to connect to an Azure Synapse database.
     /// </summary>
     /// <remarks>
     ///     See <see href="https://aka.ms/efcore-docs-dbcontext-options">Using DbContextOptions</see>, and

--- a/src/EFCore.SqlServer/Extensions/SqlServerServiceCollectionExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerServiceCollectionExtensions.cs
@@ -94,7 +94,7 @@ public static class SqlServerServiceCollectionExtensions
 
     /// <summary>
     ///     Registers the given Entity Framework <see cref="DbContext" /> as a service in the <see cref="IServiceCollection" />
-    ///     and configures it to connect to a Azure SQL database.
+    ///     and configures it to connect to an Azure SQL database.
     /// </summary>
     /// <remarks>
     ///     <para>
@@ -167,7 +167,7 @@ public static class SqlServerServiceCollectionExtensions
 
     /// <summary>
     ///     Registers the given Entity Framework <see cref="DbContext" /> as a service in the <see cref="IServiceCollection" />
-    ///     and configures it to connect to a Azure Synapse database.
+    ///     and configures it to connect to an Azure Synapse database.
     /// </summary>
     /// <remarks>
     ///     <para>

--- a/src/EFCore/ChangeTracking/ChangeTracker.cs
+++ b/src/EFCore/ChangeTracking/ChangeTracker.cs
@@ -418,7 +418,7 @@ public class ChangeTracker : IResettableService
     /// <param name="rootEntity">The entity to begin traversal from.</param>
     /// <param name="state">An arbitrary state object passed to the callback.</param>
     /// <param name="callback">
-    ///     An delegate to configure the change tracking information for each entity. The second parameter to the
+    ///     A delegate to configure the change tracking information for each entity. The second parameter to the
     ///     callback is the arbitrary state object passed above. Iteration of the graph will not continue down the graph
     ///     if the callback returns <see langword="false" />.
     /// </param>

--- a/src/EFCore/ChangeTracking/LoadOptions.cs
+++ b/src/EFCore/ChangeTracking/LoadOptions.cs
@@ -15,7 +15,7 @@ public enum LoadOptions
     ///     </para>
     ///     <para>
     ///         If the entity is tracked, then entities with the same primary key value are not replaced
-    ///         by new entities or overwritten with new data from the database. If the entity entity represented by this entry is not
+    ///         by new entities or overwritten with new data from the database. If the entity represented by this entry is not
     ///         tracked and the collection already contains entities, then calling this method will result in duplicate
     ///         instances in the collection or inverse collection for any entities with the same key value.
     ///         Use <see cref="ForceIdentityResolution" /> to avoid getting these duplicates.

--- a/src/EFCore/Diagnostics/CoreEventId.cs
+++ b/src/EFCore/Diagnostics/CoreEventId.cs
@@ -178,7 +178,7 @@ public static class CoreEventId
     public static readonly EventId SaveChangesCanceled = MakeUpdateId(Id.SaveChangesCanceled);
 
     /// <summary>
-    ///     The same entity is being tracked as a different shared entity entity type.
+    ///     The same entity is being tracked as a different shared entity type.
     ///     This event is in the <see cref="DbLoggerCategory.Update" /> category.
     /// </summary>
     public static readonly EventId DuplicateDependentEntityTypeInstanceWarning =

--- a/src/EFCore/Infrastructure/CoreOptionsExtension.cs
+++ b/src/EFCore/Infrastructure/CoreOptionsExtension.cs
@@ -585,7 +585,7 @@ public class CoreOptionsExtension : IDbContextOptionsExtension
     ///     Adds the services required to make the selected options work. This is used when there
     ///     is no external <see cref="IServiceProvider" /> and EF is maintaining its own service
     ///     provider internally. This allows database providers (and other extensions) to register their
-    ///     required services when EF is creating an service provider.
+    ///     required services when EF is creating a service provider.
     /// </summary>
     /// <param name="services">The collection to add services to.</param>
     public virtual void ApplyServices(IServiceCollection services)

--- a/src/EFCore/Infrastructure/IDbContextOptionsExtension.cs
+++ b/src/EFCore/Infrastructure/IDbContextOptionsExtension.cs
@@ -27,7 +27,7 @@ public interface IDbContextOptionsExtension
     ///     Adds the services required to make the selected options work. This is used when there
     ///     is no external <see cref="IServiceProvider" /> and EF is maintaining its own service
     ///     provider internally. This allows database providers (and other extensions) to register their
-    ///     required services when EF is creating an service provider.
+    ///     required services when EF is creating a service provider.
     /// </summary>
     /// <param name="services">The collection to add services to.</param>
     void ApplyServices(IServiceCollection services);

--- a/src/EFCore/Metadata/Conventions/EntityTypeConfigurationAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/EntityTypeConfigurationAttributeConvention.cs
@@ -51,7 +51,7 @@ public class EntityTypeConfigurationAttributeConvention : TypeAttributeConventio
     }
 
     /// <summary>
-    ///     Called after an complex type is added to the model if it has an attribute.
+    ///     Called after a complex type is added to the model if it has an attribute.
     /// </summary>
     /// <param name="complexTypeBuilder">The builder for the complex type.</param>
     /// <param name="attribute">The attribute.</param>

--- a/src/EFCore/Metadata/Conventions/IComplexPropertyAddedConvention.cs
+++ b/src/EFCore/Metadata/Conventions/IComplexPropertyAddedConvention.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions;
 
 /// <summary>
-///     Represents an operation that should be performed when a complex property is added to an type-like object.
+///     Represents an operation that should be performed when a complex property is added to a type-like object.
 /// </summary>
 /// <remarks>
 ///     See <see href="https://aka.ms/efcore-docs-conventions">Model building conventions</see> for more information and examples.

--- a/src/EFCore/Metadata/Conventions/IModelAnnotationChangedConvention.cs
+++ b/src/EFCore/Metadata/Conventions/IModelAnnotationChangedConvention.cs
@@ -12,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions;
 public interface IModelAnnotationChangedConvention : IConvention
 {
     /// <summary>
-    ///     Called after an annotation is changed on an model.
+    ///     Called after an annotation is changed on a model.
     /// </summary>
     /// <param name="modelBuilder">The builder for the model.</param>
     /// <param name="name">The annotation name.</param>

--- a/src/EFCore/Metadata/Conventions/OwnedAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/OwnedAttributeConvention.cs
@@ -42,7 +42,7 @@ public class OwnedAttributeConvention : TypeAttributeConventionBase<OwnedAttribu
     }
 
     /// <summary>
-    ///     Called after an complex type is added to the model if it has an attribute.
+    ///     Called after a complex type is added to the model if it has an attribute.
     /// </summary>
     /// <param name="complexTypeBuilder">The builder for the complex type.</param>
     /// <param name="attribute">The attribute.</param>

--- a/src/EFCore/Metadata/Conventions/PropertyAttributeConventionBase.cs
+++ b/src/EFCore/Metadata/Conventions/PropertyAttributeConventionBase.cs
@@ -86,7 +86,7 @@ public abstract class PropertyAttributeConventionBase<TAttribute> :
     }
 
     /// <summary>
-    ///     Called after a complex property is added to an type-like object.
+    ///     Called after a complex property is added to a type-like object.
     /// </summary>
     /// <param name="propertyBuilder">The builder for the complex property.</param>
     /// <param name="context">Additional information associated with convention execution.</param>

--- a/src/EFCore/Metadata/Conventions/TypeAttributeConventionBase.cs
+++ b/src/EFCore/Metadata/Conventions/TypeAttributeConventionBase.cs
@@ -83,7 +83,7 @@ public abstract class TypeAttributeConventionBase<TAttribute> : IEntityTypeAdded
         IConventionContext<IConventionEntityTypeBuilder> context);
 
     /// <summary>
-    ///     Called after an complex type is added to the model if it has an attribute.
+    ///     Called after a complex type is added to the model if it has an attribute.
     /// </summary>
     /// <param name="complexTypeBuilder">The builder for the complex type.</param>
     /// <param name="attribute">The attribute.</param>

--- a/src/EFCore/Metadata/IConventionElementType.cs
+++ b/src/EFCore/Metadata/IConventionElementType.cs
@@ -42,7 +42,7 @@ public interface IConventionElementType : IReadOnlyElementType, IConventionAnnot
     ///     Sets a value indicating whether elements in the collection can be <see langword="null" />.
     /// </summary>
     /// <param name="nullable">
-    ///     A value indicating whether whether elements in the collection can be <see langword="null" />, or <see langword="null" /> to
+    ///     A value indicating whether elements in the collection can be <see langword="null" />, or <see langword="null" /> to
     ///     reset to the default.
     /// </param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>

--- a/src/EFCore/Metadata/IConventionEntityType.cs
+++ b/src/EFCore/Metadata/IConventionEntityType.cs
@@ -582,7 +582,7 @@ public interface IConventionEntityType : IReadOnlyEntityType, IConventionTypeBas
     ///     Gets the skip navigation properties declared on this entity type.
     /// </summary>
     /// <remarks>
-    ///     This method does not return skip navigation properties declared declared on base types.
+    ///     This method does not return skip navigation properties declared on base types.
     ///     It is useful when iterating over all entity types to avoid processing the same foreign key more than once.
     ///     Use <see cref="GetSkipNavigations" /> to also return skip navigation properties declared on base types.
     /// </remarks>

--- a/src/EFCore/Metadata/IEntityType.cs
+++ b/src/EFCore/Metadata/IEntityType.cs
@@ -346,7 +346,7 @@ public interface IEntityType : IReadOnlyEntityType, ITypeBase
     ///     Gets all skip navigation properties declared on this entity type.
     /// </summary>
     /// <remarks>
-    ///     This method does not return skip navigation properties declared declared on base types.
+    ///     This method does not return skip navigation properties declared on base types.
     ///     It is useful when iterating over all entity types to avoid processing the same foreign key more than once.
     ///     Use <see cref="GetSkipNavigations" /> to also return skip navigation properties declared on base types.
     /// </remarks>

--- a/src/EFCore/Metadata/IMutableEntityType.cs
+++ b/src/EFCore/Metadata/IMutableEntityType.cs
@@ -537,7 +537,7 @@ public interface IMutableEntityType : IReadOnlyEntityType, IMutableTypeBase
     ///     Gets all skip navigation properties declared on this entity type.
     /// </summary>
     /// <remarks>
-    ///     This method does not return skip navigation properties declared declared on base types.
+    ///     This method does not return skip navigation properties declared on base types.
     ///     It is useful when iterating over all entity types to avoid processing the same foreign key more than once.
     ///     Use <see cref="GetSkipNavigations" /> to also return skip navigation properties declared on base types.
     /// </remarks>

--- a/src/EFCore/Metadata/IReadOnlyEntityType.cs
+++ b/src/EFCore/Metadata/IReadOnlyEntityType.cs
@@ -491,7 +491,7 @@ public interface IReadOnlyEntityType : IReadOnlyTypeBase
     ///     Gets all skip navigation properties declared on this entity type.
     /// </summary>
     /// <remarks>
-    ///     This method does not return skip navigation properties declared declared on base types.
+    ///     This method does not return skip navigation properties declared on base types.
     ///     It is useful when iterating over all entity types to avoid processing the same foreign key more than once.
     ///     Use <see cref="GetSkipNavigations" /> to also return skip navigation properties declared on base types.
     /// </remarks>

--- a/src/EFCore/Metadata/RuntimeProperty.cs
+++ b/src/EFCore/Metadata/RuntimeProperty.cs
@@ -10,7 +10,7 @@ using Microsoft.EntityFrameworkCore.Storage.Json;
 namespace Microsoft.EntityFrameworkCore.Metadata;
 
 /// <summary>
-///     Represents a scalar property of an structural type.
+///     Represents a scalar property of a structural type.
 /// </summary>
 /// <remarks>
 ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see> for more information and examples.

--- a/src/EFCore/Query/QueryContext.cs
+++ b/src/EFCore/Query/QueryContext.cs
@@ -44,7 +44,7 @@ public abstract class QueryContext
     public virtual DbContext Context { get; }
 
     /// <summary>
-    ///     The query parameter used in the query query.
+    ///     The query parameter used in the query.
     /// </summary>
     public virtual Dictionary<string, object?> Parameters { get; } = new();
 

--- a/src/EFCore/Storage/CoreTypeMapping.cs
+++ b/src/EFCore/Storage/CoreTypeMapping.cs
@@ -361,7 +361,7 @@ public abstract class CoreTypeMapping
                 jsonValueReaderWriter ?? Parameters.JsonValueReaderWriter));
 
     /// <summary>
-    ///     Creates a an expression tree that can be used to generate code for the literal value.
+    ///     Creates an expression tree that can be used to generate code for the literal value.
     ///     Currently, only very basic expressions such as constructor calls and factory methods taking
     ///     simple constants are supported.
     /// </summary>

--- a/src/ef/Properties/Resources.Designer.cs
+++ b/src/ef/Properties/Resources.Designer.cs
@@ -272,7 +272,7 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
             => GetString("IdempotentDescription");
 
         /// <summary>
-        ///     Show JSON output. Use with --prefix-output to parse programatically.
+        ///     Show JSON output. Use with --prefix-output to parse programmatically.
         /// </summary>
         public static string JsonDescription
             => GetString("JsonDescription");

--- a/src/ef/Properties/Resources.resx
+++ b/src/ef/Properties/Resources.resx
@@ -235,7 +235,7 @@
     <value>Generate a script that can be used on a database at any migration.</value>
   </data>
   <data name="JsonDescription" xml:space="preserve">
-    <value>Show JSON output. Use with --prefix-output to parse programatically.</value>
+    <value>Show JSON output. Use with --prefix-output to parse programmatically.</value>
   </data>
   <data name="LanguageDescription" xml:space="preserve">
     <value>The language. Defaults to 'C#'.</value>


### PR DESCRIPTION
Fixes typos, doubled words, and grammatical errors across XML documentation comments and user-facing resource strings. All changes are limited to comments and resource string values, no code paths are affected.

- Corrected a typo in the migrations security documentation (`docs/security.md`) where "do not perform **and** validation" now reads "do not perform **any** validation".
- Fixed grammatical errors and misspellings in user-facing resource strings and their generated `.Designer.cs` mirrors: `programatically` → `programmatically` (dotnet-ef), `It's recommend` → `It's recommended` (DesignStrings), and `a entity query root` → `an entity query root` (CosmosStrings).
- Corrected misspellings and removed doubled words in XML doc comments across EFCore, EFCore.Relational, and EFCore.SqlServer (e.g. `weather` → `whether`, `commited` → `committed`, and duplicated `entity entity` / `query query` / `whether whether` / `declared declared`).
- Ensured consistent terminology by fixing incorrect articles, e.g. `a entity` → `an entity`, `an complex` → `a complex`, and `a Azure` → `an Azure`.

<!--
Please check whether the PR fulfills these requirements
-->

- [x] I've read the guidelines for [contributing](https://github.com/dotnet/efcore/blob/main/.github/CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [ ] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
  - N/A — per the [Fixing typos](https://github.com/dotnet/efcore/blob/main/.github/CONTRIBUTING.md) section of the contributing guidelines, an issue is not required for simple non-code changes like fixing typos in documentation.
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [ ] Commit messages follow this format:

    Summary of the changes
    - Detail 1
    - Detail 2

    Fixes #bugnumber

- [x] Code follows the same patterns and style as existing code in this repo